### PR TITLE
Fix #768. Fixed feature info scrolling and buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-sidebar": "2.1.2",
     "react-sortable-items": "0.0.12",
     "react-spinkit": "1.1.6",
-    "react-swipe": "3.0.0",
+    "react-swipeable-views": "0.6.3",
     "react-widgets": "3.1.7",
     "redux": "3.1.3",
     "redux-logger": "2.6.1",
@@ -120,7 +120,6 @@
     "redux-undo": "0.5.0",
     "reselect": "2.5.1",
     "shpjs": "3.3.2",
-    "swipe-js-iso": "2.0.3",
     "turf": "3.0.10",
     "url": "0.10.3",
     "w3c-schemas": "1.3.1"

--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -103,6 +103,7 @@ const DefaultViewer = React.createClass({
             const PageHeader = this.props.header;
             return (
                 <Panel
+
                     eventKey={i}
                     key={i}
                     collapsible={this.props.collapsible}
@@ -137,6 +138,7 @@ const DefaultViewer = React.createClass({
                     defaultActiveKey={0}
                     index={this.state.index || 0}
                     key={"swiper"}
+                    className="swipeable-view"
                     >
                     {this.renderPages(validResponses)}
                 </Container>

--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -14,10 +14,12 @@ const Message = require('../../../components/I18N/Message');
 const {Alert, Panel, Accordion} = require('react-bootstrap');
 
 const DefaultHeader = require('./DefaultHeader');
+const ViewerPage = require('./viewers/ViewerPage');
 const DefaultViewer = React.createClass({
     propTypes: {
         format: React.PropTypes.string,
         collapsible: React.PropTypes.bool,
+        requests: React.PropTypes.array,
         responses: React.PropTypes.array,
         missingResponses: React.PropTypes.number,
         container: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.func]),
@@ -27,6 +29,11 @@ const DefaultViewer = React.createClass({
         viewers: React.PropTypes.object,
         style: React.PropTypes.object,
         containerProps: React.PropTypes.object
+    },
+    getInitialState() {
+        return {
+            index: 0
+        };
     },
     getDefaultProps() {
         return {
@@ -39,12 +46,22 @@ const DefaultViewer = React.createClass({
             container: Accordion,
             validator: MapInfoUtils.getValidator,
             viewers: MapInfoUtils.getViewers(),
-            style: {maxHeight: "500px", overflow: "auto"},
+            style: {
+                maxHeight: "500px",
+                position: "relative",
+                marginBottom: 0
+            },
             containerProps: {}
         };
     },
-    shouldComponentUpdate(nextProps) {
-        return nextProps.responses !== this.props.responses || nextProps.missingResponses !== this.props.missingResponses;
+    componentWillReceiveProps(nextProps) {
+        // reset current page on new requests set
+        if (nextProps.requests !== this.props.requests) {
+            this.setState({index: 0});
+        }
+    },
+    shouldComponentUpdate(nextProps, nextState) {
+        return nextProps.responses !== this.props.responses || nextProps.missingResponses !== this.props.missingResponses || nextState.index !== this.state.index;
     },
     renderEmptyLayers(validator) {
         const notEmptyResponses = validator.getValidResponses(this.props.responses).length;
@@ -89,9 +106,16 @@ const DefaultViewer = React.createClass({
                     eventKey={i}
                     key={i}
                     collapsible={this.props.collapsible}
-                    header={<span><PageHeader {...this.props.headerOptions} {...layerMetadata} container={() => this.refs.container}/></span>}
+                    header={<span><PageHeader
+                        size={responses.length}
+                        {...this.props.headerOptions}
+                        {...layerMetadata}
+                        index={this.state.index}
+                        onNext={() => this.next()}
+                        onPrevious={() => this.previous()}/></span>
+                    }
                     style={this.props.style}>
-                    {this.renderPage(response)}
+                    <ViewerPage response={response} format={this.props.format} viewers={this.props.viewers} />
                 </Panel>
             );
         });
@@ -107,12 +131,24 @@ const DefaultViewer = React.createClass({
         const validator = this.props.validator(this.props.format);
         const validResponses = validator.getValidResponses(this.props.responses);
         return (<div>
-                <Container {...this.props.containerProps} ref="container" defaultActiveKey={0} key={"swiper-" + this.props.responses.length + "-" + this.props.missingResponses} shouldUpdate={(nextProps, props) => {return nextProps !== props; }}>
+                <Container {...this.props.containerProps}
+                    onChangeIndex={(index) => {this.setState({index}); }}
+                    ref="container"
+                    defaultActiveKey={0}
+                    index={this.state.index || 0}
+                    key={"swiper"}
+                    >
                     {this.renderPages(validResponses)}
                 </Container>
                 {this.renderAdditionalInfo()}
             </div>
         );
+    },
+    next() {
+        this.setState({index: Math.min(this.props.validator(this.props.format).getValidResponses(this.props.responses).length - 1, this.state.index + 1)});
+    },
+    previous() {
+        this.setState({index: Math.max(0, this.state.index - 1) });
     }
 });
 

--- a/web/client/components/data/identify/SwipeHeader.jsx
+++ b/web/client/components/data/identify/SwipeHeader.jsx
@@ -7,30 +7,23 @@
  */
 
 const React = require('react');
-const ReactDOM = require('react-dom');
 
 const {Glyphicon, Button} = require('react-bootstrap');
 
 const SwipeHeader = React.createClass({
     propTypes: {
         title: React.PropTypes.string,
+        index: React.PropTypes.number,
+        size: React.PropTypes.number,
         container: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.func]),
-        useButtons: React.PropTypes.bool
+        useButtons: React.PropTypes.bool,
+        onPrevious: React.PropTypes.func,
+        onNext: React.PropTypes.func
     },
     getDefaultProps() {
         return {
-            useButtons: false
+            useButtons: true
         };
-    },
-    componentDidMount() {
-        this.interval = setInterval(() => {
-            if (this.props.container && this.props.container().swipe && ReactDOM.findDOMNode(this.refs.left)) {
-                ReactDOM.findDOMNode(this.refs.left).style.opacity = this.props.container().swipe.getPos() > 0 ? 1.0 : 0.5;
-            }
-            if (this.props.container && this.props.container().swipe && ReactDOM.findDOMNode(this.refs.right)) {
-                ReactDOM.findDOMNode(this.refs.right).style.opacity = this.props.container().swipe.getPos() < (this.props.container().swipe.getNumSlides() - 1) ? 1.0 : 0.5;
-            }
-        }, 500);
     },
     componentWillUnmount() {
         if (this.interval) {
@@ -39,13 +32,13 @@ const SwipeHeader = React.createClass({
     },
     renderLeftButton() {
         return this.props.useButtons ?
-            <Button ref="left" className="swipe-header-left-button square-button" bsStyle="primary" onClick={() => {this.props.container().swipe.prev(); }}><Glyphicon glyph="arrow-left"/></Button> :
-            <a ref="left" className="swipe-header-left-button" onClick={() => {this.props.container().swipe.prev(); }}><Glyphicon glyph="chevron-left" /></a>;
+            <Button ref="left" disabled={this.props.index === 0 ? true : false} className="swipe-header-left-button square-button" bsStyle="primary" onClick={() => {this.props.onPrevious(); }}><Glyphicon glyph="arrow-left"/></Button> :
+            <a ref="left" disabled={this.props.index === 0 ? true : false} className="swipe-header-left-button" onClick={() => {this.props.onPrevious(); }}><Glyphicon glyph="chevron-left" /></a>;
     },
     renderRightButton() {
         return this.props.useButtons ?
-            <Button ref="right" className="swipe-header-right-button square-button" bsStyle="primary" onClick={() => {this.props.container().swipe.next(); }}><Glyphicon glyph="arrow-right"/></Button> :
-            <a ref="right" className="swipe-header-right-button" onClick={() => {this.props.container().swipe.next(); }}><Glyphicon glyph="chevron-right" /></a>;
+            <Button ref="right" disabled={this.props.index === (this.props.size - 1) ? true : false } className="swipe-header-right-button square-button" bsStyle="primary" onClick={() => {this.props.onNext(); }}><Glyphicon glyph="arrow-right"/></Button> :
+            <a ref="right" disabled={this.props.index === (this.props.size - 1) ? true : false} className="swipe-header-right-button" onClick={() => {this.props.onNext(); }}><Glyphicon glyph="chevron-right" /></a>;
     },
     render() {
         return (<span>{this.renderLeftButton()} <span>{this.props.title}</span> {this.renderRightButton()}</span>);

--- a/web/client/components/data/identify/__tests__/SwipeHeader-test.jsx
+++ b/web/client/components/data/identify/__tests__/SwipeHeader-test.jsx
@@ -54,28 +54,28 @@ describe('SwipeHeader', () => {
 
         expect(header).toExist();
         const dom = ReactDOM.findDOMNode(header);
-        expect(dom.getElementsByTagName('a').length).toBe(2);
+        expect(dom.getElementsByTagName('button').length).toBe(2);
     });
 
     it('calls containers handler when swipe buttons are pressed', () => {
         const testHandlers = {
-            next: () => {},
-            prev: () => {}
+            onNext: () => {},
+            onPrevious: () => {}
         };
 
         const container = () => ({
             swipe: testHandlers
         });
 
-        const spyNext = expect.spyOn(testHandlers, 'next');
-        const spyPrev = expect.spyOn(testHandlers, 'prev');
+        const spyNext = expect.spyOn(testHandlers, 'onNext');
+        const spyPrev = expect.spyOn(testHandlers, 'onPrevious');
 
         const header = ReactDOM.render(
-            <SwipeHeader title="mytitle" container={container}/>,
+            <SwipeHeader title="mytitle" container={container} onNext={testHandlers.onNext} onPrevious={testHandlers.onPrevious}/>,
             document.getElementById("container")
         );
         const dom = ReactDOM.findDOMNode(header);
-        const buttons = dom.getElementsByTagName('a');
+        const buttons = dom.getElementsByTagName('button');
 
         ReactTestUtils.Simulate.click(buttons[0]);
         expect(spyPrev.calls.length).toEqual(1);

--- a/web/client/components/data/identify/viewers/ViewerPage.jsx
+++ b/web/client/components/data/identify/viewers/ViewerPage.jsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+
+module.exports = React.createClass({
+    propTypes: {
+        format: React.PropTypes.string,
+        viewers: React.PropTypes.object,
+        response: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object, React.PropTypes.node])
+    },
+
+    onTouchStart(event) {
+        const touch = event.touches[0];
+        this.startX = touch.pageX;
+        this.startY = touch.pageY;
+        this.setState({scrolling: false});
+    },
+    onTouchMove(event) {
+        const touch = event.touches[0];
+        const div = event.currentTarget;
+        if (this.state.scrolling) {
+            event.stopPropagation();
+            return;
+        }
+        // identify direction
+        if (Math.abs(this.startY - touch.pageY) > Math.abs(this.startX - touch.pageX)) {
+            // vertical scrolling
+            event.stopPropagation();
+            return;
+        }
+        // > 0 left, < 0
+        const dir = this.startX < touch.pageX ? "left" : "right";
+
+        if (div && dir === "left" && ((div.clientWidth < div.scrollWidth && div.scrollLeft !== 0) )) {
+            // left border not reached
+            this.setState({scrolling: true});
+            event.stopPropagation();
+
+        } else if (div && dir === "right" && (div.clientWidth + div.scrollLeft !== div.scrollWidth) ) {
+            // right border not reached
+            this.setState({scrolling: true});
+            event.stopPropagation();
+        }
+
+    },
+    onTouchEnd() {
+        this.setState({scrolling: false});
+    },
+    renderPage(response) {
+        const Viewer = this.props.viewers[this.props.format];
+        if (Viewer) {
+            return <Viewer response={response} />;
+        }
+        return null;
+    },
+    render() {
+        return (<div
+            style={{width: "100%", height: "100%", overflow: "auto"}}
+            onTouchMove={this.onTouchMove}
+            onTouchStart={this.onTouchStart}
+            onTouchEnd={this.onTouchEnd}>
+                {this.renderPage(this.props.response)}
+        </div>);
+    }
+});

--- a/web/client/product/assets/css/viewer.css
+++ b/web/client/product/assets/css/viewer.css
@@ -290,14 +290,14 @@ html, body, #container, .fill {
     }
 }
 
-#mapstore-getfeatureinfo .modal-body .panel-heading {
+#mapstore-getfeatureinfo  .panel-heading {
     background-color: white;
     border: none;
     height: 60px;
     padding: 0;
 }
 
-#mapstore-getfeatureinfo .modal-body .panel {
+#mapstore-getfeatureinfo .panel {
     border: none;
 }
 
@@ -305,16 +305,16 @@ html, body, #container, .fill {
     padding: 0;
 }
 
-#mapstore-getfeatureinfo .modal-body .panel-heading .swipe-header-left-button {
+#mapstore-getfeatureinfo .panel-heading .swipe-header-left-button {
     right: 55px;
     top: 0;
 }
 
-#mapstore-getfeatureinfo .modal-body .panel-heading .swipe-header-right-button {
+#mapstore-getfeatureinfo .panel-heading .swipe-header-right-button {
     top: 0;
 }
 
-#mapstore-getfeatureinfo .modal-body .panel-title {
+#mapstore-getfeatureinfo .panel-title {
     font-weight: bold;
 }
 

--- a/web/client/product/assets/css/viewer.css
+++ b/web/client/product/assets/css/viewer.css
@@ -290,14 +290,14 @@ html, body, #container, .fill {
     }
 }
 
-#mapstore-getfeatureinfo  .panel-heading {
+#mapstore-getfeatureinfo .swipeable-view .panel-heading {
     background-color: white;
     border: none;
     height: 60px;
     padding: 0;
 }
 
-#mapstore-getfeatureinfo .panel {
+#mapstore-getfeatureinfo .swipeable-view .panel {
     border: none;
 }
 
@@ -305,16 +305,16 @@ html, body, #container, .fill {
     padding: 0;
 }
 
-#mapstore-getfeatureinfo .panel-heading .swipe-header-left-button {
+#mapstore-getfeatureinfo .swipeable-view .panel-heading .swipe-header-left-button {
     right: 55px;
     top: 0;
 }
 
-#mapstore-getfeatureinfo .panel-heading .swipe-header-right-button {
+#mapstore-getfeatureinfo .swipeable-view .panel-heading .swipe-header-right-button {
     top: 0;
 }
 
-#mapstore-getfeatureinfo .panel-title {
+#mapstore-getfeatureinfo .swipeable-view .panel-title {
     font-weight: bold;
 }
 

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -46,7 +46,7 @@ module.exports = {
         FooterPlugin: require('./plugins/Footer')
     },
     requires: {
-        ReactSwipe: require('react-swipe'),
+        ReactSwipe: require('react-swipeable-views').default,
         SwipeHeader: require('../components/data/identify/SwipeHeader')
     }
 };


### PR DESCRIPTION
Replaces the react-swipe lib with [React Swipable Views](https://github.com/oliviertassinari/react-swipeable-views). To avoid issues related to dom events VS react events. (React Swipable is a wrapper for a pure js lib. The events bubbling can not be stopped by react). 

This changes:
1) Allow to scroll horizontally the content of the feature info if it overflows the size of the window.
2) Page change can be managed using props instead of function calls
3) Buttons are fixed with the new theme

NOTE: the default has changed to use buttons by default. Use `{headerConfigs: {useButtons: false}}` to preserve the previous behavior. 