### PR TITLE
fix #937. Add box to the home carousel

### DIFF
--- a/web/client/product/assets/css/maps.css
+++ b/web/client/product/assets/css/maps.css
@@ -70,3 +70,7 @@ div#mapstore-maptype {
     margin-bottom: 20px;
     margin-top: -35px;
 }
+.mapstore-home-examples .carousel-caption{
+    background-color: rgba(0,0,0,0.4);
+    box-shadow: 0 0 12px rgba(0,0,0,0.4);
+}


### PR DESCRIPTION
Adding a black transparent box to the carousel to make the text more readable. 