### PR TITLE
Move turf require inside GET_VECTOR_INFO reducer

### DIFF
--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -27,8 +27,6 @@ const {RESET_CONTROLS} = require('../actions/controls');
 
 const assign = require('object-assign');
 const {head} = require('lodash');
-const buffer = require('turf-buffer');
-const intersect = require('turf-intersect');
 
 function receiveResponse(state, action, type) {
     const request = head((state.requests || []).filter((req) => req.reqId === action.reqId));
@@ -112,6 +110,8 @@ function mapInfo(state = {}, action) {
             });
         }
         case GET_VECTOR_INFO: {
+            const buffer = require('turf-buffer');
+            const intersect = require('turf-intersect');
             const point = {
               "type": "Feature",
               "properties": {},


### PR DESCRIPTION
This allows the `turf` modules to be ignored when creating the webpack bundle by adding

    new webpack.IgnorePlugin(/^(turf*)$/)

to the plugins in webpack.config.js, saving around 0.5 MB from the resulting optimized build (mostly thanks to not pulling in the `jsts` modules). This clearly implies that the application promises to never attempt to identify a vector layer feature.