### PR TITLE
Fix #1001. Show save as plugin only when user is logged in

### DIFF
--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -170,8 +170,8 @@ module.exports = {
             position: 900,
             text: <Message msgId="saveAs"/>,
             icon: <Glyphicon glyph="floppy-open"/>,
-            action: editMap.bind(null, {})
-            // here should be overrided the selector if you want to hide the save as plugin once a map is saved
+            action: editMap.bind(null, {}),
+            selector: (state) => (state && state.security && state.security.user ? {} : { style: {display: "none"} })
         }
     }))
 };


### PR DESCRIPTION
Fix #1001.
Add selector to hide the Save as entry in burger menu when the user is not logged in. 