### PR TITLE
Fixes #428 Activate OpenTopoMap background

### DIFF
--- a/web/client/config.json
+++ b/web/client/config.json
@@ -96,7 +96,16 @@
 				"name": "nurc:Arc_Sample",
 				"group": "Meteo",
 				"format": "image/png"
-			}
+			},
+      {
+        "type": "tileprovider",
+        "title": "OpenTopoMap",
+        "provider": "OpenTopoMap",
+        "name": "OpenTopoMap",
+        "source": "OpenTopoMap",
+        "group": "background",
+        "visibility": false
+      }
 		]
 	}
 }


### PR DESCRIPTION
Note, Chinese and Japanese names are not render correctly.