### PR TITLE
Fixed Iss599, GetFeatureInfo now works on leaflet and openlayers

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015, GeoSolutions Sas.
+ * Copyright 2015-2016, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -314,6 +314,9 @@ var OpenlayersMap = React.createClass({
     registerHooks() {
         mapUtils.registerHook(mapUtils.RESOLUTIONS_HOOK, () => {
             return this.getResolutions();
+        });
+        mapUtils.registerHook(mapUtils.RESOLUTION_HOOK, () => {
+            return this.map.getView().getResolution();
         });
         mapUtils.registerHook(mapUtils.COMPUTE_BBOX_HOOK, (center, zoom) => {
             var olCenter = CoordinatesUtils.reproject([center.x, center.y], 'EPSG:4326', this.props.projection);

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -78,22 +78,15 @@ const MapInfoUtils = {
         };
     },
     /**
-     * Creates a new bbox.
+     * Returns a bounds object.
      * @param {number} minX Minimum X.
      * @param {number} minY Minimum Y.
      * @param {number} maxX Maximum X.
      * @param {number} maxY Maximum Y.
-     * @param {Object} optExtent Destination extent.
-     * @return {Object Extent.
+     * @return {Object} Extent.
      */
-    createBBox(minX, minY, maxX, maxY, optExtent) {
-        if (optExtent) {
-            optExtent.maxx = maxX;
-            optExtent.maxy = maxY;
-            optExtent.minx = minX;
-            optExtent.miny = minY;
-        }
-        return assign(optExtent || {}, { maxx: maxX, maxy: maxY, minx: minX, miny: minY });
+    createBBox(minX, minY, maxX, maxY) {
+        return { minx: minX, miny: minY, maxx: maxX, maxy: maxY };
     },
     /**
      * Creates a bbox of size dimensions areund the center point given to it given the
@@ -102,10 +95,9 @@ const MapInfoUtils = {
      * @param resolution {number} the resolution of the map
      * @param rotation {number} the optional rotation of the new bbox
      * @param size {object} width,height of the desired bbox
-     * @param opt_extent {object}  optional bbox if passed it will be updated
      * @return {object} the desired bbox {minx, miny, maxx, maxy}
      */
-     getProjectedBBox(center, resolution, rotation = 0, size, optExtent) {
+     getProjectedBBox(center, resolution, rotation = 0, size) {
         let dx = resolution * size[0] / 2;
         let dy = resolution * size[1] / 2;
         let cosRotation = Math.cos(rotation);
@@ -124,11 +116,10 @@ const MapInfoUtils = {
         let y1 = y - xSin + yCos;
         let y2 = y + xSin + yCos;
         let y3 = y + xSin - yCos;
-        let bbox = MapInfoUtils.createBBox(
+        let bounds = MapInfoUtils.createBBox(
             Math.min(x0, x1, x2, x3), Math.min(y0, y1, y2, y3),
-            Math.max(x0, x1, x2, x3), Math.max(y0, y1, y2, y3),
-            optExtent);
-        return bbox;
+            Math.max(x0, x1, x2, x3), Math.max(y0, y1, y2, y3));
+        return bounds;
     },
     buildIdentifyRequest(layer, props) {
         /* In order to create a valid feature info request

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -135,7 +135,7 @@ const MapInfoUtils = {
         // longitude restricted to the [-180°,+180°] range
         let lngCorrected = wrongLng - (360) * Math.floor(wrongLng / (360) + 0.5);
         const center = {x: lngCorrected, y: props.point.latlng.lat};
-        let centerProjected = CoordinatesUtils.reproject(center, props.map.bbox.crs, props.map.projection);
+        let centerProjected = CoordinatesUtils.reproject(center, 'EPSG:4326', props.map.projection);
         let bounds = MapInfoUtils.getProjectedBBox(centerProjected, resolution, rotation, size, null);
         if (layer.type === 'wms') {
             return {

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015, GeoSolutions Sas.
+ * Copyright 2015-2016, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -16,6 +16,7 @@ const GOOGLE_MERCATOR = {
 
 const EXTENT_TO_ZOOM_HOOK = 'EXTENT_TO_ZOOM_HOOK';
 const RESOLUTIONS_HOOK = 'RESOLUTIONS_HOOK';
+const RESOLUTION_HOOK = 'RESOLUTION_HOOK';
 const COMPUTE_BBOX_HOOK = 'COMPUTE_BBOX_HOOK';
 
 var hooks = {};
@@ -173,6 +174,24 @@ function getZoomForExtent(extent, mapSize, minZoom, maxZoom, dpi) {
 }
 
 /**
+* It returns the current resolution.
+*
+* @param currentZoom {number} the current zoom
+* @param minZoom {number} min zoom level.
+* @param maxZoom {number} max zoom level.
+* @param dpi {number} screen resolution in dot per inch.
+* @return {Number} the actual resolution
+*/
+function getCurrentResolution(currentZoom, minZoom, maxZoom, dpi) {
+    if (getHook("RESOLUTION_HOOK")) {
+        return getHook("RESOLUTION_HOOK")(currentZoom, minZoom, maxZoom, dpi);
+    }
+    /* if no hook is registered (leaflet) it is used the GoogleMercatorResolutions in
+       in order to get the list of resolutions */
+    return getGoogleMercatorResolutions(minZoom, maxZoom, dpi)[currentZoom];
+}
+
+/**
  * Calculates the center for for the given extent.
  *
  * @param  {Array} extent [minx, miny, maxx, maxy]
@@ -224,6 +243,7 @@ function mapUpdated(oldMap, newMap) {
 module.exports = {
     EXTENT_TO_ZOOM_HOOK,
     RESOLUTIONS_HOOK,
+    RESOLUTION_HOOK,
     COMPUTE_BBOX_HOOK,
     DEFAULT_SCREEN_DPI,
     registerHook,
@@ -240,5 +260,6 @@ module.exports = {
     getResolutions,
     getScales,
     getBbox,
-    mapUpdated
+    mapUpdated,
+    getCurrentResolution
 };

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015, GeoSolutions Sas.
+ * Copyright 2015-2016, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -11,7 +11,9 @@ var {
     getAvailableInfoFormat,
     getAvailableInfoFormatLabels,
     getAvailableInfoFormatValues,
-    getDefaultInfoFormatValue
+    getDefaultInfoFormatValue,
+    createOrUpdate,
+    getForViewAndSize
 } = require('../MapInfoUtils');
 
 describe('MapInfoUtils', () => {
@@ -60,5 +62,21 @@ describe('MapInfoUtils', () => {
         let results = getDefaultInfoFormatValue();
         expect(results).toExist();
         expect(results).toBe('text/plain');
+    });
+
+    it('it should returns a bbox', () => {
+        let results = createOrUpdate(-10, 10, -10, 10);
+        expect(results).toExist();
+        expect(results.maxx).toBe(-10);
+    });
+
+    it('it should tests the creation of a bbox given the center, resolution and size', () => {
+        let center = {x: 0, y: 0};
+        let resolution = 1;
+        let size = [10, 10];
+        let bbox = getForViewAndSize(center, resolution, 0, size, null);
+        expect(bbox).toExist();
+        expect(bbox.maxx).toBeGreaterThan(bbox.minx);
+        expect(bbox.maxy).toBeGreaterThan(bbox.miny);
     });
 });

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -73,8 +73,9 @@ describe('MapInfoUtils', () => {
     it('it should tests the creation of a bbox given the center, resolution and size', () => {
         let center = {x: 0, y: 0};
         let resolution = 1;
+        let rotation = 0;
         let size = [10, 10];
-        let bbox = getProjectedBBox(center, resolution, 0, size, null);
+        let bbox = getProjectedBBox(center, resolution, rotation, size);
         expect(bbox).toExist();
         expect(bbox.maxx).toBeGreaterThan(bbox.minx);
         expect(bbox.maxy).toBeGreaterThan(bbox.miny);

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -12,8 +12,8 @@ var {
     getAvailableInfoFormatLabels,
     getAvailableInfoFormatValues,
     getDefaultInfoFormatValue,
-    createOrUpdate,
-    getForViewAndSize
+    createBBox,
+    getProjectedBBox
 } = require('../MapInfoUtils');
 
 describe('MapInfoUtils', () => {
@@ -65,7 +65,7 @@ describe('MapInfoUtils', () => {
     });
 
     it('it should returns a bbox', () => {
-        let results = createOrUpdate(-10, 10, -10, 10);
+        let results = createBBox(-10, 10, -10, 10);
         expect(results).toExist();
         expect(results.maxx).toBe(-10);
     });
@@ -74,7 +74,7 @@ describe('MapInfoUtils', () => {
         let center = {x: 0, y: 0};
         let resolution = 1;
         let size = [10, 10];
-        let bbox = getForViewAndSize(center, resolution, 0, size, null);
+        let bbox = getProjectedBBox(center, resolution, 0, size, null);
         expect(bbox).toExist();
         expect(bbox.maxx).toBeGreaterThan(bbox.minx);
         expect(bbox.maxy).toBeGreaterThan(bbox.miny);

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015, GeoSolutions Sas.
+ * Copyright 2015-2016, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -11,15 +11,18 @@ var {
     RESOLUTIONS_HOOK,
     EXTENT_TO_ZOOM_HOOK,
     COMPUTE_BBOX_HOOK,
+    RESOLUTION_HOOK,
     registerHook,
     dpi2dpm,
     getSphericalMercatorScales,
     getSphericalMercatorScale,
     getGoogleMercatorScales,
+    getGoogleMercatorResolutions,
     getGoogleMercatorScale,
     getZoomForExtent,
     getCenterForExtent,
-    getBbox
+    getBbox,
+    getCurrentResolution
 } = require('../MapUtils');
 
 describe('Test the MapUtils', () => {
@@ -82,5 +85,17 @@ describe('Test the MapUtils', () => {
         registerHook(COMPUTE_BBOX_HOOK, () => "bbox");
         let bbox = getBbox(null, null, null);
         expect(bbox).toBe("bbox");
+    });
+    it('getCurrentResolution using the RESOLUTION_HOOK', () => {
+        registerHook(RESOLUTION_HOOK, () => {
+            return 2;
+        });
+        expect(getCurrentResolution(5, 0, 21, 96)).toBe(2);
+    });
+    it('getCurrentResolution with no HOOK', () => {
+        registerHook(RESOLUTION_HOOK, undefined );
+        let resolution = getGoogleMercatorResolutions(0, 21, 96)[2];
+        let resolution2 = getCurrentResolution(2, 0, 21, 96);
+        expect(resolution2).toEqual(resolution);
     });
 });


### PR DESCRIPTION
#599 In order to create a valid feature info request we create a bbox of 101x101 pixel that wrap the point.
The center point is repojected and a bbox of 101x101pixel is built around it.

Also added some functions in mapUtils and the tests don't throw errors.