### PR TITLE
Fix #1608 Make zoom to layer optional when add from Catalog

### DIFF
--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -26,6 +26,7 @@ const Catalog = React.createClass({
         onChangeFormat: React.PropTypes.func,
         onLayerAdd: React.PropTypes.func,
         onZoomToExtent: React.PropTypes.func,
+        zoomToLayer: React.PropTypes.bool,
         onError: React.PropTypes.func,
         pageSize: React.PropTypes.number,
         displayURL: React.PropTypes.bool,
@@ -56,6 +57,7 @@ const Catalog = React.createClass({
             onChangeFormat: () => {},
             onLayerAdd: () => {},
             onZoomToExtent: () => {},
+            zoomToLayer: true,
             onError: () => {},
             chooseCatalogUrl: true,
             records: [],
@@ -148,6 +150,7 @@ const Catalog = React.createClass({
                     catalogURL={this.getCatalogUrl() }
                     onLayerAdd={this.props.onLayerAdd}
                     onZoomToExtent={this.props.onZoomToExtent}
+                    zoomToLayer={this.props.zoomToLayer}
                     onError={this.props.onError}
                     showGetCapLinks={this.props.showGetCapLinks}
                     addAuthentication={this.props.addAuthentication}

--- a/web/client/components/catalog/RecordGrid.jsx
+++ b/web/client/components/catalog/RecordGrid.jsx
@@ -17,6 +17,7 @@ const RecordGrid = React.createClass({
         recordItem: React.PropTypes.element,
         catalogURL: React.PropTypes.string,
         onZoomToExtent: React.PropTypes.func,
+        zoomToLayer: React.PropTypes.bool,
         onLayerAdd: React.PropTypes.func,
         onError: React.PropTypes.func,
         records: React.PropTypes.array,
@@ -30,7 +31,8 @@ const RecordGrid = React.createClass({
             records: [],
             onLayerAdd: () => {},
             onError: () => {},
-            column: {xs: 12, sm: 12, md: 6, lg: 6}
+            column: {xs: 12, sm: 12, md: 6, lg: 6},
+            zoomToLayer: true
         };
     },
     renderRecordItem(record) {
@@ -40,6 +42,7 @@ const RecordGrid = React.createClass({
                 <Item
                     onLayerAdd={this.props.onLayerAdd}
                     onZoomToExtent={this.props.onZoomToExtent}
+                    zoomToLayer={this.props.zoomToLayer}
                     onError={this.props.onError}
                     catalogURL={this.props.catalogURL}
                     record={record}

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -44,6 +44,7 @@ const RecordItem = React.createClass({
     propTypes: {
         onLayerAdd: React.PropTypes.func,
         onZoomToExtent: React.PropTypes.func,
+        zoomToLayer: React.PropTypes.bool,
         record: React.PropTypes.object,
         buttonSize: React.PropTypes.string,
         onCopy: React.PropTypes.func,
@@ -57,6 +58,7 @@ const RecordItem = React.createClass({
             mapType: "leaflet",
             onLayerAdd: () => {},
             onZoomToExtent: () => {},
+            zoomToLayer: true,
             onError: () => {},
             style: {},
             buttonSize: "small",
@@ -225,7 +227,7 @@ const RecordItem = React.createClass({
                 params: params,
                 allowedSRS: allowedSRS
             });
-            if (this.props.record.boundingBox) {
+            if (this.props.record.boundingBox && this.props.zoomToLayer) {
                 let extent = this.props.record.boundingBox.extent;
                 let crs = this.props.record.boundingBox.crs;
                 this.props.onZoomToExtent(extent, crs);
@@ -259,7 +261,7 @@ const RecordItem = React.createClass({
                 params: params,
                 allowedSRS: allowedSRS
             });
-            if (this.props.record.boundingBox) {
+            if (this.props.record.boundingBox && this.props.zoomToLayer) {
                 let extent = this.props.record.boundingBox.extent;
                 let crs = this.props.record.boundingBox.crs;
                 this.props.onZoomToExtent(extent, crs);

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -56,7 +56,8 @@ const MetadataExplorerComponent = React.createClass({
         toggleControl: React.PropTypes.func,
         closeGlyph: React.PropTypes.string,
         buttonStyle: React.PropTypes.object,
-        style: React.PropTypes.object
+        style: React.PropTypes.object,
+        zoomToLayer: React.PropTypes.bool
     },
     getDefaultProps() {
         return {
@@ -71,11 +72,12 @@ const MetadataExplorerComponent = React.createClass({
             },
             panelClassName: "toolbar-panel",
             toggleControl: () => {},
-            closeGlyph: "1-close"
+            closeGlyph: "1-close",
+            zoomToLayer: true
         };
     },
     render() {
-        const panel = <div role="body" className="modal_window"><Catalog searchOnStartup={this.props.searchOnStartup} active={this.props.active} {...this.props}/></div>;
+        const panel = <div role="body" className="modal_window"><Catalog zoomToLayer={this.props.zoomToLayer} searchOnStartup={this.props.searchOnStartup} active={this.props.active} {...this.props}/></div>;
         if (this.props.wrap) {
             if (this.props.active) {
                 if (this.props.wrapWithPanel) {


### PR DESCRIPTION
localConfig

```js
...
{
 "name": "MetadataExplorer",
 "cfg": 
 {
  "zoomToLayer": false // default true
 }
}
...
```