### PR TITLE
Fixes #196. Improved usability of background and layer tree on mobile devices

### DIFF
--- a/web/client/examples/viewer/components/MapToolBar.jsx
+++ b/web/client/examples/viewer/components/MapToolBar.jsx
@@ -38,7 +38,8 @@ let MapToolBar = React.createClass({
                 top: 0,
                 right: 0,
                 marginRight: "5px",
-                marginTop: "50px"
+                marginTop: "50px",
+                zIndex: 1000
             }
         };
     },


### PR DESCRIPTION
Set the panel style by default to 1000. This should put the toolbar buttons above the map controls and below the modal dialog windows. 