### PR TITLE
Fixed #819 issued for reset info about marker in mapinfo reducer

### DIFF
--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015, GeoSolutions Sas.
+ * Copyright 2015-2016, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -202,5 +202,11 @@ describe('Test the mapInfo reducer', () => {
         expect(state).toExist();
         expect(state.showModalReverse).toBe(false);
         expect(state.reverseGeocodeData).toBe(undefined);
+    });
+
+    it('should reset the state', () => {
+        let state = mapInfo({showMarker: true}, {type: 'RESET_CONTROLS'});
+        expect(state).toExist();
+        expect(state.showMarker).toBe(false);
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -1,14 +1,14 @@
 /**
- * Copyright 2015, GeoSolutions Sas.
+ * Copyright 2015-2016, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-var {CLICK_ON_MAP} = require('../actions/map');
+const {CLICK_ON_MAP} = require('../actions/map');
 
-var {
+const {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
     LOAD_FEATURE_INFO,
@@ -21,6 +21,8 @@ var {
     SHOW_REVERSE_GEOCODE,
     HIDE_REVERSE_GEOCODE
 } = require('../actions/mapInfo');
+
+const {RESET_CONTROLS} = require('../actions/controls');
 
 const assign = require('object-assign');
 const {head} = require('lodash');
@@ -98,6 +100,13 @@ function mapInfo(state = {}, action) {
                 showModalReverse: false,
                 reverseGeocodeData: undefined
             });
+        }
+        case RESET_CONTROLS: {
+            return assign({}, state, {
+                  showMarker: false,
+                  responses: [],
+                  requests: []
+              });
         }
         default:
             return state;

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -8,7 +8,7 @@
 var expect = require('expect');
 
 var SecurityUtils = require('../SecurityUtils');
-
+const assign = require('object-assign');
 const adminA = {
     User: {
         enabled: true,
@@ -19,14 +19,14 @@ const adminA = {
     }
 };
 
-const adminB = Object.assign({}, adminA, {
+const adminB = assign({}, adminA, {
     attribute: {
         name: "UUID",
         value: "263c6917-543f-43e3-8e1a-6a0d29952f72"
     }
 });
 
-const adminC = Object.assign({}, adminA, {
+const adminC = assign({}, adminA, {
     attribute: [{
         name: "UUID",
         value: "263c6917-543f-43e3-8e1a-6a0d29952f72"


### PR DESCRIPTION
fixed the reducer mapinfo adding the RESET_CONTROLS action
        modified:   `web/client/reducers/__tests__/mapInfo-test.js`
        modified:   `web/client/reducers/mapInfo.js`


