### PR TITLE
Fix #1919. Implemented WFS download plugin

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -175,6 +175,7 @@
                 "web/client/plugins/Search.jsx",
                 "web/client/plugins/SearchServicesConfig.jsx",
                 "web/client/plugins/TOC.jsx",
+                "web/client/plugins/WFSDownload.jsx",
                 "web/client/plugins/ZoomIn.jsx",
                 "web/client/plugins/ZoomOut.jsx"
             ]

--- a/web/client/actions/__tests__/wfsdownload-test.js
+++ b/web/client/actions/__tests__/wfsdownload-test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var expect = require('expect');
+var {
+    DOWNLOAD_FEATURES,
+    DOWNLOAD_OPTIONS_CHANGE,
+    DOWNLOAD_FINISHED,
+    downloadFeatures,
+    onDownloadOptionChange,
+    onDownloadFinished
+} = require('../wfsdownload');
+
+describe('Test correctness of the wfsdownload actions', () => {
+    it('test downloadFeatures action', () => {
+        let {type, url, filterObj, downloadOptions} = downloadFeatures("url", "filterObj", "downloadOptions");
+        expect(type).toBe(DOWNLOAD_FEATURES);
+        expect(url).toBe("url");
+        expect(filterObj).toBe("filterObj");
+        expect(downloadOptions).toBe("downloadOptions");
+    });
+    it('test onDownloadOptionChange action', () => {
+        let {type, key, value} = onDownloadOptionChange("key", "value");
+        expect(type).toBe(DOWNLOAD_OPTIONS_CHANGE);
+        expect(key).toBe("key");
+        expect(value).toBe("value");
+    });
+    it('test onDownloadFinished action', () => {
+        let {type} = onDownloadFinished();
+        expect(type).toBe(DOWNLOAD_FINISHED);
+    });
+
+
+});

--- a/web/client/actions/wfsdownload.js
+++ b/web/client/actions/wfsdownload.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const DOWNLOAD_FEATURES = "WFSDOWNLOAD::DOWNLOAD_FEATURES";
+const DOWNLOAD_FINISHED = "WFSDOWNLOAD::DOWNLOAD_FINISHED";
+const DOWNLOAD_OPTIONS_CHANGE = "WFSDOWNLOAD::FORMAT_SELECTED";
+
+/**
+ * Actions for WFS Download
+ * @memberof actions
+ * @name wfsdownload
+ * @type {Object}
+ */
+module.exports = {
+    DOWNLOAD_FEATURES,
+    DOWNLOAD_OPTIONS_CHANGE,
+    DOWNLOAD_FINISHED,
+    /**
+     * action to download features
+     * @memberof actions.wfsdownload
+     * @param  {string} url             the URL of WFSDownload
+     * @param  {object} filterObj       the object that represent the WFS filterObj
+     * @param  {object} downloadOptions download options e.g. `{singlePage: true|false, selectedFormat: "csv"}`
+     * @return {action}                 The action of type `DOWNLOAD_FEATURES`
+     */
+    downloadFeatures: (url, filterObj, downloadOptions) => ({
+        type: DOWNLOAD_FEATURES,
+        url,
+        filterObj,
+        downloadOptions
+    }),
+    /**
+     * action for change download options
+     * @memberof actions.wfsdownload
+     * @param  {string} key   the value key to change. e.g. selectedFormat
+     * @param  {string|boolean} value the value of the option
+     * @return {action}       the action of type `DOWNLOAD_OPTIONS_CHANGE`
+     */
+    onDownloadOptionChange: (key, value) => ({
+        type: DOWNLOAD_OPTIONS_CHANGE,
+        key,
+        value
+    }),
+    /**
+     * action that notifies the end of the downloadOptions
+     * @memberof actions.wfsdownload
+     * @return {action} action of type `DOWNLOAD_FINISHED`
+     */
+    onDownloadFinished: () => ({
+        type: DOWNLOAD_FINISHED
+    })
+};

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -1,0 +1,75 @@
+const React = require('react');
+const {Button, Glyphicon} = require('react-bootstrap');
+const Spinner = require('react-spinkit');
+
+const Dialog = require('../../misc/Dialog');
+const Message = require('../../I18N/Message');
+const DownloadOptions = require('./DownloadOptions');
+
+const DownloadDialog = React.createClass({
+    propTypes: {
+        filterObj: React.PropTypes.object,
+        closeGlyph: React.PropTypes.string,
+        url: React.PropTypes.string,
+        onMount: React.PropTypes.func,
+        onUnmount: React.PropTypes.func,
+        enabled: React.PropTypes.bool,
+        loading: React.PropTypes.bool,
+        onClose: React.PropTypes.func,
+        onExport: React.PropTypes.func,
+        onDownloadOptionChange: React.PropTypes.func,
+        downloadOptions: React.PropTypes.object,
+        formats: React.PropTypes.array
+    },
+    getDefaultProps() {
+        return {
+            onMount: () => {},
+            onUnmount: () => {},
+            onExport: () => {},
+            onClose: () => {},
+            onDownloadOptionChange: () => {},
+            closeGlyph: "1-close",
+            formats: [
+                {name: "csv", label: "csv"},
+                {name: "shape-zip", label: "shape-zip"}
+            ]
+        };
+    },
+    componentDidMount() {
+        this.props.onMount();
+    },
+    componentWillUnmount() {
+        this.props.onUnmount();
+    },
+    onClose() {
+        this.props.onClose();
+    },
+    renderIcon() {
+        return this.props.loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
+    },
+    render() {
+        return (<Dialog id="mapstore-export" style={{display: this.props.enabled ? "block" : "none"}}>
+            <span role="header">
+                <span className="about-panel-title"><Message msgId="wfsdownload.title" /></span>
+                <button onClick={this.props.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>
+                </span>
+            <div role="body">
+                <DownloadOptions
+                    downloadOptions={this.props.downloadOptions}
+                    onChange={this.props.onDownloadOptionChange}
+                    formats={this.props.formats}/>
+                </div>
+            <div role="footer">
+                <Button
+                    bsStyle="primary"
+                    className="download-button"
+                    disabled={!this.props.downloadOptions.selectedFormat || this.props.loading}
+                    onClick={() => this.props.onExport(this.props.url, this.props.filterObj, this.props.downloadOptions)}>
+                     {this.renderIcon()} <Message msgId="wfsdownload.export" />
+                </Button>
+            </div>
+        </Dialog>);
+    }
+});
+
+module.exports = DownloadDialog;

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const Select = require('react-select');
+const {Checkbox} = require('react-bootstrap');
+const {get, head} = require('lodash');
+const Message = require('../../I18N/Message');
+/**
+ * Download Options Form. Shows a selector of the options to perform a WFS download
+ * @memberof components.data.download
+ * @name DownloadOptions
+ * @class
+ * @prop {object} downloadOptions the options to set. e.g. `{singlePage: true|false, selectedFormat: "csv"}`
+ * @prop {array} formats the selectable format options.
+ * @prop {function} onChange the function to trigger when some option changes
+ */
+module.exports = React.createClass({
+    propTypes: {
+            downloadOptions: React.PropTypes.object,
+            formats: React.PropTypes.array,
+            onChange: React.PropTypes.func
+    },
+    getSelectedFormat() {
+        return get(this.props, "downloadOptions.selectedFormat") || get(head(this.props.formats), "value");
+    },
+    getDefaultProps() {
+        return {
+            downloadOptions: {}
+        };
+    },
+    render() {
+        return (<form>
+            <label><Message msgId="wfsdownload.format" /></label>
+            <Select
+                clearable={false}
+                value={this.getSelectedFormat()}
+                onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
+                options={this.props.formats.map(f => ({value: f.name, label: f.label || f.name}))} />
+            <Checkbox checked={this.props.downloadOptions.singlePage} onChange={() => this.props.onChange("singlePage", !this.props.downloadOptions.singlePage ) }>
+                <Message msgId="wfsdownload.downloadonlycurrentpage" />
+            </Checkbox>
+        </form>);
+    }
+});

--- a/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadDialog-test.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react');
+var ReactDOM = require('react-dom');
+var DownloadDialog = require('../DownloadDialog');
+var expect = require('expect');
+const spyOn = expect.spyOn;
+const TestUtils = require('react-addons-test-utils');
+
+describe('Test for DownloadOptions component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    // test DEFAULTS
+    it('render with defaults', () => {
+        const cmp = ReactDOM.render(<DownloadDialog/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+    it('render with enabled', () => {
+        const cmp = ReactDOM.render(<DownloadDialog enabled={true} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(TestUtils.scryRenderedDOMComponentsWithClass(cmp, "Select-value-label")).toExist();
+    });
+    it('export event', () => {
+        const events = {
+            onExport: () => {}
+        };
+        spyOn(events, "onExport");
+        ReactDOM.render(<DownloadDialog onExport={events.onExport} downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        const btn = document.querySelector('button.download-button');
+        btn.click();
+        expect(events.onExport).toHaveBeenCalled();
+
+    });
+});

--- a/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var React = require('react');
+var ReactDOM = require('react-dom');
+var DownloadOptions = require('../DownloadOptions');
+var expect = require('expect');
+const spyOn = expect.spyOn;
+const TestUtils = require('react-addons-test-utils');
+
+describe('Test for DownloadOptions component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    // test DEFAULTS
+    it('render with defaults', () => {
+        const cmp = ReactDOM.render(<DownloadOptions/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+    it('render with element selected', () => {
+        const cmp = ReactDOM.render(<DownloadOptions downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(TestUtils.scryRenderedDOMComponentsWithClass(cmp, "Select-value-label")).toExist();
+    });
+    it('singlePage checkbox events', () => {
+        const events = {
+            onChange: () => {}
+        };
+        spyOn(events, "onChange");
+        ReactDOM.render(<DownloadOptions onChange={events.onChange} downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        const check = document.querySelector('input[type=checkbox]');
+        check.click();
+        expect(events.onChange).toHaveBeenCalled();
+
+    });
+});

--- a/web/client/components/data/featuregrid/DockedFeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/DockedFeatureGrid.jsx
@@ -58,7 +58,9 @@ const DockedFeatureGrid = React.createClass({
         dockSize: React.PropTypes.number,
         minDockSize: React.PropTypes.number,
         maxDockSize: React.PropTypes.number,
-        setDockSize: React.PropTypes.func
+        setDockSize: React.PropTypes.func,
+        exportAction: React.PropTypes.func,
+        exportEnabled: React.PropTypes.bool
     },
     contextTypes: {
         messages: React.PropTypes.object
@@ -251,6 +253,7 @@ const DockedFeatureGrid = React.createClass({
                                 height: "100%"
                                 }}>
                             <FeatureGrid
+                                exportAction={this.props.exportEnabled && this.props.exportAction}
                                 useIcons={true}
                                 tools={[<Button onClick={this.props.onBackToSearch} ><Glyphicon glyph="arrow-left" /><I18N.Message msgId="featuregrid.backtosearch"/></Button>]}
                                 key={"search-results-" + (this.state && this.state.searchN)}

--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -1,0 +1,68 @@
+const {DOWNLOAD_FEATURES, onDownloadFinished} = require('../actions/wfsdownload');
+const {error} = require('../actions/notifications');
+const Rx = require('rxjs');
+const {get} = require('lodash');
+const {saveAs} = require('file-saver');
+const axios = require('axios');
+const FilterUtils = require('../utils/FilterUtils');
+const {getByOutputFormat} = require('../utils/FileFormatUtils');
+
+const getWFSFeature = ({url, filterObj = {}, downloadOptions= {}} = {}) => {
+    const data = FilterUtils.toOGCFilter(filterObj.featureTypeName, filterObj, filterObj.ogcVersion);
+    return Rx.Observable.defer( () =>
+        axios.post(url + `?service=WFS&outputFormat=${downloadOptions.selectedFormat}`, data, {
+          timeout: 60000,
+          responseType: 'arraybuffer',
+          headers: {'Content-Type': 'application/xml'}
+    }));
+};
+const getFileName = action => {
+    const name = get(action, "filterObj.featureTypeName");
+    const format = getByOutputFormat(get(action, "downloadOptions.selectedFormat"));
+    if (format && format.extension) {
+        return name + "." + format.extension;
+    }
+    return name;
+};
+/*
+const str2bytes = (str) => {
+    var bytes = new Uint8Array(str.length);
+    for (let i = 0; i < str.length; i++) {
+        bytes[i] = str.charCodeAt(i);
+    }
+    return bytes;
+};
+*/
+module.exports = {
+    startFeatureExportDownload: action$ =>
+        action$.ofType(DOWNLOAD_FEATURES).switchMap(action =>
+            getWFSFeature({
+                    url: action.url,
+                    downloadOptions: action.downloadOptions,
+                    filterObj: {
+                        ...action.filterObj,
+                        pagination: get(action, "downloadOptions.singlePage") ? action.filterObj.pagination : null
+                    }
+                })
+                .do(({data, headers}) => {
+                    if (headers["content-type"] === "application/xml") { // TODO add expected mimetypes in the case you want application/dxf
+                        let xml = String.fromCharCode.apply(null, new Uint8Array(data));
+                        if (xml.indexOf("<ows:ExceptionReport") === 0 ) {
+                            throw xml;
+                        }
+                    }
+                    saveAs(new Blob([data], {type: headers && headers["content-type"]}), getFileName(action));
+                })
+                .map( () => onDownloadFinished() )
+                .catch( () => Rx.Observable.of(
+                    error({
+                        title: "wfsdownload.error.title",
+                        message: "wfsdownload.error.invalidOutputFormat",
+                        autoDismiss: 5,
+                        position: "tr"
+                    }),
+                    onDownloadFinished())
+                )
+
+        )
+};

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -149,7 +149,7 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home", "FeatureGrid", {
+            }, "Home", "FeatureGrid", "WFSDownload", {
                 "name": "TOC",
                 "cfg": {
                     "activateQueryTool": true

--- a/web/client/plugins/FeatureGrid.jsx
+++ b/web/client/plugins/FeatureGrid.jsx
@@ -9,10 +9,12 @@ const {connect} = require('react-redux');
 const {selectFeatures, dockSizeFeatures} = require('../actions/featuregrid');
 const {query, closeResponse} = require('../actions/wfsquery');
 const {changeMapView} = require('../actions/map');
+const {toggleControl} = require('../actions/controls');
 
 module.exports = {
     FeatureGridPlugin: connect((state) => ({
         open: state.query && state.query.open,
+        exportEnabled: state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.avaliable,
         features: state.query && state.query.result && state.query.result.features,
         filterObj: state.query && state.query.filterObj,
         searchUrl: state.query && state.query.searchUrl,
@@ -34,6 +36,7 @@ module.exports = {
     }),
     {
         selectFeatures,
+        exportAction: () => toggleControl("wfsdownload"),
         changeMapView,
         onQuery: query,
         onBackToSearch: closeResponse,

--- a/web/client/plugins/FeatureGrid.jsx
+++ b/web/client/plugins/FeatureGrid.jsx
@@ -14,7 +14,7 @@ const {toggleControl} = require('../actions/controls');
 module.exports = {
     FeatureGridPlugin: connect((state) => ({
         open: state.query && state.query.open,
-        exportEnabled: state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.avaliable,
+        exportEnabled: state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.available,
         features: state.query && state.query.result && state.query.result.features,
         filterObj: state.query && state.query.filterObj,
         searchUrl: state.query && state.query.searchUrl,

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const {connect} = require('react-redux');
+const {Button, Glyphicon} = require('react-bootstrap');
+const Spinner = require('react-spinkit');
+
+const {downloadFeatures, onDownloadOptionChange} = require('../actions/wfsdownload');
+const {toggleControl, setControlProperty} = require('../actions/controls');
+
+const {createSelector} = require('reselect');
+const {wfsURL, wfsFilter} = require('../selectors/query');
+
+const Dialog = require('../components/misc/Dialog');
+const Message = require('../components/I18N/Message');
+const DownloadOptions = require('../components/data/download/DownloadOptions');
+/**
+ * Provides advanced export functionalities using WFS.
+ * @memberof plugins
+ * @class
+ * @prop {object[]} formats An array of name-label objects for the allowed formats avaliable.
+ * @prop {string} closeGlyph The icon to use for close the dialog
+ * @example
+ * {
+ *  "name": "WFSDownload",
+ *  "cfg": {
+ *    "formats": [
+ *            {"name": "csv", "label": "csv"},
+ *            {"name": "shape-zip", "label": "shape-zip"},
+ *            {"name": "excel", "label": "excel"},
+ *            {"name": "excel2007", "label": "excel2007"},
+ *            {"name": "dxf-zip", "label": "dxf-zip"}
+ *    ]
+ *  }
+ * }
+ */
+const WFSDownload = React.createClass({
+    propTypes: {
+        filterObj: React.PropTypes.object,
+        closeGlyph: React.PropTypes.string,
+        url: React.PropTypes.string,
+        onMount: React.PropTypes.func,
+        onUnmount: React.PropTypes.func,
+        enabled: React.PropTypes.bool,
+        loading: React.PropTypes.bool,
+        onClose: React.PropTypes.func,
+        onExport: React.PropTypes.func,
+        onDownloadOptionChange: React.PropTypes.func,
+        downloadOptions: React.PropTypes.object,
+        formats: React.PropTypes.array
+    },
+    getDefaultProps() {
+        return {
+            onExport: () => {},
+            onClose: () => {},
+            onDownloadOptionChange: () => {},
+            closeGlyph: "1-close",
+            formats: [
+                {name: "csv", label: "csv"},
+                {name: "shape-zip", label: "shape-zip"}
+            ]
+        };
+    },
+    componentDidMount() {
+        this.props.onMount();
+    },
+    componentWillUnmount() {
+        this.props.onUnmount();
+    },
+    onClose() {
+        this.props.onClose();
+    },
+    renderIcon() {
+        return this.props.loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
+    },
+    render() {
+        return (<Dialog id="mapstore-export" style={{display: this.props.enabled ? "block" : "none"}}>
+            <span role="header">
+                <span className="about-panel-title"><Message msgId="wfsdownload.title" /></span>
+                <button onClick={this.props.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>
+                </span>
+            <div role="body">
+                <DownloadOptions
+                    downloadOptions={this.props.downloadOptions}
+                    onChange={this.props.onDownloadOptionChange}
+                    formats={this.props.formats}/>
+                </div>
+            <div role="footer">
+                <Button
+                    bsStyle="primary"
+                    disabled={!this.props.downloadOptions.selectedFormat || this.props.loading}
+                    onClick={() => this.props.onExport(this.props.url, this.props.filterObj, this.props.downloadOptions)}>
+                     {this.renderIcon()} <Message msgId="wfsdownload.export" />
+                </Button>
+            </div>
+        </Dialog>);
+    }
+});
+
+module.exports = {
+    WFSDownloadPlugin: connect(createSelector(
+            wfsURL,
+            wfsFilter,
+            state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
+            state => state && state.wfsdownload && state.wfsdownload.downloadOptions,
+            state => state && state.wfsdownload && state.wfsdownload.loading,
+            (url, filterObj, enabled, downloadOptions, loading) => ({
+                url,
+                filterObj,
+                enabled,
+                downloadOptions,
+                loading
+            })
+    ), {
+        onExport: downloadFeatures,
+        onDownloadOptionChange,
+        onMount: () => setControlProperty("wfsdownload", "avaliable", true),
+        onUnmount: () => setControlProperty("wfsdownload", "avaliable", false),
+        onClose: () => toggleControl("wfsdownload")
+    }
+    )(WFSDownload),
+    epics: require('../epics/wfsdownload'),
+    reducers: {
+        wfsdownload: require('../reducers/wfsdownload')
+    }
+};

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -5,25 +5,20 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const React = require('react');
 const {connect} = require('react-redux');
-const {Button, Glyphicon} = require('react-bootstrap');
-const Spinner = require('react-spinkit');
-
 const {downloadFeatures, onDownloadOptionChange} = require('../actions/wfsdownload');
 const {toggleControl, setControlProperty} = require('../actions/controls');
 
 const {createSelector} = require('reselect');
 const {wfsURL, wfsFilter} = require('../selectors/query');
 
-const Dialog = require('../components/misc/Dialog');
-const Message = require('../components/I18N/Message');
-const DownloadOptions = require('../components/data/download/DownloadOptions');
+const DownloadDialog = require('../components/data/download/DownloadDialog');
 /**
  * Provides advanced export functionalities using WFS.
  * @memberof plugins
+ * @name WFSDownload
  * @class
- * @prop {object[]} formats An array of name-label objects for the allowed formats avaliable.
+ * @prop {object[]} formats An array of name-label objects for the allowed formats available.
  * @prop {string} closeGlyph The icon to use for close the dialog
  * @example
  * {
@@ -39,69 +34,6 @@ const DownloadOptions = require('../components/data/download/DownloadOptions');
  *  }
  * }
  */
-const WFSDownload = React.createClass({
-    propTypes: {
-        filterObj: React.PropTypes.object,
-        closeGlyph: React.PropTypes.string,
-        url: React.PropTypes.string,
-        onMount: React.PropTypes.func,
-        onUnmount: React.PropTypes.func,
-        enabled: React.PropTypes.bool,
-        loading: React.PropTypes.bool,
-        onClose: React.PropTypes.func,
-        onExport: React.PropTypes.func,
-        onDownloadOptionChange: React.PropTypes.func,
-        downloadOptions: React.PropTypes.object,
-        formats: React.PropTypes.array
-    },
-    getDefaultProps() {
-        return {
-            onExport: () => {},
-            onClose: () => {},
-            onDownloadOptionChange: () => {},
-            closeGlyph: "1-close",
-            formats: [
-                {name: "csv", label: "csv"},
-                {name: "shape-zip", label: "shape-zip"}
-            ]
-        };
-    },
-    componentDidMount() {
-        this.props.onMount();
-    },
-    componentWillUnmount() {
-        this.props.onUnmount();
-    },
-    onClose() {
-        this.props.onClose();
-    },
-    renderIcon() {
-        return this.props.loading ? <div style={{"float": "left"}}><Spinner spinnerName="circle" noFadeIn/></div> : <Glyphicon glyph="download" />;
-    },
-    render() {
-        return (<Dialog id="mapstore-export" style={{display: this.props.enabled ? "block" : "none"}}>
-            <span role="header">
-                <span className="about-panel-title"><Message msgId="wfsdownload.title" /></span>
-                <button onClick={this.props.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>
-                </span>
-            <div role="body">
-                <DownloadOptions
-                    downloadOptions={this.props.downloadOptions}
-                    onChange={this.props.onDownloadOptionChange}
-                    formats={this.props.formats}/>
-                </div>
-            <div role="footer">
-                <Button
-                    bsStyle="primary"
-                    disabled={!this.props.downloadOptions.selectedFormat || this.props.loading}
-                    onClick={() => this.props.onExport(this.props.url, this.props.filterObj, this.props.downloadOptions)}>
-                     {this.renderIcon()} <Message msgId="wfsdownload.export" />
-                </Button>
-            </div>
-        </Dialog>);
-    }
-});
-
 module.exports = {
     WFSDownloadPlugin: connect(createSelector(
             wfsURL,
@@ -119,11 +51,11 @@ module.exports = {
     ), {
         onExport: downloadFeatures,
         onDownloadOptionChange,
-        onMount: () => setControlProperty("wfsdownload", "avaliable", true),
-        onUnmount: () => setControlProperty("wfsdownload", "avaliable", false),
+        onMount: () => setControlProperty("wfsdownload", "available", true),
+        onUnmount: () => setControlProperty("wfsdownload", "available", false),
         onClose: () => toggleControl("wfsdownload")
     }
-    )(WFSDownload),
+)(DownloadDialog),
     epics: require('../epics/wfsdownload'),
     reducers: {
         wfsdownload: require('../reducers/wfsdownload')

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -63,6 +63,7 @@ module.exports = {
         CreateNewMapPlugin: require('../plugins/CreateNewMap'),
         QueryPanelPlugin: require('../plugins/QueryPanel'),
         FeatureGridPlugin: require('../plugins/FeatureGrid'),
+        WFSDownloadPlugin: require('../plugins/WFSDownload'),
         TutorialPlugin: require('../plugins/Tutorial'),
         ThemeSwitcherPlugin: require('../plugins/ThemeSwitcher'),
         ScrollTopPlugin: require('../plugins/ScrollTop'),

--- a/web/client/reducers/__tests__/wfsdownload-test.js
+++ b/web/client/reducers/__tests__/wfsdownload-test.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {
+    onDownloadOptionChange, downloadFeatures, onDownloadFinished} = require('../../actions/wfsdownload');
+const wfsdownload = require('../wfsdownload');
+
+const expect = require('expect');
+
+describe('Test the wfsdownload reducer', () => {
+    it('downloadFeatures', () => {
+        const state = wfsdownload({}, downloadFeatures());
+        expect(state.loading).toBe(true);
+    });
+    it('onDownloadOptionChange', () => {
+        const state = wfsdownload({}, onDownloadOptionChange("selectedFormat", "csv"));
+        expect(state.downloadOptions).toExist();
+        expect(state.downloadOptions.selectedFormat).toBe("csv");
+    });
+    it('onDownloadFinished', () => {
+        const state = wfsdownload({loading: true}, onDownloadFinished());
+        expect(state.loading).toBe(false);
+    });
+
+});

--- a/web/client/reducers/wfsdownload.js
+++ b/web/client/reducers/wfsdownload.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {DOWNLOAD_OPTIONS_CHANGE, DOWNLOAD_FEATURES, DOWNLOAD_FINISHED} = require('../actions/wfsdownload');
+
+/**
+ * reducer for wfsdownload
+ * @memberof reducers
+ * @param  {Object} [state={downloadOptions: {}}]          The initial state
+ * @param  {Object} action                   the action
+ * @return {Object}                          the new state
+ *
+ * @prop {object}  downloadOptions the options for WFS download
+ * @prop {string}  downloadOptions.selectedFormat the format selectedFormat
+ * @prop {boolean} downloadOptions.singlePage export only the current page, not the whole data
+ */
+function wfsdownload( state = {downloadOptions: {singlePage: true}}, action) {
+    switch (action.type) {
+        case DOWNLOAD_FEATURES:
+            return {
+                ...state,
+                loading: true
+            };
+        case DOWNLOAD_OPTIONS_CHANGE:
+            return {
+                ...state,
+                downloadOptions: {
+                    ...state.downloadOptions,
+                    [action.key]: action.value
+                }
+            };
+        case DOWNLOAD_FINISHED: {
+            return {
+                ...state,
+                loading: false
+            };
+        }
+        default:
+            return state;
+
+    }
+    return state;
+}
+
+module.exports = wfsdownload;

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -1,0 +1,4 @@
+module.exports = {
+    wfsURL: state => state && state.query && state.query.searchUrl,
+    wfsFilter: state => state && state.query && state.query.filterObj
+};

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -779,6 +779,16 @@
                 "more": "viele"
             }
         },
+        "wfsdownload": {
+            "title": "Daten exportieren",
+            "format": "Datei Format",
+            "export": "Export",
+            "downloadonlycurrentpage": "Nur aktuelle Seite herunterladen",
+            "error": {
+                "title": "Fehler beim Export",
+                "invalidOutputFormat": "Das ausgewählte Exportformat ist nicht verfügbar"
+            }
+        },
         "vectorstyler": {
             "tooltip": "Erstelle und bearbeite den Vektor Ebenen Stil",
             "paneltitle": "Vektor Styler",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -779,6 +779,16 @@
                 "more": "more"
             }
         },
+        "wfsdownload": {
+            "title": "Export Data",
+            "format": "File Format",
+            "export": "Export",
+            "downloadonlycurrentpage": "Download only current page",
+            "error": {
+                "title": "Error during export",
+                "invalidOutputFormat": "The selected export format is not available"
+            }
+        },
         "vectorstyler": {
             "tooltip": "Create and edit vector layer style",
             "paneltitle": "Vector Styler",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -782,6 +782,16 @@
                 "more": "plus"
             }
         },
+        "wfsdownload": {
+            "title": "Exporter des données",
+            "format": "Format de fichier",
+            "export": "Exportations",
+            "downloadonlycurrentpage": "Télécharger uniquement la page actuelle",
+            "error": {
+                "title": "Erreur lors de l'exportation",
+                "invalidOutputFormat": "Le format d'exportation sélectionné n'est pas disponible"
+            }
+        },
         "vectorstyler": {
             "tooltip": "Créer et éditer un style de couche vectorielle",
             "paneltitle": "Style de couche",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -779,6 +779,16 @@
                 "more": "molte"
             }
         },
+        "wfsdownload": {
+            "title": "Esporta Dati",
+            "format": "Formato file",
+            "export": "Esporta",
+            "downloadonlycurrentpage": "Scarica solo la pagina corrente",
+            "error": {
+                "title": "Errore durante l'esportazione",
+                "invalidOutputFormat": "Il formato selezionato non è disponibile"
+            }
+        },
         "vectorstyler": {
             "tooltip": "Crea e modifica lo stile dei layer vettoriali",
             "paneltitle": "Vector Styler",

--- a/web/client/utils/FileFormatUtils.js
+++ b/web/client/utils/FileFormatUtils.js
@@ -1,0 +1,26 @@
+const {head} = require('lodash');
+const formats = [{
+        outputFormat: "shape-zip",
+        extension: "zip"
+    }, {
+            outputFormat: "csv",
+            extension: "csv"
+    }, {
+        outputFormat: "excel",
+        extension: "xls"
+    }, {
+        outputFormat: "excel2007",
+        extension: "xlsx"
+    }, {
+        outputFormat: "dxf",
+        extension: "dxf"
+    }, {
+        outputFormat: "dxf-zip",
+        extension: "zip"
+    }
+];
+
+module.exports = {
+    formats,
+    getByOutputFormat: (outF) => head(formats.filter(format => format.outputFormat === outF))
+};


### PR DESCRIPTION
This plugin provides the functionalities to export data from WFS in multiple formats.
Can be configured specifying the list of allowed fomats.
 - Fix #1919 - Add formats to the plugin
 - Add query filterObj selector
 - If the WFSPlugin is missing, the feature grid will continue working as usual, waiting for the new implementation