### PR TITLE
#394 Implemented openlayers bing maxNativeZoom parameter with default

### DIFF
--- a/web/client/components/map/openlayers/plugins/BingLayer.js
+++ b/web/client/components/map/openlayers/plugins/BingLayer.js
@@ -12,6 +12,7 @@ var ol = require('openlayers');
 Layers.registerType('bing', {
     create: (options) => {
         var key = options.apiKey;
+        var maxNativeZoom = options.maxNativeZoom || 19;
         return new ol.layer.Tile({
             preload: Infinity,
             opacity: options.opacity !== undefined ? options.opacity : 1,
@@ -19,7 +20,8 @@ Layers.registerType('bing', {
             visible: options.visibility,
             source: new ol.source.BingMaps({
               key: key,
-              imagerySet: options.name
+              imagerySet: options.name,
+              maxZoom: maxNativeZoom
             })
         });
     }


### PR DESCRIPTION
This pull request add the maxNativeZoom parameter to Bing layer for OpenLayers.
By default it is 19. 
See #394 for the reason why leaflet is not implementing it yet.