### PR TITLE
Ensure initial mousePosition state is set

### DIFF
--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -31,6 +31,7 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
         browser: require('../reducers/browser'),
         controls: require('../reducers/controls'),
         help: require('../reducers/help'),
+        mousePosition: require('../reducers/mousePosition'),
         map: () => {return null; },
         mapInitialConfig: () => {return null; },
         layers: () => {return null; }


### PR DESCRIPTION
Currently no initial state is set for `mousePosition`, and adding i.e.

    mousePosition: {
        enabled: true
    },

to `defaultState` in `appConfig.js` has no effect.