### PR TITLE
Remove deprecated react-addons-css-transition-group

### DIFF
--- a/web/client/components/TOC/Node.jsx
+++ b/web/client/components/TOC/Node.jsx
@@ -11,7 +11,7 @@ var React = require('react');
 var createReactClass = require('create-react-class');
 var assign = require('object-assign');
 const cx = require('classnames');
-const ReactCSSTransitionGroup = require('react-addons-css-transition-group');
+const {CSSTransitionGroup} = require('react-transition-group');
 
 var SortableMixin = assign(require('react-sortable-items/SortableItemMixin'), {
     renderWithSortable: function(item) {
@@ -78,7 +78,7 @@ var Node = createReactClass({
         const nodeStyle = assign({}, this.props.style, this.props.styler(this.props.node));
         let collapsible = expanded ? this.renderChildren((child) => child && child.props.position === 'collapsible') : [];
         if (this.props.animateCollapse) {
-            collapsible = <ReactCSSTransitionGroup transitionName="TOC-Node" transitionEnterTimeout={250} transitionLeaveTimeout={250}>{collapsible}</ReactCSSTransitionGroup>;
+            collapsible = <CSSTransitionGroup transitionName="TOC-Node" transitionEnterTimeout={250} transitionLeaveTimeout={250}>{collapsible}</CSSTransitionGroup>;
         }
         let content = (<div key={this.props.node.name} className={(expanded ? prefix + "-expanded" : prefix + "-collapsed") + " " + this.props.className} style={nodeStyle} >
             {this.renderChildren((child) => child && child.props.position !== 'collapsible')}


### PR DESCRIPTION
Probably missed during React15 migration