### PR TITLE
Fix #1850 made zoom to max extension always visible

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -203,7 +203,14 @@
                 },
                 "isDefault": false
             },
-            "ScaleBox", "ZoomAll", {
+            "ScaleBox", {
+              "name":"ZoomAll",
+              "override": {
+                "Toolbar": {
+                  "alwaysVisible": true
+                }
+              }
+            }, {
                 "name": "MapLoading",
                 "override": {
                     "Toolbar": {


### PR DESCRIPTION
Fix #1850.
This has been done only for desktop configuration.
It is hidden in the mobile configuration.