### PR TITLE
Styled toc icons and sizes

### DIFF
--- a/web/client/components/TOC/DefaultGroup.jsx
+++ b/web/client/components/TOC/DefaultGroup.jsx
@@ -39,20 +39,13 @@ var DefaultGroup = React.createClass({
     },
     render() {
         let {children, onToggle, ...other } = this.props;
-        const visibilityStyle = {
-            visibility: 'visible',
-            marginLeft: "5px",
-            marginRight: "5px", "float": "left",
-            marginTop: "7px"
-        };
         return (
-            <Node sortableStyle={this.props.sortableStyle} style={this.props.style} type="group" {...other}>
+            <Node className="toc-default-group" sortableStyle={this.props.sortableStyle} style={this.props.style} type="group" {...other}>
                 { this.props.groupVisibilityCheckbox &&
                   <VisibilityCheck
                             key="visibility"
                             checkType={this.props.visibilityCheckType}
-                            propertiesChangeHandler={this.props.propertiesChangeHandler}
-                            style={visibilityStyle}/>}
+                            propertiesChangeHandler={this.props.propertiesChangeHandler}/>}
                 <GroupTitle onClick={this.props.onToggle}/>
                 <GroupChildren onSort={this.props.onSort} position="collapsible">
                     {this.props.children}

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -59,7 +59,7 @@ var DefaultLayer = React.createClass({
         if (this.props.activateSettingsTool) {
             tools.push(
                 <LayersTool key="toolsettings"
-                        style={{"float": "right", marginTop: "5px", marginRight: "10px", cursor: "pointer"}}
+                        style={{"float": "right", cursor: "pointer"}}
                         glyph="adjust"
                         onClick={(node) => this.props.onSettings(node.id, "layers",
                             {opacity: parseFloat(node.opacity !== undefined ? node.opacity : 1)})}/>
@@ -81,7 +81,7 @@ var DefaultLayer = React.createClass({
             tools.push(
                 <LayersTool key="toollegend"
                         ref="target"
-                        style={{"float": "right", marginTop: "5px", marginRight: "10px", cursor: "pointer"}}
+                        style={{"float": "right", cursor: "pointer"}}
                         glyph="list"
                         onClick={(node) => this.props.onToggle(node.id, node.expanded)}/>
                 );

--- a/web/client/components/TOC/fragments/LayersTool.jsx
+++ b/web/client/components/TOC/fragments/LayersTool.jsx
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var React = require('react');
-var {Glyphicon} = require('react-bootstrap');
-
-var LayersTool = React.createClass({
+const React = require('react');
+const {Glyphicon} = require('react-bootstrap');
+require("./css/layertool.css");
+const LayersTool = React.createClass({
     propTypes: {
         node: React.PropTypes.object,
         onClick: React.PropTypes.func,

--- a/web/client/components/TOC/fragments/Title.jsx
+++ b/web/client/components/TOC/fragments/Title.jsx
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var React = require('react');
-
-var Title = React.createClass({
+const React = require('react');
+require("./css/toctitle.css");
+const Title = React.createClass({
     propTypes: {
         node: React.PropTypes.object,
         onClick: React.PropTypes.func

--- a/web/client/components/TOC/fragments/css/layertool.css
+++ b/web/client/components/TOC/fragments/css/layertool.css
@@ -1,0 +1,6 @@
+.toc-layer-tool {
+    float: right;
+     margin-top: 5px;
+     margin-right: 10px;
+     cursor: pointer;
+}

--- a/web/client/components/TOC/fragments/css/toctitle.css
+++ b/web/client/components/TOC/fragments/css/toctitle.css
@@ -1,0 +1,6 @@
+.toc-title {
+    display: inline-block;
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/web/client/components/TOC/fragments/css/visibilitycheck.css
+++ b/web/client/components/TOC/fragments/css/visibilitycheck.css
@@ -2,6 +2,13 @@ input[type="checkbox"].visibility-check,input[type="radio"].visibility-check {
     visibility: visible;
     margin-left: 5px;
     margin-right: 5px;
+    margin-top: 5px;
     float: left;
-    margin-top: 7px;
+}
+.visibility-check.glyphicon {
+    float: left;
+    overflow: hidden;
+    margin-left: 5px;
+    margin-right: 5px;
+    margin-top: 5px;
 }

--- a/web/client/components/misc/spinners/InlineSpinner/InlineSpinner.jsx
+++ b/web/client/components/misc/spinners/InlineSpinner/InlineSpinner.jsx
@@ -12,13 +12,15 @@ const {isFunction} = require('lodash');
 
 var InlineSpinner = React.createClass({
     propTypes: {
+        className: React.PropTypes.string,
         loading: React.PropTypes.oneOfType([React.PropTypes.bool, React.PropTypes.func]),
         icon: React.PropTypes.string
     },
     getDefaultProps() {
         return {
             loading: false,
-            icon: defaultIcon
+            icon: defaultIcon,
+            className: "inline-spinner"
         };
     },
     getDisplayStyle() {
@@ -32,7 +34,7 @@ var InlineSpinner = React.createClass({
     },
     render() {
         return (
-            <img src={this.props.icon} style={{
+            <img className={this.props.className} src={this.props.icon} style={{
                 display: this.getDisplayStyle(),
                 margin: '4px',
                 padding: 0,

--- a/web/client/examples/layertree/components/LayerOrGroup.jsx
+++ b/web/client/examples/layertree/components/LayerOrGroup.jsx
@@ -44,9 +44,9 @@ var LayerOrGroup = React.createClass({
                 <VisibilityCheck key="visibility" propertiesChangeHandler={this.props.propertiesChangeHandler}
                     checkType={(node) => node.group === 'background' ? 'radio' : 'checkbox'}/>,
                 <Title key="title"/>].concat(this.props.node.group !== 'background' ?
-                    [<LayersTool key="toolsettings" style={{"float": "right", marginTop: "5px", marginRight: "10px", cursor: "pointer"}} glyph="adjust"
+                    [<LayersTool key="toolsettings" style={{"float": "right", cursor: "pointer"}} glyph="adjust"
                         onClick={(node) => this.props.onSettings(node, "layers", {opacity: parseFloat(node.opacity) || 1.0})}/>,
-                    <LayersTool key="toollegend" ref="target" style={{"float": "right", marginTop: "5px", marginRight: "10px", cursor: "pointer"}} glyph="list"
+                    <LayersTool key="toollegend" ref="target" glyph="list"
                     onClick={(node) => this.props.onLegend(node)}/>,
                 <WMSLegend key="wmslegend" position="collapsible"/>] : [])
             ;


### PR DESCRIPTION
Make the icons and sizes of the toc and of the drawer menu more similar to the mockup. 
![image](https://cloud.githubusercontent.com/assets/1279510/16272346/c117f7da-389d-11e6-8e96-2a6c6beda6c2.png)

this will be more effective when also this pull request is merged:
https://github.com/geosolutions-it/MapStore2-theme/pull/55



