### PR TITLE
Add filter validity check in quick search

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
@@ -13,6 +13,7 @@ const {OverlayTrigger, Tooltip} = require('react-bootstrap');
 
 class AttributeFilter extends React.PureComponent {
     static propTypes = {
+        valid: PropTypes.bool,
         disabled: PropTypes.bool,
         onChange: PropTypes.func.isRequired,
         value: PropTypes.any,
@@ -27,6 +28,7 @@ class AttributeFilter extends React.PureComponent {
 
     static defaultProps = {
         value: '',
+        valid: true,
         onChange: () => {},
         column: {},
         placeholderMsgId: "featuregrid.filter.placeholders.default"
@@ -51,7 +53,7 @@ class AttributeFilter extends React.PureComponent {
     render() {
         let inputKey = 'header-filter--' + this.props.column.key;
         return (
-            <div key={inputKey} className="form-group">
+            <div key={inputKey} className={`form-group${(this.props.valid ? "" : " has-error")}`}>
               {this.renderTooltip(this.renderInput())}
             </div>
         );

--- a/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
@@ -7,12 +7,14 @@
   */
 
 const AttributeFilter = require('./AttributeFilter');
-const {compose, withHandlers, defaultProps} = require('recompose');
+const {trim} = require('lodash');
+const {compose, withHandlers, withState, defaultProps} = require('recompose');
 
 module.exports = compose(
     defaultProps({
         onValueChange: () => {}
     }),
+    withState("valid", "setValid", true),
     withHandlers({
         onChange: props => ({value, attribute} = {}) => {
             props.onValueChange(value);
@@ -26,6 +28,11 @@ module.exports = compose(
                 operator = "<";
             } else { // handle normal values
                 newVal = parseFloat(value, 10);
+            }
+            if (isNaN(newVal) && trim(value) !== "") {
+                props.setValid(false);
+            } else {
+                props.setValid(true);
             }
             props.onChange({
                 value: isNaN(newVal) ? undefined : newVal,

--- a/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
@@ -1,6 +1,6 @@
 const AttributeFilter = require('./AttributeFilter');
 const {compose, withHandlers, defaultProps} = require('recompose');
-
+const {trim} = require('lodash');
 module.exports = compose(
     defaultProps({
         onValueChange: () => {},
@@ -10,7 +10,8 @@ module.exports = compose(
         onChange: props => ({value, attribute} = {}) => {
             props.onValueChange(value);
             props.onChange({
-                value,
+                rawValue: value,
+                value: trim(value),
                 operator: "ilike",
                 type: 'string',
                 attribute

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/AttributeFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/AttributeFilter-test.jsx
@@ -49,6 +49,12 @@ describe('Test for AttributeFilter component', () => {
         const input = ReactTestUtils.findRenderedDOMComponentWithTag(cmp, "input");
         expect(input.value).toBe("TEST");
     });
+    it('render invalid', () => {
+        const cmp = ReactDOM.render(<AttributeFilter value={"TEST"} valid={false}/>, document.getElementById("container"));
+        const input = ReactTestUtils.findRenderedDOMComponentWithTag(cmp, "input");
+        expect(input.value).toBe("TEST");
+        expect( document.getElementsByClassName("has-error").length > 0).toBe(true);
+    });
     it('Test AttributeFilter onChange', () => {
         const actions = {
             onChange: () => {}

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
@@ -46,6 +46,17 @@ describe('Test for NumberFilter component', () => {
         ReactTestUtils.Simulate.change(input);
         expect(spyonChange).toHaveBeenCalled();
     });
+    it('Test NumberFilter validity check', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        ReactDOM.render(<NumberFilter onChange={actions.onChange} />, document.getElementById("container"));
+
+        const input = document.getElementsByTagName("input")[0];
+        input.value = "ZZZ 2";
+        ReactTestUtils.Simulate.change(input);
+        expect( document.getElementsByClassName("has-error").length > 0).toBe(true);
+    });
     it('Test NumberFilter expression', () => {
         const actions = {
             onChange: () => {},

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/StringFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/StringFilter-test.jsx
@@ -45,4 +45,18 @@ describe('Test for StringFilter component', () => {
         ReactTestUtils.Simulate.change(input);
         expect(spyonChange).toHaveBeenCalled();
     });
+    it('Test StringFilter space trim', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyonChange = expect.spyOn(actions, 'onChange');
+        ReactDOM.render(<StringFilter onChange={actions.onChange} />, document.getElementById("container"));
+        const input = document.getElementsByClassName("form-control input-sm")[0];
+        input.value = "test  ";
+        ReactTestUtils.Simulate.change(input);
+        expect(spyonChange).toHaveBeenCalled();
+        const args = spyonChange.calls[0].arguments[0];
+        expect(args.value).toBe("test");
+        expect(args.rawValue).toBe( "test  ");
+    });
 });

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/index-test.jsx
@@ -28,7 +28,7 @@ describe('Test for filterRenderer function', () => {
         Cmp = getFilterRenderer("string");
         expect(Cmp).toExist();
         ReactDOM.render(<Cmp />, document.getElementById("container"));
-        Cmp = getFilterRenderer("integer");
+        Cmp = getFilterRenderer("int");
         expect(Cmp).toExist();
         ReactDOM.render(<Cmp />, document.getElementById("container"));
         Cmp = getFilterRenderer("number");

--- a/web/client/components/data/featuregrid/filterRenderers/index.js
+++ b/web/client/components/data/featuregrid/filterRenderers/index.js
@@ -16,7 +16,7 @@ const types = {
     "defaultFilter": (type) => withProps(() =>({type: type}))(DefaultFilter),
     "string": () => StringFilter,
     "number": () => NumberFilter,
-    "integer": () => NumberFilter,
+    "int": () => NumberFilter,
     "date": () => withProps(() =>({type: "date"}))(DateTimeFilter),
     "time": () => withProps(() =>({type: "time"}))(DateTimeFilter),
     "date-time": () => withProps(() =>({type: "date-time"}))(DateTimeFilter)


### PR DESCRIPTION

## Description
This improves usability of quick filter trimming spaces from strings in filters and notifying the user if the filter is invalid.
 
![image](https://user-images.githubusercontent.com/1279510/30654971-e22ee520-9e2f-11e7-898c-fec800ff0adc.png)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
 - An invalid filter was not notified to the user. 
 - strings filters was not trimmed .e.g.  `"  TEST  "` --> `*   TEST  *`

**What is the new behavior?**
 - Invalid filter is notified with a red border of the filter input.
 - The filter strings are trimmed `"  TEST "` --> `*TEST*`

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x ] No
