### PR TITLE
Proposed changes for QWC2

### DIFF
--- a/web/client/actions/measurement.js
+++ b/web/client/actions/measurement.js
@@ -24,7 +24,9 @@ function changeMeasurementState(measureState) {
         geomType: measureState.geomType,
         len: measureState.len,
         area: measureState.area,
-        bearing: measureState.bearing
+        bearing: measureState.bearing,
+        lenUnit: measureState.lenUnit,
+        areaUnit: measureState.areaUnit
     };
 }
 

--- a/web/client/components/buttons/ZoomButton.jsx
+++ b/web/client/components/buttons/ZoomButton.jsx
@@ -62,6 +62,9 @@ const ZoomButton = React.createClass({
         );
     },
     addTooltip(btn) {
+        if (!this.props.tooltip) {
+            return btn;
+        }
         let tooltip = <Tooltip id="locate-tooltip">{this.props.tooltip}</Tooltip>;
         return (
             <OverlayTrigger placement={this.props.tooltipPlace} key={"overlay-trigger." + this.props.id} overlay={tooltip}>

--- a/web/client/components/mapcontrols/mouseposition/CRSSelector.jsx
+++ b/web/client/components/mapcontrols/mouseposition/CRSSelector.jsx
@@ -6,9 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 var React = require('react');
-var ReactDOM = require('react-dom');
-var BootstrapReact = require('react-bootstrap');
-var {Input} = BootstrapReact;
 var CoordinatesUtils = require('../../../utils/CoordinatesUtils');
 
 let CRSSelector = React.createClass({
@@ -41,22 +38,19 @@ let CRSSelector = React.createClass({
             }
         }
         return (
-              (this.props.enabled) ? (<Input
+              (this.props.enabled) ? (<select
                     id={this.props.id}
                     value={this.props.crs}
-                    type="select"
                     onChange={this.launchNewCRSAction}
                     bsSize="small"
                     {...this.props.inputProps}>
                     {list}
-                </Input>) : null
+                </select>) : null
 
         );
     },
-    launchNewCRSAction() {
-        var element = ReactDOM.findDOMNode(this);
-        var selectNode = element.getElementsByTagName('select').item(0);
-        this.props.onCRSChange(selectNode.value);
+    launchNewCRSAction(ev) {
+        this.props.onCRSChange(ev.target.value);
     }
 });
 

--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -7,7 +7,6 @@
  */
 
 const React = require('react');
-const {Input} = require('react-bootstrap');
 const mapUtils = require('../../../utils/MapUtils');
 const {isEqual} = require('lodash');
 
@@ -49,9 +48,9 @@ var ScaleBox = React.createClass({
     render() {
         let control = this.props.readOnly ?
             <label>{this.props.template(this.props.scales[this.props.currentZoomLvl], this.props.currentZoomLvl)}</label>
-        : <Input type="select" label={this.props.label} onChange={this.onComboChange} bsSize="small" value={this.props.currentZoomLvl}>
+        : <select label={this.props.label} onChange={this.onComboChange} bsSize="small" value={this.props.currentZoomLvl}>
             {this.getOptions()}
-        </Input>;
+        </select>;
         return (
 
             <div id={this.props.id} style={this.props.style}>

--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -25,7 +25,7 @@ var ScaleBox = React.createClass({
     getDefaultProps() {
         return {
             id: 'mapstore-scalebox',
-            scales: mapUtils.getGoogleMercatorScales(0, 21),
+            scales: mapUtils.getGoogleMercatorScales(0, 28),
             currentZoomLvl: 0,
             onChange() {},
             readOnly: false,

--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -37,7 +37,7 @@ var ScaleBox = React.createClass({
     },
     onComboChange(event) {
         var selectedZoomLvl = parseInt(event.nativeEvent.target.value, 10);
-        this.props.onChange(selectedZoomLvl, this.props.scales[selectedZoomLvl]);
+        this.props.onChange(selectedZoomLvl);
     },
     getOptions() {
         return this.props.scales.map((item, index) => {

--- a/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
+++ b/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
@@ -31,7 +31,7 @@ describe('ScaleBox', () => {
         expect(domNode.id).toBe('mapstore-scalebox');
 
         const comboItems = Array.prototype.slice.call(domNode.getElementsByTagName('option'), 0);
-        expect(comboItems.length).toBe(22);
+        expect(comboItems.length).toBe(29);
 
         expect(comboItems.reduce((pre, cur, i) => {
             const scale = parseInt(cur.innerHTML.replace(/1\s\:\s/i, ''), 10);

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -31,7 +31,9 @@ function measurement(state = {
                 geomType: action.geomType,
                 len: action.len,
                 area: action.area,
-                bearing: action.bearing
+                bearing: action.bearing,
+                lenUnit: action.lenUnit,
+                areaUnit: action.areaUnit
             });
         default:
             return state;


### PR DESCRIPTION
Some proposed changes / RFC:

- *Store length and area unit in store*: We'd like to store the selected measurement unit in our Measure dialog [1], so it would make sense to store it in the store.
- *Fix CRSSelector not rendering*, *Fix ScaleBox not rendering*: For some reason the controls rendered as `<Input>` aren't rendered (used i.e. in [2]). I wonder if it is related to the change

        Feature/Deprecation: Rewrite form and form control API (<FormControl>, &c.), and deprecate the old API (<Input>, &c.) (#1765)

    mentioned for v0.29 in [3]
- *Sync default maxLevel with default ZoomButton.maxZoom*: With the default settings, the zoom button can zoom further in than the available scales in the scalebox
- *Only pass zoomLevel to onChange function, the changeZoomLevel action doesn't expect a scale number as second parameter*: `changeZoomLevel` from `actions/map` is connected to `ScaleBox.props.onChange` in various examples. However, the parameters passed in `ScaleBox.onComboChange` (zoom level and scale) don't match what `changeZoomLevel` expects (zoom level and mapStateSource). The zoom buttons OTOH only pass the zoom level. Hence possibly also the `ScaleBox.onComboChange` should only pass the zoom level?
- *Don't show a tooltip if the corresponding property is empty*: If the zoom button tooltip text is empty, don't show the tooltip arrow

[1] https://github.com/sourcepole/qwc2/blob/master/js/plugins/Measure.jsx
[2] https://github.com/sourcepole/qwc2/blob/master/js/plugins/BottomBar.jsx
[3] https://github.com/react-bootstrap/react-bootstrap/blob/master/CHANGELOG.md