### PR TITLE
Store length and area unit in store

### DIFF
--- a/web/client/actions/measurement.js
+++ b/web/client/actions/measurement.js
@@ -24,7 +24,9 @@ function changeMeasurementState(measureState) {
         geomType: measureState.geomType,
         len: measureState.len,
         area: measureState.area,
-        bearing: measureState.bearing
+        bearing: measureState.bearing,
+        lenUnit: measureState.lenUnit,
+        areaUnit: measureState.areaUnit
     };
 }
 

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -31,7 +31,9 @@ function measurement(state = {
                 geomType: action.geomType,
                 len: action.len,
                 area: action.area,
-                bearing: action.bearing
+                bearing: action.bearing,
+                lenUnit: action.lenUnit,
+                areaUnit: action.areaUnit
             });
         default:
             return state;


### PR DESCRIPTION
We'd like to store the selected measurement unit in our Measure dialog [1], so it would make sense to store it in the store

[1] https://github.com/sourcepole/qwc2/blob/master/js/plugins/Measure.jsx