### PR TITLE
fix #776. Move home to omnibar

### DIFF
--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -7,16 +7,12 @@
  */
 const React = require('react');
 
-const {Glyphicon, Tooltip} = require('react-bootstrap');
-const ToggleButton = require('../../components/buttons/ToggleButton');
+const {Glyphicon, OverlayTrigger, Tooltip, Button} = require('react-bootstrap');
 const Message = require('../../components/I18N/Message');
 
 const Home = React.createClass({
     propTypes: {
-        isPanel: React.PropTypes.bool,
-        help: React.PropTypes.object,
-        changeHelpText: React.PropTypes.func,
-        changeHelpwinVisibility: React.PropTypes.func
+        icon: React.PropTypes.node
     },
     contextTypes: {
         router: React.PropTypes.object,
@@ -24,24 +20,23 @@ const Home = React.createClass({
     },
     getDefaultProps() {
         return {
-            isPanel: false,
             icon: <Glyphicon glyph="home"/>
         };
     },
     render() {
         let tooltip = <Tooltip id="toolbar-home-button">{<Message msgId="gohome"/>}</Tooltip>;
         return (
-            <ToggleButton
+            <OverlayTrigger overlay={tooltip}>
+            <Button
                 {...this.props}
                 id="home-button"
-                isButton={true}
-                pressed={false}
-                glyphicon="home"
-                helpText={<Message msgId="helptexts.gohome"/>}
+                className="square-button"
+                bsStyle="primary"
                 onClick={this.goHome}
                 tooltip={tooltip}
                 tooltipPlace="left"
-                />
+                >{this.props.icon}</Button>
+        </OverlayTrigger>
         );
     },
     goHome() {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -72,7 +72,7 @@
 		}, {
 			  "name": "Home",
 				"hide": true,
-				"hideFrom": ["Toolbar"]
+				"hideFrom": ["Toolbar", "BurgerMenu"]
 		}, {
 				"name": "TOC",
 				"hideFrom": ["Toolbar"],
@@ -313,7 +313,7 @@
 		}, {
 			  "name": "Home",
 				"hide": true,
-				"hideFrom": ["Toolbar"]
+				"hideFrom": ["Toolbar", "BurgerMenu"]
 		}, {
 				"name": "TOC",
 				"hideFrom": ["Toolbar"],

--- a/web/client/plugins/Home.jsx
+++ b/web/client/plugins/Home.jsx
@@ -34,6 +34,12 @@ module.exports = {
             text: <Message msgId="gohome"/>,
             icon: <Glyphicon glyph="home"/>,
             action: (context) => goToPage('/', context.router)
+        },
+        OmniBar: {
+            name: 'home',
+            position: 2,
+            tool: true,
+            action: (context) => goToPage('/', context.router)
         }
     }),
     reducers: {}


### PR DESCRIPTION
Fix #776.
Move the home in the omnibar. Clean up of unused parts of the home plugin. 