### PR TITLE
Show all attribute except UUID in user details

### DIFF
--- a/web/client/components/security/modals/UserDetailsModal.jsx
+++ b/web/client/components/security/modals/UserDetailsModal.jsx
@@ -44,7 +44,7 @@ const UserDetails = React.createClass({
               name: "Guest"
           },
           displayAttributes: (attr) => {
-              return attr.name === "email";
+              return attr.name !== "UUID";
           },
           onClose: () => {},
           options: {},


### PR DESCRIPTION
Actually we show only the email. We should enhance the plugin and tool container system to make the attribute customizable. 
In the meanwhile, we can show all the attribute except the UUID (authkey) for the user. 

![image](https://cloud.githubusercontent.com/assets/1279510/18581892/d9ee44aa-7c02-11e6-9992-04db102332e9.png)
