### PR TITLE
Hide tools not supported in 3d (see #1780)

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -120,6 +120,10 @@
             "web/client/actions/maptype.js",
             "web/client/actions/search.js",
 
+            "web/client/selectors/index.jsdoc",
+            "web/client/selectors/search.js",
+            "web/client/selectors/maptype.js",
+
             "web/client/reducers/index.jsdoc",
             "web/client/reducers/controls.js",
             "web/client/reducers/globeswitcher.js",
@@ -150,9 +154,12 @@
                 "web/client/plugins/MeasureResults.jsx",
                 "web/client/plugins/FullScreen.jsx",
                 "web/client/plugins/Identify.jsx",
+                "web/client/plugins/Locate.jsx",
                 "web/client/plugins/Login.jsx",
                 "web/client/plugins/ScrollTop.jsx",
-                "web/client/plugins/Search.jsx"
+                "web/client/plugins/Search.jsx",
+                "web/client/plugins/ZoomIn.jsx",
+                "web/client/plugins/ZoomOut.jsx"
             ]
         },
         "./docs/**/*md",

--- a/web/client/actions/index.jsdoc
+++ b/web/client/actions/index.jsdoc
@@ -5,8 +5,12 @@
  *
  */
 /**
- * @typedef action redux action @see {@link http://redux.js.org/docs/basics/Actions.html|the redux documentation}
+ * @external action
+ * @description Redux action.
+ * @see {@link http://redux.js.org/docs/basics/Actions.html|the redux documentation}
  */
  /**
-  * @typedef thunk a redux-thunk thunk. @see {@link https://github.com/gaearon/redux-thunk|the redux-thunk documentation}
+  * @external thunk
+  * @description A redux-thunk thunk.
+  * @see {@link https://github.com/gaearon/redux-thunk|the redux-thunk documentation}
   */

--- a/web/client/components/buttons/ZoomButton.jsx
+++ b/web/client/components/buttons/ZoomButton.jsx
@@ -13,6 +13,7 @@ const ZoomButton = React.createClass({
     propTypes: {
         id: React.PropTypes.string,
         style: React.PropTypes.object,
+        hide: React.PropTypes.bool,
         glyphicon: React.PropTypes.string,
         text: React.PropTypes.string,
         btnSize: React.PropTypes.oneOf(['large', 'small', 'xsmall']),
@@ -43,7 +44,7 @@ const ZoomButton = React.createClass({
         };
     },
     render() {
-        return this.addTooltip(
+        return !this.props.hide && this.addTooltip(
             <Button
                 id={this.props.id}
                 style={this.props.style}

--- a/web/client/epics/index.jsdoc
+++ b/web/client/epics/index.jsdoc
@@ -3,3 +3,8 @@
  * @see {@link https://redux-observable.js.org/docs/basics/Epics.html|the redux-observable documentation} for details
  * @name epics
  */
+/**
+ * @external Observable
+ * @description A RxJS Observable
+ * @see {@link http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html|Observable}
+ */

--- a/web/client/plugins/Locate.jsx
+++ b/web/client/plugins/Locate.jsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -9,16 +9,33 @@ const React = require('react');
 const {connect} = require('react-redux');
 
 const {changeLocateState} = require('../actions/locate');
-
+const {createSelector} = require('reselect');
+const {isCesium} = require('../selectors/maptype');
 const Message = require('./locale/Message');
 
 const {Glyphicon} = require('react-bootstrap');
 
 const assign = require('object-assign');
+const locateStateSelector = (state) => state.locate && state.locate.state || 'DISABLED';
 
-const LocatePlugin = connect((state) => ({
-    locate: state.locate && state.locate.state || 'DISABLED'
-}), {
+const selector = createSelector(locateStateSelector, isCesium, (locate, forceDisabled) => ({
+    locate: forceDisabled ? "PERMISSION_DENIED" : locate
+}));
+
+/**
+  * Locate Plugin. Provides button to locate the user's position on the map.
+  * By deafault it will follow the user until he moves the map. He can click again to
+  * restore the following mode.
+  * @class  Locate
+  * @memberof plugins
+  * @static
+  *
+  * @prop {string} cfg.style CSS to apply to the button
+  * @prop {string} cfg.text The button text, if any
+  * @prop {string} cfg.className the class name for the button
+  *
+  */
+const LocatePlugin = connect(selector, {
     onClick: changeLocateState
 })(require('../components/mapcontrols/locate/LocateBtn'));
 

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -13,6 +13,7 @@ const Message = require('./locale/Message');
 
 const assign = require('object-assign');
 const {createSelector} = require('reselect');
+const {isCesium} = require('../selectors/maptype');
 const {changeMeasurement} = require('../actions/measurement');
 const {toggleControl} = require('../actions/controls');
 const {MeasureDialog} = require('./measure');
@@ -36,7 +37,7 @@ const toggleMeasureTool = toggleControl.bind(null, 'measure', null);
 const Measure = connect(
     createSelector([
             selector,
-            (state) => state && state.controls && state.controls.measure && state.controls.measure.enabled
+            (state) => !isCesium(state) && state && state.controls && state.controls.measure && state.controls.measure.enabled
         ],
         (measure, show) => ({
             show,
@@ -52,6 +53,7 @@ module.exports = {
     MeasurePlugin: assign(Measure, {
         BurgerMenu: {
             name: 'measurement',
+            display: params => params.mapType !== "cesium",
             position: 9,
             panel: false,
             help: <Message msgId="helptexts.measureComponent"/>,

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -21,6 +21,7 @@ const {printSubmit, printSubmitting, configurePrintMap} = require('../actions/pr
 
 const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
+const {isCesium} = require('../selectors/maptype');
 
 const {createSelector} = require('reselect');
 
@@ -325,7 +326,7 @@ const Print = React.createClass({
 });
 
 const selector = createSelector([
-    (state) => (state.controls.print && state.controls.print.enabled ) || (state.controls.toolbar && state.controls.toolbar.active === 'print'),
+    (state) => !isCesium(state) && (state.controls.print && state.controls.print.enabled ) || (state.controls.toolbar && state.controls.toolbar.active === 'print'),
     (state) => state.print && state.print.capabilities,
     (state) => state.print && state.print.spec && assign({}, state.print.spec, state.print.map || {}),
     (state) => state.print && state.print.pdfUrl,
@@ -357,6 +358,7 @@ const PrintPlugin = connect(selector, {
 module.exports = {
     PrintPlugin: assign(PrintPlugin, {
         Toolbar: {
+            display: options => options.mapType !== "cesium",
             name: 'print',
             position: 7,
             help: <Message msgId="helptexts.print"/>,
@@ -368,6 +370,7 @@ module.exports = {
         },
         BurgerMenu: {
             name: 'print',
+            display: options => options.mapType !== "cesium",
             position: 2,
             text: <Message msgId="printbutton"/>,
             icon: <Glyphicon glyph="print"/>,

--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -11,6 +11,7 @@ const {connect} = require('../utils/PluginsUtils');
 const {createSelector} = require('reselect');
 
 const {mapSelector} = require('../selectors/map');
+const {isCesium} = require('../selectors/maptype');
 const {changeZoomLevel} = require('../actions/map');
 
 const HelpWrapper = require('./help/HelpWrapper');
@@ -19,9 +20,9 @@ const ScaleBox = require("../components/mapcontrols/scale/ScaleBox");
 
 const mapUtils = require('../utils/MapUtils');
 
-
-const selector = createSelector([mapSelector], (map) => ({
+const selector = createSelector([mapSelector, isCesium], (map, hide) => ({
     currentZoomLvl: map && map.zoom,
+    hide,
     scales: mapUtils.getScales(
         map && map.projection || 'EPSG:3857',
         map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
@@ -30,12 +31,38 @@ const selector = createSelector([mapSelector], (map) => ({
 
 require('./scalebox/scalebox.css');
 
+
+/**
+  * ScaleBox Plugin. Provides a selector for the scale of the map.
+  * @class  ScaleBox
+  * @memberof plugins
+  * @static
+  *
+  * @prop {object} cfg.style CSS to apply to the scalebox
+  * @prop {Boolean} cfg.readOnly the selector is readonly
+  * @prop {string} cfg.label label for the selector
+  * @prop {Boolean} cfg.useRawInput set true if you want to use an normal html input object
+  *
+  */
 const ScaleBoxPlugin = React.createClass({
+    propTypes: {
+        hide: React.PropTypes.bool,
+        id: React.PropTypes.string,
+        style: React.PropTypes.object,
+        scales: React.PropTypes.array,
+        currentZoomLvl: React.PropTypes.number,
+        onChange: React.PropTypes.func,
+        readOnly: React.PropTypes.bool,
+        label: React.PropTypes.string,
+        template: React.PropTypes.func,
+        useRawInput: React.PropTypes.bool
+    },
     render() {
-        return (<HelpWrapper id="mapstore-scalebox-container"
+        const {hide, ...scaleBoxProps} = this.props;
+        return !hide && (<HelpWrapper id="mapstore-scalebox-container"
             key="scalebox-help"
             helpText={<Message msgId="helptexts.scaleBox"/>}>
-                <ScaleBox key="scaleBox" {...this.props}/>
+                <ScaleBox key="scaleBox" {...scaleBoxProps}/>
         </HelpWrapper>);
     }
 });

--- a/web/client/plugins/ShapeFile.jsx
+++ b/web/client/plugins/ShapeFile.jsx
@@ -52,6 +52,7 @@ module.exports = {
     }, enabler: (state) => state.shapefile && state.shapefile.enabled || state.toolbar && state.toolbar.active === 'shapefile'}, {
         Toolbar: {
             name: 'shapefile',
+            display: options => options.mapType !== "cesium",
             position: 9,
             panel: true,
             help: <Message msgId="helptexts.shapefile"/>,
@@ -64,6 +65,7 @@ module.exports = {
         },
         BurgerMenu: {
             name: 'shapefile',
+            display: options => options.mapType !== "cesium",
             position: 4,
             text: <Message msgId="shapefile.title"/>,
             icon: <Glyphicon glyph="upload"/>,

--- a/web/client/plugins/ZoomIn.jsx
+++ b/web/client/plugins/ZoomIn.jsx
@@ -10,13 +10,30 @@ const React = require('react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 const {mapSelector} = require('../selectors/map');
+const {isCesium} = require('../selectors/maptype');
 // TODO: make step and glyphicon configurable
-const selector = createSelector([mapSelector], (map) => ({currentZoom: map && map.zoom, id: "zoomin-btn", step: 1, glyphicon: "plus"}));
+const selector = createSelector([mapSelector, isCesium], (map, hide) => ({
+    currentZoom: map && map.zoom,
+    id: "zoomin-btn",
+    step: 1,
+    glyphicon: "plus",
+    hide
+}));
 
 const {changeZoomLevel} = require('../actions/map');
 
 const Message = require('../components/I18N/Message');
 
+/**
+  * ZoomIn Plugin. Provides button to zoom in
+  * @class  ZoomIn
+  * @memberof plugins
+  * @static
+  *
+  * @prop {object} cfg.style CSS to apply to the button
+  * @prop {string} cfg.className the class name for the button
+  *
+  */
 const ZoomInButton = connect(selector, {
     onZoom: changeZoomLevel
 })(require('../components/buttons/ZoomButton'));

--- a/web/client/plugins/ZoomOut.jsx
+++ b/web/client/plugins/ZoomOut.jsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -12,13 +12,30 @@ const React = require('react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 const {mapSelector} = require('../selectors/map');
+const {isCesium} = require('../selectors/maptype');
+
 // TODO: make step and glyphicon configurable
-const selector = createSelector([mapSelector], (map) => ({currentZoom: map && map.zoom, id: "zoomout-btn", step: -1, glyphicon: "minus"}));
+const selector = createSelector([mapSelector, isCesium], (map, hide) => ({
+    currentZoom: map && map.zoom,
+    id: "zoomout-btn",
+    step: -1,
+    glyphicon: "minus",
+    hide
+}));
 
 const {changeZoomLevel} = require('../actions/map');
 
 const Message = require('../components/I18N/Message');
-
+/**
+  * ZoomOut Plugin. Provides button to zoom out
+  * @class  ZoomOut
+  * @memberof plugins
+  * @static
+  *
+  * @prop {object} cfg.style CSS to apply to the button
+  * @prop {string} cfg.className the class name for the button
+  *
+  */
 const ZoomOutButton = connect(selector, {
     onZoom: changeZoomLevel
 })(require('../components/buttons/ZoomButton'));

--- a/web/client/plugins/containers/ToolsContainer.jsx
+++ b/web/client/plugins/containers/ToolsContainer.jsx
@@ -124,23 +124,29 @@ const ToolsContainer = React.createClass({
         })(this.props.tool);
     },
     renderTools() {
-        return this.props.tools.map((tool, i) => {
-            if (tool.element) {
-                return tool.element;
-            }
-            const help = tool.help ? <HelpBadge className="mapstore-helpbadge" helpText={tool.help}/> : <span/>;
-            const tooltip = tool.tooltip ? <Message msgId={tool.tooltip}/> : null;
+        return this.props.tools
+            .filter((tool) => {
+                if (tool.display) {
+                    return tool.display({mapType: this.props.mapType});
+                }
+                return true;
+            }).map((tool, i) => {
+                if (tool.element) {
+                    return tool.element;
+                }
+                const help = tool.help ? <HelpBadge className="mapstore-helpbadge" helpText={tool.help}/> : <span/>;
+                const tooltip = tool.tooltip ? <Message msgId={tool.tooltip}/> : null;
 
-            const Tool = this.getTool(tool);
-            const toolCfg = this.getToolConfig(tool);
+                const Tool = this.getTool(tool);
+                const toolCfg = this.getToolConfig(tool);
 
-            return this.addTooltip(
-                <Tool {...toolCfg} pluginCfg={tool.cfg} tooltip={tooltip} btnSize={this.props.toolSize} bsStyle={this.props.toolStyle} help={help} key={tool.name || ("tool" + i)} mapType={this.props.mapType}
-                    {...tool.cfg} items={tool.items || []}>
-                    {(tool.cfg && tool.cfg.glyph) ? <Glyphicon glyph={tool.cfg.glyph}/> : tool.icon}{help} {tool.text}
-                </Tool>,
-            tool);
-        });
+                return this.addTooltip(
+                    <Tool {...toolCfg} pluginCfg={tool.cfg} tooltip={tooltip} btnSize={this.props.toolSize} bsStyle={this.props.toolStyle} help={help} key={tool.name || ("tool" + i)} mapType={this.props.mapType}
+                        {...tool.cfg} items={tool.items || []}>
+                        {(tool.cfg && tool.cfg.glyph) ? <Glyphicon glyph={tool.cfg.glyph}/> : tool.icon}{help} {tool.text}
+                    </Tool>,
+                tool);
+            });
     },
     renderPanels() {
         return this.props.panels

--- a/web/client/selectors/__tests__/maptype-test.js
+++ b/web/client/selectors/__tests__/maptype-test.js
@@ -1,0 +1,27 @@
+/*
+* Copyright 2017, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+const expect = require('expect');
+const {mapTypeSelector, isCesium} = require('../maptype');
+
+describe('Test maptype', () => {
+    it('test mapTypeSelector', () => {
+        const mapType = mapTypeSelector({maptype: {mapType: "cesium"}});
+
+        expect(mapType).toExist();
+        expect(mapType).toBe("cesium");
+    });
+
+    it('test isCesium', () => {
+        const bool = isCesium({maptype: {mapType: "cesium"}});
+        expect(bool).toExist();
+        expect(bool).toBe(true);
+        expect(isCesium({maptype: {mapType: "leaflet"}})).toBe(false);
+    });
+});

--- a/web/client/selectors/index.jsdoc
+++ b/web/client/selectors/index.jsdoc
@@ -1,0 +1,11 @@
+/**
+ * React/Redux selectors.
+ * @see {@link https://github.com/reactjs/reselect|Reselect} for details
+ * @name selectors
+ *
+ */
+/**
+ * @external selector
+ * @see {@link https://github.com/reactjs/reselect|Reselect} for details
+ * @description A function that computes the redux state or part of it allowing the redux store to be normalized and the react components to be re-rendered only if needed.
+ */

--- a/web/client/selectors/maptype.js
+++ b/web/client/selectors/maptype.js
@@ -1,0 +1,31 @@
+/*
+* Copyright 2017, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+const {createSelector} = require('reselect');
+
+/**
+ * selects maptype from state
+ * @memberof selectors.maptype
+ * @param  {object} state the state
+ * @return {string}       the maptype in the state
+ */
+const mapTypeSelector = (state) => state && state.maptype && state.maptype.mapType;
+
+/**
+ * Check if the mapType is cesium
+ * @function
+ * @memberof selectors.maptype
+ * @param  {object} state the state
+ * @return {boolean}
+ */
+const isCesium = createSelector(mapTypeSelector, (mt) => mt === "cesium");
+
+module.exports = {
+    mapTypeSelector,
+    isCesium
+};


### PR DESCRIPTION
This pull request is a part of #1780 and hides the following tools when the maptype is cesium:
 - Zoom In/Out
 - ScaleBox
 - Print
 - Locate
 - ShapeFile
 - Measure

It adds the display function as a allowed member of tools in a toolcontainer. If this fuction is present, it will be used to filter the tools to display. the entry. It is useful to hide entries in the ToolContainer other then hiding the window itself.

Also some documentation improved (e.g locate plugin, selectors, external types).