### PR TITLE
Fixes #2200 Double notifications of map update

### DIFF
--- a/web/client/epics/__tests__/automapupdate-test.js
+++ b/web/client/epics/__tests__/automapupdate-test.js
@@ -11,11 +11,10 @@ var expect = require('expect');
 const configureMockStore = require('redux-mock-store').default;
 const {createEpicMiddleware, combineEpics } = require('redux-observable');
 const {configureMap, mapInfoLoaded} = require('../../actions/config');
-const {loginSuccess} = require('../../actions/security');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 
-const {manageAutoMapUpdate, updateMapInfoOnLogin} = require('../automapupdate');
-const rootEpic = combineEpics(manageAutoMapUpdate, updateMapInfoOnLogin);
+const {manageAutoMapUpdate} = require('../automapupdate');
+const rootEpic = combineEpics(manageAutoMapUpdate);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
 
@@ -29,7 +28,7 @@ describe('automapupdate Epics', () => {
         epicMiddleware.replaceEpic(rootEpic);
     });
 
-    it('update map', (done) => {
+    it('trigger update map', (done) => {
 
         let configuration = configureMap({}, "id");
 
@@ -45,31 +44,18 @@ describe('automapupdate Epics', () => {
                 const actions = store.getActions();
                 expect(actions.length).toBe(3);
                 expect(actions[2].type).toBe(SHOW_NOTIFICATION);
+                expect(actions[2].level).toBe('warning');
+                expect(actions[2].action.dispatch).toEqual({
+                    type: 'REFRESH_LAYERS',
+                    options: {bbox: true, dimensions: true, search: true, title: false},
+                    layers: []
+                });
+
             } catch (e) {
                 return done(e);
             }
             done();
-        }, 500);
-
-    });
-
-    it('update map info on login success no id', (done) => {
-
-        let login = loginSuccess("userDetails", "username", "password", "authProvider");
-        let configuration = configureMap({}, "id");
-
-        store.dispatch(configuration);
-        store.dispatch(login);
-
-        setTimeout( () => {
-            try {
-                const actions = store.getActions();
-                expect(actions.length).toBe(2);
-            } catch (e) {
-                return done(e);
-            }
-            done();
-        }, 500);
+        }, 1000);
 
     });
 });

--- a/web/client/plugins/AutoMapUpdate.jsx
+++ b/web/client/plugins/AutoMapUpdate.jsx
@@ -9,7 +9,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const {connect} = require('react-redux');
-const {manageAutoMapUpdate, updateMapInfoOnLogin} = require('../epics/automapupdate');
+const {manageAutoMapUpdate} = require('../epics/automapupdate');
 const {autoMapUpdateSelector} = require('../selectors/automapupdate');
 const {setControlProperty} = require('../actions/controls');
 const {refresh} = require('../epics/layers');
@@ -74,5 +74,5 @@ const AutoMapUpdatePlugin = connect(autoMapUpdateSelector, {
 module.exports = {
     AutoMapUpdatePlugin,
     reducers: {},
-    epics: {manageAutoMapUpdate, updateMapInfoOnLogin, refresh}
+    epics: {manageAutoMapUpdate, refresh}
 };


### PR DESCRIPTION
## Description
Removed epic from automapupdate

## Requirements
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
 - [x] Bugfix


**What is the current behavior?** 
Fixes #2200

**What is the new behavior?**
- Now the auto update will be show only one time

**Does this PR introduce a breaking change?** (check one with "x")
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: