### PR TITLE
fixed #914 map size lost when reload config (before pan)

### DIFF
--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -14,12 +14,13 @@ var ConfigUtils = require('../utils/ConfigUtils');
 function mapConfig(state = null, action) {
     switch (action.type) {
         case MAP_CONFIG_LOADED:
+            let size = (state && state.map && state.map.present && state.map.present.size) || (state && state.map && state.map.size);
+
             let hasVersion = (action.config.version && action.config.version >= 2);
             // we get from the configuration what will be used as the initial state
             let mapState = (action.legacy && !hasVersion) ? ConfigUtils.convertFromLegacy(action.config) : ConfigUtils.normalizeConfig(action.config.map);
-            if (action.mapId) {
-                mapState.map = assign({}, mapState.map, {mapId: action.mapId});
-            }
+
+            mapState.map = assign({}, mapState.map, {mapId: action.mapId, size});
             // we store the map initial state for future usage
             return assign({}, mapState, {mapInitialConfig: mapState.map});
         case MAP_CONFIG_LOAD_ERROR:


### PR DESCRIPTION
This should fix the issue #914 and allow to zoom to extend even without panning the map first. 