### PR TITLE
Close #931. Add manager page and menu

### DIFF
--- a/web/client/plugins/manager/Manager.jsx
+++ b/web/client/plugins/manager/Manager.jsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+
+const {Nav, NavItem, Glyphicon} = require('react-bootstrap');
+const {connect} = require('react-redux');
+const {Message} = require('../../components/I18N/I18N');
+require('./style/manager.css');
+
+const Manager = React.createClass({
+    propTypes: {
+        items: React.PropTypes.array,
+        onItemSelected: React.PropTypes.func,
+        selectedTool: React.PropTypes.string
+    },
+    contextTypes: {
+        router: React.PropTypes.object
+    },
+    getDefaultProps() {
+        return {
+            items: [],
+            mapType: "openlayers",
+            selectedTool: "importer"
+        };
+    },
+    renderToolIcon(tool) {
+        if (tool.glyph) {
+            return <Glyphicon glyph={tool.glyph} />;
+        }
+    },
+    renderNavItems() {
+        return this.props.items.map((tool) =>
+            (<NavItem
+                eventKey={tool.id}
+                key={tool.id}
+                href="#"
+                onClick={(event) => {event.preventDefault(); this.context.router.push("/manager/" + tool.id); }}>
+                    {this.renderToolIcon(tool)}
+                    {tool.msgId ? <Message msgId={tool.msgId} /> : tool.title || tool.id}
+            </NavItem>));
+    },
+    renderPlugin() {
+        for ( let i = 0; i < this.props.items.length; i++) {
+            let tool = this.props.items[i];
+            if (tool.id === this.props.selectedTool) {
+                return <tool.plugin key={tool.id} {...tool.cfg} />;
+            }
+        }
+        return null;
+
+    },
+    render() {
+        return (<div className="Manager-Container">
+            <Nav className="Manager-Tools-Nav" bsStyle="pills" stacked activeKey={this.props.selectedTool}>
+                {this.renderNavItems()}
+            </Nav>
+            <div style={{
+                flex: 1,
+                margin: "20px"
+            }}>{this.renderPlugin()} </div>
+        </div>);
+    }
+});
+
+module.exports = {
+    ManagerPlugin: connect((state, ownProps) => ({
+        selectedTool: ownProps.tool
+    }))(Manager)
+};

--- a/web/client/plugins/manager/ManagerMenu.jsx
+++ b/web/client/plugins/manager/ManagerMenu.jsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const {connect} = require('react-redux');
+
+const assign = require('object-assign');
+
+const {DropdownButton, Glyphicon, MenuItem} = require('react-bootstrap');
+
+const Container = connect(() => ({
+    noCaret: true,
+    pullRight: true,
+    bsStyle: "primary",
+    title: <Glyphicon glyph="1-menu-manage"/>
+}))(DropdownButton);
+
+const ToolsContainer = require('../containers/ToolsContainer');
+const Message = require('../locale/Message');
+
+require('../burgermenu/burgermenu.css');
+
+const ManagerMenu = React.createClass({
+    propTypes: {
+        id: React.PropTypes.string,
+        dispatch: React.PropTypes.func,
+        role: React.PropTypes.string,
+        entries: React.PropTypes.array,
+        title: React.PropTypes.node,
+        onItemClick: React.PropTypes.func,
+        controls: React.PropTypes.object,
+        mapType: React.PropTypes.string,
+        panelStyle: React.PropTypes.object,
+        panelClassName: React.PropTypes.string
+    },
+    contextTypes: {
+        messages: React.PropTypes.object,
+        router: React.PropTypes.object
+    },
+    getDefaultProps() {
+        return {
+            id: "mapstore-burger-menu",
+            entries: [],
+            role: "",
+            onItemClick: () => {},
+            title: <MenuItem header>Manager</MenuItem>,
+            controls: [],
+            mapType: "leaflet",
+            panelStyle: {
+                minWidth: "300px",
+                right: "52px",
+                zIndex: 100,
+                position: "absolute",
+                overflow: "auto"
+            },
+            panelClassName: "toolbar-panel"
+        };
+    },
+    getTools() {
+        return [{element: <span key="burger-menu-title">{this.props.title}</span>}, ...this.props.entries.sort((a, b) => a.position - b.position).map((entry) => {
+            return {
+                action: (context) => {context.router.push(entry.path); },
+                text: entry.msgId ? <Message msgId={entry.msgId} /> : entry.text,
+                cfg: {...entry}
+            };
+        })];
+    },
+    render() {
+        if (this.props.role === "ADMIN") {
+            return (
+                <ToolsContainer id={this.props.id} className="square-button"
+                    container={Container}
+                    mapType={this.props.mapType}
+                    toolStyle="primary"
+                    activeStyle="default"
+                    stateSelector="burgermenu"
+                    eventSelector="onSelect"
+                    tool={MenuItem}
+                    tools={this.getTools()}
+                    panelStyle={this.props.panelStyle}
+                    panelClassName={this.props.panelClassName}
+                />);
+        }
+        return null;
+    }
+});
+
+module.exports = {
+    ManagerMenuPlugin: assign(connect((state) => ({
+        controls: state.controls,
+        role: state.security && state.security.user && state.security.user.role
+    }))(ManagerMenu), {
+        OmniBar: {
+            name: "managermenu",
+            position: 3,
+            tool: true,
+            priority: 1
+        }
+    }),
+    reducers: {}
+};

--- a/web/client/plugins/manager/style/manager.css
+++ b/web/client/plugins/manager/style/manager.css
@@ -1,0 +1,15 @@
+.Manager-Container {
+    display: flex;
+    flex-direction: row;
+    margin: 10px;
+    height: 100%;
+}
+
+.Manager-Container .Manager-Tools-Nav .glyphicon {
+    font-size: 25px;
+    vertical-align: middle;
+}
+.Manager-Container .Manager-Tools-Nav {
+    order: -1;
+    flex: 0 0 15em;
+}

--- a/web/client/product/appConfig.js
+++ b/web/client/product/appConfig.js
@@ -19,6 +19,14 @@ module.exports = {
         name: "mapviewer",
         path: "/viewer/:mapType/:mapId",
         component: require('./pages/MapViewer')
+    }, {
+        name: "manager",
+        path: "/manager",
+        component: require('./pages/Manager')
+    }, {
+        name: "manager",
+        path: "/manager/:tool",
+        component: require('./pages/Manager')
     }],
     pluginsDef: require('./plugins.js'),
     initialState: {

--- a/web/client/product/pages/Manager.jsx
+++ b/web/client/product/pages/Manager.jsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const {connect} = require('react-redux');
+const Page = require('../../containers/Page');
+// const seepThumb = require('../../assets/img/seepexplorer.png');
+// const emptyThumb = require('../../assets/img/empty.png');
+
+const {loadMapConfig} = require('../../actions/config');
+const {resetControls} = require('../../actions/controls');
+const ConfigUtils = require('../../utils/ConfigUtils');
+
+
+// require('../../assets/css/home.css');
+
+const Home = React.createClass({
+    propTypes: {
+        name: React.PropTypes.string,
+        mode: React.PropTypes.string,
+        params: React.PropTypes.object,
+        loadMaps: React.PropTypes.func,
+        reset: React.PropTypes.func,
+        plugins: React.PropTypes.object
+    },
+    contextTypes: {
+        router: React.PropTypes.object
+    },
+    getDefaultProps() {
+        return {
+            name: "manager",
+            mode: 'desktop',
+            loadMaps: () => {},
+            reset: () => {}
+        };
+    },
+    componentDidMount() {
+        this.props.reset();
+        this.props.loadMaps(ConfigUtils.getDefaults().geoStoreUrl);
+    },
+    render() {
+        let plugins = ConfigUtils.getConfigProp("plugins") || {};
+        let pagePlugins = {
+            "desktop": plugins.page || [],// TODO mesh page plugins with other plugins
+            "mobile": plugins.page || []
+        };
+        let pluginsConfig = {
+            "desktop": plugins[this.props.name] || [],// TODO mesh page plugins with other plugins
+            "mobile": plugins[this.props.name] || []
+        };
+
+        return (<Page
+            id="maps"
+            pagePluginsConfig={pagePlugins}
+            pluginsConfig={pluginsConfig}
+            plugins={this.props.plugins}
+            params={this.props.params}
+            />);
+    }
+});
+
+module.exports = connect((state) => {
+    return {
+        mode: 'desktop',
+        messages: state.locale && state.locale.messages || {}
+    };
+}, {
+    loadMapConfig,
+    reset: resetControls
+})(Home);

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -44,6 +44,8 @@ module.exports = {
         AttributionPlugin: require('./plugins/Attribution'),
         HeaderPlugin: require('./plugins/Header'),
         FooterPlugin: require('./plugins/Footer'),
+        ManagerPlugin: require('..//plugins/manager/Manager'),
+        ManagerMenuPlugin: require('../plugins/manager/ManagerMenu'),
         SharePlugin: require('../plugins/Share'),
         SavePlugin: require('../plugins/Save')
     },


### PR DESCRIPTION
This adds to MapStore 2 a manager page. 
This page is a generic page that contains tools for administration. A plugin to access to that menu is also included ( only administrators can see the menu )