### PR TITLE
Remove redundant vector layer feature initialization

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -224,11 +224,11 @@ describe('Openlayers layer', () => {
 
 
         expect(layer).toExist();
-        expect(layer.layer).toExist();
+        expect(layer.state.layer).toExist();
 
-        expect(layer.layer.detached).toBe(true);
+        expect(layer.state.layer.detached).toBe(true);
 
-        layer.layer.remove();
+        layer.state.layer.remove();
     });
 
     it('creates a google layer for openlayers map', () => {
@@ -544,10 +544,10 @@ describe('Openlayers layer', () => {
             <OpenlayersLayer type="bing" options={options} map={map}/>, document.getElementById("container"));
 
         expect(layer).toExist();
-        expect(layer.layer).toExist();
+        expect(layer.state.layer).toExist();
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
-        expect(layer.layer.getVisible()).toBe(true);
+        expect(layer.state.layer.getVisible()).toBe(true);
         layer.setProps({options: assign({}, {
             "type": "bing",
             "title": "Bing Aerial",
@@ -557,7 +557,7 @@ describe('Openlayers layer', () => {
             "visibility": true
         })});
         expect(map.getLayers().getLength()).toBe(1);
-        expect(layer.layer.getVisible()).toBe(true);
+        expect(layer.state.layer.getVisible()).toBe(true);
         layer.setProps({options: assign({}, {
             "type": "bing",
             "title": "Bing Aerial",
@@ -567,7 +567,7 @@ describe('Openlayers layer', () => {
             "visibility": false
         })});
         expect(map.getLayers().getLength()).toBe(1);
-        expect(layer.layer.getVisible()).toBe(false);
+        expect(layer.state.layer.getVisible()).toBe(false);
 
     });
 
@@ -607,10 +607,10 @@ describe('Openlayers layer', () => {
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
 
-        expect(layer.layer.getOpacity()).toBe(1.0);
+        expect(layer.state.layer.getOpacity()).toBe(1.0);
 
         layer.setProps({options: {opacity: 0.5}, position: 0});
-        expect(layer.layer.getOpacity()).toBe(0.5);
+        expect(layer.state.layer.getOpacity()).toBe(0.5);
     });
 
     it('respects layer ordering', () => {
@@ -632,10 +632,10 @@ describe('Openlayers layer', () => {
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
 
-        expect(layer.layer.getZIndex()).toBe(10);
+        expect(layer.state.layer.getZIndex()).toBe(10);
 
         layer.setProps({position: 2});
-        expect(layer.layer.getZIndex()).toBe(2);
+        expect(layer.state.layer.getZIndex()).toBe(2);
     });
 
     it('changes wms params', () => {
@@ -660,11 +660,11 @@ describe('Openlayers layer', () => {
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
 
-        expect(layer.layer.getSource()).toExist();
-        expect(layer.layer.getSource().getParams()).toExist();
-        expect(layer.layer.getSource().getParams().cql_filter).toBe("INCLUDE");
+        expect(layer.state.layer.getSource()).toExist();
+        expect(layer.state.layer.getSource().getParams()).toExist();
+        expect(layer.state.layer.getSource().getParams().cql_filter).toBe("INCLUDE");
 
         layer.setProps({options: {params: {cql_filter: "EXCLUDE"}}});
-        expect(layer.layer.getSource().getParams().cql_filter).toBe("EXCLUDE");
+        expect(layer.state.layer.getSource().getParams().cql_filter).toBe("EXCLUDE");
     });
 });

--- a/web/client/components/map/openlayers/plugins/VectorLayer.js
+++ b/web/client/components/map/openlayers/plugins/VectorLayer.js
@@ -106,23 +106,7 @@ var styleFunction = function(feature) {
 
 Layers.registerType('vector', {
     create: (options) => {
-        let features;
-        let featuresCrs = options.featuresCrs || 'EPSG:4326';
-        let layerCrs = options.crs || 'EPSG:3857';
-        if (options.features) {
-            let featureCollection = options.features;
-            if (Array.isArray(options.features)) {
-                featureCollection = { "type": "FeatureCollection", features: featureCollection};
-            }
-            features = (new ol.format.GeoJSON()).readFeatures(featureCollection);
-            if (featuresCrs !== layerCrs) {
-                features.forEach((f) => f.getGeometry().transform(featuresCrs, layerCrs));
-            }
-        }
-
-        const source = new ol.source.Vector({
-            features: features
-        });
+        const source = new ol.source.Vector();
 
         let style = options.nativeStyle;
         if (!style && options.style) {


### PR DESCRIPTION
- Transforming and setting the features in `map/openlayers/plugins/VectorLayer.js` is redundant and leads to features added directly to the openlayers layer which are unmanaged by react: the features are already managed in the wrapper class in `map/openlayers/Feature.jsx`
- The `this.layer` member in `map/openlayers/Layer.jsx` needs to be a state, otherwise the component isn't updated when the actual layer is constructed in `this.addLayer`, leading to `const children = layer ? [...] : null` in `render()` yielding `children = null` the very first time the layer component is rendered, because the layer wasn't yet constructed. Unless `layer` is part of the state, the component won't get refreshed when `layer` is initialized, meaning that the layer component will only be correctly rendered on the next action which triggers a repaint.
