### PR TITLE
fix #574 make zoom to extent action work

### DIFF
--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -80,4 +80,17 @@ describe('Test the map reducer', () => {
         expect(state.prop).toBe('prop');
         expect(state.projection).toBe('EPSG:4326');
     });
+
+    it('zoom to extent', () => {
+        const action = {
+            type: 'ZOOM_TO_EXTENT',
+            extent: [10, 44, 12, 46],
+            crs: "EPSG:4326"
+        };
+
+        var state = mapConfig({}, action);
+        expect(state.mapStateSource).toBe(undefined);
+        expect(state.center.x).toBe(11);
+        expect(state.center.y).toBe(45);
+    });
 });

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -38,7 +38,8 @@ function mapConfig(state = null, action) {
                 action.crs, 'EPSG:4326');
             return assign({}, state, {
                 zoom,
-                center
+                center,
+                mapStateSource: action.mapStateSource
             });
         }
         case PAN_TO: {

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -146,7 +146,7 @@ function defaultGetZoomForExtent(extent, mapSize, minZoom, maxZoom, dpi, mapReso
         return diff > previous.diff ? previous : {diff: diff, zoom: index};
     }, {diff: Number.POSITIVE_INFINITY, zoom: 0});
 
-    return Math.max(0, zoom);
+    return Math.max(0, zoom, Math.min(zoom, maxZoom));
 }
 
 /**


### PR DESCRIPTION
`mapStateSource` was copied in the reducer so it doesn't work when it is missing. 

Also added a test for the reducer. 