### PR TITLE
Fix #980 Minor ScaleBox Plugin Improvement in order to support custom projections

### DIFF
--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -17,8 +17,12 @@ const HelpWrapper = require('./help/HelpWrapper');
 const Message = require('./locale/Message');
 const ScaleBox = require("../components/mapcontrols/scale/ScaleBox");
 
+const mapUtils = require('../utils/MapUtils');
+
+
 const selector = createSelector([mapSelector], (map) => ({
-    currentZoomLvl: map && map.zoom
+    currentZoomLvl: map && map.zoom,
+    scales: mapUtils.getScales(map && map.projection || 'EPSG:3857')
 }));
 
 require('./scalebox/scalebox.css');


### PR DESCRIPTION
Hi,

Proposal for the issue #980.

The modification allow the scalebox plugin to take into account the map projection for computing scales.

Regards,
