### PR TITLE
Fix #2172 Viewport query filter uses wrong srsName

### DIFF
--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var expect = require('expect');
+
+const {UPDATE_GEOMETRY} = require('../../actions/queryform');
+const {changeMapView} = require('../../actions/map');
+
+const {testEpic} = require('./epicTestUtils');
+const {viewportSelectedEpic} = require('../wfsquery');
+
+describe('wfsquery Epics', () => {
+
+    it('viewport selected epic', (done) => {
+        testEpic(viewportSelectedEpic, 1, changeMapView({x: 0, y: 0, crs: 'EPSG:4326'}, 10, {bounds: {
+            minx: -170,
+            miny: -50,
+            maxx: 170,
+            maxy: 50
+        }, crs: 'EPSG:4326'}), actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case UPDATE_GEOMETRY:
+                        expect(action.geometry).toEqual({
+                            center: [0, 0],
+                            coordinates: [[[-170, -50], [-170, 50], [170, 50], [170, -50], [-170, -50]]],
+                            extent: [-170, -50, 170, 50],
+                            projection: 'EPSG:4326',
+                            radius: 0,
+                            type: 'Polygon' });
+                        break;
+                    default:
+                        expect(false).toBe(true);
+                }
+            });
+            done();
+        }, {queryform: { spatialField: {method: 'Viewport'}}});
+    });
+});

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -254,6 +254,13 @@ const wfsQueryEpic = (action$, store) =>
             );
         });
 
+/**
+ * Generate a spatial filter geometry from the view bounds
+ * @memberof epics.wfsquery
+ * @param {external:Observable} action$ manages `SELECT_VIEWPORT_SPATIAL_METHOD` and `CHANGE_MAP_VIEW`
+ * @return {external:Observable}
+ */
+
 const viewportSelectedEpic = (action$, store) =>
     action$.ofType(SELECT_VIEWPORT_SPATIAL_METHOD, CHANGE_MAP_VIEW)
         .switchMap((action) => {

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -85,6 +85,13 @@ const supportedSplitExtentEPSG = [
     'EPSG:3857'
 ];
 
+/**
+ * Return an extent array normalized from EPSG:4326 reprojection
+ * @param bounds {object} bounds {minx, miny, maxx, maxy}
+ * @param projection {string} the projection of bounds coordinates
+ * @return {array} extent with x values normalized from 0 to 360
+ */
+
 const normalizeExtent = (bounds, projection) => {
     const extent = projection !== 'EPSG:4326' ? [
         reproject([bounds.minx, bounds.miny], projection, 'EPSG:4326'),
@@ -108,6 +115,13 @@ const normalizeExtent = (bounds, projection) => {
     });
 };
 
+/**
+ * Reproject extent from EPSG different from 'EPSG:4326'
+ * @param extent {array} array of bounds [minx, miny, maxx, maxy] or isIDL `true` [[..bounds], [..bounds]]
+ * @param projection {string} the projection of extent coordinates
+ * @param isIDL {boolean} intersect the international date line
+ * @return {array} extent
+ */
 const reprojectExtent = (extent, projection, isIDL) => {
     if (projection === 'EPSG:4326') {
         return extent;
@@ -122,6 +136,13 @@ const reprojectExtent = (extent, projection, isIDL) => {
     ].reduce((a, b) => [...a, b.x, b.y], []));
 };
 
+/**
+ * Reproject extent to verify the intersection with the international date line (isIDL)
+ * if on IDL return double extent array
+ * @param bounds {object} {minx, miny, maxx, maxy}
+ * @param projection {string} the projection of bounds
+ * @return {object} {extent, isIDL}
+ */
 const getExtentFromNormalized = (bounds, projection) => {
     const normalizedXExtent = normalizeExtent(bounds, projection);
     const isIDL = normalizedXExtent[2] < normalizedXExtent[0];
@@ -487,6 +508,12 @@ const CoordinatesUtils = {
             geometries: features.map( ({geometry}) => geometry)
         };
     },
+    /**
+     * Return the viewport geometry from the view bounds
+     * @param bounds {object} bounds {minx, miny, maxx, maxy}
+     * @param projection {string} the projection of bounds coordinates
+     * @return {object} geomtry {type, radius, projection, coordinates, extent, center}
+     */
     getViewportGeometry: (bounds, projection) => {
         if (head(supportedSplitExtentEPSG.filter(epsg => epsg === projection))) {
             const {extent, isIDL} = getExtentFromNormalized(bounds, projection);

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -9,7 +9,7 @@
 const {processOGCGeometry, pointElement, polygonElement, lineStringElement } = require("./ogc/GML");
 const {wfsToGmlVersion} = require('./ogc/WFS/base');
 const {ogcComparisonOperators, ogcLogicalOperators, ogcSpatialOperators} = require("./ogc/Filter/operators");
-const {isNil, isUndefined} = require('lodash');
+const {isNil, isUndefined, isArray} = require('lodash');
 
 const checkOperatorValidity = (value, operator) => {
     return (!isNil(value) && operator !== "isNull" || !isUndefined(value) && operator === "isNull");
@@ -215,7 +215,20 @@ const FilterUtils = {
 
         let spatialFilter;
         if (objFilter.spatialField && objFilter.spatialField.geometry && objFilter.spatialField.operation) {
-            spatialFilter = this.processOGCSpatialFilter(versionOGC, objFilter, nsplaceholder);
+            if (objFilter.spatialField.operation === 'BBOX' && isArray(objFilter.spatialField.geometry.extent[0])) {
+                const OP = "OR";
+                const bBoxFilter = objFilter.spatialField.geometry.extent.reduce((a, extent) => {
+                    let filter = Object.assign({}, objFilter);
+                    filter.spatialField.geometry.extent = extent;
+                    return a + this.processOGCSpatialFilter(versionOGC, filter, nsplaceholder);
+                }, '');
+
+                spatialFilter = ogcLogicalOperators[OP](nsplaceholder, bBoxFilter);
+
+            } else {
+                spatialFilter = this.processOGCSpatialFilter(versionOGC, objFilter, nsplaceholder);
+            }
+
             filters.push(spatialFilter);
         }
         if (objFilter.crossLayerFilter) {

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -225,4 +225,179 @@ describe('CoordinatesUtils', () => {
         expect(CoordinatesUtils.coordsOLtoLeaflet(geojsonPoint.geometry)[0][3]).toBe(reversedPoint.geometry.coordinates[3]);
     });
 
+    it('test getViewportGeometry not listed projection', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -160,
+            miny: -50,
+            maxx: 130,
+            maxy: 60
+        }, 'EPSG:UNKOWN')).toEqual({
+            type: 'Polygon',
+            radius: 0,
+            projection: 'EPSG:UNKOWN',
+            coordinates: [ [ [ -160, -50 ], [ -160, 60 ], [ 130, 60 ], [ 130, -50 ], [ -160, -50 ] ] ],
+            extent: [-160, -50, 130, 60],
+            center: [-15, 5]
+        });
+    });
+
+    it('test getViewportGeometry projection EPSG:4326', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -160,
+            miny: -50,
+            maxx: 130,
+            maxy: 60
+        }, 'EPSG:4326')).toEqual({
+            type: 'Polygon',
+            radius: 0,
+            projection: 'EPSG:4326',
+            coordinates: [ [ [ -160, -50 ], [ -160, 60 ], [ 130, 60 ], [ 130, -50 ], [ -160, -50 ] ] ],
+            extent: [-160, -50, 130, 60],
+            center: [-15, 5]
+        });
+    });
+
+    it('test getViewportGeometry projection EPSG:4326 world view', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -190,
+            miny: -50,
+            maxx: 230,
+            maxy: 60
+        }, 'EPSG:4326')).toEqual({
+            type: 'Polygon',
+            radius: 0,
+            projection: 'EPSG:4326',
+            coordinates: [ [ [ -180, -50 ], [ -180, 60 ], [ 180, 60 ], [ 180, -50 ], [ -180, -50 ] ] ],
+            extent: [-180, -50, 180, 60],
+            center: [0, 5]
+        });
+    });
+
+    it('test getViewportGeometry projection EPSG:4326 on IDL center position > -180', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -190,
+            miny: -50,
+            maxx: -160,
+            maxy: 60
+        }, 'EPSG:4326')).toEqual({
+            type: 'MultiPolygon',
+            radius: 0,
+            projection: 'EPSG:4326',
+            coordinates: [
+                [[[ -180, -50 ], [ -180, 60 ], [ -160, 60 ], [ -160, -50 ], [ -180, -50 ]]],
+                [[[ 170, -50 ], [ 170, 60 ], [ 180, 60 ], [ 180, -50 ], [ 170, -50 ]]]
+            ],
+            extent: [
+                [-180, -50, -160, 60],
+                [170, -50, 180, 60]
+            ],
+
+            center: [ -175, 5]
+        });
+    });
+
+
+    it('test getViewportGeometry projection EPSG:4326 on IDL center position < 180', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -230,
+            miny: -50,
+            maxx: -160,
+            maxy: 60
+        }, 'EPSG:4326')).toEqual({
+            type: 'MultiPolygon',
+            radius: 0,
+            projection: 'EPSG:4326',
+            coordinates: [
+                [[[ -180, -50 ], [ -180, 60 ], [ -160, 60 ], [ -160, -50 ], [ -180, -50 ]]],
+                [[[ 130, -50 ], [ 130, 60 ], [ 180, 60 ], [ 180, -50 ], [ 130, -50 ]]]
+            ],
+            extent: [
+                [-180, -50, -160, 60],
+                [130, -50, 180, 60]
+            ],
+            center: [ 165, 5]
+        });
+
+    });
+
+    it('test getViewportGeometry projection EPSG:4326 on IDL center x values < -180', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -1640,
+            miny: -50,
+            maxx: -1950,
+            maxy: 60
+        }, 'EPSG:4326')).toEqual({
+            type: 'MultiPolygon',
+            radius: 0,
+            projection: 'EPSG:4326',
+            coordinates: [
+                [[[ -180, -50 ], [ -180, 60 ], [ -150, 60 ], [ -150, -50 ], [ -180, -50 ]]],
+                [[[ 160, -50 ], [ 160, 60 ], [ 180, 60 ], [ 180, -50 ], [ 160, -50 ]]]
+            ],
+            extent: [
+                [-180, -50, -150, 60],
+                [160, -50, 180, 60]
+            ],
+            center: [ -175, 5]
+        });
+
+    });
+
+    it('test getViewportGeometry projection EPSG:4326 on IDL x values > 180', () => {
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: 880,
+            miny: -50,
+            maxx: 930,
+            maxy: 60
+        }, 'EPSG:4326')).toEqual({
+            type: 'MultiPolygon',
+            radius: 0,
+            projection: 'EPSG:4326',
+            coordinates: [
+                [[[ -180, -50 ], [ -180, 60 ], [ -150, 60 ], [ -150, -50 ], [ -180, -50 ]]],
+                [[[ 160, -50 ], [ 160, 60 ], [ 180, 60 ], [ 180, -50 ], [ 160, -50 ]]]
+            ],
+            extent: [
+                [-180, -50, -150, 60],
+                [160, -50, 180, 60]
+            ],
+            center: [ -175, 5]
+        });
+    });
+
+    it('test getViewportGeometry projection EPSG:900913', () => {
+
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -8932736.873518841,
+            miny: 1995923.6825825204,
+            maxx: -2162250.6561310687,
+            maxy: 6584591.364598222
+        }, 'EPSG:900913')).toEqual({
+            type: 'Polygon',
+            radius: 0,
+            projection: 'EPSG:900913',
+            coordinates: [ [ [ -8932736.873518841, 1995923.68258252 ], [ -8932736.873518841, 6584591.364598221 ], [ -2162250.656131069, 6584591.364598221 ], [ -2162250.656131069, 1995923.68258252 ], [ -8932736.873518841, 1995923.68258252 ] ] ],
+            extent: [-8932736.873518841, 1995923.68258252, -2162250.656131069, 6584591.364598221],
+            center: [-5547493.764824955, 4290257.523590371]
+        });
+    });
+
+    it('test getViewportGeometry projection EPSG:900913 world view', () => {
+
+        /*EPSG:900913 -20037508.342789244 - 20037508.342789244 | EPSG:4326 -180 | 180*/
+        expect(CoordinatesUtils.getViewportGeometry({
+            minx: -77527937.55286229,
+            miny: -32150025.592971414,
+            maxx: 30799841.925342064,
+            maxy: 41268657.319279805
+        }, 'EPSG:900913')).toEqual({
+            type: 'Polygon',
+            radius: 0,
+            projection: 'EPSG:900913',
+            coordinates: [ [ [ -20037508.342789244, -32150025.59297142 ], [ -20037508.342789244, 41268657.319279306 ], [ 20037508.342789244, 41268657.319279306 ], [ 20037508.342789244, -32150025.59297142 ], [ -20037508.342789244, -32150025.59297142 ] ] ],
+            extent: [-20037508.342789244, -32150025.59297142, 20037508.342789244, 41268657.319279306],
+            center: [0, 4559315.863153942]
+        });
+    });
+
 });

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -738,4 +738,73 @@ describe('FilterUtils', () => {
         let filter = FilterUtils.processOGCCrossLayerFilter(crossLayerFilterObj);
         expect(filter).toEqual(expected);
     });
+
+    it('Check if toOGCFilter generate double bbox', () => {
+        const filterObj = {
+            featureTypeName: 'feature',
+            filterFields: [],
+            filterType: 'OGC',
+            groupFields: [{id: 1, index: 0, logic: 'OR'}],
+            hits: false,
+            ogcVersion: '1.1.0',
+            pagination: {
+                maxFeatures: 20,
+                startIndex: 0
+            },
+            sortOptions: null,
+            spatialField: {
+                attribute: 'the_geom',
+                geometry: {
+                    center: [174.19921875, 24.04052578726085],
+                    coordinates: [
+                        [[[-180, -10.228437266155943], [-180, 58.309488840677645], [-125.33203125, 58.309488840677645], [-125.33203125, -10.228437266155943], [-180, -10.228437266155943]]],
+                        [[[113.73046875, -10.228437266155943], [113.73046875, 58.309488840677645], [180, 58.309488840677645], [180, -10.228437266155943], [113.73046875, -10.228437266155943]]]
+                    ],
+                    extent: [
+                        [-180, 23.200960808078566, -134.47265625, 54.39335222384589],
+                        [160.400390625, 23.200960808078566, 180, 54.39335222384589]
+                    ],
+                    projection: 'EPSG:4326',
+                    radius: 0,
+                    type: 'MultiPolygon'
+                },
+                method: 'Viewport',
+                operation: 'BBOX'
+            }
+        };
+
+        const expected = '<wfs:GetFeature ' +
+          'startIndex="0" ' +
+          'maxFeatures="20" ' +
+          'service="WFS" ' +
+          'version="1.1.0" ' +
+          'xmlns:gml="http://www.opengis.net/gml" ' +
+          'xmlns:wfs="http://www.opengis.net/wfs" ' +
+          'xmlns:ogc="http://www.opengis.net/ogc" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">' +
+          '<wfs:Query typeName="feature" srsName="EPSG:4326">' +
+            '<ogc:Filter>' +
+              '<ogc:Or>' +
+                '<ogc:BBOX>' +
+                  '<ogc:PropertyName>the_geom</ogc:PropertyName>' +
+                  '<gml:Envelope srsName="EPSG:4326">' +
+                    '<gml:lowerCorner>-180 23.200960808078566</gml:lowerCorner>' +
+                    '<gml:upperCorner>-134.47265625 54.39335222384589</gml:upperCorner>' +
+                  '</gml:Envelope>' +
+                '</ogc:BBOX>' +
+                '<ogc:BBOX>' +
+                  '<ogc:PropertyName>the_geom</ogc:PropertyName>' +
+                  '<gml:Envelope srsName="EPSG:4326">' +
+                    '<gml:lowerCorner>160.400390625 23.200960808078566</gml:lowerCorner>' +
+                    '<gml:upperCorner>180 54.39335222384589</gml:upperCorner>' +
+                  '</gml:Envelope>' +
+                '</ogc:BBOX>' +
+              '</ogc:Or>' +
+            '</ogc:Filter>' +
+          '</wfs:Query>' +
+        '</wfs:GetFeature>';
+
+        expect(FilterUtils.toOGCFilter(filterObj.featureTypeName, filterObj, filterObj.ogcVersion, filterObj.sortOptions, filterObj.hits)).toEqual(expected);
+    });
 });


### PR DESCRIPTION
## Description
Added a control on leaflet map to change srs 'EPSG:4326'.
Openlayers return a srs 'EPSG:900913' with correct values.
Due to values positioned outside the worlds limits, here has been introduced a function to split in two multipolygon the bound and extent on the Viewport spatial filter.
![screenshot from 2017-09-19 12-20-04](https://user-images.githubusercontent.com/19175505/30587861-eb6f62aa-9d34-11e7-932a-c8146eea69b3.png)

## Requirements
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
 - [x] Bugfix

**What is the current behavior?** 
issue #2172


**What is the new behavior?**
- Added a control on leaflet map to change srs 'EPSG:4326' (Viewport)
- split bound in two polygon when view contains 180 -180 values (Viewport)

**Does this PR introduce a breaking change?** (check one with "x")
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: