### PR TITLE
Fix #1738. Optional share api and showTOC

### DIFF
--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -24,10 +24,23 @@ require('./share.css');
 
 const ShareEmbed = React.createClass({
     propTypes: {
-        shareUrl: React.PropTypes.string
+        shareUrl: React.PropTypes.string,
+        showTOCToggle: React.PropTypes.bool
     },
-    getInitialState() {
-        return {copied: false, forceDrawer: false};
+  getInitialState() {
+      return {copied: false, forceDrawer: false};
+  },
+  getDefaultProps() {
+      return {
+          showTOCToggle: true
+      };
+  },
+  renderTools() {
+        if (this.props.showTOCToggle) {
+            return (<Checkbox checked={this.state.forceDrawer} onChange={() => this.setState({forceDrawer: !this.state.forceDrawer})}>
+                <Message msgId="share.forceDrawer"/>
+             </Checkbox>);
+        }
     },
   render() {
 
@@ -44,16 +57,12 @@ const ShareEmbed = React.createClass({
                       </OverlayTrigger>);
       return (
           <div className="input-link">
-
-
               <Grid className="embed-box" fluid={true}>
                   <Row key="title">
                         <h4>
                            <Message msgId="share.embeddedLinkTitle"/>
                         </h4>
-                        <Checkbox checked={this.state.forceDrawer} onChange={() => this.setState({forceDrawer: !this.state.forceDrawer})}>
-                            <Message msgId="share.forceDrawer"/>
-                         </Checkbox>
+                        {this.renderTools()}
                     </Row>
                     <Row key="data" className="row-button">
                         <Col key="textarea" xs={10} sm={10} md={10}><textarea name="description" rows="6" value={codeEmbedded} enabled="false" readOnly /></Col>

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -45,6 +45,8 @@ let SharePanel = React.createClass({
         shareUrlReplaceString: React.PropTypes.string,
         shareApiUrl: React.PropTypes.string,
         shareConfigUrl: React.PropTypes.string,
+        embedOptions: React.PropTypes.object,
+        showAPI: React.PropTypes.bool,
         onClose: React.PropTypes.func,
         getCount: React.PropTypes.func,
         closeGlyph: React.PropTypes.string
@@ -55,6 +57,8 @@ let SharePanel = React.createClass({
             onClose: () => {},
             shareUrlRegex: "(h[^#]*)#\\/viewer\\/([^\\/]*)\\/([A-Za-z0-9]*)",
             shareUrlReplaceString: "$1embedded.html#/$3",
+            embedOptions: {},
+            showAPI: true,
             closeGlyph: "1-close"
         };
     },
@@ -76,8 +80,8 @@ let SharePanel = React.createClass({
         const shareApiUrl = this.props.shareApiUrl || this.props.shareUrl || location.href;
         const social = <ShareSocials shareUrl={shareUrl} getCount={this.props.getCount}/>;
         const direct = (<div><ShareLink shareUrl={shareUrl}/><ShareQRCode shareUrl={shareUrl}/></div>);
-        const code = (<div><ShareEmbed shareUrl={shareEmbeddedUrl}/>
-        <ShareApi shareUrl={shareApiUrl} shareConfigUrl={this.props.shareConfigUrl}/></div>);
+        const code = (<div><ShareEmbed shareUrl={shareEmbeddedUrl} {...this.props.embedOptions} />
+        {this.props.showAPI ? <ShareApi shareUrl={shareApiUrl} shareConfigUrl={this.props.shareConfigUrl}/> : null}</div>);
 
         const tabs = (<Tabs defaultActiveKey={1} id="sharePanel-tabs">
             <Tab eventKey={1} title={<Message msgId="share.direct" />}>{direct}</Tab>

--- a/web/client/components/share/__tests__/ShareEmbed-test.jsx
+++ b/web/client/components/share/__tests__/ShareEmbed-test.jsx
@@ -57,5 +57,12 @@ describe("The ShareEmbed component", () => {
         expect(textareaEmbed).toExist();
         expect(textareaEmbed.value).toEqual(iFrameStr);
     });
-
+    it('test showTOCToggle prop', () => {
+        const host = "http://localhost:8081/";
+        const hashPart = "#/abc/def/1";
+        const cmpSharePanel = ReactDOM.render(<ShareEmbed showTOCToggle={false} shareUrl={ host + hashPart }/>, document.getElementById("container"));
+        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "input");
+        let checkboxes = inputs.filter(i => i.type === "checkbox");
+        expect(checkboxes.length).toBe(0);
+    });
 });

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -10,7 +10,7 @@ const expect = require('expect');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const SharePanel = require('../SharePanel');
-
+const ReactTestUtils = require('react-addons-test-utils');
 
 describe("The SharePanel component", () => {
     beforeEach((done) => {
@@ -50,7 +50,15 @@ describe("The SharePanel component", () => {
         expect(cmpSharePanel).toExist();
         const parsed = cmpSharePanel.generateUrl("TEST", "(TE)ST", "$1");
         expect(parsed).toBe("TE");
-
+    });
+    it('test showAPI flag', () => {
+        let cmpSharePanel = ReactDOM.render(<SharePanel showAPI={false} getCount={()=>0} shareUrl="www.geo-solutions.it" isVisible={true} />, document.getElementById("container"));
+        expect(cmpSharePanel).toExist();
+        let textareaEmbed = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "textarea");
+        expect(textareaEmbed.length).toBe(1);
+        cmpSharePanel = ReactDOM.render(<SharePanel showAPI={true} getCount={()=>0} shareUrl="www.geo-solutions.it" isVisible={true} />, document.getElementById("container"));
+        textareaEmbed = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "textarea");
+        expect(textareaEmbed.length).toBe(2);
     });
 
 

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -40,6 +40,9 @@ const getConfigUrl = (url) => {
  * @prop {node} [title] the title of the page
  * @prop {string} [shareUrlRegex] reqular expression to parse the shareUrl to generate the final url, using shareUrlReplaceString
  * @prop {string} [shareUrlReplaceString] expression to be replaced by groups of the shareUrlRegex to get the final shareUrl to use for the iframe
+ * @prop {object} [embedOptions] options for the iframe version of embedded share options
+ * @prop {boolean} [embedOptions.showTOCToggle] true by default, set to false to hide the "show TOC" toggle.
+ * @prop {boolean} [showAPI] default true, if false, hides the API entry of embed.
  * @prop {function} [onClose] function to call on close window event.
  * @prop {getCount} [getCount] function used to get the count for social links.
  */


### PR DESCRIPTION
With this options you can remove via configuration the API share tool and the showTOC checkbox.