### PR TITLE
fixed authentication retrival for geostore map load.

### DIFF
--- a/web/client/actions/__tests__/config-test.js
+++ b/web/client/actions/__tests__/config-test.js
@@ -6,8 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var expect = require('expect');
-var {loadMapConfig, MAP_CONFIG_LOAD_ERROR, MAP_CONFIG_LOADED} = require('../config');
+const expect = require('expect');
+const {loadMapConfig, MAP_CONFIG_LOAD_ERROR, MAP_CONFIG_LOADED} = require('../config');
+
+const loggedGetState = () => ({
+    security: {
+        authHeader: "Basic dGVzdDp0ZXN0"
+    }
+});
 
 describe('Test configuration related actions', () => {
     it('does not load a missing configuration file', (done) => {
@@ -23,7 +29,7 @@ describe('Test configuration related actions', () => {
     });
 
     it('loads an existing configuration file', (done) => {
-        loadMapConfig('base/web/client/test-resources/testConfig.json')((e) => {
+        loadMapConfig('base/web/client/test-resources/testConfig.json', loggedGetState)((e) => {
             try {
                 expect(e).toExist();
                 expect(e.type).toBe(MAP_CONFIG_LOADED);
@@ -35,7 +41,7 @@ describe('Test configuration related actions', () => {
     });
 
     it('loads an broken configuration file', (done) => {
-        loadMapConfig('base/web/client/test-resources/testConfig.broken.json')((e) => {
+        loadMapConfig('base/web/client/test-resources/testConfig.broken.json', loggedGetState)((e) => {
             try {
                 expect(e).toExist();
                 expect(e.type).toBe('MAP_CONFIG_LOAD_ERROR');

--- a/web/client/actions/config.js
+++ b/web/client/actions/config.js
@@ -29,7 +29,7 @@ function configureError(e) {
 
 function loadMapConfig(configName, legacy) {
     return (dispatch, getState) => {
-        let options = getAuthOptionsFromState(getState);
+        let options = getAuthOptionsFromState(getState());
         return axios.get(configName, legacy ? options : null).then((response) => {
             if (typeof response.data === 'object') {
                 dispatch(configureMap(response.data, legacy));

--- a/web/client/actions/config.js
+++ b/web/client/actions/config.js
@@ -28,7 +28,7 @@ function configureError(e) {
 }
 
 function loadMapConfig(configName, legacy) {
-    return (dispatch, getState) => {
+    return (dispatch, getState = () => {}) => {
         let options = getAuthOptionsFromState(getState());
         return axios.get(configName, legacy ? options : null).then((response) => {
             if (typeof response.data === 'object') {

--- a/web/client/utils/DebugUtils.js
+++ b/web/client/utils/DebugUtils.js
@@ -22,7 +22,7 @@ var warningFilterKey = function(warning) {
 };
 
 var DebugUtils = {
-    createDebugStore: function(reducer, initialState, userMiddlewares) {
+    createDebugStore: function(reducer, initialState, userMiddlewares, enhancer) {
         let finalCreateStore;
         if (__DEVTOOLS__ && urlQuery.debug) {
             let logger = require('redux-logger')();
@@ -40,7 +40,7 @@ var DebugUtils = {
             let middlewares = (userMiddlewares || []).concat([thunkMiddleware]);
             finalCreateStore = applyMiddleware.apply(null, middlewares)(createStore);
         }
-        return finalCreateStore(reducer, initialState);
+        return finalCreateStore(reducer, initialState, enhancer);
     }
 };
 


### PR DESCRIPTION
* Fix wrong credentials usage when retrieving map configuration from GeoStore. 
* Add enhancer parameter to debug store (it is needed to introduce this lib https://github.com/rt2zz/redux-persist to persist user session) 