### PR TITLE
Fixed proxyUrl in Cesium Layers, add demo to cors

### DIFF
--- a/web/client/components/map/cesium/plugins/TileProviderLayer.js
+++ b/web/client/components/map/cesium/plugins/TileProviderLayer.js
@@ -34,7 +34,7 @@ TileProviderProxy.prototype.getURL = function(resource) {
     if (url.indexOf("//") === 0) {
         url = location.protocol + url;
     }
-    return this.proxy.url + encodeURIComponent(url + queryString);
+    return ProxyUtils.getProxyUrl() + encodeURIComponent(url + queryString);
 };
 
 function NoProxy() {

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -38,7 +38,7 @@ function WMSProxy(proxy) {
 
 WMSProxy.prototype.getURL = function(resource) {
     let {url, queryString} = splitUrl(resource);
-    return this.proxy.url + encodeURIComponent(url + queryString);
+    return ProxyUtils.getProxyUrl() + encodeURIComponent(url + queryString);
 };
 
 function NoProxy() {

--- a/web/client/components/map/cesium/plugins/WMTSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMTSLayer.js
@@ -47,7 +47,7 @@ const isValidTile = (tileMatrixSet) => (x, y, level) =>
 
 WMTSProxy.prototype.getURL = function(resource) {
     let {url, queryString} = splitUrl(resource);
-    return this.proxy + encodeURIComponent(url + queryString);
+    return ProxyUtils.getProxyUrl() + encodeURIComponent(url + queryString);
 };
 
 function NoProxy() {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -2,7 +2,7 @@
 
     "proxyUrl": {
         "url": "/mapstore/proxy/?url=",
-        "useCORS": ["https://demo.geo-solutions.it/geoserver"]
+        "useCORS": ["http://demo.geo-solutions.it/geoserver", "https://demo.geo-solutions.it/geoserver"]
     },
     "geoStoreUrl": "/mapstore/rest/geostore/",
     "printUrl": "https://demo.geo-solutions.it/geoserver/pdf/info.json",


### PR DESCRIPTION
Two problems: 

1. Cors was used if you ask from https to http server (as the map in test)
2. the proxyUrl was not correctly parsed in the case of object

Now WMTSLayer, WMSLayer and TileProvider layers in cesium get the proxy from global ConfigUtils object so I used ConfigUtils also in the proxyUrl retrival parts of the code, For the future we could implement it in a more functional style. 

