### PR TITLE
Fixes #2229: supported dimensions with no default values in WMS getca…

### DIFF
--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -137,7 +137,7 @@ const converters = {
                 service: records.service,
                 boundingBox: WMS.getBBox(record),
                 dimensions: (record.Dimension && castArray(record.Dimension) || []).map((dim) => assign({}, {
-                    values: dim._.split(',')
+                    values: dim._ && dim._.split(',') || []
                 }, dim.$ || {})),
                 references: [{
                     type: "OGC:WMS",
@@ -161,10 +161,10 @@ const converters = {
                 identifier: getNodeText(record["ows:Identifier"]),
                 tags: "",
                 tileMatrixSet: record.TileMatrixSet,
-                matrixIds: castArray(record.TileMatrixSetLink).reduce((previous, current) => {
-                    const tileMatrix = head(record.TileMatrixSet.filter((matrix) => matrix["ows:Identifier"] === current.TileMatrixSet));
-                    const tileMatrixSRS = CoordinatesUtils.getEPSGCode(tileMatrix["ows:SupportedCRS"]);
-                    const levels = current.TileMatrixSetLimits && current.TileMatrixSetLimits.TileMatrixLimits.map((limit) => ({
+                matrixIds: castArray(record.TileMatrixSetLink || []).reduce((previous, current) => {
+                    const tileMatrix = head((record.TileMatrixSet || []).filter((matrix) => matrix["ows:Identifier"] === current.TileMatrixSet));
+                    const tileMatrixSRS = tileMatrix && CoordinatesUtils.getEPSGCode(tileMatrix["ows:SupportedCRS"]);
+                    const levels = current.TileMatrixSetLimits && (current.TileMatrixSetLimits.TileMatrixLimits || []).map((limit) => ({
                         identifier: limit.TileMatrix,
                         ranges: {
                             cols: {

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const CatalogUtils = require('../CatalogUtils');
+
+describe('Test the CatalogUtils', () => {
+    it('wms dimensions without values', () => {
+        const records = CatalogUtils.getCatalogRecords('wms', {
+            records: [{
+                Dimension: [{
+                    $: {
+                        name: 'time'
+                    }
+                }]
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].dimensions.length).toBe(1);
+        expect(records[0].dimensions[0].values.length).toBe(0);
+    });
+
+    it('wms dimensions with values', () => {
+        const records = CatalogUtils.getCatalogRecords('wms', {
+            records: [{
+                Dimension: [{
+                    $: {
+                        name: 'time'
+                    },
+                    _: '1,2'
+                }]
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].dimensions.length).toBe(1);
+        expect(records[0].dimensions[0].values.length).toBe(2);
+    });
+
+    it('wmts', () => {
+        const records = CatalogUtils.getCatalogRecords('wmts', {
+            records: [{}]
+        }, {});
+        expect(records.length).toBe(1);
+    });
+
+    it('wmts with tilematrix', () => {
+        const records = CatalogUtils.getCatalogRecords('wmts', {
+            records: [{
+                "ows:WGS84BoundingBox": {
+                    "ows:LowerCorner": "-180.0 -90.0",
+                    "ows:UpperCorner": "180.0 90.0"
+                },
+                TileMatrixSetLink: [{
+                    TileMatrixSet: 'EPSG:4326',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:4326:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }],
+                TileMatrixSet: [{
+                    "ows:Identifier": "EPSG:4326",
+                    "ows:SupportedCRS": "EPSG:4326"
+                }]
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+
+    });
+
+    it('csw empty', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{}]
+        }, {});
+        expect(records.length).toBe(1);
+    });
+
+    it('csw with DC URI', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    URI: [{
+                        name: "thumbnail",
+                        value: "http://thumb"
+                    }, {
+                        name: "wms",
+                        protocol: "OGC:WMS-1.1.1-http-get-map",
+                        value: "http://geoserver"
+                    }]
+                }
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+    });
+
+    it('csw with DC references', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    references: [{
+                        name: "thumbnail",
+                        scheme: "WWW:LINK-1.0-http--image-thumbnail",
+                        value: "http://thumb"
+                    }, {
+                        name: "wms",
+                        scheme: "OGC:WMS-1.1.1-http-get-map",
+                        value: "http://geoserver"
+                    }]
+                }
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+    });
+});


### PR DESCRIPTION
…pabilities parsing

## Description
WMS capabilities parser was failing on layers with dimensions but without a list of values on some of them.

## Issues
 - Fix #2229

**Please check if the PR fulfills these requirements**
- [x The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
WMS capabilities parser was failing on layers with dimensions but without a list of values on some of them.

**What is the new behavior?**
WMS capabilities parser is not failing anymore.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
