### PR TITLE
Prevent errors for missing DescribeFeatureType

### DIFF
--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -70,7 +70,7 @@ class FeatureGrid extends React.PureComponent {
                     this.props.changes[id].hasOwnProperty(key);
             },
             isProperty: (k) => k === "geometry" || isProperty(k, this.props.describeFeatureType),
-            isValid: (val, key) => isValidValueForPropertyName(val, key, this.props.describeFeatureType)
+            isValid: (val, key) => this.props.describeFeatureType ? isValidValueForPropertyName(val, key, this.props.describeFeatureType) : true
         };
     }
     render() {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const Rx = require('rxjs');
-const {get, head, isEmpty} = require('lodash');
+const {get, head, isEmpty, find} = require('lodash');
 const { LOCATION_CHANGE } = require('react-router-redux');
 const axios = require('../libs/ajax');
 const {fidFilter} = require('../utils/ogc/Filter/filter');
@@ -68,6 +68,13 @@ const setupDrawSupport = (state, original) => {
         let changes = changesMapSelector(state);
         if (changes[feature.id] && (changes[feature.id].geometry || changes[feature.id].geometry === null)) {
             feature.geometry = changes[feature.id].geometry;
+        }
+        if (feature._new && !feature.geometry) {
+            const stateNewFeature = find(newFeaturesSelector(state), {id: feature.id});
+            if (stateNewFeature && stateNewFeature.geometry ) {
+                feature.geometry = stateNewFeature.geometry;
+            }
+
         }
         if (original) {
             feature.geometry = getFeatureById(state, feature.id) ? getFeatureById(state, feature.id).geometry : null;

--- a/web/client/examples/featuregrid/index.html
+++ b/web/client/examples/featuregrid/index.html
@@ -9,7 +9,6 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.4/leaflet.draw.css" />
         <link rel="stylesheet" href="../../dist/themes/default.css" id="theme_stylesheet">
-        <link rel="stylesheet" href="assets/css/viewer.css" id="theme_stylesheet">
         <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -1,5 +1,7 @@
+const get = require('lodash');
+
 const {getFeatureTypeProperties, isGeometryType, isValid, isValidValueForPropertyName, findGeometryProperty, getPropertyDesciptor} = require('./ogc/WFS/base');
-const getGeometryName = (describe) => findGeometryProperty(describe).name;
+const getGeometryName = (describe) => get(findGeometryProperty(describe), "name");
 const getPropertyName = (name, describe) => name === "geometry" ? getGeometryName(describe) : name;
 
 const getRow = (i, rows) => rows[i];

--- a/web/client/utils/ogc/WFS/base.js
+++ b/web/client/utils/ogc/WFS/base.js
@@ -47,7 +47,7 @@ const findGeometryProperty = (describeFeatureType) => head((getFeatureTypeProper
  */
 const getPropertyDesciptor = (propName, describeFeatureType) =>
     head(
-        getFeatureTypeProperties(describeFeatureType).filter(d => d.name === propName)
+        (getFeatureTypeProperties(describeFeatureType) || []).filter(d => d.name === propName)
     );
 /**
  * @name schemaLocation
@@ -57,7 +57,11 @@ const getPropertyDesciptor = (propName, describeFeatureType) =>
  */
 const schemaLocation = (d) => d.targetNamespace;
 const isGeometryType = (pd) => pd.type.indexOf("gml:") === 0;
-const isValidValue = (v, pd) => pd.nillable || (v !== undefined && v !== null); // TODO validate type
+const isValidValue = (v, pd) =>
+    pd === undefined
+    || pd === null
+    || pd && pd.nillable === true
+    || pd && pd.nillable === false && v !== undefined && v !== null; // TODO validate type
 const isValidProperty = ({geom, properties} = {}, pd) => isValidValue(isGeometryType(pd) ? geom : properties[pd.name], pd);
 /**
  * Base utilities for WFS.


### PR DESCRIPTION
 - Prevent red-box error when DescribeFeatureType is missing in FeatureGrid (reliability).
 - When select new row the geometry doesn't disappear (fix)

 
