### PR TITLE
Fix #1777. Forced version of react-input-autosize

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "react-dom": "15.4.2",
     "react-draggable": "2.2.3",
     "react-dropzone": "3.4.0",
+    "react-input-autosize": "1.1.0",
     "react-intl": "2.2.3",
     "react-joyride": "1.10.1",
     "react-nouislider": "1.11.0",


### PR DESCRIPTION
This is forcing MapStore 2 to include a previous react-input-autosize that didn't include react 15.
This should fix #1777 waiting for the team of react-select to fix the bug.