### PR TITLE
Fixes #2086: Hide extra X in SearchField (IE11 and Edge)

### DIFF
--- a/web/client/components/mapcontrols/search/searchbar.css
+++ b/web/client/components/mapcontrols/search/searchbar.css
@@ -13,6 +13,13 @@
     box-shadow: 2px 2px 4px #A7A7A7;
     border-radius: 4px;
 }
+
+/* hide the clearing x in IE 11 and Edge */
+.MapSearchBar input::-ms-clear,
+.MapSearchBar input::-ms-reveal {
+    display: none;
+}
+
 /*.searchclear {
     top:0;
     bottom:0;


### PR DESCRIPTION
This hides the extra clearing X in the SearchField in IE 11 and Edge browsers (see #2086).