### PR TITLE
Fixed #2103 disabled edit and search tool in 3d and closed querypanel

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,19 +16,19 @@ const getSaveMessageId = ({saving, saved}) => {
     return "featuregrid.toolbar.saveChanges";
 };
 
-module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isCesium} = {}) =>
+module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed} = {}) =>
     (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
             tooltip={<Message msgId="featuregrid.toolbar.editMode"/>}
-            disabled={disableToolbar || isCesium}
+            disabled={disableToolbar}
             visible={mode === "VIEW" && isEditingAllowed}
             onClick={events.switchEditMode}
             glyph="pencil"/>
         <TButton
             id="search"
             tooltip={<Message msgId="featuregrid.toolbar.advancedFilter"/>}
-            disabled={disableToolbar || isCesium}
+            disabled={disableToolbar || !isSearchAllowed}
             visible={mode === "VIEW"}
             onClick={events.showQueryPanel}
             glyph="filter"/>

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,19 +16,19 @@ const getSaveMessageId = ({saving, saved}) => {
     return "featuregrid.toolbar.saveChanges";
 };
 
-module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar} = {}) =>
+module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isCesium} = {}) =>
     (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
             tooltip={<Message msgId="featuregrid.toolbar.editMode"/>}
-            disabled={disableToolbar}
+            disabled={disableToolbar || isCesium}
             visible={mode === "VIEW" && isEditingAllowed}
             onClick={events.switchEditMode}
             glyph="pencil"/>
         <TButton
             id="search"
             tooltip={<Message msgId="featuregrid.toolbar.advancedFilter"/>}
-            disabled={disableToolbar}
+            disabled={disableToolbar || isCesium}
             visible={mode === "VIEW"}
             onClick={events.showQueryPanel}
             glyph="filter"/>

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -59,7 +59,7 @@ describe('Featuregrid toolbar component', () => {
             showQueryPanel: () => {}
         };
         spyOn(events, "showQueryPanel");
-        ReactDOM.render(<Toolbar events={events} mode="VIEW" />, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" isSearchAllowed/>, document.getElementById("container"));
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
         let editButton = document.getElementById("fg-search");

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -328,7 +328,7 @@ module.exports = {
 
     ),
     /**
-     * intercept geomertry changed events in draw support to update current
+     * intercept geometry changed events in draw support to update current
      * modified geometry in featuregrid
      */
     onFeatureGridGeometryEditing: (action$, store) => action$.ofType(GEOMETRY_CHANGED)
@@ -400,6 +400,11 @@ module.exports = {
                 )
                 .takeUntil(action$.ofType(CLOSE_FEATURE_GRID))
         ),
+    resetQueryPanel: (action$, store) =>
+        action$.ofType(LOCATION_CHANGE).switchMap( () => {
+            return store.getState().controls.queryPanel.enabled ? Rx.Observable.of(setControlProperty('queryPanel', "enabled", false))
+        : Rx.Observable.empty(); }
+    ),
     /**
      * Closes the feature grid when the drawer menu button has been toggled
      */

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -5,6 +5,7 @@ const {createSelector, createStructuredSelector} = require('reselect');
 const {paginationInfo, featureLoadingSelector} = require('../../../selectors/query');
 const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector} = require('../../../selectors/featuregrid');
 const {isAdminUserSelector} = require('../../../selectors/security');
+const {isCesium} = require('../../../selectors/maptype');
 const {deleteFeatures, toggleTool, clearChangeConfirmed, closeFeatureGridConfirmed, closeFeatureGrid} = require('../../../actions/featuregrid');
 const {toolbarEvents, pageEvents} = require('../index');
 
@@ -25,6 +26,7 @@ const Toolbar = connect(
         disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar,
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
+        isCesium,
         isEditingAllowed: (state) => isAdminUserSelector(state) || canEditSelector(state)
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -26,8 +26,8 @@ const Toolbar = connect(
         disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar,
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
-        isCesium,
-        isEditingAllowed: (state) => isAdminUserSelector(state) || canEditSelector(state)
+        isSearchAllowed: (state) => !isCesium(state),
+        isEditingAllowed: (state) => (isAdminUserSelector(state) || canEditSelector(state)) && !isCesium(state)
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})
 )(require('../../../components/data/featuregrid/toolbars/Toolbar'));


### PR DESCRIPTION
see #2103

Also closed query panel if it was opened and the user switches to 3D mode.

BTW, if a button is disabled it cannot have a tooltip, do you really want it? @offtherailz 