### PR TITLE
fix #267. align ol zoombar to common leaflet one

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -182,5 +182,6 @@ var OpenlayersMap = React.createClass({
         }
     }
 });
-
+// add overrides for css
+require('./mapstore-ol-overrides.css');
 module.exports = OpenlayersMap;

--- a/web/client/components/map/openlayers/mapstore-ol-overrides.css
+++ b/web/client/components/map/openlayers/mapstore-ol-overrides.css
@@ -1,0 +1,41 @@
+.ol-control button:hover, .ol-control button:focus {
+    background-color: #f4f4f4;
+}
+.ol-zoom .ol-zoom-out, .ol-zoom .ol-zoom-in{
+    width: 26px;
+    height: 26px;
+    line-height: 26px;
+    display: block;
+
+    color: black;
+    background-color: #fff;
+    border-width: 0;
+    margin:0;
+}
+.ol-zoom.ol-unselectable.ol-control .ol-zoom-in, .ol-zoom.ol-unselectable.ol-control .ol-zoom-out {
+    font-family: 'Lucida Console', Monaco, monospace;
+    text-align: center;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.ol-zoom .ol-zoom-out{
+    font-size: 18px;
+    border-radius: 0 0 4px 4px;
+}
+.ol-zoom .ol-zoom-in{
+    border-bottom: 1px solid #ccc;
+    border-radius: 4px 4px 0 0;
+    font-size: 20px;
+}
+.ol-zoom.ol-unselectable.ol-control{
+    top:10px;
+    left:10px;
+    padding:0;
+    box-shadow: rgba(0, 0, 0, 0.65098) 0px 1px 5px 0px;
+    border-radius: 4px;
+}
+
+.ol-scale-line.ol-unselectable{
+    background-color: rgba(255, 255, 255, 0.8);
+}

--- a/web/client/examples/viewer/index.html
+++ b/web/client/examples/viewer/index.html
@@ -58,17 +58,18 @@
             border-radius: 4px;
             border: 1px solid #999;
             z-index: 10;
-            top: 110px;
+            top: 90px;
             left: 2px;
             position: absolute;
             margin: 8px;
         }
         #mapstore-zoomtomaxextent {
+            box-shadow: 0px 0px 4px 2px rgba(0, 0, 0, 0.2);
             z-index: 10;
-            top: 70px;
+            top: 67px;
             left: 0px;
             position: absolute;
-            margin: 10px;
+            margin-left: 10px;
         }
 
         .btn-xs {


### PR DESCRIPTION
fix #267. Align the style of the OpenLayers zoom controls to the Leaflet's ones.
![bar](https://cloud.githubusercontent.com/assets/1279510/10912430/c3bcd9a2-8249-11e5-92ab-5362786e11cc.png)
