### PR TITLE
Don't show a tooltip if the corresponding property is empty

### DIFF
--- a/web/client/components/buttons/ZoomButton.jsx
+++ b/web/client/components/buttons/ZoomButton.jsx
@@ -62,6 +62,9 @@ const ZoomButton = React.createClass({
         );
     },
     addTooltip(btn) {
+        if (!this.props.tooltip) {
+            return btn;
+        }
         let tooltip = <Tooltip id="locate-tooltip">{this.props.tooltip}</Tooltip>;
         return (
             <OverlayTrigger placement={this.props.tooltipPlace} key={"overlay-trigger." + this.props.id} overlay={tooltip}>


### PR DESCRIPTION
If the zoom button tooltip text is empty, don't show the tooltip arrow