### PR TITLE
Fixed #800 : added a success message after that the shapefile has correctly been imported

### DIFF
--- a/web/client/actions/shapefile.js
+++ b/web/client/actions/shapefile.js
@@ -11,7 +11,7 @@ const ON_SELECT_LAYER = 'ON_SELECT_LAYER';
 const SHAPE_LOADING = 'SHAPE_LOADING';
 const ON_LAYER_ADDED = 'ON_LAYER_ADDED';
 const UPDATE_SHAPE_BBOX = 'UPDATE_SHAPE_BBOX';
-
+const ON_SHAPE_SUCCESS = 'ON_SHAPE_SUCCESS';
 
 function onShapeChoosen(layers) {
     return {
@@ -49,6 +49,12 @@ function updateShapeBBox(bbox) {
         bbox
     };
 }
+function onShapeSuccess(message) {
+    return {
+        type: ON_SHAPE_SUCCESS,
+        message
+    };
+}
 
 module.exports = {
     ON_SHAPE_CHOOSEN,
@@ -57,10 +63,12 @@ module.exports = {
     ON_SELECT_LAYER,
     ON_LAYER_ADDED,
     UPDATE_SHAPE_BBOX,
+    ON_SHAPE_SUCCESS,
     onShapeChoosen,
     onShapeError,
     shapeLoading,
     onSelectLayer,
     onLayerAdded,
-    updateShapeBBox
+    updateShapeBBox,
+    onShapeSuccess
 };

--- a/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
+++ b/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
@@ -10,6 +10,7 @@ const React = require('react');
 
 const Message = require('../../components/I18N/Message');
 const LayersUtils = require('../../utils/LayersUtils');
+const LocaleUtils = require('../../utils/LocaleUtils');
 const FileUtils = require('../../utils/FileUtils');
 let StyleUtils;
 const {Grid, Row, Col, Button} = require('react-bootstrap');
@@ -26,6 +27,7 @@ const ShapeFileUploadAndStyle = React.createClass({
         style: React.PropTypes.object,
         shapeStyle: React.PropTypes.object,
         onShapeError: React.PropTypes.func,
+        onShapeSuccess: React.PropTypes.func,
         onShapeChoosen: React.PropTypes.func,
         addShapeLayer: React.PropTypes.func,
         shapeLoading: React.PropTypes.func,
@@ -34,6 +36,7 @@ const ShapeFileUploadAndStyle = React.createClass({
         onZoomSelected: React.PropTypes.func,
         updateShapeBBox: React.PropTypes.func,
         error: React.PropTypes.string,
+        success: React.PropTypes.string,
         mapType: React.PropTypes.string,
         buttonSize: React.PropTypes.string,
         uploadMessage: React.PropTypes.object,
@@ -42,6 +45,9 @@ const ShapeFileUploadAndStyle = React.createClass({
         stylers: React.PropTypes.object,
         uploadOptions: React.PropTypes.object,
         createId: React.PropTypes.func
+    },
+    contextTypes: {
+        messages: React.PropTypes.object
     },
     getDefaultProps() {
         return {
@@ -71,6 +77,11 @@ const ShapeFileUploadAndStyle = React.createClass({
                    <div style={{textAlign: "center"}} className="alert alert-danger">{this.props.error}</div>
                 </Row>);
     },
+    renderSuccess() {
+        return (<Row>
+                   <div style={{textAlign: "center"}} className="alert alert-success">{this.props.success}</div>
+                </Row>);
+    },
     renderStyle() {
         return this.props.stylers[this.getGeomType(this.props.selected)];
     },
@@ -97,6 +108,7 @@ const ShapeFileUploadAndStyle = React.createClass({
         return (
             <Grid role="body" style={{width: "300px"}} fluid>
                 {(this.props.error) ? this.renderError() : null}
+                {(this.props.success) ? this.renderSuccess() : null}
             <Row style={{textAlign: "center"}}>
                 {
             (this.props.selected) ?
@@ -140,7 +152,7 @@ const ShapeFileUploadAndStyle = React.createClass({
             this.props.onShapeError(e.message || e);
         });
     },
-        addToMap() {
+    addToMap() {
         this.props.shapeLoading(true);
         let styledLayer = this.props.selected;
         if (!this.state.useDefaultStyle) {
@@ -150,8 +162,7 @@ const ShapeFileUploadAndStyle = React.createClass({
             this.props.shapeLoading(false);
 
             // calculates the bbox that contain last shapefile and the previous added
-            const layers = this.props.layers;
-            const bbox = layers[0].features.reduce((bboxtotal, feature) => {
+            const bbox = this.props.layers[0].features.reduce((bboxtotal, feature) => {
                 return [
                     Math.min(bboxtotal[0], feature.geometry.bbox[0]),
                     Math.min(bboxtotal[1], feature.geometry.bbox[1]),
@@ -163,6 +174,7 @@ const ShapeFileUploadAndStyle = React.createClass({
                 this.props.updateShapeBBox(bbox);
                 this.props.onZoomSelected(bbox, "EPSG:4326");
             }
+            this.props.onShapeSuccess(this.props.layers[0].name + LocaleUtils.getMessageById(this.context.messages, "shapefile.success"));
             this.props.onLayerAdded(this.props.selected);
         }).catch((e) => {
             this.props.shapeLoading(false);

--- a/web/client/plugins/ShapeFile.jsx
+++ b/web/client/plugins/ShapeFile.jsx
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 
 const Message = require('./locale/Message');
 
-const {onShapeError, shapeLoading, onShapeChoosen, onSelectLayer, onLayerAdded, updateShapeBBox} = require('../actions/shapefile');
+const {onShapeError, shapeLoading, onShapeChoosen, onSelectLayer, onLayerAdded, updateShapeBBox, onShapeSuccess} = require('../actions/shapefile');
 const {zoomToExtent} = require('../actions/map');
 const {addLayer} = require('../actions/layers');
 const {toggleControl} = require('../actions/controls');
@@ -30,6 +30,7 @@ module.exports = {
                 layers: state.shapefile && state.shapefile.layers || null,
                 selected: state.shapefile && state.shapefile.selected || null,
                 bbox: state.shapefile && state.shapefile.bbox || null,
+                success: state.shapefile && state.shapefile.success || null,
                 error: state.shapefile && state.shapefile.error || null,
                 shapeStyle: state.style || {}
             }
@@ -38,6 +39,7 @@ module.exports = {
                 onLayerAdded: onLayerAdded,
                 onSelectLayer: onSelectLayer,
                 onShapeError: onShapeError,
+                onShapeSuccess: onShapeSuccess,
                 addShapeLayer: addLayer,
                 onZoomSelected: zoomToExtent,
                 updateShapeBBox: updateShapeBBox,

--- a/web/client/reducers/shapefile.js
+++ b/web/client/reducers/shapefile.js
@@ -12,8 +12,11 @@ const {
     ON_SELECT_LAYER,
     SHAPE_LOADING,
     ON_LAYER_ADDED,
-    UPDATE_SHAPE_BBOX
+    UPDATE_SHAPE_BBOX,
+    ON_SHAPE_SUCCESS
 } = require('../actions/shapefile');
+
+const {TOGGLE_CONTROL} = require('../actions/controls');
 
 const assign = require('object-assign');
 
@@ -32,7 +35,7 @@ function shapefile(state = initialState, action) {
             return assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190]});
         }
         case ON_SHAPE_ERROR: {
-            return assign({}, state, {error: action.message});
+            return assign({}, state, {error: action.message, success: null});
         }
         case SHAPE_LOADING: {
             return assign({}, state, {loading: action.status});
@@ -49,6 +52,15 @@ function shapefile(state = initialState, action) {
         }
         case UPDATE_SHAPE_BBOX: {
             return assign({}, state, {bbox: action.bbox});
+        }
+        case ON_SHAPE_SUCCESS: {
+            return assign({}, state, {success: action.message, error: null});
+        }
+        case TOGGLE_CONTROL: {
+            if (action.control === 'shapefile') {
+                return assign({}, state, {error: null, success: null});
+            }
+            return state;
         }
         default:
             return state;

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -386,7 +386,8 @@
             "zoom": "Zoom on the shapefiles",
             "error": {"select": "Select one or more zip file"},
             "add": "Add",
-            "cancel": "Cancel"
+            "cancel": "Cancel",
+            "success" : " correctly imported"
         },
         "catalog": {
             "title": "Catalog",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -387,7 +387,8 @@
             "zoom": "Zoom sugli shapefile",
             "error": {"select": "Seleziona Shapefile compresso"},
             "add": "Importa",
-            "cancel": "Annulla"
+            "cancel": "Annulla",
+            "success" : " correttamente importato"
         },
         "catalog": {
             "title": "Catalogo",


### PR DESCRIPTION
Fixed #800.

Here is when adding a shapefile
![image](https://cloud.githubusercontent.com/assets/11991428/17108746/1bd0cbc8-5295-11e6-97ff-830d823dab6d.png)

Here is the success message
![image](https://cloud.githubusercontent.com/assets/11991428/17108782/3e871410-5295-11e6-9b91-9d8687c33415.png)

The error message, if present, disappears when a shapefile is correctly imported and the success message, if present, disappears when one or more errors occur during importation step.

When it is toggled the shapefile plugin the success message and error message are initialized.