### PR TITLE
Fix bbox format in ZOOM_TO_EXTENT reducer

### DIFF
--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -98,8 +98,20 @@ describe('Test the map reducer', () => {
         expect(state.mapStateSource).toBe(undefined);
         expect(state.center.x).toBe(11);
         expect(state.center.y).toBe(45);
+        expect(state.bbox).toExist();
+        expect(state.bbox.bounds).toExist();
+        expect(state.bbox.bounds.minx).toExist();
+        expect(state.bbox.bounds.miny).toExist();
+        expect(state.bbox.bounds.maxx).toExist();
+        expect(state.bbox.bounds.maxy).toExist();
         state = mapConfig({projection: "EPSG:900913"}, action2);
         expect(state.zoom).toBe(2);
+        expect(state.bbox).toExist();
+        expect(state.bbox.bounds).toExist();
+        expect(state.bbox.bounds.minx).toExist();
+        expect(state.bbox.bounds.miny).toExist();
+        expect(state.bbox.bounds.maxx).toExist();
+        expect(state.bbox.bounds.maxy).toExist();
 
     });
     it('change map style', () => {

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -34,25 +34,27 @@ function mapConfig(state = null, action) {
             });
         case ZOOM_TO_EXTENT: {
             let zoom = 0;
-            let bbox = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.bbox && state.bbox.crs || "EPSG:4326");
-            let wgs84BBox = CoordinatesUtils.reprojectBbox(action.extent, action.crs, "EPSG:4326");
-            if (bbox && wgs84BBox) {
+            let bounds = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.bbox && state.bbox.crs || "EPSG:4326");
+            let wgs84BBounds = CoordinatesUtils.reprojectBbox(action.extent, action.crs, "EPSG:4326");
+            if (bounds && wgs84BBounds) {
                 // center by the max. extent defined in the map's config
-                let center = MapUtils.getCenterForExtent(wgs84BBox, "EPSG:4326");
+                let center = MapUtils.getCenterForExtent(wgs84BBounds, "EPSG:4326");
                 // workaround to get zoom 0 for -180 -90... - TODO do it better
                 let full = action.crs === "EPSG:4326" && action.extent && action.extent[0] <= -180 && action.extent[1] <= -90 && action.extent[2] >= 180 && action.extent[3] >= 90;
                 if ( full ) {
                     zoom = 2;
                 } else {
-                    let mapBBox = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.projection || "EPSG:4326");
+                    let mapBBounds = CoordinatesUtils.reprojectBbox(action.extent, action.crs, state.projection || "EPSG:4326");
                     // NOTE: STATE should contain size !!!
-                    zoom = MapUtils.getZoomForExtent(mapBBox, state.size, 0, 21, null);
+                    zoom = MapUtils.getZoomForExtent(mapBBounds, state.size, 0, 21, null);
                 }
+                let newbounds = {minx: bounds[0], miny: bounds[1], maxx: bounds[2], maxy: bounds[3]};
+                let newbbox = assign({}, state.bbox, {bounds: newbounds});
                 return assign({}, state, {
                     center,
                     zoom,
                     mapStateSource: action.mapStateSource,
-                    bbox: bbox
+                    bbox: newbbox
                 });
             }
             return state;


### PR DESCRIPTION
As far as I can see, various components use/expect the bbox format in the map state to be

    map {
     bbox:
      bounds: {
       minx: ...,
       miny: ...,
       maxx: ...,
       maxy: ...
     }
    }

The `ZOOM_TO_EXTENT` reducer however writes a bbox in the format:

    map {
     bbox: [minx, miny, maxx, maxy]
    }

This can break various things, for instance rotation (since rotation is stored as a field in `bbox`).