### PR TITLE
#316 avoid duplicated keys that causes errors in samsung browser

### DIFF
--- a/web/client/examples/viewer/plugins/index.jsx
+++ b/web/client/examples/viewer/plugins/index.jsx
@@ -81,7 +81,7 @@ module.exports = {
                         bottom: "-8px",
                         right: "0px",
                         margin: "8px"
-                    }} key="about"/>,
+                    }} />,
             <HelpWrapper
                 helpText={<Message msgId="helptexts.searchBar"/>}
                 helpEnabled={props.help.enabled}


### PR DESCRIPTION
Testing issue #316 the Javascript console of the samsung galaxy integrated browser reported this error error: 
```
duplicate data property in object literal not allowed in strict mode
```

This fix avoid the error removing a duplicated key attribute in the plugin initialization