### PR TITLE
Fixes #209, bing apiKey

### DIFF
--- a/web/client/components/map/leaflet/plugins/BingLayer.js
+++ b/web/client/components/map/leaflet/plugins/BingLayer.js
@@ -10,7 +10,7 @@ var Layers = require('../../../../utils/leaflet/Layers');
 var Bing = require('leaflet-plugins/layer/tile/Bing');
 
 Layers.registerType('bing', (options) => {
-    var key = options.apiKey || "AqTGBsziZHIJYYxgivLBf0hVdrAk9mWO5cQcb8Yux8sW5M8c8opEC2lZqKR1ZZXf";
+    var key = options.apiKey;
     return new Bing(key,
         {
             subdomains: [0, 1, 2, 3],

--- a/web/client/components/map/openlayers/plugins/BingLayer.js
+++ b/web/client/components/map/openlayers/plugins/BingLayer.js
@@ -11,7 +11,7 @@ var ol = require('openlayers');
 
 Layers.registerType('bing', {
     create: (options) => {
-        var key = options.apiKey || "AqTGBsziZHIJYYxgivLBf0hVdrAk9mWO5cQcb8Yux8sW5M8c8opEC2lZqKR1ZZXf";
+        var key = options.apiKey;
         return new ol.layer.Tile({
             preload: Infinity,
             opacity: options.opacity !== undefined ? options.opacity : 1,

--- a/web/client/examples/viewer/localConfig.json
+++ b/web/client/examples/viewer/localConfig.json
@@ -1,4 +1,5 @@
 {
 	"proxyUrl": "/mapstore/proxy/?url=",
-	"geoStoreUrl": "/mapstore/rest/geostore/"
+	"geoStoreUrl": "/mapstore/rest/geostore/",
+	"bingApiKey": "AnPVX7vx5Qydc2F7gtwyNffWEi22yogqI62AzkGDu16goDilS5Z-BdkjOlnCDxJD"
 }

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -12,17 +12,29 @@ var mapConfig = require('../config');
 
 describe('Test the mapConfig reducer', () => {
     it('creates a configuration object from loaded config', () => {
-        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { map: { center: {x: 1, y: 1}, zoom: 11 }}});
+        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { map: { center: {x: 1, y: 1}, zoom: 11, layers: [] }}});
         expect(state.zoom).toExist();
         expect(state.center).toExist();
         expect(state.center.crs).toExist();
+        expect(state.layers).toExist();
     });
 
     it('creates a configuration object from legacy config', () => {
-        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { map: { center: [1361886.8627049, 5723464.1181097], zoom: 11 }}}, true);
+        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { map: { center: [1361886.8627049, 5723464.1181097], zoom: 11, layers: [] }}}, true);
         expect(state.zoom).toExist();
         expect(state.center).toExist();
         expect(state.center.crs).toExist();
+        expect(state.layers).toExist();
+    });
+
+    it('checks if bing layer gets the apiKey', () => {
+        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { map: { center: {x: 1, y: 1}, zoom: 11, layers: [{type: 'bing'}] }}});
+        expect(state.zoom).toExist();
+        expect(state.center).toExist();
+        expect(state.center.crs).toExist();
+        expect(state.layers).toExist();
+        expect(state.layers.length).toBe(1);
+        expect(state.layers[0].apiKey).toBe(null);
     });
 
     it('creates an error on wrongly loaded config', () => {

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -22,7 +22,8 @@ const centerPropType = React.PropTypes.shape({
 const urlQuery = url.parse(window.location.href, true).query;
 let defaultConfig = {
     proxyUrl: "/mapstore/proxy/?url=",
-    geoStoreUrl: "/mapstore/rest/geostore/"
+    geoStoreUrl: "/mapstore/rest/geostore/",
+    bingApiKey: null
 };
 
 var ConfigUtils = {
@@ -68,6 +69,7 @@ var ConfigUtils = {
     },
     normalizeConfig: function(config) {
         config.center = ConfigUtils.getCenter(config.center);
+        config.layers = config.layers.map(ConfigUtils.setBingKey);
         return config;
     },
     getUserConfiguration: function(defaultName, extension, geoStoreBase) {
@@ -102,7 +104,7 @@ var ConfigUtils = {
             center: latLng,
             zoom: zoom,
             maxExtent: maxExtent, // TODO convert maxExtent
-            layers: layers,
+            layers: layers.map(ConfigUtils.setBingKey),
             projection: mapConfig.projection || 'EPSG:3857'
         };
     },
@@ -255,6 +257,12 @@ var ConfigUtils = {
 
         retina: retina
         };
+    },
+    setBingKey: function(layer) {
+        if (layer.type === 'bing') {
+            layer.apiKey = defaultConfig.bingApiKey;
+        }
+        return layer;
     }
 };
 


### PR DESCRIPTION
when a map configuration is loaded, all Bing layers get the proper apiKey
from localConfig.json file.