### PR TITLE
Select link text input when focused

### DIFF
--- a/web/client/components/share/ShareLink.jsx
+++ b/web/client/components/share/ShareLink.jsx
@@ -43,7 +43,7 @@ const ShareLink = React.createClass({
                   <h4>
                      <Message msgId="share.directLinkTitle"/>
                   </h4>
-                  <Input ref="copytext" type="text" value={this.props.shareUrl} addonAfter={copyTo} readOnly/>
+                  <Input onFocus={ev => ev.target.select()} ref="copytext" type="text" value={this.props.shareUrl} addonAfter={copyTo} readOnly/>
             </div>
         );
     }

--- a/web/client/components/share/__tests__/ShareLink-test.jsx
+++ b/web/client/components/share/__tests__/ShareLink-test.jsx
@@ -38,7 +38,18 @@ describe("The ShareLink component", () => {
         const inputDirectLink = ReactDOM.findDOMNode(ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpShareLink, "input")[0]);
         expect(inputDirectLink).toExist();
         expect(inputDirectLink.value).toEqual(url);
+    });
 
+    it('should be selected when clicked', () => {
+        const cmpShareLink = ReactDOM.render(<ShareLink shareUrl={url}/>, document.getElementById("container"));
+        expect(cmpShareLink).toExist();
+
+        const inputDirectLink = ReactDOM.findDOMNode(ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpShareLink, "input")[0]);
+        expect(inputDirectLink).toExist();
+
+        ReactTestUtils.Simulate.focus(inputDirectLink);
+        let selection = inputDirectLink.value.substring(inputDirectLink.selectionStart, inputDirectLink.selectionEnd);
+        expect(selection).toEqual(url);
     });
 
 


### PR DESCRIPTION
Automatically selects the contents of the share link input when it is focused, for convenience.