### PR TITLE
Move Measure tool in DrawerMenu

### DIFF
--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -29,11 +29,11 @@ const MeasurementSupport = React.createClass({
             L.drawLocal = drawingStrings;
         }
 
-        if (this.props.measurement.geomType !== newProps.measurement.geomType &&
-                newProps.measurement.geomType !== null) {
+        if (newProps.measurement.geomType && newProps.measurement.geomType !== this.props.measurement.geomType ) {
             this.addDrawInteraction(newProps);
         }
-        if (newProps.measurement.geomType === null) {
+
+        if (!newProps.measurement.geomType) {
             this.removeDrawInteraction();
         }
     },

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -20,12 +20,11 @@ const MeasurementSupport = React.createClass({
     },
     componentWillReceiveProps(newProps) {
 
-        if (this.props.measurement.geomType !== newProps.measurement.geomType &&
-                newProps.measurement.geomType !== null) {
+        if (newProps.measurement.geomType && newProps.measurement.geomType !== this.props.measurement.geomType ) {
             this.addDrawInteraction(newProps);
         }
 
-        if (newProps.measurement.geomType === null) {
+        if (!newProps.measurement.geomType) {
             this.removeDrawInteraction();
         }
     },

--- a/web/client/components/mapcontrols/measure/MeasureResults.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureResults.jsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const {Panel} = require('react-bootstrap');
+const Draggable = require('react-draggable');
+
+const Message = require('../../../plugins/locale/Message');
+const ReactIntl = require('react-intl');
+const FormattedNumber = ReactIntl.FormattedNumber;
+const measureUtils = require('../../../utils/MeasureUtils');
+
+const {isEqual} = require('lodash');
+
+const MeasureResults = React.createClass({
+    propTypes: {
+        id: React.PropTypes.string,
+        name: React.PropTypes.string,
+        columnProperties: React.PropTypes.object,
+        propertiesChangeHandler: React.PropTypes.func,
+        lengthLabel: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
+        areaLabel: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
+        bearingLabel: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
+        uom: React.PropTypes.shape({
+                    length: React.PropTypes.shape({ unit: React.PropTypes.string.isRequired,
+                              label: React.PropTypes.string.isRequired}),
+                    area: React.PropTypes.shape({ unit: React.PropTypes.string.isRequired,
+                            label: React.PropTypes.string.isRequired})
+                        }),
+        toggleMeasure: React.PropTypes.func,
+        measurement: React.PropTypes.object,
+        lineMeasureEnabled: React.PropTypes.bool,
+        areaMeasureEnabled: React.PropTypes.bool,
+        bearingMeasureEnabled: React.PropTypes.bool,
+        separatePanel: React.PropTypes.bool,
+        title: React.PropTypes.object,
+        panelStyle: React.PropTypes.object,
+        panelClassName: React.PropTypes.string
+    },
+    getDefaultProps() {
+        return {
+            columnProperties: {
+                xs: 4,
+                sm: 4,
+                md: 4
+            },
+            id: "measure-result-panel",
+            uom: {
+                length: {unit: 'm', label: 'm'},
+                area: {unit: 'sqm', label: 'm²'}
+            },
+            separatePanel: true,
+            title: <Message msgId="measureComponent.title"/>,
+            panelStyle: {
+                minWidth: "300px",
+                left: "52px",
+                zIndex: 100,
+                position: "absolute",
+                overflow: "auto"
+            },
+            panelClassName: "drawer-menu-panel"
+        };
+    },
+    shouldComponentUpdate(nextProps) {
+        return !isEqual(nextProps, this.props);
+    },
+    onModalHiding() {
+        const newMeasureState = {
+            lineMeasureEnabled: false,
+            areaMeasureEnabled: false,
+            bearingMeasureEnabled: false,
+            geomType: null,
+            // reset old measurements
+            len: 0,
+            area: 0,
+            bearing: 0
+        };
+        this.props.toggleMeasure(newMeasureState);
+    },
+    renderHeader() {
+        return (
+            <span>
+                <Message msgId="measureComponent.title" />
+                <button onClick={this.onModalHiding} className="close"><span>×</span></button>
+            </span>
+        );
+    },
+    render() {
+        if (this.props.lineMeasureEnabled || this.props.areaMeasureEnabled || this.props.bearingMeasureEnabled ) {
+            let decimalFormat = {style: "decimal", minimumIntegerDigits: 1, maximumFractionDigits: 2, minimumFractionDigits: 2};
+            return (
+                <Draggable key={"drawer-menu--item-collapse-measures"}>
+                    <Panel header={this.renderHeader()} style={this.props.panelStyle} className={this.props.panelClassName}>
+                        <div className="panel-body">
+                            <p><span>{this.props.lengthLabel}: </span><span id="measure-len-res"><FormattedNumber key="len" {...decimalFormat} value={measureUtils.getFormattedLength(this.props.uom.length.unit, this.props.measurement.len)} /> {this.props.uom.length.label}</span></p>
+                            <p><span>{this.props.areaLabel}: </span><span id="measure-area-res"><FormattedNumber key="area" {...decimalFormat} value={measureUtils.getFormattedArea(this.props.uom.area.unit, this.props.measurement.area)} /> {this.props.uom.area.label}</span></p>
+                            <p><span>{this.props.bearingLabel}: </span><span id="measure-bearing-res">{measureUtils.getFormattedBearingValue(this.props.measurement.bearing)}</span></p>
+                        </div>
+                    </Panel>
+                </Draggable>
+            );
+        }
+        return null;
+    }
+});
+
+module.exports = MeasureResults;

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -39,7 +39,7 @@ describe("test the MeasureComponent", () => {
         expect(domNode).toExist();
         const domButtons = domNode.getElementsByTagName('button');
         expect(domButtons).toExist();
-        expect(domButtons.length).toBe(4);
+        expect(domButtons.length).toBe(3);
     });
 
     it('test creation of measurement result panel UI ', () => {
@@ -77,7 +77,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(4);
+        expect(buttons.length).toBe(3);
 
         const lineBtn = buttons.item(0);
         lineBtn.click();
@@ -111,7 +111,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(4);
+        expect(buttons.length).toBe(3);
 
         const areaBtn = buttons.item(1);
         areaBtn.click();
@@ -145,7 +145,7 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(4);
+        expect(buttons.length).toBe(3);
 
         const bearingBtn = buttons.item(2);
         bearingBtn.click();
@@ -178,19 +178,19 @@ describe("test the MeasureComponent", () => {
         expect(cmpDom).toExist();
 
         const buttons = cmpDom.getElementsByTagName('button');
-        expect(buttons.length).toBe(4);
+        expect(buttons.length).toBe(3);
 
-        const resetBtn = buttons.item(3);
-        resetBtn.click();
+        const bearingBtn = buttons.item(2);
+        // Activate
+        bearingBtn.click();
+
+        // Dectivate
+        bearingBtn.click();
 
         expect(newMeasureState).toExist();
         expect(newMeasureState.lineMeasureEnabled).toBe(false);
         expect(newMeasureState.areaMeasureEnabled).toBe(false);
         expect(newMeasureState.bearingMeasureEnabled).toBe(false);
-        expect(newMeasureState.geomType).toBe(null);
-        expect(newMeasureState.len).toBe(0);
-        expect(newMeasureState.area).toBe(0);
-        expect(newMeasureState.bearing).toBe(0);
     });
 
     it('test bearing format', () => {

--- a/web/client/components/mapcontrols/measure/measure.css
+++ b/web/client/components/mapcontrols/measure/measure.css
@@ -1,0 +1,3 @@
+.option-icon {
+    margin-right: 15px;
+}

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -93,10 +93,15 @@
 		}, {
 			"name": "Help",
 			"hideFrom": "Toolbar"
-		},  {
+		}, {
+        "name": "DrawerMenu"
+    },
+    {
        "name": "Identify",
        "showIn": ["IdentifyBar", "Settings"]
-    }, "MadeWithLove", {
+    },
+    "MadeWithLove",
+    {
 			  "name": "Locate",
 				"hide": true,
 				"override": {
@@ -116,7 +121,13 @@
 				"hide": true
 		}, {
 				"name": "Measure",
-				"hide": true
+				"hide": true,
+        "showIn": ["DrawerMenu"],
+        "cfg":{
+          "showResults": false
+        }
+		}, {
+				"name": "MeasureResults"
 		}, {
 				"name": "Print",
 				"hideFrom": ["Toolbar"]
@@ -160,12 +171,14 @@
         "id": "identifyBar"
       },
       "isDefault": false
-    }, "ScaleBox",
+    },
+    "ScaleBox",
     {
       "name": "ZoomAll",
       "hide": true
     },
-    "MapLoading", {
+    "MapLoading",
+    {
 				"name": "Snapshot",
 				"hide": true,
 				"hideFrom": ["Toolbar"],

--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -66,7 +66,7 @@ const DrawerMenu = React.createClass({
     render() {
         return (
             <div id={this.props.id}>
-                <Button id="drawer-menu-button" key="menu-button" onClick={this.props.toggleMenu}><Glyphicon glyph="menu-hamburger"/></Button>
+                <Button id="drawer-menu-button" key="menu-button" className="square-button" onClick={this.props.toggleMenu}><Glyphicon glyph="menu-hamburger"/></Button>
                 <Menu title={<Message msgId="menu" />} alignment="left">
                     {this.renderItems()}
                 </Menu>

--- a/web/client/plugins/MeasureResults.jsx
+++ b/web/client/plugins/MeasureResults.jsx
@@ -10,29 +10,22 @@ const {connect} = require('react-redux');
 
 const Message = require('./locale/Message');
 
-const lineRuleIcon = require('./toolbar/assets/img/line-ruler.png');
-
-const assign = require('object-assign');
-
 const {changeMeasurementState} = require('../actions/measurement');
 
-const Measure = require('../components/mapcontrols/measure/MeasureComponent');
+const MeasureRes = require('../components/mapcontrols/measure/MeasureResults');
 
 const MeasureComponent = React.createClass({
     render() {
         const labels = {
-            lengthButtonText: <Message msgId="measureComponent.lengthButtonText"/>,
-            areaButtonText: <Message msgId="measureComponent.areaButtonText"/>,
-            resetButtonText: <Message msgId="measureComponent.resetButtonText"/>,
             lengthLabel: <Message msgId="measureComponent.lengthLabel"/>,
             areaLabel: <Message msgId="measureComponent.areaLabel"/>,
             bearingLabel: <Message msgId="measureComponent.bearingLabel"/>
         };
-        return <Measure {...labels} {...this.props}/>;
+        return <MeasureRes {...labels} {...this.props}/>;
     }
 });
 
-const MeasurePlugin = connect((state) => {
+const MeasureResultsPlugin = connect((state) => {
     return {
         measurement: state.measurement || {},
         lineMeasureEnabled: state.measurement && state.measurement.lineMeasureEnabled || false,
@@ -44,25 +37,6 @@ const MeasurePlugin = connect((state) => {
 })(MeasureComponent);
 
 module.exports = {
-    MeasurePlugin: assign(MeasurePlugin, {
-        Toolbar: {
-            name: 'measurement',
-            position: 6,
-            panel: true,
-            exclusive: true,
-            wrap: true,
-            help: <Message msgId="helptexts.measureComponent"/>,
-            tooltip: "measureComponent.tooltip",
-            icon: <img src={lineRuleIcon} />,
-            title: "measureComponent.title",
-            hide: true
-        },
-        DrawerMenu: {
-            name: 'measurement',
-            position: 3,
-            title: 'measureComponent.title',
-            showPanel: false
-        }
-    }),
+    MeasureResultsPlugin,
     reducers: {measurement: require('../reducers/measurement')}
 };

--- a/web/client/plugins/drawer/drawer.css
+++ b/web/client/plugins/drawer/drawer.css
@@ -1,5 +1,5 @@
 /* Menu Button */
-#drawer-menu-button {
+.drawer-menu-button {
     position: absolute;
     z-index:1000;
     left: 30px;

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -14,6 +14,7 @@ module.exports = {
         TOCPlugin: require('../plugins/TOC'),
         BackgroundSwitcherPlugin: require('../plugins/BackgroundSwitcher'),
         MeasurePlugin: require('../plugins/Measure'),
+        MeasureResultsPlugin: require('../plugins/MeasureResults'),
         MapPlugin: require('../plugins/Map'),
         ToolbarPlugin: require('../plugins/Toolbar'),
         DrawerMenuPlugin: require('../plugins/DrawerMenu'),

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -143,6 +143,7 @@
         },
         "infoFormatLbl": "Identify response format",
         "measureComponent": {
+            "Measure": "Measure",
             "tooltip": "Measure length and area",
             "title": "Measure",
             "lengthButtonText": "Line",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -145,6 +145,7 @@
         },
         "infoFormatLbl": "Formato risposte interrogazioni su mappa",
         "measureComponent": {
+            "Measure": "Misura",
             "tooltip": "Misurazione lunghezza e l'area",
             "title": "Misurazione",
             "lengthButtonText": "Linea",

--- a/web/client/utils/MeasureUtils.js
+++ b/web/client/utils/MeasureUtils.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+function getFormattedBearingValue(azimuth = 0) {
+     var bearing = "";
+     if (azimuth >= 0 && azimuth < 90) {
+         bearing = "N " + this.degToDms(azimuth) + " E";
+     } else if (azimuth > 90 && azimuth <= 180) {
+         bearing = "S " + this.degToDms(180.0 - azimuth) + " E";
+     } else if (azimuth > 180 && azimuth < 270) {
+         bearing = "S " + this.degToDms(azimuth - 180.0 ) + " W";
+     } else if (azimuth >= 270 && azimuth <= 360) {
+         bearing = "N " + this.degToDms(360 - azimuth ) + " W";
+     }
+
+     return bearing;
+ }
+
+function getFormattedLength(unit = "m", length = 0) {
+    switch (unit) {
+        case 'm':
+            return length;
+        case 'ft':
+            return this.mToft(length);
+        case 'km':
+            return this.mTokm(length);
+        case 'mi':
+            return this.mTomi(length);
+        default:
+            return length;
+    }
+}
+
+function getFormattedArea(unit = "sqm", area = 0) {
+    switch (unit) {
+        case 'sqm':
+            return area;
+        case 'sqft':
+            return this.sqmTosqft(area);
+        case 'sqkm':
+            return this.sqmTosqkm(area);
+        case 'sqmi':
+            return this.sqmTosqmi(area);
+        default:
+            return area;
+    }
+}
+
+function degToDms(deg) {
+    // convert decimal deg to minutes and seconds
+    var d = Math.floor(deg);
+    var minfloat = (deg - d) * 60;
+    var m = Math.floor(minfloat);
+    var secfloat = (minfloat - m) * 60;
+    var s = Math.floor(secfloat);
+
+    return ("" + d + "° " + m + "' " + s + "'' ");
+}
+
+function mToft(length) {
+    return length * 3.28084;
+}
+
+function mTokm(length) {
+    return length * 0.001;
+}
+
+function mTomi(length) {
+    return length * 0.000621371;
+}
+
+function sqmTosqft(area) {
+    return area * 10.7639;
+}
+
+function sqmTosqkm(area) {
+    return area * 0.000001;
+}
+
+function sqmTosqmi(area) {
+    return area * 0.000000386102159;
+}
+
+module.exports = {
+    getFormattedBearingValue,
+    getFormattedLength,
+    getFormattedArea,
+    degToDms,
+    mToft,
+    mTokm,
+    mTomi,
+    sqmTosqmi,
+    sqmTosqkm,
+    sqmTosqft
+};


### PR DESCRIPTION
To display the measure results in a floating panel there is a new plugin "MeasureResults".  
The new flag "showResults" in the MeasurePlugin is set to false, the results are not visibile in the panel (to be used with the MeasureResults).  

The Reset button has been removed, to disable the tools just toggle the active button.