### PR TITLE
Fix #2040 After back to homepage or change map, notifications don't clear

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -141,6 +141,7 @@
             "web/client/epics/fullscreen.js",
             "web/client/epics/globeswitcher.js",
             "web/client/epics/maptype.js",
+            "web/client/epics/notifications.js",
             "web/client/epics/search.js",
             "web/client/epics/tutorial.js",
             "web/client/epics/wfsquery.js",

--- a/web/client/epics/__tests__/notifications-test.js
+++ b/web/client/epics/__tests__/notifications-test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var expect = require('expect');
+
+const configureMockStore = require('redux-mock-store').default;
+const {createEpicMiddleware, combineEpics } = require('redux-observable');
+const {CLEAR_NOTIFICATIONS} = require('../../actions/notifications');
+
+const {clearNotificationOnLocationChange} = require('../notifications');
+const rootEpic = combineEpics(clearNotificationOnLocationChange);
+const epicMiddleware = createEpicMiddleware(rootEpic);
+const mockStore = configureMockStore([epicMiddleware]);
+
+describe('automapupdate Epics', () => {
+    let store;
+    beforeEach(() => {
+        store = mockStore();
+    });
+
+    afterEach(() => {
+        epicMiddleware.replaceEpic(rootEpic);
+    });
+
+    it('update map', (done) => {
+
+        store.dispatch({type: '@@router/LOCATION_CHANGE'});
+
+        setTimeout( () => {
+            try {
+                const actions = store.getActions();
+                expect(actions.length).toBe(2);
+                expect(actions[1].type).toBe(CLEAR_NOTIFICATIONS);
+            } catch (e) {
+                return done(e);
+            }
+            done();
+        }, 500);
+
+    });
+});

--- a/web/client/epics/__tests__/notifications-test.js
+++ b/web/client/epics/__tests__/notifications-test.js
@@ -17,7 +17,7 @@ const rootEpic = combineEpics(clearNotificationOnLocationChange);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
 
-describe('automapupdate Epics', () => {
+describe('notifications Epics', () => {
     let store;
     beforeEach(() => {
         store = mockStore();
@@ -27,7 +27,7 @@ describe('automapupdate Epics', () => {
         epicMiddleware.replaceEpic(rootEpic);
     });
 
-    it('update map', (done) => {
+    it('test clear notifications on location change', (done) => {
 
         store.dispatch({type: '@@router/LOCATION_CHANGE'});
 

--- a/web/client/epics/notifications.js
+++ b/web/client/epics/notifications.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+const Rx = require('rxjs');
+const {clear} = require('../actions/notifications');
+const {LOCATION_CHANGE} = require('react-router-redux');
+
+/**
+ * Clear all notifications on LOCATION_CHANGE.
+ * @param {external:Observable} action$ manages `LOCATION_CHANGE`.
+ * @memberof epics.notifications
+ * @return {external:Observable}
+ */
+const clearNotificationOnLocationChange = action$ =>
+    action$.ofType(LOCATION_CHANGE)
+        .switchMap(() => Rx.Observable.of(clear()));
+
+/**
+ * Epics for notifications
+ * @name epics.notifications
+ * @type {Object}
+ */
+
+module.exports = {
+    clearNotificationOnLocationChange
+};

--- a/web/client/plugins/Notifications.jsx
+++ b/web/client/plugins/Notifications.jsx
@@ -7,6 +7,7 @@
  */
 
 const {hide} = require('../actions/notifications');
+const {clearNotificationOnLocationChange} = require('../epics/notifications');
 const {connect} = require('react-redux');
 
 
@@ -26,5 +27,8 @@ module.exports = {
     )(require('../components/notifications/NotificationContainer')),
     reducers: {
         notifications: require('../reducers/notifications')
+    },
+    epics: {
+        clearNotificationOnLocationChange
     }
 };


### PR DESCRIPTION
Added epic to clear notifications on location change


