### PR TITLE
Closes #1918. Filter WMS layer in sync with FeatureGrid

### DIFF
--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -48,6 +48,9 @@ const MODES = {
     EDIT: "EDIT",
     VIEW: "VIEW"
 };
+const START_SYNC_WMS = 'FEATUREGRID:START_SYNC_WMS';
+const STOP_SYNC_WMS = 'FEATUREGRID:STOP_SYNC_WMS';
+
 
 function clearChangeConfirmed() {
     return {
@@ -332,5 +335,7 @@ module.exports = {
     toggleTool,
     customizeAttribute,
     toggleEditMode,
-    toggleViewMode
+    toggleViewMode,
+    START_SYNC_WMS,
+    STOP_SYNC_WMS
 };

--- a/web/client/actions/wfsquery.js
+++ b/web/client/actions/wfsquery.js
@@ -19,6 +19,13 @@ const QUERY_ERROR = 'QUERY_ERROR';
 const RESET_QUERY = 'RESET_QUERY';
 const QUERY = 'QUERY';
 const INIT_QUERY_PANEL = 'INIT_QUERY_PANEL';
+const TOGGLE_SYNC_WMS = 'QUERY:TOGGLE_SYNC_WMS';
+
+function toggleSyncWms() {
+    return {
+        type: TOGGLE_SYNC_WMS
+    };
+}
 
 const axios = require('../libs/ajax');
 
@@ -154,5 +161,6 @@ module.exports = {
     FEATURE_LOADING, featureLoading,
     FEATURE_LOADED, featureLoaded,
     INIT_QUERY_PANEL, initQueryPanel,
-    loadFeature
+    loadFeature,
+    TOGGLE_SYNC_WMS, toggleSyncWms
 };

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,7 +16,8 @@ const getSaveMessageId = ({saving, saved}) => {
     return "featuregrid.toolbar.saveChanges";
 };
 
-module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload} = {}) =>
+module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, isSyncActive = false} = {}) =>
+
     (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
@@ -106,4 +107,12 @@ module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeo
             visible={selectedCount <= 1 && mode === "VIEW"}
             onClick={events.settings}
             glyph="features-grid-set"/>
+        <TButton
+            id="grid-settings"
+            tooltip={<Message msgId="featuregrid.toolbar.syncOnMap"/>}
+            disabled={disableToolbar}
+            active={isSyncActive}
+            visible={mode === "VIEW"}
+            onClick={events.sync}
+            glyph="globe"/>
     </ButtonGroup>);

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -13,6 +13,7 @@ const Cesium = require('../../../../libs/cesium');
 const assign = require('object-assign');
 const {isArray} = require('lodash');
 const WMSUtils = require('../../../../utils/cesium/WMSUtils');
+const FilterUtils = require('../../../../utils/FilterUtils');
 
 function getWMSURLs( urls ) {
     return urls.map((url) => url.split("\?")[0]);
@@ -55,6 +56,7 @@ function getQueryString(parameters) {
 
 function wmsToCesiumOptionsSingleTile(options) {
     const opacity = options.opacity !== undefined ? options.opacity : 1;
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
     const parameters = assign({
         styles: options.style || "",
         format: options.format || 'image/png',
@@ -66,7 +68,7 @@ function wmsToCesiumOptionsSingleTile(options) {
         height: options.size || 2000,
         bbox: "-180.0,-90,180.0,90",
         srs: "EPSG:4326"
-    }, options.params || {});
+    }, (CQL_FILTER ? {CQL_FILTER} : {}), options.params || {});
 
     return {
         url: (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&' + getQueryString(parameters)
@@ -75,6 +77,7 @@ function wmsToCesiumOptionsSingleTile(options) {
 
 function wmsToCesiumOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
     let proxyUrl = ConfigUtils.getProxyUrl({});
     let proxy;
     if (proxyUrl) {
@@ -93,8 +96,10 @@ function wmsToCesiumOptions(options) {
             transparent: options.transparent !== undefined ? options.transparent : true,
             opacity: opacity,
             tiled: options.tiled !== undefined ? options.tiled : true
+
         }, assign(
             {},
+            (CQL_FILTER ? {CQL_FILTER} : {}),
             (options._v_ ? {_v_: options._v_} : {}),
             (options.params || {})
         ))

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -56,7 +56,7 @@ function getQueryString(parameters) {
 
 function wmsToCesiumOptionsSingleTile(options) {
     const opacity = options.opacity !== undefined ? options.opacity : 1;
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     const parameters = assign({
         styles: options.style || "",
         format: options.format || 'image/png',
@@ -77,7 +77,7 @@ function wmsToCesiumOptionsSingleTile(options) {
 
 function wmsToCesiumOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     let proxyUrl = ConfigUtils.getProxyUrl({});
     let proxy;
     if (proxyUrl) {

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -527,4 +527,27 @@ describe('Leaflet layer', () => {
                  options={options} map={map} position={2}/>, document.getElementById("container"));
         expect(layer.layer.options.zIndex).toBe(2);
     });
+
+    it('creates a wms layer singleTile  for leaflet map', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "singleTile": true
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <LeafLetLayer type="wms"
+                 options={options} map={map}/>, document.getElementById("container"));
+        var lcount = 0;
+
+        expect(layer).toExist();
+        // count layers
+        map.eachLayer(function() {lcount++; });
+        expect(lcount).toBe(1);
+
+    });
 });

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -105,7 +105,7 @@ L.tileLayer.multipleUrlWMS = function(urls, options) {
 
 function wmsToLeafletOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     // NOTE: can we use opacity to manage visibility?
     return objectAssign({}, options.baseParams, {
         layers: options.name,

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -8,6 +8,7 @@
 
 const Layers = require('../../../../utils/leaflet/Layers');
 const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
+const FilterUtils = require('../../../../utils/FilterUtils');
 const WMSUtils = require('../../../../utils/leaflet/WMSUtils');
 const L = require('leaflet');
 const objectAssign = require('object-assign');
@@ -15,6 +16,34 @@ const {isArray, isEqual} = require('lodash');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 require('leaflet.nontiledlayer');
 
+L.NonTiledLayer.WMSCustom = L.NonTiledLayer.WMS.extend({
+    initialize: function(url, options) { // (String, Object)
+        this._wmsUrl = url;
+
+        let wmsParams = L.extend({}, this.defaultWmsParams);
+
+            // all keys that are not NonTiledLayer options go to WMS params
+        for (let i in options) {
+            if (!this.options.hasOwnProperty(i) && i.toUpperCase() !== 'CRS' && i !== "maxNativeZoom") {
+                wmsParams[i] = options[i];
+            }
+        }
+
+        this.wmsParams = wmsParams;
+
+        L.setOptions(this, options);
+    },
+    removeParams: function(params = [], noRedraw) {
+        params.forEach( key => delete this.wmsParams[key]);
+        if (!noRedraw) {
+            this.redraw();
+        }
+        return this;
+    }
+});
+L.nonTiledLayer.wmsCustom = function(url, options) {
+    return new L.NonTiledLayer.WMSCustom(url, options);
+};
 
 L.TileLayer.MultipleUrlWMS = L.TileLayer.WMS.extend({
     initialize: function(urls, options) {
@@ -60,6 +89,13 @@ L.TileLayer.MultipleUrlWMS = L.TileLayer.WMS.extend({
         const url = L.Util.template(this._urls[this._urlsIndex], {s: this._getSubdomain(tilePoint)});
 
         return url + L.Util.getParamString(this.wmsParams, url, true) + '&BBOX=' + bbox;
+    },
+    removeParams: function(params = [], noRedraw) {
+        params.forEach( key => delete this.wmsParams[key]);
+        if (!noRedraw) {
+            this.redraw();
+        }
+        return this;
     }
 });
 
@@ -69,6 +105,7 @@ L.tileLayer.multipleUrlWMS = function(urls, options) {
 
 function wmsToLeafletOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
     // NOTE: can we use opacity to manage visibility?
     return objectAssign({}, options.baseParams, {
         layers: options.name,
@@ -85,6 +122,7 @@ function wmsToLeafletOptions(options) {
         maxZoom: options.maxZoom || 23,
         maxNativeZoom: options.maxNativeZoom || 18
     }, objectAssign(
+        (CQL_FILTER ? {CQL_FILTER} : {}),
         (options._v_ ? {_v_: options._v_} : {}),
         (options.params || {})
     ));
@@ -100,7 +138,7 @@ Layers.registerType('wms', {
         const queryParameters = wmsToLeafletOptions(options) || {};
         urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters));
         if (options.singleTile) {
-            return L.nonTiledLayer.wms(urls[0], queryParameters);
+            return L.nonTiledLayer.wmsCustom(urls[0], queryParameters);
         }
         return L.tileLayer.multipleUrlWMS(urls, queryParameters);
     },
@@ -109,6 +147,7 @@ Layers.registerType('wms', {
         let oldqueryParameters = WMSUtils.filterWMSParamOptions(wmsToLeafletOptions(oldOptions));
         let newQueryParameters = WMSUtils.filterWMSParamOptions(wmsToLeafletOptions(newOptions));
         let newParameters = Object.keys(newQueryParameters).filter((key) => {return newQueryParameters[key] !== oldqueryParameters[key]; });
+        let removeParams = Object.keys(oldqueryParameters).filter((key) => { return oldqueryParameters[key] !== newQueryParameters[key]; });
         let newParams = {};
         let newLayer;
         if (oldOptions.singleTile !== newOptions.singleTile) {
@@ -116,7 +155,7 @@ Layers.registerType('wms', {
             urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, newQueryParameters));
             if (newOptions.singleTile) {
                 // return the nonTiledLayer
-                newLayer = L.nonTiledLayer.wms(urls[0], newQueryParameters);
+                newLayer = L.nonTiledLayer.wmsCustom(urls[0], newQueryParameters);
             } else {
                 newLayer = L.tileLayer.multipleUrlWMS(urls, newQueryParameters);
             }
@@ -130,6 +169,9 @@ Layers.registerType('wms', {
                 newLayer.setParams(newOptions.params);
             }
             return newLayer;
+        }
+        if (removeParams.length > 0) {
+            layer.removeParams(removeParams, newParameters.length > 0);
         }
         if ( newParameters.length > 0 ) {
             newParams = newParameters.reduce( (accumulator, currentValue) => {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -17,7 +17,7 @@ const SecurityUtils = require('../../../../utils/SecurityUtils');
 const mapUtils = require('../../../../utils/MapUtils');
 
 function wmsToOpenlayersOptions(options) {
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     // NOTE: can we use opacity to manage visibility?
     return objectAssign({}, options.baseParams, {
         LAYERS: options.name,

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -12,10 +12,12 @@ var objectAssign = require('object-assign');
 const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
 const ProxyUtils = require('../../../../utils/ProxyUtils');
 const {isArray} = require('lodash');
+const FilterUtils = require('../../../../utils/FilterUtils');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const mapUtils = require('../../../../utils/MapUtils');
 
 function wmsToOpenlayersOptions(options) {
+    const CQL_FILTER = FilterUtils.isFilterValid(options.filter) && FilterUtils.toCQLFilter(options.filter);
     // NOTE: can we use opacity to manage visibility?
     return objectAssign({}, options.baseParams, {
         LAYERS: options.name,
@@ -25,7 +27,8 @@ function wmsToOpenlayersOptions(options) {
         SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         TILED: options.tiled || false,
-        VERSION: options.version || "1.3.0"
+        VERSION: options.version || "1.3.0",
+        CQL_FILTER
     }, objectAssign(
         {},
         (options._v_ ? {_v_: options._v_} : {}),
@@ -97,7 +100,7 @@ Layers.registerType('wms', {
             }
             let oldParams = wmsToOpenlayersOptions(oldOptions);
             let newParams = wmsToOpenlayersOptions(newOptions);
-            changed = changed || ["LAYERS", "STYLES", "FORMAT", "TRANSPARENT", "TILED", "VERSION", "_v_" ].reduce((found, param) => {
+            changed = changed || ["LAYERS", "STYLES", "FORMAT", "TRANSPARENT", "TILED", "VERSION", "_v_", "CQL_FILTER"].reduce((found, param) => {
                 if (oldParams[param] !== newParams[param]) {
                     return true;
                 }

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -163,13 +163,6 @@ const createInitialQueryFlow = (action$, store, {url, name} = {}) => {
     );
 };
 
-const featureGridIsClosed = ( action$ ) =>
- action$.ofType(ASK_CLOSE_FEATURE_GRID_CONFIRM)
-      .switchMap(() =>
-         action$.ofype(CLOSE_FEATURE_GRID)
-             .takeUntil(action$.ofype(FEATURE_GRID_CLOSE_CONFIRMED))
-             .take(1));
-
 // Create action to add filter to wms layer
 const addFilterToWMSLayer = (layer, filter) => {
     return changeLayerProperties(layer, {filterObj: filter});
@@ -539,17 +532,6 @@ module.exports = {
         action$.ofType(OPEN_FEATURE_GRID)
         .switchMap(() => {
             return Rx.Observable.of(purgeMapInfoResults());
-        }),
-    /**
-     * Close sync filter wms control on faturegrid close,
-     * not on advanced search open
-     */
-    disableSyncWmsOnGridClose: (action$, store) =>
-        action$.ofType(OPEN_FEATURE_GRID).
-        switchMap(() => {
-            return action$.let(featureGridIsClosed)
-            .filter(() => isSyncWmsActive(store.getState()))
-            .map(() => removeFilterFromWMSLayer(store.getState()));
         }),
     /**
      * start sync filter with wms layer

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -31,7 +31,7 @@ const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURE
     SELECT_FEATURES, DESELECT_FEATURES, START_DRAWING_FEATURE, CREATE_NEW_FEATURE,
     CLEAR_CHANGES_CONFIRMED, FEATURE_GRID_CLOSE_CONFIRMED,
     openFeatureGrid, closeFeatureGrid, OPEN_FEATURE_GRID, CLOSE_FEATURE_GRID, CLOSE_FEATURE_GRID_CONFIRM, OPEN_ADVANCED_SEARCH, ZOOM_ALL, UPDATE_FILTER, START_SYNC_WMS,
-    STOP_SYNC_WMS, ASK_CLOSE_FEATURE_GRID_CONFIRM} = require('../actions/featuregrid');
+    STOP_SYNC_WMS} = require('../actions/featuregrid');
 
 const {TOGGLE_CONTROL, resetControls} = require('../actions/controls');
 const {setHighlightFeaturesPath} = require('../actions/highlight');

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -37,7 +37,7 @@ const Toolbar = connect(
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
         isSyncActive: state => state && state.controls && state.controls.syncwmsfilter && state.controls.syncwmsfilter.enabled,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
-        isSearchAllowed: (state) => true || !isCesium(state),
+        isSearchAllowed: (state) => !isCesium(state),
         isEditingAllowed: (state) => (isAdminUserSelector(state) || canEditSelector(state)) && !isCesium(state)
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -10,7 +10,7 @@ const React = require('react');
 const {connect} = require('react-redux');
 const {bindActionCreators} = require('redux');
 const {createSelector, createStructuredSelector} = require('reselect');
-const {paginationInfo, featureLoadingSelector, resultsSelector} = require('../../../selectors/query');
+const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive} = require('../../../selectors/query');
 const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter} = require('../../../selectors/featuregrid');
 const {isAdminUserSelector} = require('../../../selectors/security');
 const {isCesium} = require('../../../selectors/maptype');
@@ -35,7 +35,7 @@ const Toolbar = connect(
         disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar,
         disableDownload: state => (resultsSelector(state) || []).length === 0,
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
-        isSyncActive: state => state && state.controls && state.controls.syncwmsfilter && state.controls.syncwmsfilter.enabled,
+        isSyncActive: isSyncWmsActive,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
         isSearchAllowed: (state) => !isCesium(state),
         isEditingAllowed: (state) => (isAdminUserSelector(state) || canEditSelector(state)) && !isCesium(state)

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -35,8 +35,9 @@ const Toolbar = connect(
         disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar,
         disableDownload: state => (resultsSelector(state) || []).length === 0,
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
+        isSyncActive: state => state && state.controls && state.controls.syncwmsfilter && state.controls.syncwmsfilter.enabled,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
-        isSearchAllowed: (state) => !isCesium(state),
+        isSearchAllowed: (state) => true || !isCesium(state),
         isEditingAllowed: (state) => (isAdminUserSelector(state) || canEditSelector(state)) && !isCesium(state)
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})

--- a/web/client/plugins/featuregrid/toolbarEvents.js
+++ b/web/client/plugins/featuregrid/toolbarEvents.js
@@ -11,6 +11,7 @@ const {toggleTool,
     openAdvancedSearch,
     zoomAll
 } = require('../../actions/featuregrid');
+const {toggleSyncWms} = require('../../actions/wfsquery');
 
 module.exports = {
     createFeature: () => createNewFeatures([{}]),
@@ -27,5 +28,5 @@ module.exports = {
     onClose: () => closeFeatureGridConfirm(),
     showQueryPanel: () => openAdvancedSearch(),
     zoomAll: () => zoomAll(),
-    sync: () => toggleControl("syncwmsfilter")
+    sync: () => toggleSyncWms()
 };

--- a/web/client/plugins/featuregrid/toolbarEvents.js
+++ b/web/client/plugins/featuregrid/toolbarEvents.js
@@ -26,5 +26,6 @@ module.exports = {
     switchViewMode: () => toggleViewMode(),
     onClose: () => closeFeatureGridConfirm(),
     showQueryPanel: () => openAdvancedSearch(),
-    zoomAll: () => zoomAll()
+    zoomAll: () => zoomAll(),
+    sync: () => toggleControl("syncwmsfilter")
 };

--- a/web/client/reducers/query.js
+++ b/web/client/reducers/query.js
@@ -17,7 +17,8 @@ const {
     QUERY_RESULT,
     QUERY_ERROR,
     RESET_QUERY,
-    UPDATE_QUERY
+    UPDATE_QUERY,
+    TOGGLE_SYNC_WMS
 } = require('../actions/wfsquery');
 
 const {QUERY_FORM_RESET} = require('../actions/queryform');
@@ -48,7 +49,8 @@ const initialState = {
     featureTypes: {},
     data: {},
     result: null,
-    resultError: null
+    resultError: null,
+    syncWmsFilter: false
 };
 
 function query(state = initialState, action) {
@@ -131,6 +133,8 @@ function query(state = initialState, action) {
             resultError: null
         });
     }
+    case TOGGLE_SYNC_WMS:
+        return assign({}, state, {syncWmsFilter: !state.syncWmsFilter});
     default:
         return state;
     }

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -17,5 +17,6 @@ module.exports = {
     },
     isDescribeLoaded: (state, name) => !!get(state, `query.featureTypes.${name}`),
     describeSelector: (state) => get(state, `query.featureTypes.${get(state, "query.filterObj.featureTypeName")}.original`),
-    featureLoadingSelector: (state) => get(state, "query.featureLoading")
+    featureLoadingSelector: (state) => get(state, "query.featureLoading"),
+    isSyncWmsActive: (state) => get(state, "query.syncWmsFilter", false)
 };

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -902,7 +902,8 @@
                 "deleteGeometry": "Geometrie löschen",
                 "downloadGridData": "Daten herunterladen",
                 "hideShowColumns": "Spalten ausblenden / anzeigen",
-                "zoomAll": "Zoom zur Erweterung der Seite"
+                "zoomAll": "Zoom zur Erweterung der Seite",
+                "syncOnMap": "Karte mit Filter synchronisieren"
             }
         },
         "wfsdownload": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -901,7 +901,8 @@
                 "deleteGeometry": "Delete geometry",
                 "downloadGridData": "Download grid data",
                 "hideShowColumns": "Hide/show columns",
-                "zoomAll": "Zoom to page extent"
+                "zoomAll": "Zoom to page extent",
+                "syncOnMap": "Sync map with fitler"
             }
         },
         "wfsdownload": {

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -905,7 +905,8 @@
                 "deleteGeometry": "Eliminar geometría",
                 "downloadGridData": "Descargar datos",
                 "hideShowColumns": "Ocultar / mostrar columnas",
-                "zoomAll": "Zoom a la extensión de la página"
+                "zoomAll": "Zoom a la extensión de la página",
+                "syncOnMap": "Sincronizar mapa con filtro"
             }
         },
         "wfsdownload": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -906,7 +906,8 @@
                 "deleteGeometry": "Supprimer la géométrie",
                 "downloadGridData": "Télécharger les données",
                 "hideShowColumns": "Masquer / afficher les colonnes",
-                "zoomAll": "Zoom sur la page"
+                "zoomAll": "Zoom sur la page",
+                "syncOnMap": "Synchroniser la carte avec un filtre"
             }
         },
         "wfsdownload": {

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -902,7 +902,8 @@
                 "deleteGeometry": "Elimina la geometria",
                 "downloadGridData": "Esporta i dati della griglia",
                 "hideShowColumns": "Nascondi/mostra colonne",
-                "zoomAll": "Zoom all'estensione della pagina"
+                "zoomAll": "Zoom all'estensione della pagina",
+                "syncOnMap": "Sincronizza la mappa con i filtri"
             }
         },
         "wfsdownload": {

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -745,7 +745,8 @@ const FilterUtils = {
     ogcDateField,
     ogcListField,
     ogcStringField,
-    isLikeOrIlike: (operator) => operator === "ilike" || operator === "like"
+    isLikeOrIlike: (operator) => operator === "ilike" || operator === "like",
+    isFilterValid: (f = {}) => (f.filterFields && f.filterFields.length > 0) || (f.simpleFilterFields && f.simpleFilterFields.length > 0) || (f.spatialField && f.spatialField.geometry && f.spatialField.operation)
 };
 
 module.exports = FilterUtils;

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -7,7 +7,7 @@
  */
 
 const WMSUtils = {
-    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filter" ]
+    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterObj" ]
 };
 
 module.exports = WMSUtils;

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -7,7 +7,7 @@
  */
 
 const WMSUtils = {
-    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_" ]
+    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filter" ]
 };
 
 module.exports = WMSUtils;

--- a/web/client/utils/cesium/WMSUtils.js
+++ b/web/client/utils/cesium/WMSUtils.js
@@ -7,7 +7,7 @@
  */
 
 const WMSUtils = {
-    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterObj" ]
+    PARAM_OPTIONS: ["layers", "styles", "style", "format", "transparent", "version", "tiled", "opacity", "zindex", "srs", "singletile", "_v_", "filterobj" ]
 };
 
 module.exports = WMSUtils;

--- a/web/client/utils/leaflet/WMSUtils.js
+++ b/web/client/utils/leaflet/WMSUtils.js
@@ -8,7 +8,7 @@
 var objectAssign = require('object-assign');
 
 var WMSUtils = {
-    PARAM_OPTIONS: ["layers", "styles", "format", "transparent", "version", "tiled", "zindex", "_v_" ],
+    PARAM_OPTIONS: ["layers", "styles", "format", "transparent", "version", "tiled", "zindex", "_v_", "cql_filter"],
     wmsToLeafletOptions: function(options) {
         var opacity = options.opacity !== undefined ? options.opacity : 1;
         // NOTE: can we use opacity to manage visibility?

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -9,7 +9,7 @@
 const MapUtils = require('../MapUtils');
 const CoordinatesUtils = require('../CoordinatesUtils');
 const {isArray, isObject, head} = require('lodash');
-
+const FilterUtils = require('../FilterUtils');
 const assign = require('object-assign');
 
 module.exports = {
@@ -36,7 +36,7 @@ module.exports = {
 
         const locale = props.currentLocale ? head(props.currentLocale.split('-')) : null;
         const ENV = locale ? 'locale:' + locale : '';
-
+        const CQL_FILTER = FilterUtils.isFilterValid(layer.filterObj) && FilterUtils.toCQLFilter(layer.filterObj);
         return {
             request: {
                 service: 'WMS',
@@ -59,7 +59,7 @@ module.exports = {
                 feature_count: props.maxItems,
                 info_format: props.format || 'application/json',
                 ENV,
-                ...assign({}, layer.baseParams, layer.params, props.params)
+                ...assign({}, (CQL_FILTER ? {CQL_FILTER} : {}), layer.baseParams, layer.params, props.params)
             },
             metadata: {
                 title: isObject(layer.title) ? layer.title[props.currentLocale] || layer.title.default : layer.title,

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -9,6 +9,7 @@
 const MapUtils = require('../MapUtils');
 const CoordinatesUtils = require('../CoordinatesUtils');
 const WMTSUtils = require('../WMTSUtils');
+const FilterUtils = require('../FilterUtils');
 
 const {isArray, isObject} = require('lodash');
 
@@ -42,6 +43,8 @@ module.exports = {
 
         const matrixIds = WMTSUtils.limitMatrix(layer.matrixIds && WMTSUtils.getMatrixIds(layer.matrixIds, tileMatrixSet || srs) || WMTSUtils.getDefaultMatrixId(layer), resolutions.length);
 
+        const CQL_FILTER = FilterUtils.isFilterValid(layer.filterObj) && FilterUtils.toCQLFilter(layer.filterObj);
+
         return {
             request: {
                 service: 'WMTS',
@@ -49,7 +52,7 @@ module.exports = {
                 layer: layer.name,
                 infoformat: props.format,
                 style: layer.style || '',
-                ...assign({}, layer.baseParams, layer.params, props.params),
+                ...assign({}, (CQL_FILTER ? {CQL_FILTER} : {}), layer.baseParams, layer.params, props.params),
                 tilecol: tileCol,
                 tilerow: tileRow,
                 tilematrix: matrixIds[Math.round(props.map.zoom)],


### PR DESCRIPTION
Added sync on map button to toolbar of featuregrid plugin.
When active the selected layer showed on map is reloaded with the properly configured cql filter.
Is it possible to esclude from sync the quick filter query, adding disableQuickFilterSync = true in featuregrid state.

Docs:
state param: 
1) query.syncWmsFilter default false. if active the current filterObj is pasted to 
 the featuregrid.selectedLayer options.
2) featuregrid.disableQuickFilterSync default false. When true syncing of quick filters is avoided

Leaflet, Ol and Cesium WMS/T plugins generate properly configurate cql_filter if filterObj is present in layer.options.
Same is done in mapinfo/ wms and wmst utils during the creation of the request params.

