### PR TITLE
Improvements to the Snapshot Tool

### DIFF
--- a/web/client/actions/snapshot.js
+++ b/web/client/actions/snapshot.js
@@ -14,10 +14,11 @@ const SNAPSHOT_ADD_QUEUE = 'SNAPSHOT_ADD_QUEUE';
 const SNAPSHOT_REMOVE_QUEUE = 'SNAPSHOT_REMOVE_QUEUE';
 const SAVE_IMAGE = 'SAVE_IMAGE';
 
-function changeSnapshotState(state) {
+function changeSnapshotState(state, tainted) {
     return {
         type: CHANGE_SNAPSHOT_STATE,
-        state: state
+        state: state,
+        tainted
     };
 }
 function onSnapshotError(error) {

--- a/web/client/components/map/leaflet/snapshot/__tests__/GrabMap-test.jsx
+++ b/web/client/components/map/leaflet/snapshot/__tests__/GrabMap-test.jsx
@@ -42,6 +42,18 @@ describe("test the Leaflet GrabMap component", () => {
         const tb = ReactDOM.render(<GrabMap active={true} timeout={0} onSnapshotReady={() => { expect(tb.isTainted()).toBe(false); done(); }} layers={[{loading: false, visibility: true}, {loading: false}]}/>, document.getElementById("snap"));
         expect(tb).toExist();
     });
+    it('snapshot creation with opacity', (done) => {
+        const tb = ReactDOM.render(<GrabMap active={true} timeout={0} onSnapshotReady={() => { expect(tb.isTainted()).toBe(false); done(); }} layers={[{loading: false, opacity: 0.5, visibility: true}, {loading: false}]}/>, document.getElementById("snap"));
+        expect(tb).toExist();
+    });
+    it('snapshot creation with only one layer', (done) => {
+        const tb = ReactDOM.render(<GrabMap active={true} timeout={0} onSnapshotReady={() => { expect(tb.isTainted()).toBe(false); done(); }} layers={[{loading: false}]}/>, document.getElementById("snap"));
+        expect(tb).toExist();
+    });
+    it('snapshot creation with only one layer', (done) => {
+        const tb = ReactDOM.render(<GrabMap active={true} timeout={0} onSnapshotReady={() => { expect(tb.isTainted()).toBe(false); done(); }} layers={[{loading: false}]}/>, document.getElementById("snap"));
+        expect(tb).toExist();
+    });
 /*
     it('snapshot update', (done) => {
         const tb = ReactDOM.render(<GrabMap active={false} timeout={0} onSnapshotReady={() => { expect(tb.isTainted()).toBe(false); done(); }} layers={[{loading: false, visibility: true}, {loading: false}]}/>, document.getElementById("snap"));

--- a/web/client/components/map/leaflet/snapshot/snapshotMapStyle.css
+++ b/web/client/components/map/leaflet/snapshot/snapshotMapStyle.css
@@ -1,0 +1,10 @@
+  .snapshot_hidden_map{
+            position:absolute;
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            visibility: hidden;
+            overflow: hidden;
+            z-index:-1000;
+        }

--- a/web/client/components/map/openlayers/snapshot/__tests__/GrabMap-test.jsx
+++ b/web/client/components/map/openlayers/snapshot/__tests__/GrabMap-test.jsx
@@ -56,6 +56,9 @@ describe("the OL GrabMap component", () => {
         const tb = ReactDOM.render(<GrabMap config={map} layers={layers} snapstate={{state: "DISABLED"}} active={false} timeout={0} onSnapshotReady={() => { done(); }}/>, document.getElementById("snap"));
         expect(tb).toExist();
         tb.setProps({active: true});
+        // emulate map load
+        tb.layerLoading();
+        tb.layerLoad();
         // force snapshot creation
         tb.createSnapshot();
     });

--- a/web/client/components/mapcontrols/Snapshot/SnapshotPanel.jsx
+++ b/web/client/components/mapcontrols/Snapshot/SnapshotPanel.jsx
@@ -7,7 +7,7 @@
  */
 
 const React = require('react');
-const {Button, Col, Grid, Row, Image, Glyphicon, Table, Panel} = require('react-bootstrap');
+const {Button, Col, Grid, Row, Image, Glyphicon, Table, Panel, Alert} = require('react-bootstrap');
 const {DateFormat} = require('../../I18N/I18N');
 require("./css/snapshot.css");
 
@@ -187,6 +187,11 @@ let SnapshotPanel = React.createClass({
         }
         return panel;
     },
+    renderTaintedMessage() {
+        if (this.props.snapshot && this.props.snapshot && this.props.snapshot.tainted) {
+            return <Alert bsStyle="warning"><Message msgId="snapshot.taintedMessage" /></Alert>;
+        }
+    },
     render() {
         let bingOrGoogle = this.isBingOrGoogle();
         let snapshotReady = this.isSnapshotReady();
@@ -211,6 +216,7 @@ let SnapshotPanel = React.createClass({
 
                 <Row key="buttons" htopclassName="pull-right" style={{marginTop: "5px"}}>
                     { this.renderButton(!bingOrGoogle && snapshotReady)}
+                    { this.renderTaintedMessage()}
                     {this.renderSnapshotQueue()}
                 </Row>
 

--- a/web/client/components/mapcontrols/Snapshot/SnapshotQueue.jsx
+++ b/web/client/components/mapcontrols/Snapshot/SnapshotQueue.jsx
@@ -21,6 +21,7 @@ let SnapshotQueue = React.createClass({
         queue: React.PropTypes.array,
         browser: React.PropTypes.string,
         onRemoveSnapshot: React.PropTypes.func,
+        onSnapshotError: React.PropTypes.func,
         downloadImg: React.PropTypes.func,
         mapType: React.PropTypes.string
 
@@ -39,6 +40,7 @@ let SnapshotQueue = React.createClass({
     getDefaultProps() {
         return {
             onRemoveSnapshot: () => {},
+            onSnapshotError: () => {},
             mapType: 'leaflet'
         };
     },
@@ -68,12 +70,17 @@ let SnapshotQueue = React.createClass({
         return <noscript />;
     },
     saveImage(canvas, config) {
-        let dataURL = canvas.toDataURL();
-        this.props.onRemoveSnapshot(config);
-        setTimeout(() => {
-            this.props.downloadImg(dataURL);
-        }, 0);
-
+        try {
+            this.props.onSnapshotError();
+            let dataURL = canvas.toDataURL();
+            this.props.onRemoveSnapshot(config);
+            setTimeout(() => {
+                this.props.downloadImg(dataURL);
+            }, 0);
+        } catch(e) {
+            this.props.onSnapshotError("Error saving snapshot");
+            this.props.onRemoveSnapshot(config);
+        }
     }
 
 });

--- a/web/client/components/mapcontrols/Snapshot/__tests__/SnapshotPanel-test.jsx
+++ b/web/client/components/mapcontrols/Snapshot/__tests__/SnapshotPanel-test.jsx
@@ -40,7 +40,8 @@ describe("test the SnapshotPanel", () => {
         tb.setProps({active: false, snapshot: {state: "DISABLED"}, layers: []});
     });
 
-    it('component error', () => {
+
+    it('component disabled', () => {
         let layers = [{loading: false, type: "google", visibility: true}, {loading: true}];
         let map = {size: {width: 20, height: 20}, zoom: 10};
         const tb = ReactDOM.render(<SnapshotPanel map={map} layers={layers} timeout={0} snapshot={{state: "DISABLED"}} active={true}/>, document.getElementById("container"));
@@ -48,10 +49,23 @@ describe("test the SnapshotPanel", () => {
         expect(document.getElementsByTagName('h4').length).toBe(1);
     });
 
+    it('component error', () => {
+        let layers = [{loading: false, type: "google", visibility: true}, {loading: true}];
+        let map = {size: {width: 20, height: 20}, zoom: 10};
+        const tb = ReactDOM.render(<SnapshotPanel map={map} snapshot={{error: "ERROR"}} layers={layers} timeout={0} snapshot={{state: "DISABLED"}} active={true}/>, document.getElementById("container"));
+        expect(tb).toExist();
+        expect(document.getElementsByTagName('h4').length).toBe(1);
+    });
+
+    it('component tainted', () => {
+        const tb = ReactDOM.render(<SnapshotPanel snapshot={{tainted: true}} timeout={0} snapshot={{state: "DISABLED"}} active={false}/>, document.getElementById("container"));
+        expect(tb).toExist();
+    });
+
     it('loading queue display', () => {
         let layers = [{loading: false, type: "google", visibility: true}, {loading: true}];
         let map = {size: {width: 20, height: 20}, zoom: 10};
-        const tb = ReactDOM.render(<SnapshotPanel map={map} layers={layers} timeout={0} snapshot={{state: "DISABLED", queue: [{key: 1}]}} active={true}/>, document.getElementById("container"));
+        const tb = ReactDOM.render(<SnapshotPanel map={map} layers={layers} wrap={true} snapshot={{tainted: true}} timeout={0} snapshot={{state: "DISABLED", queue: [{key: 1}]}} active={true}/>, document.getElementById("container"));
         expect(tb).toExist();
         ReactTestUtils.scryRenderedDOMComponentsWithClass(tb, "label-danger");
     });

--- a/web/client/plugins/Snapshot.jsx
+++ b/web/client/plugins/Snapshot.jsx
@@ -10,7 +10,7 @@ const React = require('react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 
-const {onCreateSnapshot, changeSnapshotState, saveImage, onRemoveSnapshot} = require('../actions/snapshot');
+const {onCreateSnapshot, changeSnapshotState, saveImage, onRemoveSnapshot, onSnapshotError} = require('../actions/snapshot');
 
 const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
@@ -46,6 +46,7 @@ const SnapshotPlugin = connect((state) => ({
     queue: state.snapshot && state.snapshot.queue || []
 }), {
     downloadImg: saveImage,
+    onSnapshotError,
     onRemoveSnapshot
 })(require("../components/mapcontrols/Snapshot/SnapshotQueue"));
 

--- a/web/client/reducers/snapshot.js
+++ b/web/client/reducers/snapshot.js
@@ -14,7 +14,8 @@ function snapshot(state = null, action) {
     switch (action.type) {
         case CHANGE_SNAPSHOT_STATE:
             return assign({}, state, {
-                state: action.state
+                state: action.state,
+                tainted: action.tainted
             });
         case SNAPSHOT_READY:
             return assign({}, state, {

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -491,7 +491,8 @@
             "date": "Date",
             "layers": "Layers",
             "size": "Size",
-            "notsupported": "Snapshot not supported"
+            "notsupported": "Snapshot not supported",
+            "taintedMessage": "Save snapshot functionality is limited for browser security limitations. For better result right-click on the preview and select 'Save image as' (supported by Firefox and Chrome)"
         },
         "shapefile": {
             "title": "Add Local Shapefile",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -491,7 +491,8 @@
             "date": "Date",
             "layers": "Layers",
             "size": "Size",
-            "notsupported": "Snapshot not supported"
+            "notsupported": "Snapshot not supported",
+            "taintedMessage": "Save snapshot functionality is limited by some browser security rules. For better result right-click on the preview and select 'Save image as' (supported by Firefox and Chrome)"
         },
         "shapefile": {
             "title": "Add Local Shapefile",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -493,7 +493,8 @@
             "date": "Date",
             "layers": "Couches",
             "size": "Taille",
-            "notsupported": "Capture d'image non supportée"
+            "notsupported": "Capture d'image non supportée",
+            "taintedMessage": "La fonctionnalité de sauvegarde est limitée pour les limitations de sécurité du navigateur. Pour un meilleur résultat, cliquez avec le bouton droit de la souris sur l'aperçu et sélectionnez 'Enregistrer l'image sous...' (prise en charge par Firefox et Chrome)"
         },
         "shapefile": {
             "title": "Ajouter un fichier Shape local",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -492,7 +492,8 @@
             "date": "Data",
             "layers": "Livelli",
             "size": "Dimensione",
-            "notsupported": "Snapshot non supportato"
+            "notsupported": "Snapshot non supportato",
+            "taintedMessage": "La funzionalità di salvataggio dell'istantanea è limitata a causa di alcune regole di sicurezza. Per un risultato migliore cliccare con il tasto destro sull'anteprima e selezionare  'Salva immagine con nome' (supportato solo da Mozilla Firefox e Google Chrome)"
         },
         "shapefile": {
             "title": "Carica Shapefile",


### PR DESCRIPTION
 - Fix #1267. Now if the canvas is tainted, a warning suggest the user how to have a better result
 - Removed glitch when leaflet try to save snapshot (a box was appearing in top-right corner)
 - Simplified the snapshot creation procedure (triggers)
 - Error management in case of tainted canvas in the save mode (see #1269)
 - Various Fixes with wrong sizes of snapshot
 - Now leaflet snapshot support resized map when the drawer menu do not overlap
 - Increased test coverage