### PR TITLE
Fix #602. Filter Maps on the home screen

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -3,6 +3,7 @@
 	"geoStoreUrl": "/mapstore/rest/geostore/",
   "printUrl": "http://demo.geo-solutions.it/geoserver/pdf/info.json",
 	"bingApiKey": "AhuXBu7ipR1gNbBfXhtUAyCZ6rkC5PkWpxs2MnMRZ1ZupxQfivjLCch22ozKSCAn",
+	"initialMapFilter": "MS2",
 	"plugins": {
 		"mobile": ["Home", {
 			"name": "About",

--- a/web/client/product/app.jsx
+++ b/web/client/product/app.jsx
@@ -33,7 +33,7 @@ function startApp() {
         let locale = LocaleUtils.getUserLocale();
         store.dispatch(loadLocale('translations', locale));
 
-        store.dispatch(loadMaps(ConfigUtils.getDefaults().geoStoreUrl));
+        store.dispatch(loadMaps(ConfigUtils.getDefaults().geoStoreUrl, "MS2"));
 
         store.dispatch(loadPrintCapabilities(ConfigUtils.getConfigProp('printUrl')));
     });

--- a/web/client/product/app.jsx
+++ b/web/client/product/app.jsx
@@ -33,7 +33,7 @@ function startApp() {
         let locale = LocaleUtils.getUserLocale();
         store.dispatch(loadLocale('translations', locale));
 
-        store.dispatch(loadMaps(ConfigUtils.getDefaults().geoStoreUrl, "MS2"));
+        store.dispatch(loadMaps(ConfigUtils.getDefaults().geoStoreUrl, ConfigUtils.getDefaults().initialMapFilter || "*"));
 
         store.dispatch(loadPrintCapabilities(ConfigUtils.getConfigProp('printUrl')));
     });


### PR DESCRIPTION
This changes allow to configure in "localConfig" an initial filter for the maps loaded in the home page. 