### PR TITLE
Quick filter empty string handling

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/StringFilter.jsx
@@ -11,7 +11,7 @@ module.exports = compose(
             props.onValueChange(value);
             props.onChange({
                 rawValue: value,
-                value: trim(value),
+                value: trim(value) ? trim(value) : undefined,
                 operator: "ilike",
                 type: 'string',
                 attribute

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/StringFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/StringFilter-test.jsx
@@ -59,4 +59,26 @@ describe('Test for StringFilter component', () => {
         expect(args.value).toBe("test");
         expect(args.rawValue).toBe( "test  ");
     });
+    it('Test empty string trigger none', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyonChange = expect.spyOn(actions, 'onChange');
+        ReactDOM.render(<StringFilter onChange={actions.onChange} />, document.getElementById("container"));
+        const input = document.getElementsByClassName("form-control input-sm")[0];
+        input.value = "test";
+        ReactTestUtils.Simulate.change(input);
+        expect(spyonChange).toHaveBeenCalled();
+
+        input.value = " ";
+        ReactTestUtils.Simulate.change(input);
+        const args = spyonChange.calls[1].arguments[0];
+        expect(args.value).toBe(undefined);
+        expect(args.rawValue).toBe(" ");
+        input.value = "";
+        ReactTestUtils.Simulate.change(input);
+        const args2 = spyonChange.calls[2].arguments[0];
+        expect(args2.value).toBe(undefined);
+        expect(args2.rawValue).toBe("");
+    });
 });


### PR DESCRIPTION
## Description
Improve string editors behiviour in quick filter

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Sometimes typing quickly a filter with empty string could be triggered. This becomes annoying if you use WMS layer filtering functionality (#1918, that is going to be merged). This triggers some temporary errors on the layer that triggers layer disable (because of the checks on tile error count).

**What is the new behavior?**
Empty strings are never passed from the component.

**Does this PR introduce a breaking change?** (check one with "x")
 - [x] No