### PR TITLE
fix #2145 remove mouse position from mobile

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -127,16 +127,6 @@
                     "wrap": true
                 }
             }, {
-                "name": "MousePosition",
-                "cfg": {
-                    "id": "mapstore-mouseposition-mobile",
-                    "showCRS": false,
-                    "showLabels": false,
-                    "showToggle": false,
-                    "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
-                    "additionalCRS": {}
-                }
-            }, {
                 "name": "Search",
                 "cfg": {
                     "withToggle": ["max-width: 768px", "min-width: 768px"]


### PR DESCRIPTION
#2145 

i've just remove it from the configuration. 
it did not make much sense having the mousePosition plugin with the mobile device.