### PR TITLE
When toggling the drawer-menu, map's width is resized

### DIFF
--- a/web/client/actions/__tests__/map-test.js
+++ b/web/client/actions/__tests__/map-test.js
@@ -13,11 +13,13 @@ var {
     CHANGE_MOUSE_POINTER,
     CHANGE_ZOOM_LVL,
     CHANGE_MAP_CRS,
+    CHANGE_MAP_STYLE,
     changeMapView,
     clickOnMap,
     changeMousePointer,
     changeZoomLevel,
-    changeMapCrs
+    changeMapCrs,
+    changeMapStyle
 } = require('../map');
 
 describe('Test correctness of the map actions', () => {
@@ -73,5 +75,16 @@ describe('Test correctness of the map actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(CHANGE_MAP_CRS);
         expect(retval.crs).toBe(testVal);
+    });
+
+    it('changeMapStyle', () => {
+        let style = {width: 100};
+        let mapStateSource = "test";
+        var retval = changeMapStyle(style, mapStateSource);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(CHANGE_MAP_STYLE);
+        expect(retval.style).toBe(style);
+        expect(retval.mapStateSource).toBe(mapStateSource);
     });
 });

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -13,6 +13,7 @@ const CHANGE_ZOOM_LVL = 'CHANGE_ZOOM_LVL';
 const PAN_TO = 'PAN_TO';
 const ZOOM_TO_EXTENT = 'ZOOM_TO_EXTENT';
 const CHANGE_MAP_CRS = 'CHANGE_MAP_CRS';
+const CHANGE_MAP_STYLE = 'CHANGE_MAP_STYLE';
 
 
 function changeMapView(center, zoom, bbox, size, mapStateSource, projection) {
@@ -72,6 +73,13 @@ function zoomToExtent(extent, crs) {
     };
 }
 
+function changeMapStyle(style, mapStateSource) {
+    return {
+        type: CHANGE_MAP_STYLE,
+        style,
+        mapStateSource
+    };
+}
 module.exports = {
     CHANGE_MAP_VIEW,
     CLICK_ON_MAP,
@@ -80,11 +88,13 @@ module.exports = {
     PAN_TO,
     ZOOM_TO_EXTENT,
     CHANGE_MAP_CRS,
+    CHANGE_MAP_STYLE,
     changeMapView,
     clickOnMap,
     changeMousePointer,
     changeZoomLevel,
     changeMapCrs,
     zoomToExtent,
-    panTo
+    panTo,
+    changeMapStyle
 };

--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -13,6 +13,8 @@ const Message = require('./locale/Message');
 
 const {toggleControl, setControlProperty} = require('../actions/controls');
 
+const {changeMapStyle} = require('../actions/map');
+
 const {Button, Glyphicon, Panel} = require('react-bootstrap');
 
 const Section = require('./drawer/Section');
@@ -24,7 +26,8 @@ const Menu = connect((state) => ({
     activeKey: state.controls.drawer && state.controls.drawer.menu
 }), {
     onToggle: toggleControl.bind(null, 'drawer', null),
-    onChoose: partialRight(setControlProperty.bind(null, 'drawer', 'menu'), true)
+    onChoose: partialRight(setControlProperty.bind(null, 'drawer', 'menu'), true),
+    changeMapStyle: changeMapStyle
 })(require('./drawer/Menu'));
 
 require('./drawer/drawer.css');

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -18,13 +18,30 @@ var Menu = React.createClass({
         show: React.PropTypes.bool,
         onToggle: React.PropTypes.func,
         onChoose: React.PropTypes.func,
-        single: React.PropTypes.bool
+        single: React.PropTypes.bool,
+        width: React.PropTypes.number,
+        overlapMap: React.PropTypes.bool,
+        changeMapStyle: React.PropTypes.func
     },
     getDefaultProps() {
         return {
             docked: false,
-            single: false
+            single: false,
+            width: 300,
+            overlapMap: true
         };
+    },
+    componentDidMount() {
+        if (!this.overlapMap && this.props.show) {
+            let style = {left: this.props.width, width: `calc(100% - ${this.props.width}px)`};
+            this.props.changeMapStyle(style, "drawerManu");
+        }
+    },
+    componentDidUpdate(prevProps) {
+        if (!this.props.overlapMap && prevProps.show !== this.props.show) {
+            let style = this.props.show ? {left: this.props.width, width: `calc(100% - ${this.props.width}px)`} : {};
+            this.props.changeMapStyle(style, "drawerManu");
+        }
     },
     renderChildren(child, index) {
         let props = {
@@ -70,7 +87,7 @@ var Menu = React.createClass({
             <Sidebar styles={{
                     sidebar: {
                         zIndex: 1022,
-                        width: '300px'
+                        width: this.props.width
                     },
                     overlay: {
                         zIndex: 1021

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -34,13 +34,13 @@ var Menu = React.createClass({
     componentDidMount() {
         if (!this.overlapMap && this.props.show) {
             let style = {left: this.props.width, width: `calc(100% - ${this.props.width}px)`};
-            this.props.changeMapStyle(style, "drawerManu");
+            this.props.changeMapStyle(style, "drawerMenu");
         }
     },
     componentDidUpdate(prevProps) {
         if (!this.props.overlapMap && prevProps.show !== this.props.show) {
             let style = this.props.show ? {left: this.props.width, width: `calc(100% - ${this.props.width}px)`} : {};
-            this.props.changeMapStyle(style, "drawerManu");
+            this.props.changeMapStyle(style, "drawerMenu");
         }
     },
     renderChildren(child, index) {

--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -102,4 +102,14 @@ describe('Test the map reducer', () => {
         expect(state.zoom).toBe(2);
 
     });
+    it('change map style', () => {
+        const action = {
+            type: 'CHANGE_MAP_STYLE',
+            style: {width: 100},
+            mapStateSource: "test"
+        };
+        var state = mapConfig({projection: "EPSG:4326"}, action);
+        expect(state.mapStateSource).toBe("test");
+        expect(state.style.width).toBe(100);
+    });
 });

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -7,7 +7,7 @@
  */
 
 var {CHANGE_MAP_VIEW, CHANGE_MOUSE_POINTER,
-    CHANGE_ZOOM_LVL, CHANGE_MAP_CRS, ZOOM_TO_EXTENT, PAN_TO} = require('../actions/map');
+    CHANGE_ZOOM_LVL, CHANGE_MAP_CRS, ZOOM_TO_EXTENT, PAN_TO, CHANGE_MAP_STYLE} = require('../actions/map');
 
 var assign = require('object-assign');
 var MapUtils = require('../utils/MapUtils');
@@ -60,6 +60,9 @@ function mapConfig(state = null, action) {
             return assign({}, state, {
                 center
             });
+        }
+        case CHANGE_MAP_STYLE: {
+            return assign({}, state, {mapStateSource: action.mapStateSource, style: action.style, resize: state.resize ? state.resize + 1 : 1});
         }
         default:
             return state;

--- a/web/client/utils/MapHistory.js
+++ b/web/client/utils/MapHistory.js
@@ -14,10 +14,10 @@ const mapConfigHistory = (reducer) => {
         let unredoState;
         // If undo modified the state we change mapStateSource
         if (action.type === Undoable.ActionTypes.UNDO && state.past.length > 0) {
-            let mapC = assign({}, newState.present, {mapStateSource: "undoredo"});
+            let mapC = assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
             unredoState = assign({}, newState, {present: mapC});
         }else if (action.type === Undoable.ActionTypes.REDO && state.future.length > 0) {
-            let mapC = assign({}, newState.present, {mapStateSource: "undoredo"});
+            let mapC = assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
             unredoState = assign({}, newState, {present: mapC});
         }
         return unredoState || newState;


### PR DESCRIPTION
 To avoid drawer-menu overlaps the map, add 
               "menuOptions": {
                        "overlapMap": false
                    }
to drawer menu plugin configuration.
It's also possible to chose a different menu size, passing the width in menuOptions.
Remember to override drawermenu.css .nav{ max-width: 300px} if you want a larger drawermenu
Config examples:
{
                "cfg": {
                    "buttonClassName": "square-button",
                    "buttonStyle": "primary",
                    "glyph": "1-stilo",
                    "singleSection": true,
                    "menuOptions": {
                        "width": 250,
                        "overlapMap": false
                    }
                },
                "name": "DrawerMenu"
            }