### PR TITLE
Multi identify

### DIFF
--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -57,7 +57,8 @@ const Identify = React.createClass({
         bodyClassName: React.PropTypes.string,
         asPanel: React.PropTypes.bool,
         headerGlyph: React.PropTypes.string,
-        closeGlyph: React.PropTypes.string
+        closeGlyph: React.PropTypes.string,
+        allowMultiselection: React.PropTypes.bool
     },
     getDefaultProps() {
         return {
@@ -103,12 +104,15 @@ const Identify = React.createClass({
             bodyClassName: "panel-body",
             asPanel: true,
             headerGlyph: "info-sign",
-            closeGlyph: ""
+            closeGlyph: "",
+            allowMultiselection: false
         };
     },
     componentWillReceiveProps(newProps) {
         if (this.needsRefresh(newProps)) {
-            this.props.purgeResults();
+            if (!newProps.point.modifiers || newProps.point.modifiers.ctrl !== true || !newProps.allowMultiselection) {
+                this.props.purgeResults();
+            }
             const queryableLayers = newProps.layers.filter(newProps.queryableLayersFilter);
             queryableLayers.forEach((layer) => {
                 const {url, request, metadata} = this.props.buildRequest(layer, newProps);

--- a/web/client/components/data/identify/__tests__/Identify-test.jsx
+++ b/web/client/components/data/identify/__tests__/Identify-test.jsx
@@ -199,6 +199,27 @@ describe('Identify', () => {
         expect(spyPurgeResults.calls.length).toEqual(2);
     });
 
+    it('creates the Identify component does not purge if multiselection enabled', () => {
+        const testHandlers = {
+            purgeResults: () => {}
+        };
+
+        const spyPurgeResults = expect.spyOn(testHandlers, 'purgeResults');
+
+        const identify = ReactDOM.render(
+            <Identify
+                queryableLayersFilter={() => true}
+                enabled={true} layers={[{}, {}]} {...testHandlers} buildRequest={() => ({})}
+                multiSelection={true}
+                />,
+            document.getElementById("container")
+        );
+        identify.setProps({point: {pixel: {x: 1, y: 1}, modifiers: {ctrl: false}}});
+        expect(spyPurgeResults.calls.length).toEqual(1);
+        identify.setProps({point: {pixel: {x: 1, y: 1}, modifiers: {ctrl: true}}});
+        expect(spyPurgeResults.calls.length).toEqual(1);
+    });
+
     it('creates the Identify component uses custom viewer', () => {
         const Viewer = (props) => <span className="myviewer">{props.responses.length}</span>;
         const identify = ReactDOM.render(

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -106,6 +106,11 @@ let LeafletMap = React.createClass({
                     latlng: {
                         lat: event.latlng.lat,
                         lng: event.latlng.lng
+                    },
+                    modifiers: {
+                        alt: event.originalEvent.altKey,
+                        ctrl: event.originalEvent.ctrlKey,
+                        shift: event.originalEvent.shiftKey
                     }
                 });
             }

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -152,10 +152,12 @@ describe('LeafletMap', () => {
             expect(spy.calls[0].arguments.length).toEqual(1);
             expect(spy.calls[0].arguments[0].pixel).toExist();
             expect(spy.calls[0].arguments[0].latlng).toExist();
+            expect(spy.calls[0].arguments[0].modifiers).toExist();
+            expect(spy.calls[0].arguments[0].modifiers.alt).toEqual(false);
+            expect(spy.calls[0].arguments[0].modifiers.ctrl).toEqual(false);
+            expect(spy.calls[0].arguments[0].modifiers.shift).toEqual(false);
             done();
         }, 600);
-
-
     });
 
     it('check if the map changes when receive new props', () => {

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -135,6 +135,11 @@ var OpenlayersMap = React.createClass({
                     latlng: {
                         lat: coords[1],
                         lng: tLng
+                    },
+                    modifiers: {
+                        alt: event.originalEvent.altKey,
+                        ctrl: event.originalEvent.ctrlKey,
+                        shift: event.originalEvent.shiftKey
                     }
                 });
             }


### PR DESCRIPTION
Adds a `multiSelection` property to the Identify component which allows multiple identify requests to be captured without purging the results if the ctrl modifier is pressed when clicking.

Note: I've been unsuccessful in finding any way to simulate a click in openlayers to implement the 'click' test below... Any ideas how this can be done? The way ol upstream does it[1] in the test suite relies on many private methods...

    +    it('check if the handler for "click" event is called', (done) => {
    +        const testHandlers = {
    +            handler: () => {}
    +        };
    +        var spy = expect.spyOn(testHandlers, 'handler');
    +
    +        const map = ReactDOM.render(
    +            <OpenlayersMap
    +                center={{y: 43.9, x: 10.3}}
    +                zoom={11}
    +                onClick={testHandlers.handler}
    +            />
    +        , document.getElementById("map"));
    +
    +        const olMap = map.map;
    +        const mapDiv = olMap.getViewport();
    +
    +        let downEvent = document.createEvent('MouseEvents');
    +        downEvent.initEvent ("mousedown", true, true);
    +        mapDiv.dispatchEvent(downEvent);
    +        let upEvent = document.createEvent('MouseEvents');
    +        upEvent.initEvent ("mouseup", true, true);
    +        mapDiv.dispatchEvent(upEvent);
    +        let clickEvent = document.createEvent('MouseEvents');
    +        clickEvent.initEvent ("click", true, true);
    +        mapDiv.dispatchEvent(clickEvent);
    +
    +//         mapDiv.click();
    +        setTimeout(() => {
    +          try {
    +            expect(spy.calls.length).toEqual(1);
    +            expect(spy.calls[0].arguments.length).toEqual(1);
    +            expect(spy.calls[0].arguments[0].pixel).toExist();
    +            expect(spy.calls[0].arguments[0].latlng).toExist();
    +            expect(spy.calls[0].arguments[0].modifiers).toExist();
    +            expect(spy.calls[0].arguments[0].modifiers.altKey).toEqual(false);
    +            expect(spy.calls[0].arguments[0].modifiers.ctrlKey).toEqual(false);
    +            expect(spy.calls[0].arguments[0].modifiers.shiftKey).toEqual(false);
    +          } catch(e) {
    +            return done(e);
    +          }
    +            done();
    +        }, 600);
    +    });

[1] https://github.com/openlayers/ol3/blob/master/test/spec/ol/interaction/modify.test.js#L80