### PR TITLE
Honour queryable field in layer info when bulding WMS getFeatureInfo request

### DIFF
--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -152,12 +152,16 @@ const MapInfoUtils = {
         const center = {x: lngCorrected, y: props.point.latlng.lat};
         let centerProjected = CoordinatesUtils.reproject(center, 'EPSG:4326', props.map.projection);
         let bounds = MapInfoUtils.getProjectedBBox(centerProjected, resolution, rotation, size, null);
+        let queryLayers = layer.name;
+        if (layer.queryLayers) {
+            queryLayers = layer.queryLayers.join(",");
+        }
 
         return {
             request: {
                 id: layer.id,
                 layers: layer.name,
-                query_layers: layer.name,
+                query_layers: queryLayers,
                 styles: layer.style,
                 x: ((widthBBox % 2) === 1) ? Math.ceil(widthBBox / 2) : widthBBox / 2,
                 y: ((widthBBox % 2) === 1) ? Math.ceil(widthBBox / 2) : widthBBox / 2,

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -13,7 +13,8 @@ var {
     getAvailableInfoFormatValues,
     getDefaultInfoFormatValue,
     createBBox,
-    getProjectedBBox
+    getProjectedBBox,
+    buildIdentifyWMSRequest
 } = require('../MapInfoUtils');
 
 describe('MapInfoUtils', () => {
@@ -79,5 +80,48 @@ describe('MapInfoUtils', () => {
         expect(bbox).toExist();
         expect(bbox.maxx).toBeGreaterThan(bbox.minx);
         expect(bbox.maxy).toBeGreaterThan(bbox.miny);
+    });
+
+    it('buildIdentifyWMSRequest should honour queryLayers', () => {
+        let props = {
+            map: {
+                zoom: 0,
+                projection: 'EPSG:4326'
+            },
+            point: {
+                latlng: {
+                    lat: 0,
+                    lng: 0
+                }
+            }
+        };
+        let layer1 = {
+            type: "wms",
+            queryLayers: ["sublayer1", "sublayer2"],
+            name: "layer",
+            url: "http://localhost"
+        };
+        let req1 = buildIdentifyWMSRequest(layer1, props);
+        expect(req1.request).toExist();
+        expect(req1.request.query_layers).toEqual("sublayer1,sublayer2");
+
+        let layer2 = {
+            type: "wms",
+            name: "layer",
+            url: "http://localhost"
+        };
+        let req2 = buildIdentifyWMSRequest(layer2, props);
+        expect(req2.request).toExist();
+        expect(req2.request.query_layers).toEqual("layer");
+
+        let layer3 = {
+            type: "wms",
+            name: "layer",
+            queryLayers: [],
+            url: "http://localhost"
+        };
+        let req3 = buildIdentifyWMSRequest(layer3, props);
+        expect(req3.request).toExist();
+        expect(req3.request.query_layers).toEqual("");
     });
 });


### PR DESCRIPTION
In QWC2, the entire project is published as one WMS with individual layers in
the QGIS project handled as sublayers of this WMS layer. We keep track of the
individual sublayers by extending the WMS layer params object with the fields:

    sublayers: Array
    opacities: Array
    queryable: Array

This commit makes MapInfoUtils::buildIdentifyWMSRequest honour the queryable
array to exclude sublayers from the query which are flagged as non-identifyable.