### PR TITLE
Feature Grid header style

### DIFF
--- a/web/client/components/data/featuregrid/featuregrid.css
+++ b/web/client/components/data/featuregrid/featuregrid.css
@@ -1,5 +1,5 @@
-.featuregrid .ag-header-cell, .ag-header-row{
-    background-color: #078AA3;
+.ag-fresh .ag-header{
+    background: #078AA3;
     color: white;
     font-family: Raleway;
 }


### PR DESCRIPTION
now light blue color of the feature grid is visible even when horizontal scrolling.
![image](https://cloud.githubusercontent.com/assets/1279510/21846961/c1a30dce-d7f9-11e6-9485-dac5fb628bcc.png)
