### PR TITLE
Fix infinite loop when query panel is closed.

### DIFF
--- a/web/client/components/data/featuregrid/DockedFeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/DockedFeatureGrid.jsx
@@ -217,13 +217,13 @@ const DockedFeatureGrid = React.createClass({
             );
         }
 
-        let cols = this.props.columnsDef.map((column) => {
+        let cols = this.props.columnsDef && this.props.columnsDef.map((column) => {
             if (!column.profiles || (column.profiles && column.profiles.indexOf(this.props.profile) !== -1)) {
                 return assign({}, column, {field: "properties." + column.field});
             }
         }).filter((c) => c);
 
-        if (this.sortModel && this.sortModel.length > 0) {
+        if (cols && this.sortModel && this.sortModel.length > 0) {
             cols = cols.map((c) => {
                 let model = head(this.sortModel.filter((m) => m.colId === c.field));
                 if ( model ) {
@@ -235,7 +235,7 @@ const DockedFeatureGrid = React.createClass({
 
         let gridConf = this.props.pagination ? {dataSource: this.getDataSource(this.props.dataSourceOptions), features: []} : {features: this.props.features};
 
-        if (this.props.filterObj) {
+        if (this.props.filterObj && cols) {
             return (
                 <Dock
                     position={"bottom" /* 'left', 'top', 'right', 'bottom' */}

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -33,7 +33,7 @@ const MapPlugin = React.createClass({
     },
     getDefaultProps() {
         return {
-            mapType: 'cesium',
+            mapType: 'leaflet',
             actions: {},
             zoomControl: true,
             mapLoadingMessage: "map.loading",

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -33,7 +33,7 @@ const MapPlugin = React.createClass({
     },
     getDefaultProps() {
         return {
-            mapType: 'leaflet',
+            mapType: 'cesium',
             actions: {},
             zoomControl: true,
             mapLoadingMessage: "map.loading",

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -209,7 +209,7 @@ const LayerTree = React.createClass({
                     <DefaultLayer
                             settingsOptions={this.props.settingsOptions}
                             onToggle={this.props.onToggleLayer}
-                            onToggleQuerypanel={this.props.onToggleQuery}
+                            onToggleQuerypanel={this.props.onToggleQuery }
                             onZoom={this.props.onZoomToExtent}
                             onSettings={this.props.onSettings}
                             propertiesChangeHandler={this.props.layerPropertiesChangeHandler}
@@ -237,7 +237,7 @@ const LayerTree = React.createClass({
     },
     renderQueryPanel() {
         return (<div>
-            <Button id="query-close-button" bsStyle="primary" key="menu-button" className="square-button" onClick={this.props.onToggleQuery}><Glyphicon glyph="arrow-left"/></Button>
+            <Button id="query-close-button" bsStyle="primary" key="menu-button" className="square-button" onClick={this.props.onToggleQuery.bind(this, null, null)}><Glyphicon glyph="arrow-left"/></Button>
             <SmartQueryForm/>
         </div>);
     },


### PR DESCRIPTION
This error happens when closing the query panel (in debug mode) .

![image](https://cloud.githubusercontent.com/assets/1279510/21802545/77616e0a-d726-11e6-9433-fc976be115fa.png)
This is due to the onClick event bind directly to the action, passing the wrong parameters (the mouseEvent instead of the search URL). 
In debug this causes an immutable error, in general the state becomes not consistent anymore. 