### PR TITLE
Move intl polyfill require in app.jsx this Fixes #257

### DIFF
--- a/web/client/components/I18N/I18N.jsx
+++ b/web/client/components/I18N/I18N.jsx
@@ -6,15 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-if (!global.Intl) {
-    require.ensure([
-        'intl'
-    ], function(require) {
-        require('intl');
-        module.exports.Message = require('./Message');
-        module.exports.HTML = require('./HTML');
-    });
-} else {
-    module.exports.Message = require('./Message');
-    module.exports.HTML = require('./HTML');
-}
+module.exports.Message = require('./Message');
+module.exports.HTML = require('./HTML');
+

--- a/web/client/examples/home/app.jsx
+++ b/web/client/examples/home/app.jsx
@@ -13,21 +13,35 @@ var {loadMaps} = require('../../actions/maps');
 
 var ConfigUtils = require('../../utils/ConfigUtils');
 
-var Home = require('./containers/Home');
+
 var Debug = require('../../components/development/Debug');
 
 var store = require('./stores/homestore');
 
-ConfigUtils.loadConfiguration().then(() => {
-    store.dispatch(loadLocale('translations'));
-    store.dispatch(loadMaps());
-});
+function startApp() {
+    ConfigUtils.loadConfiguration().then(() => {
+        store.dispatch(loadLocale('translations'));
+        store.dispatch(loadMaps());
+    });
+    let Home = require('./containers/Home');
 
-React.render(
-    <Debug store={store}>
-        <Provider store={store}>
-            {() => <Home />}
-        </Provider>
-    </Debug>,
-    document.getElementById('container')
-);
+    React.render(
+        <Debug store={store}>
+            <Provider store={store}>
+                {() => <Home />}
+            </Provider>
+        </Debug>,
+        document.getElementById('container')
+    );
+}
+
+if (!global.Intl) {
+    require.ensure(['intl', 'intl/locale-data/jsonp/en.js', 'intl/locale-data/jsonp/it.js'], (require) => {
+        global.Intl = require('intl');
+        require('intl/locale-data/jsonp/en.js');
+        require('intl/locale-data/jsonp/it.js');
+        startApp();
+    });
+}else {
+    startApp();
+}

--- a/web/client/examples/mouseposition/app.jsx
+++ b/web/client/examples/mouseposition/app.jsx
@@ -17,78 +17,93 @@ var Col = BootstrapReact.Col;
 var LMap = require('../../components/map/leaflet/Map');
 var LLayer = require('../../components/map/leaflet/Layer');
 var mouseposition = require('../../reducers/mousePosition');
-var MousePosition = require("../../components/mapcontrols/mouseposition/MousePosition");
 var {changeMousePosition} = require('../../actions/mousePosition');
 var store = createStore(combineReducers({browser, mouseposition}));
-var LabelDD = require("../../components/mapcontrols/mouseposition/MousePositionLabelDD");
-var LabelDM = require("../../components/mapcontrols/mouseposition/MousePositionLabelDM");
-var LabelDMSNW = require("../../components/mapcontrols/mouseposition/MousePositionLabelDMSNW");
-var SearchGeoS = require("./components/FindGeoSolutions.jsx");
+
 require('../../components/map/leaflet/plugins/OSMLayer');
 require("./components/mouseposition.css");
+
+function startApp() {
+    let MousePosition = require("../../components/mapcontrols/mouseposition/MousePosition");
+    let LabelDD = require("../../components/mapcontrols/mouseposition/MousePositionLabelDD");
+    let LabelDM = require("../../components/mapcontrols/mouseposition/MousePositionLabelDM");
+    let LabelDMSNW = require("../../components/mapcontrols/mouseposition/MousePositionLabelDMSNW");
+    let SearchGeoS = require("./components/FindGeoSolutions.jsx");
     /**
     * Detect Browser's properties and save in app state.
     **/
 
-store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
+    store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
 
-let App = React.createClass({
-    propTypes: {
-        browser: React.PropTypes.object,
-        mousePosition: React.PropTypes.object
-    },
-    getDefaultProps() {
-        return {
-            browser: {touch: false}
-        };
-    },
-    render() {
-        if (this.props.browser.touch) {
-            return <div className="error">This example does not work on mobile</div>;
+    let App = React.createClass({
+        propTypes: {
+            browser: React.PropTypes.object,
+            mousePosition: React.PropTypes.object
+        },
+        getDefaultProps() {
+            return {
+                browser: {touch: false}
+            };
+        },
+        render() {
+            if (this.props.browser.touch) {
+                return <div className="error">This example does not work on mobile</div>;
+            }
+            return (<div id="viewer" >
+                    <Grid fluid={false} className="mousepositionsbar">
+                    <Row>
+                        <Col lg={4} md={6} xs={12}>
+                            <MousePosition id="sGeoS" key="sGeoS"
+                                mousePosition={this.props.mousePosition} crs="EPSG:4326"
+                                degreesTemplate={SearchGeoS}/>
+                        </Col>
+                        <Col lg={4} md={6} xs={12}>
+                            <MousePosition id="wgs84" key="wgs84" mousePosition={this.props.mousePosition} crs="EPSG:4326"/>
+                        </Col>
+                        <Col lg={4} md={4} xs={6}>
+                            <MousePosition id="degreedecimal" key="degreedecimal" enabled
+                        mousePosition={this.props.mousePosition} crs="EPSG:4326"
+                        degreesTemplate={LabelDD}/>
+                        </Col>
+                    </Row></Grid>
+                    <MousePosition id="google" key="google_prj" mousePosition={this.props.mousePosition} crs="EPSG:900913"/>
+
+                    <MousePosition id="degreeminute" key="degreeminute"
+                        mousePosition={this.props.mousePosition} crs="EPSG:4326"
+                        degreesTemplate={LabelDM}/>
+                    <MousePosition id="dmsnw" key="dmsnw"
+                        mousePosition={this.props.mousePosition} crs="EPSG:4326"
+                        degreesTemplate={LabelDMSNW}/>
+                    <LMap key="map"
+                        center={{
+                            y: 43.878160,
+                            x: 10.276508,
+                            crs: "EPSG:4326"
+                            }}
+                        zoom={13}
+                        projection="EPSG:900913"
+                        onMouseMove={ (posi) => { store.dispatch(changeMousePosition(posi)); }}
+                        mapStateSource="map"
+                    >
+                        <LLayer type="osm" position={0} key="osm" options={{name: "osm"}} />
+                    </LMap>
+              </div>
+               );
         }
-        return (<div id="viewer" >
-                <Grid fluid={false} className="mousepositionsbar">
-                <Row>
-                    <Col lg={4} md={6} xs={12}>
-                        <MousePosition id="sGeoS" key="sGeoS"
-                            mousePosition={this.props.mousePosition} crs="EPSG:4326"
-                            degreesTemplate={SearchGeoS}/>
-                    </Col>
-                    <Col lg={4} md={6} xs={12}>
-                        <MousePosition id="wgs84" key="wgs84" mousePosition={this.props.mousePosition} crs="EPSG:4326"/>
-                    </Col>
-                    <Col lg={4} md={4} xs={6}>
-                        <MousePosition id="degreedecimal" key="degreedecimal" enabled
-                    mousePosition={this.props.mousePosition} crs="EPSG:4326"
-                    degreesTemplate={LabelDD}/>
-                    </Col>
-                </Row></Grid>
-                <MousePosition id="google" key="google_prj" mousePosition={this.props.mousePosition} crs="EPSG:900913"/>
+    });
 
-                <MousePosition id="degreeminute" key="degreeminute"
-                    mousePosition={this.props.mousePosition} crs="EPSG:4326"
-                    degreesTemplate={LabelDM}/>
-                <MousePosition id="dmsnw" key="dmsnw"
-                    mousePosition={this.props.mousePosition} crs="EPSG:4326"
-                    degreesTemplate={LabelDMSNW}/>
-                <LMap key="map"
-                    center={{
-                        y: 43.878160,
-                        x: 10.276508,
-                        crs: "EPSG:4326"
-                        }}
-                    zoom={13}
-                    projection="EPSG:900913"
-                    onMouseMove={ (posi) => { store.dispatch(changeMousePosition(posi)); }}
-                    mapStateSource="map"
-                >
-                    <LLayer type="osm" position={0} key="osm" options={{name: "osm"}} />
-                </LMap>
-          </div>
-           );
-    }
-});
+    let cmp = React.render(React.createElement(App), document.getElementById('container'));
+    store.subscribe(() => cmp.setProps({mousePosition: store.getState().mouseposition.position}));
+    store.subscribe(() => cmp.setProps({browser: store.getState().browser}));
+}
 
-let cmp = React.render(React.createElement(App), document.getElementById('container'));
-store.subscribe(() => cmp.setProps({mousePosition: store.getState().mouseposition.position}));
-store.subscribe(() => cmp.setProps({browser: store.getState().browser}));
+if (!global.Intl ) {
+    require.ensure(['intl', 'intl/locale-data/jsonp/en.js', 'intl/locale-data/jsonp/it.js'], (require) => {
+        global.Intl = require('intl');
+        require('intl/locale-data/jsonp/en.js');
+        require('intl/locale-data/jsonp/it.js');
+        startApp();
+    });
+}else {
+    startApp();
+}

--- a/web/client/examples/mouseposition/components/mouseposition.css
+++ b/web/client/examples/mouseposition/components/mouseposition.css
@@ -82,7 +82,7 @@
         }
         #degreeminute .label {
             display: inline-block;
-            width: 300px;
+            width: 350px;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/web/client/examples/scalebar/app.jsx
+++ b/web/client/examples/scalebar/app.jsx
@@ -54,7 +54,7 @@ require('../../components/map/leaflet/plugins/TileProviderLayer');
     **/
 store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
 const zoomLabelArray = ['-----------', '----------', '---------', '-------', '-------', '------', '-----',
-                     '----', '---', '--', ',', '+', '++', '+++', '++++', '+++++', '++++++', '+++++++', '++++++++',
+                     '----', '---', '--', '-', '+', '++', '+++', '++++', '+++++', '++++++', '+++++++', '++++++++',
                      '+++++++++', '++++++++++', '+++++++++++' ];
 
 let MyMap = React.createClass({

--- a/web/client/examples/viewer/app.jsx
+++ b/web/client/examples/viewer/app.jsx
@@ -18,11 +18,9 @@ var LocaleUtils = require('../../utils/LocaleUtils');
 
 var Debug = require('../../components/development/Debug');
 
-
-require.ensure(['./plugins'], (require) => {
-    var plugins = require('./plugins');
-    var store = require('./stores/viewerstore')(plugins.reducers);
-    var Viewer = require('./containers/Viewer')(plugins.actions);
+function startApp(plugins) {
+    let store = require('./stores/viewerstore')(plugins.reducers);
+    let Viewer = require('./containers/Viewer')(plugins.actions);
 
     /**
     * Detect Browser's properties and save in app state.
@@ -46,4 +44,19 @@ require.ensure(['./plugins'], (require) => {
         </Debug>,
         document.getElementById('container')
     );
-});
+
+}
+if (!global.Intl ) {
+    require.ensure(['intl', 'intl/locale-data/jsonp/en.js', 'intl/locale-data/jsonp/it.js', './plugins'], (require) => {
+        global.Intl = require('intl');
+        require('intl/locale-data/jsonp/en.js');
+        require('intl/locale-data/jsonp/it.js');
+        let plugins = require('./plugins');
+        startApp(plugins);
+    });
+}else {
+    require.ensure(["./plugins"], (require) => {
+        var plugins = require('./plugins');
+        startApp(plugins);
+    });
+}


### PR DESCRIPTION
The request of  Intl polyfill, needed for Safari < 10, is moved in app.jsx.
This allow all plugins that use react-intl to work.
Some  application, doesn't use any intl so it's possible to omit the polyfill request (faster)
i.e.
scalebox and layertree 
