### PR TITLE
Fix #2244 reset controls now skip correctly some controls

### DIFF
--- a/web/client/reducers/__tests__/controls-test.js
+++ b/web/client/reducers/__tests__/controls-test.js
@@ -109,7 +109,7 @@ describe('Test the controls reducer', () => {
         const state = controls(
             {
                 c1: { enabled: true},
-                c2: { enabled: false},
+                c2: { enabled: true},
                 c3: { idonthaveenabledfield: "whatever"}
             }, {
                 type: RESET_CONTROLS,

--- a/web/client/reducers/__tests__/controls-test.js
+++ b/web/client/reducers/__tests__/controls-test.js
@@ -10,7 +10,17 @@ const expect = require('expect');
 const controls = require('../controls');
 const {TOGGLE_CONTROL, SET_CONTROL_PROPERTY, RESET_CONTROLS} = require('../../actions/controls');
 
-describe('Test the constrols reducer', () => {
+describe('Test the controls reducer', () => {
+    it('default case', () => {
+        const state = controls({
+            mycontrol: {
+                enabled: true
+            }
+        }, {});
+        expect(state.mycontrol).toExist();
+        expect(state.mycontrol.enabled).toBe(true);
+    });
+
     it('toggles a control the first time', () => {
         const state = controls({}, {
             type: TOGGLE_CONTROL,
@@ -58,15 +68,32 @@ describe('Test the constrols reducer', () => {
         expect(state.mycontrol.prop).toBe('val');
     });
 
+    it('set a control property with toggle', () => {
+        const state = controls({
+            mycontrol: {
+                enabled: true,
+                prop: "val"
+            }
+        }, {
+            type: SET_CONTROL_PROPERTY,
+            control: 'mycontrol',
+            property: 'prop',
+            value: 'val',
+            toggle: true
+        });
+        expect(state.mycontrol).toExist();
+        expect(state.mycontrol.prop).toBe(undefined);
+    });
 
-    it('reset the controls', () => {
+    it('reset the controls without skip ', () => {
         const state = controls(
             {
                 c1: { enabled: true},
                 c2: { enabled: false},
                 c3: { idonthaveenabledfield: "whatever"}
             }, {
-                type: RESET_CONTROLS
+                type: RESET_CONTROLS,
+                skip: []
             });
         expect(state.c1).toExist();
         expect(state.c2).toExist();
@@ -74,5 +101,27 @@ describe('Test the constrols reducer', () => {
         expect(state.c1.enabled).toBe(false);
         expect(state.c2.enabled).toBe(false);
         expect(state.c3.enabled).toNotExist();
+        expect(state.c3.idonthaveenabledfield).toExist();
+        expect(state.c3.idonthaveenabledfield).toBe("whatever");
+    });
+
+    it('reset the controls with skip c1,c3', () => {
+        const state = controls(
+            {
+                c1: { enabled: true},
+                c2: { enabled: false},
+                c3: { idonthaveenabledfield: "whatever"}
+            }, {
+                type: RESET_CONTROLS,
+                skip: ["c1", "c3"]
+            });
+        expect(state.c1).toExist();
+        expect(state.c2).toExist();
+        expect(state.c3).toExist();
+        expect(state.c1.enabled).toBe(true);
+        expect(state.c2.enabled).toBe(false);
+        expect(state.c3.enabled).toNotExist();
+        expect(state.c3.idonthaveenabledfield).toExist();
+        expect(state.c3.idonthaveenabledfield).toBe("whatever");
     });
 });

--- a/web/client/reducers/controls.js
+++ b/web/client/reducers/controls.js
@@ -67,7 +67,11 @@ function controls(state = {}, action) {
             })
         });
     case RESET_CONTROLS: {
-        const resetted = Object.keys(state).reduce((previous, controlName) => {
+        let newControls = Object.keys(state);
+        if (action && action.skip && action.skip.length) {
+            newControls = Object.keys(state).filter(c => action.skip.indexOf(c) === -1);
+        }
+        const resetted = newControls.reduce((previous, controlName) => {
             return assign(previous, {
                 [controlName]: assign({}, state[controlName], state[controlName].enabled === true ? {
                     enabled: false

--- a/web/client/reducers/controls.js
+++ b/web/client/reducers/controls.js
@@ -67,10 +67,7 @@ function controls(state = {}, action) {
             })
         });
     case RESET_CONTROLS: {
-        let newControls = Object.keys(state);
-        if (action && action.skip && action.skip.length) {
-            newControls = Object.keys(state).filter(c => action.skip.indexOf(c) === -1);
-        }
+        const newControls = Object.keys(state).filter(c => (action.skip || []).indexOf(c) === -1);
         const resetted = newControls.reduce((previous, controlName) => {
             return assign(previous, {
                 [controlName]: assign({}, state[controlName], state[controlName].enabled === true ? {


### PR DESCRIPTION
## Description
Now reset controls rest correctly the controls. previously it was ignorign the "skip" param.

## Issues
 - Fix #2244

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
controls are always reset to a false value and if we cannot avoid to reset one or more controls.

**What is the new behavior?**
now one or more controls can be skipped from resetting.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
