### PR TITLE
Implement a basic dynamic help mechanism

### DIFF
--- a/web/client/actions/help.js
+++ b/web/client/actions/help.js
@@ -8,6 +8,7 @@
 
 const CHANGE_HELP_STATE = 'CHANGE_HELP_STATE';
 const CHANGE_HELP_TEXT = 'CHANGE_HELP_TEXT';
+const CHANGE_HELPWIN_VIZ = 'CHANGE_HELPWIN_VIZ';
 
 function changeHelpState(enabled) {
     return {
@@ -23,9 +24,18 @@ function changeHelpText(helpText) {
     };
 }
 
+function changeHelpwinVisibility(helpwinViz) {
+    return {
+        type: CHANGE_HELPWIN_VIZ,
+        helpwinViz: helpwinViz
+    };
+}
+
 module.exports = {
     CHANGE_HELP_STATE,
     CHANGE_HELP_TEXT,
+    CHANGE_HELPWIN_VIZ,
     changeHelpState,
-    changeHelpText
+    changeHelpText,
+    changeHelpwinVisibility
 };

--- a/web/client/actions/help.js
+++ b/web/client/actions/help.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const CHANGE_HELP_STATE = 'CHANGE_HELP_STATE';
+const CHANGE_HELP_TEXT = 'CHANGE_HELP_TEXT';
+
+function changeHelpState(enabled) {
+    return {
+        type: CHANGE_HELP_STATE,
+        enabled: enabled
+    };
+}
+
+function changeHelpText(helpText) {
+    return {
+        type: CHANGE_HELP_TEXT,
+        helpText: helpText
+    };
+}
+
+module.exports = {
+    CHANGE_HELP_STATE,
+    CHANGE_HELP_TEXT,
+    changeHelpState,
+    changeHelpText
+};

--- a/web/client/components/Help/HelpBadge.jsx
+++ b/web/client/components/Help/HelpBadge.jsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react');
+var BootstrapReact = require('react-bootstrap');
+var Badge = BootstrapReact.Badge;
+
+/**
+ * A badge to show that there is a help text available for the parent component.
+ * Also updates the current help text (state) when the badge is clicked.
+ *
+ * Component's properies:
+ *  - helpText: {string}      the text to be displayed when this badge is clicked
+ *  - isVisible: {bool}       flag to steer visibility of the badge
+ *  - changeHelpText (func)   action to change the current help text
+ */
+var HelpBadge = React.createClass({
+    propTypes: {
+        helpText: React.PropTypes.string,
+        isVisible: React.PropTypes.bool,
+        changeHelpText: React.PropTypes.func
+    },
+    getDefaultProps() {
+        return {
+            helpText: '',
+            isVisible: false
+        };
+    },
+    onClick() {
+        this.props.changeHelpText({helpText: this.props.helpText});
+    },
+    render() {
+        return (
+            <Badge
+                onClick={this.onClick}
+                className={this.props.isVisible ? '' : 'hidden'}
+            >?</Badge>
+        );
+    }
+});
+
+module.exports = HelpBadge;

--- a/web/client/components/Help/HelpBadge.jsx
+++ b/web/client/components/Help/HelpBadge.jsx
@@ -20,6 +20,7 @@ var Badge = BootstrapReact.Badge;
  */
 var HelpBadge = React.createClass({
     propTypes: {
+        id: React.PropTypes.string,
         helpText: React.PropTypes.string,
         isVisible: React.PropTypes.bool,
         changeHelpText: React.PropTypes.func
@@ -36,6 +37,7 @@ var HelpBadge = React.createClass({
     render() {
         return (
             <Badge
+                id={this.props.id}
                 onClick={this.onClick}
                 className={this.props.isVisible ? '' : 'hidden'}
             >?</Badge>

--- a/web/client/components/Help/HelpBadge.jsx
+++ b/web/client/components/Help/HelpBadge.jsx
@@ -24,7 +24,8 @@ var HelpBadge = React.createClass({
         helpText: React.PropTypes.string,
         isVisible: React.PropTypes.bool,
         changeHelpText: React.PropTypes.func,
-        changeHelpwinVisibility: React.PropTypes.func
+        changeHelpwinVisibility: React.PropTypes.func,
+        className: React.PropTypes.string
     },
     getDefaultProps() {
         return {
@@ -41,7 +42,7 @@ var HelpBadge = React.createClass({
             <Badge
                 id={this.props.id}
                 onMouseOver={this.onMouseOver}
-                className={this.props.isVisible ? '' : 'hidden'}
+                className={(this.props.isVisible ? '' : 'hidden ') + (this.props.className ? this.props.className : '')}
             >?</Badge>
         );
     }

--- a/web/client/components/Help/HelpBadge.jsx
+++ b/web/client/components/Help/HelpBadge.jsx
@@ -23,7 +23,8 @@ var HelpBadge = React.createClass({
         id: React.PropTypes.string,
         helpText: React.PropTypes.string,
         isVisible: React.PropTypes.bool,
-        changeHelpText: React.PropTypes.func
+        changeHelpText: React.PropTypes.func,
+        changeHelpwinVisibility: React.PropTypes.func
     },
     getDefaultProps() {
         return {
@@ -31,14 +32,15 @@ var HelpBadge = React.createClass({
             isVisible: false
         };
     },
-    onClick() {
+    onMouseOver() {
         this.props.changeHelpText({helpText: this.props.helpText});
+        this.props.changeHelpwinVisibility({helpwinViz: true});
     },
     render() {
         return (
             <Badge
                 id={this.props.id}
-                onClick={this.onClick}
+                onMouseOver={this.onMouseOver}
                 className={this.props.isVisible ? '' : 'hidden'}
             >?</Badge>
         );

--- a/web/client/components/Help/HelpTextPanel.jsx
+++ b/web/client/components/Help/HelpTextPanel.jsx
@@ -35,6 +35,7 @@ var HelpTextPanel = React.createClass({
     render() {
         return (
             <div
+                id={this.props.id}
                 className={this.props.isVisible ? '' : 'hidden'}
                 style={{position: "absolute", top: "140px", "margin-left": "8px"}}>
                 <Panel

--- a/web/client/components/Help/HelpTextPanel.jsx
+++ b/web/client/components/Help/HelpTextPanel.jsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react');
+var BootstrapReact = require('react-bootstrap');
+var Panel = BootstrapReact.Panel;
+
+/**
+ * A panel showning th current selectd help text.
+ *
+ * Component's properies:
+ *  - id: {string}            the components identifier
+ *  - helpText: {string}      the text to display
+ *  - isVisible: {bool}       flag to steer visibility of the badge
+ *  - title (string)          header text of this panel
+ */
+var HelpTextPanel = React.createClass({
+    propTypes: {
+        id: React.PropTypes.string,
+        helpText: React.PropTypes.string,
+        isVisible: React.PropTypes.bool,
+        title: React.PropTypes.string
+    },
+    getDefaultProps() {
+        return {
+            id: 'mapstore-helptext-panel',
+            isVisible: false,
+            title: 'HELP'
+        };
+    },
+    render() {
+        return (
+            <div
+                className={this.props.isVisible ? '' : 'hidden'}
+                style={{position: "absolute", top: "140px", "margin-left": "8px"}}>
+                <Panel
+                    header={this.props.title}>
+                    {this.props.helpText}
+                </Panel>
+            </div>
+        );
+    }
+});
+
+module.exports = HelpTextPanel;

--- a/web/client/components/Help/HelpToggleBtn.jsx
+++ b/web/client/components/Help/HelpToggleBtn.jsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+var React = require('react');
+var ToggleButton = require('../buttons/ToggleButton');
+require("./help.css");
+
+/**
+ * A toggle button class for enabling / disabling help modus
+ */
+let HelpToggleBtn = React.createClass({
+    propTypes: {
+        key: React.PropTypes.string,
+        isButton: React.PropTypes.bool,
+        glyphicon: React.PropTypes.string,
+        pressed: React.PropTypes.bool,
+        changeHelpState: React.PropTypes.func,
+        changeHelpwinVisibility: React.PropTypes.func
+    },
+    getDefaultProps() {
+        return {
+            key: 'helpButton',
+            isButton: true,
+            glyphicon: 'question-sign'
+        };
+    },
+    onClick: function() {
+        this.props.changeHelpState(!this.props.pressed);
+        this.props.changeHelpwinVisibility(false);
+    },
+    render: function() {
+        return (
+            <ToggleButton
+                key={this.props.key}
+                isButton={this.props.isButton}
+                glyphicon={this.props.glyphicon}
+                pressed={this.props.pressed}
+                onClick={this.onClick}/>
+        );
+    }
+});
+
+module.exports = HelpToggleBtn;

--- a/web/client/components/Help/HelpWrapper.jsx
+++ b/web/client/components/Help/HelpWrapper.jsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+var React = require('react');
+var HelpBadge = require('./HelpBadge');
+require("./help.css");
+
+/**
+ * A wrapper to add a help badge to an element.
+ *
+ * Component's properies:
+ *  - helpText: {string}      the text to be displayed when this badge is clicked
+ *  - helpEnabled: {bool}     flag to steer visibility of the badge
+ *  - changeHelpText (func)   action to change the current help text
+ */
+let HelpWrapper = React.createClass({
+    propTypes: {
+        helpText: React.PropTypes.string,
+        helpEnabled: React.PropTypes.bool,
+        changeHelpText: React.PropTypes.func
+    },
+
+    render: function() {
+        return (
+            <div style={{position: "absolute"}}>
+                <HelpBadge
+                    id={"helpbadge-" + this.props.children.key}
+                    isVisible = {this.props.helpEnabled}
+                    helpText = {this.props.helpText}
+                    changeHelpText = {this.props.changeHelpText}
+                />
+                {this.props.children}
+            </div>);
+    }
+});
+
+module.exports = HelpWrapper;

--- a/web/client/components/Help/HelpWrapper.jsx
+++ b/web/client/components/Help/HelpWrapper.jsx
@@ -23,7 +23,8 @@ let HelpWrapper = React.createClass({
     propTypes: {
         helpText: React.PropTypes.string,
         helpEnabled: React.PropTypes.bool,
-        changeHelpText: React.PropTypes.func
+        changeHelpText: React.PropTypes.func,
+        changeHelpwinVisibility: React.PropTypes.func
     },
 
     render: function() {
@@ -34,6 +35,7 @@ let HelpWrapper = React.createClass({
                     isVisible = {this.props.helpEnabled}
                     helpText = {this.props.helpText}
                     changeHelpText = {this.props.changeHelpText}
+                    changeHelpwinVisibility = {this.props.changeHelpwinVisibility}
                 />
                 {this.props.children}
             </div>);

--- a/web/client/components/Help/HelpWrapper.jsx
+++ b/web/client/components/Help/HelpWrapper.jsx
@@ -28,7 +28,7 @@ let HelpWrapper = React.createClass({
 
     render: function() {
         return (
-            <div style={{position: "absolute"}}>
+            <div>
                 <HelpBadge
                     id={"helpbadge-" + this.props.children.key}
                     isVisible = {this.props.helpEnabled}

--- a/web/client/components/Help/__test__/HelpBadge-test.jsx
+++ b/web/client/components/Help/__test__/HelpBadge-test.jsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react/addons');
+var HelpBadge = require('../HelpBadge');
+var expect = require('expect');
+var ReactTestUtils = React.addons.TestUtils;
+
+describe('Test for HelpBadge', () => {
+    afterEach((done) => {
+        React.unmountComponentAtNode(document.body);
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    // test DEFAULTS
+    it('creates the component with defaults', () => {
+        const helpBadge = React.render(<HelpBadge/>, document.body);
+        expect(helpBadge).toExist();
+
+        const helpToggleBtnDom = React.findDOMNode(helpBadge);
+        expect(helpToggleBtnDom).toExist();
+        expect(helpToggleBtnDom.className.indexOf('badge') >= 0).toBe(true);
+        expect(helpToggleBtnDom.className.indexOf('hidden') >= 0).toBe(true);
+        expect(helpToggleBtnDom.innerHTML).toBe("?");
+    });
+
+    it('creates the component with custom props', () => {
+        const helpBadge = React.render(<HelpBadge
+                        id="fooid"
+                        isVisible={true}
+                        className="foofoo"
+                        />, document.body);
+        expect(helpBadge).toExist();
+
+        const helpBadgeDom = React.findDOMNode(helpBadge);
+        expect(helpBadgeDom).toExist();
+        expect(helpBadgeDom.id).toExist();
+        expect(helpBadgeDom.className.indexOf('foofoo') >= 0).toBe(true);
+        expect(helpBadgeDom.className.indexOf('hidden') < 0).toBe(true);
+    });
+
+    it('test mouseover triggers correct functions', () => {
+        var triggered = 0;
+        const onMouseOverFn = {
+            changeHelpText: () => {triggered++; },
+            changeHelpwinVisibility: () => {triggered++; }
+        };
+        const helpBadge = React.render(<HelpBadge
+            changeHelpText={onMouseOverFn.changeHelpText}
+            changeHelpwinVisibility={onMouseOverFn.changeHelpwinVisibility}/>, document.body);
+        expect(helpBadge).toExist();
+        const helpBadgeDom = React.findDOMNode(helpBadge);
+        expect(helpBadgeDom).toExist();
+
+        ReactTestUtils.Simulate.mouseOver(helpBadgeDom);
+
+        expect(triggered).toBe(2);
+    });
+
+});

--- a/web/client/components/Help/__test__/HelpTextPanel-test.jsx
+++ b/web/client/components/Help/__test__/HelpTextPanel-test.jsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react/addons');
+var HelpTextPanel = require('../HelpTextPanel');
+var expect = require('expect');
+
+describe('Test for HelpTextPanel', () => {
+    afterEach((done) => {
+        React.unmountComponentAtNode(document.body);
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    // test DEFAULTS
+    it('creates the component with defaults', () => {
+        const helpPanel = React.render(<HelpTextPanel/>, document.body);
+        expect(helpPanel).toExist();
+
+        const helpPanelDom = React.findDOMNode(helpPanel);
+        expect(helpPanelDom).toExist();
+        // expect(helpPanelDom.id).toExist();
+        expect(helpPanelDom.className.indexOf('hidden') >= 0).toBe(true);
+
+        // header text
+        const panelHeader = helpPanelDom.getElementsByClassName('panel-heading').item(0);
+        expect(panelHeader).toExist();
+        expect(panelHeader.innerHTML === "HELP").toBe(true);
+
+        // text in body
+        const panelBody = helpPanelDom.getElementsByClassName('panel-body').item(0);
+        expect(panelBody).toExist();
+        expect(panelBody.innerHTML).toBe("");
+    });
+
+    it('creates the component with custom props', () => {
+        const helpPanel = React.render(<HelpTextPanel
+                        id="fooid"
+                        isVisible={true}
+                        title="footitle"
+                        helpText="foohelptext"
+                        />, document.body);
+        expect(helpPanel).toExist();
+
+        const helpPanelDom = React.findDOMNode(helpPanel);
+        expect(helpPanelDom).toExist();
+        expect(helpPanelDom.id).toBe("fooid");
+        expect(helpPanelDom.className.indexOf('hidden') < 0).toBe(true);
+
+        // header text
+        const panelHeader = helpPanelDom.getElementsByClassName('panel-heading').item(0);
+        expect(panelHeader).toExist();
+        expect(panelHeader.innerHTML).toBe("footitle");
+
+        // text in body
+        const panelBody = helpPanelDom.getElementsByClassName('panel-body').item(0);
+        expect(panelBody).toExist();
+        expect(panelBody.innerHTML).toBe("foohelptext");
+    });
+
+});

--- a/web/client/components/Help/__test__/HelpToggleBtn-test.jsx
+++ b/web/client/components/Help/__test__/HelpToggleBtn-test.jsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react/addons');
+var HelpToggleBtn = require('../HelpToggleBtn');
+var expect = require('expect');
+
+describe('Test for HelpToggleBtn', () => {
+    afterEach((done) => {
+        React.unmountComponentAtNode(document.body);
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    // test DEFAULTS
+    it('creates the component with defaults', () => {
+        const helpToggleBtn = React.render(<HelpToggleBtn/>, document.body);
+        expect(helpToggleBtn).toExist();
+
+        const helpToggleBtnDom = React.findDOMNode(helpToggleBtn);
+        expect(helpToggleBtnDom).toExist();
+
+        const icons = helpToggleBtnDom.getElementsByTagName('span');
+        expect(icons.length).toBe(1);
+
+        expect(helpToggleBtnDom.className.indexOf('default') >= 0).toBe(true);
+        expect(helpToggleBtnDom.innerHTML).toExist();
+    });
+
+    it('test button state', () => {
+        const helpToggleBtn = React.render(<HelpToggleBtn pressed/>, document.body);
+        expect(helpToggleBtn).toExist();
+
+        const helpToggleBtnDom = React.findDOMNode(helpToggleBtn);
+
+        expect(helpToggleBtnDom.className.indexOf('primary') >= 0).toBe(true);
+    });
+
+    it('test click handler calls right functions', () => {
+        var triggered = 0;
+        const clickFn = {
+            changeHelpState: () => {triggered++; },
+            changeHelpwinVisibility: () => {triggered++; }
+        };
+        // const spy = expect.spyOn(testHandlers, 'onClick');
+        const helpToggleBtn = React.render(<HelpToggleBtn
+            pressed
+            changeHelpState={clickFn.changeHelpState}
+            changeHelpwinVisibility={clickFn.changeHelpwinVisibility}/>, document.body);
+
+        const helpToggleBtnDom = React.findDOMNode(helpToggleBtn);
+        helpToggleBtnDom.click();
+
+        expect(triggered).toEqual(2);
+    });
+
+});

--- a/web/client/components/Help/__test__/HelpWrapper-test.jsx
+++ b/web/client/components/Help/__test__/HelpWrapper-test.jsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react/addons');
+var HelpWrapper = require('../HelpWrapper');
+var expect = require('expect');
+
+describe('Test for HelpWrapper', () => {
+    afterEach((done) => {
+        React.unmountComponentAtNode(document.body);
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    // test DEFAULTS
+    it('wraps child component properly', () => {
+        const helpWrapper = React.render(<HelpWrapper><div id="child-div" key="child-key"></div></HelpWrapper>, document.body);
+        expect(helpWrapper).toExist();
+
+        const helpWrapperDom = React.findDOMNode(helpWrapper);
+        expect(helpWrapperDom).toExist();
+
+        // creates a help badge
+        const badge = helpWrapperDom.getElementsByTagName('span').item(0);
+        expect(badge).toExist();
+        expect(badge.id).toExist();
+        expect(badge.id).toBe("helpbadge-child-key");
+        expect(badge.className.indexOf('badge') >= 0).toBe(true);
+        expect(badge.className.indexOf('hidden') >= 0).toBe(true);
+        expect(badge.innerHTML).toBe("?");
+
+        // the wrapped child from outside
+        const child = helpWrapperDom.getElementsByTagName('div').item(0);
+        expect(child).toExist();
+        expect(child.id).toExist();
+        expect(child.id).toBe("child-div");
+    });
+
+});

--- a/web/client/components/Help/help.css
+++ b/web/client/components/Help/help.css
@@ -1,0 +1,7 @@
+#helpbadge-zoomToMaxExtent {
+    display: inline;
+    position: absolute;
+    left: 34px;
+    top: 72px;
+    z-index: 100000
+}

--- a/web/client/components/Help/help.css
+++ b/web/client/components/Help/help.css
@@ -5,3 +5,19 @@
     top: 72px;
     z-index: 100000
 }
+
+#helpbadge-scaleBox {
+    display: inline;
+    position: absolute;
+    left: 116px;
+    bottom: 48px;
+    z-index: 100000
+}
+
+#helpbadge-seachBar {
+    display: inline;
+    position: absolute;
+    left: 46px;
+    top: 10px;
+    z-index: 100000
+}

--- a/web/client/components/Help/help.css
+++ b/web/client/components/Help/help.css
@@ -1,3 +1,14 @@
+.mapstore-tb-helpbadge {
+    display: block;
+    position: absolute;
+    z-index: 1000;
+}
+
+.mapstore-tb-warpperdiv {
+    margin-top: -1px;
+    margin-bottom: -1px;
+}
+
 #helpbadge-zoomToMaxExtent {
     display: inline;
     position: absolute;

--- a/web/client/components/buttons/ToggleButton.jsx
+++ b/web/client/components/buttons/ToggleButton.jsx
@@ -18,13 +18,15 @@ var ToggleButton = React.createClass({
         pressed: React.PropTypes.bool,
         onClick: React.PropTypes.func,
         tooltip: React.PropTypes.element,
-        tooltipPlace: React.PropTypes.string
+        tooltipPlace: React.PropTypes.string,
+        style: React.PropTypes.object
     },
     getDefaultProps() {
         return {
             onClick: () => {},
             pressed: false,
-            tooltipPlace: "top"
+            tooltipPlace: "top",
+            style: {width: "100%"}
         };
     },
     onClick() {
@@ -32,7 +34,7 @@ var ToggleButton = React.createClass({
     },
     renderButton() {
         return (
-            <Button id={this.props.id} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.pressed ? 'primary' : 'default'}>
+            <Button id={this.props.id} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.pressed ? 'primary' : 'default'} style={this.props.style}>
                 {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
                 {this.props.glyphicon && this.props.text ? "\u00A0" : null}
                 {this.props.text}

--- a/web/client/components/buttons/ZoomToMaxExtentButton.jsx
+++ b/web/client/components/buttons/ZoomToMaxExtentButton.jsx
@@ -11,6 +11,7 @@ var BootstrapReact = require('react-bootstrap');
 var Button = BootstrapReact.Button;
 var Glyphicon = BootstrapReact.Glyphicon;
 var ImageButton = require('./ImageButton');
+var HelpBadge = require('../Help/HelpBadge');
 
 const mapUtils = require('../../utils/MapUtils');
 const configUtils = require('../../utils/ConfigUtils');
@@ -35,9 +36,12 @@ var ZoomToMaxExtentButton = React.createClass({
         btnSize: React.PropTypes.oneOf(['large', 'medium', 'small', 'xsmall']),
         mapConfig: React.PropTypes.object,
         actions: React.PropTypes.shape({
-            changeMapView: React.PropTypes.func
+            changeMapView: React.PropTypes.func,
+            changeHelpText: React.PropTypes.func
         }),
-        btnType: React.PropTypes.oneOf(['normal', 'image'])
+        btnType: React.PropTypes.oneOf(['normal', 'image']),
+        helpEnabled: React.PropTypes.bool,
+        helpText: React.PropTypes.string
     },
     getDefaultProps() {
         return {
@@ -52,19 +56,33 @@ var ZoomToMaxExtentButton = React.createClass({
     render() {
         if (this.props.btnType === 'normal') {
             return (
-                <Button
-                    id={this.props.id}
-                    bsStyle="default"
-                    bsSize={this.props.btnSize}
-                    onClick={() => this.zoomToMaxExtent()}>
-                    {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
-                    {this.props.glyphicon && this.props.text ? "\u00A0" : null}
-                    {this.props.text}
-                </Button>
+                <div id={this.props.id}>
+                    <Button
+                        bsStyle="default"
+                        bsSize={this.props.btnSize}
+                        onClick={() => this.zoomToMaxExtent()}>
+                        {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
+                        {this.props.glyphicon && this.props.text ? "\u00A0" : null}
+                        {this.props.text}
+                    </Button>
+                    <HelpBadge
+                        isVisible = {this.props.helpEnabled}
+                        helpText={this.props.helpText}
+                        changeHelpText={this.props.actions.changeHelpText} />
+                </div>
             );
         }
-        return (<ImageButton id={this.props.id} image={this.props.image}
-            onClick={() => this.zoomToMaxExtent()} style={this.props.style}/>);
+        return (
+            <div id={this.props.id}>
+                <ImageButton
+                    image={this.props.image}
+                    onClick={() => this.zoomToMaxExtent()} />
+                <HelpBadge
+                    isVisible = {this.props.helpEnabled}
+                    helpText={this.props.helpText}
+                    changeHelpText={this.props.actions.changeHelpText} />
+            </div>
+        );
     },
     zoomToMaxExtent() {
         var mapConfig = this.props.mapConfig;

--- a/web/client/components/buttons/ZoomToMaxExtentButton.jsx
+++ b/web/client/components/buttons/ZoomToMaxExtentButton.jsx
@@ -11,7 +11,6 @@ var BootstrapReact = require('react-bootstrap');
 var Button = BootstrapReact.Button;
 var Glyphicon = BootstrapReact.Glyphicon;
 var ImageButton = require('./ImageButton');
-var HelpBadge = require('../Help/HelpBadge');
 
 const mapUtils = require('../../utils/MapUtils');
 const configUtils = require('../../utils/ConfigUtils');
@@ -56,32 +55,22 @@ var ZoomToMaxExtentButton = React.createClass({
     render() {
         if (this.props.btnType === 'normal') {
             return (
-                <div id={this.props.id}>
-                    <Button
-                        bsStyle="default"
-                        bsSize={this.props.btnSize}
-                        onClick={() => this.zoomToMaxExtent()}>
-                        {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
-                        {this.props.glyphicon && this.props.text ? "\u00A0" : null}
-                        {this.props.text}
-                    </Button>
-                    <HelpBadge
-                        isVisible = {this.props.helpEnabled}
-                        helpText={this.props.helpText}
-                        changeHelpText={this.props.actions.changeHelpText} />
-                </div>
+                <Button
+                    id={this.props.id}
+                    bsStyle="default"
+                    bsSize={this.props.btnSize}
+                    onClick={() => this.zoomToMaxExtent()}>
+                    {this.props.glyphicon ? <Glyphicon glyph={this.props.glyphicon}/> : null}
+                    {this.props.glyphicon && this.props.text ? "\u00A0" : null}
+                    {this.props.text}
+                </Button>
             );
         }
         return (
-            <div id={this.props.id}>
-                <ImageButton
-                    image={this.props.image}
-                    onClick={() => this.zoomToMaxExtent()} />
-                <HelpBadge
-                    isVisible = {this.props.helpEnabled}
-                    helpText={this.props.helpText}
-                    changeHelpText={this.props.actions.changeHelpText} />
-            </div>
+            <ImageButton
+                id={this.props.id}
+                image={this.props.image}
+                onClick={() => this.zoomToMaxExtent()} />
         );
     },
     zoomToMaxExtent() {

--- a/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
@@ -22,10 +22,9 @@ describe('This test for ZoomToMaxExtentButton', () => {
 
     // test DEFAULTS
     it('test default properties', () => {
-        const actions = {};
         const zmeBtn = React.render(
             <Provider store={store}>
-                {() => <ZoomToMaxExtentButton actions={actions}/>}
+                {() => <ZoomToMaxExtentButton/>}
             </Provider>,
             document.body);
         expect(zmeBtn).toExist();
@@ -34,17 +33,15 @@ describe('This test for ZoomToMaxExtentButton', () => {
         expect(zmeBtnNode).toExist();
         expect(zmeBtnNode.id).toBe("mapstore-zoomtomaxextent");
 
-        const buttonMarkup = zmeBtnNode.getElementsByTagName('button');
-        expect(buttonMarkup.length > 0).toBe(true);
-        expect(buttonMarkup[0].className.indexOf('default') >= 0).toBe(true);
-        expect(buttonMarkup[0].innerHTML).toExist();
+        expect(zmeBtnNode).toExist();
+        expect(zmeBtnNode.className.indexOf('default') >= 0).toBe(true);
+        expect(zmeBtnNode.innerHTML).toExist();
     });
 
     it('test glyphicon property', () => {
-        const actions = {};
         const zmeBtn = React.render(
             <Provider store={store}>
-                {() => <ZoomToMaxExtentButton actions={actions}/>}
+                {() => <ZoomToMaxExtentButton/>}
             </Provider>,
             document.body);
         expect(zmeBtn).toExist();
@@ -53,14 +50,13 @@ describe('This test for ZoomToMaxExtentButton', () => {
         expect(zmeBtnNode).toExist();
         expect(zmeBtnNode).toExist();
         const icons = zmeBtnNode.getElementsByTagName('span');
-        expect(icons.length).toBe(2);
+        expect(icons.length).toBe(1);
     });
 
     it('test glyphicon property with text', () => {
-        const actions = {};
         const zmeBtn = React.render(
             <Provider store={store}>
-                {() => <ZoomToMaxExtentButton glyphicon="info-sign" text="button" actions={actions}/>}
+                {() => <ZoomToMaxExtentButton glyphicon="info-sign" text="button"/>}
             </Provider>,
             document.body);
         expect(zmeBtn).toExist();
@@ -70,7 +66,7 @@ describe('This test for ZoomToMaxExtentButton', () => {
         expect(zmeBtnNode).toExist();
 
         const btnItems = zmeBtnNode.getElementsByTagName('span');
-        expect(btnItems.length).toBe(4);
+        expect(btnItems.length).toBe(3);
 
         expect(btnItems[0].innerHTML).toBe("");
         expect(btnItems[1].innerHTML).toBe("&nbsp;");
@@ -113,10 +109,7 @@ describe('This test for ZoomToMaxExtentButton', () => {
             const cmpDom = document.getElementById("mapstore-zoomtomaxextent");
             expect(cmpDom).toExist();
 
-            const buttonMarkup = cmpDom.childNodes[0];
-            expect(buttonMarkup).toExist();
-
-            buttonMarkup.click();
+            cmpDom.click();
             expect(spy.calls.length).toBe(1);
             expect(spy.calls[0].arguments.length).toBe(4);
         };
@@ -126,15 +119,10 @@ describe('This test for ZoomToMaxExtentButton', () => {
     });
 
     it('creates the component with a ImageButton', () => {
-        const actions = {};
-        const zmeBtn = React.render(<ZoomToMaxExtentButton btnType="image" actions={actions}/>, document.body);
+        const zmeBtn = React.render(<ZoomToMaxExtentButton btnType="image"/>, document.body);
         expect(zmeBtn).toExist();
         const zmeBtnNode = React.findDOMNode(zmeBtn);
         expect(zmeBtnNode).toExist();
-
-        const buttonMarkup = zmeBtnNode.childNodes[0];
-        expect(buttonMarkup).toExist();
-
-        expect(buttonMarkup.localName).toBe("img");
+        expect(zmeBtnNode.localName).toBe("img");
     });
 });

--- a/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
@@ -22,9 +22,10 @@ describe('This test for ZoomToMaxExtentButton', () => {
 
     // test DEFAULTS
     it('test default properties', () => {
+        const actions = {};
         const zmeBtn = React.render(
             <Provider store={store}>
-                {() => <ZoomToMaxExtentButton/>}
+                {() => <ZoomToMaxExtentButton actions={actions}/>}
             </Provider>,
             document.body);
         expect(zmeBtn).toExist();
@@ -33,15 +34,17 @@ describe('This test for ZoomToMaxExtentButton', () => {
         expect(zmeBtnNode).toExist();
         expect(zmeBtnNode.id).toBe("mapstore-zoomtomaxextent");
 
-        expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode.className.indexOf('default') >= 0).toBe(true);
-        expect(zmeBtnNode.innerHTML).toExist();
+        const buttonMarkup = zmeBtnNode.getElementsByTagName('button');
+        expect(buttonMarkup.length > 0).toBe(true);
+        expect(buttonMarkup[0].className.indexOf('default') >= 0).toBe(true);
+        expect(buttonMarkup[0].innerHTML).toExist();
     });
 
     it('test glyphicon property', () => {
+        const actions = {};
         const zmeBtn = React.render(
             <Provider store={store}>
-                {() => <ZoomToMaxExtentButton/>}
+                {() => <ZoomToMaxExtentButton actions={actions}/>}
             </Provider>,
             document.body);
         expect(zmeBtn).toExist();
@@ -50,13 +53,14 @@ describe('This test for ZoomToMaxExtentButton', () => {
         expect(zmeBtnNode).toExist();
         expect(zmeBtnNode).toExist();
         const icons = zmeBtnNode.getElementsByTagName('span');
-        expect(icons.length).toBe(1);
+        expect(icons.length).toBe(2);
     });
 
     it('test glyphicon property with text', () => {
+        const actions = {};
         const zmeBtn = React.render(
             <Provider store={store}>
-                {() => <ZoomToMaxExtentButton glyphicon="info-sign" text="button"/>}
+                {() => <ZoomToMaxExtentButton glyphicon="info-sign" text="button" actions={actions}/>}
             </Provider>,
             document.body);
         expect(zmeBtn).toExist();
@@ -66,7 +70,7 @@ describe('This test for ZoomToMaxExtentButton', () => {
         expect(zmeBtnNode).toExist();
 
         const btnItems = zmeBtnNode.getElementsByTagName('span');
-        expect(btnItems.length).toBe(3);
+        expect(btnItems.length).toBe(4);
 
         expect(btnItems[0].innerHTML).toBe("");
         expect(btnItems[1].innerHTML).toBe("&nbsp;");
@@ -109,7 +113,10 @@ describe('This test for ZoomToMaxExtentButton', () => {
             const cmpDom = document.getElementById("mapstore-zoomtomaxextent");
             expect(cmpDom).toExist();
 
-            cmpDom.click();
+            const buttonMarkup = cmpDom.childNodes[0];
+            expect(buttonMarkup).toExist();
+
+            buttonMarkup.click();
             expect(spy.calls.length).toBe(1);
             expect(spy.calls[0].arguments.length).toBe(4);
         };
@@ -119,10 +126,15 @@ describe('This test for ZoomToMaxExtentButton', () => {
     });
 
     it('creates the component with a ImageButton', () => {
-        const zmeBtn = React.render(<ZoomToMaxExtentButton btnType="image"/>, document.body);
+        const actions = {};
+        const zmeBtn = React.render(<ZoomToMaxExtentButton btnType="image" actions={actions}/>, document.body);
         expect(zmeBtn).toExist();
         const zmeBtnNode = React.findDOMNode(zmeBtn);
         expect(zmeBtnNode).toExist();
-        expect(zmeBtnNode.localName).toBe("img");
+
+        const buttonMarkup = zmeBtnNode.childNodes[0];
+        expect(buttonMarkup).toExist();
+
+        expect(buttonMarkup.localName).toBe("img");
     });
 });

--- a/web/client/components/mapcontrols/Locate/LocateBtn.jsx
+++ b/web/client/components/mapcontrols/Locate/LocateBtn.jsx
@@ -16,14 +16,16 @@ var LocateBtn = React.createClass({
         pressed: React.PropTypes.bool,
         onClick: React.PropTypes.func,
         tooltip: React.PropTypes.element,
-        tooltipPlace: React.PropTypes.string
+        tooltipPlace: React.PropTypes.string,
+        style: React.PropTypes.object
     },
     getDefaultProps() {
         return {
             id: "locate-btn",
             onClick: () => {},
             pressed: false,
-            tooltipPlace: "left"
+            tooltipPlace: "left",
+            style: {width: "100%"}
         };
     },
     onClick() {
@@ -31,7 +33,7 @@ var LocateBtn = React.createClass({
     },
     renderButton() {
         return (
-            <Button id={this.props.id} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.pressed ? 'primary' : 'default'}>
+            <Button id={this.props.id} {...this.props.btnConfig} onClick={this.onClick} bsStyle={this.props.pressed ? 'primary' : 'default'} style={this.props.style}>
                 <Glyphicon glyph="map-marker"/>
             </Button>
         );

--- a/web/client/examples/viewer/components/MapToolBar.jsx
+++ b/web/client/examples/viewer/components/MapToolBar.jsx
@@ -11,6 +11,8 @@ var {Collapse, Panel, Button, ButtonGroup, Tooltip, OverlayTrigger} = require('r
 
 var assign = require('object-assign');
 
+var HelpBadge = require('../../../components/Help/HelpBadge');
+
 /**
  * This toolbar renders as an accordion for big screens, as a
  * toolbar with small screens, rendering the content as a modal
@@ -23,7 +25,10 @@ let MapToolBar = React.createClass({
         containerStyle: React.PropTypes.object,
         propertiesChangeHandler: React.PropTypes.func,
         onActivateItem: React.PropTypes.func,
-        activeKey: React.PropTypes.string
+        activeKey: React.PropTypes.string,
+        helpEnabled: React.PropTypes.bool,
+        changeHelpText: React.PropTypes.func,
+        changeHelpwinVisibility: React.PropTypes.func
     },
     getDefaultProps() {
         return {
@@ -69,6 +74,7 @@ let MapToolBar = React.createClass({
 
         }, this);
         var buttons = React.Children.map(this.props.children, (item) => {
+            let returnObject;
             if (item.props.isPanel) {
                 let tooltip = <Tooltip id="toolbar-map-layers-button">{item.props.buttonTooltip}</Tooltip>;
                 let panelButton = (
@@ -81,9 +87,28 @@ let MapToolBar = React.createClass({
                         </Button>
                     </OverlayTrigger>
                 );
-                return panelButton;
+                returnObject = panelButton;
+
+            } else {
+                returnObject = item;
             }
-            return item;
+
+            // if we have a help text provided we add a HelpBadge
+            if (item.props.helpText && item.props.helpText !== '') {
+                return (
+                    <div className="mapstore-tb-warpperdiv">
+                        <HelpBadge
+                            className="mapstore-tb-helpbadge"
+                            helpText={item.props.helpText}
+                            isVisible={this.props.helpEnabled}
+                            changeHelpText={this.props.changeHelpText}
+                            changeHelpwinVisibility={this.props.changeHelpwinVisibility}
+                            />
+                        {returnObject}
+                    </div>);
+            }
+            // no help text provided
+            return returnObject;
 
         }, this);
         return (<div style={this.props.containerStyle}>

--- a/web/client/examples/viewer/containers/Viewer.jsx
+++ b/web/client/examples/viewer/containers/Viewer.jsx
@@ -56,7 +56,9 @@ var Viewer = React.createClass({
         hideSpinner: React.PropTypes.func,
         changeMeasurementState: React.PropTypes.func,
         measurement: React.PropTypes.object,
-        searchResults: React.PropTypes.array
+        searchResults: React.PropTypes.array,
+        changeHelpState: React.PropTypes.func,
+        changeHelpText: React.PropTypes.func
     },
     render() {
         if (this.props.map) {
@@ -143,7 +145,8 @@ module.exports = (actions) => {
             mousePositionCrs: state.mousePosition ? state.mousePosition.crs : null,
             mousePositionEnabled: state.mousePosition ? state.mousePosition.enabled || false : false,
             measurement: state.measurement ? state.measurement : {lineMeasureEnabled: false, areaMeasureEnabled: false, bearingMeasureEnabled: false, geomType: null, len: 0, area: 0, bearing: 0},
-            searchResults: state.searchResults || null
+            searchResults: state.searchResults || null,
+            help: state.help ? state.help : {enabled: false, helpText: ''}
         };
     }, dispatch => {
         return bindActionCreators(assign({}, {

--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -94,8 +94,12 @@ module.exports = {
                 activeKey={props.floatingPanel.activeKey}
                 onActivateItem={props.activatePanel}
                 key="mapToolbar"
+                helpEnabled={props.help.enabled}
+                changeHelpText={props.changeHelpText}
+                changeHelpwinVisibility={props.changeHelpwinVisibility}
                 >
                  <LocateBtn
+                     helpText={<Message msgId="helptexts.locateBtn"/>}
                         pressed={props.locate.enabled}
                         onClick={props.changeLocateState}
                         tooltip={<Message msgId="locate.tooltip"/>}/>
@@ -104,12 +108,14 @@ module.exports = {
                     isButton={true}
                     pressed={props.mapInfo.enabled}
                     glyphicon="info-sign"
+                    helpText={<Message msgId="helptexts.infoButton"/>}
                     onClick={props.changeMapInfoState}/>
                 <LayerTree
                     key="layerSwitcher"
                     isPanel={true}
                     buttonTooltip={<Message msgId="layers"/>}
                     title={<Message msgId="layers"/>}
+                    helpText={<Message msgId="helptexts.layerSwitcher"/>}
                     groups={props.layers.groups}
                     propertiesChangeHandler={props.changeLayerProperties}
                     onToggleGroup={(group, status) => props.toggleNode(group, 'groups', status)}
@@ -121,6 +127,7 @@ module.exports = {
                     isPanel={true}
                     layers={props.layers.flat.filter((layer) => layer.group === "background")}
                     title={<div><Message msgId="background"/></div>}
+                    helpText={<Message msgId="helptexts.backgroundSwitcher"/>}
                     buttonTooltip={<Message msgId="backgroundSwither.tooltip"/>}
                     propertiesChangeHandler={props.changeLayerProperties}/>
                 <MeasureComponent
@@ -128,6 +135,7 @@ module.exports = {
                     isPanel={true}
                     title={<div><Message msgId="measureComponent.title"/></div>}
                     buttonTooltip={<Message msgId="measureComponent.tooltip"/>}
+                    helpText={<Message msgId="helptexts.measureComponent"/>}
                     lengthButtonText={<Message msgId="measureComponent.lengthButtonText"/>}
                     areaButtonText={<Message msgId="measureComponent.areaButtonText"/>}
                     resetButtonText={<Message msgId="measureComponent.resetButtonText"/>}
@@ -143,7 +151,8 @@ module.exports = {
                 <Settings
                     key="settingsPanel"
                     isPanel={true}
-                    buttonTooltip={<Message msgId="settings" />}>
+                    buttonTooltip={<Message msgId="settings" />}
+                    helpText={<Message msgId="helptexts.settingsPanel"/>}>
                     <h5><Message msgId="language" /></h5>
                     <LangBar key="langSelector"
                     currentLocale={props.locale}

--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -21,6 +21,7 @@ var floatingPanel = require('../reducers/floatingPanel');
 var mousePosition = require('../../../reducers/mousePosition');
 var measurement = require('../../../reducers/measurement');
 var {searchResults} = require('../../../reducers/search');
+var help = require('../../../reducers/help');
 
 var LocateBtn = require("../../../components/mapcontrols/Locate/LocateBtn");
 var locate = require('../../../reducers/locate');
@@ -38,6 +39,9 @@ var {changeMapView, changeZoomLevel} = require('../../../actions/map');
 var {textSearch, resultsPurge} = require("../../../actions/search");
 
 var {changeMeasurementState} = require('../../../actions/measurement');
+
+var {changeHelpState, changeHelpText} = require('../../../actions/help');
+var HelpTextPanel = require('../../../components/Help/HelpTextPanel');
 
 var React = require('react');
 
@@ -168,6 +172,12 @@ module.exports = {
                             disabled: (props.mapHistory.future.length > 0) ? false : true
                     }}/>
                 </Settings>
+                <ToggleButton
+                    key="helpButton"
+                    isButton={true}
+                    glyphicon="question-sign"
+                    pressed={props.help.enabled}
+                    onClick={props.changeHelpState}/>
             </MapToolBar>,
             <GetFeatureInfo
                 key="getFeatureInfo"
@@ -196,12 +206,19 @@ module.exports = {
                 key="zoomToMaxExtent"
                 mapConfig={props.map}
                 actions={{
-                    changeMapView: props.changeMapView
-                }} />,
-            <GlobalSpinner key="globalSpinner"/>
+                    changeMapView: props.changeMapView,
+                    changeHelpText: props.changeHelpText
+                }}
+                helpEnabled={props.help.enabled}
+                helpText="This is the help for ZoomToMaxExtentButton"/>,
+            <GlobalSpinner key="globalSpinner"/>,
+            <HelpTextPanel
+                key="helpTextPanel"
+                isVisible={props.help.enabled}
+                helpText={props.help.helpText}/>
         ];
     },
-    reducers: {mapInfo, floatingPanel, mousePosition, measurement, searchResults, locate},
+    reducers: {mapInfo, floatingPanel, mousePosition, measurement, searchResults, locate, help},
     actions: {
         getFeatureInfo,
         textSearch,
@@ -223,6 +240,8 @@ module.exports = {
         undo,
         redo,
         changeMapInfoFormat,
-        changeMeasurementState
+        changeMeasurementState,
+        changeHelpState,
+        changeHelpText
     }
 };

--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -81,7 +81,7 @@ module.exports = {
                         margin: "8px"
                     }} key="about"/>,
             <HelpWrapper
-                helpText="This is the help for SearchBar"
+                helpText={<Message msgId="helptexts.searchBar"/>}
                 helpEnabled={props.help.enabled}
                 changeHelpText={props.changeHelpText}
                 >
@@ -206,7 +206,7 @@ module.exports = {
                 mousePosition={props.mousePosition}
                 crs={(props.mousePositionCrs) ? props.mousePositionCrs : props.map.projection}/>,
             <HelpWrapper
-                helpText="This is the help for ScaleBox"
+                helpText={<Message msgId="helptexts.scaleBox"/>}
                 helpEnabled={props.help.enabled}
                 changeHelpText={props.changeHelpText}
                 >
@@ -216,7 +216,7 @@ module.exports = {
                     currentZoomLvl={props.map.zoom} />
             </HelpWrapper>,
             <HelpWrapper
-                helpText="This is the help for ZoomToMaxExtentButton"
+                helpText={<Message msgId="helptexts.zoomToMaxExtentButton"/>}
                 helpEnabled={props.help.enabled}
                 changeHelpText={props.changeHelpText}
                 >

--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -41,6 +41,7 @@ var {textSearch, resultsPurge} = require("../../../actions/search");
 var {changeMeasurementState} = require('../../../actions/measurement');
 
 var {changeHelpState, changeHelpText} = require('../../../actions/help');
+var HelpWrapper = require('../../../components/Help/HelpWrapper');
 var HelpTextPanel = require('../../../components/Help/HelpTextPanel');
 
 var React = require('react');
@@ -202,15 +203,19 @@ module.exports = {
                 key="scaleBox"
                 onChange={props.changeZoomLevel}
                 currentZoomLvl={props.map.zoom} />,
-            <ZoomToMaxExtentButton
-                key="zoomToMaxExtent"
-                mapConfig={props.map}
-                actions={{
-                    changeMapView: props.changeMapView,
-                    changeHelpText: props.changeHelpText
-                }}
+            <HelpWrapper
+                helpText="This is the help for ZoomToMaxExtentButton"
                 helpEnabled={props.help.enabled}
-                helpText="This is the help for ZoomToMaxExtentButton"/>,
+                changeHelpText={props.changeHelpText}
+                >
+                <ZoomToMaxExtentButton
+                    key="zoomToMaxExtent"
+                    mapConfig={props.map}
+                    actions={{
+                        changeMapView: props.changeMapView
+                    }}
+                />
+            </HelpWrapper>,
             <GlobalSpinner key="globalSpinner"/>,
             <HelpTextPanel
                 key="helpTextPanel"

--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -40,9 +40,10 @@ var {textSearch, resultsPurge} = require("../../../actions/search");
 
 var {changeMeasurementState} = require('../../../actions/measurement');
 
-var {changeHelpState, changeHelpText} = require('../../../actions/help');
+var {changeHelpState, changeHelpText, changeHelpwinVisibility} = require('../../../actions/help');
 var HelpWrapper = require('../../../components/Help/HelpWrapper');
 var HelpTextPanel = require('../../../components/Help/HelpTextPanel');
+var HelpToggleBtn = require('../../../components/Help/HelpToggleBtn');
 
 var React = require('react');
 
@@ -84,6 +85,7 @@ module.exports = {
                 helpText={<Message msgId="helptexts.searchBar"/>}
                 helpEnabled={props.help.enabled}
                 changeHelpText={props.changeHelpText}
+                changeHelpwinVisibility={props.changeHelpwinVisibility}
                 >
                 <SearchBar key="seachBar" onSearch={props.textSearch} onSearchReset={props.resultsPurge}/>
             </HelpWrapper>,
@@ -179,12 +181,10 @@ module.exports = {
                             disabled: (props.mapHistory.future.length > 0) ? false : true
                     }}/>
                 </Settings>
-                <ToggleButton
-                    key="helpButton"
-                    isButton={true}
-                    glyphicon="question-sign"
+                <HelpToggleBtn
                     pressed={props.help.enabled}
-                    onClick={props.changeHelpState}/>
+                    changeHelpState={props.changeHelpState}
+                    changeHelpwinVisibility={props.changeHelpwinVisibility}/>
             </MapToolBar>,
             <GetFeatureInfo
                 key="getFeatureInfo"
@@ -209,6 +209,7 @@ module.exports = {
                 helpText={<Message msgId="helptexts.scaleBox"/>}
                 helpEnabled={props.help.enabled}
                 changeHelpText={props.changeHelpText}
+                changeHelpwinVisibility={props.changeHelpwinVisibility}
                 >
                 <ScaleBox
                     key="scaleBox"
@@ -219,6 +220,7 @@ module.exports = {
                 helpText={<Message msgId="helptexts.zoomToMaxExtentButton"/>}
                 helpEnabled={props.help.enabled}
                 changeHelpText={props.changeHelpText}
+                changeHelpwinVisibility={props.changeHelpwinVisibility}
                 >
                 <ZoomToMaxExtentButton
                     key="zoomToMaxExtent"
@@ -231,7 +233,7 @@ module.exports = {
             <GlobalSpinner key="globalSpinner"/>,
             <HelpTextPanel
                 key="helpTextPanel"
-                isVisible={props.help.enabled}
+                isVisible={props.help.helpwinViz}
                 helpText={props.help.helpText}/>
         ];
     },
@@ -259,6 +261,7 @@ module.exports = {
         changeMapInfoFormat,
         changeMeasurementState,
         changeHelpState,
-        changeHelpText
+        changeHelpText,
+        changeHelpwinVisibility
     }
 };

--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -80,8 +80,14 @@ module.exports = {
                         right: "0px",
                         margin: "8px"
                     }} key="about"/>,
-                <SearchBar onSearch={props.textSearch} onSearchReset={props.resultsPurge}/>,
-                <NominatimResultList results={props.searchResults} onItemClick={(props.changeMapView)} afterItemClick={props.resultsPurge} mapConfig={props.map}/>,
+            <HelpWrapper
+                helpText="This is the help for SearchBar"
+                helpEnabled={props.help.enabled}
+                changeHelpText={props.changeHelpText}
+                >
+                <SearchBar key="seachBar" onSearch={props.textSearch} onSearchReset={props.resultsPurge}/>
+            </HelpWrapper>,
+            <NominatimResultList results={props.searchResults} onItemClick={(props.changeMapView)} afterItemClick={props.resultsPurge} mapConfig={props.map}/>,
             <MapToolBar
                 activeKey={props.floatingPanel.activeKey}
                 onActivateItem={props.activatePanel}
@@ -199,10 +205,16 @@ module.exports = {
                 enabled={props.mousePositionEnabled}
                 mousePosition={props.mousePosition}
                 crs={(props.mousePositionCrs) ? props.mousePositionCrs : props.map.projection}/>,
-            <ScaleBox
-                key="scaleBox"
-                onChange={props.changeZoomLevel}
-                currentZoomLvl={props.map.zoom} />,
+            <HelpWrapper
+                helpText="This is the help for ScaleBox"
+                helpEnabled={props.help.enabled}
+                changeHelpText={props.changeHelpText}
+                >
+                <ScaleBox
+                    key="scaleBox"
+                    onChange={props.changeZoomLevel}
+                    currentZoomLvl={props.map.zoom} />
+            </HelpWrapper>,
             <HelpWrapper
                 helpText="This is the help for ZoomToMaxExtentButton"
                 helpEnabled={props.help.enabled}

--- a/web/client/reducers/help.js
+++ b/web/client/reducers/help.js
@@ -8,7 +8,8 @@
 
 var {
     CHANGE_HELP_STATE,
-    CHANGE_HELP_TEXT
+    CHANGE_HELP_TEXT,
+    CHANGE_HELPWIN_VIZ
 } = require('../actions/help');
 
 const assign = require('object-assign');
@@ -22,6 +23,11 @@ function help(state = null, action) {
         case CHANGE_HELP_TEXT: {
             return assign({}, state, {
                 helpText: action.helpText
+            });
+        }
+        case CHANGE_HELPWIN_VIZ: {
+            return assign({}, state, {
+                helpwinViz: action.helpwinViz
             });
         }
         default:

--- a/web/client/reducers/help.js
+++ b/web/client/reducers/help.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var {
+    CHANGE_HELP_STATE,
+    CHANGE_HELP_TEXT
+} = require('../actions/help');
+
+const assign = require('object-assign');
+
+function help(state = null, action) {
+    switch (action.type) {
+        case CHANGE_HELP_STATE:
+            return assign({}, state, {
+                enabled: action.enabled
+            });
+        case CHANGE_HELP_TEXT: {
+            return assign({}, state, {
+                helpText: action.helpText
+            });
+        }
+        default:
+            return state;
+    }
+}
+
+module.exports = help;

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -184,6 +184,11 @@
         "feetUnit": "feet",
         "popup": "You are within {distance} {unit} from this point",
         "outsideMapBoundsMsg": "You seem located outside the boundaries of the map"
+    },
+        "helptexts": {
+            "scaleBox": "This is the helptext for the ScaleBox",
+            "zoomToMaxExtentButton": "This is the helptext for the ZoomToMaxExtentButton",
+            "searchBar": "This is the helptext for the SearchBar"
         }
     }
 }

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -188,7 +188,14 @@
         "helptexts": {
             "scaleBox": "This is the helptext for the ScaleBox",
             "zoomToMaxExtentButton": "This is the helptext for the ZoomToMaxExtentButton",
-            "searchBar": "This is the helptext for the SearchBar"
+            "searchBar": "This is the helptext for the SearchBar",
+            "layerSwitcher": "This is the helptext for the LayerSwitcher",
+            "settingsPanel": "This is the helptext for the SettingsPanel",
+            "measureComponent": "This is the helptext for the MeasureComponent",
+            "backgroundSwitcher": "This is the helptext for the BackgroundSwitcher",
+            "layerSwitcher": "This is the helptext for the LayerSwitcher",
+            "infoButton": "This is the helptext for the InfoButton",
+            "locateBtn": "This is the helptext for the LocateBtn"
         }
     }
 }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -184,7 +184,11 @@
         "feetUnit": "piedi",
         "popup": "Sei nel raggio di {distance} {unit} da questo punto",
         "outsideMapBoundsMsg": "Sembri al di fuori dei confini della mappa"
-
+    },
+        "helptexts": {
+            "scaleBox": "Questo è il testo di aiuto per ScaleBox",
+            "zoomToMaxExtentButton": "Questo è il testo di aiuto per ZoomToMaxExtentButton",
+            "searchBar": "Questo è il testo di aiuto per SearchBar"
         }
     }
 }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -188,7 +188,14 @@
         "helptexts": {
             "scaleBox": "Questo è il testo di aiuto per ScaleBox",
             "zoomToMaxExtentButton": "Questo è il testo di aiuto per ZoomToMaxExtentButton",
-            "searchBar": "Questo è il testo di aiuto per SearchBar"
+            "searchBar": "Questo è il testo di aiuto per SearchBar",
+            "layerSwitcher": "Questo è il testo di aiuto per LayerSwitcher",
+            "settingsPanel": "Questo è il testo di aiuto per SettingsPanel",
+            "measureComponent": "Questo è il testo di aiuto per MeasureComponent",
+            "backgroundSwitcher": "Questo è il testo di aiuto per BackgroundSwitcher",
+            "layerSwitcher": "Questo è il testo di aiuto per LayerSwitcher",
+            "infoButton": "Questo è il testo di aiuto per InfoButton",
+            "locateBtn": "Questo è il testo di aiuto per LocateBtn"
         }
     }
 }


### PR DESCRIPTION
This adds a dynamic help system to highlight 'help-augmented' elements
by a badge and show the corresponding help text by clicking the badge. The highlighting can be activated / deactivated by a button in the toolbar.

To show the mechanism the ZoomToMaxExtentButton is extended by such a "help-badge" 

Fixes #155