### PR TITLE
SharePlugin : removed the skipping test

### DIFF
--- a/web/client/components/share/_tests_/ShareLink-test.jsx
+++ b/web/client/components/share/_tests_/ShareLink-test.jsx
@@ -41,6 +41,5 @@ describe("The ShareLink component", () => {
 
     });
 
-    it('it simulates the click and verify the call of onClick');
 
 });


### PR DESCRIPTION
I just removed the useless skipping test for the sharelink component