### PR TITLE
Fix #1314 Support to print vector layer

### DIFF
--- a/web/client/components/map/leaflet/Feature.jsx
+++ b/web/client/components/map/leaflet/Feature.jsx
@@ -107,7 +107,7 @@ var geometryToLayer = function(geojson, options) {
         return new L.FeatureGroup(layers);
     case 'GeometryCollection':
         for (i = 0, len = geometry.geometries.length; i < len; i++) {
-            layer = this.geometryToLayer({
+            layer = geometryToLayer({
                 geometry: geometry.geometries[i],
                 type: 'Feature',
                 properties: geojson.properties

--- a/web/client/components/map/leaflet/Layer.jsx
+++ b/web/client/components/map/leaflet/Layer.jsx
@@ -8,6 +8,7 @@
 var React = require('react');
 var Layers = require('../../../utils/leaflet/Layers');
 var assign = require('object-assign');
+var {isEqual} = require('lodash');
 
 const LeafletLayer = React.createClass({
     propTypes: {
@@ -44,6 +45,26 @@ const LeafletLayer = React.createClass({
             this.updateZIndex(newProps.position);
         }
         this.updateLayer(newProps, this.props);
+    },
+    shouldComponentUpdate(newProps) {
+        // the reduce returns true when a prop is changed
+        // optimizing when options are equal ignorning loading key
+        return !(["map", "type", "srs", "position", "zoomOffset", "onInvalid", "onClick", "options"].reduce( (prev, p) => {
+            switch (p) {
+                case "map":
+                case "type":
+                case "srs":
+                case "position":
+                case "zoomOffset":
+                case "onInvalid":
+                case "onClick":
+                    return prev && this.props[p] === newProps[p];
+                case "options":
+                    return prev && (this.props[p] === newProps[p] || isEqual({...this.props[p], loading: false}, {...newProps[p], loading: false}));
+                default:
+                    return prev;
+            }
+        }, true));
     },
     componentWillUnmount() {
         if (this.layer && this.props.map) {
@@ -105,6 +126,7 @@ const LeafletLayer = React.createClass({
                 this.layer.layerName = options.name;
                 this.layer.layerId = options.id;
             }
+            this.forceUpdate();
         }
     },
     updateLayer(newProps, oldProps) {

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -9,6 +9,7 @@ var React = require('react/addons');
 var ReactDOM = require('react-dom');
 var L = require('leaflet');
 var LeafLetLayer = require('../Layer.jsx');
+var Feature = require('../Feature.jsx');
 var expect = require('expect');
 
 require('../../../../utils/leaflet/Layers');
@@ -18,6 +19,7 @@ require('../plugins/WMSLayer');
 require('../plugins/GoogleLayer');
 require('../plugins/BingLayer');
 require('../plugins/MapQuest');
+require('../plugins/VectorLayer');
 
 describe('Leaflet layer', () => {
     let map;
@@ -175,6 +177,119 @@ describe('Leaflet layer', () => {
         let urls;
         map.eachLayer((l) => urls = l._urls);
         expect(urls.length).toBe(1);
+    });
+
+    it('creates a vector layer for leaflet map', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "vector_sample",
+            "group": "sample",
+            "features": [
+                  { "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+                    "properties": {"prop0": "value0"}
+                    },
+                  { "type": "Feature",
+                    "geometry": {
+                      "type": "LineString",
+                      "coordinates": [
+                        [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+                        ]
+                      },
+                    "properties": {
+                      "prop0": "value0",
+                      "prop1": 0.0
+                      }
+                    },
+                  { "type": "Feature",
+                     "geometry": {
+                       "type": "Polygon",
+                       "coordinates": [
+                         [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
+                           [100.0, 1.0], [100.0, 0.0] ]
+                         ]
+                     },
+                     "properties": {
+                       "prop0": "value0",
+                       "prop1": {"this": "that"}
+                       }
+                   },
+                   { "type": "Feature",
+                      "geometry": { "type": "MultiPoint",
+                        "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
+                      },
+                      "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                        }
+                   },
+                   { "type": "Feature",
+                      "geometry": { "type": "MultiLineString",
+                        "coordinates": [
+                            [ [100.0, 0.0], [101.0, 1.0] ],
+                            [ [102.0, 2.0], [103.0, 3.0] ]
+                          ]
+                      },
+                      "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                        }
+                    },
+                    { "type": "Feature",
+                       "geometry": { "type": "MultiPolygon",
+                        "coordinates": [
+                          [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+                          [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+                           [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+                          ]
+                      },
+                       "properties": {
+                         "prop0": "value0",
+                         "prop1": {"this": "that"}
+                         }
+                     },
+                     { "type": "Feature",
+                        "geometry": { "type": "GeometryCollection",
+                            "geometries": [
+                              { "type": "Point",
+                                "coordinates": [100.0, 0.0]
+                                },
+                              { "type": "LineString",
+                                "coordinates": [ [101.0, 0.0], [102.0, 1.0] ]
+                                }
+                            ]
+                        },
+                        "properties": {
+                          "prop0": "value0",
+                          "prop1": {"this": "that"}
+                          }
+                      }
+               ]
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            (<LeafLetLayer type="vector"
+                 options={options} map={map}>
+                {options.features.map((feature) => (<Feature
+                    key={feature.id}
+                    type={feature.type}
+                    geometry={feature.geometry}
+                    msId={feature.id}
+                    featuresCrs={ 'EPSG:4326' }
+                        />))}</LeafLetLayer>), document.getElementById("container"));
+        expect(layer).toExist();
+        let l2 = ReactDOM.render(
+            (<LeafLetLayer type="vector"
+                 options={options} map={map}>
+                {options.features.map((feature) => (<Feature
+                    key={feature.id}
+                    type={feature.type}
+                    geometry={feature.geometry}
+                    msId={feature.id}
+                    featuresCrs={ 'EPSG:4326' }
+                        />))}</LeafLetLayer>), document.getElementById("container"));
+        expect(l2).toExist();
     });
 
     it('creates a wms layer for leaflet map with custom tileSize', () => {

--- a/web/client/components/map/openlayers/Layer.jsx
+++ b/web/client/components/map/openlayers/Layer.jsx
@@ -104,6 +104,7 @@ const OpenlayersLayer = React.createClass({
             if (this.layer && !this.layer.detached) {
                 this.addLayer(options);
             }
+            this.forceUpdate();
         }
     },
     updateLayer(newProps, oldProps) {

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -89,7 +89,6 @@ const MapPreview = React.createClass({
                         geometry={feature.geometry}
                         msId={feature.id}
                         featuresCrs={ layer.featuresCrs || 'EPSG:4326' }
-                        // FEATURE STYLE OVERWRITE LAYER STYLE
                         style={ feature.style || layer.style || null }/>
                 );
             });
@@ -121,7 +120,7 @@ const MapPreview = React.createClass({
                 mapOptions={mapOptions}
                 >
                 {this.props.layers.map((layer, index) =>
-                    <Layer key={layer.name} position={index} type={layer.type}
+                    <Layer key={layer.id || layer.name} position={index} type={layer.type}
                         options={assign({}, this.adjustResolution(layer), {srs: projection})}>
                         {this.renderLayerContent(layer)}
                     </Layer>

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -14,6 +14,7 @@ const {Button, Glyphicon} = require('react-bootstrap');
 
 let PMap;
 let Layer;
+let Feature;
 
 const MapPreview = React.createClass({
     propTypes: {
@@ -54,6 +55,7 @@ const MapPreview = React.createClass({
         PMap = require('../map/' + this.props.mapType + '/Map');
         Layer = require('../map/' + this.props.mapType + '/Layer');
         require('../map/' + this.props.mapType + '/plugins/index');
+        Feature = require('../map/' + this.props.mapType + '/index').Feature;
     },
     getRatio() {
         if (this.props.width && this.props.layoutSize && this.props.resolutions) {
@@ -76,6 +78,23 @@ const MapPreview = React.createClass({
                 "MAP.RESOLUTION": dpi
             })
         });
+    },
+    renderLayerContent(layer) {
+        if (layer.features && layer.type === "vector") {
+            return layer.features.map( (feature) => {
+                return (
+                    <Feature
+                        key={feature.id}
+                        type={feature.type}
+                        geometry={feature.geometry}
+                        msId={feature.id}
+                        featuresCrs={ layer.featuresCrs || 'EPSG:4326' }
+                        // FEATURE STYLE OVERWRITE LAYER STYLE
+                        style={ feature.style || layer.style || null }/>
+                );
+            });
+        }
+        return null;
     },
     render() {
         const style = assign({}, this.props.style, {
@@ -103,7 +122,10 @@ const MapPreview = React.createClass({
                 >
                 {this.props.layers.map((layer, index) =>
                     <Layer key={layer.name} position={index} type={layer.type}
-                        options={assign({}, this.adjustResolution(layer), {srs: projection})}/>
+                        options={assign({}, this.adjustResolution(layer), {srs: projection})}>
+                        {this.renderLayerContent(layer)}
+                    </Layer>
+
                 )}
                 </PMap>
                 {this.props.enableScalebox ? <ScaleBox id="mappreview-scalebox"

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -255,6 +255,7 @@ const PrintUtils = {
              "fillColor": style.fillColor,
              "fillOpacity": style.fillOpacity,
              // "rotation": "30",
+             "externalGraphic": style.iconUrl,
              // "graphicName": "circle",
              // "graphicOpacity": 0.4,
              "pointRadius": style.radius,
@@ -303,7 +304,13 @@ const PrintUtils = {
                 };
             case 'Point':
             case 'MultiPoint': {
-                return {
+                return layer.styleName === "marker" ? {
+                    "externalGraphic": "http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/images/marker-icon.png",
+                    "graphicWidth": 25,
+                    "graphicHeight": 41,
+                    "graphicXOffset": -12, // different offset
+                    "graphicYOffset": -41
+                } : {
                     "fillColor": "#FF0000",
                     "fillOpacity": 0,
                     "strokeColor": "#FF0000",

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -98,7 +98,8 @@ describe('CoordinatesUtils', () => {
         expect(reprojectedTestPoint.features[0]).toExist();
         expect(reprojectedTestPoint.features[0].type).toBe("Feature");
         expect(reprojectedTestPoint.features[0].geometry.type).toBe("Point");
-        expect(reprojectedTestPoint.features[0].geometry.coordinates[0]).toBe(-12523490.492568726);
-        expect(reprojectedTestPoint.features[0].geometry.coordinates[1]).toBe(5195238.005360028);
+        // approximate values should be the same
+        expect(reprojectedTestPoint.features[0].geometry.coordinates[0].toFixed(4)).toBe((-12523490.492568726).toFixed(4));
+        expect(reprojectedTestPoint.features[0].geometry.coordinates[1].toFixed(4)).toBe((5195238.005360028).toFixed(4));
     });
 });

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -72,4 +72,33 @@ describe('CoordinatesUtils', () => {
         expect(CoordinatesUtils.getCompatibleSRS('EPSG:3857', {'EPSG:900913': true, 'EPSG:3857': true})).toBe('EPSG:3857');
         expect(CoordinatesUtils.getCompatibleSRS('EPSG:3857', {'EPSG:3857': true})).toBe('EPSG:3857');
     });
+    it('test reprojectGeoJson', () => {
+        const testPoint = {
+            type: "FeatureCollection",
+            features: [
+               {
+                  type: "Feature",
+                  geometry: {
+                     type: "Point",
+                     coordinates: [
+                        -112.50042920000001,
+                        42.22829164089942
+                     ]
+                  },
+                  properties: {
+                     "serial_num": "12C324776"
+                  },
+                  id: 0
+               }
+            ]
+        };
+        const reprojectedTestPoint = CoordinatesUtils.reprojectGeoJson(testPoint, "EPSG:4326", "EPSG:900913");
+        expect(reprojectedTestPoint).toExist();
+        expect(reprojectedTestPoint.features).toExist();
+        expect(reprojectedTestPoint.features[0]).toExist();
+        expect(reprojectedTestPoint.features[0].type).toBe("Feature");
+        expect(reprojectedTestPoint.features[0].geometry.type).toBe("Point");
+        expect(reprojectedTestPoint.features[0].geometry.coordinates[0]).toBe(-12523490.492568726);
+        expect(reprojectedTestPoint.features[0].geometry.coordinates[1]).toBe(5195238.005360028);
+    });
 });

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -7,7 +7,6 @@
  */
 const expect = require('expect');
 const PrintUtils = require('../PrintUtils');
-const {isEqual} = require('lodash');
 
 const layer = {
     url: "http://mygeoserver",
@@ -95,15 +94,20 @@ describe('PrintUtils', () => {
         expect(specs[0].customParams.myparam).toBe("myvalue");
     });
     it('vector layer generation for print', () => {
-        const specs = PrintUtils.getMapfishLayersSpecification([vectorLayer], {projection: "EPSG:900913"}, 'map');
+        const specs = PrintUtils.getMapfishLayersSpecification([vectorLayer], {projection: "EPSG:3857"}, 'map');
         expect(specs).toExist();
         expect(specs.length).toBe(1);
-        expect(isEqual(specs[0], mapFishVectorLayer)).toBe(true);
+        expect(specs[0].geoJson.features[0].geometry.coordinates[0], mapFishVectorLayer).toBe(mapFishVectorLayer.geoJson.features[0].geometry.coordinates[0]);
     });
     it('vector layer default point style', () => {
         const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "Point"}}]});
         expect(style).toExist();
         expect(style.pointRadius).toBe(5);
+    });
+    it('vector layer default marker style', () => {
+        const style = PrintUtils.getOlDefaultStyle({styleName: "marker", features: [{geometry: {type: "Point"}}]});
+        expect(style).toExist();
+        expect(style.externalGraphic).toExist();
     });
     it('vector layer default polygon style', () => {
         const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "Polygon"}}]});

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -7,6 +7,7 @@
  */
 const expect = require('expect');
 const PrintUtils = require('../PrintUtils');
+const {isEqual} = require('lodash');
 
 const layer = {
     url: "http://mygeoserver",
@@ -15,7 +16,74 @@ const layer = {
     params: {myparam: "myvalue"}
 };
 
-
+const vectorLayer = {
+  "type": "vector",
+  "visibility": true,
+  "group": "Local shape",
+  "id": "web2014all_mv__14",
+  "name": "web2014all_mv",
+  "hideLoading": true,
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -112.50042920000001,
+          42.22829164089942
+        ]
+      },
+      "properties": {
+        "serial_num": "12C324776"
+      },
+      "id": 0
+    }
+  ],
+  "style": {
+    "weight": 3,
+    "radius": 10,
+    "opacity": 1,
+    "fillOpacity": 0.1,
+    "color": "rgb(0, 0, 255)",
+    "fillColor": "rgb(0, 0, 255)"
+  }
+};
+const mapFishVectorLayer = {
+   "type": "Vector",
+   "name": "web2014all_mv",
+   "opacity": 1,
+   "styleProperty": "ms_style",
+   "styles": {
+      "1": {
+         "fillColor": "rgb(0, 0, 255)",
+         "fillOpacity": 0.1,
+         "pointRadius": 10,
+         "strokeColor": "rgb(0, 0, 255)",
+         "strokeOpacity": 1,
+         "strokeWidth": 3
+      }
+   },
+   "geoJson": {
+      "type": "FeatureCollection",
+      "features": [
+         {
+            "type": "Feature",
+            "geometry": {
+               "type": "Point",
+               "coordinates": [
+                  -12523490.492568726,
+                  5195238.005360028
+               ]
+            },
+            "properties": {
+               "serial_num": "12C324776",
+               "ms_style": 1
+            },
+            "id": 0
+         }
+      ]
+   }
+};
 describe('PrintUtils', () => {
 
     it('custom params are applied to wms layers', () => {
@@ -25,5 +93,27 @@ describe('PrintUtils', () => {
         expect(specs.length).toBe(1);
         expect(specs[0].customParams.myparam).toExist();
         expect(specs[0].customParams.myparam).toBe("myvalue");
+    });
+    it('vector layer generation for print', () => {
+        const specs = PrintUtils.getMapfishLayersSpecification([vectorLayer], {projection: "EPSG:900913"}, 'map');
+        expect(specs).toExist();
+        expect(specs.length).toBe(1);
+        expect(isEqual(specs[0], mapFishVectorLayer)).toBe(true);
+    });
+    it('vector layer default point style', () => {
+        const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "Point"}}]});
+        expect(style).toExist();
+        expect(style.pointRadius).toBe(5);
+    });
+    it('vector layer default polygon style', () => {
+        const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "Polygon"}}]});
+        expect(style).toExist();
+        expect(style.strokeWidth).toBe(3);
+
+    });
+    it('vector layer default line style', () => {
+        const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "LineString"}}]});
+        expect(style).toExist();
+        expect(style.strokeWidth).toBe(3);
     });
 });

--- a/web/client/utils/openlayers/StyleUtils.js
+++ b/web/client/utils/openlayers/StyleUtils.js
@@ -20,6 +20,14 @@ const toVectorStyle = function(layer, style) {
         if (style.marker && (geomT === 'Point' || geomT === 'MultiPoint')) {
             newLayer.styleName = "marker";
         }else {
+            newLayer.style = {
+                weight: style.width,
+                radius: style.radius,
+                opacity: style.color.a,
+                fillOpacity: style.fill.a,
+                color: getColor(style.color),
+                fillColor: getColor(style.fill)
+            };
             let stroke = new ol.style.Stroke({
                             color: getColor(style.color),
                             width: style.width


### PR DESCRIPTION
- Support vector style for leaflet layers
 - Conversion to OL2 style format
 - add reprojectGeoJson utility method to CoordinateUtils
 - Print preview support
 - Markers
 - ForceUpdate when layer's created (needed to display features on vector layer mount). 
 - Optimized leaflet layer rendering
This fixes #1315 too, because I created a style abstraction that can be used in every map.