### PR TITLE
Fixes #68, reduces bundle size to deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "clean": "rm -Rf ./web/client/dist",
-    "compile": "npm run clean && mkdirp ./web/client/dist && webpack",
+    "compile": "npm run clean && mkdirp ./web/client/dist && webpack --config prod-webpack.config.js",
     "start": "webpack-dev-server --progress --colors --port 8081 --content-base web/client",
     "test": "karma start ./karma.conf.single-run.js",
     "continuoustest": "karma start ./karma.conf.continuous-test.js",

--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -1,0 +1,13 @@
+var webpackConfig = require('./webpack.config.js');
+var UglifyJsPlugin = require("webpack/lib/optimize/UglifyJsPlugin");
+
+webpackConfig.plugins.push(
+    new UglifyJsPlugin({
+        compress: {warnings: false},
+        mangle: true
+    })
+);
+webpackConfig.devtool = undefined;
+webpackConfig.debug = false;
+
+module.exports = webpackConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 var path = require("path");
 var CommonsChunkPlugin = require("webpack/lib/optimize/CommonsChunkPlugin");
-var UglifyJsPlugin = require("webpack/lib/optimize/UglifyJsPlugin");
 var rewriteUrl = function(replacePath) {
     return function(req, opt) {  // gets called with request and proxy object
         var queryIndex = req.url.indexOf('?');
@@ -8,8 +7,6 @@ var rewriteUrl = function(replacePath) {
         req.url = req.path.replace(opt.path, replacePath) + query;
     };
 };
-
-var PROD = JSON.parse(process.env.PROD_DEV || "0");
 
 module.exports = {
     entry: {
@@ -21,13 +18,7 @@ module.exports = {
         publicPath: "/dist/",
         filename: "[name].js"
     },
-    plugins: PROD ? [
-        new CommonsChunkPlugin("commons", "mapstore-commons.js"),
-        new UglifyJsPlugin({
-            compress: {warnings: false},
-            mangle: true
-        })
-    ] : [
+    plugins: [
         new CommonsChunkPlugin("commons", "mapstore-commons.js")
     ],
     resolve: {
@@ -42,7 +33,6 @@ module.exports = {
         proxy: [{
             path: new RegExp("/mapstore/rest/geostore/(.*)"),
             rewrite: rewriteUrl("/geostore/rest/$1"),
-            host: "mapstore.geo-solutions.it",
             target: "http://mapstore.geo-solutions.it"
         }]
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
         proxy: [{
             path: new RegExp("/mapstore/rest/geostore/(.*)"),
             rewrite: rewriteUrl("/geostore/rest/$1"),
+            host: "mapstore.geo-solutions.it",
             target: "http://mapstore.geo-solutions.it"
         }]
     },


### PR DESCRIPTION
The file:
- `webpack.config.js` is used during development;
- `prod-webpack.config.js` is used to extend the previous one during compiling.

When we run `npm run compile` source files are minimized and no source map files are created.