### PR TITLE
Make onMapViewChanges configurable as property of MapPlugin

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -9,6 +9,7 @@
 const React = require('react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
+const {changeMapView} = require('../actions/map');
 
 var Spinner = require('react-spinkit');
 
@@ -27,7 +28,8 @@ const MapPlugin = React.createClass({
         loadingSpinner: React.PropTypes.bool,
         tools: React.PropTypes.array,
         options: React.PropTypes.object,
-        toolsOptions: React.PropTypes.object
+        toolsOptions: React.PropTypes.object,
+        changeMapViewAction: React.PropTypes.func
     },
     getDefaultProps() {
         return {
@@ -51,7 +53,8 @@ const MapPlugin = React.createClass({
                     },
                     layers: [{type: "osm"}]
                 }
-            }
+            },
+            changeMapViewAction: changeMapView
         };
     },
     componentWillMount() {
@@ -119,7 +122,7 @@ const MapPlugin = React.createClass({
         </div>);
     },
     updatePlugins(props) {
-        plugins = require('./map/index')(props.mapType);
+        plugins = require('./map/index')(props.mapType, props.changeMapViewAction);
     }
 });
 const {mapSelector} = require('../selectors/map');

--- a/web/client/plugins/map/index.js
+++ b/web/client/plugins/map/index.js
@@ -8,7 +8,7 @@
 
 const React = require('react');
 
-const {changeMapView, clickOnMap} = require('../../actions/map');
+const {clickOnMap} = require('../../actions/map');
 const {layerLoading, layerLoad, invalidLayer} = require('../../actions/layers');
 const {changeMousePosition} = require('../../actions/mousePosition');
 const {changeMeasurementState} = require('../../actions/measurement');
@@ -21,14 +21,14 @@ const assign = require('object-assign');
 
 const Empty = () => { return <span/>; };
 
-module.exports = (mapType) => {
+module.exports = (mapType, changeMapViewAction) => {
 
     const components = require('./' + mapType + '/index');
 
     const LMap = connect((state) => ({
         mousePosition: state.mousePosition || {enabled: false}
     }), {
-        onMapViewChanges: changeMapView,
+        onMapViewChanges: changeMapViewAction,
         onClick: clickOnMap,
         onMouseMove: changeMousePosition,
         onLayerLoading: layerLoading,


### PR DESCRIPTION
In QWC2 we need to override the changeMapView action to store the current map center coordinates in the URL.

AFAICS the simplest solution allowing for maximum code-reuse is to make the `onMapViewChanges` callback configurable at MapPlugin level.

CC @mbarto 