### PR TITLE
Fix #1393, align feature grid headers to the theme.

### DIFF
--- a/web/client/components/data/featuregrid/DockedFeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/DockedFeatureGrid.jsx
@@ -222,6 +222,7 @@ const DockedFeatureGrid = React.createClass({
         if (this.props.open && this.props.filterObj && cols) {
             return (
                 <Dock
+                    zIndex={1030 /*below dialogs, above left menu*/}
                     position={"bottom" /* 'left', 'top', 'right', 'bottom' */}
                     size={this.state.size}
                     dimMode={"none" /*'transparent', 'none', 'opaque'*/}

--- a/web/client/components/data/featuregrid/featuregrid.css
+++ b/web/client/components/data/featuregrid/featuregrid.css
@@ -20,3 +20,15 @@
     right: 0;
     bottom: 0;
 }
+.ag-body {
+    /* !important is needed, we need to override inline attributes of ag-grid */
+    padding-top: 55px !important;
+}
+.ag-header, .ag-header-row, .ag-header-container .ag-header-row {
+    /* !important is needed, we need to override inline attributes of ag-grid */
+    height:55px !important;
+}
+.ag-fresh .ag-header-cell-label {
+    padding-top: 17px;
+    cursor: pointer;
+}


### PR DESCRIPTION
 - Header of the feature grid (aggrid) are now forced to have the same sizes of the other headers
 - Mouse pointer changes when hover header (to change sorting)
 - ZIndex of the grid's dock is now below all dialogs, but still above the toc