### PR TITLE
Fix #1329. Use layer params in GFI

### DIFF
--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -229,11 +229,10 @@ const Identify = React.createClass({
                 op[next] = layer[next];
             }else if (next === "params" && excludeList.length > 0) {
                 let params = layer[next];
-                op[next] = Object.keys(params).reduce((pr, n) => {
+                Object.keys(params).forEach((n) => {
                     if (excludeList.findIndex((el) => {return (el === n); }) === -1) {
-                        pr[n] = params[n];
+                        op[n] = params[n];
                     }
-                    return pr;
                 }, {});
             }
             return op;

--- a/web/client/components/data/identify/__tests__/Identify-test.jsx
+++ b/web/client/components/data/identify/__tests__/Identify-test.jsx
@@ -237,4 +237,38 @@ describe('Identify', () => {
         expect(dom.innerHTML.indexOf('Lat:') !== -1).toBe(true);
         expect(dom.innerHTML.indexOf('Long:') !== -1).toBe(true);
     });
+    it('test options and parameters filtering', () => {
+        const Viewer = (props) => <span className="myviewer">{props.responses.length}</span>;
+        const layer = {
+            INTERNAL_OPTION: true,
+            WMS_OPTION: true,
+            params: {
+            ONLY_GETMAP: true,
+            WMS_PARAMETER_TO_SHARE: true
+        }};
+        const identify = ReactDOM.render(
+            <Identify
+                excludeParams={["ONLY_GETMAP"]}
+                excludeOptions={["INTERNAL_OPTION"]}
+                enableRevGeocode={true}
+                queryableLayersFilter={() => true}
+                point={{latlng: {lat: 40, lng: 10}}}
+                viewer={Viewer}
+                enabled={true}
+                layers={[layer]}
+                sendRequest={[{}, {}]}
+                buildRequest={() => ({})}
+                requests={[{}]}
+                reverseGeocodeData={{display_name: "test"}} />,
+            document.getElementById("container")
+        );
+        expect(identify).toExist();
+        let params = identify.filterRequestParams(layer);
+        expect(params).toExist();
+        expect(params.ONLY_GETMAP).toNotExist();
+        expect(params.INTERNAL_OPTION).toNotExist();
+        expect(params.WMS_PARAMETER_TO_SHARE).toBe(true);
+        expect(params.WMS_OPTION).toBe(true);
+
+    });
 });

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -177,7 +177,7 @@ const MapInfoUtils = {
                       bounds.maxy,
                 feature_count: props.maxItems,
                 info_format: props.format,
-                ...assign({}, layer.baseParams, props.params)
+                ...assign({}, layer.baseParams, layer.params, props.params)
             },
             metadata: {
                 title: layer.title,


### PR DESCRIPTION
 - Now the getFeatureInfo gets the params from the layer.
 - The params are overridable by the params property of the feature info (the tool was using them only in the previous implementation)
 - Fixed the excludeParameter filter to add parameter properly (before it was sending to the server a json called params)
 - Add a unit test for this