### PR TITLE
Fixed position of panels in toolbar plugin

### DIFF
--- a/web/client/plugins/Toolbar.jsx
+++ b/web/client/plugins/Toolbar.jsx
@@ -54,7 +54,7 @@ const Toolbar = React.createClass({
                 zIndex: 100,
                 position: "absolute",
                 overflow: "auto",
-                top: "0"
+                maxWidth: "1400px"
             },
             panelClassName: "toolbar-panel",
             items: [],

--- a/web/client/plugins/Toolbar.jsx
+++ b/web/client/plugins/Toolbar.jsx
@@ -54,7 +54,7 @@ const Toolbar = React.createClass({
                 zIndex: 100,
                 position: "absolute",
                 overflow: "auto",
-                maxWidth: "1400px"
+                left: "450px"
             },
             panelClassName: "toolbar-panel",
             items: [],


### PR DESCRIPTION
Previously was setted a top:0px for every panel in the toolbar
