### PR TITLE
Do not show password prompt for current user. Fixes #1883

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-dev-server": "2.4.1",
     "webpack-parallel-uglify-plugin": "0.4.0"
   },
-  "//": "replace react-sortable-items with official on npm when 0.0.10 with remove_deprecated PR in included",
+  "//": "replace react-sortable-items with official on npm when it will support React 15",
   "dependencies": {
     "@carnesen/redux-add-action-listener-enhancer": "0.0.1",
     "@turf/inside": "4.1.0",

--- a/web/client/actions/__tests__/users-test.js
+++ b/web/client/actions/__tests__/users-test.js
@@ -36,6 +36,7 @@ describe('Test correctness of the users actions', () => {
         retFun((action) => {
             expect(action.type).toBe(USERMANAGER_GETUSERS);
             count++;
+            // we check the second action because the first one is the "loading" one
             if (count === 2) {
                 expect(action.users).toExist();
                 expect(action.users[0]).toExist();
@@ -59,9 +60,23 @@ describe('Test correctness of the users actions', () => {
                 expect(action.users[0].groups).toExist();
                 done();
             }
-
         }, () => ({users: { searchText: "users.json"}}));
+    });
 
+    it('getUsers with empty search', (done) => {
+        const retFun = getUsers(false, {params: {start: 5, limit: 10}});
+        expect(retFun).toExist();
+        let count = 0;
+        retFun((action) => {
+            expect(action.type).toBe(USERMANAGER_GETUSERS);
+            count++;
+            if (count === 2) {
+                expect(action.searchText).toBe("*");
+                expect(action.start).toBe(5);
+                expect(action.limit).toBe(10);
+                done();
+            }
+        }, () => ({}));
     });
 
     it('getUsers error', (done) => {
@@ -75,9 +90,7 @@ describe('Test correctness of the users actions', () => {
                 expect(action.error).toExist();
                 done();
             }
-
         });
-
     });
 
     it('getUsers issue returning empty response', (done) => {

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -37,7 +37,8 @@ const UserDialog = React.createClass({
       buttonSize: React.PropTypes.string,
       inputStyle: React.PropTypes.object,
       attributes: React.PropTypes.array,
-      minPasswordSize: React.PropTypes.number
+      minPasswordSize: React.PropTypes.number,
+      hidePasswordFields: React.PropTypes.bool
   },
   getDefaultProps() {
       return {
@@ -66,7 +67,8 @@ const UserDialog = React.createClass({
               padding: "5px",
               border: "1px solid #078AA3"
           },
-          minPasswordSize: 6
+          minPasswordSize: 6,
+          hidePasswordFields: false
       };
   },
   getAttributeValue(name) {
@@ -81,11 +83,33 @@ const UserDialog = React.createClass({
           return null;
       }
       let pw = this.props.user.newPassword;
-      if (pw.length === 0) {
-          return null;
-      }
       return this.isMainPasswordValid(pw) ? "success" : "warning";
-
+  },
+  renderPasswordFields() {
+      return (
+      <div>
+          <FormGroup validationState={this.getPwStyle()}>
+              <ControlLabel><Message msgId="user.password"/></ControlLabel>
+              <FormControl ref="newPassword"
+                  key="newPassword"
+                  type="password"
+                  name="newPassword"
+                  autoComplete="new-password"
+                  style={this.props.inputStyle}
+                  onChange={this.handleChange} />
+          </FormGroup>
+          <FormGroup validationState={ (this.isValidPassword() ? "success" : "error") }>
+              <ControlLabel><Message msgId="user.retypePwd"/></ControlLabel>
+              <FormControl ref="confirmPassword"
+                  key="confirmPassword"
+                  name="confirmPassword"
+                  type="password"
+                  autoComplete="new-password"
+                  style={this.props.inputStyle}
+                  onChange={this.handleChange} />
+          </FormGroup>
+      </div>
+      );
   },
   renderGeneral() {
       return (<div style={{clear: "both"}}>
@@ -100,26 +124,7 @@ const UserDialog = React.createClass({
               onChange={this.handleChange}
               value={this.props.user && this.props.user.name || ""}/>
       </FormGroup>
-      <FormGroup validationState={this.getPwStyle()}>
-          <ControlLabel><Message msgId="user.password"/></ControlLabel>
-          <FormControl ref="newPassword"
-              key="newPassword"
-              type="password"
-              name="newPassword"
-              autoComplete="new-password"
-              style={this.props.inputStyle}
-              onChange={this.handleChange} />
-      </FormGroup>
-      <FormGroup validationState={ (this.isValidPassword() ? "success" : "error") || null}>
-          <ControlLabel><Message msgId="user.retypePwd"/></ControlLabel>
-          <FormControl ref="confirmPassword"
-              key="confirmPassword"
-              name="confirmPassword"
-              type="password"
-              autoComplete="new-password"
-              style={this.props.inputStyle}
-              onChange={this.handleChange} />
-      </FormGroup>
+      {this.props.hidePasswordFields ? null : this.renderPasswordFields() }
       <select name="role" style={this.props.inputStyle} onChange={this.handleChange} value={this.props.user && this.props.user.role || ""}>
         <option value="ADMIN">ADMIN</option>
         <option value="USER">USER</option>

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -25,6 +25,10 @@ const disabledUser = {
     enabled: false,
     groups: [{
         groupName: "GROUP1"
+    }],
+    attribute: [{
+        name: "notes",
+        value: "this user is disabled"
     }]
 };
 const adminUser = {
@@ -33,6 +37,11 @@ const adminUser = {
     role: "ADMIN",
     enabled: true
 };
+const newUser = {
+    role: "USER",
+    "enabled": true
+};
+
 describe("Test UserDialog Component", () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -49,16 +58,24 @@ describe("Test UserDialog Component", () => {
         let comp = ReactDOM.render(
             <UserDialog user={enabledUser}/>, document.getElementById("container"));
         expect(comp).toExist();
+        expect(document.getElementsByName("newPassword").length).toBe(1);
+        expect(document.getElementsByName("confirmPassword").length).toBe(1);
+        expect(document.getElementsByName("enabled").length).toBe(1);
+        expect(document.getElementsByName("enabled").item(0).checked).toBe(true);
     });
     it('Test disabled user rendering', () => {
         let comp = ReactDOM.render(
             <UserDialog user={disabledUser}/>, document.getElementById("container"));
         expect(comp).toExist();
+        expect(document.getElementsByName("enabled").length).toBe(1);
+        expect(document.getElementsByName("enabled").item(0).checked).toBe(false);
     });
     it('Test admin user rendering', () => {
         let comp = ReactDOM.render(
             <UserDialog user={adminUser}/>, document.getElementById("container"));
         expect(comp).toExist();
+        expect(document.getElementsByName("role").length).toBe(1);
+        expect(document.getElementsByName("role").item(0).value).toBe("ADMIN");
     });
     it('Test user loading', () => {
         let comp = ReactDOM.render(
@@ -88,6 +105,97 @@ describe("Test UserDialog Component", () => {
             <UserDialog user={{...enabledUser, newPassword: "aaabbbà", confirmPassword: "aaabbbà"}}/>, document.getElementById("container"));
         expect(comp).toExist();
         expect(comp.isValidPassword()).toBe(false);
+    });
+    it('Test without password fields', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={enabledUser} hidePasswordFields={true}/>, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(document.getElementsByName("newPassword").length).toBe(0);
+        expect(document.getElementsByName("confirmPassword").length).toBe(0);
+    });
+    it('Test new user', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={newUser} />, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(document.getElementsByName("newPassword").length).toBe(1);
+        expect(document.getElementsByName("confirmPassword").length).toBe(1);
+        expect(document.getElementsByName("role").length).toBe(1);
+        expect(document.getElementsByName("role").item(0).value).toBe("USER");
+        expect(document.getElementsByName("enabled").length).toBe(1);
+        expect(document.getElementsByName("enabled").item(0).checked).toBe(true);
 
+    });
+    it('Test empty user', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={null} />, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(document.getElementsByName("name").length).toBe(1);
+        expect(document.getElementsByName("newPassword").length).toBe(1);
+        expect(document.getElementsByName("confirmPassword").length).toBe(1);
+        expect(document.getElementsByName("role").length).toBe(1);
+        expect(document.getElementsByName("role").item(0).value).toBe("ADMIN");
+        expect(document.getElementsByName("enabled").length).toBe(1);
+        expect(document.getElementsByName("enabled").item(0).checked).toBe(false);
+    });
+    it('calls the checkbox callback', () => {
+        const handlers = {
+            onChange() {}
+        };
+        let spy = expect.spyOn(handlers, "onChange");
+        let comp = ReactDOM.render(
+            <UserDialog user={null} onChange={handlers.onChange} />, document.getElementById("container"));
+        expect(comp).toExist();
+        document.getElementsByName("enabled").item(0).click();
+
+        comp = ReactDOM.render(
+            <UserDialog user={newUser} onChange={handlers.onChange} />, document.getElementById("container"));
+        document.getElementsByName("enabled").item(0).click();
+        expect(spy.calls.length).toBe(2);
+    });
+    it('calls the save callback', () => {
+        const handlers = {
+            onSave() {}
+        };
+        let spy = expect.spyOn(handlers, "onSave");
+        let comp = ReactDOM.render(
+            <UserDialog user={{
+                id: 1,
+                name: "USER1",
+                role: "USER",
+                enabled: true,
+                status: "modified"
+            }} onSave={handlers.onSave} />, document.getElementById("container"));
+        expect(comp).toExist();
+        let domnode = ReactDOM.findDOMNode(comp);
+        domnode.getElementsByTagName("button").item(4).click();
+
+        expect(spy.calls.length).toBe(1);
+    });
+    it('displays the spinner', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={{
+                id: 1,
+                name: "USER1",
+                role: "USER",
+                "enabled": true,
+                status: "saving"
+            }} />, document.getElementById("container"));
+        expect(comp).toExist();
+        let domnode = ReactDOM.findDOMNode(comp);
+        expect(domnode.getElementsByClassName("btn-primary")[3].disabled).toBe(true);
+        expect(domnode.getElementsByClassName("spinner").length).toNotBe(0);
+    });
+    it('displays the success style', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={{
+                id: 1,
+                name: "USER1",
+                role: "USER",
+                enabled: true,
+                status: "saved"
+            }} />, document.getElementById("container"));
+        expect(comp).toExist();
+        let domnode = ReactDOM.findDOMNode(comp);
+        expect(domnode.getElementsByClassName("btn-success").length).toBe(1);
     });
 });

--- a/web/client/plugins/manager/users/UserDialog.jsx
+++ b/web/client/plugins/manager/users/UserDialog.jsx
@@ -16,7 +16,8 @@ const mapStateToProps = (state) => {
         modal: true,
         show: users && !!users.currentUser,
         user: users && users.currentUser,
-        groups: users && users.groups
+        groups: users && users.groups,
+        hidePasswordFields: users && users.currentUser && state.security && state.security.user && state.security.user.id === users.currentUser.id
     };
 };
 const mapDispatchToProps = (dispatch) => {


### PR DESCRIPTION
The current user, usually the admin, still has the standard "change password" tool from the dropdown menu.