### PR TITLE
first implementation for #343

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,10 +76,12 @@
     "react-redux": "^4.0.2",
     "react-sidebar": "^2.1.1",
     "react-sortable-items": "0.0.11",
+    "react-swipe": "^3.0.0",
     "redux": "^3.0.5",
     "redux-logger": "^2.0.0",
     "redux-thunk": "^0.1.0",
     "redux-undo": "^0.5.0",
+    "swipe-js-iso": "^2.0.1",
     "url": "~0.10.3"
   },
   "scripts": {

--- a/web/client/components/spinners/BasicSpinner/basicSpinner.css
+++ b/web/client/components/spinners/BasicSpinner/basicSpinner.css
@@ -117,7 +117,6 @@
 
 }
 .spinner-card{
-  display: table-cell;
   text-align: center;
   vertical-align: middle;
   height: 20px;

--- a/web/client/examples/viewer/components/getFeatureInfo/GetFeatureInfoViewer.jsx
+++ b/web/client/examples/viewer/components/getFeatureInfo/GetFeatureInfoViewer.jsx
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const {Alert, Accordion, Panel, Glyphicon} = require('react-bootstrap');
+const ReactSwipe = require('react-swipe');
+var JSONFeatureInfoViewer = require('./infoViewers/JSONFeatureInfoViewer');
+var HTMLFeatureInfoViewer = require('./infoViewers/HTMLFeatureInfoViewer');
+var TEXTFeatureInfoViewer = require('./infoViewers/TEXTFeatureInfoViewer');
+var FeatureInfoUtils = require('../../../../utils/FeatureInfoUtils');
+var MapInfoUtils = require('../../../../utils/MapInfoUtils');
+const I18N = require('../../../../components/I18N/I18N');
+
+const GetFeatureInfoViewer = React.createClass({
+    propTypes: {
+        infoFormat: React.PropTypes.oneOf(
+            MapInfoUtils.getAvailableInfoFormatValues()
+        ),
+        responses: React.PropTypes.array,
+        missingRequests: React.PropTypes.number,
+        display: React.PropTypes.string
+    },
+    getDefaultProps() {
+        return {
+            display: "accordion",
+            responses: [],
+            missingRequests: 0
+        };
+    },
+    shouldComponentUpdate(nextProps) {
+        return nextProps.responses !== this.props.responses || nextProps.missingRequests !== this.props.missingRequests;
+    },
+    getValidator() {
+        var infoFormats = MapInfoUtils.getAvailableInfoFormat();
+        switch (this.props.infoFormat) {
+            case infoFormats.JSON:
+                return FeatureInfoUtils.Validator.JSON;
+            case infoFormats.HTML:
+                return FeatureInfoUtils.Validator.HTML;
+            case infoFormats.TEXT:
+                return FeatureInfoUtils.Validator.TEXT;
+            default:
+                return null;
+        }
+    },
+    /**
+     * render empty layers or not valid responses section.
+     */
+    renderEmptyLayers(validator) {
+        const notEmptyResponses = validator.getValidResponses(this.props.responses).length;
+        const filteredResponses = validator.getNoValidResponses(this.props.responses);
+        if (this.props.missingRequests === 0 && notEmptyResponses === 0) {
+            return null;
+        }
+        if (filteredResponses.length !== 0) {
+            const titles = filteredResponses.map((res) => {
+                const {layerMetadata} = res;
+                return layerMetadata.title;
+            });
+            return (
+                <Alert bsStyle={"info"}>
+                    <I18N.Message msgId={"noInfoForLayers"} />
+                    <b>{titles.join(', ')}</b>
+                </Alert>
+            );
+        }
+        return null;
+    },
+    /**
+     * Render a single layer feature info
+     */
+    renderInfoPage(response) {
+        var infoFormats = MapInfoUtils.getAvailableInfoFormat();
+        switch (this.props.infoFormat) {
+            case infoFormats.JSON:
+                return <JSONFeatureInfoViewer display={this.props.display} response={response} />;
+            case infoFormats.HTML:
+                return <HTMLFeatureInfoViewer display={this.props.display} response={response} />;
+            case infoFormats.TEXT:
+                return <TEXTFeatureInfoViewer display={this.props.display} response={response} />;
+            default:
+                return null;
+        }
+    },
+    /**
+     * Some info about the event
+     */
+    renderAdditionalInfo() {
+        var infoFormats = MapInfoUtils.getAvailableInfoFormat();
+        switch (this.props.infoFormat) {
+            case infoFormats.JSON:
+                return this.renderEmptyLayers(FeatureInfoUtils.Validator.JSON);
+            case infoFormats.HTML:
+                return this.renderEmptyLayers(FeatureInfoUtils.Validator.HTML);
+            case infoFormats.TEXT:
+                return this.renderEmptyLayers(FeatureInfoUtils.Validator.TEXT);
+            default:
+                return null;
+        }
+    },
+    renderLeftButton() {
+        return <a style={{"float": "left"}} onClick={() => {this.refs.container.swipe.prev(); }}><Glyphicon glyph="chevron-left" /></a>;
+    },
+    renderRightButton() {
+        return <a style={{"float": "right"}} onClick={() => {this.refs.container.swipe.next(); }}><Glyphicon glyph="chevron-right" /></a>;
+    },
+    renderPageHeader(res, layerMetadata) {
+        return (<span>{this.props.display === "accordion" ? "" : this.renderLeftButton()} <span>{layerMetadata.title}</span> {this.props.display === "accordion" ? "" : this.renderRightButton()}</span>);
+    },
+    /**
+     * render all the feature info pages
+     */
+    renderPages(responses) {
+        if (this.props.missingRequests === 0 && responses.length === 0) {
+            return (
+                <Alert bsStyle={"danger"}>
+                    <h4><I18N.HTML msgId={"noFeatureInfo"}/></h4>
+                </Alert>
+            );
+        }
+        return responses.map((res, i) => {
+            const {response, layerMetadata} = res;
+            var pageHeader = this.renderPageHeader(res, layerMetadata, i);
+            return (
+                <Panel
+                    eventKey={i}
+                    key={i}
+                    collapsible={this.props.display === "accordion"}
+                    header={pageHeader}
+                    style={this.props.display === "accordion" ?
+                        {overflowX: "auto"} : {maxHeight: "100%", overflow: "auto"}}>
+                    {this.renderInfoPage(response)}
+                </Panel>
+            );
+        });
+    },
+    render() {
+        const Container = this.props.display === "accordion" ? Accordion : ReactSwipe;
+        const validator = this.getValidator();
+        const validResponses = validator.getValidResponses(this.props.responses);
+        return (<div>
+                <Container ref="container" defaultActiveKey={0} key={"swiper-" + this.props.responses.length + "-" + this.props.missingRequests} shouldUpdate={(nextProps, props) => {return nextProps !== props; }}>
+                    {this.renderPages(validResponses)}
+                </Container>
+                {this.renderAdditionalInfo()}
+            </div>
+        );
+    }
+});
+
+module.exports = GetFeatureInfoViewer;

--- a/web/client/examples/viewer/components/getFeatureInfo/infoViewers/HTMLFeatureInfoViewer.jsx
+++ b/web/client/examples/viewer/components/getFeatureInfo/infoViewers/HTMLFeatureInfoViewer.jsx
@@ -7,87 +7,30 @@
  */
 
 const React = require('react');
-const {Alert, Accordion, Panel} = require('react-bootstrap');
 
 const HtmlRenderer = require('../../../../../components/misc/HtmlRenderer');
-const I18N = require('../../../../../components/I18N/I18N');
 
 const regexpBody = /^[\s\S]*<body>([\s\S]*)<\/body>[\s\S]*$/i;
 const regexpStyle = /(<style[\s\=\w\/\"]*>[^<]*<\/style>)/i;
 
-const HTMLFeatureInfoViewr = React.createClass({
+const HTMLFeatureInfoViewer = React.createClass({
     propTypes: {
-        responses: React.PropTypes.array,
-        missingRequests: React.PropTypes.number
+        response: React.PropTypes.string,
+        layerMetadata: React.PropTypes.object
     },
-    getDefaultProps() {
-        return {
-            responses: [],
-            missingRequests: 0
-        };
-    },
-    getValidResponses(responses) {
-        return responses.filter((res) => typeof res.response === "string" && res.response.indexOf("<?xml") !== 0 && res.response.replace(regexpBody, '$1').trim().length !== 0);
-    },
-    getNoValidResponses(responses) {
-        return responses.filter((res) => !(typeof res.response === "string" && res.response.indexOf("<?xml") !== 0 && res.response.replace(regexpBody, '$1').trim().length !== 0));
-    },
-    renderInfo(responses) {
-        const filteredResponses = this.getValidResponses(responses);
-        if (this.props.missingRequests === 0 && filteredResponses.length === 0) {
-            return (
-                <Alert bsStyle={"danger"}>
-                    <h4><I18N.HTML msgId={"noFeatureInfo"}/></h4>
-                </Alert>
-            );
-        }
-        return filteredResponses.map((res, i) => {
-            const {response, layerMetadata} = res;
-            // gets css rules from the response and removes which are related to body tag.
-            let styleMatch = regexpStyle.exec(response);
-            let style = styleMatch && styleMatch.length === 2 ? regexpStyle.exec(response)[1] : "";
-            style = style.replace(/body[,]+/g, '');
-            // gets feature info managing an eventually empty response
-            let content = response.replace(regexpBody, '$1').trim();
-            return (
-                <Panel header={layerMetadata.title} eventKey={i + 1} key={i} style={{overflowX: "auto"}}>
-                    <HtmlRenderer key={i} html={style + content} />
-                </Panel>
-            );
-        });
-    },
-    renderEmpryLayer(responses) {
-        const notEmptyResponses = this.getValidResponses(responses).length;
-        const filteredResponses = this.getNoValidResponses(responses);
-        if (this.props.missingRequests === 0 && notEmptyResponses === 0) {
-            return null;
-        }
-        if (filteredResponses.length !== 0) {
-            const titles = filteredResponses.map((res) => {
-                const {layerMetadata} = res;
-                return layerMetadata.title;
-            });
-            return (
-                <Alert bsStyle={"info"}>
-                    <I18N.Message msgId={"noInfoForLayers"} />
-                    <b>{titles.join(', ')}</b>
-                </Alert>
-            );
-        }
-        return null;
+    shouldComponentUpdate(nextProps) {
+        return nextProps.response !== this.props.response || nextProps.layerMetadata !== this.props.layerMetadata;
     },
     render() {
-        let pages = this.renderInfo(this.props.responses);
-        let emptyLayers = this.renderEmpryLayer(this.props.responses);
-        return (
-            <div>
-                <Accordion defaultActiveKey={1}>
-                    {pages}
-                </Accordion>
-                {emptyLayers}
-            </div>
-        );
+        let response = this.props.response;
+        // gets css rules from the response and removes which are related to body tag.
+        let styleMatch = regexpStyle.exec(response);
+        let style = styleMatch && styleMatch.length === 2 ? regexpStyle.exec(response)[1] : "";
+        style = style.replace(/body[,]+/g, '');
+        // gets feature info managing an eventually empty response
+        let content = response.replace(regexpBody, '$1').trim();
+        return (<HtmlRenderer html={style + content} />);
     }
 });
 
-module.exports = HTMLFeatureInfoViewr;
+module.exports = HTMLFeatureInfoViewer;

--- a/web/client/examples/viewer/components/getFeatureInfo/infoViewers/JSONFeatureInfoViewer.jsx
+++ b/web/client/examples/viewer/components/getFeatureInfo/infoViewers/JSONFeatureInfoViewer.jsx
@@ -7,24 +7,20 @@
  */
 
 var React = require('react');
-var {Alert, Accordion, Panel} = require('react-bootstrap');
+
 
 var ApplyTemplate = require('../../../../../components/misc/ApplyTemplate');
 var PropertiesViewer = require('../../../../../components/misc/PropertiesViewer');
-var I18N = require('../../../../../components/I18N/I18N');
 
 var JSONFeatureInfoViewr = React.createClass({
     propTypes: {
-        responses: React.PropTypes.array,
-        missingRequests: React.PropTypes.number
+        response: React.PropTypes.string,
+        layerMetadata: React.PropTypes.object
     },
-    getDefaultProps() {
-        return {
-            responses: [],
-            missingRequests: 0
-        };
+    shouldComponentUpdate(nextProps) {
+        return nextProps.response !== this.props.response || nextProps.layerMetadata !== this.props.layerMetadata;
     },
-    renderInfo(responses) {
+    render() {
         const getFeatureProps = feature => feature.properties;
         const getFormattedContent = (feature, i) => {
             return (
@@ -33,53 +29,8 @@ var JSONFeatureInfoViewr = React.createClass({
                 </ApplyTemplate>
             );
         };
-        const filteredResponses = responses.filter((res) => res.response && res.response.features && res.response.features.length);
-        if (this.props.missingRequests === 0 && filteredResponses.length === 0) {
-            return (
-                <Alert bsStyle={"danger"}>
-                    <h4><I18N.HTML msgId={"noFeatureInfo"}/></h4>
-                </Alert>
-            );
-        }
-        return filteredResponses.map((res, i) => {
-            const {response, layerMetadata} = res;
-
-            return (
-                <Panel header={layerMetadata.title} eventKey={i + 1} key={i}>
-                    {response.features.map(getFormattedContent)}
-                </Panel>
-            );
-        });
-    },
-    renderEmpryLayer(responses) {
-        const notEmptyResponses = responses.filter((res) => res.response && res.response.features && res.response.features.length).length;
-        const filteredResponses = responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
-        if (this.props.missingRequests === 0 && notEmptyResponses === 0) {
-            return null;
-        }
-        if (filteredResponses.length !== 0) {
-            const titles = filteredResponses.map((res) => {
-                const {layerMetadata} = res;
-                return layerMetadata.title;
-            });
-            return (
-                <Alert bsStyle={"info"}>
-                    <I18N.Message msgId={"noInfoForLayers"} />
-                    <b>{titles.join(', ')}</b>
-                </Alert>
-            );
-        }
-        return null;
-    },
-    render() {
-        let pages = this.renderInfo(this.props.responses);
-        let emptyLayers = this.renderEmpryLayer(this.props.responses);
-        return (
-            <div>
-                <Accordion defaultActiveKey={1}>
-                    {pages}
-                </Accordion>
-                {emptyLayers}
+        return (<div>
+                {this.props.response.features.map(getFormattedContent)}
             </div>
         );
     }

--- a/web/client/examples/viewer/components/getFeatureInfo/infoViewers/TEXTFeatureInfoViewer.jsx
+++ b/web/client/examples/viewer/components/getFeatureInfo/infoViewers/TEXTFeatureInfoViewer.jsx
@@ -7,69 +7,17 @@
  */
 
 const React = require('react');
-const {Alert, Accordion, Panel} = require('react-bootstrap');
-
-const I18N = require('../../../../../components/I18N/I18N');
 
 const TEXTFeatureInfoViewer = React.createClass({
     propTypes: {
-        responses: React.PropTypes.array,
-        missingRequests: React.PropTypes.number
+        response: React.PropTypes.string,
+        layerMetadata: React.PropTypes.object
     },
-    getDefaultProps() {
-        return {
-            responses: [],
-            missingRequests: 0
-        };
-    },
-    renderInfo(responses) {
-        const filteredResponses = responses.filter((res) => res.response !== "" && res.response !== "no features were found\n" && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0));
-        if (this.props.missingRequests === 0 && filteredResponses.length === 0) {
-            return (
-                <Alert bsStyle={"danger"}>
-                    <h4><I18N.HTML msgId={"noFeatureInfo"}/></h4>
-                </Alert>
-            );
-        }
-        return filteredResponses.map((res, i) => {
-            const {response, layerMetadata} = res;
-            return (
-                <Panel header={layerMetadata.title} eventKey={i + 1} key={i}>
-                    <pre>{response}</pre>
-                </Panel>
-            );
-        });
-    },
-    renderEmpryLayer(responses) {
-        const notEmptyResponses = responses.filter((res) => res.response !== "" && res.response !== "no features were found\n" && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0)).length;
-        const filteredResponses = responses.filter((res) => res.response === "" || res.response === "no features were found\n" || res.response && (typeof res.response === "string" && res.response.indexOf("<?xml") === 0));
-        if (this.props.missingRequests === 0 && notEmptyResponses === 0) {
-            return null;
-        }
-        if (filteredResponses.length !== 0) {
-            const titles = filteredResponses.map((res) => {
-                const {layerMetadata} = res;
-                return layerMetadata.title;
-            });
-            return (
-                <Alert bsStyle={"info"}>
-                    <I18N.Message msgId={"noInfoForLayers"} />
-                    <b>{titles.join(', ')}</b>
-                </Alert>
-            );
-        }
-        return null;
+    shouldComponentUpdate(nextProps) {
+        return nextProps.response !== this.props.response || nextProps.layerMetadata !== this.props.layerMetadata;
     },
     render() {
-        var pages = this.renderInfo(this.props.responses);
-        let emptyLayers = this.renderEmpryLayer(this.props.responses);
-        return (
-            <div>
-                <Accordion defaultActiveKey={1}>
-                    {pages}
-                </Accordion>
-                {emptyLayers}
-            </div>
+        return (<pre>{this.props.response}</pre>
         );
     }
 });

--- a/web/client/examples/viewer/css/mobile.css
+++ b/web/client/examples/viewer/css/mobile.css
@@ -225,3 +225,16 @@ div.MapSearchBar input {
     left: 5px !important;
     right:5px !important;
 }
+#mapstore-getfeatureinfo {
+    margin-bottom: 0;
+}
+#mapstore-getfeatureinfo > .panel-body{
+    padding: 0;
+}
+#mapstore-getfeatureinfo > .panel-body .panel-heading {
+    text-align: center;
+}
+#mapstore-getfeatureinfo > .panel-body .panel-body{
+    max-height: 170px;
+    overflow-y: auto;
+}

--- a/web/client/examples/viewer/plugins/mobile.jsx
+++ b/web/client/examples/viewer/plugins/mobile.jsx
@@ -142,6 +142,17 @@ module.exports = {
                 crs={(props.mousePositionCrs) ? props.mousePositionCrs : props.map.projection}/>,
             <GetFeatureInfo
                 key="getFeatureInfo"
+                style={{position: "absolute",
+                    width: "100%",
+                    bottom: "0px",
+                    zIndex: 1010,
+                    maxHeight: "70%",
+                    marginBottom: 0
+                }}
+                draggable={false}
+                collapsible={true}
+                display="swipe"
+                bodyClass="mobile-feature-info"
                 enabled={props.mapInfo.enabled}
                 htmlResponses={props.mapInfo.responses}
                 htmlRequests={props.mapInfo.requests}

--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -1,0 +1,74 @@
+
+const INFO_FORMATS = {
+    "TEXT": "text/plain",
+    "HTML": "text/html",
+    "JSONP": "text/javascript",
+    "JSON": "application/json",
+    "GML 2": "application/vnd.ogc.gml",
+    "GML 3": "application/vnd.ogc.gml/3.1.1"
+};
+const regexpBody = /^[\s\S]*<body>([\s\S]*)<\/body>[\s\S]*$/i;
+const regexpStyle = /(<style[\s\=\w\/\"]*>[^<]*<\/style>)/i;
+
+const Validator = {
+    HTML: {
+        /**
+         *Parse the HTML to get only the valid html responses
+         */
+        getValidResponses(responses) {
+            return responses.filter((res) => typeof res.response === "string" && res.response.indexOf("<?xml") !== 0 && res.response.replace(regexpBody, '$1').trim().length !== 0);
+        },
+        /**
+         * Parse the HTML to get only the NOT valid html responses
+         */
+        getNoValidResponses(responses) {
+            return responses.filter((res) => !(typeof res.response === "string" && res.response.indexOf("<?xml") !== 0 && res.response.replace(regexpBody, '$1').trim().length !== 0));
+        }
+    },
+    TEXT: {
+        /**
+         *Parse the TEXT to get only the valid text responses
+         */
+        getValidResponses(responses) {
+            return responses.filter((res) => res.response !== "" && res.response !== "no features were found\n" && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0));
+        },
+        /**
+         * Parse the TEXT to get only the NOT valid text responses
+         */
+        getNoValidResponses(responses) {
+            return responses.filter((res) => res.response === "" || res.response === "no features were found\n" || res.response && (typeof res.response === "string" && res.response.indexOf("<?xml") === 0));
+        }
+    },
+    JSON: {
+        /**
+         *Parse the JSON to get only the valid json responses
+         */
+        getValidResponses(responses) {
+            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
+        },
+        /**
+         * Parse the JSON to get only the NOT valid json responses
+         */
+        getNoValidResponses(responses) {
+            return responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
+        }
+    }
+};
+const Parser = {
+    HTML: {
+        getBody(html) {
+            return html.replace(regexpBody, '$1').trim();
+        },
+        getStyle(html) {
+            // gets css rules from the response and removes which are related to body tag.
+            let styleMatch = regexpStyle.exec(html);
+            let style = styleMatch && styleMatch.length === 2 ? regexpStyle.exec(html)[1] : "";
+            style = style.replace(/body[,]+/g, '');
+            return style;
+        },
+        getBodyWithStyle(html) {
+            return Parser.HTML.getStyle(html) + Parser.HTML.getBody(html);
+        }
+    }
+};
+module.exports = {INFO_FORMATS, Validator, Parser};

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -6,15 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const INFO_FORMATS = {
-    "TEXT": "text/plain",
-    "HTML": "text/html",
-    "JSONP": "text/javascript",
-    "JSON": "application/json",
-    "GML 2": "application/vnd.ogc.gml",
-    "GML 3": "application/vnd.ogc.gml/3.1.1"
-};
-
+const INFO_FORMATS = require("./FeatureInfoUtils").INFO_FORMATS;
 /**
  * specifies which info formats are currently supported
  */

--- a/web/client/utils/__tests__/FeatureInfoUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoUtils-test.js
@@ -1,0 +1,84 @@
+var expect = require('expect');
+var FeatureInfoUtils = require('../FeatureInfoUtils');
+
+describe('FeatureInfoUtils', () => {
+    // **********************************
+    // HTML
+    // **********************************
+    const styleSample = '<style type="text/css">.sample {border:1px solid #ddd;}</style>';
+    const bodySample = '<div class="sample">TEST text</div>';
+    const rowHTML = '<html>'
+        + '<head>'
+        + '<title>Geoserver GetFeatureInfo output</title>'
+        + styleSample
+        + '</head>'
+        + '<body>'
+        + bodySample
+        + '</body>'
+        + '</html>';
+
+    const bodyWithStyle = styleSample + bodySample;
+    const emptyHTML = '<html>'
+        + '<head>'
+        + '<title>Geoserver GetFeatureInfo output</title>'
+        + styleSample
+        + '</head>'
+        + '<body>'
+        + '</body>'
+        + '</html>';
+    it('HTML Parser', () => {
+        var parsedBody = FeatureInfoUtils.Parser.HTML.getBody(rowHTML);
+        var parsedStyle = FeatureInfoUtils.Parser.HTML.getStyle(rowHTML);
+        var parsedHTML = FeatureInfoUtils.Parser.HTML.getBodyWithStyle(rowHTML);
+        expect(parsedBody).toBe(bodySample);
+        expect(parsedStyle).toBe(styleSample);
+        expect(parsedHTML).toBe(bodyWithStyle);
+
+    });
+    it('HTML Validator', () => {
+        let results = FeatureInfoUtils.Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML}]);
+        expect(results.length).toBe(1);
+        expect(results[0].response).toBe(rowHTML);
+
+        let notValidResults = FeatureInfoUtils.Validator.HTML.getNoValidResponses([{response: emptyHTML}, {response: rowHTML}]);
+        expect(notValidResults.length).toBe(1);
+        expect(notValidResults[0].response).toBe(emptyHTML);
+    });
+
+    // **********************************
+    // TEXT
+    // **********************************
+    const baseTextGFI = 'GetFeatureInfo results:\n';
+    const notValid = '';
+    const validTEXT = baseTextGFI
+        + '\n'
+        + "Layer 'LimiteRegionale''\n"
+        + "Feature 0:'\n"
+        + "uuid = 'fc1132ee-cf89-4fb0-a25d-315bb3c34568''\n";
+
+    it('TEXT Validator', () => {
+        let results = FeatureInfoUtils.Validator.TEXT.getValidResponses([{response: notValid}, {response: validTEXT}]);
+        expect(results.length).toBe(1);
+        expect(results[0].response).toBe(validTEXT);
+
+        let notValidResults = FeatureInfoUtils.Validator.TEXT.getNoValidResponses([{response: notValid}, {response: validTEXT}]);
+        expect(notValidResults.length).toBe(1);
+        expect(notValidResults[0].response).toBe(notValid);
+    });
+
+    // **********************************
+    // JSON
+    // **********************************
+    const validJSON = {"type": "FeatureCollection", "totalFeatures": "unknown", "features": [{"type": "Feature", "id": "", "geometry": null, "properties": {"precip30min": 816}}], "crs": null};
+    const emptyJSON = {"type": "FeatureCollection", "totalFeatures": "unknown", "features": [], "crs": null};
+    it('JSON Validator', () => {
+        let results = FeatureInfoUtils.Validator.JSON.getValidResponses([{response: validJSON}, {response: emptyJSON}]);
+        expect(results.length).toBe(1);
+        expect(results[0].response).toBe(validJSON);
+
+        let notValidResults = FeatureInfoUtils.Validator.JSON.getNoValidResponses([{response: validJSON}, {response: emptyJSON}]);
+        expect(notValidResults.length).toBe(1);
+        expect(notValidResults[0].response).toBe(emptyJSON);
+    });
+
+});


### PR DESCRIPTION
* Reorganized and cleaned up the feature info tool. 
* Setup the layout for mobile feature info. The pages are swipable on mobile devices. 
* fixed issues with Feature Info wrong responses and format change issues. 
![image](https://cloud.githubusercontent.com/assets/1279510/12268872/fb8898a8-b94e-11e5-914f-f0675406421c.png)


This can be a first implementation of #343. Proposed future improvements for mobile:
* display arrows in mobile layout only if there are other pages
* Display the page number e.g. (1 of 5)
* Implement gesture to shift the feature info panel  up and down. 
* Hide the searchbar and move up the location tool when the feature info panel is expanded. 
* Pan the map to make the marker visible at the center of the page. 