### PR TITLE
Fix plugins example to use epics

### DIFF
--- a/web/client/examples/plugins/store.js
+++ b/web/client/examples/plugins/store.js
@@ -5,9 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {combineReducers} = require('../../utils/PluginsUtils');
+const {combineReducers, combineEpics} = require('../../utils/PluginsUtils');
 const {createDebugStore} = require('../../utils/DebugUtils');
 const LayersUtils = require('../../utils/LayersUtils');
+
+const {createEpicMiddleware} = require('redux-observable');
 
 const map = require('../../reducers/map');
 
@@ -24,7 +26,8 @@ module.exports = (plugins, custom) => {
         pluginsConfig: require('./reducers/config'),
         custom
     });
-
+    const rootEpic = combineEpics(plugins);
+    const epicMiddleware = createEpicMiddleware(rootEpic);
     const rootReducer = (state, action) => {
         if (action.type === 'LOADED_STATE') {
             return action.state;
@@ -39,5 +42,5 @@ module.exports = (plugins, custom) => {
         return newState;
     };
 
-    return createDebugStore(rootReducer, {});
+    return createDebugStore(rootReducer, {}, [epicMiddleware]);
 };


### PR DESCRIPTION
This fixes the plugins store to use the epics from the plugin itself (search now will not work without it). 
Is a good sample of how to update all the old stores with epics. 
