### PR TITLE
Fix #2224. Create users with UUID (capital letters)

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -247,13 +247,8 @@ var Api = {
     },
     createUser: function(user, options) {
         const url = "users/";
-        const postUser = assign({}, user);
-        if (postUser.newPassword) {
-            postUser.password = postUser.newPassword;
-        }
-        // uuid is time-based
-        postUser.attribute = {name: "uuid", value: uuidv1()};
-        return axios.post(url, {User: postUser}, this.addBaseUrl(parseOptions(options))).then(function(response) {return response.data; });
+
+        return axios.post(url, {User: Api.utils.initUser(user)}, this.addBaseUrl(parseOptions(options))).then(function(response) {return response.data; });
     },
     deleteUser: function(id, options = {}) {
         const url = "users/user/" + id;
@@ -337,6 +332,25 @@ var Api = {
         return axios.post(url, null, this.addBaseUrl(parseOptions(options))).then(function(response) {
             return response.data;
         });
+    },
+    utils: {
+        /**
+         * initialize User with newPassword and UUID
+         * @param  {object} user The user object
+         * @return {object}      The user object adapted for creation (newPassword, UUID)
+         */
+        initUser: (user) => {
+            const postUser = assign({}, user);
+            if (postUser.newPassword) {
+                postUser.password = postUser.newPassword;
+            }
+            // uuid is time-based
+            const uuidAttr = {
+                name: "UUID", value: uuidv1()
+            };
+            postUser.attribute = postUser.attribute && postUser.attribute.length > 0 ? [...postUser.attribute, uuidAttr] : [uuidAttr];
+            return postUser;
+        }
     }
 };
 

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -27,4 +27,17 @@ describe('Test correctness of the GeoStore APIs', () => {
         }));
         expect(API.encodeContent(result).indexOf('\\')).toBe(-1);
     });
+    it('test user creation utils', () => {
+        const originalUser = {name: "username", newPassword: "PASSWORD"};
+        const user = API.utils.initUser(originalUser);
+        expect(user.password).toBe(originalUser.newPassword);
+        expect(user.attribute).toExist();
+        expect(user.attribute.length).toBe(1);
+        expect(user.attribute.length).toBe(1);
+        expect(user.attribute[0].name).toBe("UUID");
+        expect(user.attribute[0].value).toExist();
+        const originalUser2 = {name: "username", newPassword: "PASSWORD", attribute: [{name: "email", value: "test@test.test"}]};
+        const user2 = API.utils.initUser(originalUser2);
+        expect(user2.attribute.length).toBe(2);
+    });
 });


### PR DESCRIPTION
## Description
This fixes UUID attribute creation for users with capital letters. This is needed when you use fixed authorization key strategy of authentication and sync with GeoServer. 
## Issues
 - Fix #2224

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Users was created with an attribute named `uuid`. Other attributes was not forwarded to the creation

**What is the new behavior?**
Users was created with an attribute named `UUID`. Other attributes are now forwarded correctly 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
