### PR TITLE
Fix  #167. disable rotation for Google background

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -169,6 +169,7 @@ describe('Leaflet layer', () => {
                     this.setMapTypeId = function() {};
                     this.setCenter = function() {};
                     this.setZoom = function() {};
+                    this.setTilt = function() {};
                 },
                 LatLng: function() {
 

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -163,6 +163,7 @@ describe('Openlayers layer', () => {
                     this.setMapTypeId = function() {};
                     this.setCenter = function() {};
                     this.setZoom = function() {};
+                    this.setTilt = function() {};
                 },
                 LatLng: function() {
 
@@ -199,6 +200,7 @@ describe('Openlayers layer', () => {
                     this.setMapTypeId = function() {};
                     this.setCenter = function() {};
                     this.setZoom = function() {};
+                    this.setTilt = function() {};
                 },
                 LatLng: function() {
 
@@ -242,6 +244,7 @@ describe('Openlayers layer', () => {
                     this.setMapTypeId = function() {};
                     this.setCenter = function() {};
                     this.setZoom = function() {};
+                    this.setTilt = function() {};
                 },
                 LatLng: function() {
 

--- a/web/client/components/map/openlayers/plugins/GoogleLayer.js
+++ b/web/client/components/map/openlayers/plugins/GoogleLayer.js
@@ -162,6 +162,7 @@ Layers.registerType('google', {
             }
             if (gmap && layersMap) {
                 gmap.setMapTypeId(layersMap[options.name]);
+                gmap.setTilt(0);
             }
         } else {
             gmapsStyle.visibility = 'hidden'; // used only for the renered div


### PR DESCRIPTION
This disable Google rotation (tilt) by default in OpenLayers maps