### PR TITLE
Fixed the_geom configured to initial state on query form reset

### DIFF
--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -424,13 +424,17 @@ describe('Test the queryform reducer', () => {
         };
 
         const initialState = {
-            test: true
+            test: true,
+            spatialField: {
+                attribute: "GEOMETRY"
+            }
         };
 
         let state = queryform(initialState, testAction);
         expect(state).toExist();
 
         expect(state.test).toEqual(true);
+        expect(state.spatialField.attribute).toEqual("GEOMETRY");
     });
 
     it('Show Generated Filter', () => {

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -189,13 +189,15 @@ function queryform(state = initialState, action) {
             return newState;
         }
         case REMOVE_SPATIAL_SELECT: {
-            return assign({}, state, {spatialField: assign({}, state.spatialField, initialState.spatialField)});
+            let spatialField = assign({}, initialState.spatialField, { attribute: state.spatialField.attribute });
+            return assign({}, state, {spatialField: assign({}, state.spatialField, spatialField)});
         }
         case SHOW_SPATIAL_DETAILS: {
             return assign({}, state, {showDetailsPanel: action.show});
         }
         case QUERY_FORM_RESET: {
-            return assign({}, state, initialState);
+            let spatialField = assign({}, initialState.spatialField, { attribute: state.spatialField.attribute });
+            return assign({}, state, initialState, {spatialField});
         }
         case SHOW_GENERATED_FILTER: {
             return assign({}, state, {showGeneratedFilter: action.data});


### PR DESCRIPTION
The query builder changes the attribute on spatial filter to the initial state when the query form has been reset or the the spatial selector has been removed.
This causes empty result in feature grid so I added two assign function to catch the current geometry attribute and assign it to the state.