### PR TITLE
modified renderButtons() in drawer/Menu.jsx (issue 1526)

### DIFF
--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -69,7 +69,8 @@ var Menu = React.createClass({
                     {button}
                 </OverlayTrigger>
             ) : button;
-    });
+          });
+    },
     renderContent() {
         const header = this.props.single ? (
             <div className="navHeader" style={{width: "100%", minHeight: "35px"}}>

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -8,6 +8,7 @@
 var React = require('react');
 var {Glyphicon, Button, OverlayTrigger, Tooltip} = require('react-bootstrap');
 var Sidebar = require('react-sidebar').default;
+var Message = require('../../components/I18N/Message');
 
 var Menu = React.createClass({
     propTypes: {
@@ -62,9 +63,9 @@ var Menu = React.createClass({
             const button = (<Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
                         {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
                     </Button>);
-            const tooltip = <Tooltip key={"tooltip." + child.props.eventKey} id={"tooltip." + child.props.eventKey}>{child.props.buttonConfig.tooltip || ''}</Tooltip>;
+            const tooltip = <Tooltip key={"tooltip." + child.props.eventKey} id={"tooltip." + child.props.eventKey}><Message msgId={child.props.buttonConfig.tooltip}/></Tooltip>;
             return child.props.buttonConfig.tooltip ? (
-                <OverlayTrigger placement={"top"} key={"overlay-trigger." + child.props.eventKey}
+                <OverlayTrigger placement={"bottom"} key={"overlay-trigger." + child.props.eventKey}
                     overlay={tooltip}>
                     {button}
                 </OverlayTrigger>

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -69,7 +69,7 @@ var Menu = React.createClass({
                     {button}
                 </OverlayTrigger>
             ) : button;
-          });
+        });
     },
     renderContent() {
         const header = this.props.single ? (

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 var React = require('react');
-var {Glyphicon, Button} = require('react-bootstrap');
+var {Glyphicon, Button, OverlayTrigger, Tooltip} = require('react-bootstrap');
 var Sidebar = require('react-sidebar').default;
 
 var Menu = React.createClass({

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -58,11 +58,28 @@ var Menu = React.createClass({
         );
     },
     renderButtons() {
-        return this.props.children.map((child) => (
-            <Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
-                {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
-            </Button>
-        ));
+        let toReturn = [];
+        this.props.children.map((child) => {
+            if (child && child.props.buttonConfig && child.props.buttonConfig.tooltip) {
+                let myTooltip = (<Tooltip key={"tooltip." + child.props.eventKey} id={"tooltip." + child.props.eventKey} >{child.props.buttonConfig.tooltip}</Tooltip>);
+                toReturn.push(myTooltip);
+                toReturn.push(
+                    <OverlayTrigger placement={"top"} key={"overlay-trigger." + child.props.eventKey} overlay={myTooltip}>
+                    <Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
+                        {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
+                    </Button>
+                </OverlayTrigger>
+                );
+            } else {
+                toReturn.push(
+                    <Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
+                        {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
+                    </Button>
+                );
+            }
+        }
+    );
+        return toReturn;
     },
     renderContent() {
         const header = this.props.single ? (

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -58,29 +58,18 @@ var Menu = React.createClass({
         );
     },
     renderButtons() {
-        let toReturn = [];
-        this.props.children.map((child) => {
-            if (child && child.props.buttonConfig && child.props.buttonConfig.tooltip) {
-                let myTooltip = (<Tooltip key={"tooltip." + child.props.eventKey} id={"tooltip." + child.props.eventKey} >{child.props.buttonConfig.tooltip}</Tooltip>);
-                toReturn.push(myTooltip);
-                toReturn.push(
-                    <OverlayTrigger placement={"top"} key={"overlay-trigger." + child.props.eventKey} overlay={myTooltip}>
-                    <Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
+        return this.props.children.map((child) => {
+            const button = (<Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
                         {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
-                    </Button>
+                    </Button>);
+            const tooltip = <Tooltip key={"tooltip." + child.props.eventKey} id={"tooltip." + child.props.eventKey}>{child.props.buttonConfig.tooltip || ''}</Tooltip>;
+            return child.props.buttonConfig.tooltip ? (
+                <OverlayTrigger placement={"top"} key={"overlay-trigger." + child.props.eventKey}
+                    overlay={tooltip}>
+                    {button}
                 </OverlayTrigger>
-                );
-            } else {
-                toReturn.push(
-                    <Button key={child.props.eventKey} bsSize="large" className={(child.props.buttonConfig && child.props.buttonConfig.buttonClassName) ? child.props.buttonConfig.buttonClassName : "square-button"} onClick={this.props.onChoose.bind(null, child.props.eventKey)} bsStyle={this.props.activeKey === child.props.eventKey ? 'default' : 'primary'}>
-                        {child.props.glyph ? <Glyphicon glyph={child.props.glyph} /> : child.props.icon}
-                    </Button>
-                );
-            }
-        }
-    );
-        return toReturn;
-    },
+            ) : button;
+    });
     renderContent() {
         const header = this.props.single ? (
             <div className="navHeader" style={{width: "100%", minHeight: "35px"}}>


### PR DESCRIPTION
config's ex:
"name": "Measure",
                "override": {
                    "DrawerMenu": {
                        "buttonConfig": {
                          **"tooltip": "Measure"**,
                            "buttonClassName": "square-button no-border"
                        },
                        "glyph": "1-stilo",
                        "position": 4
                    }
                }