### PR TITLE
Fixed layer loading events for ol fixes #266

### DIFF
--- a/web/client/components/map/openlayers/Layer.jsx
+++ b/web/client/components/map/openlayers/Layer.jsx
@@ -25,6 +25,7 @@ const OpenlayersLayer = React.createClass({
     },
 
     componentDidMount() {
+        this.tilestoload = 0;
         this.createLayer(this.props.type, this.props.options);
     },
     componentWillReceiveProps(newProps) {
@@ -57,17 +58,27 @@ const OpenlayersLayer = React.createClass({
     createLayer(type, options) {
         if (type) {
             this.layer = Layers.createLayer(type, options, this.props.map, this.props.mapId);
-
             if (this.layer) {
                 this.props.map.addLayer(this.layer);
                 this.layer.getSource().on('tileloadstart', () => {
-                    this.props.onLayerLoading(options.name);
+                    if (this.tilestoload === 0) {
+                        this.props.onLayerLoading(options.name);
+                        this.tilestoload++;
+                    } else {
+                        this.tilestoload++;
+                    }
                 });
                 this.layer.getSource().on('tileloadend', () => {
-                    this.props.onLayerLoad(options.name);
+                    this.tilestoload--;
+                    if (this.tilestoload === 0) {
+                        this.props.onLayerLoad(options.name);
+                    }
                 });
                 this.layer.getSource().on('tileloaderror', () => {
-                    this.props.onLayerLoad(options.name);
+                    this.tilestoload--;
+                    if (this.tilestoload === 0) {
+                        this.props.onLayerLoad(options.name);
+                    }
                 });
             }
         }


### PR DESCRIPTION
Ol is missing layerloadend or layerready events. Until now we used tileloadstart and tileloadend to update layer's loading state. This forces the app to render to many times, more then twice the number of tiles it as to load. App performance were terrible.
Now Layers.jx waits for all layer's tileloadend events before fire layerload action.
Maybe, to improve the performance, we could think to a more general maploading mapready state changhe. In this case we could load as many layers as we like without decreasing performace becouse of rerenderding.