### PR TITLE
Fix #164: Add mapStateSource to state to avoid duplicated operations

### DIFF
--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -14,13 +14,14 @@ const LAYER_LOAD = 'LAYER_LOAD';
 const SHOW_SPINNER = 'SHOW_SPINNER';
 const HIDE_SPINNER = 'HIDE_SPINNER';
 
-function changeMapView(center, zoom, bbox, size) {
+function changeMapView(center, zoom, bbox, size, mapStateSource) {
     return {
         type: CHANGE_MAP_VIEW,
         center: center,
         zoom: zoom,
         bbox: bbox,
-        size: size
+        size: size,
+        mapStateSource: mapStateSource
     };
 }
 

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -102,7 +102,7 @@ describe('LeafletMap', () => {
 
         leafletMap.on('moveend', () => {
             expect(spy.calls.length).toEqual(expectedCalls);
-            expect(spy.calls[0].arguments.length).toEqual(4);
+            expect(spy.calls[0].arguments.length).toEqual(5);
 
             expect(spy.calls[0].arguments[0].y).toEqual(43.9);
             expect(spy.calls[0].arguments[0].x).toEqual(10.3);

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -15,6 +15,7 @@ var OpenlayersMap = React.createClass({
         id: React.PropTypes.string,
         center: ConfigUtils.PropTypes.center,
         zoom: React.PropTypes.number.isRequired,
+        mapStateSource: ConfigUtils.PropTypes.mapStateSource,
         projection: React.PropTypes.string,
         onMapViewChanges: React.PropTypes.func,
         onClick: React.PropTypes.func,
@@ -81,7 +82,7 @@ var OpenlayersMap = React.createClass({
                 },
                 crs: view.getProjection().getCode(),
                 rotation: view.getRotation()
-            }, size);
+            }, size, this.props.id);
         });
         map.on('click', (event) => {
             if (this.props.onClick) {
@@ -117,21 +118,12 @@ var OpenlayersMap = React.createClass({
         this.forceUpdate();
     },
     componentWillReceiveProps(newProps) {
-        var view = this.map.getView();
         if (newProps.mousePointer !== this.props.mousePointer) {
             this.setMousePointer(newProps.mousePointer);
         }
 
-        const currentCenter = this.props.center;
-        const centerIsUpdated = newProps.center.y === currentCenter.y &&
-                               newProps.center.x === currentCenter.x;
-
-        if (!centerIsUpdated) {
-            let center = ol.proj.transform([newProps.center.x, newProps.center.y], 'EPSG:4326', this.props.projection);
-            view.setCenter(center);
-        }
-        if (newProps.zoom !== this.props.zoom) {
-            view.setZoom(newProps.zoom);
+        if (this.props.id !== newProps.mapStateSource) {
+            this._updateMapPositionFromNewProps(newProps);
         }
     },
     componentWillUnmount() {
@@ -148,6 +140,20 @@ var OpenlayersMap = React.createClass({
                 {children}
             </div>
         );
+    },
+    _updateMapPositionFromNewProps(newProps) {
+        var view = this.map.getView();
+        const currentCenter = this.props.center;
+        const centerIsUpdated = newProps.center.y === currentCenter.y &&
+                               newProps.center.x === currentCenter.x;
+
+        if (!centerIsUpdated) {
+            let center = ol.proj.transform([newProps.center.x, newProps.center.y], 'EPSG:4326', this.props.projection);
+            view.setCenter(center);
+        }
+        if (newProps.zoom !== this.props.zoom) {
+            view.setZoom(newProps.zoom);
+        }
     },
     normalizeCenter: function(center) {
         return ol.proj.transform(center, this.props.projection, 'EPSG:4326');

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -107,7 +107,7 @@ describe('OpenlayersMap', () => {
 
         olMap.on('moveend', () => {
             expect(spy.calls.length).toEqual(1);
-            expect(spy.calls[0].arguments.length).toEqual(4);
+            expect(spy.calls[0].arguments.length).toEqual(5);
             expect(normalizeFloat(spy.calls[0].arguments[0].y, 1)).toBe(43.9);
             expect(normalizeFloat(spy.calls[0].arguments[0].x, 1)).toBe(10.3);
             expect(spy.calls[0].arguments[1]).toBe(12);
@@ -138,7 +138,7 @@ describe('OpenlayersMap', () => {
 
         olMap.on('moveend', () => {
             expect(spy.calls.length).toEqual(1);
-            expect(spy.calls[0].arguments.length).toEqual(4);
+            expect(spy.calls[0].arguments.length).toEqual(5);
             expect(normalizeFloat(spy.calls[0].arguments[0].y, 1)).toBe(44);
             expect(normalizeFloat(spy.calls[0].arguments[0].x, 1)).toBe(10);
             expect(spy.calls[0].arguments[1]).toBe(11);

--- a/web/client/examples/viewer/components/Map.jsx
+++ b/web/client/examples/viewer/components/Map.jsx
@@ -41,6 +41,7 @@ var VMap = React.createClass({
             <LMap id="map"
                 center={this.props.config.center}
                 zoom={this.props.config.zoom}
+                mapStateSource={this.props.config.mapStateSource}
                 projection={this.props.config.projection || 'EPSG:3857'}
                 onMapViewChanges={this.props.onMapViewChanges}
                 onClick={this.props.onClick}

--- a/web/client/examples/viewer/containers/Viewer.jsx
+++ b/web/client/examples/viewer/containers/Viewer.jsx
@@ -99,8 +99,8 @@ var Viewer = React.createClass({
         }
         return null;
     },
-    manageNewMapView(center, zoom, bbox, size) {
-        this.props.changeMapView(center, zoom, bbox, size);
+    manageNewMapView(center, zoom, bbox, size, mapStateSource) {
+        this.props.changeMapView(center, zoom, bbox, size, mapStateSource);
     },
     manageMousePosition(evt) {
         if ( this.props.mousePosition.enabled) {

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -25,7 +25,8 @@ function mapConfig(state = null, action) {
                 center: action.center,
                 zoom: action.zoom,
                 bbox: action.bbox,
-                size: action.size
+                size: action.size,
+                mapStateSource: action.mapStateSource
             });
         case CHANGE_LAYER_PROPERTIES: {
             let layers = state.layers.slice(0);


### PR DESCRIPTION
Add the map state source to allow a check to avoid the to call map component callbacks to set position when the map component itself already updated the position. 
This should help to: 
* avoid unnecessary operations
* avoid problems during animations