### PR TITLE
Implementation of nested search services #1122

### DIFF
--- a/web/client/actions/__tests__/search-test.js
+++ b/web/client/actions/__tests__/search-test.js
@@ -21,7 +21,7 @@ var {
     textSearch,
     selectSearchItem,
     selectNestedService,
-    cancelSelectedItem,
+    cancelSelectedItem
 } = require('../search');
 
 describe('Test correctness of the search actions', () => {

--- a/web/client/actions/__tests__/search-test.js
+++ b/web/client/actions/__tests__/search-test.js
@@ -13,11 +13,15 @@ var {
     TEXT_SEARCH_ERROR,
     TEXT_SEARCH_STARTED,
     TEXT_SEARCH_ITEM_SELECTED,
+    TEXT_SEARCH_NESTED_SERVICES_SELECTED,
+    TEXT_SEARCH_CANCEL_ITEM,
     searchResultLoaded,
     searchTextLoading,
     searchResultError,
     textSearch,
-    selectSearchItem
+    selectSearchItem,
+    selectNestedService,
+    cancelSelectedItem,
 } = require('../search');
 
 describe('Test correctness of the search actions', () => {
@@ -58,5 +62,21 @@ describe('Test correctness of the search actions', () => {
         expect(retval.item).toEqual("A");
         expect(retval.mapConfig).toBe("B");
     });
+    it('serch item cancelled', () => {
+        const retval = cancelSelectedItem("ITEM");
+        expect(retval).toExist();
+        expect(retval.type).toBe(TEXT_SEARCH_CANCEL_ITEM);
+        expect(retval.item).toEqual("ITEM");
+    });
+    it('serch nested service selected', () => {
+        const items = [{text: "TEXT"}];
+        const services = [{type: "wfs"}, {type: "wms"}];
+        const retval = selectNestedService(services, items, "TEST");
+        expect(retval).toExist();
+        expect(retval.type).toBe(TEXT_SEARCH_NESTED_SERVICES_SELECTED);
+        expect(retval.items).toEqual(items);
+        expect(retval.services).toEqual(services);
+    });
+
 
 });

--- a/web/client/actions/search.js
+++ b/web/client/actions/search.js
@@ -14,8 +14,9 @@ const TEXT_SEARCH_RESET = 'TEXT_SEARCH_RESET';
 const TEXT_SEARCH_ADD_MARKER = 'TEXT_SEARCH_ADD_MARKER';
 const TEXT_SEARCH_TEXT_CHANGE = 'TEXT_SEARCH_TEXT_CHANGE';
 const TEXT_SEARCH_LOADING = 'TEXT_SEARCH_LOADING';
+const TEXT_SEARCH_NESTED_SERVICES_SELECTED = 'TEXT_SEARCH_NESTED_SERVICE_SELECTED';
 const TEXT_SEARCH_ERROR = 'TEXT_SEARCH_ERROR';
-
+const TEXT_SEARCH_CANCEL_ITEM = 'TEXT_SEARCH_CANCEL_ITEM';
 const TEXT_SEARCH_ITEM_SELECTED = 'TEXT_SEARCH_ITEM_SELECTED';
 
 function searchResultLoaded(results, append=false, services) {
@@ -83,7 +84,21 @@ function selectSearchItem(item, mapConfig) {
     };
 
 }
+function selectNestedService(services, items, searchText) {
+    return {
+        type: TEXT_SEARCH_NESTED_SERVICES_SELECTED,
+        searchText,
+        services,
+        items
+    };
+}
 
+function cancelSelectedItem(item) {
+    return {
+        type: TEXT_SEARCH_CANCEL_ITEM,
+        item
+    };
+}
 
 module.exports = {
     TEXT_SEARCH_STARTED,
@@ -96,6 +111,8 @@ module.exports = {
     TEXT_SEARCH_ADD_MARKER,
     TEXT_SEARCH_TEXT_CHANGE,
     TEXT_SEARCH_ITEM_SELECTED,
+    TEXT_SEARCH_NESTED_SERVICES_SELECTED,
+    TEXT_SEARCH_CANCEL_ITEM,
     searchTextLoading,
     searchResultError,
     searchResultLoaded,
@@ -104,5 +121,7 @@ module.exports = {
     resetSearch,
     addMarker,
     searchTextChanged,
-    selectSearchItem
+    selectNestedService,
+    selectSearchItem,
+    cancelSelectedItem
 };

--- a/web/client/api/searchText.js
+++ b/web/client/api/searchText.js
@@ -20,18 +20,18 @@ const toNominatim = (fc) =>
 */
 
 module.exports = {
-    nominatim: (searchText, {options = null} = {}) =>
+    nominatim: (searchText, options = {}) =>
         require('./Nominatim')
         .geocode(searchText, options)
         .then( res => GeoCodeUtils.nominatimToGeoJson(res.data)),
-    wfs: (searchText, {url, typeName, queriableAttributes, outputFormat="application/json", predicate ="ILIKE", ...params }) => {
+    wfs: (searchText, {url, typeName, queriableAttributes, outputFormat="application/json", predicate ="ILIKE", staticFilter="", ...params }) => {
         return WFS
             .getFeatureSimple(url, assign({
                     maxFeatures: 10,
                     startIndex: 0,
                     typeName,
                     outputFormat,
-                    cql_filter: queriableAttributes.map( attr => `${attr} ${predicate} '%${searchText}%'`).join(' OR ')
+                    cql_filter: queriableAttributes.map( attr => `${attr} ${predicate} '%${searchText}%'`).join(' OR ').concat(staticFilter)
                 }, params))
             .then( response => response.features );
     }

--- a/web/client/components/mapcontrols/search/SearchResult.jsx
+++ b/web/client/components/mapcontrols/search/SearchResult.jsx
@@ -9,10 +9,20 @@
 const React = require('react');
 const {get} = require('lodash');
 
+const {generateTemplateString} = require('../../../utils/TemplateUtils');
 
 let SearchResult = React.createClass({
     propTypes: {
+        /* field name or template.
+         * e.g. "properties.subTitle"
+         * e.g. "This is a subtitle for ${properties.subTitle}"
+         */
+        subTitle: React.PropTypes.string,
         item: React.PropTypes.object,
+        /* field name or template.
+         * e.g. "properties.displayName"
+         * e.g. "This is a title for ${properties.title}"
+         */
         displayName: React.PropTypes.string,
         idField: React.PropTypes.string,
         icon: React.PropTypes.string,
@@ -35,9 +45,10 @@ let SearchResult = React.createClass({
         }
         let item = this.props.item;
         return (
-            <div key={item.osm_id} className="search-result NominatimResult" onClick={this.onClick}>
+            <div key={item.osm_id} className="search-result" onClick={this.onClick}>
                 <div className="icon"> <img src={item.icon} /></div>
-                {get(item, this.props.displayName) }
+                <div className="text-result-title">{get(item, this.props.displayName) || generateTemplateString(this.props.displayName || "")(item) }</div>
+                <small className="text-info">{this.props.subTitle && get(item, this.props.subTitle) || generateTemplateString(this.props.subTitle || "")(item) }</small>
             </div>
         );
     }

--- a/web/client/components/mapcontrols/search/SearchResultList.jsx
+++ b/web/client/components/mapcontrols/search/SearchResultList.jsx
@@ -36,6 +36,7 @@ let SearchResultList = React.createClass({
         return this.props.results.map((item, idx)=> {
             const service = this.findService(item) || {};
             return (<SearchResult
+                subTitle={service.subTitle}
                 idField={service.idField}
                 displayName={service.displayName}
                 key={item.osm_id || "res_" + idx} item={item} onItemClick={this.onItemClick}/>);
@@ -59,8 +60,8 @@ let SearchResultList = React.createClass({
     },
     findService(item) {
         const services = this.props.searchOptions && this.props.searchOptions.services;
-        if (services && item.__SERVICE__ !== null) {
-            if ( typeof item.__SERVICE__ === "string" ) {
+        if (item.__SERVICE__ !== null) {
+            if (services && typeof item.__SERVICE__ === "string" ) {
                 for (let i = 0; i < services.length; i++) {
                     if (services[i] && services[i].id === item.__SERVICE__) {
                         return services[i];
@@ -72,8 +73,8 @@ let SearchResultList = React.createClass({
                     }
                 }
 
-            } else {
-                return services[item.__SERVICE__];
+            } else if (typeof item.__SERVICE__ === "object") {
+                return item.__SERVICE__;
             }
         }
     }

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -132,6 +132,20 @@ describe("test the SearchBar", () => {
             done();
         }, 50);
     });
+    it('test autofocus on selected items', (done) => {
+        let tb = ReactDOM.render(<SearchBar searchText="test" delay={0} typeAhead={true} blurResetDelay={0} />, document.getElementById("container"));
+        let input = TestUtils.scryRenderedDOMComponentsWithTag(tb, "input")[0];
+        expect(input).toExist();
+        let spyOnFocus = expect.spyOn(input, 'focus');
+        input = ReactDOM.findDOMNode(input);
+        input.value = "test";
+        TestUtils.Simulate.blur(input);
+        ReactDOM.render(<SearchBar searchText="test" delay={0} typeAhead={true} blurResetDelay={0} selectedItems={[{text: "TEST"}]}/>, document.getElementById("container"));
+        setTimeout(() => {
+            expect(spyOnFocus.calls.length).toEqual(1);
+            done();
+        }, 210);
+    });
 
     it('test that options are passed to search action', () => {
         var tb;
@@ -162,5 +176,25 @@ describe("test the SearchBar", () => {
         expect(tb).toExist();
         let error = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(tb, "searcherror")[0]);
         expect(error).toExist();
+    });
+
+    it('test cancel items', (done) => {
+        const testHandlers = {
+            onCancelSelectedItem: () => {}
+        };
+
+        const spy = expect.spyOn(testHandlers, 'onCancelSelectedItem');
+        let tb = ReactDOM.render(<SearchBar searchText="test" delay={0} typeAhead={true} blurResetDelay={0} onCancelSelectedItem={testHandlers.onCancelSelectedItem} />, document.getElementById("container"));
+        let input = TestUtils.scryRenderedDOMComponentsWithTag(tb, "input")[0];
+        expect(input).toExist();
+        input = ReactDOM.findDOMNode(input);
+
+        // backspace with empty searchText causes trigger of onCancelSelectedItem
+        ReactDOM.render(<SearchBar searchText="" delay={0} typeAhead={true} blurResetDelay={0} onCancelSelectedItem={testHandlers.onCancelSelectedItem} selectedItems={[{text: "TEST"}]}/>, document.getElementById("container"));
+        TestUtils.Simulate.keyDown(input, {key: "Backspace", keyCode: 8, which: 8});
+        setTimeout(() => {
+            expect(spy.calls.length).toEqual(1);
+            done();
+        }, 10);
     });
 });

--- a/web/client/components/mapcontrols/search/__tests__/SearchResult-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchResult-test.jsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var expect = require('expect');
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var SearchResult = require('../SearchResult');
+const TestUtils = require('react-addons-test-utils');
+const item = {
+    properties: {
+        prop1: 1,
+        prop2: 2
+    }
+};
+describe("test the NominatimResult", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('test component creation', () => {
+        const tb = ReactDOM.render(<SearchResult item={item}/>, document.getElementById("container"));
+        expect(tb).toExist();
+
+    });
+
+    it('create component without item', () => {
+        const tb = ReactDOM.render(<SearchResult />, document.getElementById("container"));
+        expect(tb).toExist();
+    });
+
+    it('create component with displayName and subtitle', () => {
+        const tb = ReactDOM.render(<SearchResult item={item} displayName="test ${properties.prop1}" subTitle="test ${properties.prop2}"/>, document.getElementById("container"));
+        expect(tb).toExist();
+        const title = TestUtils.findRenderedDOMComponentWithClass(tb, "text-result-title");
+        const subTitle = TestUtils.findRenderedDOMComponentWithClass(tb, "text-info");
+
+        expect(title).toExist();
+        expect(subTitle).toExist();
+        expect(title.textContent).toBe("test 1");
+        expect(subTitle.textContent).toBe("test 2");
+    });
+
+    it('test click handler', () => {
+        const testHandlers = {
+            clickHandler: (pressed) => {return pressed; }
+        };
+        const spy = expect.spyOn(testHandlers, 'clickHandler');
+        var tb = ReactDOM.render(<SearchResult item={item} onItemClick={testHandlers.clickHandler}/>, document.getElementById("container"));
+        let elem = TestUtils.findRenderedDOMComponentWithClass(tb, "search-result");
+        expect(elem).toExist();
+        ReactDOM.findDOMNode(elem).click();
+        expect(spy.calls.length).toEqual(1);
+    });
+});

--- a/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const SearchResultList = require('../SearchResultList');
+const SearchResult = require('../SearchResult');
+const TestUtils = require('react-addons-test-utils');
+
+const results = [{
+    id: "ID",
+    properties: {
+        prop1: 1
+    },
+    __SERVICE__: {
+        subTitle: "TEST",
+        displayName: "${properties.prop1}",
+        idField: "id"
+    }
+}];
+
+describe("test the SearchResultList", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('test component creation', () => {
+
+        const tb = ReactDOM.render(<SearchResultList results={results}/>, document.getElementById("container"));
+        expect(tb).toExist();
+
+    });
+
+    it('create component without items', () => {
+        const tb = ReactDOM.render(<SearchResultList />, document.getElementById("container"));
+        expect(tb).toExist();
+    });
+
+    it('create component with empty items array', () => {
+        const tb = ReactDOM.render(<SearchResultList results={[]} notFoundMessage="not found"/>, document.getElementById("container"));
+        expect(tb).toExist();
+    });
+
+    it('get service info from internal object', () => {
+        let tb = ReactDOM.render(<SearchResultList results={results} notFoundMessage="not found"/>, document.getElementById("container"));
+        expect(tb).toExist();
+
+        let title = TestUtils.findRenderedDOMComponentWithClass(tb, "text-result-title");
+        let subTitle = TestUtils.findRenderedDOMComponentWithClass(tb, "text-info");
+
+        expect(title.textContent).toBe("1");
+        expect(subTitle.textContent).toBe("TEST");
+
+    });
+    it('get service info from search Options by id', () => {
+        const tb = ReactDOM.render((<SearchResultList searchOptions={{
+            services: [{
+                id: "S1",
+                displayName: "S1",
+                subTitle: "S1"
+            }]
+        }} results={[{
+            id: "ID",
+            properties: {
+                prop1: 1
+            },
+            __SERVICE__: "S1"
+        }]} notFoundMessage="not found"/>), document.getElementById("container"));
+        expect(tb).toExist();
+
+        let title = TestUtils.findRenderedDOMComponentWithClass(tb, "text-result-title");
+        let subTitle = TestUtils.findRenderedDOMComponentWithClass(tb, "text-info");
+
+        expect(title.textContent).toBe("S1");
+        expect(subTitle.textContent).toBe("S1");
+
+    });
+    it('get service info from search Options by type', () => {
+        const tb = ReactDOM.render((<SearchResultList searchOptions={{
+            services: [{
+                id: "S1",
+                displayName: "S1",
+                subTitle: "S1"
+            }]
+        }} results={[{
+            id: "ID",
+            properties: {
+                prop1: 1
+            },
+            __SERVICE__: "S1"
+        }]} notFoundMessage="not found"/>), document.getElementById("container"));
+        expect(tb).toExist();
+
+        let title = TestUtils.findRenderedDOMComponentWithClass(tb, "text-result-title");
+        let subTitle = TestUtils.findRenderedDOMComponentWithClass(tb, "text-info");
+
+        expect(title.textContent).toBe("S1");
+        expect(subTitle.textContent).toBe("S1");
+
+    });
+
+    it('test click handler', () => {
+        const testHandlers = {
+            clickHandler: () => {},
+            afterClick: () => {}
+        };
+        var items = [{
+            osm_id: 1,
+            display_name: "Name",
+            boundingbox: [1, 2, 3, 4]
+        }];
+        const spy = expect.spyOn(testHandlers, 'clickHandler');
+        var tb = ReactDOM.render(<SearchResultList results={items} mapConfig={{size: 100, projection: "EPSG:4326"}}
+            onItemClick={testHandlers.clickHandler}
+            afterItemClick={testHandlers.afterItemClick}/>, document.getElementById("container"));
+        let elem = TestUtils.scryRenderedComponentsWithType(tb, SearchResult);
+        expect(elem.length).toBe(1);
+
+        let elem1 = TestUtils.findRenderedDOMComponentWithClass(elem[0], "search-result");
+        ReactDOM.findDOMNode(elem1).click();
+        expect(spy.calls.length).toEqual(1);
+    });
+
+
+});

--- a/web/client/components/mapcontrols/search/searchbar.css
+++ b/web/client/components/mapcontrols/search/searchbar.css
@@ -166,3 +166,10 @@
         width: 580px;
     }
 }
+
+.input-group-addon .selectedItem-text {
+    font-size: 14px;
+    overflow: hidden;
+    max-width: 400px;
+    text-overflow: ellipsis;
+}

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -11,7 +11,7 @@ var expect = require('expect');
 
 const configureMockStore = require('redux-mock-store').default;
 const { createEpicMiddleware, combineEpics } = require('redux-observable');
-const { textSearch, selectSearchItem, TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_RESULTS_PURGE } = require('../../actions/search');
+const { textSearch, selectSearchItem, TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_TEXT_CHANGE } = require('../../actions/search');
 const {CHANGE_MAP_VIEW} = require('../../actions/map');
 const {searchEpic, searchItemSelected } = require('../search');
 const rootEpic = combineEpics(searchEpic, searchItemSelected);
@@ -50,9 +50,9 @@ describe('search Epics', () => {
             expect(actions[2].type).toBe(TEXT_SEARCH_RESULTS_LOADED);
             expect(actions[3].type).toBe(TEXT_SEARCH_LOADING);
             done();
-        }, 1000);
+        }, 400);
     });
-    it('produces the selectSearchItem epic', (done) => {
+    it('produces the selectSearchItem epic', () => {
         let action = selectSearchItem({
           "type": "Feature",
           "bbox": [125, 10, 126, 11],
@@ -72,13 +72,65 @@ describe('search Epics', () => {
         });
 
         store.dispatch( action );
-        setTimeout(() => {
-            let actions = store.getActions();
-            expect(actions.length).toBe(4);
-            expect(actions[1].type).toBe(CHANGE_MAP_VIEW);
-            expect(actions[2].type).toBe(TEXT_SEARCH_ADD_MARKER);
-            expect(actions[3].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
-            done();
-        }, 1000);
+
+        let actions = store.getActions();
+        expect(actions.length).toBe(4);
+        expect(actions[1].type).toBe(CHANGE_MAP_VIEW);
+        expect(actions[2].type).toBe(TEXT_SEARCH_ADD_MARKER);
+        expect(actions[3].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
+    });
+
+    it('searchItemSelected epic with nested services', () => {
+        let nestedService = {
+            filterTemplate: "TEST_FILTER_TEMPLATE",
+            nestedPlaceholder: "TEST_NESTED_PLACEHOLDER"
+        };
+        const TEXT = "Dinagat Islands";
+        let action = selectSearchItem({
+          "type": "Feature",
+          "bbox": [125, 10, 126, 11],
+          "geometry": {
+            "type": "Point",
+            "coordinates": [125.6, 10.1]
+          },
+          "properties": {
+            "name": TEXT
+        },
+        "__SERVICE__": {
+            displayName: "${properties.name}",
+            type: "wfs",
+            searchTextTemplate: "${properties.name}",
+            nestedPlaceholder: "SEARCH NESTED",
+            then: [nestedService]
+        }
+        }, {
+            size: {
+                width: 200,
+                height: 200
+            },
+            projection: "EPSG:4326"
+        });
+
+        store.dispatch( action );
+
+        let actions = store.getActions();
+        expect(actions.length).toBe(6);
+        expect(actions[1].type).toBe(CHANGE_MAP_VIEW);
+        expect(actions[2].type).toBe(TEXT_SEARCH_ADD_MARKER);
+        expect(actions[3].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
+        expect(actions[4].type).toBe(TEXT_SEARCH_NESTED_SERVICES_SELECTED);
+        expect(actions[4].services[0]).toEqual({
+            ...nestedService,
+            options: {
+                staticFilter: "TEST_FILTER_TEMPLATE"
+            }
+        });
+        expect(actions[4].items).toEqual({
+            placeholder: "SEARCH NESTED",
+            text: TEXT
+        });
+        expect(actions[5].type).toBe(TEXT_SEARCH_TEXT_CHANGE);
+        expect(actions[5].searchText).toBe("Dinagat Islands");
+
     });
 });

--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -7,7 +7,7 @@
  */
 var expect = require('expect');
 var search = require('../search');
-const {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR, TEXT_SEARCH_RESULTS_PURGE} = require('../../actions/search');
+const {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_CANCEL_ITEM} = require('../../actions/search');
 
 describe('Test the search reducer', () => {
     it('search results loading', () => {
@@ -68,5 +68,47 @@ describe('Test the search reducer', () => {
         });
         expect(state.results).toBe(null);
     });
+    it('nested search service selected', () => {
+        let state = search({
+                results: ["result1", "result2"]
+            }, {
+                type: TEXT_SEARCH_NESTED_SERVICES_SELECTED,
+                services: [{
 
+                }],
+                searchText: "TEST",
+                selectedItems: [{
+                    text: "text"
+                }]
+
+        });
+        expect(state.selectedItems.length).toBe(1);
+        expect(state.selectedServices.length).toBe(1);
+        state = search(state, {
+                type: TEXT_SEARCH_NESTED_SERVICES_SELECTED,
+                services: [{
+
+                }],
+                searchText: "TEST",
+                selectedItems: [{
+                    text: "text"
+                }]
+
+        });
+        expect(state.selectedItems.length).toBe(2);
+        expect(state.selectedServices.length).toBe(1);
+    });
+    it('nested search cancel item', () => {
+        let itemToCacel = {text: "text2"};
+        let state = search({
+                searchText: "",
+                selectedItems: [{text: "text1"}, itemToCacel]
+            }, {
+                type: TEXT_SEARCH_CANCEL_ITEM,
+                item: itemToCacel
+
+        });
+        expect(state.searchText).toBe("text2");
+        expect(state.selectedItems.length).toBe(1);
+    });
 });

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_RESET, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_TEXT_CHANGE, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR} = require('../actions/search');
+var {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_RESET, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_TEXT_CHANGE, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR,
+    TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_CANCEL_ITEM} = require('../actions/search');
 
 const assign = require('object-assign');
 
@@ -27,11 +28,22 @@ function search(state = null, action) {
             }
             return assign({}, state, { results: results, error: null });
         case TEXT_SEARCH_RESULTS_PURGE:
-            return assign({}, state, { results: null, error: null });
+            return assign({}, state, { results: null, error: null});
         case TEXT_SEARCH_ADD_MARKER:
             return assign({}, state, { markerPosition: action.markerPosition });
         case TEXT_SEARCH_RESET:
             return null;
+        case TEXT_SEARCH_NESTED_SERVICES_SELECTED:
+            return assign({}, state, {
+                selectedServices: action.services,
+                searchText: action.searchText,
+                selectedItems: (state.selectedItems || []).concat(action.items)
+             });
+        case TEXT_SEARCH_CANCEL_ITEM:
+            return assign({}, {
+                selectedItems: state.selectedItems && state.selectedItems.filter(item => item !== action.item),
+                searchText: state.searchText === "" && action.item && action.item.text ? action.item.text.substring(0, action.item.text.length) : state.searchText
+            });
         default:
             return state;
     }

--- a/web/client/utils/TemplateUtils.js
+++ b/web/client/utils/TemplateUtils.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+    /**
+     * generates a template string to use for static replacements.
+     * It's useful for using a similar syntax for static configured strings to
+     * use as templates.
+     */
+    generateTemplateString: (function() {
+        var cache = {};
+
+        function generateTemplate(template) {
+
+            var fn = cache[template];
+
+            if (!fn) {
+            // Replace ${expressions} (etc) with ${map.expressions}.
+                let sanitized = template
+                .replace(/\$\{([\s]*[^;\s\{]+[\s]*)\}/g, function(_, match) {
+                    return `\$\{map.${match.trim()}\}`;
+                })
+                // Afterwards, replace anything that's not ${map.expressions}' (etc) with a blank string.
+                .replace(/(\$\{(?!map\.)[^}]+\})/g, '');
+
+                fn = Function('map', `return \`${sanitized}\``);
+                cache[template] = fn;
+
+            }
+            return fn;
+        }
+        return generateTemplate;
+    })()
+};

--- a/web/client/utils/__tests__/TemplateUtils-test.js
+++ b/web/client/utils/__tests__/TemplateUtils-test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var expect = require('expect');
+var TemplateUtils = require('../TemplateUtils');
+
+
+describe('TemplateUtils', () => {
+    beforeEach( () => {
+
+    });
+    afterEach((done) => {
+        document.body.innerHTML = '';
+
+        setTimeout(done);
+    });
+    it('test template generation', () => {
+        let templateFunction = TemplateUtils.generateTemplateString("this is a ${test}");
+        expect(templateFunction).toExist();
+        let templateResult = templateFunction({test: "TEST"});
+        expect(templateResult).toBe("this is a TEST");
+    });
+    it('test template cache', () => {
+        let templateFunction = TemplateUtils.generateTemplateString("this is a ${test}");
+        expect(templateFunction).toExist();
+        let templateResult = templateFunction({test: "TEST"});
+        expect(templateResult).toBe("this is a TEST");
+        let templateFunction2 = TemplateUtils.generateTemplateString("this is a ${test}");
+        expect(templateFunction2).toExist();
+        let templateResult2 = templateFunction2({test: "TEST"});
+        expect(templateResult2).toBe("this is a TEST");
+        expect(templateFunction).toBe(templateFunction2);
+        let templateFunction3 = TemplateUtils.generateTemplateString("this is a second ${test}");
+        let templateResult3 = templateFunction3({test: "TEST"});
+        expect(templateResult3).toBe("this is a second TEST");
+
+    });
+});


### PR DESCRIPTION
Nested services can be configured be used when a item from a service is already selected, to refine the search. (See #1122).

 - You can use mixed services
 - You can display selected items
 - You can populate searchbar with some text when an item is selected (useful also for nominatim)
 - Can change the text search placeholder
 - Improved search result to support templating system (displayName and subTitle)
 - Every string can be defined using a template from the selected item