### PR TITLE
Add support for blacklist and word splitting in wfs search

### DIFF
--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -98,7 +98,8 @@ const ToggleButton = require('./searchbar/ToggleButton');
  *        "queriableAttributes": ["attribute_to_query"],
  *        "sortBy": "ID",
  *        "srsName": "EPSG:4326",
- *        "maxFeatures": 4
+ *        "maxFeatures": 4,
+ *        "blackist": [... an array of strings to exclude from the final search filter ]
  *      },
  *      "nestedPlaceholder": "Write other text to refine the search...",
  *      "then": [ ... an array of services to use when one item of this service is selected]


### PR DESCRIPTION
wfs text search now use the text of the search splitted in words. 
The words can be filtered using a blacklist. The result must contain all the words in the one of the attributes selected. 