### PR TITLE
Persist support

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "react-widgets": "3.1.7",
     "redux": "3.1.3",
     "redux-logger": "2.6.1",
+    "redux-persist": "3.1.1",
     "redux-thunk": "0.1.0",
     "redux-undo": "0.5.0",
     "reselect": "2.5.1",

--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -22,6 +22,7 @@ const StandardApp = React.createClass({
     propTypes: {
         appStore: React.PropTypes.func,
         pluginsDef: React.PropTypes.object,
+        storeOpts: React.PropTypes.object,
         initialActions: React.PropTypes.array,
         appComponent: React.PropTypes.func,
         printingEnabled: React.PropTypes.bool
@@ -36,7 +37,7 @@ const StandardApp = React.createClass({
         };
     },
     componentWillMount() {
-        this.store = this.props.appStore(this.props.pluginsDef.plugins);
+        this.store = this.props.appStore(this.props.pluginsDef.plugins, this.props.storeOpts);
         if (!global.Intl ) {
             require.ensure(['intl', 'intl/locale-data/jsonp/en.js', 'intl/locale-data/jsonp/it.js'], (require) => {
                 global.Intl = require('intl');

--- a/web/client/product/app.jsx
+++ b/web/client/product/app.jsx
@@ -14,7 +14,7 @@ const {loadMaps} = require('../actions/maps');
 
 const StandardApp = require('../components/app/StandardApp');
 
-const {pages, pluginsDef, initialState} = require('./appConfig');
+const {pages, pluginsDef, initialState, storeOpts} = require('./appConfig');
 
 const StandardRouter = connect((state) => ({
     locale: state.locale || {},
@@ -31,6 +31,7 @@ const initialActions = [
 ];
 
 const appConfig = {
+    storeOpts,
     appStore,
     pluginsDef,
     initialActions,

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -51,7 +51,7 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
     };
     if (storeOpts && storeOpts.persist) {
         let store = DebugUtils.createDebugStore(rootReducer, defaultState, [], autoRehydrate());
-        persistStore(store, storeOpts.persistOptions);
+        persistStore(store, storeOpts.persist);
         return store;
     }
     return DebugUtils.createDebugStore(rootReducer, defaultState);

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -19,8 +19,9 @@ const {combineReducers} = require('../utils/PluginsUtils');
 
 const LayersUtils = require('../utils/LayersUtils');
 const {CHANGE_BROWSER_PROPERTIES} = require('../actions/browser');
+const {persistStore, autoRehydrate} = require('redux-persist');
 
-module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {}, plugins) => {
+module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {}, plugins, storeOpts) => {
     const allReducers = combineReducers(plugins, {
         ...appReducers,
         locale: require('../reducers/locale'),
@@ -48,5 +49,12 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
 
         return newState;
     };
+    if (storeOpts && storeOpts.persist) {
+        let store = DebugUtils.createDebugStore(rootReducer, defaultState, [], autoRehydrate());
+        persistStore(store, storeOpts.persistOptions);
+        return store;
+    }
     return DebugUtils.createDebugStore(rootReducer, defaultState);
+
+
 };


### PR DESCRIPTION
Introduced `redux-persist` lib to store application state. An additional param storeOpts can be configured to have the `persist` attribute, with the `redux-persist` configuration options. 
A sample configuration can be:
```
storeOpts: {
        persist: {
            whitelist: ['security']
        }
    }
```
This will store the user session (for the moment is the whole session). 
By default it uses the localStorage. We can add some option in the future to pass the storage (can even me remote).

the only problem seems to be that the store is not correctly rehidrated when using react devtools. I'll open an issue for that. 