### PR TITLE
Fix #1577. Reduced throttling interval

### DIFF
--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -117,7 +117,7 @@ let LeafletMap = React.createClass({
                 });
             }
         });
-        const mouseMove = throttle(this.mouseMoveEvent, 500);
+        const mouseMove = throttle(this.mouseMoveEvent, 100);
         this.map.on('dragstart', () => { this.map.off('mousemove', mouseMove); });
         this.map.on('dragend', () => { this.map.on('mousemove', mouseMove); });
         this.map.on('mousemove', mouseMove);

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -129,7 +129,7 @@ var OpenlayersMap = React.createClass({
                 });
             }
         });
-        const mouseMove = throttle(this.mouseMoveEvent, 500);
+        const mouseMove = throttle(this.mouseMoveEvent, 100);
         map.on('pointermove', mouseMove);
 
         this.updateMapInfoState();


### PR DESCRIPTION
I have 42ms of average rendering on my machine. 500 make sense only when debug+ react_perf are activated 
reduced to 100ms, this avoid the coordinates to update too late and look like is not performing well. 
