### PR TITLE
Add possibility to pass custom options to search action

### DIFF
--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -38,7 +38,8 @@ let SearchBar = React.createClass({
         blurResetDelay: React.PropTypes.number,
         typeAhead: React.PropTypes.bool,
         searchText: React.PropTypes.string,
-        style: React.PropTypes.object
+        style: React.PropTypes.object,
+        searchOptions: React.PropTypes.object
     },
     contextTypes: {
         messages: React.PropTypes.object
@@ -117,7 +118,7 @@ let SearchBar = React.createClass({
         if (text === undefined || text === "") {
             this.props.onSearchReset();
         } else {
-            this.props.onSearch(text);
+            this.props.onSearch(text, this.props.searchOptions);
         }
 
     },

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -119,4 +119,25 @@ describe("test the SearchBar", () => {
             done();
         }, 50);
     });
+
+    it('test that options are passed to search action', () => {
+        var TestUtils = React.addons.TestUtils;
+        var tb;
+        const testHandlers = {
+            onSearchHandler: (text, options) => { return [text, options]; },
+            onSearchTextChangeHandler: (text) => { tb.setProps({searchText: text}); }
+        };
+
+        let searchOptions = {displaycrs: "EPSG:3857"};
+        const spy = expect.spyOn(testHandlers, 'onSearchHandler');
+        tb = ReactDOM.render(<SearchBar delay={0} typeAhead={false} onSearch={testHandlers.onSearchHandler} onSearchTextChange={testHandlers.onSearchTextChangeHandler} searchOptions={searchOptions}/>, document.getElementById("container"));
+        let input = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithTag(tb, "input")[0]);
+
+        expect(input).toExist();
+        input.value = "test";
+        TestUtils.Simulate.change(input);
+        TestUtils.Simulate.keyDown(input, {key: "Enter", keyCode: 13, which: 13});
+        expect(spy.calls.length).toEqual(1);
+        expect(spy).toHaveBeenCalledWith('test', searchOptions);
+    });
 });


### PR DESCRIPTION
To implement a coordinate search which can search in the currently specified coordinate system, the search handler needs to know the current CRS.