### PR TITLE
Fixes #1788: configurability of SettingModal showElevationChart

### DIFF
--- a/web/client/components/TOC/fragments/SettingsModal.jsx
+++ b/web/client/components/TOC/fragments/SettingsModal.jsx
@@ -41,6 +41,7 @@ const SettingsModal = React.createClass({
         closeText: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
         options: React.PropTypes.object,
         chartStyle: React.PropTypes.object,
+        showElevationChart: React.PropTypes.bool,
         buttonSize: React.PropTypes.string,
         closeGlyph: React.PropTypes.string,
         panelStyle: React.PropTypes.object,
@@ -135,6 +136,7 @@ const SettingsModal = React.createClass({
             return (<Elevation
                elevationText={this.props.elevationText}
                chartStyle={this.props.chartStyle}
+               showElevationChart={this.props.showElevationChart}
                element={this.props.element}
                elevations={elevationDim}
                appState={this.state || {}}

--- a/web/client/components/TOC/fragments/settings/Elevation.jsx
+++ b/web/client/components/TOC/fragments/settings/Elevation.jsx
@@ -20,18 +20,20 @@ module.exports = React.createClass({
         elevations: React.PropTypes.object,
         onChange: React.PropTypes.func,
         appState: React.PropTypes.object,
-        chartStyle: React.PropTypes.object
+        chartStyle: React.PropTypes.object,
+        showElevationChart: React.PropTypes.bool
     },
     getDefaultProps() {
         return {
-            onChange: () => {}
+            onChange: () => {},
+            showElevationChart: true
         };
     },
     shouldComponentUpdate(nextProps) {
         return this.props.element.id !== nextProps.element.id;
     },
     renderElevationsChart(elevations) {
-        if (this.props.elevations.showChart) {
+        if (this.props.showElevationChart) {
             return (
                 <ElevationChart
                     elevations={elevations}
@@ -66,7 +68,7 @@ module.exports = React.createClass({
                             }
                         }
                     }}
-                    tooltips={!this.props.elevations.showChart}
+                    tooltips={!this.props.showElevationChart}
                     onChange={(value) => {
                         this.props.onChange("params", Object.assign({}, {
                             [this.props.elevations.name]: value[0]

--- a/web/client/components/TOC/fragments/settings/__tests__/Elevation-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Elevation-test.jsx
@@ -40,7 +40,6 @@ describe('test Layer Properties Elevation component', () => {
               name: "ELEVATION",
               units: "Meters",
               positive: false,
-              showChart: true,
               values: ["1.5", "5.0", "10.0", "15.0", "20.0", "25.0", "30.0"]
             }
         };

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -47,7 +47,6 @@ const getElevationDimension = (dimensions = []) => {
     return dimensions.reduce((previous, dim) => {
         return (dim.name.toLowerCase() === 'elevation' || dim.name.toLowerCase() === 'depth') ?
             assign({
-                showChart: true,
                 positive: dim.name.toLowerCase() === 'elevation'
             }, dim, {
                 name: dim.name.toLowerCase() === 'elevation' ? dim.name : 'DIM_' + dim.name


### PR DESCRIPTION
To configure it in the TOC plugin:
```
{
                 "name": "TOC",
                 "cfg": {
                  "settingsOptions":  {
                      "showElevationChart": false
                    }
                 }
}
```