### PR TITLE
Input rendering

### DIFF
--- a/web/client/components/mapcontrols/mouseposition/CRSSelector.jsx
+++ b/web/client/components/mapcontrols/mouseposition/CRSSelector.jsx
@@ -18,7 +18,8 @@ let CRSSelector = React.createClass({
         availableCRS: React.PropTypes.object,
         crs: React.PropTypes.string,
         enabled: React.PropTypes.bool,
-        onCRSChange: React.PropTypes.func
+        onCRSChange: React.PropTypes.func,
+        useRawInput: React.PropTypes.bool
     },
     getDefaultProps() {
         return {
@@ -26,7 +27,8 @@ let CRSSelector = React.createClass({
             availableCRS: CoordinatesUtils.getAvailableCRS(),
             crs: null,
             onCRSChange: function() {},
-            enabled: false
+            enabled: false,
+            useRawInput: false
         };
     },
     render() {
@@ -40,23 +42,38 @@ let CRSSelector = React.createClass({
                 list.push(<option value={val} key={val}>{label}</option>);
             }
         }
-        return (
-              (this.props.enabled) ? (<Input
+        if (this.props.enabled && this.props.useRawInput) {
+            return (
+                <select
                     id={this.props.id}
                     value={this.props.crs}
-                    type="select"
                     onChange={this.launchNewCRSAction}
                     bsSize="small"
                     {...this.props.inputProps}>
                     {list}
-                </Input>) : null
-
-        );
+                </select>);
+        } else if (this.props.enabled && !this.props.useRawInput) {
+            return (
+                <Input
+                  type="select"
+                  id={this.props.id}
+                  value={this.props.crs}
+                  onChange={this.launchNewCRSAction}
+                  bsSize="small"
+                  {...this.props.inputProps}>
+                  {list}
+              </Input>);
+        }
+        return null;
     },
-    launchNewCRSAction() {
-        var element = ReactDOM.findDOMNode(this);
-        var selectNode = element.getElementsByTagName('select').item(0);
-        this.props.onCRSChange(selectNode.value);
+    launchNewCRSAction(ev) {
+        if (this.props.useRawInput) {
+            this.props.onCRSChange(ev.target.value);
+        } else {
+            let element = ReactDOM.findDOMNode(this);
+            let selectNode = element.getElementsByTagName('select').item(0);
+            this.props.onCRSChange(selectNode.value);
+        }
     }
 });
 

--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -20,7 +20,8 @@ var ScaleBox = React.createClass({
         onChange: React.PropTypes.func,
         readOnly: React.PropTypes.bool,
         label: React.PropTypes.string,
-        template: React.PropTypes.func
+        template: React.PropTypes.func,
+        useRawInput: React.PropTypes.bool
     },
     getDefaultProps() {
         return {
@@ -29,7 +30,8 @@ var ScaleBox = React.createClass({
             currentZoomLvl: 0,
             onChange() {},
             readOnly: false,
-            template: (scale) => ("1 : " + Math.round(scale))
+            template: (scale) => ("1 : " + Math.round(scale)),
+            useRawInput: false
         };
     },
     shouldComponentUpdate(nextProps) {
@@ -47,11 +49,24 @@ var ScaleBox = React.createClass({
         });
     },
     render() {
-        let control = this.props.readOnly ?
-            <label>{this.props.template(this.props.scales[this.props.currentZoomLvl], this.props.currentZoomLvl)}</label>
-        : <Input type="select" label={this.props.label} onChange={this.onComboChange} bsSize="small" value={this.props.currentZoomLvl}>
-            {this.getOptions()}
-        </Input>;
+        var control = null;
+        if (this.props.readOnly) {
+            control = (
+                <label>{this.props.template(this.props.scales[this.props.currentZoomLvl], this.props.currentZoomLvl)}</label>
+            );
+        } else if (this.props.useRawInput) {
+            control = (
+                <select label={this.props.label} onChange={this.onComboChange} bsSize="small" value={this.props.currentZoomLvl}>
+                    {this.getOptions()}
+                </select>
+            );
+        } else {
+            control = (
+                <Input type="select" label={this.props.label} onChange={this.onComboChange} bsSize="small" value={this.props.currentZoomLvl}>
+                    {this.getOptions()}
+                </Input>
+            );
+        }
         return (
 
             <div id={this.props.id} style={this.props.style}>


### PR DESCRIPTION
For some reason the controls rendered as `<Input>` aren't rendered (used i.e. in [1]). I wonder if it is related to the change

    Feature/Deprecation: Rewrite form and form control API (<FormControl>, &c.), and deprecate the old API (<Input>, &c.) (#1765)

mentioned for v0.29 in [2]

[1] https://github.com/sourcepole/qwc2/blob/master/js/plugins/BottomBar.jsx
[2] https://github.com/react-bootstrap/react-bootstrap/blob/master/CHANGELOG.md