### PR TITLE
fix #1072. Add webpack directive to ignore from parsing certain libs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = {
       extensions: ["", ".js", ".jsx"]
     },
     module: {
+        noParse: [/html2canvas/],
         loaders: [
             { test: /\.css$/, loader: 'style!css'},
             { test: /\.less$/, loader: "style!css!less-loader" },


### PR DESCRIPTION
No more warning, this should increase performances too. 

![image](https://cloud.githubusercontent.com/assets/1279510/19081169/9ded035a-8a59-11e6-99c2-a4024626ad7c.png)
