### PR TITLE
Fixes #69

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -12,14 +12,14 @@ var axios = require('axios');
  */
 var Api = {
     getData: function(id, geoStoreBase) {
-        var url = geoStoreBase || "/rest/geostore/";
+        var url = geoStoreBase || "/mapstore/rest/geostore/";
         url += "data/" + id;
         return axios.get(url).then(function(response) {
             return response.data;
         });
     },
     getResourcesByCategory: function(category, query, params, geoStoreBase) {
-        var url = geoStoreBase || "/rest/geostore/";
+        var url = geoStoreBase || "/mapstore/rest/geostore/";
         var q = query || "*";
         url += "extjs/search/category/" + category + "/*" + q + "*/";
         return axios.get(url, params).then(function(response) {return response.data; });

--- a/web/client/api/MapConfigDAO.js
+++ b/web/client/api/MapConfigDAO.js
@@ -21,7 +21,7 @@ var Api = {
      * Returns Merged configurations from base url and GeoStore
      */
     getMergedConfig: function(baseConfigURL, mapId, geoStoreBase) {
-        var url = ( geoStoreBase || "/rest/geostore/" ) + "data/" + mapId;
+        var url = ( geoStoreBase || "/mapstore/rest/geostore/" ) + "data/" + mapId;
         if (!mapId) {
             return Api.get(baseConfigURL);
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = {
     },
     devServer: {
         proxy: [{
-            path: new RegExp("/rest/geostore/(.*)"),
+            path: new RegExp("/mapstore/rest/geostore/(.*)"),
             rewrite: rewriteUrl("/geostore/rest/$1"),
             target: "http://mapstore.geo-solutions.it"
         }]


### PR DESCRIPTION
All default geostore base paths are changed to `/mapstore/rest/geostore/`.

The development proxy has been updated according to the new base path.