### PR TITLE
Prevent axios to request /null urls

### DIFF
--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -52,7 +52,9 @@ const extractInfo = (data) => {
 };
 
 const featureTypeSelectedEpic = action$ =>
-    action$.ofType(FEATURE_TYPE_SELECTED).switchMap(action => {
+    action$.ofType(FEATURE_TYPE_SELECTED)
+    .filter(action => action.url !== null)  // Axios will try to request a /null url without this filter
+    .switchMap(action => {
         return Rx.Observable.defer( () =>
             axios.get(action.url + '?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=' + action.typeName + '&outputFormat=application/json'))
         .map((response) => {


### PR DESCRIPTION
Every time the user closes the query panel, a FEATURE_TYPE_SELECTED action is dispatched.
When closing the panel, such action will not have an url set.
If the action is not filtered, axios will try to request a **/null** path, for example:
http://dev.mapstore2.geo-solutions.it/mapstore/null?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=null&outputFormat=application/json

To reproduce:
- add a queryable layer from the catalog
- open the query panel
- close the query panel