### PR TITLE
Remove the whole plugin in disable function. Add docs

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -103,6 +103,7 @@ const PluginsContainer = React.createClass({
         (this.props.pluginsConfig && this.props.pluginsConfig[this.props.mode] || [])
             .map((plugin) => PluginsUtils.getPluginDescriptor(this.getState, this.props.plugins,
                 this.props.pluginsConfig[this.props.mode], plugin, this.state.loadedPlugins))
+            .filter(plugin => PluginsUtils.filterDisabledPlugins({plugin: plugin && plugin.impl || plugin}, this.getState))
             .filter((plugin) => plugin && plugin.impl.loadPlugin).forEach((plugin) => {
                 if (!this.state.loadedPlugins[plugin.name]) {
                     if (!plugin.impl.enabler || plugin.impl.enabler(state)) {

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -15,7 +15,19 @@ const defaultMonitoredState = [{name: "mapType", path: 'maptype.mapType'}, {name
 const {combineEpics} = require('redux-observable');
 
 const {memoize, get} = require('lodash');
-
+/**
+ * Gives a reduced version of the status to check.
+ * It cached the last state to prevent re-evaluations if the input didn't change.
+ * @memberof utils.PluginsUtils
+ * @function
+ * @param {Object} state the state
+ * @param {Object[]} monitor an array of objects in the form `{name: "a", path: "b"}` used to produce the monitoredState
+ * @return {Object} the state filtered using the monitor rules
+ * @example
+ * const monitor =[{name: "a", path: "b"}`];
+ * const state = {b: "test"}
+ * filterState(state, monitor); // returns {a: "test"}
+ */
 const filterState = memoize((state, monitor) => {
     return monitor.reduce((previous, current) => {
         return assign(previous, {
@@ -65,9 +77,16 @@ const handleExpression = (state, context, expression) => {
     }
     return expression;
 };
-
+/**
+ * filters the plugins passed evaluating the dsiablePluginIf expression with the given context
+ * @memberof utils.PluginsUtils
+ * @param  {Object} item         the plugins
+ * @param  {function} [state={}]   The state to evaluate
+ * @param  {Object} [plugins={}] the plugins object to get requires
+ * @return {Boolean}             the result of the expression evaluation in the given context.
+ */
 const filterDisabledPlugins = (item, state = {}, plugins = {}) => {
-    const disablePluginIf = item && item.plugin && item.plugin.disablePluginIf || item.cfg.disablePluginIf;
+    const disablePluginIf = item && item.plugin && item.plugin.disablePluginIf || item.cfg && item.cfg.disablePluginIf;
     if (disablePluginIf && !(item && item.cfg && item.cfg.skipAutoDisable)) {
         return !handleExpression(state, plugins.requires, disablePluginIf);
     }

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -154,6 +154,13 @@ describe('PluginsUtils', () => {
             {},
             {}
         )).toBe(false);
+
+        // check ignore other items, if any
+        expect(PluginsUtils.filterDisabledPlugins(
+            {},
+            {},
+            {}
+        )).toBe(true);
     });
     it('getMonitoredState', () => {
         expect(PluginsUtils.getMonitoredState({maptype: {mapType: "leaflet"}}).mapType).toBe("leaflet");


### PR DESCRIPTION
This pull request makes the disable functionality remove also the whole plugin (in case it is rendered directly) and adds documentation. 
