### PR TITLE
 #1015 Scalebox plugin and non default DPI

### DIFF
--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -22,7 +22,10 @@ const mapUtils = require('../utils/MapUtils');
 
 const selector = createSelector([mapSelector], (map) => ({
     currentZoomLvl: map && map.zoom,
-    scales: mapUtils.getScales(map && map.projection || 'EPSG:3857')
+    scales: mapUtils.getScales(
+        map && map.projection || 'EPSG:3857',
+        map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
+     )
 }));
 
 require('./scalebox/scalebox.css');


### PR DESCRIPTION
Hi,

Scales can be computed with a non-default DPI. (See #1015)

Sample configuration :

```
  "map": {
    ....,
    "mapOptions" : {
        "view" : {
            "resolutions" : [49.0, 42.0, 28.0, 21.0, 14.0, 7.0, 5.6, 3.5, 2.8, 2.1, 1.4, 0.7, 0.56, 0.28, 0.14, 0.07, 0.056, 0.035, 0.028, 0.014],
            "DPI" : 90.71428571428571
        }
    },
