### PR TITLE
Fix default state of map reducers

### DIFF
--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -149,6 +149,13 @@ describe('Test the map reducer', () => {
         expect(state.mapOptions.view).toExist();
         expect(state.mapOptions.view.resolutions).toNotExist();
         expect(state.mapOptions.view.prop).toBe('prop');
+
+        // add map scales with no initial state
+        state = mapConfig(undefined, action);
+        expect(state).toExist();
+        expect(state.mapOptions).toExist();
+        expect(state.mapOptions.view).toExist();
+        expect(state.mapOptions.view.resolutions).toExist();
     });
 
     it('zoom to extent', () => {

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -15,7 +15,7 @@ var assign = require('object-assign');
 var MapUtils = require('../utils/MapUtils');
 var CoordinatesUtils = require('../utils/CoordinatesUtils');
 
-function mapConfig(state = null, action) {
+function mapConfig(state = {}, action) {
     switch (action.type) {
         case CHANGE_MAP_VIEW:
             const {type, ...params} = action;


### PR DESCRIPTION
Replace the null initial state with an empty dict.