### PR TITLE
#47 fixing for empty test coverage report

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,63 +1,61 @@
 module.exports = function karmaConfig(config) {
-    var postLoaders = [];
-    // postloader compiles the jsx
-    // so is needed only for coverage test, not in continuostest
-    // assume singleRun = false means you are debugging
-    if (config.singleRun) {
-        postLoaders.push({
-            test: /\.jsx$/,
-            exclude: /(__tests__|node_modules|legacy)\//,
-            loader: 'istanbul-instrumenter'
-        });
-    }
     config.set({
 
-    browsers: [ 'Chrome' ],
+        browsers: [ 'Chrome' ],
 
-    singleRun: true,
+        singleRun: true,
 
-    frameworks: [ 'mocha' ],
+        frameworks: [ 'mocha' ],
 
-    files: [
-      'tests.webpack.js'
-    ],
-
-    preprocessors: {
-      'tests.webpack.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    reporters: [ 'dots', 'coverage', 'coveralls' ],
-
-    junitReporter: {
-      outputDir: './web/target/karma-tests-results',
-      suite: ''
-    },
-
-    coverageReporter: {
-      dir: './coverage/',
-      reporters: [
-        { type: 'html', subdir: 'report-html' },
-        { type: 'cobertura', subdir: '.', file: 'cobertura.txt' },
-        { type: 'lcovonly', subdir: '.' }
-      ]
-  },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      module: {
-        loaders: [
-          { test: /\.jsx$/, loader: 'babel-loader' }
+        files: [
+            'tests.webpack.js'
         ],
-        postLoaders: postLoaders
-      },
-      resolve: {
-          extensions: ['', '.js', '.json', '.jsx']
-      }
-    },
 
-    webpackServer: {
-      noInfo: true
-    }
+        preprocessors: {
+            'tests.webpack.js': [ 'webpack', 'sourcemap' ]
+        },
 
-  });
+        reporters: [ 'dots', 'coverage', 'coveralls' ],
+
+        junitReporter: {
+            outputDir: './web/target/karma-tests-results',
+            suite: ''
+        },
+
+        coverageReporter: {
+            dir: './coverage/',
+            reporters: [
+                { type: 'html', subdir: 'report-html' },
+                { type: 'cobertura', subdir: '.', file: 'cobertura.txt' },
+                { type: 'lcovonly', subdir: '.' }
+            ],
+            instrumenterOptions: {
+                istanbul: { noCompact: true }
+            }
+        },
+
+        webpack: {
+            devtool: 'inline-source-map',
+            module: {
+                loaders: [
+                    { test: /\.jsx$/, loader: 'babel-loader' }
+                ],
+                postLoaders: [
+                    {
+                        test: /\.jsx$/,
+                        exclude: /(__tests__|node_modules|legacy)\//,
+                        loader: 'istanbul-instrumenter'
+                    }
+                ]
+            },
+            resolve: {
+                extensions: ['', '.js', '.json', '.jsx']
+            }
+        },
+
+        webpackServer: {
+            noInfo: true
+        }
+
+    });
 };


### PR DESCRIPTION
In karma configuration file, `postLoaders` was never initialized.

To keep source files uncompressed during test debugging, the following `coverageReporter`
configuration was added:

    instrumenterOptions: {
        istanbul: { noCompact: true }
    }
