### PR TITLE
Intl not defined

### DIFF
--- a/web/client/components/I18N/Message.jsx
+++ b/web/client/components/I18N/Message.jsx
@@ -15,7 +15,7 @@ const FormattedMessage = ReactIntl.FormattedMessage;
 
 const LocaleUtils = require('../../utils/LocaleUtils');
 
-var Message = React.createClass({
+const Message = React.createClass({
     propTypes: {
         locale: React.PropTypes.string,
         messages: React.PropTypes.object,

--- a/web/client/components/I18N/Message.jsx
+++ b/web/client/components/I18N/Message.jsx
@@ -6,6 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 const React = require('react');
+if (!global.Intl) {
+    require('intl');
+}
 const ReactIntl = require('react-intl');
 
 const FormattedMessage = ReactIntl.FormattedMessage;


### PR DESCRIPTION
On Firefox mobile our application fails to load with `Intl is not defined`. The suggested upstream fix [1] solved the issue.

[1] https://github.com/yahoo/react-intl/issues/17#issuecomment-56984521