### PR TITLE
Fix #1694 Resolutions selector don't work in print 

### DIFF
--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -39,7 +39,7 @@ var ScaleBox = React.createClass({
     },
     onComboChange(event) {
         var selectedZoomLvl = parseInt(event.nativeEvent.target.value, 10);
-        this.props.onChange(selectedZoomLvl);
+        this.props.onChange(selectedZoomLvl, this.props.scales[selectedZoomLvl]);
     },
     getOptions() {
         return this.props.scales.map((item, index) => {


### PR DESCRIPTION
the wrong scale issue was due to the missing scale value on onChange but the server response sometimes is still undefined without throw errors on the request.
Could it be because of multiple requests with high dpi (150 / 300)?
