### PR TITLE
Fix #2065. Add loading spinner on startup

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -5,6 +5,80 @@
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
         <title>MapStore 2 HomePage</title>
+        <style>
+        ._ms2_init_center {
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            overflow: show;
+            margin: auto;
+        }
+        ._ms2_init_spinner {
+            height: 4em;
+            width: 4em;
+        }
+        ._ms2_init_spinner > div,
+        ._ms2_init_spinner > div:after {
+          border-radius: 50%;
+          width: 10em;
+          height: 10em;
+        }
+        ._ms2_init_spinner > div {
+          margin: -3em -4em;
+          font-size: 16px;
+          position: relative;
+          text-indent: -9999em;
+          border: 1.1em solid rgba(119,119,119, 0.2);
+          border-left: 1.1em solid #777777;
+          -webkit-transform: translateZ(0);
+          -ms-transform: translateZ(0);
+          transform: translateZ(0);
+          -webkit-animation: _ms2_init_anim 1.1s infinite linear;
+          animation: _ms2_init_anim 1.1s infinite linear;
+        }
+        @-webkit-keyframes _ms2_init_anim {
+          0% {
+            -webkit-transform: rotate(0deg);
+            transform: rotate(0deg);
+          }
+          100% {
+            -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+          }
+        }
+        @keyframes _ms2_init_anim {
+          0% {
+            -webkit-transform: rotate(0deg);
+            transform: rotate(0deg);
+          }
+          100% {
+            -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+          }
+        }
+        ._ms2_init_text {
+            -webkit-animation: _ms2_init_text_anim 2s linear 0s infinite normal;
+            animation: _ms2_init_text_anim 2s linear 0s infinite normal;
+            color: #6F6F6f;
+            font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+            font-size: 20px;
+            font-weight: bold;
+            height: 0.75em;
+            width:  6em;
+            text-align: center;
+            margin: auto;
+            z-index: 1000;
+        }
+        @keyframes _ms2_init_text_anim {
+            0%  {opacity: 0}
+            20% {opacity: 0}
+            50% {opacity: 1}
+            70% {opacity: .75}
+            100%{opacity: 0}
+        }
+        </style>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway" type='text/css'>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.4/leaflet.draw.css" />
@@ -21,9 +95,14 @@
         <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
         <script src="libs/cesium-navigation/cesium-navigation.js"></script>
         <link rel="stylesheet" href="libs/cesium-navigation/cesium-navigation.css" />
+
     </head>
     <body>
-        <div id="container"></div>
+        <div id="container">
+            <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
+            <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
+        </div>
         <script src="dist/mapstore2.js"></script>
+
     </body>
 </html>


### PR DESCRIPTION
Added loading spinner on starup.
It is in the `index.html ` because it needs to be loaded immediately. 
Because of this: 
 - You have to port it in every index.html (e.g. projects)
 - It have to be independent  from the theme

![loading](https://user-images.githubusercontent.com/1279510/29219522-999906e2-7eb8-11e7-85eb-25039f47cb00.gif)
