### PR TITLE
fixes #582 map reducers for zoom to extent and add layer

### DIFF
--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -87,10 +87,19 @@ describe('Test the map reducer', () => {
             extent: [10, 44, 12, 46],
             crs: "EPSG:4326"
         };
+        // full extent
+        const action2 = {
+            type: 'ZOOM_TO_EXTENT',
+            extent: [10, 44, 12, 46],
+            crs: "EPSG:4326"
+        };
 
         var state = mapConfig({}, action);
         expect(state.mapStateSource).toBe(undefined);
         expect(state.center.x).toBe(11);
         expect(state.center.y).toBe(45);
+        state = mapConfig({}, action2);
+        expect(state.zoom).toBe(2);
+
     });
 });

--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -90,15 +90,15 @@ describe('Test the map reducer', () => {
         // full extent
         const action2 = {
             type: 'ZOOM_TO_EXTENT',
-            extent: [10, 44, 12, 46],
+            extent: [-180, -90, 180, 90],
             crs: "EPSG:4326"
         };
 
-        var state = mapConfig({}, action);
+        var state = mapConfig({projection: "EPSG:4326"}, action);
         expect(state.mapStateSource).toBe(undefined);
         expect(state.center.x).toBe(11);
         expect(state.center.y).toBe(45);
-        state = mapConfig({}, action2);
+        state = mapConfig({projection: "EPSG:900913"}, action2);
         expect(state.zoom).toBe(2);
 
     });

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -154,8 +154,8 @@ function layers(state = [], action) {
             // TODO: layers
         }
         case ADD_LAYER: {
-            let newLayers = (state.flat || []).slice();
-            let newGroups = (state.groups || []).slice();
+            let newLayers = (state.flat || []).concat();
+            let newGroups = (state.groups || []).concat();
             const newLayer = (action.layer.id) ? action.layer : assign({}, action.layer, {id: action.layer.name + "__" + newLayers.length});
             newLayers.push(newLayer);
             const groupName = newLayer.group || 'Default';

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -42,7 +42,7 @@ function mapConfig(state = null, action) {
             if ( full ) {
                 zoom = 2;
             } else {
-                let mapBBox = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.projection);
+                let mapBBox = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.projection || "EPSG:4326");
                 zoom = MapUtils.getZoomForExtent(mapBBox, state.size, 0, 21, null);
             }
             return assign({}, state, {


### PR DESCRIPTION
The fix remove errors for invariant violation in add layers and make zoom to extent reducer calculate correctly the zoom level. 

NOTE: There is a workaround to set the zoom to 2 if the extension is full. We should improve this in the future. 

