### PR TITLE
Added styler to shapefile import component

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "proj4": "~2.3.6",
     "react": "0.14.8",
     "react-bootstrap": "0.28.1",
+    "react-color": "^2.0.0",
     "react-dom": "0.14.8",
     "react-draggable": "1.3.4",
     "react-dropzone": "^3.4.0",

--- a/web/client/actions/__tests__/shapefile-test.js
+++ b/web/client/actions/__tests__/shapefile-test.js
@@ -22,7 +22,7 @@ describe('Test correctness of the shapefile actions', () => {
         const retVal = onShapeChoosen('val');
         expect(retVal).toExist();
         expect(retVal.type).toBe(ON_SHAPE_CHOOSEN);
-        expect(retVal.files).toBe('val');
+        expect(retVal.layers).toBe('val');
     });
 
     it('onShapeError', () => {

--- a/web/client/actions/__tests__/style-test.js
+++ b/web/client/actions/__tests__/style-test.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+const {
+    SET_STYLE_PARAMETER,
+    setStyleParameter
+} = require('../style');
+
+describe('Test correctness of the style actions', () => {
+
+    it('setStyleParameter', () => {
+        const retVal = setStyleParameter('name', 'val');
+        expect(retVal).toExist();
+        expect(retVal.type).toBe(SET_STYLE_PARAMETER);
+        expect(retVal.name).toBe('name');
+        expect(retVal.value).toBe('val');
+    });
+});

--- a/web/client/actions/shapefile.js
+++ b/web/client/actions/shapefile.js
@@ -10,10 +10,10 @@ const ON_SHAPE_ERROR = 'ON_SHAPE_ERROR';
 const SHAPE_LOADING = 'SHAPE_LOADING';
 
 
-function onShapeChoosen(files) {
+function onShapeChoosen(layers) {
     return {
         type: ON_SHAPE_CHOOSEN,
-        files
+        layers
     };
 }
 function onShapeError(message) {

--- a/web/client/actions/shapefile.js
+++ b/web/client/actions/shapefile.js
@@ -7,13 +7,21 @@
  */
 const ON_SHAPE_CHOOSEN = 'ON_SHAPE_CHOOSEN';
 const ON_SHAPE_ERROR = 'ON_SHAPE_ERROR';
+const ON_SELECT_LAYER = 'ON_SELECT_LAYER';
 const SHAPE_LOADING = 'SHAPE_LOADING';
+const ON_LAYER_ADDED = 'ON_LAYER_ADDED';
 
 
 function onShapeChoosen(layers) {
     return {
         type: ON_SHAPE_CHOOSEN,
         layers
+    };
+}
+function onSelectLayer(layer) {
+    return {
+        type: ON_SELECT_LAYER,
+        layer
     };
 }
 function onShapeError(message) {
@@ -28,11 +36,21 @@ function shapeLoading(status) {
         status
     };
 }
+function onLayerAdded(layer) {
+    return {
+        type: ON_LAYER_ADDED,
+        layer
+    };
+}
 module.exports = {
     ON_SHAPE_CHOOSEN,
     ON_SHAPE_ERROR,
     SHAPE_LOADING,
+    ON_SELECT_LAYER,
+    ON_LAYER_ADDED,
     onShapeChoosen,
     onShapeError,
-    shapeLoading
+    shapeLoading,
+    onSelectLayer,
+    onLayerAdded
 };

--- a/web/client/actions/style.js
+++ b/web/client/actions/style.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const SET_STYLE_PARAMETER = 'SET_STYLE_PARAMETER';
+
+function setStyleParameter(name, value) {
+    return {
+        type: SET_STYLE_PARAMETER,
+        name,
+        value
+    };
+}
+
+module.exports = {
+    SET_STYLE_PARAMETER,
+    setStyleParameter
+};

--- a/web/client/components/map/leaflet/Feature.jsx
+++ b/web/client/components/map/leaflet/Feature.jsx
@@ -58,12 +58,12 @@ var geometryToLayer = function(geojson, options) {
     case 'LineString':
     case 'MultiLineString':
         latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, coordsToLatLng);
-        return new L.Polyline(latlngs, options);
+        return new L.Polyline(latlngs, options.style);
 
     case 'Polygon':
     case 'MultiPolygon':
         latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, coordsToLatLng);
-        return new L.Polygon(latlngs, options);
+        return new L.Polygon(latlngs, options.style);
 
     case 'GeometryCollection':
         for (i = 0, len = geometry.geometries.length; i < len; i++) {
@@ -90,15 +90,18 @@ let Feature = React.createClass({
         styleName: React.PropTypes.string,
         properties: React.PropTypes.object,
         container: React.PropTypes.object, // TODO it must be a L.GeoJSON
-        geometry: React.PropTypes.object // TODO check for geojson format for geometry
+        geometry: React.PropTypes.object, // TODO check for geojson format for geometry
+        style: React.PropTypes.object
     },
     componentDidMount() {
         if (this.props.container) {
+            let style = this.props.style;
             this._layer = geometryToLayer({
                 type: this.props.type,
-                geometry: this.props.geometry,
+                geometry: this.props.geometry}, {
+                style: style,
                 pointToLayer: this.props.styleName !== "marker" ? function(feature, latlng) {
-                    return L.circleMarker(latlng, {
+                    return L.circleMarker(latlng, style || {
                         radius: 5,
                         color: "red",
                         weight: 1,
@@ -115,9 +118,11 @@ let Feature = React.createClass({
             this.props.container.removeLayer(this._layer);
             this._layer = geometryToLayer({
                 type: newProps.type,
-                geometry: newProps.geometry,
+                geometry: newProps.geometry},
+                {
+                style: newProps.style,
                 pointToLayer: newProps.styleName !== "marker" ? function(feature, latlng) {
-                    return L.circleMarker(latlng, {
+                    return L.circleMarker(latlng, newProps.style || {
                         radius: 5,
                         color: "red",
                         weight: 1,

--- a/web/client/components/map/leaflet/plugins/VectorLayer.jsx
+++ b/web/client/components/map/leaflet/plugins/VectorLayer.jsx
@@ -21,9 +21,10 @@ var createVectorLayer = function(options) {
     const {hideLoading} = options;
     return L.geoJson([]/* options.features */, {
         pointToLayer: options.styleName !== "marker" ? function(feature, latlng) {
-            return L.circleMarker(latlng, defaultStyle);
+            return L.circleMarker(latlng, options.style || defaultStyle);
         } : null,
-        hideLoading: hideLoading
+        hideLoading: hideLoading,
+        style: options.style || defaultStyle
     });
 };
 

--- a/web/client/components/style/ColorPicker.jsx
+++ b/web/client/components/style/ColorPicker.jsx
@@ -1,0 +1,61 @@
+const React = require('react');
+
+const { SketchPicker } = require('react-color');
+require('./colorpicker.css');
+const ColorPicker = React.createClass({
+  propTypes: {
+        value: React.PropTypes.shape({r: React.PropTypes.number, g: React.PropTypes.number, b: React.PropTypes.number, a: React.PropTypes.number}),
+        onChangeColor: React.PropTypes.func,
+        text: React.PropTypes.string,
+        line: React.PropTypes.bool,
+        disabled: React.PropTypes.bool
+    },
+  getInitialState() {
+      return {
+        displayColorPicker: false
+      };
+  },
+  getDefaultProps() {
+      return {
+          disabled: false,
+          line: false,
+          text: "Color",
+          value: {
+              r: 0,
+              g: 0,
+              b: 0,
+              a: 1
+          },
+        onChangeColor: () => {}
+      };
+  },
+  getStyle() {
+      let color = this.state.color || this.props.value;
+      return this.props.line ?
+      {
+        color: `rgba(${ color.r }, ${ color.g }, ${ color.b }, ${ color.a })`,
+        background: `rgba(${ 256 - color.r }, ${ 256 - color.g }, ${ 256 - color.b }, 1)`
+      }
+      :
+      {
+        background: `rgba(${ color.r }, ${ color.g }, ${ color.b }, ${ color.a })`,
+        color: `rgba(${ 256 - color.r }, ${ 256 - color.g }, ${ 256 - color.b }, 1)`
+      };
+  },
+  render() {
+      return (
+      <div>
+        <div className={this.props.disabled ? "cp-disabled" : "cp-swatch" }style={this.getStyle()} onClick={ () => { if (!this.props.disabled) { this.setState({ displayColorPicker: !this.state.displayColorPicker }); } } }>
+        {this.props.text}
+        </div>
+        { this.state.displayColorPicker ? <div className="cp-popover">
+          <div className="cp-cover" onClick={ () => { this.setState({ displayColorPicker: false }); this.props.onChangeColor(this.state.color); }}/>
+          <SketchPicker color={ this.state.color || this.props.value} onChange={ (color) => { this.setState({ color: color.rgb }); }} />
+        </div> : null }
+
+      </div>
+    );
+  }
+});
+
+module.exports = ColorPicker;

--- a/web/client/components/style/StyleCanvas.jsx
+++ b/web/client/components/style/StyleCanvas.jsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+// const Tuscany = require('./Tuscany').split(" ");
+const defaultIcon = require('../map/openlayers/img/marker-icon.png');
+const StyleCanvas = React.createClass({
+    propTypes: {
+        style: React.PropTypes.object,
+        shapeStyle: React.PropTypes.object,
+        geomType: React.PropTypes.oneOf(['Polygon', 'Polyline', 'Point', 'Marker', undefined]),
+        width: React.PropTypes.number,
+        height: React.PropTypes.number
+    },
+    getDefaultProps() {
+        return {
+          style: {},
+          shapeStyle: {},
+          geomType: 'Polygon',
+          width: 100,
+          height: 80
+        };
+    },
+    componentDidMount: function() {
+      let context = this.refs.styleCanvas.getContext('2d');
+      this.paint(context);
+  },
+
+    componentDidUpdate: function() {
+      let context = this.refs.styleCanvas.getContext('2d');
+      context.clearRect(0, 0, 500, 500);
+      this.paint(context);
+  },
+  render() {
+      return <canvas ref="styleCanvas" style={this.props.style} width={this.props.width} height={this.props.height} />;
+  },
+  paint(ctx) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.fillStyle = `rgba(${ this.props.shapeStyle.fill.r }, ${ this.props.shapeStyle.fill.g }, ${ this.props.shapeStyle.fill.b }, ${ this.props.shapeStyle.fill.a })`;
+      ctx.strokeStyle = `rgba(${ this.props.shapeStyle.color.r }, ${ this.props.shapeStyle.color.g }, ${ this.props.shapeStyle.color.b }, ${ this.props.shapeStyle.color.a })`;
+      ctx.lineWidth = this.props.shapeStyle.width;
+      switch (this.props.geomType) {
+          case 'Polygon': {
+              this.paintPolygon(ctx);
+              break;
+          }
+          case 'Polyline': {
+              this.paintPolyline(ctx);
+              break;
+          }
+          case 'Point': {
+              this.paintPoint(ctx);
+              break;
+          }
+          case 'Marker': {
+              this.paintMarker(ctx);
+              break;
+          }
+          default: {
+              return;
+          }
+      }
+      ctx.restore();
+  },
+  paintPolygon(ctx) {
+      ctx.transform(1, 0, 0, 1, -27.5, 0);
+      ctx.moveTo(55, 8);
+      ctx.lineTo(100, 8);
+      ctx.lineTo(117.5, 40);
+      ctx.lineTo(100, 72);
+      ctx.lineTo(55, 72);
+      ctx.lineTo(37.5, 40);
+      ctx.closePath();
+     // ctx.moveTo(117.5, 40);
+     // ctx.arc(77.5, 40, 40, 0, 2 * Math.PI);
+      ctx.fill();
+      ctx.stroke();
+  },
+  paintPolyline(ctx) {
+      ctx.transform(1, 0, 0, 1, 0, 0);
+      ctx.moveTo(10, 20);
+      ctx.bezierCurveTo(40, 40, 70, 0, 90, 20);
+      ctx.stroke();
+  },
+  paintPoint(ctx) {
+      // ctx.moveTo(50, 40);
+      ctx.arc(50, 48.5, this.props.shapeStyle.radius, 0, 2 * Math.PI);
+      ctx.fill();
+      ctx.stroke();
+  },
+  paintMarker(ctx) {
+      // ctx.moveTo(50, 40);
+      let icon = new Image();
+      icon.src = defaultIcon;
+      try {
+          ctx.drawImage(icon, 42.5, 24);
+      }catch (e) {
+          return;
+      }
+  }
+});
+
+module.exports = StyleCanvas;

--- a/web/client/components/style/StylePoint.jsx
+++ b/web/client/components/style/StylePoint.jsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const {Grid, Row, Col} = require('react-bootstrap');
+const ColorPicker = require('./ColorPicker');
+const StyleCanvas = require('./StyleCanvas');
+const numberLocalizer = require('react-widgets/lib/localizers/simple-number');
+numberLocalizer();
+const {NumberPicker} = require('react-widgets');
+require('react-widgets/lib/less/react-widgets.less');
+
+const StylePoint = React.createClass({
+    propTypes: {
+        shapeStyle: React.PropTypes.object,
+        setStyleParameter: React.PropTypes.func
+    },
+    getDefaultProps() {
+        return {
+            shapeStyle: {},
+            setStyleParameter: () => {}
+        };
+    },
+    render() {
+        return (
+            <Grid fluid={true}>
+                <Row>
+                    <Col xs={4} style={{padding: 0}}>
+                        <StyleCanvas style={{ padding: 0, margin: "auto", display: "block"}}
+                            height={97}
+                            shapeStyle={this.props.shapeStyle}
+                            geomType={this.props.shapeStyle.marker ? "Marker" : "Point"}
+                        />
+                    </Col>
+                    <Col xs={7}>
+                        <Row>
+                            <Col xs={1}>
+                                <input aria-label="..." type="checkbox" defaultChecked={this.props.shapeStyle.marker} onChange={(e) => { this.props.setStyleParameter("marker", e.target.checked); }}/>
+                            </Col>
+                            <Col style={{paddingLeft: 0, paddingTop: 1}} xs={4}>
+                                <label>Marker</label>
+                            </Col>
+                        </Row>
+                        <Row >
+                            <Col xs={4}>
+                                <ColorPicker
+                                    disabled={this.props.shapeStyle.marker}
+                                    value={this.props.shapeStyle.color}
+                                    line={true}
+                                    text="Stroke"
+                                    onChangeColor={(color) => {if (color) { this.props.setStyleParameter("color", color); } }} />
+                            </Col>
+                            <Col xs={8} style={{paddingRight: 0, paddingLeft: 30}}>
+                                <NumberPicker disabled={this.props.shapeStyle.marker} onChange={(number) => {this.props.setStyleParameter("width", number); }} min={1} max={15} step={1} value={this.props.shapeStyle.width}/>
+                            </Col>
+                        </Row>
+                        <Row style={{marginTop: 4}}>
+                            <Col xs={4}>
+                                <ColorPicker
+                                    disabled={this.props.shapeStyle.marker}
+                                    value={this.props.shapeStyle.fill}
+                                    line={false}
+                                    text="Fill"
+                                    onChangeColor={(color) => { if (color) { this.props.setStyleParameter("fill", color); } }} />
+                            </Col>
+                            <Col xs={8} style={{paddingRight: 0, paddingLeft: 30}}>
+                                <NumberPicker disabled={this.props.shapeStyle.marker} onChange={(number) => {this.props.setStyleParameter("radius", number); }} min={1} max={35} step={1} value={this.props.shapeStyle.radius}/>
+                            </Col>
+                        </Row>
+                    </Col>
+                </Row>
+                </Grid>);
+    }
+});
+
+module.exports = StylePoint;

--- a/web/client/components/style/StylePoint.jsx
+++ b/web/client/components/style/StylePoint.jsx
@@ -51,7 +51,7 @@ const StylePoint = React.createClass({
                                 <ColorPicker
                                     disabled={this.props.shapeStyle.marker}
                                     value={this.props.shapeStyle.color}
-                                    line={true}
+                                    line={false}
                                     text="Stroke"
                                     onChangeColor={(color) => {if (color) { this.props.setStyleParameter("color", color); } }} />
                             </Col>

--- a/web/client/components/style/StylePolygon.jsx
+++ b/web/client/components/style/StylePolygon.jsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const {Grid, Row, Col} = require('react-bootstrap');
+const ColorPicker = require('./ColorPicker');
+const StyleCanvas = require('./StyleCanvas');
+const numberLocalizer = require('react-widgets/lib/localizers/simple-number');
+numberLocalizer();
+const {NumberPicker} = require('react-widgets');
+require('react-widgets/lib/less/react-widgets.less');
+
+const StylePolygon = React.createClass({
+    propTypes: {
+        shapeStyle: React.PropTypes.object,
+        setStyleParameter: React.PropTypes.func
+    },
+    getDefaultProps() {
+        return {
+            shapeStyle: {},
+            setStyleParameter: () => {}
+        };
+    },
+    render() {
+        return (<Grid fluid={true}>
+                <Row>
+                    <Col xs={4} style={{padding: 0}}>
+                        <StyleCanvas style={{ padding: 0, margin: "auto", display: "block"}}
+                            shapeStyle={this.props.shapeStyle}
+                            geomType="Polygon"
+                        />
+                    </Col>
+                    <Col xs={7}>
+                        <Row style={{marginTop: 7}}>
+                            <Col xs={4}>
+                                <ColorPicker
+                                    value={this.props.shapeStyle.color}
+                                    line={true}
+                                    text="Stroke"
+                                    onChangeColor={(color) => {if (color) { this.props.setStyleParameter("color", color); } }} />
+                            </Col>
+                            <Col xs={8} style={{paddingRight: 0, paddingLeft: 30}}>
+                                <NumberPicker onChange={(number) => {this.props.setStyleParameter("width", number); }} min={1} max={15} step={1} value={this.props.shapeStyle.width}/>
+                            </Col>
+                        </Row>
+                        <Row style={{marginTop: 4}}>
+                            <Col xs={6}>
+                                <ColorPicker
+                                    value={this.props.shapeStyle.fill}
+                                    line={false}
+                                    text="Fill"
+                                    onChangeColor={(color) => { if (color) { this.props.setStyleParameter("fill", color); } }} />
+                            </Col>
+
+                        </Row>
+                    </Col>
+                </Row>
+                </Grid>);
+    }
+});
+
+module.exports = StylePolygon;

--- a/web/client/components/style/StylePolygon.jsx
+++ b/web/client/components/style/StylePolygon.jsx
@@ -40,7 +40,7 @@ const StylePolygon = React.createClass({
                             <Col xs={4}>
                                 <ColorPicker
                                     value={this.props.shapeStyle.color}
-                                    line={true}
+                                    line={false}
                                     text="Stroke"
                                     onChangeColor={(color) => {if (color) { this.props.setStyleParameter("color", color); } }} />
                             </Col>

--- a/web/client/components/style/StylePolyline.jsx
+++ b/web/client/components/style/StylePolyline.jsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const {Grid, Row, Col} = require('react-bootstrap');
+const ColorPicker = require('./ColorPicker');
+const StyleCanvas = require('./StyleCanvas');
+const numberLocalizer = require('react-widgets/lib/localizers/simple-number');
+numberLocalizer();
+const {NumberPicker} = require('react-widgets');
+require('react-widgets/lib/less/react-widgets.less');
+
+const StylePolyline = React.createClass({
+    propTypes: {
+        shapeStyle: React.PropTypes.object,
+        setStyleParameter: React.PropTypes.func
+    },
+    getDefaultProps() {
+        return {
+            shapeStyle: {},
+            setStyleParameter: () => {}
+        };
+    },
+    render() {
+        return (<Grid fluid={true}>
+                <Row>
+                    <Col xs={4} style={{padding: 0}}>
+                        <StyleCanvas style={{ padding: 0, margin: "auto", display: "block"}}
+                            shapeStyle={this.props.shapeStyle}
+                            geomType="Polyline"
+                            height={40}
+                        />
+                    </Col>
+                    <Col xs={7}>
+                        <Row style={{marginTop: 7}}>
+                            <Col xs={4}>
+                                <ColorPicker
+                                    value={this.props.shapeStyle.color}
+                                    line={true}
+                                    text="Stroke"
+                                    onChangeColor={(color) => {if (color) { this.props.setStyleParameter("color", color); } }} />
+                            </Col>
+                            <Col xs={8} style={{paddingRight: 0, paddingLeft: 30}}>
+                                <NumberPicker onChange={(number) => {this.props.setStyleParameter("width", number); }} min={1} max={15} step={1} value={this.props.shapeStyle.width}/>
+                            </Col>
+                        </Row>
+                    </Col>
+                </Row>
+                </Grid>);
+    }
+});
+
+module.exports = StylePolyline;

--- a/web/client/components/style/StylePolyline.jsx
+++ b/web/client/components/style/StylePolyline.jsx
@@ -41,7 +41,7 @@ const StylePolyline = React.createClass({
                             <Col xs={4}>
                                 <ColorPicker
                                     value={this.props.shapeStyle.color}
-                                    line={true}
+                                    line={false}
                                     text="Stroke"
                                     onChangeColor={(color) => {if (color) { this.props.setStyleParameter("color", color); } }} />
                             </Col>

--- a/web/client/components/style/__tests__/ColorPiker-test.jsx
+++ b/web/client/components/style/__tests__/ColorPiker-test.jsx
@@ -1,0 +1,28 @@
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ColorPicker = require('../ColorPicker');
+
+describe("Test the ColorPicker style component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates component with defaults', () => {
+        const cmp = ReactDOM.render(<ColorPicker line={true}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+    it('creates component loading', () => {
+        const cmp = ReactDOM.render(<ColorPicker line={false} disabled={true}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+});

--- a/web/client/components/style/__tests__/StyleCanvas-test.jsx
+++ b/web/client/components/style/__tests__/StyleCanvas-test.jsx
@@ -1,0 +1,43 @@
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const StyleCanvas = require('../StyleCanvas');
+
+let shapeStyle = {
+    color: { r: 0, g: 0, b: 255, a: 1 },
+    width: 3,
+    fill: { r: 0, g: 0, b: 255, a: 0.1 },
+    radius: 10,
+    marker: false
+};
+
+describe("Test the StyleCanvas style component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('test component drawing polygon', () => {
+        const cmp = ReactDOM.render(<StyleCanvas shapeStyle={shapeStyle} geomType="Polygon"/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+    it('test component drawing line', () => {
+        const cmp = ReactDOM.render(<StyleCanvas shapeStyle={shapeStyle} geomType="Polyline"/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+    it('test component drawing point', () => {
+        const cmp = ReactDOM.render(<StyleCanvas shapeStyle={shapeStyle} geomType="Point"/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+    it('test component drawing marker', () => {
+        const cmp = ReactDOM.render(<StyleCanvas shapeStyle={shapeStyle} geomType="Marker"/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+});

--- a/web/client/components/style/__tests__/StylePoint-test.jsx
+++ b/web/client/components/style/__tests__/StylePoint-test.jsx
@@ -1,0 +1,31 @@
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const StylePoint = require('../StylePoint');
+
+let shapeStyle = {
+    color: { r: 0, g: 0, b: 255, a: 1 },
+    width: 3,
+    fill: { r: 0, g: 0, b: 255, a: 0.1 },
+    radius: 10,
+    marker: false
+};
+
+describe("Test the StylePoint style component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('create component with default', () => {
+        const cmp = ReactDOM.render(<StylePoint shapeStyle={shapeStyle}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+
+});

--- a/web/client/components/style/__tests__/StylePolygon-test.jsx
+++ b/web/client/components/style/__tests__/StylePolygon-test.jsx
@@ -1,0 +1,31 @@
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const StylePolygon = require('../StylePolygon');
+
+let shapeStyle = {
+    color: { r: 0, g: 0, b: 255, a: 1 },
+    width: 3,
+    fill: { r: 0, g: 0, b: 255, a: 0.1 },
+    radius: 10,
+    marker: false
+};
+
+describe("Test the StylePolygon style component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('create component with default', () => {
+        const cmp = ReactDOM.render(<StylePolygon shapeStyle={shapeStyle}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+
+});

--- a/web/client/components/style/__tests__/StylePolyline-test.jsx
+++ b/web/client/components/style/__tests__/StylePolyline-test.jsx
@@ -1,0 +1,31 @@
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const StylePolyline = require('../StylePolyline');
+
+let shapeStyle = {
+    color: { r: 0, g: 0, b: 255, a: 1 },
+    width: 3,
+    fill: { r: 0, g: 0, b: 255, a: 0.1 },
+    radius: 10,
+    marker: false
+};
+
+describe("Test the StylePolyline style component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('create component with default', () => {
+        const cmp = ReactDOM.render(<StylePolyline shapeStyle={shapeStyle}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+
+
+});

--- a/web/client/components/style/colorpicker.css
+++ b/web/client/components/style/colorpicker.css
@@ -1,0 +1,45 @@
+ .cp-color
+ {
+  width: 24px;
+  height: 24px;
+  -webkit-border-radius: 12px;
+  -moz-border-radius: 12px;
+  border-radius: 12px;
+}
+.cp-swatch
+{
+  padding: 6px;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(0,0,0,.2);
+  display: inline-block;
+  cursor: pointer;
+  min-width: 60px;
+  min-height: 34px;
+  text-align: center;
+}
+.cp-disabled
+{
+  padding: 6px;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(0,0,0,.2);
+  display: inline-block;
+  cursor: not-allowed;
+  min-width: 60px;
+  min-height: 34px;
+  text-align: center;
+}
+.cp-popover
+{
+  position: fixed;
+  z-index: 1000;
+}
+.cp-cover
+{
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -63,7 +63,9 @@ const MapPlugin = React.createClass({
                     <plugins.Feature
                         key={feature.id}
                         type={feature.type}
-                        geometry={feature.geometry}/>
+                        geometry={feature.geometry}
+                        // FEATURE STYLE OVERWRITE LAYER STYLE
+                        style={ feature.style || layer.style || null }/>
                 );
             });
         }

--- a/web/client/plugins/ShapeFile.jsx
+++ b/web/client/plugins/ShapeFile.jsx
@@ -9,33 +9,79 @@
 const React = require('react');
 const {connect} = require('react-redux');
 
+
 const LayersUtils = require('../utils/LayersUtils');
 const FileUtils = require('../utils/FileUtils');
+let StyleUtils;
+const {Grid, Row, Col, Button} = require('react-bootstrap');
 
-const {Grid, Row} = require('react-bootstrap');
 
-const Message = require('../components/I18N/Message');
+const Message = require('./Message');
 
-const {SelectShape} = require('./shapefile/index');
-const {onShapeError, shapeLoading} = require('../actions/shapefile');
+const {SelectShape, StylePolygon, StylePolyline, StylePoint} = require('./shapefile/index');
+const {onShapeError, shapeLoading, onShapeChoosen} = require('../actions/shapefile');
 const {addLayer} = require('../actions/layers');
-
 
 const ShapeFile = React.createClass({
     propTypes: {
-        files: React.PropTypes.object,
+        layers: React.PropTypes.array,
         style: React.PropTypes.object,
+        shapeStyle: React.PropTypes.object,
         onShapeError: React.PropTypes.func,
+        onShapeChoosen: React.PropTypes.func,
         addShapeLayer: React.PropTypes.func,
         shapeLoading: React.PropTypes.func,
-        error: React.PropTypes.string
+        error: React.PropTypes.string,
+        mapType: React.PropTypes.string
+    },
+    componentWillMount() {
+        StyleUtils = require('../utils/StyleUtils')(this.props.mapType);
+    },
+    getInitialState() {
+        return {
+            useDefaultStyle: false
+        };
+    },
+    getGeomType(layers) {
+        if (layers[0] && layers[0].features && layers[0].features[0] && layers[0].features[0].geometry) {
+            return layers[0].features[0].geometry.type;
+        }
     },
     renderError() {
-
         return (<Row>
                    <div style={{textAlign: "center"}} className="alert alert-danger">{this.props.error}</div>
                 </Row>);
-
+    },
+    renderStyle() {
+        switch (this.getGeomType(this.props.layers || [])) {
+            case 'Polygon':
+            case 'MultiPolygon': {
+                return (<StylePolygon/>);
+            }
+            case 'MultiLineString':
+            case 'LineString':
+            {
+                return (<StylePolyline/>);
+            }
+            case 'Point':
+            case 'MultiPoint': {
+                return (<StylePoint/>);
+            }
+            default: {
+                return null;
+            }
+        }
+    },
+    renderDefaultStyle() {
+        return (this.props.layers && this.props.layers[0]) ? (
+            <Row>
+                <Col xs={1}>
+                    <input aria-label="..." type="checkbox" defaultChecked={this.state.useDefaultStyle} onChange={(e) => {this.setState({useDefaultStyle: e.target.checked}); }}/>
+                </Col>
+                <Col style={{paddingLeft: 0, paddingTop: 1}} xs={5}>
+                    <label>Default style</label>
+                </Col>
+            </Row>) : null;
     },
     render() {
         return (
@@ -43,6 +89,13 @@ const ShapeFile = React.createClass({
                 {(this.props.error) ? this.renderError() : null}
             <Row style={{textAlign: "center"}}>
                 <SelectShape errorMessage="shapefile.error.select" text={<Message msgId="shapefile.placeholder"/>} onShapeChoosen={this.addShape}/>
+            </Row>
+            <Row style={{marginBottom: 10}}>
+                {(this.state.useDefaultStyle) ? null : this.renderStyle()}
+            </Row>
+            {this.renderDefaultStyle()}
+            <Row >
+                <Col xsOffset={9} xs={4}> <Button disabled={!this.props.layers} onClick={this.addToMap}>{<Message msgId="shapefile.add"/>}</Button></Col>
             </Row>
             </Grid>
             );
@@ -55,31 +108,54 @@ const ShapeFile = React.createClass({
             });
         }, this);
         Promise.all(queue).then((geoJsons) => {
-            geoJsons.forEach((geoJson) => {
+            let ls = geoJsons.reduce((layers, geoJson) => {
                 if (geoJson) {
-                    geoJson.map((layer) => {
-                        this.props.addShapeLayer(LayersUtils.geoJSONToLayer(layer));
-                    });
+                    return layers.concat(geoJson.map((layer) => {
+                        return LayersUtils.geoJSONToLayer(layer);
+                    }));
                 }
-            }, this);
+            }, []);
+            this.props.onShapeChoosen(ls);
+            this.props.shapeLoading(false);
+        }).catch((e) => {
+            this.props.shapeLoading(false);
+            this.props.onShapeError(e.message || e);
+        });
+    },
+    addToMap() {
+
+        this.props.shapeLoading(true);
+        let queue = this.props.layers.map((layer) => {
+            let styledLayer = layer;
+            if (!this.state.useDefaultStyle) {
+                styledLayer = StyleUtils.toVectorStyle(layer, this.props.shapeStyle);
+            }
+            Promise.resolve(this.props.addShapeLayer( styledLayer ));
+        }, this);
+        Promise.all(queue).then(() => {
             this.props.shapeLoading(false);
         }).catch((e) => {
             this.props.shapeLoading(false);
             this.props.onShapeError(e.message || e);
         });
     }
-
 });
 
 module.exports = {
     ShapeFile: connect((state) => (
         {
-            error: state.shapefile && state.shapefile.error || null
+            layers: state.shapefile && state.shapefile.layers || null,
+            error: state.shapefile && state.shapefile.error || null,
+            shapeStyle: state.style || {}
         }
         ), {
+            onShapeChoosen: onShapeChoosen,
             onShapeError: onShapeError,
             addShapeLayer: addLayer,
             shapeLoading: shapeLoading
         })(ShapeFile),
-    reducers: {shapefile: require('../reducers/shapefile')}
+    reducers: {
+        shapefile: require('../reducers/shapefile'),
+        style: require('../reducers/style')
+    }
 };

--- a/web/client/plugins/shapefile/index.js
+++ b/web/client/plugins/shapefile/index.js
@@ -8,6 +8,7 @@
 const {connect} = require('react-redux');
 
 const {onShapeError} = require('../../actions/shapefile');
+const {setStyleParameter} = require('../../actions/style');
 
 const SelectShape = connect((state) => (
         {
@@ -16,6 +17,34 @@ const SelectShape = connect((state) => (
         ), {
     onShapeError: onShapeError
 })(require('../../components/shapefile/SelectShape'));
+
+const StylePolygon = connect((state) => (
+        {
+            shapeStyle: state.style || {}
+        }
+        ), {
+    setStyleParameter: setStyleParameter
+})(require('../../components/style/StylePolygon'));
+
+const StylePoint = connect((state) => (
+        {
+            shapeStyle: state.style || {}
+        }
+        ), {
+    setStyleParameter: setStyleParameter
+})(require('../../components/style/StylePoint'));
+
+const StylePolyline = connect((state) => (
+        {
+            shapeStyle: state.style || {}
+        }
+        ), {
+    setStyleParameter: setStyleParameter
+})(require('../../components/style/StylePolyline'));
+
 module.exports = {
-    SelectShape
+    SelectShape,
+    StylePolygon,
+    StylePolyline,
+    StylePoint
 };

--- a/web/client/reducers/__tests__/shapefile-test.js
+++ b/web/client/reducers/__tests__/shapefile-test.js
@@ -19,7 +19,7 @@ describe('Test the shapefile reducer', () => {
         const state = shapefile(undefined, {
             type: ''
         });
-        expect(state.files).toBe(null);
+        expect(state.layers).toBe(null);
         expect(state.error).toBe(null);
         expect(state.loading).toBe(false);
 
@@ -27,9 +27,9 @@ describe('Test the shapefile reducer', () => {
     it('shepefile choosen', () => {
         const state = shapefile(undefined, {
             type: ON_SHAPE_CHOOSEN,
-            files: 'test'
+            layers: 'test'
         });
-        expect(state.files).toBe('test');
+        expect(state.layers).toBe('test');
     });
 
     it('shepefile error', () => {

--- a/web/client/reducers/__tests__/style-test.js
+++ b/web/client/reducers/__tests__/style-test.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const style = require('../style');
+const {
+    SET_STYLE_PARAMETER
+} = require('../../actions/style');
+
+describe('Test the style reducer', () => {
+    it('set a style parameter', () => {
+        const state = style(undefined, {
+            type: SET_STYLE_PARAMETER,
+            name: 'param',
+            value: 'val'
+        });
+        expect(state.param).toBe('val');
+    });
+
+});

--- a/web/client/reducers/shapefile.js
+++ b/web/client/reducers/shapefile.js
@@ -9,7 +9,9 @@
 const {
     ON_SHAPE_CHOOSEN,
     ON_SHAPE_ERROR,
-    SHAPE_LOADING
+    ON_SELECT_LAYER,
+    SHAPE_LOADING,
+    ON_LAYER_ADDED
 } = require('../actions/shapefile');
 
 const assign = require('object-assign');
@@ -17,19 +19,31 @@ const assign = require('object-assign');
 const initialState = {
     layers: null,
     error: null,
-    loading: false
+    loading: false,
+    selected: null
 };
 
 function shapefile(state = initialState, action) {
     switch (action.type) {
         case ON_SHAPE_CHOOSEN: {
-            return assign({}, state, {layers: action.layers});
+            let selected = (action.layers && action.layers[0]) ? action.layers[0] : null;
+            return assign({}, state, {layers: action.layers, selected: selected});
         }
         case ON_SHAPE_ERROR: {
             return assign({}, state, {error: action.message});
         }
         case SHAPE_LOADING: {
             return assign({}, state, {loading: action.status});
+        }
+        case ON_SELECT_LAYER: {
+            return assign({}, state, {selected: action.layer});
+        }
+        case ON_LAYER_ADDED: {
+            let newLayers = state.layers.filter((l) => {
+                return action.layer.name !== l.name;
+            }, this);
+            let selected = (newLayers && newLayers[0]) ? newLayers[0] : null;
+            return assign({}, state, {layers: newLayers, selected: selected});
         }
         default:
             return state;

--- a/web/client/reducers/shapefile.js
+++ b/web/client/reducers/shapefile.js
@@ -15,7 +15,7 @@ const {
 const assign = require('object-assign');
 
 const initialState = {
-    files: null,
+    layers: null,
     error: null,
     loading: false
 };
@@ -23,7 +23,7 @@ const initialState = {
 function shapefile(state = initialState, action) {
     switch (action.type) {
         case ON_SHAPE_CHOOSEN: {
-            return assign({}, state, {files: action.files});
+            return assign({}, state, {layers: action.layers});
         }
         case ON_SHAPE_ERROR: {
             return assign({}, state, {error: action.message});

--- a/web/client/reducers/style.js
+++ b/web/client/reducers/style.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {
+    SET_STYLE_PARAMETER
+} = require('../actions/style');
+
+const assign = require('object-assign');
+
+const initialSpec = {
+    color: { r: 0, g: 0, b: 255, a: 1 },
+    width: 3,
+    fill: { r: 0, g: 0, b: 255, a: 0.1 },
+    radius: 10,
+    marker: false
+};
+
+function style(state = initialSpec, action) {
+    switch (action.type) {
+        case SET_STYLE_PARAMETER: {
+            return assign({}, state, {[action.name]: action.value});
+        }
+        default:
+            return state;
+    }
+}
+
+module.exports = style;

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -325,7 +325,8 @@
             "tooltip": "Add a local shape file to the map.",
             "placeholder": "Drop your file here or click to select shape file to import.",
             "error": {"select": "Select one or more zip file"},
-            "add": "Add"
+            "add": "Add",
+            "cancel": "Cancel"
         }
     }
 }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -326,7 +326,8 @@
             "tooltip": "Aggiungi uno shape file alla mappa.",
             "placeholder": "Trascina qui il file o fai click per selezionare lo shape file da importare.",
             "error": {"select": "Seleziona Shapefile compresso"},
-            "add": "Importa"
+            "add": "Importa",
+            "cancel": "Annulla"
         }
     }
 }

--- a/web/client/utils/StyleUtils.js
+++ b/web/client/utils/StyleUtils.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = (mapType) => {
+    return {
+        toVectorStyle: require('./' + mapType + '/StyleUtils')
+    };
+};

--- a/web/client/utils/leaflet/StyleUtils.js
+++ b/web/client/utils/leaflet/StyleUtils.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const assign = require('object-assign');
+
+const getColor = function(color) {
+        return `rgb(${ color.r }, ${ color.g }, ${ color.b })`;
+    };
+const getGeomType = function(layer) {
+    return (layer.features && layer.features[0]) ? layer.features[0].geometry.type : undefined;
+};
+const toVectorStyle = function(layer, style) {
+        let newLayer = assign({}, layer);
+        let geomT = getGeomType(layer);
+        if (style.marker && (geomT === 'Point' || geomT === 'MultiPoint')) {
+            newLayer.styleName = "marker";
+        }else {
+            newLayer.style = {
+                weight: style.width,
+                radius: style.radius,
+                opacity: style.color.a,
+                fillOpacity: style.fill.a,
+                color: getColor(style.color),
+                fillColor: getColor(style.fill)
+            };
+        }
+        return newLayer;
+    };
+
+module.exports = toVectorStyle;

--- a/web/client/utils/openlayers/StyleUtils.js
+++ b/web/client/utils/openlayers/StyleUtils.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const assign = require('object-assign');
+const ol = require('openlayers');
+
+const getColor = function(color) {
+        return `rgba(${ color.r }, ${ color.g }, ${ color.b }, ${ color.a })`;
+    };
+const getGeomType = function(layer) {
+    return (layer.features && layer.features[0]) ? layer.features[0].geometry.type : undefined;
+};
+const toVectorStyle = function(layer, style) {
+        let newLayer = assign({}, layer);
+        let geomT = getGeomType(layer);
+        if (style.marker && (geomT === 'Point' || geomT === 'MultiPoint')) {
+            newLayer.styleName = "marker";
+        }else {
+            let stroke = new ol.style.Stroke({
+                            color: getColor(style.color),
+                            width: style.width
+                        });
+            let fill = new ol.style.Fill({
+                            color: getColor(style.fill)
+                        });
+            switch (getGeomType(layer)) {
+                case 'Polygon':
+                case 'MultiPolygon': {
+                    newLayer.style = new ol.style.Style({
+                        stroke: stroke,
+                        fill: fill
+                    });
+                    break;
+                }
+                case 'MultiLineString':
+                case 'LineString':
+                {
+                    newLayer.style = new ol.style.Style({
+                        stroke: stroke
+                    });
+                    break;
+                }
+                case 'Point':
+                case 'MultiPoint': {
+                    newLayer.style = new ol.style.Style({
+                        image: new ol.style.Circle({
+                            radius: style.radius,
+                            fill: fill,
+                            stroke: stroke
+                            })});
+                    break;
+                }
+                default: {
+                    newLayer.style = null;
+                }
+            }
+        }
+        return newLayer;
+    };
+
+module.exports = toVectorStyle;


### PR DESCRIPTION
ShapeFile plugin, allow users to import local (shape  and geoJson format) zipped files.
Files, can be dragged or selected. Allow importing multiple files and zip file with multiple shapefiles.
After selecting the shapefile to be imported, users can choose the style for the shape geometry type.
In case of multiple import, the first file determine the geometry type for the styler.
<img width="1279" alt="screen shot 2016-05-03 at 10 52 08" src="https://cloud.githubusercontent.com/assets/9317650/14979065/5f403e7c-1120-11e6-8afd-6f8c57a4e2f8.png">
<img width="440" alt="screen shot 2016-05-03 at 10 53 31" src="https://cloud.githubusercontent.com/assets/9317650/14979074/676f6410-1120-11e6-890f-029a8e6ad111.png">
<img width="1280" alt="screen shot 2016-05-03 at 10 53 15" src="https://cloud.githubusercontent.com/assets/9317650/14979084/6fdc2a0c-1120-11e6-99a5-f12a6b021cd8.png">


