### PR TITLE
Fix #1829 Details panel doesn't add new geometry to the query form

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -110,7 +110,8 @@ const DrawSupport = React.createClass({
                     geometry = new ol.geom.LineString(geom.coordinates); break;
                 }
                 case "Polygon": {
-                    geometry = new ol.geom.Polygon(geom.coordinates); break;
+                    geometry = geom.radius && geom.center ?
+                    ol.geom.Polygon.fromCircle(new ol.geom.Circle([geom.center.x, geom.center.y], geom.radius), 100) : new ol.geom.Polygon(geom.coordinates); break;
                 }
                 default: {
                     geometry = geom.radius && geom.center ?
@@ -257,13 +258,17 @@ const DrawSupport = React.createClass({
             let radius;
             let extent = drawnGeometry.getExtent();
             let type = drawnGeometry.getType();
+
             let center = ol.extent.getCenter(drawnGeometry.getExtent());
             let coordinates = drawnGeometry.getCoordinates();
+
+            let isCircleType = coordinates.length > 0 && coordinates[0] && coordinates[0].length === 101 ? true : false;
+
             if (startingPoint) {
                 coordinates = concat(startingPoint, coordinates);
                 drawnGeometry.setCoordinates(coordinates);
             }
-            if (type === "Circle") {
+            if (isCircleType) {
                 radius = Math.sqrt(Math.pow(center[0] - coordinates[0][0][0], 2) + Math.pow(center[1] - coordinates[0][0][1], 2));
             }
 
@@ -271,7 +276,7 @@ const DrawSupport = React.createClass({
                 type,
                 extent: extent,
                 center: center,
-                coordinates: type === "Polygon" ? coordinates[0].concat([coordinates[0][0]]) : coordinates,
+                coordinates: coordinates[0].concat([coordinates[0][0]]),
                 radius: radius,
                 projection: this.props.map.getView().getProjection().getCode()
             };
@@ -282,6 +287,7 @@ const DrawSupport = React.createClass({
             });
             let modify = new ol.interaction.Modify(modifyProps);
             this.props.map.addInteraction(modify);*/
+
             this.props.onEndDrawing(geometry, this.props.drawOwner);
             if (this.props.options.stopAfterDrawing) {
                 this.props.onChangeDrawingStatus('stop', this.props.drawMethod, this.props.drawOwner);

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -262,7 +262,7 @@ const DrawSupport = React.createClass({
             let center = ol.extent.getCenter(drawnGeometry.getExtent());
             let coordinates = drawnGeometry.getCoordinates();
 
-            let isCircleType = coordinates.length > 0 && coordinates[0] && coordinates[0].length === 101 ? true : false;
+            let isCircleType = type === 'Polygon' && coordinates.length > 0 && coordinates[0] && coordinates[0].length === 101 ? true : false;
 
             if (startingPoint) {
                 coordinates = concat(startingPoint, coordinates);
@@ -276,7 +276,7 @@ const DrawSupport = React.createClass({
                 type,
                 extent: extent,
                 center: center,
-                coordinates: coordinates[0].concat([coordinates[0][0]]),
+                coordinates: type === "Polygon" ? coordinates[0].concat([coordinates[0][0]]) : coordinates,
                 radius: radius,
                 projection: this.props.map.getView().getProjection().getCode()
             };

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -368,7 +368,9 @@ const FilterUtils = {
         // Array of LinearRing coordinate array. The first element in the array represents the exterior ring.
         // Any subsequent elements represent interior rings (or holes).
         // ///////////////////////////////////////////////////////////////////////////////////////////////////////
-        coordinates.forEach((element, index) => {
+
+        const normalizedCoords = coordinates.length && isArray(coordinates[0]) && coordinates[0].length && isArray(coordinates[0][0]) ? coordinates : [coordinates];
+        normalizedCoords.forEach((element, index) => {
             let coords = element.map((coordinate) => {
                 return coordinate[0] + (version === "1.0.0" ? "," : " ") + coordinate[1];
             });


### PR DESCRIPTION
- Fixed geometry detail panel Circle and BBOX selections
- Fixed circle selection in OpenLayers
- Fixed coordinates in OGC filter (this issue didn't let OpenLayers to send a complete request)