### PR TITLE
Fix #1145. Preserve state for catalog after close

### DIFF
--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -19,12 +19,12 @@ function catalog(state = null, action) {
                 layerError: null
             });
         case CATALOG_RESET: {
-            return {
+            return assign({}, state, {
                 result: null,
                 loadingError: null,
                 format: action.format,
                 layerError: null
-            };
+            });
         }
         case RECORD_LIST_LOAD_ERROR:
             return assign({}, state, {


### PR DESCRIPTION
Fix #1145.
This preserves the initial state even on catalog reset, keeping the catalog settings. 