### PR TITLE
Fixes #137, openlayer/leaflet attribution is removed

### DIFF
--- a/web/client/components/leaflet/Map.jsx
+++ b/web/client/components/leaflet/Map.jsx
@@ -25,7 +25,8 @@ var LeafletMap = React.createClass({
           onMapViewChanges() {},
           onClick() {},
           mapOptions: {
-              zoomAnimation: false
+              zoomAnimation: false,
+              attributionControl: false
           },
           projection: "EPSG:3857"
         };

--- a/web/client/components/openlayers/Map.jsx
+++ b/web/client/components/openlayers/Map.jsx
@@ -43,7 +43,8 @@ var OpenlayersMap = React.createClass({
         ]);
         let controls = this.props.mapOptions.controls || ol.control.defaults({
             attributionOptions: ({
-                collapsible: false
+              collapsible: false,
+              className: "hidden"
             })
         });
         var map = new ol.Map({

--- a/web/client/examples/viewer/index.html
+++ b/web/client/examples/viewer/index.html
@@ -33,6 +33,10 @@
             padding: 0;
         }
 
+        .hidden {
+            display: none !important;
+        }
+
         #mapstore-infobutton {
             z-index: 10;
             top: 0px;


### PR DESCRIPTION
- for **leaflet**: the proper option has been set;
- for **openlayers**: a css class, named 'hidden', has been defined and applied to attribution control.