### PR TITLE
Fix #1586. Linkedin image with white background (backport)

### DIFF
--- a/web/client/product/components/home/MailingLists.jsx
+++ b/web/client/product/components/home/MailingLists.jsx
@@ -89,7 +89,10 @@ var MailingLists = React.createClass({
                             <tbody>
                             <tr>
                                 <td>
-                                    <img src={LinkedinGroup} height="50" width="100" alt="Linkedin Groups" />
+                                    <img style={{
+                                            background: "white",
+                                            borderRadius: "2px 2px 2px 2px"
+                                        }} src={LinkedinGroup} height="50" width="100" alt="Linkedin Groups" />
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1279510/23999557/0f18dd54-0a59-11e7-99cf-bc3208cc5584.png)
