### PR TITLE
Support for navigation history in cesium

### DIFF
--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -18,7 +18,7 @@ const CHANGE_MAP_STYLE = 'CHANGE_MAP_STYLE';
 const CHANGE_ROTATION = 'CHANGE_ROTATION';
 
 
-function changeMapView(center, zoom, bbox, size, mapStateSource, projection) {
+function changeMapView(center, zoom, bbox, size, mapStateSource, projection, viewerOptions) {
     return {
         type: CHANGE_MAP_VIEW,
         center,
@@ -26,7 +26,8 @@ function changeMapView(center, zoom, bbox, size, mapStateSource, projection) {
         bbox,
         size,
         mapStateSource,
-        projection
+        projection,
+        viewerOptions
     };
 }
 

--- a/web/client/plugins/ZoomIn.jsx
+++ b/web/client/plugins/ZoomIn.jsx
@@ -37,5 +37,5 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: { zoomIn: require("../reducers/map")}
+    reducers: {}
 };

--- a/web/client/plugins/ZoomOut.jsx
+++ b/web/client/plugins/ZoomOut.jsx
@@ -38,5 +38,5 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: {zoomOut: require("../reducers/map")}
+    reducers: {}
 };

--- a/web/client/utils/MapHistory.js
+++ b/web/client/utils/MapHistory.js
@@ -20,7 +20,7 @@ const mapConfigHistory = (reducer) => {
             let mapC = assign({}, newState.present, {mapStateSource: "undoredo", style: state.present.style, resize: state.present.resize});
             unredoState = assign({}, newState, {present: mapC});
         }
-        return unredoState || newState;
+        return unredoState || {past: newState.past, present: newState.present, future: newState.future};
     };
 };
 


### PR DESCRIPTION
 - Fixed infinite nested history, removing it (is not needed at all)
 - Removed wrong reducers for ZoomIn and ZoomOut buttons
 - Now the CHANGE_MAP_VIEW action accept a viewerOptions to store specific viewer options in history. It can be used for rotation in OpenLayers, for the future