### PR TITLE
Always lint sources before testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "start": "webpack-dev-server --progress --colors --port 8081 --hot --inline --content-base web/client",
     "examples": "webpack-dev-server --progress --colors --port 8081 --hot --inline --content-base web/client --config examples-webpack.config.js",
     "test": "karma start ./karma.conf.single-run.js",
+    "pretest": "npm run lint",
     "continuoustest": "karma start ./karma.conf.continuous-test.js",
     "mvntest": "karma start ./karma.conf.single-run.js --reporters junit,dots,coverage",
     "lint": "eslint web/client --ext .jsx,.js",


### PR DESCRIPTION
This PR suggests to add a `pretest` script which calls the `lint` script automatically when one runs `npm test`.

Please review.