### PR TITLE
Fix #2049 Drawer Menu shows a scroll bar in Edge and IE

### DIFF
--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -111,6 +111,9 @@ class Menu extends React.Component {
                     right: this.props.show ? 0 : 'auto',
                     width: '0',
                     overflow: 'visible'
+                },
+                content: {
+                    overflowY: 'auto'
                 }
             }} sidebarClassName="nav-menu" onSetOpen={() => {
                 this.props.onToggle();


### PR DESCRIPTION
Added overflow-y auto to avoid scrollbar in Edge and IE 