### PR TITLE
Remove source map and fixed camel case filename error

### DIFF
--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -21,6 +21,7 @@ webpackConfig.plugins = [
     new NormalModuleReplacementPlugin(/openlayers$/, path.join(__dirname, "web", "client", "libs", "openlayers")),
     new NormalModuleReplacementPlugin(/proj4$/, path.join(__dirname, "web", "client", "libs", "proj4")),
     new UglifyJsPlugin({
+        sourceMap: false,
         compress: {warnings: false},
         mangle: true
     })

--- a/web/client/plugins/shapefile/index.js
+++ b/web/client/plugins/shapefile/index.js
@@ -18,7 +18,7 @@ const ShapeFileUploadAndStyle = connect((state) => (
             }
         ), {
     onShapeError: onShapeError
-})(require('../../components/shapefile/ShapeFileUploadAndStyle'));
+})(require('../../components/shapefile/ShapefileUploadAndStyle'));
 
 const StylePolygon = connect((state) => (
         {


### PR DESCRIPTION
There was an issue of file name. 
Anyway on linux using the `sourceMap : true` causes a slow down of the build. It has been disabled until we can investigate more: 
reference: 
https://github.com/webpack/webpack/issues/537

Possible issues can be caused by:

 https://github.com/mishoo/UglifyJS2/pull/1024

or 

https://github.com/webpack/webpack/issues/537#issuecomment-132077479