### PR TITLE
Fix Snapshot does not update while moving the map on Firefox 

### DIFF
--- a/web/client/components/map/leaflet/snapshot/__tests__/Preview-test.jsx
+++ b/web/client/components/map/leaflet/snapshot/__tests__/Preview-test.jsx
@@ -16,7 +16,9 @@ describe("test the Leaflet Preview component", () => {
         // emulate empty map
         document.body.innerHTML = '<div><div id="snap"></div>' +
             '<div id="map" style="width:100%; height:100%"><canvas></canvas>' +
-                '<div class="leaflet-tile-pane"><div class="leaflet-layer"></div></div>' +
+                '<div class="leaflet-map-pane">' +
+                    '<div class="leaflet-tile-pane"><div class="leaflet-layer"></div></div>' +
+                '</div>' +
             '</div></div>';
         setTimeout(done);
     });


### PR DESCRIPTION
Found on Firefox 51.0 - 52.0
to reproduce:
- open snapshot plugin
- move the map
- the snapshot is still the same
![untitled](https://cloud.githubusercontent.com/assets/19175505/24003804/c2513532-0a64-11e7-86a3-bbd38e012e32.gif)

