### PR TITLE
Fix WMTS to return a valid object when array

### DIFF
--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -19,7 +19,7 @@ const WMTSUtils = {
             return CoordinatesUtils.getEquivalentSRS(srs, allowedSRS).reduce((previous, current) => {
                 if (isArray(tileMatrixSet)) {
                     const matching = head(tileMatrixSet.filter((matrix) => (matrix["ows:Identifier"] === current || CoordinatesUtils.getEPSGCode(matrix["ows:SupportedCRS"]) === current)));
-                    return matching && matching["ows:Identifier"] && !matrixIds[previous] || previous;
+                    return matching && matching["ows:Identifier"] && !matrixIds[previous] ? current : previous;
                 } else if (isObject(tileMatrixSet)) {
                     return tileMatrixSet[current] || previous;
                 }


### PR DESCRIPTION
This fixes `WMTS.getTileMatrixSet` to return the right object instead of boolean when tileMatrixSet is array. Fixing WMTS with Leaflet and Openlayers