### PR TITLE
Fixed #1472 handled multiple markers/points when bearing is activated

### DIFF
--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -128,7 +128,6 @@ const MeasurementSupport = React.createClass({
                 this.updateMeasurementResults();
                 this.drawControl._finishShape();
                 this.drawControl.disable();
-                this.drawing = false;
             } else {
                 this.updateMeasurementResults();
             }

--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -121,26 +121,16 @@ const MeasurementSupport = React.createClass({
         } else {
             let bearingMarkers = this.drawControl._markers || [];
 
-            if (bearingMarkers.length <= 2 ) {
+            if (this.props.measurement.geomType === 'Bearing' && bearingMarkers.length >= 2) {
+                this.drawControl._markers = slice(this.drawControl._markers, 0, 2);
+                this.drawControl._poly._latlngs = slice(this.drawControl._poly._latlngs, 0, 2);
+                this.drawControl._poly._originalPoints = slice(this.drawControl._poly._originalPoints, 0, 2);
                 this.updateMeasurementResults();
-            }
-            if (bearingMarkers.length === 2 && this.props.measurement.geomType === 'Bearing') {
                 this.drawControl._finishShape();
                 this.drawControl.disable();
                 this.drawing = false;
-            }
-            if (bearingMarkers.length > 2) {
-                if (this.props.measurement.geomType === 'Bearing') {
-                    this.drawControl._markers = slice(this.drawControl._markers, 0, 2);
-                    this.drawControl._poly._latlngs = slice(this.drawControl._poly._latlngs, 0, 2);
-                    this.drawControl._poly._originalPoints = slice(this.drawControl._poly._originalPoints, 0, 2);
-                    this.updateMeasurementResults();
-                    this.drawControl._finishShape();
-                    this.drawControl.disable();
-                    this.drawing = false;
-                } else {
-                    this.updateMeasurementResults();
-                }
+            } else {
+                this.updateMeasurementResults();
             }
         }
     },

--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -54,7 +54,7 @@ const MeasurementSupport = React.createClass({
             this.lastLayer = evt.layer;
 
             if (this.props.measurement.geomType === 'Point') {
-                let pos = this.drawControl._marker.getLatLng();
+                let pos = this.drawControl._markers.getLatLng();
                 let point = {x: pos.lng, y: pos.lat, srs: 'EPSG:4326'};
                 let newMeasureState = assign({}, this.props.measurement, {point: point});
                 this.props.changeMeasurementState(newMeasureState);
@@ -119,7 +119,7 @@ const MeasurementSupport = React.createClass({
             this.drawControl.enable();
             this.drawing = true;
         } else {
-            let bearingMarkers = this.drawControl._markers;
+            let bearingMarkers = this.drawControl._markers || [];
 
             if (bearingMarkers.length <= 2 ) {
                 this.updateMeasurementResults();

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -145,9 +145,9 @@ const MeasurementSupport = React.createClass({
         if (this.props.measurement.geomType === 'Bearing' &&
                 sketchCoords.length > 1) {
             // calculate the azimuth as base for bearing information
-            bearing = CoordinatesUtils.calculateAzimuth(
-                sketchCoords[0], sketchCoords[1], this.props.projection);
+            bearing = CoordinatesUtils.calculateAzimuth(sketchCoords[0], sketchCoords[1], this.props.projection);
             if (sketchCoords.length > 2) {
+                this.drawInteraction.sketchCoords_ = [sketchCoords[0], sketchCoords[1], sketchCoords[0]];
                 this.drawInteraction.finishDrawing();
             }
         }

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -142,12 +142,12 @@ const MeasurementSupport = React.createClass({
         let bearing = 0;
         let sketchCoords = this.sketchFeature.getGeometry().getCoordinates();
 
-        if (this.props.measurement.geomType === 'Bearing' &&
-                sketchCoords.length > 1) {
+        if (this.props.measurement.geomType === 'Bearing' && sketchCoords.length > 1) {
             // calculate the azimuth as base for bearing information
             bearing = CoordinatesUtils.calculateAzimuth(sketchCoords[0], sketchCoords[1], this.props.projection);
             if (sketchCoords.length > 2) {
                 this.drawInteraction.sketchCoords_ = [sketchCoords[0], sketchCoords[1], sketchCoords[0]];
+                this.sketchFeature.getGeometry().setCoordinates(this.drawInteraction.sketchCoords_);
                 this.drawInteraction.finishDrawing();
             }
         }


### PR DESCRIPTION
Fixed #1472
The listener on the click on the map apply some sort of debouncing. This is causing sometimes to skip the case when 2 markers are added and passes from 1 to 3 (for example).

When this happens it stops drawing any other marker and it calculate the bearing on the first 2 inserted. 
