### PR TITLE
Fix #1188 Add presets for the whole task

### DIFF
--- a/web/client/api/geoserver/Importer.js
+++ b/web/client/api/geoserver/Importer.js
@@ -30,7 +30,7 @@ var Api = {
     updateTask: function( geoserverBaseUrl, importId, taskId, element, body, options) {
         let url = geoserverBaseUrl + "imports/" + importId + "/tasks/" + taskId;
         // element can be target, layer, transforms...
-        if (element) {
+        if (element && element !== "task") {
             url += "/" + element;
         }
         return axios.put(url, body, options);


### PR DESCRIPTION
Importer provides the possibility to update the whole tranform chain updating the "transformChain" entry in the task.

Allowing this in the task, we can configure presets like this to allow correct transforms preset, so it fix #1188:

```
{
        "state": "READY",
        "data": {
            "format": "GeoTIFF"
        },
        "changes": {
            "task": {
                "transformChain": {
                    "type": "raster",
                "transforms": [{
                     "type": "GdalWarpTransform",
                     "options": [ "-t_srs", "EPSG:4326", "-co", "TILED=YES", "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512"]
                 }, {
                     "type": "GdalAddoTransform",
                     "options": [ "-r", "average"],
                     "levels" : [2, 4, 8, 16, 32, 64, 128]
                 }]
             }
            }
        }

    }
```