### PR TITLE
Added jsx Template, based on babel-standalone lib

### DIFF
--- a/karma.conf.continuous-test.js
+++ b/karma.conf.continuous-test.js
@@ -1,3 +1,5 @@
+var path = require("path");
+var NormalModuleReplacementPlugin = require("webpack/lib/NormalModuleReplacementPlugin");
 module.exports = function karmaConfig(config) {
     config.set({
 
@@ -38,6 +40,9 @@ module.exports = function karmaConfig(config) {
 
         webpack: {
             devtool: 'inline-source-map',
+            plugins: [
+                new NormalModuleReplacementPlugin(/babel-standalone$/, path.join(__dirname, "web", "client", "libs", "babel"))
+            ],
             module: {
                 loaders: [
                     { test: /\.jsx?$/, exclude: /(ol\.js$)/, loader: 'babel-loader', query: {stage: 0} },

--- a/karma.conf.single-run.js
+++ b/karma.conf.single-run.js
@@ -1,3 +1,5 @@
+var path = require("path");
+var NormalModuleReplacementPlugin = require("webpack/lib/NormalModuleReplacementPlugin");
 module.exports = function karmaConfig(config) {
     config.set({
 
@@ -38,6 +40,9 @@ module.exports = function karmaConfig(config) {
 
         webpack: {
             devtool: 'inline-source-map',
+            plugins: [
+                new NormalModuleReplacementPlugin(/babel-standalone$/, path.join(__dirname, "web", "client", "libs", "babel"))
+                ],
             module: {
                 loaders: [
                     { test: /\.jsx?$/, exclude: /(ol\.js$)/, loader: 'babel-loader', query: {stage: 0} },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "//": "replace react-sortable-items with official on npm when 0.0.10 with remove_deprecated PR in included",
   "dependencies": {
     "axios": "^0.8.1",
+    "babel-standalone": "^6.4.4",
     "bootstrap": "^3.3.5",
     "classnames": "^2.1.5",
     "es6-promise": "^2.3.0",
@@ -83,8 +84,8 @@
     "react-sidebar": "^2.1.1",
     "react-sortable-items": "0.0.11",
     "react-swipe": "^3.0.0",
-    "redux": "3.1.3",
     "react-widgets": "^3.1.7",
+    "redux": "3.1.3",
     "redux-logger": "^2.0.0",
     "redux-thunk": "^0.1.0",
     "redux-undo": "^0.5.0",

--- a/web/client/components/template/jsx/Template.jsx
+++ b/web/client/components/template/jsx/Template.jsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const Babel = require('babel-standalone');
+const {isEqual} = require("lodash");
+
+const Template = React.createClass({
+    propTypes: {
+        template: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
+        model: React.PropTypes.object
+    },
+    getDefaultProps() {
+        return {
+            template: "",
+            model: {}
+        };
+    },
+    componentWillMount() {
+        let template = (typeof this.props.template === 'function') ? this.props.template() : this.props.template;
+        this.comp = Babel.transform(template, { presets: ['es2015', 'react', 'stage-0'] }).code;
+    },
+    shouldComponentUpdate(nextProps) {
+        return !isEqual(nextProps, this.props);
+    },
+    renderCard() {
+        /*eslint-disable */
+        let model = this.props.model;
+        return eval(this.comp);
+        /*eslint-enable */
+    },
+    render() {
+        return (<div>{this.renderCard()}</div>);
+    }
+});
+
+module.exports = Template;

--- a/web/client/components/template/jsx/__tests__/Template-test.jsx
+++ b/web/client/components/template/jsx/__tests__/Template-test.jsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react/addons');
+var expect = require('expect');
+var ReactDOM = require('react-dom');
+var Template = require('../Template');
+const Babel = require('babel-standalone');
+
+describe("Test JSX Template", () => {
+    beforeEach((done) => {
+        Babel.bind({
+            "<div id='template'/>": "'use strict';React.createElement('div', { id: 'template' })",
+            "<div id={model.id}/>": "'use strict';React.createElement('div', { id: model.id })"
+      });
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        Babel.clear();
+        setTimeout(done);
+    });
+
+    it('Test Template render jsx string', () => {
+        let comp = ReactDOM.render(
+            <Template template="<div id='template'/>"/>, document.getElementById("container"));
+        expect(comp).toExist();
+        const cmpDom = document.getElementById("template");
+        expect(cmpDom).toExist();
+        expect(cmpDom.id).toExist();
+        expect(cmpDom.id).toBe("template");
+    });
+    it('Test Template render jsx as functipn', () => {
+        let comp = ReactDOM.render(
+            <Template
+                template={ () => { return "<div id='template'/>"; } } />, document.getElementById("container"));
+        expect(comp).toExist();
+        const cmpDom = document.getElementById("template");
+        expect(cmpDom).toExist();
+        expect(cmpDom.id).toExist();
+        expect(cmpDom.id).toBe("template");
+    });
+    it('Test Template render jsx string with model substitution', () => {
+        let comp = ReactDOM.render(
+            <Template template="<div id={model.id}/>" model={{id: "template"}} />
+            , document.getElementById("container"));
+        expect(comp).toExist();
+        const cmpDom = document.getElementById("template");
+        expect(cmpDom).toExist();
+        expect(cmpDom.id).toExist();
+        expect(cmpDom.id).toBe("template");
+    });
+    it('Test Template update', () => {
+        let comp = ReactDOM.render(
+            <Template template="<div id={model.id}/>" model={{id: "template"}} />
+            , document.getElementById("container"));
+        expect(comp).toExist();
+        let cmpDom = document.getElementById("template");
+        expect(cmpDom).toExist();
+        expect(cmpDom.id).toExist();
+        expect(cmpDom.id).toBe("template");
+        comp.setProps({model: {id: "template-update" }});
+        cmpDom = document.getElementById("template-update");
+        expect(cmpDom).toExist();
+        expect(cmpDom.id).toExist();
+        expect(cmpDom.id).toBe("template-update");
+    });
+});

--- a/web/client/libs/babel.js
+++ b/web/client/libs/babel.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const Babel = (function() {
+    let cache;
+    return {
+        transform: function(str) {
+            return { code: cache[str]};
+        },
+        bind: function(obj) {
+            cache = obj;
+        },
+        clear: function() {
+            cache = null;
+        }
+    };
+})();
+
+module.exports = Babel;


### PR DESCRIPTION
Template components accept to props, template and model.
Tamplate could be valid jsx string or a function returning a valid jsx string.
Model is object containing data.
In template string you can refer to model properties.
Example:
 <Template template="<div id={model.id}/>" model={ {id: 10} }/>
This will render a div with id = 10;