### PR TITLE
fix #1083 Improved message for 'add local shapefile'

### DIFF
--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -491,7 +491,7 @@
         "shapefile": {
             "title": "Add Local Shapefile",
             "tooltip": "Add a local shapefile to the map.",
-            "placeholder": "Drop your file here or click to select shapefile to import.",
+            "placeholder": "Drop your files here or click to select the shapefiles to import. (shapefiles must be contained in zip archives)",
             "defaultStyle": "Default style",
             "zoom": "Zoom on the shapefiles",
             "error": {"select": "Select one or more zip file"},

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -493,7 +493,7 @@
         "shapefile": {
             "title": "Ajouter un fichier Shape local",
             "tooltip": "Ajouter un fichier Shape local à la carte.",
-            "placeholder": "Déposer votre fichier ici ou cliquer pour choisir le fichier shape à importer.",
+            "placeholder": "Déposez vos fichiers ici ou cliquez sur pour sélectionner les shapefiles à importer. (Shapefiles doivent être contenus dans des archives zip)",
             "defaultStyle": "Style par défaut",
             "zoom": "Zoomer sur le fichier shape",
             "error": {"select": "Sélectionner un ou plusieurs fichiers zip"},

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1,4 +1,4 @@
-{
+    {
     "locale": "it-IT",
     "messages": {
         "Language": "Lingua",
@@ -492,7 +492,7 @@
         "shapefile": {
             "title": "Carica Shapefile",
             "tooltip": "Aggiungi uno shapefile alla mappa.",
-            "placeholder": "Trascina qui il file o fai click per selezionare lo shapefile da importare.(gli shapefiles devono essere contenuti in archivi zip)",
+            "placeholder": "Trascina qui i file o fai click per selezionare gli shapefile da importare.(gli shapefiles devono essere contenuti in archivi zip)",
             "defaultStyle": "Stile di default",
             "zoom": "Zoom sugli shapefile",
             "error": {"select": "Seleziona Shapefile compresso"},

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -492,7 +492,7 @@
         "shapefile": {
             "title": "Carica Shapefile",
             "tooltip": "Aggiungi uno shapefile alla mappa.",
-            "placeholder": "Trascina qui il file o fai click per selezionare lo shapefile da importare.",
+            "placeholder": "Trascina qui il file o fai click per selezionare lo shapefile da importare.(gli shapefiles devono essere contenuti in archivi zip)",
             "defaultStyle": "Stile di default",
             "zoom": "Zoom sugli shapefile",
             "error": {"select": "Seleziona Shapefile compresso"},


### PR DESCRIPTION
Improved message for " add local Shapefile " for all supported languages to suggest the user to use zip archives. 