### PR TITLE
Changed share plugin glyphicons and remove icon in drawer menu

### DIFF
--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -37,7 +37,7 @@ const ShareEmbed = React.createClass({
       const copyTo = (<OverlayTrigger placement="bottom" overlay={tooltip}>
                           <CopyToClipboard text={codeEmbedded} onCopy={ () => this.setState({copied: true}) } >
                               <Button className="buttonCopyTextArea" bsStyle="info">
-                                  <Glyphicon glyph="paperclip" onMouseLeave={() => {this.setState({copied: false}); }} />
+                                  <Glyphicon glyph="copy" onMouseLeave={() => {this.setState({copied: false}); }} />
                               </Button>
                           </CopyToClipboard>
                       </OverlayTrigger>);

--- a/web/client/components/share/ShareLink.jsx
+++ b/web/client/components/share/ShareLink.jsx
@@ -34,7 +34,7 @@ const ShareLink = React.createClass({
         const copyTo = (<OverlayTrigger placement="bottom" overlay={tooltip}>
                             <CopyToClipboard text={this.props.shareUrl} onCopy={ () => this.setState({copied: true}) } >
                                 <Button className="buttonCopy" bsStyle="info" onMouseLeave={() => {this.setState({copied: false}); }} >
-                                    <Glyphicon glyph="paperclip"/>
+                                    <Glyphicon glyph="copy"/>
                                 </Button>
                             </CopyToClipboard>
                         </OverlayTrigger>);

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -35,7 +35,7 @@ module.exports = {
             name: 'share',
             position: 1000,
             text: <Message msgId="share.title"/>,
-            icon: <Glyphicon glyph="paperclip"/>,
+        icon: <Glyphicon glyph="share-alt"/>,
             action: toggleControl.bind(null, 'share', null)
         }
     })

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -49,14 +49,14 @@ var Menu = React.createClass({
     renderContent() {
         const header = this.props.single ? (
             <div className="navHeader" style={{width: "100%", minHeight: "35px"}}>
-                <Glyphicon glyph="remove" onClick={this.props.onToggle} style={{position: "absolute", left: "0", padding: "15px", cursor: "pointer"}}/>
+                <Glyphicon glyph="1-close no-border btn-default" onClick={this.props.onToggle} style={{position: "absolute", left: "0", padding: "15px", cursor: "pointer"}}/>
                 <div className="navButtons">
                     {this.renderButtons()}
                 </div>
             </div>
         ) : (<div className="navHeader" style={{width: "100%", minHeight: "35px"}}>
             <span className="title">{this.props.title}</span>
-            <Glyphicon glyph="remove" onClick={this.props.onToggle} style={{position: "absolute", right: "0", padding: "15px", cursor: "pointer"}}/>
+            <Glyphicon glyph="1-close no-border btn-default" onClick={this.props.onToggle} style={{position: "absolute", right: "0", padding: "15px", cursor: "pointer"}}/>
         </div>);
         return (<div className={"nav-content"}>
             {header}

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -49,14 +49,14 @@ var Menu = React.createClass({
     renderContent() {
         const header = this.props.single ? (
             <div className="navHeader" style={{width: "100%", minHeight: "35px"}}>
-                <Glyphicon glyph="1-close no-border btn-default" onClick={this.props.onToggle} style={{position: "absolute", left: "0", padding: "15px", cursor: "pointer"}}/>
+                <Glyphicon glyph="1-close" className="no-border btn-default" onClick={this.props.onToggle} style={{position: "absolute", left: "0", padding: "15px", cursor: "pointer"}}/>
                 <div className="navButtons">
                     {this.renderButtons()}
                 </div>
             </div>
         ) : (<div className="navHeader" style={{width: "100%", minHeight: "35px"}}>
             <span className="title">{this.props.title}</span>
-            <Glyphicon glyph="1-close no-border btn-default" onClick={this.props.onToggle} style={{position: "absolute", right: "0", padding: "15px", cursor: "pointer"}}/>
+            <Glyphicon glyph="1-close" className="no-border btn-default" onClick={this.props.onToggle} style={{position: "absolute", right: "0", padding: "15px", cursor: "pointer"}}/>
         </div>);
         return (<div className={"nav-content"}>
             {header}


### PR DESCRIPTION
The icons of share plugin are updated with the new ones and it is changed the "remove" to "1-close" glyphicon in the drawer menu