### PR TITLE
Fix #262. Disable pinch to zoom on map viewer

### DIFF
--- a/web/client/examples/viewer/index.html
+++ b/web/client/examples/viewer/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
         <title>MapStore 2 Viewer</title>
         <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
         <link rel="stylesheet" href="http://rawgit.com/Leaflet/Leaflet.draw/0.2.3/dist/leaflet.draw.css" />


### PR DESCRIPTION
The attributes in the meta-tag disable the pinch to zoom on the whole viewport. Fixes #262