### PR TITLE
fix #1326 : Added limits for group name and desc and a message

### DIFF
--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -44,6 +44,7 @@ const GroupDialog = React.createClass({
       closeGlyph: React.PropTypes.string,
       style: React.PropTypes.object,
       buttonSize: React.PropTypes.string,
+      descLimit: React.PropTypes.number,
       inputStyle: React.PropTypes.object
   },
   getDefaultProps() {
@@ -56,6 +57,7 @@ const GroupDialog = React.createClass({
           options: {},
           useModal: true,
           closeGlyph: "",
+          descLimit: 255,
           style: {},
           buttonSize: "large",
           includeCloseButton: true,
@@ -82,11 +84,13 @@ const GroupDialog = React.createClass({
           style={this.props.inputStyle}
           label={<Message msgId="usergroups.groupName"/> }
           onChange={this.handleChange}
+          maxLength={255}
           value={this.props.group && this.props.group.groupName}/>
       <Input type="textarea"
           ref="description"
           key="description"
           name="description"
+          maxLength={255}
           readOnly={this.props.group && this.props.group.id}
           style={this.props.inputStyle}
           label={<Message msgId="usergroups.groupDescription"/>}
@@ -187,15 +191,17 @@ const GroupDialog = React.createClass({
             style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}
             >
           <span role="header">
-              <span className="user-panel-title">{(this.props.group && this.props.group.groupName) || <Message msgId="usergroups.newGroup" />}</span>
               <button onClick={this.props.onClose} className="login-panel-close close">
                   {this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}
               </button>
+              <span className="user-panel-title">{(this.props.group && this.props.group.groupName) || <Message msgId="usergroups.newGroup" />}</span>
           </span>
           <div role="body">
           <Tabs defaultActiveKey={1} key="tab-panel">
               <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="1-group"/></Button>} >
                   {this.renderGeneral()}
+                  {this.checkNameLenght()}
+                  {this.checkDescLenght()}
               </Tab>
               <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="1-group-add"/></Button>} >
                   {this.renderMembersTab()}
@@ -207,6 +213,16 @@ const GroupDialog = React.createClass({
               {this.renderButtons()}
           </div>
       </Dialog>);
+  },
+  checkNameLenght() {
+      return this.props.group && this.props.group.groupName && this.props.group.groupName.length === 255 ? (<div className="alert alert-warning">
+            <Message msgId="usergroups.nameLimit"/>
+        </div>) : null;
+  },
+  checkDescLenght() {
+      return this.props.group && this.props.group.description && this.props.group.description.length === 255 ? (<div className="alert alert-warning">
+            <Message msgId="usergroups.descLimit"/>
+        </div>) : null;
   },
   isSaving() {
       return this.props.group && this.props.group.status === "saving";

--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -44,7 +44,6 @@ const GroupDialog = React.createClass({
       closeGlyph: React.PropTypes.string,
       style: React.PropTypes.object,
       buttonSize: React.PropTypes.string,
-      descLimit: React.PropTypes.number,
       inputStyle: React.PropTypes.object
   },
   getDefaultProps() {
@@ -57,7 +56,6 @@ const GroupDialog = React.createClass({
           options: {},
           useModal: true,
           closeGlyph: "",
-          descLimit: 255,
           style: {},
           buttonSize: "large",
           includeCloseButton: true,

--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -44,6 +44,8 @@ const GroupDialog = React.createClass({
       closeGlyph: React.PropTypes.string,
       style: React.PropTypes.object,
       buttonSize: React.PropTypes.string,
+      descLimit: React.PropTypes.number,
+      nameLimit: React.PropTypes.number,
       inputStyle: React.PropTypes.object
   },
   getDefaultProps() {
@@ -56,6 +58,8 @@ const GroupDialog = React.createClass({
           options: {},
           useModal: true,
           closeGlyph: "",
+          descLimit: 255,
+          nameLimit: 255,
           style: {},
           buttonSize: "large",
           includeCloseButton: true,
@@ -82,13 +86,13 @@ const GroupDialog = React.createClass({
           style={this.props.inputStyle}
           label={<Message msgId="usergroups.groupName"/> }
           onChange={this.handleChange}
-          maxLength={255}
+          maxLength={this.props.nameLimit}
           value={this.props.group && this.props.group.groupName}/>
       <Input type="textarea"
           ref="description"
           key="description"
           name="description"
-          maxLength={255}
+          maxLength={this.props.descLimit}
           readOnly={this.props.group && this.props.group.id}
           style={this.props.inputStyle}
           label={<Message msgId="usergroups.groupDescription"/>}
@@ -213,12 +217,12 @@ const GroupDialog = React.createClass({
       </Dialog>);
   },
   checkNameLenght() {
-      return this.props.group && this.props.group.groupName && this.props.group.groupName.length === 255 ? (<div className="alert alert-warning">
+      return this.props.group && this.props.group.groupName && this.props.group.groupName.length === this.props.nameLimit ? (<div className="alert alert-warning">
             <Message msgId="usergroups.nameLimit"/>
         </div>) : null;
   },
   checkDescLenght() {
-      return this.props.group && this.props.group.description && this.props.group.description.length === 255 ? (<div className="alert alert-warning">
+      return this.props.group && this.props.group.description && this.props.group.description.length === this.props.descLimit ? (<div className="alert alert-warning">
             <Message msgId="usergroups.descLimit"/>
         </div>) : null;
   },

--- a/web/client/components/manager/users/style/userdialog.css
+++ b/web/client/components/manager/users/style/userdialog.css
@@ -17,3 +17,8 @@
 .group-edit-dialog .user-thumb .user-status {
     display: none;
 }
+
+.user-edit-dialog .modal-header, .group-edit-dialog .modal-header {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -484,6 +484,8 @@
         "usergroups": {
           "searchGroups": "Search Groups...",
           "groups": "Groups",
+          "nameLimit": "The name is limited to 255 characters.",
+          "descLimit": "The description is limited to 255 characters.",
           "editGroup": "Edit Group",
           "deleteGroup": "Delete Group",
           "removeUser": "Remove User",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -484,6 +484,8 @@
         "usergroups": {
           "searchGroups": "Search Groups...",
           "groups": "Groups",
+          "nameLimit": "The name is limited to 255 characters.",
+          "descLimit": "The description is limited to 255 characters.",
           "editGroup": "Edit Group",
           "deleteGroup": "Delete Group",
           "removeUser": "Remove User",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -486,6 +486,8 @@
         "usergroups": {
           "searchGroups": "rechercher des groupes...",
           "groups": "Groupes",
+          "nameLimit": "Le nom est limité à 255 caractères.",
+          "descLimit": "La description est limité à 255 caractères.",
           "editGroup": "Modifier",
           "deleteGroup": "Supprimer",
           "removeUser": "supprimer l'utilisateur",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -483,6 +483,8 @@
         },
         "usergroups": {
           "searchGroups": "Cerca gruppi...",
+          "nameLimit": "La massima lunghezza del nome del gruppo è prevista in 255 caratteri.",
+          "descLimit": "La massima lunghezza della descrizione del gruppo è prevista in 255 caratteri.",
           "groups": "Gruppi",
           "editGroup": "Modifica Gruppo",
           "deleteGroup": "Rimuovi Gruppo",


### PR DESCRIPTION
fixed #1326
- provided a maxLength to the input field
- provided a localized message when the limit is reached for both the name and the description
- Header now display a long message correctly if there are some spaces