### PR TITLE
Sync default maxLevel with default ZoomButton.maxZoom

### DIFF
--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -25,7 +25,7 @@ var ScaleBox = React.createClass({
     getDefaultProps() {
         return {
             id: 'mapstore-scalebox',
-            scales: mapUtils.getGoogleMercatorScales(0, 21),
+            scales: mapUtils.getGoogleMercatorScales(0, 28),
             currentZoomLvl: 0,
             onChange() {},
             readOnly: false,

--- a/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
+++ b/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
@@ -31,7 +31,7 @@ describe('ScaleBox', () => {
         expect(domNode.id).toBe('mapstore-scalebox');
 
         const comboItems = Array.prototype.slice.call(domNode.getElementsByTagName('option'), 0);
-        expect(comboItems.length).toBe(22);
+        expect(comboItems.length).toBe(29);
 
         expect(comboItems.reduce((pre, cur, i) => {
             const scale = parseInt(cur.innerHTML.replace(/1\s\:\s/i, ''), 10);


### PR DESCRIPTION
With the default settings, the zoom button can zoom further in than the available scales in the scalebox