### PR TITLE
Fix #1579. Group cache clean on creation/delete (Backport)

### DIFF
--- a/web/client/actions/usergroups.js
+++ b/web/client/actions/usergroups.js
@@ -325,6 +325,7 @@ module.exports = {
     deleteGroup, DELETEGROUP,
     STATUS_SUCCESS,
     STATUS_LOADING,
+    STATUS_CREATED,
     STATUS_ERROR,
     STATUS_DELETED
 };

--- a/web/client/reducers/__tests__/users-test.js
+++ b/web/client/reducers/__tests__/users-test.js
@@ -13,6 +13,8 @@ const {
     USERMANAGER_UPDATE_USER, USERMANAGER_DELETE_USER, USERMANAGER_GETGROUPS
 } = require('../../actions/users');
 
+const {UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED} = require('../../actions/usergroups');
+
 describe('Test the users reducer', () => {
     it('default loading', () => {
         let oldState = {test: "test"};
@@ -165,6 +167,34 @@ describe('Test the users reducer', () => {
         });
         expect(state.groups).toExist();
         expect(state.groupsStatus).toBe("success");
+    });
+    it('test group cache clean after group creation', () => {
+        const state = users({}, {
+            type: USERMANAGER_GETGROUPS,
+            groups: [{groupName: "group1", id: 10, description: "test"}],
+            status: "success"
+        });
+        expect(state.groups).toExist();
+        expect(state.groupsStatus).toBe("success");
+        let stateWOutgroups = users(state, {
+            type: UPDATEGROUP,
+            status: STATUS_CREATED
+        });
+        expect(stateWOutgroups.group).toBe(undefined);
+    });
+    it('test group cache clean after group delete', () => {
+        const state = users({}, {
+            type: USERMANAGER_GETGROUPS,
+            groups: [{groupName: "group1", id: 10, description: "test"}],
+            status: "success"
+        });
+        expect(state.groups).toExist();
+        expect(state.groupsStatus).toBe("success");
+        let stateWOutgroups = users(state, {
+            type: DELETEGROUP,
+            status: STATUS_DELETED
+        });
+        expect(stateWOutgroups.group).toBe(undefined);
     });
 
 });

--- a/web/client/reducers/users.js
+++ b/web/client/reducers/users.js
@@ -10,6 +10,8 @@ const {
     USERMANAGER_GETUSERS, USERMANAGER_EDIT_USER, USERMANAGER_EDIT_USER_DATA, USERMANAGER_UPDATE_USER, USERMANAGER_DELETE_USER,
     USERMANAGER_GETGROUPS, USERS_SEARCH_TEXT_CHANGED
 } = require('../actions/users');
+
+const {UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED} = require('../actions/usergroups');
 const assign = require('object-assign');
 
 const {findIndex} = require('lodash');
@@ -123,6 +125,26 @@ function users(state = {
                 groupsStatus: action.status,
                 groupsError: action.error
             });
+        }
+        case UPDATEGROUP: {
+            if (action.status === STATUS_CREATED) {
+                return assign({}, state, {
+                    groups: null,
+                    groupsStatus: null,
+                    groupsError: null
+                });
+            }
+            return state;
+        }
+        case DELETEGROUP: {
+            if (action.status === STATUS_DELETED) {
+                return assign({}, state, {
+                    groups: null,
+                    groupsStatus: null,
+                    groupsError: null
+                });
+            }
+            return state;
         }
         default:
             return state;


### PR DESCRIPTION
Now groups list will be updated when some changes are applied from the group manager.