### PR TITLE
Implemented filter builder

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -148,6 +148,7 @@
             "web/client/utils/CoordinatesUtils.js",
             "web/client/utils/PluginsUtils.js",
             "web/client/utils/PrintUtils.js",
+            "web/client/utils/ogc/WFS/RequestBuilder.js",
             "web/client/utils/ShareUtils.js"
           ],
           "jsapi": "web/client/jsapi/MapStore2.js",

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -6,7 +6,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {processOGCGeometry, closePolygon, pointElement, polygonElement, lineStringElement } = require("./ogc/GML");
+const {processOGCGeometry, pointElement, polygonElement, lineStringElement } = require("./ogc/GML");
+const {wfsToGmlVersion} = require('./ogc/WFS/base');
 const {ogcComparisonOperators, ogcLogicalOperators, ogcSpatialOperators} = require("./ogc/Filter/operators");
 const normalizeVersion = (version) => {
     if (!version) {
@@ -307,11 +308,10 @@ const FilterUtils = {
     },
 
     processOGCSimpleFilterField,
-    closePolygon: closePolygon,
-    getGmlPointElement: pointElement,
-    getGmlPolygonElement: polygonElement,
-    getGmlLineStringElement: lineStringElement,
-    processOGCGeometry,
+    getGmlPointElement: (c, srs, v) => pointElement(c, srs, wfsToGmlVersion(v)),
+    getGmlPolygonElement: (c, srs, v) => polygonElement(c, srs, wfsToGmlVersion(v)),
+    getGmlLineStringElement: (c, srs, v) => lineStringElement(c, srs, wfsToGmlVersion(v)),
+    processOGCGeometry: (v, geom) => processOGCGeometry(wfsToGmlVersion(v), geom),
     processOGCSpatialFilter: function(version, objFilter, nsplaceholder) {
         let ogc =
             propertyTagReference[nsplaceholder].startTag +
@@ -323,7 +323,7 @@ const FilterUtils = {
             case "DWITHIN":
             case "WITHIN":
             case "CONTAINS": {
-                ogc += this.processOGCGeometry(version, objFilter.spatialField.geometry);
+                ogc += processOGCGeometry(wfsToGmlVersion(version), objFilter.spatialField.geometry);
 
                 if (objFilter.spatialField.operation === "DWITHIN") {
                     ogc += '<' + nsplaceholder + ':Distance units="m">' + (objFilter.spatialField.geometry.distance || 0) + '</' + nsplaceholder + ':Distance>';

--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -5,18 +5,14 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {logical, spatial, comparison, literal, propertyName, distance} = require('./operators');
+const {logical, spatial, comparison, literal, propertyName, valueReference, distance} = require('./operators');
+const {filter, fidFilter} = require('./filter');
 const {processOGCGeometry} = require("../GML");
-const {wfsToGmlVersion} = require("../WFS/base");
 // const isValidXML = (value, {filterNS, gmlNS}) => value.indexOf(`<${filterNS}:` === 0) || value.indexOf(`<${gmlNS}:`) === 0;
 
-module.exports = function({filterNS= "ogc", gmlVersion, wfsVersion} = {}) {
-    let gmlV = gmlVersion;
-    if (!gmlV && wfsVersion) {
-        gmlV = wfsToGmlVersion(wfsVersion);
-    } else if (!gmlV) {
-        gmlV = "3.1.1";
-    }
+module.exports = function({filterNS= "ogc", gmlVersion, wfsVersion = "1.1.0"} = {}) {
+    let gmlV = gmlVersion || "3.1.1";
+
     const getGeom = (geom) => processOGCGeometry(gmlV, geom);
     const getValue = (value) => {
         if (typeof value === "object" && !(value instanceof Date)) {
@@ -24,26 +20,29 @@ module.exports = function({filterNS= "ogc", gmlVersion, wfsVersion} = {}) {
         }
         return literal(filterNS, value);
     };
+    const propName = wfsVersion.indexOf("2.") === 0 ? valueReference : propertyName;
     return {
+        filter: filter.bind(null, filterNS),
+        fidFilter: fidFilter.bind(null, filterNS),
         and: logical.and.bind(null, filterNS),
         or: logical.or.bind(null, filterNS),
         not: logical.not.bind(null, filterNS),
         property: function(name) {
             return {
-                equalTo: (value) => comparison.equal(filterNS, propertyName(filterNS, name), getValue(value)),
-                greaterThen: (value) => comparison.greater(filterNS, propertyName(filterNS, name), getValue(value)),
-                greaterThenOrEqualTo: (value) => comparison.greaterOrEqual(filterNS, propertyName(filterNS, name), getValue(value)),
-                lessThen: (value) => comparison.less(filterNS, propertyName(filterNS, name), getValue(value)),
-                lessThenOrEqualTo: (value) => comparison.lessOrEqual(filterNS, propertyName(filterNS, name), getValue(value)),
-                notEqualTo: (value) => comparison.notEqual(filterNS, propertyName(filterNS, name), getValue(value)),
-                between: (value1, value2) => comparison.between(filterNS, propertyName(filterNS, name), getValue(value1), getValue(value2)),
-                like: (value, options) => comparison.like(filterNS, propertyName(filterNS, name), getValue(value), options),
-                ilike: (value, options) => comparison.ilike(filterNS, propertyName(filterNS, name), getValue(value), options),
-                isNull: () => comparison.isNull(filterNS, propertyName(filterNS, name)),
-                intersects: (value) => spatial.intersects(filterNS, propertyName(filterNS, name), getGeom(value)),
-                within: (value) => spatial.within(filterNS, propertyName(filterNS, name), getGeom(value)),
-                dwithin: (geom, dist, units="m") => spatial.dwithin(filterNS, propertyName(filterNS, name), getGeom(geom), distance(filterNS, dist, units)),
-                contains: (value) => spatial.contains(filterNS, propertyName(filterNS, name), getGeom(value))
+                equalTo: (value) => comparison.equal(filterNS, propName(filterNS, name), getValue(value)),
+                greaterThen: (value) => comparison.greater(filterNS, propName(filterNS, name), getValue(value)),
+                greaterThenOrEqualTo: (value) => comparison.greaterOrEqual(filterNS, propName(filterNS, name), getValue(value)),
+                lessThen: (value) => comparison.less(filterNS, propName(filterNS, name), getValue(value)),
+                lessThenOrEqualTo: (value) => comparison.lessOrEqual(filterNS, propName(filterNS, name), getValue(value)),
+                notEqualTo: (value) => comparison.notEqual(filterNS, propName(filterNS, name), getValue(value)),
+                between: (value1, value2) => comparison.between(filterNS, propName(filterNS, name), getValue(value1), getValue(value2)),
+                like: (value, options) => comparison.like(filterNS, propName(filterNS, name), getValue(value), options),
+                ilike: (value, options) => comparison.ilike(filterNS, propName(filterNS, name), getValue(value), options),
+                isNull: () => comparison.isNull(filterNS, propName(filterNS, name)),
+                intersects: (value) => spatial.intersects(filterNS, propName(filterNS, name), getGeom(value)),
+                within: (value) => spatial.within(filterNS, propName(filterNS, name), getGeom(value)),
+                dwithin: (geom, dist, units="m") => spatial.dwithin(filterNS, propName(filterNS, name), getGeom(geom), distance(filterNS, dist, units)),
+                contains: (value) => spatial.contains(filterNS, propName(filterNS, name), getGeom(value))
                 // TODO bbox equals, disjoint, touches, overlaps
 
 

--- a/web/client/utils/ogc/Filter/FilterBuilder.js
+++ b/web/client/utils/ogc/Filter/FilterBuilder.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {logical, spatial, comparison, literal, propertyName, distance} = require('./operators');
+const {processOGCGeometry} = require("../GML");
+const {wfsToGmlVersion} = require("../WFS/base");
+// const isValidXML = (value, {filterNS, gmlNS}) => value.indexOf(`<${filterNS}:` === 0) || value.indexOf(`<${gmlNS}:`) === 0;
+
+module.exports = function({filterNS= "ogc", gmlVersion, wfsVersion} = {}) {
+    let gmlV = gmlVersion;
+    if (!gmlV && wfsVersion) {
+        gmlV = wfsToGmlVersion(wfsVersion);
+    } else if (!gmlV) {
+        gmlV = "3.1.1";
+    }
+    const getGeom = (geom) => processOGCGeometry(gmlV, geom);
+    const getValue = (value) => {
+        if (typeof value === "object" && !(value instanceof Date)) {
+            // TODO return GML;
+        }
+        return literal(filterNS, value);
+    };
+    return {
+        and: logical.and.bind(null, filterNS),
+        or: logical.or.bind(null, filterNS),
+        not: logical.not.bind(null, filterNS),
+        property: function(name) {
+            return {
+                equalTo: (value) => comparison.equal(filterNS, propertyName(filterNS, name), getValue(value)),
+                greaterThen: (value) => comparison.greater(filterNS, propertyName(filterNS, name), getValue(value)),
+                greaterThenOrEqualTo: (value) => comparison.greaterOrEqual(filterNS, propertyName(filterNS, name), getValue(value)),
+                lessThen: (value) => comparison.less(filterNS, propertyName(filterNS, name), getValue(value)),
+                lessThenOrEqualTo: (value) => comparison.lessOrEqual(filterNS, propertyName(filterNS, name), getValue(value)),
+                notEqualTo: (value) => comparison.notEqual(filterNS, propertyName(filterNS, name), getValue(value)),
+                between: (value1, value2) => comparison.between(filterNS, propertyName(filterNS, name), getValue(value1), getValue(value2)),
+                like: (value, options) => comparison.like(filterNS, propertyName(filterNS, name), getValue(value), options),
+                ilike: (value, options) => comparison.ilike(filterNS, propertyName(filterNS, name), getValue(value), options),
+                isNull: () => comparison.isNull(filterNS, propertyName(filterNS, name)),
+                intersects: (value) => spatial.intersects(filterNS, propertyName(filterNS, name), getGeom(value)),
+                within: (value) => spatial.within(filterNS, propertyName(filterNS, name), getGeom(value)),
+                dwithin: (geom, dist, units="m") => spatial.dwithin(filterNS, propertyName(filterNS, name), getGeom(geom), distance(filterNS, dist, units)),
+                contains: (value) => spatial.contains(filterNS, propertyName(filterNS, name), getGeom(value))
+                // TODO bbox equals, disjoint, touches, overlaps
+
+
+            };
+        }
+    };
+
+};

--- a/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/FilterBuilder-test.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+ // Disable ESLint because some of the names to include are not in camel case
+const expect = require('expect');
+const FilterBuilder = require('../FilterBuilder');
+const {processOGCGeometry} = require("../../GML");
+describe('FilterBuilder', () => {
+    it('comparison', () => {
+        const b = new FilterBuilder();
+        expect(b.property("PROPERTY").equalTo("VALUE"))
+        .toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(b.property("PROPERTY").greaterThen(1))
+        .toBe("<ogc:PropertyIsGreaterThan><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsGreaterThan>");
+        expect(b.property("PROPERTY").lessThen(1))
+        .toBe("<ogc:PropertyIsLessThan><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsLessThan>");
+        expect(b.property("PROPERTY").greaterThenOrEqualTo(1))
+        .toBe("<ogc:PropertyIsGreaterThanOrEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsGreaterThanOrEqualTo>");
+        expect(b.property("PROPERTY").lessThenOrEqualTo(1))
+        .toBe("<ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsLessThanOrEqualTo>");
+        expect(b.property("PROPERTY").notEqualTo("VALUE"))
+        .toBe("<ogc:PropertyIsNotEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsNotEqualTo>");
+        expect(b.property("PROPERTY").between(1, 2)).toBe("<ogc:PropertyIsBetween><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>1</ogc:Literal><ogc:Literal>2</ogc:Literal></ogc:PropertyIsBetween>");
+        expect(b.property("PROPERTY").like("VALUE"))
+        .toBe('<ogc:PropertyIsLike matchCase="true" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsLike>');
+        expect(b.property("PROPERTY").ilike("VALUE"))
+        .toBe('<ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsLike>');
+        expect(b.property("PROPERTY").isNull())
+        .toBe("<ogc:PropertyIsNull><ogc:PropertyName>PROPERTY</ogc:PropertyName></ogc:PropertyIsNull>");
+    });
+    it('spatial', () => {
+        const b = new FilterBuilder();
+        const testGeom = {type: "Point", coordinates: [1, 2]};
+        const geomGML = processOGCGeometry("3.1.1", testGeom);
+        expect(b.property("GEOMETRY").intersects( testGeom ))
+            .toBe(`<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>${geomGML}</ogc:Intersects>`);
+        expect(b.property("GEOMETRY").contains( testGeom )).toBe(`<ogc:Contains><ogc:PropertyName>GEOMETRY</ogc:PropertyName>${geomGML}</ogc:Contains>`);
+        expect(b.property("GEOMETRY").within(testGeom) ).toBe(`<ogc:Within><ogc:PropertyName>GEOMETRY</ogc:PropertyName>${geomGML}</ogc:Within>`);
+        expect(b.property("GEOMETRY").dwithin(testGeom, 200)).toBe(`<ogc:DWithin><ogc:PropertyName>GEOMETRY</ogc:PropertyName>${geomGML}<ogc:Distance units="m">200</ogc:Distance></ogc:DWithin>`);
+    });
+    it('logical', () => {
+        const b = new FilterBuilder();
+        const testGeom1 = {type: "Point", coordinates: [1, 2]};
+        const geomGML1 = processOGCGeometry("3.1.1", testGeom1);
+        const intersectsElem1 = `<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>${geomGML1}</ogc:Intersects>`;
+        const testGeom2 = {type: "Point", coordinates: [3, 4]};
+        const geomGML2 = processOGCGeometry("3.1.1", testGeom2);
+        const intersectsElem2 = `<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>${geomGML2}</ogc:Intersects>`;
+
+        // as argument list
+        expect(
+            b.and(b.property("GEOMETRY").intersects(testGeom1), b.property("GEOMETRY").intersects(testGeom2))
+        ).toBe(`<ogc:And>${intersectsElem1}${intersectsElem2}</ogc:And>`);
+        expect(
+            b.or(b.property("GEOMETRY").intersects(testGeom1), b.property("GEOMETRY").intersects(testGeom2))
+        ).toBe(`<ogc:Or>${intersectsElem1}${intersectsElem2}</ogc:Or>`);
+
+        // as array
+        expect(
+            b.and([b.property("GEOMETRY").intersects(testGeom1), b.property("GEOMETRY").intersects(testGeom2)])
+        ).toBe(`<ogc:And>${intersectsElem1}${intersectsElem2}</ogc:And>`);
+        expect(
+            b.or([b.property("GEOMETRY").intersects(testGeom1), b.property("GEOMETRY").intersects(testGeom2)])
+        ).toBe(`<ogc:Or>${intersectsElem1}${intersectsElem2}</ogc:Or>`);
+
+        // not
+        expect(
+            b.not(b.property("GEOMETRY").intersects(testGeom1))
+        ).toBe(`<ogc:Not>${intersectsElem1}</ogc:Not>`);
+
+        // compose
+        expect(b.or(
+            b.and(b.property("GEOMETRY").intersects(testGeom1), b.not(b.property("GEOMETRY").intersects(testGeom2))),
+            b.and(b.property("GEOMETRY").intersects(testGeom2), b.not(b.property("GEOMETRY").intersects(testGeom1)))
+        )).toBe(`<ogc:Or><ogc:And>${intersectsElem1}<ogc:Not>${intersectsElem2}</ogc:Not></ogc:And>`
+            + `<ogc:And>${intersectsElem2}<ogc:Not>${intersectsElem1}</ogc:Not></ogc:And>`
+            + `</ogc:Or>`);
+    });
+
+});

--- a/web/client/utils/ogc/Filter/__tests__/operators-test.js
+++ b/web/client/utils/ogc/Filter/__tests__/operators-test.js
@@ -7,10 +7,10 @@
  */
  // Disable ESLint because some of the names to include are not in camel case
 const expect = require('expect');
-const {ogcComparisonOperators, ogcLogicalOperators, ogcSpatialOperators} = require('../operators');
+const {ogcComparisonOperators, ogcLogicalOperators, ogcSpatialOperators, logical, spatial, comparison, literal, propertyName} = require('../operators');
 
 describe('OGC Operators', () => {
-    it('ogcComparisonOperators', () => {
+    it('comparison object', () => {
         expect(ogcComparisonOperators["="]("ogc", "TEST")).toBe("<ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo>");
         expect(ogcComparisonOperators[">"]("ogc", "TEST")).toBe("<ogc:PropertyIsGreaterThan>TEST</ogc:PropertyIsGreaterThan>");
         expect(ogcComparisonOperators["<"]("ogc", "TEST")).toBe("<ogc:PropertyIsLessThan>TEST</ogc:PropertyIsLessThan>");
@@ -21,7 +21,7 @@ describe('OGC Operators', () => {
         expect(ogcComparisonOperators.ilike("ogc", "TEST")).toBe('<ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">TEST</ogc:PropertyIsLike>');
         expect(ogcComparisonOperators.isNull("ogc", "TEST")).toBe('<ogc:PropertyIsNull>TEST</ogc:PropertyIsNull>');
     });
-    it('ogcLogicalOperators', () => {
+    it('ogcLogicalOperators object', () => {
         const AND = "AND";
         const OR = "OR";
         const AND_NOT = "AND NOT";
@@ -29,7 +29,7 @@ describe('OGC Operators', () => {
         expect(ogcLogicalOperators[OR]("ogc", "TEST")).toBe("<ogc:Or>TEST</ogc:Or>");
         expect(ogcLogicalOperators[AND_NOT]("ogc", "TEST")).toBe("<ogc:Not>TEST</ogc:Not>");
     });
-    it('ogcSpatialOperators', () => {
+    it('ogcSpatialOperators object', () => {
         const INTERSECTS = "INTERSECTS";
         const BBOX = "BBOX";
         const CONTAINS = "CONTAINS";
@@ -40,5 +40,61 @@ describe('OGC Operators', () => {
         expect(ogcSpatialOperators[CONTAINS]("ogc", "TEST")).toBe("<ogc:Contains>TEST</ogc:Contains>");
         expect(ogcSpatialOperators[DWITHIN]("ogc", "TEST")).toBe("<ogc:DWithin>TEST</ogc:DWithin>");
         expect(ogcSpatialOperators[WITHIN]("ogc", "TEST")).toBe("<ogc:Within>TEST</ogc:Within>");
+    });
+    it('logical functions with array', () => {
+        expect(logical.and("ogc",
+            [ogcComparisonOperators["="]("ogc", "TEST"),
+            ogcComparisonOperators[">"]("ogc", "TEST")
+        ])).toBe('<ogc:And><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo><ogc:PropertyIsGreaterThan>TEST</ogc:PropertyIsGreaterThan></ogc:And>');
+        expect(logical.or("ogc",
+            [ogcComparisonOperators["="]("ogc", "TEST"),
+            ogcComparisonOperators[">"]("ogc", "TEST")
+        ])).toBe('<ogc:Or><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo><ogc:PropertyIsGreaterThan>TEST</ogc:PropertyIsGreaterThan></ogc:Or>');
+        expect(logical.not("ogc",
+            [ogcComparisonOperators["="]("ogc", "TEST")]
+        )).toBe('<ogc:Not><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo></ogc:Not>');
+
+    });
+    it('logical functions with arg list', () => {
+        expect(logical.and("ogc",
+            ogcComparisonOperators["="]("ogc", "TEST"),
+            ogcComparisonOperators[">"]("ogc", "TEST")
+        )).toBe('<ogc:And><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo><ogc:PropertyIsGreaterThan>TEST</ogc:PropertyIsGreaterThan></ogc:And>');
+        expect(logical.or("ogc",
+            ogcComparisonOperators["="]("ogc", "TEST"),
+            ogcComparisonOperators[">"]("ogc", "TEST")
+        )).toBe('<ogc:Or><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo><ogc:PropertyIsGreaterThan>TEST</ogc:PropertyIsGreaterThan></ogc:Or>');
+        expect(logical.not("ogc",
+            ogcComparisonOperators["="]("ogc", "TEST")
+        )).toBe('<ogc:Not><ogc:PropertyIsEqualTo>TEST</ogc:PropertyIsEqualTo></ogc:Not>');
+    });
+    it('spatial functions', () => {
+        expect(spatial.intersects("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:Intersects><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:Intersects>");
+        expect(spatial.bbox("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:BBOX><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:BBOX>");
+        expect(spatial.contains("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:Contains><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:Contains>");
+        expect(spatial.within("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:Within><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:Within>");
+        expect(spatial.dwithin("ogc", propertyName("ogc", "GEOMETRY"), "TEST")).toBe("<ogc:DWithin><ogc:PropertyName>GEOMETRY</ogc:PropertyName>TEST</ogc:DWithin>");
+    });
+    it('comparison functions', () => {
+        expect(comparison.equal("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(comparison.greater("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsGreaterThan><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsGreaterThan>");
+        expect(comparison.less("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsLessThan><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsLessThan>");
+        expect(comparison.greaterOrEqual("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsGreaterThanOrEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsGreaterThanOrEqualTo>");
+        expect(comparison.lessOrEqual("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsLessThanOrEqualTo>");
+        expect(comparison.notEqual("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsNotEqualTo><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsNotEqualTo>");
+        expect(comparison.between("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe("<ogc:PropertyIsBetween><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsBetween>");
+        expect(comparison.like("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe('<ogc:PropertyIsLike matchCase="true" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsLike>');
+        expect(comparison.ilike("ogc", propertyName("ogc", "PROPERTY"), literal("ogc", "VALUE")))
+            .toBe('<ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>PROPERTY</ogc:PropertyName><ogc:Literal>VALUE</ogc:Literal></ogc:PropertyIsLike>');
+        expect(comparison.isNull("ogc", propertyName("ogc", "PROPERTY")))
+            .toBe("<ogc:PropertyIsNull><ogc:PropertyName>PROPERTY</ogc:PropertyName></ogc:PropertyIsNull>");
     });
 });

--- a/web/client/utils/ogc/Filter/base.js
+++ b/web/client/utils/ogc/Filter/base.js
@@ -5,9 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const filter = (content, ns = "ogc") => `<${ns}:Filter>${Array.isArray(content) ? content.join("") : content}</${ns}:Filter>`;
-const fidFilter = (fid, ns = "ogc") =>
-    filter(`<${ns}:FeatureId fid="${fid}"/>`, ns);
+const filter = (ns = "ogc", content) => `<${ns}:Filter>${Array.isArray(content) ? content.join("") : content}</${ns}:Filter>`;
+const fidFilter = (ns ="ogc", fid) =>
+    filter(ns, `<${ns}:FeatureId fid="${fid}"/>`);
 
 module.exports = {
     fidFilter,

--- a/web/client/utils/ogc/Filter/filter.js
+++ b/web/client/utils/ogc/Filter/filter.js
@@ -5,7 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {filter, fidFilter} = require('./filter');
+const filter = (ns = "ogc", content) => `<${ns}:Filter>${Array.isArray(content) ? content.join("") : content}</${ns}:Filter>`;
+const fidFilter = (ns = "ogc", fid ) =>
+    filter(ns, `<${ns}:FeatureId fid="${fid}"/>`);
+
 module.exports = {
     fidFilter,
     filter

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -31,6 +31,7 @@ const ogcSpatialOperators = {
     "WITHIN": (ns, content) => `<${ns}:Within>${content}</${ns}:Within>`
 };
 const propertyName = (ns, name) => `<${ns}:PropertyName>${name}</${ns}:PropertyName>`;
+const valueReference = (ns, name) => `<${ns}:ValueReference>${name}</${ns}:ValueReference>`;
 const literal = (ns, value) => `<${ns}:Literal>${value}</${ns}:Literal>`;
 const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content);
 const logical = {
@@ -66,6 +67,7 @@ module.exports = {
     ogcLogicalOperators,
     ogcSpatialOperators,
     propertyName,
+    valueReference,
     distance,
     literal,
     logical,

--- a/web/client/utils/ogc/Filter/operators.js
+++ b/web/client/utils/ogc/Filter/operators.js
@@ -23,15 +23,52 @@ const ogcLogicalOperators = {
         "AND NOT": (ns, content) => `<${ns}:Not>${content}</${ns}:Not>`
 };
 
-var ogcSpatialOperators = {
+const ogcSpatialOperators = {
     "INTERSECTS": (ns, content) => `<${ns}:Intersects>${content}</${ns}:Intersects>`,
     "BBOX": (ns, content) => `<${ns}:BBOX>${content}</${ns}:BBOX>`,
     "CONTAINS": (ns, content) => `<${ns}:Contains>${content}</${ns}:Contains>`,
     "DWITHIN": (ns, content) => `<${ns}:DWithin>${content}</${ns}:DWithin>`,
     "WITHIN": (ns, content) => `<${ns}:Within>${content}</${ns}:Within>`
 };
+const propertyName = (ns, name) => `<${ns}:PropertyName>${name}</${ns}:PropertyName>`;
+const literal = (ns, value) => `<${ns}:Literal>${value}</${ns}:Literal>`;
+const multiop = (ns, op, content) => op(ns, Array.isArray(content) ? content.join("") : content);
+const logical = {
+    and: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.AND, [content, ...other]) : multiop(ns, ogcLogicalOperators.AND, content),
+    or: (ns, content, ...other) => other && other.length > 0 ? multiop(ns, ogcLogicalOperators.OR, [content, ...other]) : multiop(ns, ogcLogicalOperators.OR, content),
+    not: (ns, content) => multiop(ns, ogcLogicalOperators["AND NOT"], content)
+};
+
+
+const spatial = {
+    intersects: (ns, ...args) => multiop(ns, ogcSpatialOperators.INTERSECTS, args),
+    within: (ns, ...args) => multiop(ns, ogcSpatialOperators.WITHIN, args),
+    bbox: (ns, ...args) => multiop(ns, ogcSpatialOperators.BBOX, args),
+    dwithin: (ns, ...args) => multiop(ns, ogcSpatialOperators.DWITHIN, args),
+    contains: (ns, ...args) => multiop(ns, ogcSpatialOperators.CONTAINS, args)
+};
+const distance = (ns, content, units="m") => `<${ns}:Distance units="${units}">${content}</${ns}:Distance>`;
+const comparison = {
+    equal: (ns, ...args) => multiop(ns, ogcComparisonOperators["="], args),
+    greater: (ns, ...args) => multiop(ns, ogcComparisonOperators[">"], args),
+    less: (ns, ...args) => multiop(ns, ogcComparisonOperators["<"], args),
+    greaterOrEqual: (ns, ...args) => multiop(ns, ogcComparisonOperators[">="], args),
+    lessOrEqual: (ns, ...args) => multiop(ns, ogcComparisonOperators["<="], args),
+    notEqual: (ns, ...args) => multiop(ns, ogcComparisonOperators["<>"], args),
+    between: (ns, ...args) => multiop(ns, ogcComparisonOperators["><"], args),
+    like: (ns, ...args) => multiop(ns, ogcComparisonOperators.like, args),
+    ilike: (ns, ...args) => multiop(ns, ogcComparisonOperators.ilike, args),
+    isNull: (ns, ...args) => multiop(ns, ogcComparisonOperators.isNull, args)
+};
+
 module.exports = {
     ogcComparisonOperators,
     ogcLogicalOperators,
-    ogcSpatialOperators
+    ogcSpatialOperators,
+    propertyName,
+    distance,
+    literal,
+    logical,
+    spatial,
+    comparison
 };

--- a/web/client/utils/ogc/GML/index.js
+++ b/web/client/utils/ogc/GML/index.js
@@ -1,5 +1,5 @@
 const {isArray} = require('lodash');
-const isGML2 = (version) => version.indexOf("2") === 0;
+const isGML2 = (version) => version.indexOf("2.") === 0;
 const closePolygon = (coords) => {
     if (coords.length >= 3) {
         const first = coords[0];

--- a/web/client/utils/ogc/GML/index.js
+++ b/web/client/utils/ogc/GML/index.js
@@ -1,5 +1,5 @@
 const {isArray} = require('lodash');
-const isGML1 = (version) => version === "1.0.0";
+const isGML2 = (version) => version.indexOf("2") === 0;
 const closePolygon = (coords) => {
     if (coords.length >= 3) {
         const first = coords[0];
@@ -12,9 +12,9 @@ const closePolygon = (coords) => {
 };
 const pointElement = (coordinates, srsName, version) => {
     let gmlPoint = '<gml:Point srsDimension="2"';
-    const gml1 = isGML1(version);
+    const gml2 = isGML2(version);
     gmlPoint += srsName ? ' srsName="' + srsName + '">' : '>';
-    if (gml1) {
+    if (gml2) {
         gmlPoint += '<gml:coord><X>' + coordinates[0] + '</X><Y>' + coordinates[1] + '</Y></gml:coord>';
     } else {
         gmlPoint += '<gml:pos>' + coordinates.join(" ") + '</gml:pos>';
@@ -26,7 +26,7 @@ const pointElement = (coordinates, srsName, version) => {
 };
 
 const polygonElement = (coordinates, srsName, version) => {
-    const gml1 = isGML1(version);
+    const gml2 = isGML2(version);
     let gmlPolygon = '<gml:Polygon';
     gmlPolygon += srsName ? ' srsName="' + srsName + '">' : '>';
 
@@ -38,16 +38,16 @@ const polygonElement = (coordinates, srsName, version) => {
     const normalizedCoords = coordinates.length && isArray(coordinates[0]) && coordinates[0].length && isArray(coordinates[0][0]) ? coordinates : [coordinates];
     normalizedCoords.forEach((element, index) => {
         let coords = closePolygon(element).map((coordinate) => {
-            return coordinate[0] + (gml1 ? "," : " ") + coordinate[1];
+            return coordinate[0] + (gml2 ? "," : " ") + coordinate[1];
         });
-        const exterior = (gml1 ? "outerBoundaryIs" : "exterior");
-        const interior = (gml1 ? "innerBoundaryIs" : "exterior");
+        const exterior = (gml2 ? "outerBoundaryIs" : "exterior");
+        const interior = (gml2 ? "innerBoundaryIs" : "exterior");
         gmlPolygon +=
             (index < 1 ? '<gml:' + exterior + '>' : '<gml:' + interior + '>') +
                     '<gml:LinearRing>' +
-                    (gml1 ? '<gml:coordinates>' : '<gml:posList>') +
+                    (gml2 ? '<gml:coordinates>' : '<gml:posList>') +
                             coords.join(" ") +
-                    (gml1 ? '</gml:coordinates>' : '</gml:posList>') +
+                    (gml2 ? '</gml:coordinates>' : '</gml:posList>') +
                     '</gml:LinearRing>' +
             (index < 1 ? '</gml:' + exterior + '>' : '</gml:' + interior + '>');
     });
@@ -56,7 +56,7 @@ const polygonElement = (coordinates, srsName, version) => {
     return gmlPolygon;
 };
 const lineStringElement = (coordinates, srsName, version) => {
-    const gml1 = isGML1(version);
+    const gml2 = isGML2(version);
     let gml = '<gml:LineString';
     gml += srsName ? ' srsName="' + srsName + '">' : '>';
 
@@ -66,11 +66,11 @@ const lineStringElement = (coordinates, srsName, version) => {
     // ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
     let coords = coordinates.map((coordinate) => {
-        return coordinate[0] + (gml1 ? "," : " ") + coordinate[1];
+        return coordinate[0] + (gml2 ? "," : " ") + coordinate[1];
     });
-    gml += (gml1 ? '<gml:coordinates>' : '<gml:posList>') +
+    gml += (gml2 ? '<gml:coordinates>' : '<gml:posList>') +
               coords.join(" ") +
-                (gml1 ? '</gml:coordinates>' : '</gml:posList>');
+                (gml2 ? '</gml:coordinates>' : '</gml:posList>');
 
     gml += '</gml:LineString>';
     return gml;
@@ -113,8 +113,8 @@ const processOGCGeometry = (version, geometry) => {
               srsName, version);
             break;
         case "MultiLineString":
-        const multyLineTagName = version === "2.0" ? "MultiCurve" : "MultiLineString";
-        const lineMemberTagName = version === "2.0" ? "curveMember" : "lineStringMember";
+        const multyLineTagName = version === "3.2" ? "MultiCurve" : "MultiLineString";
+        const lineMemberTagName = version === "3.2" ? "curveMember" : "lineStringMember";
 
         ogc += `<gml:${multyLineTagName} srsName="${srsName}">`;
 
@@ -135,8 +135,8 @@ const processOGCGeometry = (version, geometry) => {
                 srsName, version);
             break;
         case "MultiPolygon":
-            const multyPolygonTagName = version === "2.0" ? "MultiSurface" : "MultiPolygon";
-            const polygonMemberTagName = version === "2.0" ? "surfaceMembers" : "polygonMember";
+            const multyPolygonTagName = version === "3.2" ? "MultiSurface" : "MultiPolygon";
+            const polygonMemberTagName = version === "3.2" ? "surfaceMembers" : "polygonMember";
 
             ogc += `<gml:${multyPolygonTagName} srsName="${srsName}">`;
 

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -26,16 +26,19 @@ const getStaticAttributesWFS2 = (ver) => 'service="WFS" version="' + ver + '" ' 
         'http://schemas.opengis.net/gml/3.2.1/gml.xsd"';
 
 /**
- * Returns WFS Request Builder.
+ * Returns WFS Request Builder to allow the creation of WFS requests.
+ * It gets all the functionalities of `FilterBuilder`, plus adds `getFeature`, `query` ...
+ * @see utils.ogc.Filter.FilterBuilder
  * @name RequestBuilder
- * @method
+ * @augments utils.ogc.Filter.FilterBuilder
  * @memberof utils.ogc.WFS
+ * @constuctor
  * @param {Object} [options] the options to create the request builder
  * @param  {String} [options.wfsVersion="1.1.0"] the version of WFS
  * @param  {String} [options.gmlVersion]         gml Version ()
  * @param  {String} [options.filterNS]           NameSpace to use for filters
 *  @param  {String} [options.wfsNS="wfs"]        namespace to use for WFS tags
- * @return {Object}                      a request builder.
+ * @return {Object} A request builder. it contains all the `FilterBuilder` methods, plus the getFeature, query... methods
  * The request builder provides all the methods to compose the request (query, filter...). You can use it this way
  * ```
  * const requestBuilder = require('.../RequestBuilder');
@@ -79,11 +82,22 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wf
         ...filterBuilder({gmlVersion: gmlV, wfsVersion, filterNS: filterNS || wfsVersion === "2.0" ? "fes" : "ogc"}),
         /**
          * generate a getFeature request.
+         * @memberof utils.ogc.WFS.RequestBuilder
+         * @instance
          * @param  {object} opts    object with : `resultType` (null or 'hits'), outputFormat, startIndex, maxFeatures
          * @param  {string|string[]} content content of the request
-         * @return {string}         The request body
+         * @return {string} The request body
          */
         getFeature: (content, opts) => `<${wfsNS}:GetFeature ${requestAttributes(opts)}>${Array.isArray(content) ? content.join("") : content}</${wfsNS}:GetFeature>`,
+        /**
+         * generate a getFeature query.
+         * @memberof utils.ogc.WFS.RequestBuilder
+         * @instance
+         * @param  {string} featureName the feature name
+         * @param  {string|string[]} content content of the request
+         * @param  {object} [options] object with attribute: `srsName`.
+         * @return {string} The request body
+         */
         query: (featureName, content, {srsName ="EPSG:4326"} = {}) =>
             `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" srsName="${srsName}">`
             + `${Array.isArray(content) ? content.join("") : content}`

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -54,11 +54,9 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wf
          * @return {string}         The request body
          */
         getFeature: (content, opts) => `<${wfsNS}:GetFeature ${requestAttributes(opts)}>${Array.isArray(content) ? content.join("") : content}</${wfsNS}:GetFeature>`,
-        query: (featureName, content, ...other) =>
-            `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" srsName="EPSG:4326">`
-            + (other && other.length > 0
-                    ? `${[Array.isArray(content) ? content.join("") : content, ...other].join("") }`
-                    : `${Array.isArray(content) ? content.join("") : content}`)
+        query: (featureName, content, {srsName ="EPSG:4326"} = {}) =>
+            `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" srsName="${srsName}">`
+            + `${Array.isArray(content) ? content.join("") : content}`
             + `</${wfsNS}:Query>`
     };
 

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const filterBuilder = require('../Filter/FilterBuilder');
+const {wfsToGmlVersion} = require("./base");
+const getStaticAttributesWFS1 = (ver) => 'service="WFS" version="' + ver + '" ' +
+    (ver === "1.0.0" ? 'outputFormat="GML2" ' : "") +
+    'xmlns:gml="http://www.opengis.net/gml" ' +
+    'xmlns:wfs="http://www.opengis.net/wfs" ' +
+    'xmlns:ogc="http://www.opengis.net/ogc" ' +
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+    'xsi:schemaLocation="http://www.opengis.net/wfs ' +
+    (ver === "1.0.0" ? `http://schemas.opengis.net/wfs/${ver}/WFS-basic.xsd"` : `http://schemas.opengis.net/wfs/${ver}/wfs.xsd"`);
+const getStaticAttributesWFS2 = (ver) => 'service="WFS" version="' + ver + '" ' +
+    'xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+    'xmlns:fes="http://www.opengis.net/fes/2.0" ' +
+    'xmlns:gml="http://www.opengis.net/gml/3.2" ' +
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+    'xsi:schemaLocation="http://www.opengis.net/wfs/2.0 ' +
+        'http://schemas.opengis.net/wfs/2.0/wfs.xsd ' +
+        'http://www.opengis.net/gml/3.2 ' +
+        'http://schemas.opengis.net/gml/3.2.1/gml.xsd"';
+
+module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wfs"}) {
+    let gmlV = gmlVersion;
+    if (!gmlV && wfsVersion) {
+        gmlV = wfsToGmlVersion(wfsVersion);
+    } else if (!gmlV) {
+        gmlV = "3.1.1";
+    }
+    const requestAttributes = ({
+        resultType,
+        outputFormat,
+        startIndex,
+        maxFeatures
+    } = {}) => {
+        const getMaxFeatures = (mf) => wfsVersion.indexOf("2.") === 0 ? `count=${mf}` : `maxFeatures=${mf}`;
+        return (wfsVersion.indexOf("1.") === 0 ? getStaticAttributesWFS1(wfsVersion) : getStaticAttributesWFS2(wfsVersion))
+            + (resultType ? ` resultType=${resultType}` : "")
+            + (outputFormat ? ` outputFormat=${outputFormat}` : ``)
+            + ((startIndex || startIndex === 0) ? ` startIndex=${startIndex}` : "")
+            + ((maxFeatures || maxFeatures === 0) ? ` ${getMaxFeatures(maxFeatures)}` : "");
+    };
+    return {
+        ...filterBuilder({gmlVersion: gmlV, wfsVersion, filterNS: filterNS || wfsVersion === "2.0" ? "fes" : "ogc"}),
+        /**
+         * generate a getFeature request.
+         * @param  {object} opts    object with : `resultType` (null or 'hits'), outputFormat, startIndex, maxFeatures
+         * @param  {string|string[]} content content of the request
+         * @return {string}         The request body
+         */
+        getFeature: (content, opts) => `<${wfsNS}:GetFeature ${requestAttributes(opts)}>${Array.isArray(content) ? content.join("") : content}</${wfsNS}:GetFeature>`,
+        query: (featureName, content, ...other) =>
+            `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" srsName="EPSG:4326">`
+            + (other && other.length > 0
+                    ? `${[Array.isArray(content) ? content.join("") : content, ...other].join("") }`
+                    : `${Array.isArray(content) ? content.join("") : content}`)
+            + `</${wfsNS}:Query>`
+    };
+
+};

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -25,7 +25,37 @@ const getStaticAttributesWFS2 = (ver) => 'service="WFS" version="' + ver + '" ' 
         'http://www.opengis.net/gml/3.2 ' +
         'http://schemas.opengis.net/gml/3.2.1/gml.xsd"';
 
-module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wfs"}) {
+/**
+ * Returns WFS Request Builder.
+ * @name RequestBuilder
+ * @method
+ * @memberof utils.ogc.WFS
+ * @param {Object} [options] the options to create the request builder
+ * @param  {String} [options.wfsVersion="1.1.0"] the version of WFS
+ * @param  {String} [options.gmlVersion]         gml Version ()
+ * @param  {String} [options.filterNS]           NameSpace to use for filters
+*  @param  {String} [options.wfsNS="wfs"]        namespace to use for WFS tags
+ * @return {Object}                      a request builder.
+ * The request builder provides all the methods to compose the request (query, filter...). You can use it this way
+ * ```
+ * const requestBuilder = require('.../RequestBuilder');
+ * const {getFeature, query, filter, property} = requestBuilder({wfsVersion: "1.0.0"});
+ * const reqBody = getFeature(query(
+ *      "workspace:layer",
+ *      filter(
+ *          and(
+ *              property("P1").equals("v1"),
+ *              proprety("the_geom").intersects(geoJSONGeometry)
+ *          )
+ *      ),
+ *      {srsName="EPSG:4326"} // 3rd for query is optional
+ *      )
+ * {maxFeatures: 10, startIndex: 0, resultType: 'hits', outputFormat: 'application/json'} // 3rd  argument of getFeature is optional, and contains the options for the request.
+ * );
+ *
+ * ```
+ */
+module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wfs"} = {}) {
     let gmlV = gmlVersion;
     if (!gmlV && wfsVersion) {
         gmlV = wfsToGmlVersion(wfsVersion);
@@ -38,11 +68,11 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wf
         startIndex,
         maxFeatures
     } = {}) => {
-        const getMaxFeatures = (mf) => wfsVersion.indexOf("2.") === 0 ? `count=${mf}` : `maxFeatures=${mf}`;
+        const getMaxFeatures = (mf) => wfsVersion.indexOf("2.") === 0 ? `count="${mf}"` : `maxFeatures="${mf}"`;
         return (wfsVersion.indexOf("1.") === 0 ? getStaticAttributesWFS1(wfsVersion) : getStaticAttributesWFS2(wfsVersion))
-            + (resultType ? ` resultType=${resultType}` : "")
-            + (outputFormat ? ` outputFormat=${outputFormat}` : ``)
-            + ((startIndex || startIndex === 0) ? ` startIndex=${startIndex}` : "")
+            + (resultType ? ` resultType="${resultType}"` : "")
+            + (outputFormat ? ` outputFormat="${outputFormat}"` : ``)
+            + ((startIndex || startIndex === 0) ? ` startIndex="${startIndex}"` : "")
             + ((maxFeatures || maxFeatures === 0) ? ` ${getMaxFeatures(maxFeatures)}` : "");
     };
     return {

--- a/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
+++ b/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+const requestBuilder = require('../RequestBuilder');
+
+const TEST_REQUEST_V2 = '<wfs:GetFeature service="WFS" version="2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"><wfs:Query typeNames="ft_name_test" srsName="EPSG:4326"><fes:Filter><fes:And><fes:Or><fes:PropertyIsEqualTo><fes:ValueReference>highway_system</fes:ValueReference><fes:Literal>state</fes:Literal></fes:PropertyIsEqualTo></fes:Or></fes:And></fes:Filter></wfs:Query></wfs:GetFeature>';
+
+const TEST_REQUEST_V1_POLY = '<wfs:GetFeature service="WFS" version="1.0.0" outputFormat="GML2" xmlns:gml="http://www.opengis.net/gml" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd"><wfs:Query typeName="ft_name_test" srsName="EPSG:4326"><ogc:Filter><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,1 1,2 2,2 2,1 1,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogc:Intersects></ogc:Filter></wfs:Query></wfs:GetFeature>';
+describe('RequestBuilder Operators', () => {
+    it('RequestBuilder WFS 2.0', () => {
+        const {filter, and, or, getFeature, property, query} = requestBuilder({wfsVersion: "2.0"});
+        expect(
+            getFeature(query("ft_name_test",
+                    filter(and(or(property("highway_system").equalTo("state"))))
+            ))
+        ).toBe(TEST_REQUEST_V2);
+    });
+    it('RequestBuilder WFS 1.0.0', () => {
+        const geom = {
+            "type": "Polygon",
+            "projection": "EPSG:4326",
+            "coordinates": [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
+        };
+        const {filter, getFeature, property, query} = requestBuilder({wfsVersion: "1.0.0"});
+        expect(
+            getFeature(query("ft_name_test",
+                    filter(property("geometry").intersects(geom))
+            ))
+        ).toBe(TEST_REQUEST_V1_POLY);
+    });
+    it('RequestBuilder WFS - 1.1.0 Polygon', () => {
+        let geom = {
+            "type": "Polygon",
+            "projection": "EPSG:4326",
+            "coordinates": [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
+        };
+        const {filter, getFeature, property, query} = requestBuilder({wfsVersion: "1.1.0"});
+        let expected = '<wfs:GetFeature service="WFS" version="1.1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"><wfs:Query typeName="ft_name_test" srsName="EPSG:4326"><ogc:Filter><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:4326"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:Filter></wfs:Query></wfs:GetFeature>';
+        expect(
+            getFeature(query("ft_name_test",
+                    filter(property("geometry").intersects(geom))
+            ))
+        ).toBe(expected);
+    });
+});

--- a/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
+++ b/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -61,5 +61,19 @@ describe('RequestBuilder Operators', () => {
                     {srsName: "EPSG:3857"}
             ))
         ).toBe(expected2);
+
+        // params
+        let geom3 = {
+            "type": "Polygon",
+            "projection": "EPSG:3857",
+            "coordinates": [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
+        };
+        let expected3 = '<wfs:GetFeature service="WFS" version="1.1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" outputFormat="application/json"><wfs:Query typeName="ft_name_test" srsName="EPSG:3857"><ogc:Filter><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:3857"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:Filter></wfs:Query></wfs:GetFeature>';
+        expect(
+            getFeature(query("ft_name_test",
+                    filter(property("geometry").intersects(geom3)),
+                    {srsName: "EPSG:3857"}
+            ), {outputFormat: "application/json"})
+        ).toBe(expected3);
     });
 });

--- a/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
+++ b/web/client/utils/ogc/WFS/__tests__/RequestBuilder-test.js
@@ -47,5 +47,19 @@ describe('RequestBuilder Operators', () => {
                     filter(property("geometry").intersects(geom))
             ))
         ).toBe(expected);
+
+        // test change srsName
+        let geom2 = {
+            "type": "Polygon",
+            "projection": "EPSG:3857",
+            "coordinates": [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
+        };
+        let expected2 = '<wfs:GetFeature service="WFS" version="1.1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"><wfs:Query typeName="ft_name_test" srsName="EPSG:3857"><ogc:Filter><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:3857"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:Filter></wfs:Query></wfs:GetFeature>';
+        expect(
+            getFeature(query("ft_name_test",
+                    filter(property("geometry").intersects(geom2)),
+                    {srsName: "EPSG:3857"}
+            ))
+        ).toBe(expected2);
     });
 });

--- a/web/client/utils/ogc/WFS/base.js
+++ b/web/client/utils/ogc/WFS/base.js
@@ -8,6 +8,18 @@
 
 const {head, get} = require('lodash');
 const {processOGCGeometry} = require("../GML");
+const WFS_TO_GML = {
+    "1.0.0": "2.0",
+    "1.1.0": "3.1.1",
+    "2.0": "3.2",
+    "2.0.0": "3.2"
+};
+/**
+ * retrieve default GML version from WFS version
+ * @param  {string} v WFS version
+ * @return {string}   GML version
+ */
+const wfsToGmlVersion = (v = "1.1.0") => WFS_TO_GML[v];
 /**
  * Provides the array of featureType properties
  * @param  {object} describeFeatureType the describeFeatureType object
@@ -83,5 +95,6 @@ module.exports = {
      * getTypeName({targetPrefix: "topp",featureTypes: [{typeName: "states"}]); // --> topp:states
      */
     getTypeName: (dft) => dft.targetPrefix ? dft.targetPrefix + ":" + dft.featureTypes[0].typeName : dft.featureTypes[0].typeName,
+    wfsToGmlVersion,
     processOGCGeometry
 };

--- a/web/client/utils/ogc/WFST/v1_1_0/delete.js
+++ b/web/client/utils/ogc/WFST/v1_1_0/delete.js
@@ -18,7 +18,7 @@ const {getTypeName} = require('../../WFS/base');
  */
 const deleteFeaturesByFilter = (content, typeName) =>
     `<wfs:Delete typeName="${typeName}">${content}</wfs:Delete>`;
-const deleteById = (fid, typeName) => deleteFeaturesByFilter(fidFilter(fid), typeName);
+const deleteById = (fid, typeName) => deleteFeaturesByFilter(fidFilter("ogc", fid), typeName);
 const deleteFeature = (feature, describe) => deleteById(feature.features && feature.features.length === 1 ? feature.features[0].id : feature.id, getTypeName(describe));
 module.exports = {
       deleteFeaturesByFilter,

--- a/web/client/utils/ogc/__tests__/WFS-T-test.js
+++ b/web/client/utils/ogc/__tests__/WFS-T-test.js
@@ -8,7 +8,7 @@
 
 const expect = require('expect');
 const {insert, update, property, deleteFeature, transaction} = require('../WFST');
-const {fidFilter} = require('../Filter/base');
+const {fidFilter} = require('../Filter/filter');
 const {featureTypeSchema} = require('../WFS/base');
 const describeStates = require('json-loader!../../../test-resources/wfs/describe-states.json');
 const describePois = require('json-loader!../../../test-resources/wfs/describe-pois.json');

--- a/web/client/utils/ogc/__tests__/WFS-T-test.js
+++ b/web/client/utils/ogc/__tests__/WFS-T-test.js
@@ -45,7 +45,7 @@ describe('Test WFS-T request bodies generation', () => {
     });
     it('WFS-T transaction with update', () => {
         const result = transaction(
-            [update([property("NAME", "newName"), fidFilter("poi.7")], describePois)
+            [update([property("NAME", "newName"), fidFilter("ogc", "poi.7")], describePois)
             ],
             featureTypeSchema(describePois));
         expect(result).toExist();


### PR DESCRIPTION
Made a more generic filter generator. This allows to generate OGC Filters, using syntax like
```
property("a").like("*a*")
```
We can use the same syntax to create builders for ECQL or even some server side stuff.