### PR TITLE
Adding zone fields capabilities to the spatial query panel

### DIFF
--- a/web/client/actions/__tests__/queryform-test.js
+++ b/web/client/actions/__tests__/queryform-test.js
@@ -22,6 +22,25 @@ const {
     SELECT_SPATIAL_OPERATION,
     REMOVE_SPATIAL_SELECT,
     SHOW_SPATIAL_DETAILS,
+    ZONE_SEARCH,
+    ZONE_SEARCH_ERROR,
+    ZONE_FILTER,
+    OPEN_MENU,
+    ZONE_CHANGE,
+    ZONES_RESET,
+    SHOW_GENERATED_FILTER,
+    QUERY_FORM_RESET,
+    CHANGE_DWITHIN_VALUE,
+    changeDwithinValue,
+    resetZones,
+    zoneChange,
+    openMenu,
+    zoneSearch,
+    zoneSearchError,
+    zoneFilter,
+    zoneGetValues,
+    query,
+    reset,
     addFilterField,
     addGroupField,
     removeFilterField,
@@ -189,5 +208,91 @@ describe('Test correctness of the queryform actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(SHOW_SPATIAL_DETAILS);
         expect(retval.show).toBe(true);
+    });
+
+    it('changeDwithinValue', () => {
+        let retval = changeDwithinValue(1);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(CHANGE_DWITHIN_VALUE);
+        expect(retval.distance).toBe(1);
+    });
+
+    it('query', () => {
+        let retval = query("url", null);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(SHOW_GENERATED_FILTER);
+        expect(retval.data).toBe(null);
+    });
+
+    it('reset', () => {
+        let retval = reset();
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(QUERY_FORM_RESET);
+    });
+
+    it('resetZones', () => {
+        let retval = resetZones();
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(ZONES_RESET);
+    });
+
+    it('zoneFilter', () => {
+        let retval = zoneFilter(null, 1);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(ZONE_FILTER);
+        expect(retval.data).toBe(null);
+        expect(retval.id).toBe(1);
+    });
+
+    it('zoneSearchError', () => {
+        let retval = zoneSearchError("error");
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(ZONE_SEARCH_ERROR);
+        expect(retval.error).toBe("error");
+    });
+
+    it('zoneSearch', () => {
+        let retval = zoneSearch(true, 1);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(ZONE_SEARCH);
+        expect(retval.active).toBe(true);
+        expect(retval.id).toBe(1);
+    });
+
+    it('loads an existing zones file', (done) => {
+        zoneGetValues('../../test-resources/featureGrid-test-data.json')((e) => {
+            try {
+                expect(e).toExist();
+                done();
+            } catch(ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('openMenu', () => {
+        let retval = openMenu(true, 1);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(OPEN_MENU);
+        expect(retval.active).toBe(true);
+        expect(retval.id).toBe(1);
+    });
+
+    it('zoneChange', () => {
+        let retval = zoneChange(1, "value", null);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(ZONE_CHANGE);
+        expect(retval.value).toBe("value");
+        expect(retval.id).toBe(1);
+        expect(retval.rawValue).toBe(null);
     });
 });

--- a/web/client/actions/queryform.js
+++ b/web/client/actions/queryform.js
@@ -25,7 +25,17 @@ const QUERY_FORM_RESET = 'QUERY_FORM_RESET';
 const SHOW_GENERATED_FILTER = 'SHOW_GENERATED_FILTER';
 const CHANGE_DWITHIN_VALUE = 'CHANGE_DWITHIN_VALUE';
 
-// const axios = require('../libs/ajax');
+const ZONE_SEARCH = 'ZONE_SEARCH';
+const ZONE_SEARCH_ERROR = 'ZONE_SEARCH_ERROR';
+const ZONE_FILTER = 'ZONE_FILTER';
+
+const OPEN_MENU = 'OPEN_MENU';
+
+const ZONE_CHANGE = 'ZONE_CHANGE';
+
+const ZONES_RESET = 'ZONES_RESET';
+
+const axios = require('../libs/ajax');
 
 function addFilterField(groupId) {
     return {
@@ -173,6 +183,75 @@ function reset() {
     };
 }
 
+function resetZones() {
+    return {
+        type: ZONES_RESET
+    };
+}
+
+function zoneFilter(searchResult, id) {
+    return {
+        type: ZONE_FILTER,
+        data: searchResult,
+        id: id
+    };
+}
+
+function zoneSearchError(error) {
+    return {
+        type: ZONE_SEARCH_ERROR,
+        error: error
+    };
+}
+
+function zoneSearch(active, id) {
+    return {
+        type: ZONE_SEARCH,
+        active: active,
+        id: id
+    };
+}
+
+function zoneGetValues(url, filter, id) {
+    return (dispatch) => {
+        return axios.post(url, filter, {
+            timeout: 10000,
+            headers: {'Accept': 'application/json', 'Content-Type': 'text/plain'}
+        }).then((response) => {
+            let config = response.data;
+            if (typeof config !== "object") {
+                try {
+                    config = JSON.parse(config);
+                } catch(e) {
+                    dispatch(zoneSearchError('Search result broken (' + url + ":   " + filter + '): ' + e.message));
+                }
+            }
+
+            dispatch(zoneFilter(config, id));
+            dispatch(zoneSearch(false, id));
+        }).catch((e) => {
+            dispatch(zoneSearchError(e));
+        });
+    };
+}
+
+function openMenu(active, id) {
+    return {
+        type: OPEN_MENU,
+        active: active,
+        id: id
+    };
+}
+
+function zoneChange(id, value, rawValue) {
+    return {
+        type: ZONE_CHANGE,
+        id: id,
+        value: value,
+        rawValue: rawValue
+    };
+}
+
 module.exports = {
     ADD_FILTER_FIELD,
     REMOVE_FILTER_FIELD,
@@ -193,6 +272,19 @@ module.exports = {
     // WFS_LOAD_ERROR,
     SHOW_GENERATED_FILTER,
     CHANGE_DWITHIN_VALUE,
+    ZONE_SEARCH,
+    ZONE_SEARCH_ERROR,
+    ZONE_FILTER,
+    OPEN_MENU,
+    ZONE_CHANGE,
+    ZONES_RESET,
+    resetZones,
+    zoneChange,
+    openMenu,
+    zoneSearch,
+    zoneSearchError,
+    zoneFilter,
+    zoneGetValues,
     addFilterField,
     removeFilterField,
     updateFilterField,

--- a/web/client/components/data/query/ComboField.jsx
+++ b/web/client/components/data/query/ComboField.jsx
@@ -14,6 +14,7 @@ const LocaleUtils = require('../../../utils/LocaleUtils');
 
 const ComboField = React.createClass({
     propTypes: {
+        busy: React.PropTypes.bool,
         style: React.PropTypes.object,
         valueField: React.PropTypes.string,
         textField: React.PropTypes.string,
@@ -28,9 +29,14 @@ const ComboField = React.createClass({
         fieldException: React.PropTypes.object,
         comboFilterType: React.PropTypes.oneOfType([
             React.PropTypes.bool,
-            React.PropTypes.string
+            React.PropTypes.string,
+            React.PropTypes.func
         ]),
+        disabled: React.PropTypes.bool,
+        options: React.PropTypes.object,
         onUpdateField: React.PropTypes.func,
+        onToggle: React.PropTypes.func,
+        onSearch: React.PropTypes.func,
         onUpdateExceptionField: React.PropTypes.func
     },
     contextTypes: {
@@ -38,9 +44,12 @@ const ComboField = React.createClass({
     },
     getDefaultProps() {
         return {
+            options: {},
+            busy: false,
             style: {
                 width: "100%"
             },
+            disabled: false,
             valueField: null,
             textField: null,
             fieldOptions: [],
@@ -50,6 +59,8 @@ const ComboField = React.createClass({
             fieldException: null,
             comboFilterType: false,
             onUpdateField: () => {},
+            onToggle: () => {},
+            onSearch: () => {},
             onUpdateExceptionField: () => {}
         };
     },
@@ -60,6 +71,9 @@ const ComboField = React.createClass({
 
         const ddList = this.props.valueField !== null && this.props.textField !== null ? (
             <DropdownList
+                {...this.props.options}
+                busy={this.props.busy}
+                disabled={this.props.disabled}
                 valueField={this.props.valueField}
                 textField={this.props.textField}
                 data={this.props.fieldOptions}
@@ -69,9 +83,14 @@ const ComboField = React.createClass({
                 placeholder={placeholder}
                 filter={this.props.comboFilterType}
                 style={style}
-                onChange={(value) => this.props.onUpdateField(this.props.fieldRowId, this.props.fieldName, value[this.props.valueField], this.props.attType)}/>
+                onChange={(value) => this.props.onUpdateField(this.props.fieldRowId, this.props.fieldName, value[this.props.valueField], this.props.attType, value)}
+                onToggle={this.props.onToggle}
+                onSearch={this.props.onSearch}/>
         ) : (
             <DropdownList
+                {...this.props.options}
+                busy={this.props.busy}
+                disabled={this.props.disabled}
                 data={this.props.fieldOptions}
                 value={this.props.fieldValue}
                 caseSensitive={false}
@@ -79,7 +98,9 @@ const ComboField = React.createClass({
                 placeholder={placeholder}
                 filter={this.props.comboFilterType}
                 style={style}
-                onChange={(value) => this.props.onUpdateField(this.props.fieldRowId, this.props.fieldName, value, this.props.attType)}/>
+                onChange={(value) => this.props.onUpdateField(this.props.fieldRowId, this.props.fieldName, value, this.props.attType)}
+                onToggle={this.props.onToggle}
+                onSearch={this.props.onSearch}/>
         );
 
         return ddList;

--- a/web/client/components/data/query/ZoneField.jsx
+++ b/web/client/components/data/query/ZoneField.jsx
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+
+const ComboField = require('./ComboField');
+
+const FilterUtils = require('../../../utils/FilterUtils');
+
+const ZoneField = React.createClass({
+    propTypes: {
+        zoneId: React.PropTypes.number,
+        url: React.PropTypes.string,
+        typeName: React.PropTypes.string,
+        wfs: React.PropTypes.string,
+        busy: React.PropTypes.bool,
+        values: React.PropTypes.array,
+        value: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.string,
+            React.PropTypes.number
+        ]),
+        label: React.PropTypes.string,
+        searchText: React.PropTypes.string,
+        searchMethod: React.PropTypes.string,
+        searchAttribute: React.PropTypes.string,
+        comboFilterType: React.PropTypes.oneOfType([
+            React.PropTypes.bool,
+            React.PropTypes.string,
+            React.PropTypes.func
+        ]),
+        open: React.PropTypes.bool,
+        disabled: React.PropTypes.bool,
+        dependsOn: React.PropTypes.object,
+        valueField: React.PropTypes.string,
+        textField: React.PropTypes.string,
+        onSearch: React.PropTypes.func,
+        onFilter: React.PropTypes.func,
+        onOpenMenu: React.PropTypes.func,
+        onChange: React.PropTypes.func
+    },
+    contextTypes: {
+        messages: React.PropTypes.object
+    },
+    getDefaultProps() {
+        return {
+            zoneId: null,
+            url: null,
+            typeName: null,
+            wfs: "1.1.0",
+            busy: false,
+            values: [],
+            value: null,
+            valueField: null,
+            textField: null,
+            label: null,
+            disabled: false,
+            searchText: "*",
+            searchMethod: "ilike",
+            searchAttribute: null,
+            comboFilterType: "contains",
+            onSearch: () => {},
+            onFilter: () => {},
+            onOpenMenu: () => {},
+            onChange: () => {}
+        };
+    },
+    getFilter(searchText = "*", operator = "=") {
+        let filterObj = {
+            filterFields: [{
+                attribute: this.props.searchAttribute,
+                operator: operator,
+                value: searchText,
+                type: "list"
+            }]
+        };
+
+        if (this.props.dependsOn) {
+            filterObj.filterFields.push({
+                attribute: this.props.dependsOn.field,
+                operator: "=",
+                value: this.props.dependsOn.value,
+                type: "list"
+            });
+        }
+
+        const filter = FilterUtils.toOGCFilter(this.props.typeName, filterObj, this.props.wfs, {
+            sortBy: this.props.searchAttribute,
+            sortOrder: "ASC"
+        });
+        return filter;
+    },
+    render() {
+        let values = [];
+        if (this.props.values && this.props.values.length > 0) {
+            values = this.props.values.map((item) => {
+
+                let valueField = item;
+                this.props.valueField.split('.').forEach(part => {
+                    valueField = valueField ? valueField[part] : null;
+                });
+
+                let textField = item;
+                this.props.textField.split('.').forEach(part => {
+                    textField = textField ? textField[part] : null;
+                });
+
+                return {id: valueField, name: textField, item: item};
+            });
+        }
+
+        let label = this.props.label ? (<label>{this.props.label}</label>) : (<span/>);
+
+        return (
+            <div className="zone-combo">
+                {label}
+                <ComboField
+                    key={new Date().getUTCMilliseconds()}
+                    busy={this.props.busy}
+                    disabled={this.props.disabled}
+                    valueField={'id'}
+                    textField={'name'}
+                    fieldOptions={values}
+                    fieldValue={this.props.value}
+                    fieldName="zone"
+                    options={{
+                        open: this.props.open
+                    }}
+                    comboFilterType={this.props.comboFilterType}
+                    onUpdateField={this.zoneUpdateValue}
+                    onToggle={(toggle) => {
+                        if (values && values.length > 0) {
+                            this.props.onOpenMenu(toggle, this.props.zoneId);
+                        }
+
+                        if (toggle && (!this.props.values || this.props.values.length < 1)) {
+                            const filter = this.getFilter(this.props.searchText, this.props.searchMethod);
+                            this.props.onSearch(true, this.props.zoneId);
+                            this.props.onFilter(this.props.url, filter, this.props.zoneId);
+                        }
+                    }}/>
+            </div>
+        );
+    },
+    zoneUpdateValue(id, fieldName, value, attType, rawValue) {
+        this.props.onChange(this.props.zoneId, value, rawValue.item);
+    },
+    searching: false
+});
+
+module.exports = ZoneField;

--- a/web/client/components/data/query/__tests__/SpatialFilter-test.jsx
+++ b/web/client/components/data/query/__tests__/SpatialFilter-test.jsx
@@ -10,6 +10,8 @@ const ReactDOM = require('react-dom');
 
 const SpatialFilter = require('../SpatialFilter.jsx');
 
+const {featureCollection} = require('../../../../test-resources/featureCollectionZone.js');
+
 const expect = require('expect');
 
 describe('SpatialFilter', () => {
@@ -63,5 +65,72 @@ describe('SpatialFilter', () => {
 
         let operationPanelRows = combosPanel[2].getElementsByClassName('row');
         expect(operationPanelRows.length).toBe(2);
+    });
+
+    it('creates the SpatialFilter with the ZoneField component', () => {
+        let spatialField = {
+            method: "ZONE",
+            attribute: "the_geom",
+            operation: "INTERSECTS",
+            geometry: null,
+            zoneFields: [{
+                id: 1,
+                url: null,
+                typeName: "geosolutions:zones",
+                values: featureCollection.features,
+                value: null,
+                valueField: "properties.ITD_Dist_n",
+                textField: "properties.DistNum",
+                searchText: "*",
+                searchMethod: "ilike",
+                searchAttribute: "DistNum",
+                label: "Zones"
+            }, {
+                id: 2,
+                url: null,
+                typeName: "geosolutions:county",
+                label: "County",
+                values: [],
+                value: null,
+                valueField: "properties.juris_code",
+                textField: "properties.name2",
+                searchText: "*",
+                searchMethod: "ilike",
+                searchAttribute: "name2",
+                disabled: true,
+                dependson: {
+                    id: 1,
+                    field: "itd_dist",
+                    value: null
+                }
+            }]
+        };
+
+        const spatialfilter = ReactDOM.render(
+            <SpatialFilter
+                spatialField={spatialField}
+                spatialPanelExpanded={false}
+                showDetailsPanel={false}
+                spatialMethodOptions={[
+                    {id: "ZONE", name: "queryform.spatialfilter.methods.zone"}
+                ]}
+                spatialOperations={[
+                    {id: "INTERSECTS", name: "queryform.spatialfilter.operations.intersects"}
+                ]}/>,
+            document.getElementById("container")
+        );
+
+        expect(spatialfilter).toExist();
+        expect(spatialfilter.props.spatialField).toExist();
+        expect(spatialfilter.props.spatialField).toBe(spatialField);
+        expect(spatialfilter.props.spatialPanelExpanded).toBe(false);
+        expect(spatialfilter.props.showDetailsPanel).toBe(false);
+
+        const spatialFilterDOMNode = expect(ReactDOM.findDOMNode(spatialfilter));
+        expect(spatialFilterDOMNode).toExist();
+
+        let combosPanels = spatialFilterDOMNode.actual.getElementsByClassName('zone-combo');
+        expect(combosPanels).toExist();
+        expect(combosPanels.length).toBe(2);
     });
 });

--- a/web/client/components/data/query/__tests__/ZoneField-test.jsx
+++ b/web/client/components/data/query/__tests__/ZoneField-test.jsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const ZoneField = require('../ZoneField.jsx');
+const {featureCollection} = require('../../../../test-resources/featureCollectionZone.js');
+
+const expect = require('expect');
+
+describe('ZoneField', () => {
+
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates the ZoneField component', () => {
+        const zone = {
+            id: 1,
+            url: null,
+            typeName: "geosolutions:zones",
+            values: featureCollection.features,
+            value: null,
+            valueField: "properties.ITD_Dist_n",
+            textField: "properties.DistNum",
+            searchText: "*",
+            searchMethod: "ilike",
+            searchAttribute: "DistNum",
+            label: "ITD District"
+        };
+
+        const zoneField = ReactDOM.render(
+            <ZoneField
+                key={zone.id}
+                open={zone.open || false}
+                zoneId={zone.id}
+                url={zone.url}
+                typeName={zone.typeName}
+                wfs={zone.wfs}
+                busy={zone.busy || false}
+                label={zone.label}
+                values={zone.values}
+                value={zone.value}
+                valueField= {zone.valueField}
+                textField= {zone.textField}
+                searchText={zone.searchText}
+                searchMethod={zone.searchMethod}
+                searchAttribute={zone.searchAttribute}
+                disabled={zone.disabled || false}
+                dependsOn={zone.dependson}/>,
+            document.getElementById("container")
+        );
+
+        expect(zoneField).toExist();
+
+        expect(zoneField.props.values).toExist();
+        expect(zoneField.props.values.length).toBe(6);
+        expect(zoneField.props.typeName).toBe("geosolutions:zones");
+        expect(zoneField.props.busy).toBe(false);
+        expect(zoneField.props.open).toBe(false);
+        expect(zoneField.props.disabled).toBe(false);
+
+        const zoneFieldDOMNode = expect(ReactDOM.findDOMNode(zoneField));
+        expect(zoneFieldDOMNode).toExist();
+    });
+});

--- a/web/client/components/map/openlayers/Layer.jsx
+++ b/web/client/components/map/openlayers/Layer.jsx
@@ -42,13 +42,20 @@ const OpenlayersLayer = React.createClass({
         if (newProps.position !== this.props.position && this.layer.setZIndex) {
             this.layer.setZIndex(newProps.position);
         }
-        if (this.props.options && this.props.options.params && this.layer && this.layer.getSource() && this.layer.getSource().updateParams) {
-            const changed = Object.keys(this.props.options.params).reduce((found, param) => {
-                if (newProps.options.params[param] !== this.props.options.params[param]) {
-                    return true;
-                }
-                return found;
-            }, false);
+
+        if (this.props.options && this.layer && this.layer.getSource() && this.layer.getSource().updateParams) {
+            let changed = false;
+            if (this.props.options.params && newProps.options.params) {
+                changed = Object.keys(this.props.options.params).reduce((found, param) => {
+                    if (newProps.options.params[param] !== this.props.options.params[param]) {
+                        return true;
+                    }
+                    return found;
+                }, false);
+            } else if (!this.props.options.params && newProps.options.params) {
+                changed = true;
+            }
+
             if (changed) {
                 this.layer.getSource().updateParams(newProps.options.params);
             }

--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -8,6 +8,8 @@
 const expect = require('expect');
 const queryform = require('../queryform');
 
+const {featureCollection} = require('../../test-resources/featureCollectionZone.js');
+
 describe('Test the queryform reducer', () => {
 
     it('returns the initial state on unrecognized action', () => {
@@ -414,5 +416,318 @@ describe('Test the queryform reducer', () => {
         expect(state).toExist();
 
         expect(state.showDetailsPanel).toEqual(true);
+    });
+
+    it('Query Form Reset', () => {
+        let testAction = {
+            type: "QUERY_FORM_RESET"
+        };
+
+        const initialState = {
+            test: true
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+
+        expect(state.test).toEqual(true);
+    });
+
+    it('Show Generated Filter', () => {
+        let testAction = {
+            type: "SHOW_GENERATED_FILTER",
+            data: "data"
+        };
+
+        const initialState = {
+            showGeneratedFilter: "test"
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+
+        expect(state.showGeneratedFilter).toEqual("data");
+    });
+
+    it('Zone Filter', () => {
+        let testAction = {
+            type: "ZONE_FILTER",
+            data: {features: [{
+                id: 1,
+                name: "value1"
+            }, {
+                id: 2,
+                name: "value2"
+            }]},
+            id: 1
+        };
+
+        const initialState = {
+            spatialField: {
+                method: "ZONE",
+                attribute: "geom3857",
+                operation: "INTERSECTS",
+                geometry: null,
+                zoneFields: [{
+                    id: 1,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: [],
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute"
+                }, {
+                    id: 2,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: [],
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute",
+                    disabled: true,
+                    dependson: {
+                        id: 1,
+                        field: "att3",
+                        value: null
+                    }
+                }]
+            }
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+        expect(state.spatialField).toExist();
+        expect(state.spatialField.zoneFields[0].values.length).toBe(2);
+
+        expect(state.spatialField.zoneFields[0].open).toBe(true);
+    });
+
+    it('Zone Search', () => {
+        let testAction = {
+            type: "ZONE_SEARCH",
+            active: true,
+            id: 1
+        };
+
+        const initialState = {
+            spatialField: {
+                method: "ZONE",
+                attribute: "geom3857",
+                operation: "INTERSECTS",
+                geometry: null,
+                zoneFields: [{
+                    id: 1,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: [],
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute"
+                }, {
+                    id: 2,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: [],
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute",
+                    disabled: true,
+                    dependson: {
+                        id: 1,
+                        field: "att3",
+                        value: null
+                    }
+                }]
+            }
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+        expect(state.spatialField).toExist();
+        expect(state.spatialField.zoneFields[0].busy).toBe(true);
+    });
+
+    it('Zone Change', () => {
+        let testAction = {
+            type: "ZONE_CHANGE",
+            id: 1,
+            value: "Five",
+            rawValue: {
+                "type": "Feature",
+                "id": "zones.5",
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [
+                            [
+                                [
+                                    -112.52004032,
+                                    43.54002689
+                                ],
+                                [
+                                    -112.52008024,
+                                    43.42515586
+                                ],
+                                [
+                                    -112.2234772,
+                                    43.42473004
+                                ],
+                                [
+                                    -112.1032533,
+                                    43.42498078
+                                ],
+                                [
+                                    -112.52004032,
+                                    43.54002689
+                                ]
+                            ]
+                        ]
+                    ]
+                },
+                "geometry_name": "the_geom",
+                "properties": {
+                    "Shape_Leng": 732018.056416,
+                    "Shape_Area": 2.44128352236E10,
+                    "District_N": "5",
+                    "SUM_Counti": 7,
+                    "Orient": 0,
+                    "OrientPg": 0,
+                    "ITD_Dist_n": 5,
+                    "DistNum": "Five",
+                    "Area_sqmi": 9425.848
+                }
+            }
+        };
+
+        const initialState = {
+            spatialField: {
+                method: "ZONE",
+                attribute: "the_geom",
+                operation: "INTERSECTS",
+                geometry: null,
+                zoneFields: [{
+                    id: 1,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: featureCollection.features,
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute"
+                }, {
+                    id: 2,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: [],
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute",
+                    disabled: true,
+                    dependson: {
+                        id: 1,
+                        field: "att3",
+                        value: null
+                    }
+                }]
+            }
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+        expect(state.spatialField).toExist();
+
+        expect(state.spatialField.zoneFields[0].value).toEqual("Five");
+        expect(state.spatialField.zoneFields[0].rawValue).toExist();
+    });
+
+    it('Zone Reset', () => {
+        let testAction = {
+            type: "ZONES_RESET"
+        };
+
+        const initialState = {
+            spatialField: {
+                method: "ZONE",
+                attribute: "the_geom",
+                operation: "INTERSECTS",
+                geometry: null,
+                zoneFields: [{
+                    id: 1,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: featureCollection.features,
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute"
+                }]
+            }
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+        expect(state.spatialField).toExist();
+        expect(state.spatialField.zoneFields[0].values.length).toBe(0);
+    });
+
+    it('Open Zones Menu', () => {
+        let testAction = {
+            type: "OPEN_MENU",
+            active: true,
+            id: 1
+        };
+
+        const initialState = {
+            spatialField: {
+                method: "ZONE",
+                attribute: "the_geom",
+                operation: "INTERSECTS",
+                geometry: null,
+                zoneFields: [{
+                    id: 1,
+                    url: "http://localhost:8080/",
+                    typeName: "typeName1",
+                    values: featureCollection.features,
+                    value: null,
+                    valueField: "properties.attr1",
+                    textField: "properties.attr2",
+                    searchText: "*",
+                    searchMethod: "ilike",
+                    searchAttribute: "att2",
+                    label: "Attribute"
+                }]
+            }
+        };
+
+        let state = queryform(initialState, testAction);
+        expect(state).toExist();
+        expect(state.spatialField).toExist();
+        expect(state.spatialField.zoneFields[0].open).toBe(true);
     });
 });

--- a/web/client/test-resources/featureCollectionZone.js
+++ b/web/client/test-resources/featureCollectionZone.js
@@ -1,0 +1,286 @@
+const featureCollection = {
+   "type": "FeatureCollection",
+   "totalFeatures": 6,
+   "features": [
+      {
+         "type": "Feature",
+         "id": "zones.5",
+         "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+               [
+                  [
+                     [
+                        -112.52004032,
+                        43.54002689
+                     ],
+                     [
+                        -112.52008024,
+                        43.42515586
+                     ],
+                     [
+                        -112.2234772,
+                        43.42473004
+                     ],
+                     [
+                        -112.1032533,
+                        43.42498078
+                     ],
+                     [
+                        -112.52004032,
+                        43.54002689
+                     ]
+                  ]
+               ]
+            ]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+            "Shape_Leng": 732018.056416,
+            "Shape_Area": 2.44128352236E10,
+            "District_N": "5",
+            "SUM_Counti": 7,
+            "Orient": 0,
+            "OrientPg": 0,
+            "ITD_Dist_n": 5,
+            "DistNum": "Five",
+            "Area_sqmi": 9425.848
+         }
+      },
+      {
+         "type": "Feature",
+         "id": "zones.4",
+         "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+               [
+                  [
+                     [
+                        -114.84394937,
+                        43.99293337
+                     ],
+                     [
+                        -114.81381868,
+                        43.99294072
+                     ],
+                     [
+                        -114.81377165,
+                        43.92773026
+                     ],
+                     [
+                        -114.68119274,
+                        43.92770444
+                     ],
+                     [
+                        -114.84394937,
+                        43.99293337
+                     ]
+                  ]
+               ]
+            ]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+            "Shape_Leng": 856042.114854,
+            "Shape_Area": 2.98796874154E10,
+            "District_N": "4",
+            "SUM_Counti": 8,
+            "Orient": 0,
+            "OrientPg": 0,
+            "ITD_Dist_n": 4,
+            "DistNum": "Four",
+            "Area_sqmi": 11536.612
+         }
+      },
+      {
+         "type": "Feature",
+         "id": "zones.1",
+         "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+               [
+                  [
+                     [
+                        -116.0395103,
+                        47.97156032
+                     ],
+                     [
+                        -116.03039597,
+                        47.97281595
+                     ],
+                     [
+                        -116.02824069,
+                        47.97043533
+                     ],
+                     [
+                        -116.02819447,
+                        47.96900172
+                     ],
+                     [
+                        -116.0395103,
+                        47.97156032
+                     ]
+                  ]
+               ]
+            ]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+            "Shape_Leng": 787123.596725,
+            "Shape_Area": 2.05430041227E10,
+            "District_N": "1",
+            "SUM_Counti": 5,
+            "Orient": 0,
+            "OrientPg": 0,
+            "ITD_Dist_n": 1,
+            "DistNum": "One",
+            "Area_sqmi": 7931.698
+         }
+      },
+      {
+         "type": "Feature",
+         "id": "zones.6",
+         "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+               [
+                  [
+                     [
+                        -113.98088522,
+                        45.70249707
+                     ],
+                     [
+                        -113.97407408,
+                        45.70288626
+                     ],
+                     [
+                        -113.97149076,
+                        45.70224246
+                     ],
+                     [
+                        -113.97177477,
+                        45.7008759
+                     ],
+                     [
+                        -113.98088522,
+                        45.70249707
+                     ]
+                  ]
+               ]
+            ]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+            "Shape_Leng": 1635177.45711,
+            "Shape_Area": 5.00548921075E10,
+            "District_N": "6",
+            "SUM_Counti": 9,
+            "Orient": 90,
+            "OrientPg": 90,
+            "ITD_Dist_n": 6,
+            "DistNum": "Six",
+            "Area_sqmi": 19326.302
+         }
+      },
+      {
+         "type": "Feature",
+         "id": "zones.3",
+         "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+               [
+                  [
+                     [
+                        -116.65991996,
+                        45.26765704
+                     ],
+                     [
+                        -116.34286167,
+                        45.2679069
+                     ],
+                     [
+                        -116.34121353,
+                        45.26599929
+                     ],
+                     [
+                        -116.34111062,
+                        45.26181824
+                     ],
+                     [
+                        -116.65991996,
+                        45.26765704
+                     ]
+                  ]
+               ]
+            ]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+            "Shape_Leng": 1290586.42214,
+            "Shape_Area": 5.67742286386E10,
+            "District_N": "3",
+            "SUM_Counti": 10,
+            "Orient": 0,
+            "OrientPg": 0,
+            "ITD_Dist_n": 3,
+            "DistNum": "Three",
+            "Area_sqmi": 21920.652
+         }
+      },
+      {
+         "type": "Feature",
+         "id": "zones.2",
+         "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+               [
+                  [
+                     [
+                        -117.01278166,
+                        47.13074585
+                     ],
+                     [
+                        -117.00484037,
+                        47.13006567
+                     ],
+                     [
+                        -117.00101519,
+                        47.13048742
+                     ],
+                     [
+                        -116.99727372,
+                        47.12702915
+                     ],
+                     [
+                        -117.01278166,
+                        47.13074585
+                     ]
+                  ]
+               ]
+            ]
+         },
+         "geometry_name": "the_geom",
+         "properties": {
+            "Shape_Leng": 993111.526568,
+            "Shape_Area": 3.47070619276E10,
+            "District_N": "2",
+            "SUM_Counti": 5,
+            "Orient": 0,
+            "OrientPg": 0,
+            "ITD_Dist_n": 2,
+            "DistNum": "Two",
+            "Area_sqmi": 13400.471
+         }
+      }
+   ],
+   "crs": {
+      "type": "name",
+      "properties": {
+         "name": "urn:ogc:def:crs:EPSG::4326"
+      }
+   }
+};
+
+module.exports = {
+    featureCollection
+};


### PR DESCRIPTION
- Adding the ZoneField component to the spatial filter to allow the geolocation query capabilities with cascading support
- Improving the FilterUtils component with sorting options
- Improving and updating test cases
- Provided a fix for WMS params in openlayers layer wrapper
 