### PR TITLE
Fix #1434 Wrong order of windows in GetFeatureInfo + Reverse GeoCoding

### DIFF
--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -168,7 +168,8 @@ const Identify = React.createClass({
                 revGeocodeDisplayName={reverseGeocodeData.error ? <Message msgId="identifyRevGeocodeError" /> : this.props.reverseGeocodeData.display_name}
                 hideRevGeocode={this.props.hideRevGeocode}
                 identifyRevGeocodeSubmitText={<Message msgId="identifyRevGeocodeSubmitText" />}
-                identifyRevGeocodeCloseText={<Message msgId="identifyRevGeocodeCloseText" />} />);
+                identifyRevGeocodeCloseText={<Message msgId="identifyRevGeocodeCloseText" />}
+                modalOptions={{bsClass: 'mapstore-identify-modal modal'}} />);
             return this.props.wrapRevGeocode ? (
                 <Panel
                     header={<span><Glyphicon glyph="globe" />&nbsp;<Message msgId="identifyRevGeocodeHeader" /></span>}>

--- a/web/client/components/data/identify/css/identify.css
+++ b/web/client/components/data/identify/css/identify.css
@@ -43,3 +43,7 @@
 #mapstore-getfeatureinfo .swipeable-view .panel-title {
     font-weight: bold;
 }
+
+.mapstore-identify-modal {
+    z-index: 2001;
+}


### PR DESCRIPTION
Added new class to GeocodeViewer of  Identify componenent with z-index to 2001.
The .modal-dialog-container class in [viewer.css](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/product/assets/css/viewer.css#L92-L94) has a 2000 z-index with !important rule that overrides the z-index of the Draggable and Panel components in Identify.

preview:
![zorder](https://cloud.githubusercontent.com/assets/19175505/22926612/96b52128-f2ad-11e6-9d3a-947d7f290e7e.png)
