### PR TITLE
Fixes #2267: wrong zoom in print mappreview when useFixedScales=false

### DIFF
--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -36,7 +36,8 @@ class MapPreview extends React.Component {
         resolutions: PropTypes.array,
         printRatio: PropTypes.number,
         layout: PropTypes.string,
-        layoutSize: PropTypes.object
+        layoutSize: PropTypes.object,
+        useFixedScales: PropTypes.bool
     };
 
     static defaultProps = {
@@ -51,7 +52,8 @@ class MapPreview extends React.Component {
         height: 270,
         enableRefresh: true,
         enableScalebox: true,
-        printRatio: 96.0 / 72.0
+        printRatio: 96.0 / 72.0,
+        useFixedScales: false
     };
 
     componentWillMount() {
@@ -121,7 +123,7 @@ class MapPreview extends React.Component {
                 interactive={false}
                 onMapViewChanges={this.props.onMapViewChanges}
                 zoomControl={false}
-                zoom={this.props.scales ? PrintUtils.getMapZoom(this.props.map.scaleZoom, this.props.scales) : this.props.map.zoom}
+                zoom={this.props.useFixedScales && this.props.scales ? PrintUtils.getMapZoom(this.props.map.scaleZoom, this.props.scales) : this.props.map.zoom}
                 center={this.props.map.center}
                 id="print_preview"
                 registerHooks={false}

--- a/web/client/components/print/__tests__/MapPreview-test.jsx
+++ b/web/client/components/print/__tests__/MapPreview-test.jsx
@@ -82,4 +82,44 @@ describe("Test the MapPreview component", () => {
         expect(node).toExist();
         expect(node.getElementsByClassName('leaflet-layer').length).toBe(2);
     });
+
+    it('uses map zoom when useFixedScales is false', () => {
+        const layers = [{
+            name: 'layer1',
+            type: "wms",
+            visibility: false,
+            url: "http://fake"
+        }, {
+            name: 'layer2',
+            visibility: true,
+            type: "osm"
+        }, {
+            name: 'layer3',
+            visibility: true,
+            type: "wms",
+            url: "http://fake"
+        }];
+        const cmp = ReactDOM.render(<MapPreview layers={layers} map={{center: {x: 10.0, y: 40.0}, zoom: 5}}/>, document.getElementById("container"));
+        expect(cmp.refs.mappa.props.zoom).toBe(5);
+    });
+
+    it('calculate zoom on given scales when useFixedScales is true', () => {
+        const layers = [{
+            name: 'layer1',
+            type: "wms",
+            visibility: false,
+            url: "http://fake"
+        }, {
+            name: 'layer2',
+            visibility: true,
+            type: "osm"
+        }, {
+            name: 'layer3',
+            visibility: true,
+            type: "wms",
+            url: "http://fake"
+        }];
+        const cmp = ReactDOM.render(<MapPreview layers={layers} map={{center: {x: 10.0, y: 40.0}, zoom: 5, scaleZoom: 3}} useFixedScales scales={[100, 1000, 10000, 100000]}/>, document.getElementById("container"));
+        expect(cmp.refs.mappa.props.zoom).toBe(13);
+    });
 });

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -248,6 +248,7 @@ class Print extends React.Component {
                         layout={layoutName}
                         layoutSize={layout && layout.map || {width: 10, height: 10}}
                         resolutions={MapUtils.getResolutions()}
+                        useFixedScales={this.props.useFixedScales}
                         {...this.props.mapPreviewOptions}
                         />
                     {this.isBackgroundIgnored() ? <DefaultBackgroundOption label={LocaleUtils.getMessageById(this.context.messages, "print.defaultBackground")}/> : null}


### PR DESCRIPTION
## Description
With useFixedScales set to false (default) the Print MapPreview is using a wrong zoom.

## Issues
 - Fix #2267

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Wrong zoom in Print preview.

**What is the new behavior?**
Right zoom also when useFixedScales is false.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

