### PR TITLE
Fixed #943 : Improved error handling for Edit Metadata

### DIFF
--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -11,9 +11,11 @@ var {
     // CREATE_THUMBNAIL, createThumbnail,
     MAP_UPDATING, mapUpdating,
     PERMISSIONS_UPDATED, permissionsUpdated,
-    THUMBNAIL_DELETED, thumbnailDeleted,
     ATTRIBUTE_UPDATED, attributeUpdated,
-    SAVE_MAP, saveMap
+    SAVE_MAP, saveMap,
+    DISPLAY_METADATA_EDIT, onDisplayMetadataEdit,
+    RESET_UPDATING, resetUpdating,
+    THUMBNAIL_ERROR, thumbnailError
 } = require('../maps');
 
 describe('Test correctness of the maps actions', () => {
@@ -48,14 +50,6 @@ describe('Test correctness of the maps actions', () => {
         expect(retval.user).toBe(user);
     });
 
-    it('thumbnailDeleted', () => {
-        let resourceId = 13;
-        var retval = thumbnailDeleted(resourceId);
-        expect(retval).toExist();
-        expect(retval.type).toBe(THUMBNAIL_DELETED);
-        expect(retval.resourceId).toBe(resourceId);
-    });
-
     it('attributeUpdated', () => {
         let resourceId = 13;
         let name = "thumbnail";
@@ -69,6 +63,31 @@ describe('Test correctness of the maps actions', () => {
         expect(retval.value).toBe(value);
     });
 
+    it('thumbnailError', () => {
+        let resourceId = 1;
+        let error = {status: 404, message: "not found"};
+        let retval = thumbnailError(resourceId, error);
+        expect(retval).toExist();
+        expect(retval.type).toBe(THUMBNAIL_ERROR);
+        expect(retval.resourceId).toBe(resourceId);
+        expect(retval.error.status).toBe(error.status);
+    });
+
+    it('resetUpdating', () => {
+        let resourceId = 1;
+        let retval = resetUpdating(resourceId);
+        expect(retval).toExist();
+        expect(retval.type).toBe(RESET_UPDATING);
+        expect(retval.resourceId).toBe(resourceId);
+    });
+
+    it('onDisplayMetadataEdit', () => {
+        let dispMetadataValue = true;
+        let retval = onDisplayMetadataEdit(dispMetadataValue);
+        expect(retval).toExist();
+        expect(retval.type).toBe(DISPLAY_METADATA_EDIT);
+        expect(retval.displayMetadataEditValue).toBe(dispMetadataValue);
+    });
 
     it('saveMap', () => {
         let thumbnail = "myThumnbnailUrl";

--- a/web/client/actions/currentMap.js
+++ b/web/client/actions/currentMap.js
@@ -9,6 +9,7 @@
 const EDIT_MAP = 'EDIT_MAP';
 const UPDATE_CURRENT_MAP = 'UPDATE_CURRENT_MAP';
 const ERROR_CURRENT_MAP = 'ERROR_CURRENT_MAP';
+const REMOVE_THUMBNAIL = 'REMOVE_THUMBNAIL';
 
 function editMap(map) {
     return {
@@ -35,8 +36,16 @@ function errorCurrentMap(errors, resourceId) {
 }
 
 
+function removeThumbnail(resourceId) {
+    return {
+        type: REMOVE_THUMBNAIL,
+        resourceId
+    };
+}
+
 module.exports = {
     EDIT_MAP, editMap,
     UPDATE_CURRENT_MAP, updateCurrentMap,
-    ERROR_CURRENT_MAP, errorCurrentMap
+    ERROR_CURRENT_MAP, errorCurrentMap,
+    REMOVE_THUMBNAIL, removeThumbnail
 };

--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -21,10 +21,11 @@ const MAP_DELETING = 'MAP_DELETING';
 const MAP_DELETED = 'MAP_DELETED';
 const MAP_SAVED = 'MAP_SAVED';
 const ATTRIBUTE_UPDATED = 'ATTRIBUTE_UPDATED';
-const THUMBNAIL_DELETED = 'THUMBNAIL_DELETED';
 const PERMISSIONS_UPDATED = 'PERMISSIONS_UPDATED';
-const THUMBNAIL_ERROR = ' THUMBNAIL_ERROR';
-
+const THUMBNAIL_ERROR = 'THUMBNAIL_ERROR';
+const SAVE_ALL = 'SAVE_ALL';
+const DISPLAY_METADATA_EDIT = 'DISPLAY_METADATA_EDIT';
+const RESET_UPDATING = 'RESET_UPDATING';
 const SAVE_MAP = 'SAVE_MAP';
 
 function mapsLoading(searchText, params) {
@@ -108,15 +109,6 @@ function mapDeleting(resourceId, result, error) {
     };
 }
 
-function thumbnailDeleted(resourceId, result, error) {
-    return {
-        type: THUMBNAIL_DELETED,
-        resourceId,
-        result,
-        error
-    };
-}
-
 function attributeUpdated(resourceId, name, value, type, error) {
     return {
         type: ATTRIBUTE_UPDATED,
@@ -134,6 +126,29 @@ function thumbnailError(resourceId, error) {
         error
     };
 }
+
+function saveMap(map, resourceId) {
+    return {
+        type: SAVE_MAP,
+        resourceId,
+        map
+    };
+}
+
+function onDisplayMetadataEdit(displayMetadataEditValue) {
+    return {
+        type: DISPLAY_METADATA_EDIT,
+        displayMetadataEditValue
+    };
+}
+
+function resetUpdating(resourceId) {
+    return {
+        type: RESET_UPDATING,
+        resourceId
+    };
+}
+
 
 function loadMaps(geoStoreUrl, searchText="*", params={start: 0, limit: 20}) {
     return (dispatch) => {
@@ -158,6 +173,21 @@ function updateMap(resourceId, content, options) {
     };
 }
 
+function updateMapMetadata(resourceId, newName, newDescription, onReset, options) {
+    return (dispatch) => {
+        GeoStoreApi.putResourceMetadata(resourceId, newName, newDescription, options).then(() => {
+            dispatch(mapUpdated(resourceId, newName, newDescription, "success"));
+            if (onReset) {
+                dispatch(onReset);
+            }
+        }).catch((e) => {
+            // dispatch(mapUpdated(resourceId, newName, newDescription, "failure", e));
+            dispatch(thumbnailError(resourceId, e));
+        });
+    };
+}
+
+
 function updatePermissions(resourceId, groupPermission, group, userPermission, user, options) {
     return (dispatch) => {
         GeoStoreApi.addResourcePermissions(resourceId, groupPermission, group, userPermission, user, options).then(() => {
@@ -178,13 +208,11 @@ function updateAttribute(resourceId, name, value, type, options) {
     };
 }
 
-
-function createThumbnail(nameThumbnail, dataThumbnail, categoryThumbnail, resourceIdMap, options) {
+function createThumbnail(map, metadataMap, nameThumbnail, dataThumbnail, categoryThumbnail, resourceIdMap, onSuccess, onReset, options) {
     return (dispatch, getState) => {
         let metadata = {
             name: nameThumbnail
         };
-        dispatch(mapUpdating(resourceIdMap));
         return GeoStoreApi.createResource(metadata, dataThumbnail, categoryThumbnail, options).then((response) => {
             let state = getState();
             let groups = get(state, "security.user.groups.group");
@@ -195,7 +223,6 @@ function createThumbnail(nameThumbnail, dataThumbnail, categoryThumbnail, resour
             } else {
                 group = groups[index];
             }
-
             let user = get(state, "security.user");
             let userPermission = {
                 canRead: true,
@@ -209,32 +236,59 @@ function createThumbnail(nameThumbnail, dataThumbnail, categoryThumbnail, resour
             const thumbnailUrl = ConfigUtils.getDefaults().geoStoreUrl + "data/" + response.data + "/raw?decode=datauri";
             const encodedThumbnailUrl = encodeURIComponent(encodeURIComponent(thumbnailUrl));
             dispatch(updateAttribute(resourceIdMap, "thumbnail", encodedThumbnailUrl, "STRING", options)); // UPDATE resource map with new attribute
+            if (onSuccess) {
+                dispatch(onSuccess);
+            }
+            if (onReset) {
+                dispatch(onReset);
+            }
+            dispatch(saveMap(map, resourceIdMap));
+            dispatch(thumbnailError(resourceIdMap, null));
         }).catch((e) => {
             dispatch(thumbnailError(resourceIdMap, e));
         });
     };
 }
 
-function deleteThumbnail(resourceId, mapId, options) {
+function saveAll(map, metadataMap, nameThumbnail, dataThumbnail, categoryThumbnail, resourceIdMap, options) {
     return (dispatch) => {
-        GeoStoreApi.deleteResource(resourceId, options).then(() => {
-            dispatch(thumbnailDeleted(resourceId, "success"));
-            if (mapId) {
-                dispatch(updateAttribute(mapId, "thumbnail", "NODATA", "STRING", options));
-            }
-        })/*.catch((e) => {
-            dispatch(thumbnailError(resourceId, e));
-        })*/;
+        dispatch(mapUpdating(resourceIdMap));
+        if (dataThumbnail !== null && metadataMap !== null) {
+            dispatch(createThumbnail(map, metadataMap, nameThumbnail, dataThumbnail, categoryThumbnail, resourceIdMap,
+                updateMapMetadata(resourceIdMap, metadataMap.name, metadataMap.description, onDisplayMetadataEdit(false), options), null, options));
+        } else if (dataThumbnail !== null) {
+            dispatch(createThumbnail(map, metadataMap, nameThumbnail, dataThumbnail, categoryThumbnail, resourceIdMap, null, onDisplayMetadataEdit(false), options));
+        } else if (metadataMap !== null) {
+            dispatch(updateMapMetadata(resourceIdMap, metadataMap.name, metadataMap.description, onDisplayMetadataEdit(false), options));
+        } else {
+            dispatch(resetUpdating(resourceIdMap));
+            dispatch(onDisplayMetadataEdit(false));
+        }
+
     };
 }
 
-function updateMapMetadata(resourceId, newName, newDescription, options) {
+function deleteThumbnail(resourceId, resourceIdMap, options) {
     return (dispatch) => {
-        dispatch(mapUpdating(resourceId));
-        GeoStoreApi.putResourceMetadata(resourceId, newName, newDescription, options).then(() => {
-            dispatch(mapUpdated(resourceId, newName, newDescription, "success"));
+        GeoStoreApi.deleteResource(resourceId, options).then(() => {
+            dispatch(mapUpdating(resourceIdMap));
+            if (resourceIdMap) {
+                dispatch(updateAttribute(resourceIdMap, "thumbnail", "NODATA", "STRING", options));
+                dispatch(resetUpdating(resourceIdMap));
+            }
+            dispatch(onDisplayMetadataEdit(false));
         }).catch((e) => {
-            dispatch(mapUpdated(resourceId, newName, newDescription, "failure", e));
+            // Even if is not possible to delete the Thumbnail from geostore -> reset the attribute in order to display the default thumbnail
+            if (e.status === 403) {
+                if (resourceIdMap) {
+                    dispatch(updateAttribute(resourceIdMap, "thumbnail", "NODATA", "STRING", options));
+                }
+                dispatch(onDisplayMetadataEdit(false));
+                dispatch(thumbnailError(resourceIdMap, null));
+            } else {
+                dispatch(onDisplayMetadataEdit(true));
+                dispatch(thumbnailError(resourceIdMap, e));
+            }
         });
     };
 }
@@ -264,16 +318,8 @@ function deleteMap(resourceId, options) {
     };
 }
 
-function saveMap(map, resourceId) {
-    return {
-        type: SAVE_MAP,
-        resourceId,
-        map
-    };
-}
-
 
 module.exports = {
-    MAPS_LIST_LOADED, MAPS_LIST_LOADING, MAPS_LIST_LOAD_ERROR, MAP_CREATED, MAP_UPDATING, MAP_UPDATED, MAP_DELETED, MAP_DELETING, MAP_SAVED, ATTRIBUTE_UPDATED, THUMBNAIL_DELETED, PERMISSIONS_UPDATED, SAVE_MAP, THUMBNAIL_ERROR,
-    loadMaps, updateMap, updateMapMetadata, deleteMap, deleteThumbnail, createThumbnail, thumbnailDeleted, createMap, mapUpdating, updatePermissions, permissionsUpdated, attributeUpdated, saveMap, thumbnailError
+    MAPS_LIST_LOADED, MAPS_LIST_LOADING, MAPS_LIST_LOAD_ERROR, MAP_CREATED, MAP_UPDATING, MAP_UPDATED, MAP_DELETED, MAP_DELETING, MAP_SAVED, ATTRIBUTE_UPDATED, PERMISSIONS_UPDATED, SAVE_MAP, THUMBNAIL_ERROR, SAVE_ALL, DISPLAY_METADATA_EDIT, RESET_UPDATING,
+    loadMaps, updateMap, updateMapMetadata, deleteMap, deleteThumbnail, createThumbnail, createMap, mapUpdating, updatePermissions, permissionsUpdated, attributeUpdated, saveMap, thumbnailError, saveAll, onDisplayMetadataEdit, resetUpdating
 };

--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -11,7 +11,7 @@ const Message = require('../I18N/Message');
 const GridCard = require('../misc/GridCard');
 const thumbUrl = require('./style/default.png');
 const assign = require('object-assign');
-const MetadataModal = require('./modals/MetadataModal');
+
 const ConfirmModal = require('./modals/ConfirmModal');
 
 
@@ -29,6 +29,9 @@ const MapCard = React.createClass({
         onEdit: React.PropTypes.func,
         onSaveMap: React.PropTypes.func,
         onSave: React.PropTypes.func,
+        onSaveAll: React.PropTypes.func,
+        onDisplayMetadataEdit: React.PropTypes.func,
+        onRemoveThumbnail: React.PropTypes.func,
         onErrorCurrentMap: React.PropTypes.func,
         onUpdateCurrentMap: React.PropTypes.func,
         onCreateThumbnail: React.PropTypes.func,
@@ -50,6 +53,9 @@ const MapCard = React.createClass({
             onErrorCurrentMap: ()=> {},
             onUpdateCurrentMap: ()=> {},
             onEdit: ()=> {},
+            onDisplayMetadataEdit: ()=> {},
+            onSaveAll: () => {},
+            onRemoveThumbnail: ()=> {},
             onSave: ()=> {},
             onSaveMap: () => {}
         };
@@ -60,9 +66,7 @@ const MapCard = React.createClass({
         };
     },
     onEdit: function(map) {
-        this.refs.metadataModal.setMapNameValue(map.name);
         this.props.onEdit(map);
-        this.open();
     },
     onConfirmDelete() {
         this.props.onMapDelete(this.props.map.id);
@@ -102,15 +106,6 @@ const MapCard = React.createClass({
         return (
            <GridCard className="map-thumb" style={this.getCardStyle()} header={this.props.map.title || this.props.map.name} actions={availableAction}>
                <div className="map-thumb-description">{this.props.map.description}</div>
-               <MetadataModal ref="metadataModal" show={this.state.displayMetadataEdit} onHide={this.close} onClose={this.close}
-                   map={this.props.currentMap}
-                   onSave={this.props.onSave}
-                   onEdit={this.props.onEdit}
-                   onSaveMap={this.props.onSaveMap}
-                   onDeleteThumbnail={this.props.onDeleteThumbnail}
-                   onCreateThumbnail={this.props.onCreateThumbnail}
-                   onErrorCurrentMap={this.props.onErrorCurrentMap}
-                   onUpdateCurrentMap={this.props.onUpdateCurrentMap}/>
                <ConfirmModal ref="deleteMapModal" show={this.state.displayDeleteDialog} onHide={this.close} onClose={this.close} onConfirm={this.onConfirmDelete} titleText={<Message msgId="manager.deleteMap" />} confirmText={<Message msgId="manager.deleteMap" />} cancelText={<Message msgId="cancel" />} body={<Message msgId="manager.deleteMapMessage" />} />
            </GridCard>
         );
@@ -124,14 +119,17 @@ const MapCard = React.createClass({
         }
     },
     close() {
-        this.props.onUpdateCurrentMap([], this.props.map.thumbnail);
-        this.props.onErrorCurrentMap([], this.props.map.id);
+        // When the modal is closed the state of currentMap is restored to the initial situation
+        this.props.onUpdateCurrentMap([], this.props.map && this.props.map.thumbnail);
+        this.props.onErrorCurrentMap([], this.props.map && this.props.map.id);
+        // TODO Launch an action in order to change the state
         this.setState({
             displayMetadataEdit: false,
             displayDeleteDialog: false
         });
     },
     open() {
+        this.props.onDisplayMetadataEdit(true);
         this.setState({
             displayMetadataEdit: true
         });

--- a/web/client/components/maps/MapGrid.jsx
+++ b/web/client/components/maps/MapGrid.jsx
@@ -10,7 +10,7 @@ const React = require('react');
 const {Grid, Row, Col} = require('react-bootstrap');
 const MapCard = require('./MapCard');
 const Spinner = require('react-spinkit');
-
+const MetadataModal = require('./modals/MetadataModal');
 var MapGrid = React.createClass({
     propTypes: {
         panelProps: React.PropTypes.object,
@@ -25,7 +25,10 @@ var MapGrid = React.createClass({
         // CALLBACKS
         updateMapMetadata: React.PropTypes.func,
         editMap: React.PropTypes.func,
+        saveAll: React.PropTypes.func,
         saveMap: React.PropTypes.func,
+        onDisplayMetadataEdit: React.PropTypes.func,
+        removeThumbnail: React.PropTypes.func,
         errorCurrentMap: React.PropTypes.func,
         updateCurrentMap: React.PropTypes.func,
         createThumbnail: React.PropTypes.func,
@@ -51,9 +54,12 @@ var MapGrid = React.createClass({
             createThumbnail: () => {},
             deleteThumbnail: () => {},
             errorCurrentMap: () => {},
+            saveAll: () => {},
+            onDisplayMetadataEdit: () => {},
             updateCurrentMap: () => {},
             deleteMap: () => {},
             saveMap: () => {},
+            removeThumbnail: () => {},
             editMap: () => {}
         };
     },
@@ -66,8 +72,11 @@ var MapGrid = React.createClass({
                 <Col key={map.id} {...this.props.colProps}>
                     <MapCard viewerUrl={viewerUrl} mapType={mapType}
                         map={map}
+                        onSaveAll={this.props.saveAll}
+                        onDisplayMetadataEdit={this.props.onDisplayMetadataEdit}
                         onSave={this.props.updateMapMetadata}
                         onSaveMap={this.props.saveMap}
+                        onRemoveThumbnail={this.props.removeThumbnail}
                         onEdit={this.props.editMap}
                         onCreateThumbnail={this.props.createThumbnail}
                         onDeleteThumbnail={this.props.deleteThumbnail}
@@ -90,6 +99,18 @@ var MapGrid = React.createClass({
                     <Row>
                         {this.props.bottom}
                     </Row>
+                    <MetadataModal ref="metadataModal" show={this.props.currentMap.displayMetadataEdit} onHide={() => {this.props.onDisplayMetadataEdit(false); }}
+                        onClose={() => {this.props.onDisplayMetadataEdit(false); }}
+                        map={this.props.currentMap}
+                        onSaveAll={this.props.saveAll}
+                        onSave={this.props.saveMap}
+                        onEdit={this.props.editMap}
+                        onRemoveThumbnail={this.props.removeThumbnail}
+                        onSaveMap={this.props.saveMap}
+                        onDeleteThumbnail={this.props.deleteThumbnail}
+                        onCreateThumbnail={this.props.createThumbnail}
+                        onErrorCurrentMap={this.props.errorCurrentMap}
+                        onUpdateCurrentMap={this.props.updateCurrentMap}/>
                 </Grid>
         );
     }

--- a/web/client/components/maps/__tests__/MapGrid-test.jsx
+++ b/web/client/components/maps/__tests__/MapGrid-test.jsx
@@ -34,7 +34,8 @@ describe('This test for MapGrid', () => {
     it('checks data', () => {
         var map1 = {id: 1, name: "a", description: "description"};
         var map2 = {id: 2, name: "b", description: "description"};
-        const mapList = ReactDOM.render(<MapGrid maps={[map1, map2]}/>, document.getElementById("container"));
+        let currentMap = {displayMetadataEdit: true};
+        const mapList = ReactDOM.render(<MapGrid maps={[map1, map2]} currentMap={currentMap} show={true}/>, document.getElementById("container"));
         expect(mapList).toExist();
         const dom = ReactDOM.findDOMNode(mapList);
         expect(dom).toExist();

--- a/web/client/components/maps/modals/MetadataModal.jsx
+++ b/web/client/components/maps/modals/MetadataModal.jsx
@@ -41,6 +41,8 @@ const MetadataModal = React.createClass({
         // CALLBACKS
         onSave: React.PropTypes.func,
         onSaveMap: React.PropTypes.func,
+        onSaveAll: React.PropTypes.func,
+        onRemoveThumbnail: React.PropTypes.func,
         onErrorCurrentMap: React.PropTypes.func,
         onUpdateCurrentMap: React.PropTypes.func,
         onCreateThumbnail: React.PropTypes.func,
@@ -69,6 +71,8 @@ const MetadataModal = React.createClass({
             onCreateThumbnail: ()=> {},
             onDeleteThumbnail: ()=> {},
             onSave: ()=> {},
+            onSaveAll: () => {},
+            onRemoveThumbnail: ()=> {},
             onSaveMap: ()=> {},
             onClose: () => {}
         };
@@ -78,21 +82,41 @@ const MetadataModal = React.createClass({
             this.refs.mapMetadataForm.setMapNameValue(newName);
         }
     },
+    componentWillReceiveProps(newProps) {
+        if (newProps.map && this.props.map && !newProps.map.loading && this.state && this.state.saving) {
+            this.setState({
+              saving: false
+            });
+        }
+        // if ((newProps.map && newProps.map.errors && newProps.map.errors.length === 0) && !newProps.map.thumbnailError) {
+        /*if (this.props.map && newProps.map && (this.props.map.updating === true && newProps.map.updating === false )) {
+            this.props.onClose();
+        }*/
+        /*if (this.props.map &&
+            this.props.map.thumbnailUpdating === true && newProps.map.thumbnailUpdating === false &&
+            this.props.map.metadataUpdating === true && newProps.map.metadataUpdating === false &&
+            this.props.map.updating === true && newProps.map.updating === false &&
+            (newProps.map && newProps.map.errors && newProps.map.errors.length === 0) && !newProps.map.thumbnailError) {
+            this.props.onClose();
+        }*/
+        // }
+    },
     onSave() {
+        this.setState({
+            saving: true
+        });
+        let metadata = null;
 
         if ( this.isMetadataChanged() ) {
             let name = this.refs.mapMetadataForm.refs.mapName.getValue();
             let description = this.refs.mapMetadataForm.refs.mapDescription.getValue();
-            this.props.onSave(this.props.map.id, name, description);
+            metadata = {
+                name: name,
+                description: description
+            };
+            // this.props.onSave(this.props.map.id, name, description);
         }
-        this.refs.thumbnail.updateThumbnail();
-        if (this.props.map.errors && this.props.map.errors.length === 0 && !this.props.map.thumbnailError) {
-            this.props.onSaveMap(this.props.map, this.props.map.id);
-            this.setState({
-                saving: true
-            });
-            this.props.onClose();
-        }
+        this.refs.thumbnail.updateThumbnail(this.props.map, metadata);
     },
     renderLoading() {
         return this.props.map && this.props.map.updating ? <Spinner spinnerName="circle" key="loadingSpinner" noFadeIn/> : null;
@@ -139,6 +163,8 @@ const MetadataModal = React.createClass({
                             <Col xs={7}>
                                 <Thumbnail
                                     map={this.props.map}
+                                    onSaveAll={this.props.onSaveAll}
+                                    onRemoveThumbnail={this.props.onRemoveThumbnail}
                                     onError={this.props.onErrorCurrentMap}
                                     onUpdate={this.props.onUpdateCurrentMap}
                                     onCreateThumbnail={this.props.onCreateThumbnail}
@@ -167,6 +193,9 @@ const MetadataModal = React.createClass({
             this.refs.mapMetadataForm.refs.mapDescription.getValue() !== this.props.map.description ||
             this.refs.mapMetadataForm.refs.mapName.getValue() !== this.props.map.name
         );
+    },
+    isThumbnailChanged() {
+        return this.refs && this.refs.thumbnail && this.refs.thumbnail.files && this.refs.thumbnail.files.length > 0;
     }
 });
 

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -8,8 +8,8 @@
 
 const React = require('react');
 const {connect} = require('react-redux');
-const {loadMaps, updateMapMetadata, deleteMap, createThumbnail, deleteThumbnail, saveMap, thumbnailError} = require('../actions/maps');
-const {editMap, updateCurrentMap, errorCurrentMap} = require('../actions/currentMap');
+const {loadMaps, updateMapMetadata, deleteMap, createThumbnail, deleteThumbnail, saveMap, thumbnailError, saveAll, onDisplayMetadataEdit, resetUpdating} = require('../actions/maps');
+const {editMap, updateCurrentMap, errorCurrentMap, removeThumbnail} = require('../actions/currentMap');
 const ConfigUtils = require('../utils/ConfigUtils');
 const MapsGrid = connect((state) => {
     return {
@@ -24,6 +24,10 @@ const MapsGrid = connect((state) => {
     updateMapMetadata,
     editMap,
     saveMap,
+    removeThumbnail,
+    onDisplayMetadataEdit,
+    resetUpdating,
+    saveAll,
     updateCurrentMap,
     errorCurrentMap,
     thumbnailError,

--- a/web/client/reducers/currentMap.js
+++ b/web/client/reducers/currentMap.js
@@ -11,7 +11,7 @@ const {
 } = require('../actions/currentMap');
 
 const {
-    THUMBNAIL_ERROR
+    THUMBNAIL_ERROR, MAP_UPDATING, SAVE_MAP, DISPLAY_METADATA_EDIT, RESET_UPDATING
 } = require('../actions/maps');
 
 
@@ -20,22 +20,36 @@ const assign = require('object-assign');
 const initialState = {
     files: [],
     errors: [],
-    newThumbnail: null
+    newThumbnail: null,
+    thumbnailError: null,
+    displayMetadataEdit: false
 };
 
 function currentMap(state = initialState, action) {
     switch (action.type) {
         case EDIT_MAP: {
-            return assign({}, state, action.map, {newThumbnail: (action.map && action.map.thumbnail) ? action.map.thumbnail : null });
+            return assign({}, state, action.map, {newThumbnail: (action.map && action.map.thumbnail) ? action.map.thumbnail : null, displayMetadataEdit: true, thumbnailError: null });
         }
         case UPDATE_CURRENT_MAP: {
             return assign({}, state, {newThumbnail: action.thumbnail, files: action.files});
+        }
+        case MAP_UPDATING: {
+            return assign({}, state, {updating: true});
         }
         case ERROR_CURRENT_MAP: {
             return assign({}, state, {thumbnailError: null, errors: action.errors});
         }
         case THUMBNAIL_ERROR: {
-            return assign({}, state, {thumbnailError: action.error || null, errors: null });
+            return assign({}, state, {thumbnailError: action.error, errors: [], updating: false});
+        }
+        case SAVE_MAP: {
+            return assign({}, state, {thumbnailError: null});
+        }
+        case DISPLAY_METADATA_EDIT: {
+            return assign({}, state, {displayMetadataEdit: action.displayMetadataEditValue});
+        }
+        case RESET_UPDATING: {
+            return assign({}, state, {updating: false});
         }
         default:
             return state;

--- a/web/client/reducers/maps.js
+++ b/web/client/reducers/maps.js
@@ -6,12 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {MAPS_LIST_LOADED, MAPS_LIST_LOADING, MAPS_LIST_LOAD_ERROR, MAP_CREATED, MAP_UPDATING, MAP_UPDATED, MAP_DELETING, MAP_DELETED, ATTRIBUTE_UPDATED, THUMBNAIL_DELETED, SAVE_MAP, PERMISSIONS_UPDATED, THUMBNAIL_ERROR} = require('../actions/maps');
+const {MAPS_LIST_LOADED, MAPS_LIST_LOADING, MAPS_LIST_LOAD_ERROR, MAP_CREATED, MAP_UPDATING, MAP_UPDATED, MAP_DELETING, MAP_DELETED, ATTRIBUTE_UPDATED, SAVE_MAP, PERMISSIONS_UPDATED, THUMBNAIL_ERROR, RESET_UPDATING} = require('../actions/maps');
 const MAP_TYPE_CHANGED = "MAP_TYPE_CHANGED"; // NOTE: this is from home action in product. move to maps actions when finished;
 const assign = require('object-assign');
 function maps(state = {
     mapType: "openlayers",
-    enabled: false }, action) {
+    enabled: false,
+    errors: [] }, action) {
     switch (action.type) {
         case MAP_TYPE_CHANGED: {
             return assign({}, state, {
@@ -73,7 +74,7 @@ function maps(state = {
             let newMaps = (state.results === "" ? [] : [...state.results] );
             for (let i = 0; i < newMaps.length; i++) {
                 if (newMaps[i].id && newMaps[i].id === action.resourceId) {
-                    newMaps[i] = assign({}, newMaps[i], { loadingError: action.error ? action.error : null}); // TODO remove decodeURIComponent to reuse this reducer!!!
+                    newMaps[i] = assign({}, newMaps[i], { loadingError: action.error ? action.error : null});
                 }
             }
             return assign({}, state, {results: newMaps});
@@ -107,23 +108,27 @@ function maps(state = {
             };
             return assign({}, state, newMapsState);
         }
-        case THUMBNAIL_DELETED: {
-            let newMaps = (state.results === "" ? [] : [...state.results] );
-            return assign({}, state, {results: newMaps.filter(function(el) {
-                return el.id && el.id !== action.resourceId;
-            })});
-        }
         case SAVE_MAP: {
             let newMaps = (state.results === "" ? [] : [...state.results] );
 
             for (let i = 0; i < newMaps.length; i++) {
                 if (newMaps[i].id && newMaps[i].id === action.resourceId ) {
-                    newMaps[i] = assign({}, newMaps[i], action.map);
+                    newMaps[i] = assign({}, newMaps[i], {files: action.map.files, errors: action.map.errors, newThumbnail: action.map.newThumbnail, thumbnailError: action.map.thumbnailError, thumbnail: action.map.thumbnail});
                 }
             }
             return assign({}, state, {results: newMaps});
         }
         case THUMBNAIL_ERROR: {
+            let newMaps = (state.results === "" ? [] : [...state.results] );
+
+            for (let i = 0; i < newMaps.length; i++) {
+                if (newMaps[i].id && newMaps[i].id === action.resourceId ) {
+                    newMaps[i] = assign({}, newMaps[i], {updating: false});
+                }
+            }
+            return assign({}, state, {results: newMaps});
+        }
+        case RESET_UPDATING: {
             let newMaps = (state.results === "" ? [] : [...state.results] );
 
             for (let i = 0; i < newMaps.length; i++) {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -122,9 +122,9 @@
             "errorSize": "Max allowed size: 500kb",
             "error": "The provided image is not valid",
             "thumbnailError": {
-                "error404" : "An error occured during the creation of the thumbnail",
-                "error403" : "An error occured during the deletion of the thumbnail",
-                "errorDefault" : "An error occurred on the server"
+                "error404" : "An error occured while creating the thumbnail",
+                "error403" : "You are not allowed to update the map",
+                "errorDefault" : "Network error"
             }
         },
         "print":{

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -122,8 +122,8 @@
             "error": "L'immagine fornita non è valida",
             "thumbnailError": {
                 "error404" : "Non è stato possibile creare la thumbnail sul server",
-                "error403" : "Non disponi dei permessi per aggiornare la thumbnail",
-                "errorDefault" : "Il server ha riscontrato un errore"
+                "error403" : "Non disponi dei permessi per aggiornare la mappa",
+                "errorDefault" : "Errore di rete"
             }
         },
         "print":{


### PR DESCRIPTION
#943 Fixed the modal opening and closing. Improved error handling.
I also moved MetadataModal outside the mapcard, We should do also for confirm modal avoiding to use setState for displaying the ConfirmModal.