### PR TITLE
Fix #1612. Extent calculation for GeoJson supported

### DIFF
--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -234,53 +234,46 @@ const CoordinatesUtils = {
         }
         return newExtent;
     },
+    /**
+     * Calculates the extent for the geoJSON passed. It used a small buffer for points.
+     * Like turf/bbox but works only with simple geometries.
+     * @deprecated  We may replace it with turf/bbox + turf/buffer in the future, so using it with geometry is discouraged
+     * @param {geoJSON|geometry} GeoJSON or geometry
+     * @return {array} extent of the geoJSON
+     */
     getGeoJSONExtent: function(geoJSON) {
         let newExtent = [Infinity, Infinity, -Infinity, -Infinity];
-
+        const reduceCollectionExtent = (extent, collectionElement) => {
+            let ext = this.getGeoJSONExtent(collectionElement);
+            if (this.isValidExtent(ext)) {
+                return this.extendExtent(ext, extent);
+            }
+        };
         if (geoJSON.coordinates) {
-            if (geoJSON.type !== "Point" && geoJSON.type !== "GeometryCollection") {
-                const flatCoordinates = chunk(flattenDeep(geoJSON.coordinates), 2);
-                return flatCoordinates.reduce((extent, point) => {
-                    return [
-                        (point[0] < extent[0]) ? point[0] : extent[0],
-                        (point[1] < extent[1]) ? point[1] : extent[1],
-                        (point[0] > extent[2]) ? point[0] : extent[2],
-                        (point[1] > extent[3]) ? point[1] : extent[3]
-                    ];
-                }, newExtent);
-            }else if (geoJSON.type === "Point") {
+            if (geoJSON.type === "Point") {
                 let point = geoJSON.coordinates;
                 newExtent[0] = point[0] - point[0] * 0.01;
                 newExtent[1] = point[1] - point[1] * 0.01;
                 newExtent[2] = point[0] + point[0] * 0.01;
                 newExtent[3] = point[1] + point[1] * 0.01;
-            }else if (geoJSON.type === "GeometryCollection") {
-                return geoJSON.geometies.reduce((extent, geometry) => {
-                    let ext = this.getGeoJSONExtent(geometry);
-                    if (this.isValidExtent(ext)) {
-                        return [
-                            (ext[0] < extent[0]) ? ext[0] : extent[0],
-                            (ext[1] < extent[1]) ? ext[1] : extent[1],
-                            (ext[2] > extent[2]) ? ext[2] : extent[2],
-                            (ext[3] > extent[3]) ? ext[3] : extent[3]
-                        ];
-                    }
-                }, newExtent);
             }
+            // other kinds of geometry
+            const flatCoordinates = chunk(flattenDeep(geoJSON.coordinates), 2);
+            return flatCoordinates.reduce((extent, point) => {
+                return [
+                    (point[0] < extent[0]) ? point[0] : extent[0],
+                    (point[1] < extent[1]) ? point[1] : extent[1],
+                    (point[0] > extent[2]) ? point[0] : extent[2],
+                    (point[1] > extent[3]) ? point[1] : extent[3]
+                ];
+            }, newExtent);
+
+        } else if (geoJSON.type === "GeometryCollection") {
+            let geometries = geoJSON.geometries;
+            return geometries.reduce(reduceCollectionExtent, newExtent);
         } else if (geoJSON.type) {
             if (geoJSON.type === "FeatureCollection") {
-                return geoJSON.features.reduce((extent, feature) => {
-                    const ext = this.getGeoJSONExtent(feature);
-                    if (this.isValidExtent(ext)) {
-                        return [
-                            (ext[0] < extent[0]) ? ext[0] : extent[0],
-                            (ext[1] < extent[1]) ? ext[1] : extent[1],
-                            (ext[2] > extent[2]) ? ext[2] : extent[2],
-                            (ext[3] > extent[3]) ? ext[3] : extent[3]
-                        ];
-                    }
-                    return extent;
-                }, newExtent);
+                return geoJSON.features.reduce(reduceCollectionExtent, newExtent);
             } else if (geoJSON.type === "Feature" && geoJSON.geometry) {
                 return this.getGeoJSONExtent(geoJSON.geometry);
             }

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -102,4 +102,65 @@ describe('CoordinatesUtils', () => {
         expect(reprojectedTestPoint.features[0].geometry.coordinates[0].toFixed(4)).toBe((-12523490.492568726).toFixed(4));
         expect(reprojectedTestPoint.features[0].geometry.coordinates[1].toFixed(4)).toBe((5195238.005360028).toFixed(4));
     });
+
+    it('test geojson extent', () => {
+        let geojsonPoint = {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [125.6, 10.1]
+          },
+          "properties": {
+            "name": "Dinagat Islands"
+          }
+        };
+        expect(CoordinatesUtils.getGeoJSONExtent(geojsonPoint)[0] <= 125.6).toBe(true);
+        expect(CoordinatesUtils.getGeoJSONExtent(geojsonPoint)[1] <= 10.1).toBe(true);
+        expect(CoordinatesUtils.getGeoJSONExtent(geojsonPoint)[2] >= 125.6).toBe(true);
+        expect(CoordinatesUtils.getGeoJSONExtent(geojsonPoint)[3] >= 10.1).toBe(true);
+        let featureCollection = { "type": "FeatureCollection",
+            "features": [
+              { "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+                "properties": {"prop0": "value0"}
+              },
+              { "type": "Feature",
+                "geometry": {
+                    "type": "GeometryCollection",
+                    "geometries": [{"type": "Point", "coordinates": [102.0, 0.5]}]
+                },
+                "properties": {"prop0": "value0"}
+              },
+              { "type": "Feature",
+                "geometry": {
+                  "type": "LineString",
+                  "coordinates": [
+                    [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+                    ]
+                  },
+                "properties": {
+                  "prop0": "value0",
+                  "prop1": 0.0
+                  }
+                },
+              { "type": "Feature",
+                 "geometry": {
+                   "type": "Polygon",
+                   "coordinates": [
+                     [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
+                       [100.0, 1.0], [100.0, 0.0] ]
+                     ]
+                 },
+                 "properties": {
+                   "prop0": "value0",
+                   "prop1": {"this": "that"}
+                   }
+                 }
+               ]
+        };
+        expect(CoordinatesUtils.getGeoJSONExtent(featureCollection)[0]).toBe(100.0);
+        expect(CoordinatesUtils.getGeoJSONExtent(featureCollection)[1]).toBe(0.0);
+        expect(CoordinatesUtils.getGeoJSONExtent(featureCollection)[2]).toBe(105.0);
+        expect(CoordinatesUtils.getGeoJSONExtent(featureCollection)[3]).toBe(1.0);
+    });
 });


### PR DESCRIPTION
Now GeoJson extent calculation support also `Feature` and `FeatureCollection` (before this only geometry was supported). 