### PR TITLE
Fix #1956 Tutorial autostart do not work anymore

### DIFF
--- a/web/client/actions/__tests__/tutorial-test.js
+++ b/web/client/actions/__tests__/tutorial-test.js
@@ -11,12 +11,14 @@ var expect = require('expect');
 var {
     START_TUTORIAL,
     SETUP_TUTORIAL,
+    INIT_TUTORIAL,
     UPDATE_TUTORIAL,
     DISABLE_TUTORIAL,
     RESET_TUTORIAL,
     CLOSE_TUTORIAL,
     TOGGLE_TUTORIAL,
     startTutorial,
+    initTutorial,
     setupTutorial,
     updateTutorial,
     disableTutorial,
@@ -31,6 +33,24 @@ describe('Test the tutorial actions', () => {
         const retval = startTutorial();
         expect(retval).toExist();
         expect(retval.type).toBe(START_TUTORIAL);
+    });
+
+    it('initTutorial', () => {
+        const id = 'id';
+        const steps = 'steps';
+        const style = 'style';
+        const checkbox = 'checkbox';
+        const defaultStep = 'defaultStep';
+        const presetList = 'presetList';
+        const retval = initTutorial(id, steps, style, checkbox, defaultStep, presetList);
+        expect(retval).toExist();
+        expect(retval.type).toBe(INIT_TUTORIAL);
+        expect(retval.id).toBe(id);
+        expect(retval.steps).toBe(steps);
+        expect(retval.style).toBe(style);
+        expect(retval.checkbox).toBe(checkbox);
+        expect(retval.defaultStep).toBe(defaultStep);
+        expect(retval.presetList).toBe(presetList);
     });
 
     it('setupTutorial', () => {

--- a/web/client/actions/tutorial.js
+++ b/web/client/actions/tutorial.js
@@ -7,6 +7,7 @@
  */
 
 const START_TUTORIAL = 'START_TUTORIAL';
+const INIT_TUTORIAL = 'INIT_TUTORIAL';
 const SETUP_TUTORIAL = 'SETUP_TUTORIAL';
 const UPDATE_TUTORIAL = 'UPDATE_TUTORIAL';
 const DISABLE_TUTORIAL = 'DISABLE_TUTORIAL';
@@ -17,6 +18,18 @@ const TOGGLE_TUTORIAL = 'TOGGLE_TUTORIAL';
 function startTutorial() {
     return {
         type: START_TUTORIAL
+    };
+}
+
+function initTutorial(id, steps, style, checkbox, defaultStep, presetList) {
+    return {
+        type: INIT_TUTORIAL,
+        id,
+        steps,
+        style,
+        checkbox,
+        defaultStep,
+        presetList
     };
 }
 
@@ -66,6 +79,7 @@ function toggleTutorial() {
 
 module.exports = {
     START_TUTORIAL,
+    INIT_TUTORIAL,
     SETUP_TUTORIAL,
     UPDATE_TUTORIAL,
     DISABLE_TUTORIAL,
@@ -73,6 +87,7 @@ module.exports = {
     CLOSE_TUTORIAL,
     TOGGLE_TUTORIAL,
     startTutorial,
+    initTutorial,
     setupTutorial,
     updateTutorial,
     disableTutorial,

--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -9,6 +9,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const Joyride = require('react-joyride').default;
 const I18N = require('../I18N/I18N');
+const assign = require('object-assign');
 
 require('react-joyride/lib/react-joyride-compiled.css');
 require('./style/tutorial.css');
@@ -49,7 +50,6 @@ class Tutorial extends React.Component {
         presetList: PropTypes.object,
         intro: PropTypes.bool,
         introPosition: PropTypes.number,
-        rawSteps: PropTypes.array,
         showCheckbox: PropTypes.bool,
         defaultStep: PropTypes.object,
         introStyle: PropTypes.object,
@@ -81,7 +81,6 @@ class Tutorial extends React.Component {
         preset: 'default_tutorial',
         presetList: {},
         introPosition: (window.innerHeight - 348) / 2,
-        rawSteps: [],
         showCheckbox: true,
         defaultStep: {
             title: '',
@@ -120,9 +119,9 @@ class Tutorial extends React.Component {
     };
 
     componentWillMount() {
-        let rawSteps = this.props.rawSteps.length > 0 ? this.props.rawSteps : this.props.presetList[this.props.preset] || [];
+        let defaultSteps = this.props.presetList[this.props.preset] || [];
         let checkbox = this.props.showCheckbox ? <div id="tutorial-intro-checkbox-container"><input type="checkbox" id="tutorial-intro-checkbox" className="tutorial-tooltip-intro-checkbox" onChange={this.props.actions.onDisable}/><span><I18N.Message msgId={"tutorial.checkbox"}/></span></div> : <div id="tutorial-intro-checkbox-container"/>;
-        this.props.actions.onSetup('default', rawSteps, this.props.introStyle, checkbox, this.props.defaultStep);
+        this.props.actions.onSetup('default', defaultSteps, this.props.introStyle, checkbox, this.props.defaultStep, assign({}, this.props.presetList, {default_tutorial: defaultSteps}));
     }
 
     componentWillUpdate(newProps) {

--- a/web/client/components/tutorial/__tests__/Tutorial-test.jsx
+++ b/web/client/components/tutorial/__tests__/Tutorial-test.jsx
@@ -12,14 +12,6 @@ const ReactDOM = require('react-dom');
 const Tutorial = require('../Tutorial');
 const I18N = require('../../I18N/I18N');
 
-const rawSteps = [
-    {
-        title: 'raw',
-        text: 'test',
-        selector: '#intro-tutorial'
-    }
-];
-
 const presetList = {
     test: [
         {
@@ -87,7 +79,7 @@ describe("Test the Tutorial component", () => {
         expect(cmp).toExist();
 
         expect(spySetup).toHaveBeenCalled();
-        expect(spySetup).toHaveBeenCalledWith('default', [], {}, <div id="tutorial-intro-checkbox-container"/>, {});
+        expect(spySetup).toHaveBeenCalledWith('default', [], {}, <div id="tutorial-intro-checkbox-container"/>, {}, {default_tutorial: []});
 
         const domNode = ReactDOM.findDOMNode(cmp);
         expect(domNode).toExist();
@@ -120,7 +112,7 @@ describe("Test the Tutorial component", () => {
         expect(cmp).toExist();
 
         expect(spySetup).toHaveBeenCalled();
-        expect(spySetup).toHaveBeenCalledWith('default', presetList.test, {}, <div id="tutorial-intro-checkbox-container"><input type="checkbox" id="tutorial-intro-checkbox" className="tutorial-tooltip-intro-checkbox" onChange={cmp.props.actions.onDisable}/><span><I18N.Message msgId={"tutorial.checkbox"}/></span></div>, {});
+        expect(spySetup).toHaveBeenCalledWith('default', presetList.test, {}, <div id="tutorial-intro-checkbox-container"><input type="checkbox" id="tutorial-intro-checkbox" className="tutorial-tooltip-intro-checkbox" onChange={cmp.props.actions.onDisable}/><span><I18N.Message msgId={"tutorial.checkbox"}/></span></div>, {}, {default_tutorial: presetList.test, test: presetList.test});
 
         const domNode = ReactDOM.findDOMNode(cmp);
         expect(domNode).toExist();
@@ -152,41 +144,6 @@ describe("Test the Tutorial component", () => {
 
         const back = cmp.checkFirstValidStep(0, 'back');
         expect(back).toBe(-1);
-    });
-
-    it('test component with raw steps', () => {
-        const spySetup = expect.spyOn(actions, 'onSetup');
-        const spyClose = expect.spyOn(actions, 'onClose');
-        const spyStart = expect.spyOn(actions, 'onStart');
-        const spyUpdate = expect.spyOn(actions, 'onUpdate');
-
-        const cmp = ReactDOM.render(<Tutorial introStyle={{}} rawSteps={rawSteps} steps={rawSteps} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox={false} actions={actions}/>, document.getElementById("container"));
-        expect(cmp).toExist();
-
-        expect(spySetup).toHaveBeenCalled();
-        expect(spySetup).toHaveBeenCalledWith('default', rawSteps, {}, <div id="tutorial-intro-checkbox-container"/>, {});
-
-        const domNode = ReactDOM.findDOMNode(cmp);
-        expect(domNode).toExist();
-        expect(domNode.children.length).toBe(2);
-
-        const joyride = domNode.getElementsByClassName('joyride');
-        expect(joyride).toExist();
-        expect(joyride.length).toBe(1);
-
-        const intro = domNode.getElementsByClassName('tutorial-presentation-position');
-        expect(intro).toExist();
-        expect(intro.length).toBe(1);
-
-        cmp.componentWillUpdate({status: 'error'});
-        expect(spyStart).toHaveBeenCalled();
-
-        cmp.componentWillUpdate({status: 'run'});
-        expect(spyClose).toNotHaveBeenCalled();
-
-        cmp.onTour({type: 'step:before'});
-        expect(spyUpdate).toHaveBeenCalled();
-        expect(spyUpdate).toHaveBeenCalledWith({type: 'step:before'}, rawSteps);
     });
 
     it('test component with error on update', () => {

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -50,7 +50,7 @@ const switchTutorialEpic = (action$, store) =>
             const defaultName = path ? 'default' : action.payload;
             return !isEmpty(presetList) ? Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
                 setupTutorial(path + mobile, presetList[path + mobile + '_tutorial']) :
-                setupTutorial(defaultName + 'default' + mobile, presetList['default' + mobile + '_tutorial'])
+                setupTutorial(defaultName + mobile, presetList['default' + mobile + '_tutorial'])
             ) : Rx.Observable.empty();
         });
 

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -37,22 +37,24 @@ const closeTutorialEpic = (action$) =>
 
 const switchTutorialEpic = (action$, store) =>
     action$.ofType(LOCATION_CHANGE)
-        .audit(() => action$.ofType(MAPS_LIST_LOADED, CHANGE_MAP_VIEW))
         .filter(action =>
             action.payload
             && action.payload.pathname)
-        .switchMap( (action) => {
-            const path = findMapType(action.payload.pathname);
-            const state = store.getState();
-            const presetList = state.tutorial && state.tutorial.presetList || {};
-            const browser = state.browser;
-            const mobile = browser && browser.mobile ? '_mobile' : '';
-            const defaultName = path ? 'default' : action.payload && action.payload.pathname || 'default';
-            return !isEmpty(presetList) ? Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
-                setupTutorial(path + mobile, presetList[path + mobile + '_tutorial']) :
-                setupTutorial(defaultName + mobile, presetList['default' + mobile + '_tutorial'])
-            ) : Rx.Observable.empty();
-        });
+        .switchMap( (action) =>
+            action$.ofType(MAPS_LIST_LOADED, CHANGE_MAP_VIEW)
+                .switchMap( () => {
+                    const path = findMapType(action.payload.pathname);
+                    const state = store.getState();
+                    const presetList = state.tutorial && state.tutorial.presetList || {};
+                    const browser = state.browser;
+                    const mobile = browser && browser.mobile ? '_mobile' : '';
+                    const defaultName = path ? 'default' : action.payload && action.payload.pathname || 'default';
+                    return !isEmpty(presetList) ? Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
+                        setupTutorial(path + mobile, presetList[path + mobile + '_tutorial']) :
+                        setupTutorial(defaultName + mobile, presetList['default' + mobile + '_tutorial'])
+                    ) : Rx.Observable.empty();
+                })
+        );
 
 /**
  * Epics for Tutorial

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -47,9 +47,10 @@ const switchTutorialEpic = (action$, store) =>
             const presetList = state.tutorial && state.tutorial.presetList || {};
             const browser = state.browser;
             const mobile = browser && browser.mobile ? '_mobile' : '';
+            const defaultName = path ? 'default' : action.payload;
             return !isEmpty(presetList) ? Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
                 setupTutorial(path + mobile, presetList[path + mobile + '_tutorial']) :
-                setupTutorial('default' + mobile, presetList['default' + mobile + '_tutorial'])
+                setupTutorial(defaultName + 'default' + mobile, presetList['default' + mobile + '_tutorial'])
             ) : Rx.Observable.empty();
         });
 

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -14,6 +14,7 @@ const {TOGGLE_3D} = require('../actions/globeswitcher');
 const defaultRegex = /\/(viewer)\/(\w+)\/(\d+)/;
 const findMapType = path => path.match(defaultRegex) && path.replace(defaultRegex, "$2");
 const { LOCATION_CHANGE } = require('react-router-redux');
+const {isEmpty} = require('lodash');
 
 /**
  * Closes the tutorial if 3D button has been toggled
@@ -46,10 +47,10 @@ const switchTutorialEpic = (action$, store) =>
             const presetList = state.tutorial && state.tutorial.presetList || {};
             const browser = state.browser;
             const mobile = browser && browser.mobile ? '_mobile' : '';
-            return Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
+            return !isEmpty(presetList) ? Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
                 setupTutorial(path + mobile, presetList[path + mobile + '_tutorial']) :
                 setupTutorial('default' + mobile, presetList['default' + mobile + '_tutorial'])
-            );
+            ) : Rx.Observable.empty();
         });
 
 /**

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -47,7 +47,7 @@ const switchTutorialEpic = (action$, store) =>
             const presetList = state.tutorial && state.tutorial.presetList || {};
             const browser = state.browser;
             const mobile = browser && browser.mobile ? '_mobile' : '';
-            const defaultName = path ? 'default' : action.payload;
+            const defaultName = path ? 'default' : action.payload && action.payload.pathname || 'default';
             return !isEmpty(presetList) ? Rx.Observable.of(presetList[path + mobile + '_tutorial'] ?
                 setupTutorial(path + mobile, presetList[path + mobile + '_tutorial']) :
                 setupTutorial(defaultName + mobile, presetList['default' + mobile + '_tutorial'])

--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -9,7 +9,7 @@
 const React = require('react');
 const {connect} = require('react-redux');
 const {bindActionCreators} = require('redux');
-const {setupTutorial, startTutorial, updateTutorial, disableTutorial, resetTutorial, closeTutorial, toggleTutorial} = require('../actions/tutorial');
+const {initTutorial, startTutorial, updateTutorial, disableTutorial, resetTutorial, closeTutorial, toggleTutorial} = require('../actions/tutorial');
 const presetList = require('./tutorial/preset');
 const assign = require('object-assign');
 const I18N = require('../components/I18N/I18N');
@@ -183,7 +183,6 @@ const tutorialPluginSelector = createSelector([tutorialSelector],
         run: tutorial.run,
         autoStart: tutorial.start,
         status: tutorial.status,
-        presetList,
         tourAction: tutorial.tourAction,
         stepIndex: tutorial.stepIndex
     }));
@@ -191,7 +190,7 @@ const tutorialPluginSelector = createSelector([tutorialSelector],
 const Tutorial = connect(tutorialPluginSelector, (dispatch) => {
     return {
         actions: bindActionCreators({
-            onSetup: setupTutorial,
+            onSetup: initTutorial,
             onStart: startTutorial,
             onUpdate: updateTutorial,
             onDisable: disableTutorial,
@@ -199,7 +198,15 @@ const Tutorial = connect(tutorialPluginSelector, (dispatch) => {
             onClose: closeTutorial
         }, dispatch)
     };
-})(require('../components/tutorial/Tutorial'));
+}, (stateProps, dispatchProps, ownProps) => ({
+        ...stateProps,
+        ...dispatchProps,
+        ...ownProps,
+        presetList: {
+            ...presetList,
+            ...ownProps.presetList
+        }
+}))(require('../components/tutorial/Tutorial'));
 
 module.exports = {
     TutorialPlugin: assign(Tutorial, {

--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -18,163 +18,75 @@ const {createSelector} = require('reselect');
 const {tutorialSelector} = require('../selectors/tutorial');
 const {closeTutorialEpic, switchTutorialEpic} = require('../epics/tutorial');
 
-/*
-    //////////////////////////
-    // TUTORIAL CONFIGURATION
-    //////////////////////////
-
-    PRESET AND RAW STEPS
-    steps of the tutorial can be added as preset or rawSteps.
-    Preset is a new .js file in the folder client/plugins/tutorial/preset while
-    rawSteps is a cfg property of Tutorial in localConfig.json.
-    Both are an array of "step object" * that represent the tutorial sequence.
-
-    Preset must be required in the preset.js file (client/plugins/tutorial/preset.js)
-    and declared in the cfg of Tutorial in localConfig.json (e.g. "preset": "NameOfThePresetFile").
-    If not declared the default preset is "map".
-
-    ! rawSteps overrides the preset file.
-
-    * example array of "step object"
-    [
-        {
-            translation: 'myIntroTranslation', //title and text of popup
-            selector: '#intro-tutorial' //dom target id
-        },
-        {
-            translation: 'myFirstStepTranslation',
-            selector: '#first-selector'
-        },
-        {
-            title: 'mySecondStepTitle',
-            text: 'mySecondStepText',
-            selector: '#second-selector',
-            position: 'left' // popup position
-        },
-        ...
-    ]
-
-    AUTOSTART INTRODUCTION
-    to show the tutorial with introduction and autostart
-    the first step of the array, in the preset file or rawSteps property,
-    must be an object with selector equal to '#intro-tutorial'.
-    After the first run the tutorial can be activated again from the burger menu.
-
-    custom preset file example
-    module.exports = [
-        {
-            translation: 'myIntroTranslation',
-            selector: '#intro-tutorial'
-        },
-        {
-            translation: 'myFirstStepTranslation',
-            selector: '#first-selector'
-        },
-        ...
-    ];
-
-    ACTIVATE MENU WITHOUT AUTOSTART
-    to show the tutorial without introduction/autostart
-    and to activate it from burger menu
-    every selector must be different from '#intro-tutorial'
-
-    custom preset file example
-    module.exports = [
-        {
-            translation: 'myFirstStepTranslation',
-            selector: '#first-selector'
-        },
-        {
-            translation: 'mySecondStepTranslation',
-            selector: '#second-selector'
-        },
-        ...
-    ];
-
-    SHOW CHECKBOX PROPERTY
-    the showCheckbox property can be added to localConfig.json in the cfg of Tutorial section
-    to display the checkbox that disable the autostart of tutorial
-    value -> true/false
-    default true
-
-    ! works only whit introduction/autostart
-
-    //////////////////////////
-    // STEP PROPERTIES
-    //////////////////////////
-
-    SELECTORS
-    every selector must be unique, start with # and different from '#error-tutorial'.
-
-    TRANSLATION - TRANSLATION HTML
-    to add the title and text of the step with property translation
-    insert a new object in the translation file at the tutorial section
-    with title and text properties
-
-    steps example
-    [
-        {
-            translation: 'myIntroTranslation',
-            selector: '#intro-tutorial'
-        },
-        {
-            translation: 'myFirstStepTranslation',
-            selector: '#first-selector'
-        },
-        {
-            translation: 'mySecondStepTranslation',
-            selector: '#second-selector'
-        },
-        {
-            translationHTML: 'myHTMLStepTranslation',
-            selector: '#html-translation-selector'
-        }
-    ]
-
-    translation file example
-    ...
-    "tutorial": {
-        ...
-        "myIntroTranslation": {
-            "title": "My intro title",
-            "text": "My intro description"
-        },
-        "myFirstStepTranslation": {
-            "title": "My first step title",
-            "text": "My first step description"
-        },
-        "mySecondStepTranslation": {
-            "title": "My second step title",
-            "text": "My second step description"
-        },
-        "myHTMLStepTranslation": {
-            "title": "<div style="color:blue;">My html step title</div>",
-            "text": "<div style="color:red;">My html step description</div>"
-        }
-        ...
-    }
-    ...
-
-    TITLE AND TEXT PROPERTIES
-    title and text can be added directly
-    to the step object
-
-    ! they override the translation property
-
-    step example
-    {
-        title: 'My title',
-        text: 'My description',
-        selector: '#my-selector'
-    }
-
-    OTHER JOYRIDE STANDARD STEP PROPERTIES
-    position: Relative position of you beacon and tooltip. It can be one of these:top, top-left, top-right, bottom, bottom-left, bottom-right, right and left. This defaults to bottom.
-    type: The event type that trigger the tooltip: click or hover. Defaults to click
-    isFixed: If true, the tooltip will remain in a fixed position within the viewport. Defaults to false.
-    allowClicksThruHole: Set to true to allow pointer-events (hover, clicks, etc) or touch events within overlay hole. If true, the hole:click callback will not be sent. Defaults to false. Takes precedence over a allowClicksThruHole prop provided to <Joyride />
-    style: An object with stylesheet options.
-*/
+/**
+ * Tutorial plugin. Enables the steps of tutorial.
+ * @prop {string} cfg.preset overrides the default_tutorial with another from the preset folder
+ * @prop {object} cfg.presetList overrides preset list of MapStore2
+ * @prop {boolean} cfg.showCheckbox shows/hides checkbox to disable tutorial next autostart
+ * @prop {number} cfg.scrollOffset changes the scroll offset
+ * @memberof plugins
+ * @class Tutorial
+ * @example
+ * // preset example in localConfig
+ * // overrides the default_tutorial with another from the preset folder
+ * // by changing the name
+ * {
+ *  "name": "Tutorial",
+ *  "cfg": {
+ *   "preset": "home_tutorial"
+ *  }
+ * }
+ *
+ * // presetList example in localConfig
+ * // overrides preset list of MapStore2
+ * // note: set first step selector to ""#intro-tutorial", enables autostart of tutorial
+ * {
+ *  "name": "Tutorial",
+ *  "cfg": {
+ *   "presetList": {
+ *    "default_tutorial": [
+ *     {
+ *      "title": "Welcome",
+ *      "text": "my intro text",
+ *      "selector": "#intro-tutorial"
+ *     },
+ *     {
+ *      "translation": "myTranslation" // id from translation file,
+ *      "selector": "#my-first-step-selector"
+ *     },
+ *     {
+ *      "translationHTML": "myTranslationHTML" // id from translation file,
+ *      "selector": "#my-first-step-selector"
+ *     }
+ *    ]
+ *   }
+ *  }
+ * }
+ *
+ * // translation file example
+ * ...
+ *  "tutorial": {
+ *   ...
+ *   "myIntroTranslation": {
+ *    "title": "My intro title",
+ *    "text": "My intro description"
+ *   },
+ *    "myTranslation": {
+ *    "title": "My first step title",
+ *    "text": "My first step description"
+ *   },
+ *   "mySecondStepTranslation": {
+ *    "title": "My second step title",
+ *    "text": "My second step description"
+ *   },
+ *   "myTranslationHTML": {
+ *    "title": "<div style="color:blue;">My html step title</div>",
+ *    "text": "<div style="color:red;">My html step description</div>"
+ *   }
+ *   ...
+ *  }
+ * ...
+ */
 
 const tutorialPluginSelector = createSelector([tutorialSelector],
     (tutorial) => ({

--- a/web/client/reducers/__tests__/tutorial-test.js
+++ b/web/client/reducers/__tests__/tutorial-test.js
@@ -12,6 +12,7 @@ const tutorial = require('../tutorial');
 
 const {
     START_TUTORIAL,
+    INIT_TUTORIAL,
     SETUP_TUTORIAL,
     UPDATE_TUTORIAL,
     DISABLE_TUTORIAL,
@@ -40,6 +41,20 @@ describe('Test the tutorial reducer', () => {
         expect(state.run).toBe(true);
         expect(state.start).toBe(true);
         expect(state.status).toBe('run');
+    });
+
+    it('setup the tutorial with intro', () => {
+        const state = tutorial({}, {
+            type: INIT_TUTORIAL,
+            style: 'style',
+            defaultStep: 'defaultStep',
+            checkbox: 'checkbox',
+            presetList: 'presetList'
+        });
+        expect(state.style).toBe('style');
+        expect(state.defaultStep).toBe('defaultStep');
+        expect(state.checkbox).toBe('checkbox');
+        expect(state.presetList).toBe('presetList');
     });
 
     it('setup the tutorial with intro', () => {

--- a/web/client/reducers/tutorial.js
+++ b/web/client/reducers/tutorial.js
@@ -8,6 +8,7 @@
 
 const {
     START_TUTORIAL,
+    INIT_TUTORIAL,
     SETUP_TUTORIAL,
     UPDATE_TUTORIAL,
     DISABLE_TUTORIAL,
@@ -29,7 +30,8 @@ const initialState = {
     status: 'close',
     stepIndex: 0,
     tourAction: 'next',
-    id: ''
+    id: '',
+    presetList: {}
 };
 
 function tutorial(state = initialState, action) {
@@ -39,6 +41,13 @@ function tutorial(state = initialState, action) {
                 run: true,
                 start: true,
                 status: 'run'
+            });
+        case INIT_TUTORIAL:
+            return assign({}, state, {
+                style: action.style,
+                defaultStep: action.defaultStep,
+                checkbox: action.checkbox,
+                presetList: action.presetList
             });
         case SETUP_TUTORIAL:
             let setup = {};


### PR DESCRIPTION
Fix #1956 
rawSteps configuration causes autostart issues while using dynamic tutorial (e.g. switch between 2d and 3d map tutorials).
Instead of rawSteps we could override the the preset list of tutorial in MapStore2 with the presetList configuration as in this PR.
rawSteps has been removed.

This is the new configuration:
```
{
  "name": "Tutorial",
  "cfg": {
    "presetList": {
      "default_tutorial": [{
          "title": "Welcome",
          "selector": "#intro-tutorial"
        }, {
          "translation": "drawerMenu",
          "selector": "#drawer-menu-button"
        },
        {
          "translation": "home",
          "selector": "#home-button"
        },
        {
          "translation": "burgerMenu",
          "selector": "#mapstore-burger-menu"
        }
      ]
    }
  }
}
```