### PR TITLE
#31 legacy map loading and merge support 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
 /**
  * ES6
  */
-    //"no-var": 2,                     // http://eslint.org/docs/rules/no-var
+    "no-var": 0,                     // http://eslint.org/docs/rules/no-var
     "prefer-const": 0,               // http://eslint.org/docs/rules/prefer-const
 
 /**

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "object-assign": "^3.0.0",
     "proj4": "~2.3.6",
     "react": "^0.13.3",
-    "react-bootstrap": "^0.24.3"
+    "react-bootstrap": "^0.24.3",
+    "url": "~0.10.3"
   },
   "scripts": {
     "clean": "rm -Rf ./web/dist",

--- a/web/client/api/MapConfigDAO.js
+++ b/web/client/api/MapConfigDAO.js
@@ -5,10 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-
 var axios = require('axios');
-
+var ConfigUtils = require('../utils/ConfigUtils');
 /**
  * API for local config
  */
@@ -18,6 +16,27 @@ var Api = {
             // render map
             return response.data;
         });
+    },
+
+    /**
+     * Returns Merged configurations from base url and GeoStore
+     */
+    getMergedConfig: function(baseConfigURL, mapId, geoStoreBase) {
+        var url = ( geoStoreBase || "/rest/geostore/" ) + "data/" + mapId;
+        var me = this;
+        if (!mapId) {
+            return this.get(baseConfigURL);
+        }
+
+        return axios.all([axios.get(baseConfigURL), axios.get(url)])
+            .then( function(args) {
+                var baseConfig = args[0];
+                var mapConfig = args[1];
+                return ConfigUtils.mergeConfigs(baseConfig, mapConfig);
+            }).catch(function() {
+                // TODO manage the error
+                return me.get(baseConfigURL);
+            });
     }
 };
 

--- a/web/client/api/MapConfigDAO.js
+++ b/web/client/api/MapConfigDAO.js
@@ -30,8 +30,8 @@ var Api = {
 
         return axios.all([axios.get(baseConfigURL), axios.get(url)])
             .then( function(args) {
-                var baseConfig = args[0];
-                var mapConfig = args[1];
+                var baseConfig = args[0].data;
+                var mapConfig = args[1].data;
                 return ConfigUtils.mergeConfigs(baseConfig, mapConfig);
             }).catch(function() {
                 // TODO manage the error

--- a/web/client/examples/viewer/app.jsx
+++ b/web/client/examples/viewer/app.jsx
@@ -8,12 +8,13 @@
 var React = require('react');
 var MapViewController = require('../../components/Map/MapViewController');
 var InfoButton = require('../../components/InfoButton/InfoButton');
-
 var ConfigUtils = require('../../utils/ConfigUtils');
+var url = require('url');
 
 var Api = require('../../api/MapConfigDAO');
 
-Api.get("../data/mapStoreConfig.json").then( function(legacyConfig) {
+// window.geoStoreBase = "http://mapstore.geo-solutions.it/geostore/rest/"
+Api.getMergedConfig("../data/mapStoreConfig.json", url.parse(window.location.href, true).query.mapId, window.geoStoreBase).then( function(legacyConfig) {
     const mapId = "map";
     // convert from legacy
     const conf = ConfigUtils.convertFromLegacy(legacyConfig);

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -93,6 +93,14 @@ var ConfigUtils = {
         if (candidateVisible) {
             candidateVisible.visibility = true;
         }
+    },
+    /**
+     * Utility to merge different configs
+     */
+    mergeConfigs: function(baseConfig, mapConfig) {
+        baseConfig.map = mapConfig.map;
+        baseConfig.gsSources = mapConfig.gsSources || mapConfig.sources;
+        return baseConfig;
     }
 };
 

--- a/web/client/utils/__tests__/ConfigUtils-test.jsx
+++ b/web/client/utils/__tests__/ConfigUtils-test.jsx
@@ -7,72 +7,113 @@
  */
 var expect = require('expect');
 var ConfigUtils = require('../ConfigUtils');
-var lconfig = {
-    "gsSources": {
-        "mapquest": {
-            "ptype": "gxp_mapquestsource"
-        },
-        "osm": {
-            "ptype": "gxp_osmsource"
-        },
-        "google": {
-            "ptype": "gxp_googlesource"
-        },
-        "bing": {
-            "ptype": "gxp_bingsource"
-        },
-        "ol": {
-            "ptype": "gxp_olsource"
-        },
-        "demo": {
-            "url": "http://demo.geo-solutions.it/geoserver/wms"
-        }
-    },
-    "map": {
-        "projection": "EPSG:900913",
-        "units": "m",
-        "center": [1250000.000000, 5370000.000000],
-        "zoom": 5,
-        "maxExtent": [
-            -20037508.34, -20037508.34,
-            20037508.34, 20037508.34
-        ],
-        "layers": [{
-                "source": "google",
-                "title": "Google Hybrid",
-                "name": "HYBRID",
-                "group": "background"
-            }, {
-                "source": "mapquest",
-                "title": "MapQuest OpenStreetMap",
-                "name": "osm",
-                "group": "background"
-            }, {
-                "source": "osm",
-                "title": "Open Street Map",
-                "name": "mapnik",
-                "group": "background",
-                "visibility": true // this should be replaced with false
-            }, {
-                "source": "osm",
-                "title": "Open Street Map",
-                "name": "mapnik",
-                "group": "background",
-                "visibility": true
-            }, {
-                "source": "demo",
-                "visibility": true,
-                "opacity": 0.5,
-                "title": "Weather data",
-                "name": "nurc:Arc_Sample",
-                "group": "Meteo",
-                "format": "image/png"
-            }]
-    }
+var lconfig = {};
+var testMap = {
+   "defaultSourceType": "gxp_wmssource",
+   "map": {
+      "center": [
+         1361886.8627049,
+         5723464.1181097
+      ],
+      "extent": [
+         -2.003750834E7,
+         -2.003750834E7,
+         2.003750834E7,
+         2.003750834E7
+      ],
+      "zoom": 10,
+      "layers": [
+         {
+            "title": "c1101031_iba",
+            "source": "gxp-source-508",
+            "visibility": true,
+            "name": "cite:c1101031_iba",
+            "opacity": 1
+         }
+      ],
+      "projection": "EPSG:900913",
+      "units": "m"
+   },
+   "sources": {
+      "gxp-source-508": {
+         "projection": "EPSG:900913",
+         "url": "http://test.org"
+      }
+
+   }
 };
+function resetLConfig() {
+    lconfig = {
+        "gsSources": {
+            "mapquest": {
+                "ptype": "gxp_mapquestsource"
+            },
+            "osm": {
+                "ptype": "gxp_osmsource"
+            },
+            "google": {
+                "ptype": "gxp_googlesource"
+            },
+            "bing": {
+                "ptype": "gxp_bingsource"
+            },
+            "ol": {
+                "ptype": "gxp_olsource"
+            },
+            "demo": {
+                "url": "http://demo.geo-solutions.it/geoserver/wms"
+            }
+        },
+        "map": {
+            "projection": "EPSG:900913",
+            "units": "m",
+            "center": [1250000.000000, 5370000.000000],
+            "zoom": 5,
+            "maxExtent": [
+                -20037508.34, -20037508.34,
+                20037508.34, 20037508.34
+            ],
+            "layers": [{
+                    "source": "google",
+                    "title": "Google Hybrid",
+                    "name": "HYBRID",
+                    "group": "background"
+                }, {
+                    "source": "mapquest",
+                    "title": "MapQuest OpenStreetMap",
+                    "name": "osm",
+                    "group": "background"
+                }, {
+                    "source": "osm",
+                    "title": "Open Street Map",
+                    "name": "mapnik",
+                    "group": "background",
+                    "visibility": true // this should be replaced with false
+                }, {
+                    "source": "osm",
+                    "title": "Open Street Map",
+                    "name": "mapnik",
+                    "group": "background",
+                    "visibility": true
+                }, {
+                    "source": "demo",
+                    "visibility": true,
+                    "opacity": 0.5,
+                    "title": "Weather data",
+                    "name": "nurc:Arc_Sample",
+                    "group": "Meteo",
+                    "format": "image/png"
+                }]
+        }
+    };
+}
 describe('ConfigUtils', () => {
+    beforeEach( () => {
+        resetLConfig();
+    });
     afterEach((done) => {
         document.body.innerHTML = '';
+
         setTimeout(done);
     });
     it('convert from legacy and check projection conversion', () => {
@@ -107,5 +148,12 @@ describe('ConfigUtils', () => {
         expect(config.layers[2].visibility).toBe(false);
         expect(config.layers[3].visibility).toBe(true);
         expect(config.layers[4].visibility).toBe(true);
+    });
+
+    it('check merge config', () => {
+        var config = ConfigUtils.mergeConfigs(lconfig, testMap);
+        // check layers replaced
+        expect(config.map.layers.length).toBe(1);
+        expect(config.gsSources["gxp-source-508"]).toExist();
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,11 @@
 var path = require("path");
-
+var rewriteUrl = function(replacePath) {
+    return function(req, opt) {  // gets called with request and proxy object
+        var queryIndex = req.url.indexOf('?');
+        var query = queryIndex >= 0 ? req.url.substr(queryIndex) : "";
+        req.url = req.path.replace(opt.path, replacePath) + query;
+    };
+};
 module.exports = {
     entry: path.join(__dirname, "web", "client", "examples", "viewer", "app"),
     output: {
@@ -16,7 +22,13 @@ module.exports = {
         ]
     },
     devServer: {
+        proxy: [{
+            path: new RegExp("/rest/geostore/(.*)"),
+            rewrite: rewriteUrl("/geostore/rest/$1"),
+            target: "http://mapstore.geo-solutions.it"
+        }]
     },
+
     devtool: 'inline-source-map',
     debug: true
 };


### PR DESCRIPTION
This changes allow to load a map by id in the viewer using mapId=<id>
e.g. : `http://localhost:8081/examples/viewer/?mapId=165`

The configuration is merged with the local mapStoreConfig.js in the viewer. 

