### PR TITLE
Fixed cesium test, made fly optional

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -41,9 +41,11 @@ let CesiumMap = React.createClass({
           standardHeight: 512,
           zoomToHeight: 80000000,
           viewerOptions: {
-              heading: 0,
-              pitch: -1 * Math.PI / 2,
-              roll: 0
+              orientation: {
+                  heading: 0,
+                  pitch: -1 * Math.PI / 2,
+                  roll: 0
+              }
           }
         };
     },
@@ -213,11 +215,16 @@ let CesiumMap = React.createClass({
                 ),
                 orientation: newProps.viewerOptions.orientation
             };
-            this.map.camera.flyTo(position, {duration: 1});
+            this.setView(position);
         }
     },
-
-
+    setView(position) {
+        if (this.props.mapOptions && this.props.mapOptions.flyTo) {
+            this.map.camera.flyTo(position, this.props.mapOptions.defaultFlightOptions);
+        } else {
+            this.map.camera.setView(position);
+        }
+    },
     updateMapInfoState() {
         const center = this.getCenter();
         const zoom = this.getZoomFromHeight(center.height);

--- a/web/client/components/map/cesium/__tests__/Map-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test-chrome.jsx
@@ -78,8 +78,9 @@ describe('CesiumMap', () => {
         expect(map.map.imageryLayers.length).toBe(1);
     });
 
-    it('check if the handler for "moveend" event is called', () => {
-        const expectedCalls = 2;
+    it('check if the handler for "moveend" event is called', (done) => {
+        const expectedCalls = 1;
+        const precision = 1000000000;
         const testHandlers = {
             handler: () => {}
         };
@@ -87,38 +88,52 @@ describe('CesiumMap', () => {
 
         const map = ReactDOM.render(
             <CesiumMap
-                center={{y: 43.9, x: 10.3}}
-                zoom={11}
+                center={{y: 10, x: 44}}
+                zoom={5}
                 onMapViewChanges={testHandlers.handler}
+                viewerOptions={{
+                    orientation: {
+                        heading: 0,
+                        pitch: -1 * Math.PI / 2,
+                        roll: 0
+                    }
+                }}
+
             />
         , document.getElementById("container"));
 
         const cesiumMap = map.map;
         cesiumMap.camera.moveEnd.addEventListener(() => {
-            expect(spy.calls.length).toEqual(expectedCalls);
-            expect(spy.calls[0].arguments.length).toEqual(6);
+            // check arguments
+            expect(spy.calls[0].arguments.length).toEqual(7);
+            expect(spy.calls.length).toBe(expectedCalls);
+            // check camera moved
+            expect(Math.round(spy.calls[0].arguments[0].y * precision) / precision).toBe(30);
+            expect(Math.round(spy.calls[0].arguments[0].x * precision) / precision).toBe(20);
+            expect(spy.calls[0].arguments[1]).toEqual(5);
 
-            expect(spy.calls[0].arguments[0].y).toEqual(43.9);
-            expect(spy.calls[0].arguments[0].x).toEqual(10.3);
-            expect(spy.calls[0].arguments[1]).toEqual(11);
+            expect(spy.calls[0].arguments[6].orientation.heading).toBe(1);
 
-            expect(spy.calls[1].arguments[0].y).toEqual(44);
-            expect(spy.calls[1].arguments[0].x).toEqual(10);
-            expect(spy.calls[1].arguments[1]).toEqual(12);
-
-            for (let c = 0; c < expectedCalls; c++) {
+            for (let c = 0; c < spy.calls.length; c++) {
                 expect(spy.calls[c].arguments[2].bounds).toExist();
                 expect(spy.calls[c].arguments[2].crs).toExist();
                 expect(spy.calls[c].arguments[3].height).toExist();
                 expect(spy.calls[c].arguments[3].width).toExist();
             }
+            done();
+
         });
         cesiumMap.camera.setView({
             destination: Cesium.Cartesian3.fromDegrees(
-                10,
-                44,
+                20,
+                30,
                 5000000
-            )
+            ),
+            orientation: {
+                heading: 1,
+                pitch: -1 * Math.PI / 2,
+                roll: 0
+            }
         });
     });
     it('check mouse click handler', (done) => {
@@ -165,32 +180,4 @@ describe('CesiumMap', () => {
         expect(Math.round(cesiumMap.camera.positionCartographic.longitude * 180.0 / Math.PI)).toBe(10);
     });
 
-    it('check that the map orientation does not change on pan / zoom', () => {
-        let map = ReactDOM.render(
-            <CesiumMap
-                center={{y: 43.9, x: 10.3}}
-                zoom={10}
-            />
-        , document.getElementById("container"));
-
-        const cesiumMap = map.map;
-        cesiumMap.camera.lookUp(1.0);
-        cesiumMap.camera.lookRight(1.0);
-        const precision = Math.pow(10, 8);
-        const heading = Math.round(cesiumMap.camera.heading * precision) / precision;
-        const pitch = Math.round(cesiumMap.camera.pitch * precision) / precision;
-        const roll = Math.round(cesiumMap.camera.roll * precision) / precision;
-
-        map = ReactDOM.render(
-            <CesiumMap
-                center={{y: 44, x: 10}}
-                zoom={12}
-            />
-        , document.getElementById("container"));
-
-        expect(Math.round(cesiumMap.camera.heading * precision) / precision).toBe(heading);
-        expect(Math.round(cesiumMap.camera.pitch * precision) / precision).toBe(pitch);
-        expect(Math.round(cesiumMap.camera.roll * precision) / precision).toBe(roll);
-
-    });
 });

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -14,6 +14,7 @@
     "themePrefix": "ms2",
     "defaultMapOptions": {
       "cesium": {
+          "flyTo": true,
           "terrainProvider": {
               "type": "cesium",
               "url": "https://assets.agi.com/stk-terrain/world",


### PR DESCRIPTION
This makes flyTo animation optional for the cesium map. Set it disabled by default, enabled from `localConfig`
Also fixed some tests : 
- removed test `check that the map orientation does not change on pan / zoom` because now the orientation follows the viewerOptions.orientation parameter.
- fixed `check if the handler for "moveend" event is called` that wasn't executed and had wrong checks