### PR TITLE
Plugins disable functionalities

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -76,7 +76,7 @@ const PluginsContainer = React.createClass({
     },
     renderPlugins(plugins) {
         return plugins
-            .filter((Plugin) => !PluginsUtils.handleExpression(this.props.pluginsState, this.props.plugins && this.props.plugins.requires, Plugin.hide))
+            .filter((Plugin) => !PluginsUtils.handleExpression(this.getState, this.props.plugins && this.props.plugins.requires, Plugin.hide))
             .map(this.getPluginDescriptor)
             .filter((Plugin) => Plugin && !Plugin.impl.loadPlugin)
             .filter(this.filterPlugins)

--- a/web/client/containers/Embedded.jsx
+++ b/web/client/containers/Embedded.jsx
@@ -17,7 +17,7 @@ const ConfigUtils = require('../utils/ConfigUtils');
 const PluginsContainer = connect((state) => ({
     mode: (urlQuery.mode || (state.browser && state.browser.mobile ? 'mobile' : 'desktop')),
     pluginsState: state && state.controls || {},
-    monitoredState: PluginsUtils.filterState(state, ConfigUtils.getConfigProp('monitorState') || [])
+    monitoredState: PluginsUtils.getMonitoredState(state, ConfigUtils.getConfigProp('monitorState'))
 }))(require('../components/plugins/PluginsContainer'));
 
 const Embedded = React.createClass({

--- a/web/client/containers/MapViewer.jsx
+++ b/web/client/containers/MapViewer.jsx
@@ -19,7 +19,7 @@ const PluginsContainer = connect((state) => ({
     pluginsConfig: state.plugins || ConfigUtils.getConfigProp('plugins') || null,
     mode: (urlQuery.mode || state.mode || (state.browser && state.browser.mobile ? 'mobile' : 'desktop')),
     pluginsState: state && state.controls || {},
-    monitoredState: PluginsUtils.filterState(state, ConfigUtils.getConfigProp('monitorState') || [])
+    monitoredState: PluginsUtils.getMonitoredState(state, ConfigUtils.getConfigProp('monitorState'))
 }))(require('../components/plugins/PluginsContainer'));
 
 const MapViewer = React.createClass({

--- a/web/client/containers/Page.jsx
+++ b/web/client/containers/Page.jsx
@@ -16,7 +16,7 @@ const ConfigUtils = require('../utils/ConfigUtils');
 
 const PluginsContainer = connect((state) => ({
     mode: urlQuery.mode || ((urlQuery.mobile || (state.browser && state.browser.mobile)) ? 'mobile' : 'desktop'),
-    monitoredState: PluginsUtils.filterState(state, ConfigUtils.getConfigProp('monitorState') || [])
+    monitoredState: PluginsUtils.getMonitoredState(state, ConfigUtils.getConfigProp('monitorState'))
 }))(require('../components/plugins/PluginsContainer'));
 
 const Page = React.createClass({

--- a/web/client/plugins/Locate.jsx
+++ b/web/client/plugins/Locate.jsx
@@ -26,6 +26,7 @@ require('./locate/locate.css');
 
 module.exports = {
     LocatePlugin: assign(LocatePlugin, {
+        disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: 'locate',
             position: 2,

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -50,6 +50,7 @@ const Measure = connect(
 
 module.exports = {
     MeasurePlugin: assign(Measure, {
+        disablePluginIf: "{state('mapType') === 'cesium'}",
         BurgerMenu: {
             name: 'measurement',
             position: 9,

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -356,6 +356,7 @@ const PrintPlugin = connect(selector, {
 
 module.exports = {
     PrintPlugin: assign(PrintPlugin, {
+        disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: 'print',
             position: 7,

--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -18,7 +18,7 @@ const Message = require('./locale/Message');
 const ScaleBox = require("../components/mapcontrols/scale/ScaleBox");
 
 const mapUtils = require('../utils/MapUtils');
-
+const assign = require('object-assign');
 
 const selector = createSelector([mapSelector], (map) => ({
     currentZoomLvl: map && map.zoom,
@@ -30,7 +30,7 @@ const selector = createSelector([mapSelector], (map) => ({
 
 require('./scalebox/scalebox.css');
 
-const ScaleBoxPlugin = React.createClass({
+const ScaleBoxTool = React.createClass({
     render() {
         return (<HelpWrapper id="mapstore-scalebox-container"
             key="scalebox-help"
@@ -40,10 +40,12 @@ const ScaleBoxPlugin = React.createClass({
     }
 });
 
-
+const ScaleBoxPlugin = connect(selector, {
+    onChange: changeZoomLevel
+})(ScaleBoxTool);
 module.exports = {
-    ScaleBoxPlugin: connect(selector, {
-        onChange: changeZoomLevel
-    })(ScaleBoxPlugin),
+    ScaleBoxPlugin: assign(ScaleBoxPlugin, {
+        disablePluginIf: "{state('mapType') === 'cesium'}"
+    }),
     reducers: {}
 };

--- a/web/client/plugins/ShapeFile.jsx
+++ b/web/client/plugins/ShapeFile.jsx
@@ -50,6 +50,7 @@ module.exports = {
             resolve(ShapeFilePlugin);
         });
     }, enabler: (state) => state.shapefile && state.shapefile.enabled || state.toolbar && state.toolbar.active === 'shapefile'}, {
+        disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: 'shapefile',
             position: 9,

--- a/web/client/plugins/ZoomIn.jsx
+++ b/web/client/plugins/ZoomIn.jsx
@@ -10,6 +10,7 @@ const React = require('react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 const {mapSelector} = require('../selectors/map');
+
 // TODO: make step and glyphicon configurable
 const selector = createSelector([mapSelector], (map) => ({currentZoom: map && map.zoom, id: "zoomin-btn", step: 1, glyphicon: "plus"}));
 
@@ -28,6 +29,7 @@ const assign = require('object-assign');
 
 module.exports = {
     ZoomInPlugin: assign(ZoomInButton, {
+        disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: "ZoomIn",
             position: 3,

--- a/web/client/plugins/ZoomOut.jsx
+++ b/web/client/plugins/ZoomOut.jsx
@@ -29,6 +29,7 @@ const assign = require('object-assign');
 
 module.exports = {
     ZoomOutPlugin: assign(ZoomOutButton, {
+        disablePluginIf: "{state('mapType') === 'cesium'}",
         Toolbar: {
             name: "ZoomOut",
             position: 4,

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -143,6 +143,25 @@ describe('PluginsUtils', () => {
     it('handleExpression', () => {
         expect(PluginsUtils.handleExpression({state1: "test1"}, {context1: "test2"}, "{state.state1 + ' ' + context.context1}")).toBe("test1 test2");
     });
+    it('filterState', () => {
+        expect(PluginsUtils.filterState({state1: "test1"}, [{name: "A", path: "state1"}]).A).toBe("test1");
+    });
+    it('filterDisabledPlugins', () => {
+        expect(PluginsUtils.filterDisabledPlugins(
+            {plugin: {
+                disablePluginIf: "{true}"
+            }},
+            {},
+            {}
+        )).toBe(false);
+    });
+    it('getMonitoredState', () => {
+        expect(PluginsUtils.getMonitoredState({maptype: {mapType: "leaflet"}}).mapType).toBe("leaflet");
+    });
+
+    it('handleExpression', () => {
+        expect(PluginsUtils.handleExpression({state1: "test1"}, {context1: "test2"}, "{state.state1 + ' ' + context.context1}")).toBe("test1 test2");
+    });
     it('dispatch', () => {
         const expr = PluginsUtils.handleExpression(() => ({
             dispatch: (action) => action


### PR DESCRIPTION
This pull request is a part of #1780 and hides the following tools when the maptype is cesium:

Zoom In/Out
ScaleBox
Print
Locate
ShapeFile
Measure
It adds the `filterDisabledPlugins` function in PluginUtils that uses the disablePluginIf inside the plugin definition as an expression to parse.
It adds also mapType and user as defaults of monitoredState.