### PR TITLE
Fixed #860 : Removed help tool from mobile configuration

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -19,9 +19,8 @@
         "zoomControl": false,
         "tools": ["locate"]
 			}
-		}, {
-			"name": "Help"
-		}, {
+		},
+		{
         "name": "DrawerMenu",
 				"cfg": {
 					"glyph": "1-stilo",


### PR DESCRIPTION
Fixed #860 : Removed help tool from mobile configuration
![image](https://cloud.githubusercontent.com/assets/11991428/17139112/692a6222-5343-11e6-89c1-1488076121ea.png)
