### PR TITLE
query tool: Add WFS service URL for combos

### DIFF
--- a/web/client/components/data/query/GroupField.jsx
+++ b/web/client/components/data/query/GroupField.jsx
@@ -69,15 +69,15 @@ const GroupField = React.createClass({
                 // The complete attribute config object
                 let attribute = attributes.filter((attr) => attr.id === filterField.attribute)[0];
                 // The reference ID of the related attribute field value
-                let attributeRefId = attribute.values.filter((value) => value.name === filterField.value)[0][selected.dependson.from];
+                let attributeRefId = attribute.values.filter((value) => value[attribute.labelField] === filterField.value)[0][selected.dependson.from];
                 // The filtered values that match the attribute refId
                 let values = selected.values.filter((value) => value[selected.dependson.to] === attributeRefId);
 
-                return (selected && selected.type === "list" ? values.map((value) => value.name || value) : null);
+                return (selected && selected.type === "list" ? values.map((value) => value[selected.labelField] || value) : null);
             }
         }
 
-        return (selected && selected.type === "list" ? selected.values.map((value) => value.name || value) : null);
+        return (selected && selected.type === "list" ? selected.values.map((value) => value[selected.labelField] || value) : null);
     },
     renderFilterField(filterField) {
         let selectedAttribute = this.props.attributes.filter((attribute) => attribute.id === filterField.attribute)[0];

--- a/web/client/components/data/query/__tests__/GroupField-test.jsx
+++ b/web/client/components/data/query/__tests__/GroupField-test.jsx
@@ -138,6 +138,8 @@ describe('GroupField', () => {
             {
                 id: "Attribute",
                 type: "list",
+                idField: "id",
+                labelField: "name",
                 values: [
                     {id: 1, name: "attribute1"},
                     {id: 2, name: "attribute2"},
@@ -149,6 +151,8 @@ describe('GroupField', () => {
                 id: "Attribute2",
                 dependson: {field: "Attribute", from: "id", to: "id"},
                 type: "list",
+                idField: "id",
+                labelField: "name",
                 values: [
                     {id: 1, name: "attribute_a"},
                     {id: 1, name: "attribute_b"},


### PR DESCRIPTION
This pull request allows the possibility to give the combo values from the WFS json output format.
New parameters to use for each attribute configuration:

"valueService": the WFS URL in json oputputformat
"idField": the id field af the feature type,
"labelField": the ft attribute to use as label,
