### PR TITLE
Fixed #884 : Long shapefile file names overlap the success message area

### DIFF
--- a/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
+++ b/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
@@ -79,7 +79,7 @@ const ShapeFileUploadAndStyle = React.createClass({
     },
     renderSuccess() {
         return (<Row>
-                   <div style={{textAlign: "center"}} className="alert alert-success">{this.props.success}</div>
+                   <div style={{textAlign: "center", overflowWrap: "break-word"}} className="alert alert-success">{this.props.success}</div>
                 </Row>);
     },
     renderStyle() {


### PR DESCRIPTION
fixed #884 : Now it doesn't overlap as described in the following picture
![image](https://cloud.githubusercontent.com/assets/11991428/17140567/32e92724-5349-11e6-9ac0-66ed2454ca9e.png)
