### PR TITLE
Fix #965. Add default value for currentMap

### DIFF
--- a/web/client/components/maps/MapGrid.jsx
+++ b/web/client/components/maps/MapGrid.jsx
@@ -47,6 +47,7 @@ var MapGrid = React.createClass({
                     "marginBottom": "20px"
                 }
             },
+            currentMap: {},
             maps: [],
             // CALLBACKS
             onChangeMapType: function() {},


### PR DESCRIPTION
This prevent errors due to empty props. 