### PR TITLE
Fix #1235. Hide zoom to when loading error occours

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -132,6 +132,7 @@ var DefaultLayer = React.createClass({
         if (this.props.activateLegendTool) {
             tools.push(
                 <LayersTool key="toollegend"
+                        className="toc-legendTool"
                         ref="target"
                         style={{"float": "right", cursor: "pointer"}}
                         glyph="list"
@@ -141,6 +142,7 @@ var DefaultLayer = React.createClass({
         if (this.props.activateZoomTool && this.props.node.bbox && !this.props.node.loadingError) {
             tools.push(
                 <LayersTool key="toolzoom"
+                        className="toc-zoomTool"
                         ref="target"
                         style={{"float": "right", cursor: "pointer"}}
                         glyph="1-full-screen"

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -138,7 +138,7 @@ var DefaultLayer = React.createClass({
                         onClick={(node) => this.props.onToggle(node.id, node.expanded)}/>
                 );
         }
-        if (this.props.activateZoomTool && this.props.node.bbox) {
+        if (this.props.activateZoomTool && this.props.node.bbox && !this.props.node.loadingError) {
             tools.push(
                 <LayersTool key="toolzoom"
                         ref="target"

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -130,7 +130,7 @@ describe('test DefaultLayer module component', () => {
         expect(comp).toExist();
         const domNode = ReactDOM.findDOMNode(comp);
         expect(domNode).toExist();
-        const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "glyphicon")[1]);
+        const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "toc-legendTool")[0]);
         expect(tool).toExist();
         tool.click();
         expect(spy.calls.length).toBe(1);
@@ -162,10 +162,40 @@ describe('test DefaultLayer module component', () => {
         expect(comp).toExist();
         const domNode = ReactDOM.findDOMNode(comp);
         expect(domNode).toExist();
-        const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "glyphicon")[1]);
+        const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "toc-zoomTool")[0]);
         expect(tool).toExist();
         tool.click();
         expect(spy.calls.length).toBe(1);
+    });
+
+    it('hide zoom tool when error occours', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            loadingError: true,
+            bbox: {
+                crs: "EPSG:4326",
+                bounds: {
+                    minx: 11.0,
+                    maxx: 13.0,
+                    miny: 43.0,
+                    maxy: 44.0
+                }
+            }
+        };
+        const actions = {
+            onZoom: () => {}
+        };
+        const comp = ReactDOM.render(<Layer visibilityCheckType="checkbox" node={l} activateZoomTool={true} onZoom={actions.onZoom}/>,
+            document.getElementById("container"));
+        expect(comp).toExist();
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const tool = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(comp, "toc-zoomTool")[0]);
+        expect(tool).toNotExist();
     });
 
     it('tests removelayer tool', () => {

--- a/web/client/components/TOC/fragments/LayersTool.jsx
+++ b/web/client/components/TOC/fragments/LayersTool.jsx
@@ -19,7 +19,8 @@ const LayersTool = React.createClass({
         onClick: React.PropTypes.func,
         style: React.PropTypes.object,
         glyph: React.PropTypes.string,
-        tooltip: React.PropTypes.string
+        tooltip: React.PropTypes.string,
+        className: React.PropTypes.string
     },
     getDefaultProps() {
         return {
@@ -28,7 +29,8 @@ const LayersTool = React.createClass({
         };
     },
     render() {
-        const tool = (<Glyphicon className="toc-layer-tool" style={this.props.style}
+        const cn = this.props.className ? " " + this.props.className : "";
+        const tool = (<Glyphicon className={"toc-layer-tool" + cn} style={this.props.style}
                    glyph={this.props.glyph}
                    onClick={(options) => this.props.onClick(this.props.node, options || {})}/>);
         return this.props.tooltip ? (


### PR DESCRIPTION
It can be a temporary solution waiting for a reorganization of the tools for the next release. 

![image](https://cloud.githubusercontent.com/assets/1279510/19922833/ba85c744-a0e4-11e6-88d1-a168b2697655.png)
