### PR TITLE
Fix #1501. Restored correct default property

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -41,7 +41,7 @@ const DefaultViewer = React.createClass({
             format: MapInfoUtils.getDefaultInfoFormatValue(),
             responses: [],
             missingResponses: 0,
-            collapsible: true,
+            collapsible: false,
             header: DefaultHeader,
             headerOptions: {},
             container: Accordion,
@@ -104,7 +104,6 @@ const DefaultViewer = React.createClass({
             const PageHeader = this.props.header;
             return (
                 <Panel
-
                     eventKey={i}
                     key={i}
                     collapsible={this.props.collapsible}


### PR DESCRIPTION
collapsible property for DefaultViewer is always false by default.
If you look at mapstore.geo-solutions.it, you can see the identify panel is not collapsible. 
