### PR TITLE
Fix #2217. Fixed issues with quick filter

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
@@ -9,7 +9,7 @@
 const AttributeFilter = require('./AttributeFilter');
 const {trim} = require('lodash');
 const {compose, withHandlers, withState, defaultProps} = require('recompose');
-
+const EXPRESSION_REGEX = /\s*(!==|!=|<>|<=|>=|===|==|=|<|>)?\s*(\d*\.?\d*)\s*/;
 module.exports = compose(
     defaultProps({
         onValueChange: () => {}
@@ -20,15 +20,20 @@ module.exports = compose(
             props.onValueChange(value);
             let operator = "=";
             let newVal;
-            if (value.indexOf('>') > -1) { // handle greater then
-                newVal = parseFloat(value.split('>')[1], 10);
-                operator = ">";
-            } else if (value.indexOf('<') > -1) { // handle less then
-                newVal = parseFloat(value.split('<')[1], 10);
-                operator = "<";
-            } else { // handle normal values
+            const match = EXPRESSION_REGEX.exec(value);
+            if (match) {
+                operator = match[1] || "=";
+                // replace with standard opeartors
+                if (operator === "!==" | operator === "!=") {
+                    operator = "<>";
+                } else if (operator === "===" | operator === "==") {
+                    operator = "=";
+                }
+                newVal = parseFloat(match[2]);
+            } else {
                 newVal = parseFloat(value, 10);
             }
+
             if (isNaN(newVal) && trim(value) !== "") {
                 props.setValid(false);
             } else {

--- a/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
@@ -9,7 +9,7 @@
 const AttributeFilter = require('./AttributeFilter');
 const {trim} = require('lodash');
 const {compose, withHandlers, withState, defaultProps} = require('recompose');
-const EXPRESSION_REGEX = /\s*(!==|!=|<>|<=|>=|===|==|=|<|>)?\s*(\d*\.?\d*)\s*/;
+const EXPRESSION_REGEX = /\s*(!==|!=|<>|<=|>=|===|==|=|<|>)?\s*(-?\d*\.?\d*)\s*/;
 module.exports = compose(
     defaultProps({
         onValueChange: () => {}

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
@@ -10,6 +10,35 @@ const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-dom/test-utils');
 const NumberFilter = require('../NumberFilter');
 const expect = require('expect');
+const EXPRESSION_TESTS = [
+    ["2", "=", 2],
+    ["2.", "=", 2],
+    ["2.1", "=", 2.1],
+    [" 2.1 ", "=", 2.1],
+    ["> 2", ">", 2],
+    [">= 2", ">=", 2],
+    ["< 2", "<", 2],
+    ["<= 2", "<=", 2],
+    ["=2", "=", 2],
+    ["==2", "=", 2],
+    ["=== 2", "=", 2],
+    ["!== 2", "<>", 2],
+    ["!= 2", "<>", 2],
+    ["<> 2", "<>", 2],
+    ["", "=", undefined],
+    [" ", "=", undefined],
+    ["ZZZ", "=", undefined]
+];
+const testExperssion = (spyonChange, spyonValueChange, rawValue, expectedOperator, expectedValue) => {
+    const input = document.getElementsByTagName("input")[0];
+    input.value = rawValue;
+    ReactTestUtils.Simulate.change(input);
+    const args = spyonChange.calls[spyonChange.calls.length - 1].arguments[0];
+    const valueArgs = spyonValueChange.calls[spyonValueChange.calls.length - 1].arguments[0];
+    expect(args.value).toBe(expectedValue);
+    expect(args.operator).toBe(expectedOperator);
+    expect(valueArgs).toBe(rawValue);
+};
 
 describe('Test for NumberFilter component', () => {
     beforeEach((done) => {
@@ -57,7 +86,7 @@ describe('Test for NumberFilter component', () => {
         ReactTestUtils.Simulate.change(input);
         expect( document.getElementsByClassName("has-error").length > 0).toBe(true);
     });
-    it('Test NumberFilter expression', () => {
+    it('Test NumberFilter expressions', () => {
         const actions = {
             onChange: () => {},
             onValueChange: () => {}
@@ -65,19 +94,6 @@ describe('Test for NumberFilter component', () => {
         const spyonChange = expect.spyOn(actions, 'onChange');
         const spyonValueChange = expect.spyOn(actions, 'onValueChange');
         ReactDOM.render(<NumberFilter onChange={actions.onChange} onValueChange={actions.onValueChange} />, document.getElementById("container"));
-
-        const input = document.getElementsByTagName("input")[0];
-        input.value = "> 2";
-        ReactTestUtils.Simulate.change(input);
-        const args = spyonChange.calls[0].arguments[0];
-        expect(args.value).toBe(2);
-        expect(args.operator).toBe(">");
-        expect(spyonValueChange).toHaveBeenCalled();
-        expect(spyonValueChange).toHaveBeenCalledWith("> 2");
-        input.value = "< 2";
-        ReactTestUtils.Simulate.change(input);
-        const args2 = spyonChange.calls[1].arguments[0];
-        expect(args2.value).toBe(2);
-        expect(args2.operator).toBe("<");
+        EXPRESSION_TESTS.map( params => testExperssion(spyonChange, spyonValueChange, ...params));
     });
 });

--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
@@ -25,6 +25,7 @@ const EXPRESSION_TESTS = [
     ["!== 2", "<>", 2],
     ["!= 2", "<>", 2],
     ["<> 2", "<>", 2],
+    ["<> -2", "<>", -2],
     ["", "=", undefined],
     [" ", "=", undefined],
     ["ZZZ", "=", undefined]

--- a/web/client/epics/__tests__/epicTestUtils.js
+++ b/web/client/epics/__tests__/epicTestUtils.js
@@ -1,7 +1,7 @@
 
 const Rx = require('rxjs');
-const { ActionsObservable } = require('redux-observable');
-
+const { ActionsObservable, combineEpics } = require('redux-observable');
+const TEST_TIMEOUT = "EPICTEST:TIMEOUT";
 module.exports = {
     /**
      * Utility to test an epic
@@ -24,5 +24,16 @@ module.exports = {
         } else {
             actions.next(action);
         }
-    }
+    },
+    /**
+     * The action emitted by the addTimeoutEpic
+     * @type {string}
+     */
+    TEST_TIMEOUT,
+    /**
+     * Combine the epic with another than emits TEST_TIMEOUT action.
+     * @param {function} epic         The epic to combine
+     * @param {Number} [timeout=1000] milliseconds to wait after emit the TEST_TIMEOUT action.
+     */
+    addTimeoutEpic: (epic, timeout = 1000) => combineEpics(epic, () => Rx.Observable.timer(timeout).map(() => ({type: TEST_TIMEOUT, timeout})))
 };

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -11,7 +11,7 @@ const axios = require('../libs/ajax');
 const Url = require('url');
 const {changeSpatialAttribute, SELECT_VIEWPORT_SPATIAL_METHOD, updateGeometrySpatialField} = require('../actions/queryform');
 const {CHANGE_MAP_VIEW} = require('../actions/map');
-const {FEATURE_TYPE_SELECTED, QUERY, featureLoading, featureTypeLoaded, featureTypeError, querySearchResponse, queryError} = require('../actions/wfsquery');
+const {FEATURE_TYPE_SELECTED, QUERY, UPDATE_QUERY, featureLoading, featureTypeLoaded, featureTypeError, querySearchResponse, queryError} = require('../actions/wfsquery');
 const {paginationInfo, isDescribeLoaded, describeSelector} = require('../selectors/query');
 const {mapSelector} = require('../selectors/map');
 const FilterUtils = require('../utils/FilterUtils');
@@ -251,7 +251,7 @@ const wfsQueryEpic = (action$, store) =>
                         return Rx.Observable.of(queryError(error));
                     })
                     .concat(Rx.Observable.of(featureLoading(false)))
-            );
+            ).takeUntil(action$.ofType(UPDATE_QUERY));
         });
 
 /**


### PR DESCRIPTION
## Description
This fixes issues with FeatureGrid quick filter issues of wrong filter generation and adding many all comparison operators for number editor.
## Issues
 - Fix #2217 . With new filter and solved race condition
 - Fix #2218 . Now <> is managed. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
 - Quick filter supports only 2 (without operator is an equal filter) > 2 and < 2
 - Typing, sometimes you don't have the expected result (you can not see the last filter applied)

**What is the new behavior?**
 - Now quick filter supports expessions like: 
  - `2`, `-2.2`, `= 2`, `== 2`, `=== 2`
  - `> 2`, `>= 2 `
  - `< 2`,` <= 2`
  - `<> 2`,` != 2`, `!== 2`

 - The race condition has been removed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

**Other information**:
Added a test utility function that combines the epic with a(nother) epic that emits an action after a configured time. 
Using this with testEpic function you can check conditions like `takeUntil`, verifying that the side effect is blocked and that some actions are not emitted in the time interval provided. 
