### PR TITLE
Fix #1723. Setup travis build for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 4
 script: npm run travis
-addons:  
+addons:
   firefox: latest
 before_install:
     - export DISPLAY=:99.0
@@ -12,3 +12,4 @@ before_install:
 branches:
   only:
     - master
+    - /^\d{4}\.\d{2}.\d{2}$/


### PR DESCRIPTION
 - This Fix #1723 allowing to run travis build to every release branch ( format YYYY.MM.mm)
This may trigger the build. As from the documentation : 

> Travis CI uses the .travis.yml file from the branch containing the git commit that triggers the build. Include branches using a safelist, or exclude them using a blocklist.

After merge back to master, this should work forever.