### PR TITLE
Fix #917. Auto-load of missing info for map access

### DIFF
--- a/web/client/actions/__tests__/config-test.js
+++ b/web/client/actions/__tests__/config-test.js
@@ -7,7 +7,7 @@
  */
 
 const expect = require('expect');
-const {loadMapConfig, MAP_CONFIG_LOAD_ERROR, MAP_CONFIG_LOADED} = require('../config');
+const {loadMapConfig, loadMapInfo, MAP_CONFIG_LOAD_ERROR, MAP_CONFIG_LOADED} = require('../config');
 
 const loggedGetState = () => ({
     security: {
@@ -46,6 +46,30 @@ describe('Test configuration related actions', () => {
                 expect(e).toExist();
                 expect(e.type).toBe('MAP_CONFIG_LOAD_ERROR');
                 done();
+            } catch(ex) {
+                done(ex);
+            }
+        });
+    });
+    it('getResource access info', (done) => {
+        loadMapInfo('base/web/client/test-resources/geostore/ShortResource.json', 1)((actionCreator) => {
+            try {
+                switch (actionCreator.type) {
+                    case "MAP_INFO_LOAD_START":
+                        expect(actionCreator.mapId).toBe(1);
+                        break;
+                    case "MAP_INFO_LOADED":
+                        let resourceInfo = actionCreator.info;
+                        expect(resourceInfo).toExist();
+                        expect(resourceInfo.canEdit).toExist();
+                        expect(resourceInfo.id).toBe(1);
+                        done();
+                        break;
+                    default:
+                        done("ERROR");
+                        break;
+                }
+
             } catch(ex) {
                 done(ex);
             }

--- a/web/client/actions/config.js
+++ b/web/client/actions/config.js
@@ -11,6 +11,10 @@ var axios = require('../libs/ajax');
 const MAP_CONFIG_LOADED = 'MAP_CONFIG_LOADED';
 const MAP_CONFIG_LOAD_ERROR = 'MAP_CONFIG_LOAD_ERROR';
 
+const MAP_INFO_LOAD_START = 'MAP_INFO_LOAD_START';
+const MAP_INFO_LOADED = 'MAP_INFO_LOADED';
+const MAP_INFO_LOAD_ERROR = 'MAP_INFO_LOAD_ERROR';
+
 function configureMap(conf, mapId) {
     return {
         type: MAP_CONFIG_LOADED,
@@ -44,5 +48,51 @@ function loadMapConfig(configName, mapId) {
         });
     };
 }
+function mapInfoLoaded(info, mapId) {
+    return {
+        type: MAP_INFO_LOADED,
+        mapId,
+        info
+    };
+}
+function mapInfoLoadError(mapId, error) {
+    return {
+        type: MAP_INFO_LOAD_ERROR,
+        mapId,
+        error
+    };
+}
+function mapInfoLoadStart(mapId) {
+    return {
+        type: MAP_INFO_LOAD_START,
+        mapId
+    };
+}
+function loadMapInfo(url, mapId) {
+    return (dispatch) => {
+        dispatch(mapInfoLoadStart(mapId));
+        return axios.get(url).then((response) => {
+            if (typeof response.data === 'object') {
+                if (response.data.ShortResource) {
+                    dispatch(mapInfoLoaded(response.data.ShortResource, mapId));
+                } else {
+                    dispatch(mapInfoLoaded(response.data, mapId));
+                }
 
-module.exports = {MAP_CONFIG_LOADED, MAP_CONFIG_LOAD_ERROR, loadMapConfig, configureMap};
+            } else {
+                try {
+                    JSON.parse(response.data);
+                } catch(e) {
+                    dispatch(mapInfoLoadError( mapId, e));
+                }
+            }
+        }).catch((e) => {
+            dispatch(mapInfoLoadError(mapId, e));
+        });
+
+    };
+
+}
+module.exports = {MAP_CONFIG_LOADED, MAP_CONFIG_LOAD_ERROR,
+    MAP_INFO_LOAD_START, MAP_INFO_LOADED, MAP_INFO_LOAD_ERROR,
+     loadMapConfig, loadMapInfo, configureMap};

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -48,4 +48,16 @@ describe('Test the mapConfig reducer', () => {
         var state = mapConfig(1, {type: 'UNKNOWN'});
         expect(state).toBe(1);
     });
+    it('get map info', () => {
+        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', mapId: 1, config: { version: 2, map: {center: {x: 1, y: 1}, zoom: 11, layers: [] }}});
+        state = mapConfig(state, {type: "MAP_INFO_LOAD_START", mapId: 1});
+        expect(state.map).toExist();
+        expect(state.map.info).toExist();
+        expect(state.map.info.loading).toBe(true);
+        expect(state.map.center.crs).toExist();
+        state = mapConfig(state, {type: "MAP_INFO_LOADED", mapId: 1, info: {canEdit: true, canDelete: true}});
+        expect(state.map).toExist();
+        expect(state.map.info).toExist();
+        expect(state.map.info.canEdit).toBe(true);
+    });
 });

--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -94,7 +94,7 @@ describe('Test the map reducer', () => {
             crs: "EPSG:4326"
         };
 
-        var state = mapConfig({projection: "EPSG:4326"}, action);
+        var state = mapConfig({projection: "EPSG:4326", size: {width: 400, height: 400}}, action);
         expect(state.mapStateSource).toBe(undefined);
         expect(state.center.x).toBe(11);
         expect(state.center.y).toBe(45);

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -6,12 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {MAP_CONFIG_LOADED, MAP_CONFIG_LOAD_ERROR} = require('../actions/config');
+var {MAP_CONFIG_LOADED, MAP_INFO_LOAD_START, MAP_INFO_LOADED, MAP_INFO_LOAD_ERROR, MAP_CONFIG_LOAD_ERROR} = require('../actions/config');
 
 var assign = require('object-assign');
 var ConfigUtils = require('../utils/ConfigUtils');
 
 function mapConfig(state = null, action) {
+    let map;
     switch (action.type) {
         case MAP_CONFIG_LOADED:
             let size = (state && state.map && state.map.present && state.map.present.size) || (state && state.map && state.map.size);
@@ -27,6 +28,28 @@ function mapConfig(state = null, action) {
             return {
                 loadingError: action.error
             };
+        case MAP_INFO_LOAD_START:
+            map = state && state.map && state.map.present ? state.map.present : state && state.map;
+            if (map && (map.mapId === action.mapId)) {
+                map = assign({}, map, {info: {loading: true}});
+                return assign({}, state, {map: map});
+            }
+            return state;
+        case MAP_INFO_LOAD_ERROR: {
+            map = state && state.map && state.map.present ? state.map.present : state && state.map;
+            if (map && (map.mapId === action.mapId)) {
+                map = assign({}, map, {info: {error: action.error}});
+                return assign({}, state, {map: map});
+            }
+            return state;
+        }
+        case MAP_INFO_LOADED:
+            map = state && state.map && state.map.present ? state.map.present : state && state.map;
+            if (map && (map.mapId === action.mapId)) {
+                map = assign({}, map, {info: action.info});
+                return assign({}, state, {map: map});
+            }
+            return state;
         default:
             return state;
     }

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -43,6 +43,7 @@ function mapConfig(state = null, action) {
                 zoom = 2;
             } else {
                 let mapBBox = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.projection || "EPSG:4326");
+                // NOTE: STATE should contain size !!!
                 zoom = MapUtils.getZoomForExtent(mapBBox, state.size, 0, 21, null);
             }
             return assign({}, state, {

--- a/web/client/test-resources/geostore/ShortResource.json
+++ b/web/client/test-resources/geostore/ShortResource.json
@@ -1,0 +1,11 @@
+{
+  "ShortResource":{
+    "id":1,
+    "name":"Test Map",
+    "description":"",
+    "canDelete":true,
+    "canEdit":true,
+    "creation":"2015-03-24T11:05:27.274+00:00",
+    "lastUpdate":"2016-08-08T09:57:25.235+00:00"
+  }
+}


### PR DESCRIPTION
Now The map gets the proper access info if mapId is present, to show the save button.
Also fixed a zoomToExtend failing problem in test.  