### PR TITLE
Don't assume that vector layer geometries are EPSG:4326

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -387,6 +387,44 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().getLength()).toBe(1);
     });
 
+    it('creates a vector layer specifying the feature CRS for openlayers map', () => {
+        var options = {
+            crs: 'EPSG:4326',
+            features: {
+              'type': 'FeatureCollection',
+              'crs': {
+                'type': 'name',
+                'properties': {
+                  'name': 'EPSG:4326'
+                }
+              },
+              'featureCrs': 'EPSG:3857',
+              'features': [
+                  {
+                      'type': 'Feature',
+                      'geometry': {
+                          'type': 'Polygon',
+                          'coordinates': [[
+                              [1447153.3803125600, 5311971.8469454700],
+                              [1669792.3618991000, 5311971.8469454700],
+                              [1669792.3618991000, 5465442.1833227500],
+                              [1447153.3803125600, 5465442.1833227500]
+                          ]]
+                      }
+                  }
+              ]
+          }
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="vector"
+                 options={options} map={map}/>, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+    });
+
     it('change layer visibility for Google Layer', () => {
         var google = {
             maps: {

--- a/web/client/components/map/openlayers/plugins/VectorLayer.js
+++ b/web/client/components/map/openlayers/plugins/VectorLayer.js
@@ -107,13 +107,17 @@ var styleFunction = function(feature) {
 Layers.registerType('vector', {
     create: (options) => {
         let features;
+        let featuresCrs = options.featuresCrs || 'EPSG:4326';
+        let layerCrs = options.crs || 'EPSG:3857';
         if (options.features) {
             let featureCollection = options.features;
             if (Array.isArray(options.features)) {
                 featureCollection = { "type": "FeatureCollection", features: featureCollection};
             }
             features = (new ol.format.GeoJSON()).readFeatures(featureCollection);
-            features.forEach((f) => f.getGeometry().transform('EPSG:4326', options.crs || 'EPSG:3857'));
+            if (featuresCrs !== layerCrs) {
+                features.forEach((f) => f.getGeometry().transform(featuresCrs, layerCrs));
+            }
         }
 
         const source = new ol.source.Vector({


### PR DESCRIPTION
Allow to specify which CRS the feature geometries are specified in, instead of assuming EPSG:4326.