### PR TITLE
fix #408 added featureInfoParams in layer configuration 

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -78,8 +78,8 @@ function newMapInfoRequest(reqId, reqConfig) {
  * @param wmsBasePath {string} base path to the wms service
  * @param requestParams {object} map of params for a getfeatureinfo request.
  */
-function getFeatureInfo(wmsBasePath, requestParams, lMetaData) {
-    const defaultParams = {
+function getFeatureInfo(wmsBasePath, requestParams, lMetaData, options = {}) {
+    const defaultParams = assign({
         service: 'WMS',
         version: '1.1.1',
         request: 'GetFeatureInfo',
@@ -88,7 +88,7 @@ function getFeatureInfo(wmsBasePath, requestParams, lMetaData) {
         x: 0,
         y: 0,
         exceptions: 'application/json'
-    };
+    }, options);
     const param = assign({}, defaultParams, requestParams);
     const reqId = uuid.v1();
     return (dispatch) => {

--- a/web/client/examples/viewer/components/getFeatureInfo/GetFeatureInfo.jsx
+++ b/web/client/examples/viewer/components/getFeatureInfo/GetFeatureInfo.jsx
@@ -126,7 +126,7 @@ var GetFeatureInfo = React.createClass({
                     regex: layer.featureInfoRegex
                 };
                 const url = layer.url.replace(/[?].*$/g, '');
-                this.props.actions.getFeatureInfo(url, requestConf, layerMetadata);
+                this.props.actions.getFeatureInfo(url, requestConf, layerMetadata, layer.featureInfoParams);
             }
             this.props.actions.showMapinfoMarker();
         }


### PR DESCRIPTION
`featureInfoParams` can be used to add or override parameters for the GFI request. 