### PR TITLE
Only pass zoomLevel to onChange function, the changeZoomLevel action doesn't expect a scale number as second parameter

### DIFF
--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -37,7 +37,7 @@ var ScaleBox = React.createClass({
     },
     onComboChange(event) {
         var selectedZoomLvl = parseInt(event.nativeEvent.target.value, 10);
-        this.props.onChange(selectedZoomLvl, this.props.scales[selectedZoomLvl]);
+        this.props.onChange(selectedZoomLvl);
     },
     getOptions() {
         return this.props.scales.map((item, index) => {


### PR DESCRIPTION
`changeZoomLevel` from `actions/map` is connected to `ScaleBox.props.onChange` in various examples. However, the parameters passed in `ScaleBox.onComboChange` (zoom level and scale) don't match what `changeZoomLevel` expects (zoom level and mapStateSource). The zoom buttons OTOH only pass the zoom level. Hence possibly also the `ScaleBox.onComboChange` should only pass the zoom level?
