### PR TITLE
Fixed draw support and epic general error handling

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -169,7 +169,6 @@ const DrawSupport = React.createClass({
             features: features,
             condition: ol.events.condition.always
         };
-
         // Prepare the properties for the BBOX drawing
         let roiProps = {};
         switch (geometryType) {
@@ -241,7 +240,6 @@ const DrawSupport = React.createClass({
             }
             default : return {};
         }
-
         let drawProps = assign({}, drawBaseProps, roiProps);
 
         // create an interaction to draw with
@@ -293,6 +291,9 @@ const DrawSupport = React.createClass({
         this.props.map.addInteraction(draw);
         this.drawInteraction = draw;
         this.drawSource.clear();
+        if (newProps.features.length > 0 ) {
+            this.addFeatures(newProps.features || []);
+        }
     },
     removeDrawInteraction: function() {
         if (this.drawInteraction !== null) {

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -12,7 +12,23 @@ const expect = require('expect');
 const PluginsUtils = require('../PluginsUtils');
 const assign = require('object-assign');
 const MapSearchPlugin = require('../../plugins/MapSearch');
+const Rx = require('rxjs');
+const { ActionsObservable } = require('redux-observable');
 
+const epicTest = (epic, count, action, callback, state = {}) => {
+    const actions = new Rx.Subject();
+    const actions$ = new ActionsObservable(actions);
+    const store = { getState: () => state };
+    epic(actions$, store)
+        .take(count)
+        .toArray()
+        .subscribe(callback);
+    if (action.length) {
+        action.map(act => actions.next(act));
+    } else {
+        actions.next(action);
+    }
+};
 describe('PluginsUtils', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -80,10 +96,36 @@ describe('PluginsUtils', () => {
     });
     it('combineEpics', () => {
         const plugins = {MapSearchPlugin: MapSearchPlugin};
-        const appEpics = {appEpics: (actions$) => actions$.ofType('TEST_ACTION').map({type: "NEW_ACTION_TEST"})};
+        const appEpics = {appEpics: (actions$) => actions$.ofType('TEST_ACTION').map(() => ({type: "NEW_ACTION_TEST"}))};
         const epics = PluginsUtils.combineEpics(plugins, appEpics);
         expect(typeof epics ).toEqual('function');
     });
+    it('combineEpics with defaultEpicWrapper', (done) => {
+        const plugins = {MapSearchPlugin: MapSearchPlugin};
+        const appEpics = {
+            appEpics: (actions$) => actions$.filter( a => a.type === 'TEST_ACTION').map(() => ({type: "RESPONSE"})),
+            appEpics2: (actions$) => actions$.filter( a => a.type === 'TEST_ACTION1').map(() => {throw new Error(); })};
+        const epics = PluginsUtils.combineEpics(plugins, appEpics);
+        expect(typeof epics ).toEqual('function');
+        epicTest(epics, 1, [{type: 'TEST_ACTION1'}, {type: 'TEST_ACTION'}], actions => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe("RESPONSE");
+            done();
+        });
+    });
+
+    it('combineEpics with custom wrapper', (done) => {
+        const plugins = {MapSearchPlugin: MapSearchPlugin};
+        let counter = 0;
+        const appEpics = {
+            appEpics: (actions$) => actions$.filter( a => a.type === 'TEST_ACTION').map(() => ({type: "RESPONSE"}))};
+        const epics = PluginsUtils.combineEpics(plugins, appEpics, epic => (...args) => {counter++; return epic(...args); });
+        epicTest( epics, 1, [{type: 'TEST_ACTION1'}, {type: 'TEST_ACTION'}], () => {
+            expect(counter).toBe(1);
+            done();
+        });
+    });
+
     it('connect', () => {
         const MyComponent = (props) => <div>{props.test}</div>;
         const Connected = PluginsUtils.connect((state) => ({test: state.test}), {})(MyComponent);


### PR DESCRIPTION
Updated drawSupport for openlayers.
Added the possibility to draw features when the draw interaction starts.

Also introduced a wrapper for every epic to catch errors without breaking the epic infrastructure.
Added some test.