### PR TITLE
Add Customizable layer origin for ol3 wms Fix #1184

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -163,7 +163,6 @@ describe('Openlayers layer', () => {
             <OpenlayersLayer type="wms"
                  options={options} map={map}/>, document.getElementById("container"));
 
-
         expect(layer).toExist();
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
@@ -184,11 +183,32 @@ describe('Openlayers layer', () => {
             <OpenlayersLayer type="wms"
                  options={options} map={map}/>, document.getElementById("container"));
 
-
         expect(layer).toExist();
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
         expect(map.getLayers().item(0).getSource().urls.length).toBe(2);
+    });
+
+    it('creates a wms layer with custom origin', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "origin": [0, 0],
+            "url": ["http://demo.geo-solutions.it/geoserver/wms"]
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                 options={options} map={map}/>, document.getElementById("container"));
+
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(map.getLayers().item(0).getSource().getTileGrid().getOrigin()).toEqual([0, 0]);
     });
 
     it('creates a wms layer with proxy  for openlayers map', () => {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -59,7 +59,7 @@ Layers.registerType('wms', {
                 })
             });
         }
-        const mapSrs = map && map.getView() && map.getView().getProjection() && map.getView().getProjection() && map.getView().getProjection().getCode() || 'EPSG:3857';
+        const mapSrs = map && map.getView() && map.getView().getProjection() && map.getView().getProjection().getCode() || 'EPSG:3857';
         const extent = ol.proj.get(CoordinatesUtils.normalizeSRS(options.srs || mapSrs, options.allowedSRS)).getExtent();
         return new ol.layer.Tile({
             opacity: options.opacity !== undefined ? options.opacity : 1,


### PR DESCRIPTION
Hi,

This PR allow the customisation of origin of WMS Layer in OL3. This is related to #1184.
This PR configure also the correct resolutions of the map to the tilegrid instead of default OL3 resolutions.

Regards,


