### PR TITLE
Fixes #2227: shows error message on adding WMTS layer if the current …

### DIFF
--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -303,12 +303,12 @@ class Catalog extends React.Component {
                                 </FormGroup>
                                 <FormGroup controlId="buttons" key="buttons">
                                     {this.renderButtons()}
+                                    {this.props.layerError ? this.renderError(this.props.layerError) : null}
                                 </FormGroup>
                             </Form>)}
                     footer={this.renderPagination()}>
                             <div>
                                 {this.renderResult()}
-                                {this.props.layerError ? this.renderError(this.props.layerError) : null}
                             </div>
                         </BorderLayout>
             ) : (

--- a/web/client/components/map/leaflet/plugins/WMTSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMTSLayer.js
@@ -13,7 +13,7 @@ const assign = require('object-assign');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const WMTSUtils = require('../../../../utils/WMTSUtils');
 const WMTS = require('../../../../utils/leaflet/WMTS');
-const {isObject, isArray} = require('lodash');
+const {isArray, isObject} = require('lodash');
 
 L.tileLayer.wmts = function(urls, options, matrixOptions) {
     return new WMTS(urls, options, matrixOptions);

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -20,7 +20,7 @@ const WMTSUtils = {
         return matrixIds;
     },
     getMatrixIds: (matrix, srs) => {
-        return (isObject(matrix) && matrix[srs] || matrix).map((el) => el.identifier);
+        return ((isObject(matrix) && matrix[srs]) || isArray(matrix) || []).map((el) => el.identifier);
     },
     limitMatrix: (matrix, len) => {
         if (matrix.length > len) {
@@ -31,7 +31,7 @@ const WMTSUtils = {
         }
         return matrix;
     },
-    getTileMatrixSet: (tileMatrixSet, srs, allowedSRS, matrixIds = {}) => {
+    getTileMatrixSet: (tileMatrixSet, srs, allowedSRS, matrixIds = {}, defaultMatrix = srs) => {
         if (tileMatrixSet && isString(tileMatrixSet)) {
             return tileMatrixSet;
         }
@@ -44,10 +44,10 @@ const WMTSUtils = {
                     return tileMatrixSet[current] || previous;
                 }
                 return previous;
-            }, srs);
+            }, defaultMatrix);
         }
 
-        return srs;
+        return defaultMatrix;
     }
 };
 

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -20,7 +20,7 @@ const WMTSUtils = {
         return matrixIds;
     },
     getMatrixIds: (matrix, srs) => {
-        return ((isObject(matrix) && matrix[srs]) || isArray(matrix) || []).map((el) => el.identifier);
+        return ((isObject(matrix) && isArray(matrix[srs]) && matrix[srs]) || (isArray(matrix) && matrix) || []).map((el) => el.identifier);
     },
     limitMatrix: (matrix, len) => {
         if (matrix.length > len) {

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -77,6 +77,82 @@ describe('Test the CatalogUtils', () => {
 
     });
 
+    it('wmts with tilematrix filtered', () => {
+        const records = CatalogUtils.getCatalogRecords('wmts', {
+            records: [{
+                "ows:WGS84BoundingBox": {
+                    "ows:LowerCorner": "-180.0 -90.0",
+                    "ows:UpperCorner": "180.0 90.0"
+                },
+                TileMatrixSetLink: [{
+                    TileMatrixSet: 'EPSG:4326',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:4326:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }],
+                TileMatrixSet: [{
+                    "ows:Identifier": "EPSG:4326",
+                    "ows:SupportedCRS": "EPSG:4326"
+                }],
+                SRS: ['EPSG:4326', 'EPSG:3857']
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].references.length).toBe(1);
+        expect(records[0].references[0].SRS.length).toBe(1);
+    });
+
+    it('wmts with tilematrix not filtered', () => {
+        const records = CatalogUtils.getCatalogRecords('wmts', {
+            records: [{
+                "ows:WGS84BoundingBox": {
+                    "ows:LowerCorner": "-180.0 -90.0",
+                    "ows:UpperCorner": "180.0 90.0"
+                },
+                TileMatrixSetLink: [{
+                    TileMatrixSet: 'EPSG:4326',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:4326:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }, {
+                    TileMatrixSet: 'EPSG:3857',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:3857:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }],
+                TileMatrixSet: [{
+                    "ows:Identifier": "EPSG:4326",
+                    "ows:SupportedCRS": "EPSG:4326"
+                }, {
+                    "ows:Identifier": "EPSG:3857",
+                    "ows:SupportedCRS": "EPSG:3857"
+                }],
+                SRS: ['EPSG:4326', 'EPSG:3857']
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].references.length).toBe(1);
+        expect(records[0].references[0].SRS.length).toBe(2);
+    });
+
     it('csw empty', () => {
         const records = CatalogUtils.getCatalogRecords('csw', {
             records: [{}]

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const WMTSUtils = require('../WMTSUtils');
+
+describe('Test the WMTSUtils', () => {
+    it('get matrix ids with object', () => {
+        const ids = WMTSUtils.getMatrixIds({
+            "EPSG:4326": [{
+                identifier: 'EPSG:4326'
+            }]
+        }, 'EPSG:4326');
+        expect(ids.length).toBe(1);
+        expect(ids[0]).toBe('EPSG:4326');
+    });
+
+    it('get matrix ids with array', () => {
+        const ids = WMTSUtils.getMatrixIds([{
+                identifier: 'EPSG:4326'
+            }], 'EPSG:4326');
+        expect(ids.length).toBe(1);
+        expect(ids[0]).toBe('EPSG:4326');
+    });
+});

--- a/web/client/utils/leaflet/WMTS.js
+++ b/web/client/utils/leaflet/WMTS.js
@@ -60,6 +60,9 @@ var WMTS = L.TileLayer.extend({
         let se = crs.project(map.unproject(sePoint, tilePoint.z));
         let tilewidth = se.x - nw.x;
         let t = map.getZoom();
+        if (!this.matrixIds[t]) {
+            return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        }
         let ident = this.matrixIds[t].identifier;
         let X0 = this.matrixIds[t].topLeftCorner.lng;
         let Y0 = this.matrixIds[t].topLeftCorner.lat;


### PR DESCRIPTION
…SRS is not supported by the layer

## Description
Fixing WMTS SRS support in Catalog.

## Issues
 - Fix #2227

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
When a WMTS service supports a list of SRS, but a specific layer has a shorter list, the full SRS list is used to decide if the layers can be added to map.

**What is the new behavior?**
The supported SRS list is filtered for each layer, so that an error message is shown if the current map SRS is not supported for that layer.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
