### PR TITLE
fix #565. Fixed react-color dependency to the working one

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "proj4": "~2.3.6",
     "react": "0.14.8",
     "react-bootstrap": "0.28.1",
-    "react-color": "^2.0.0",
+    "react-color": "2.0.0",
     "react-dom": "0.14.8",
     "react-draggable": "1.3.4",
     "react-dropzone": "^3.4.0",


### PR DESCRIPTION
This commit of react-color add the dependency to react 15 in production. Fixing the version to the 2.0.0 (the previous, current is 2.1.0) the problem is solved. 

The commit that caused the issue: 
https://github.com/casesandberg/react-color/commit/09ab61fc2a1c6a8a08f0b39954d559106f1cd880