### PR TITLE
Fixes #2271 added "how to add new lang" doc

### DIFF
--- a/docs/developer-guide/add-new-language.md
+++ b/docs/developer-guide/add-new-language.md
@@ -1,0 +1,24 @@
+# How to Add a new language
+
+Let's say we want to add the russian language.
+In order to add a new language to MapStore 2 you need to follow these steps:
+
+1. Update the LocaleUtils.js file web\client\utils adding the support for the new language
+  - add and entry in the supportedLocales object like
+  ```
+  "ru": {
+        code: "ru-RU",
+        description: "Pоссийский"
+    }
+  ```
+  - add a param in the ensureIntl function like and the relative require
+    ```
+    'intl/locale-data/jsonp/ru.js'
+
+    ...
+
+    require('intl/locale-data/jsonp/ru.js');
+    ```
+1. add the relative flag inside web\client\components\I18N\images\flags  naming it ru-RU.png
+1. add the russian translations inside web\client\translations naming it data.ru-RU (remember to change the locale property into ru-RU)
+1. create a fragment, related to the cookie module, inside web\client\translations\fragments\cookie naming it cookieDetails-ru-RU

--- a/docs/developer-guide/developing-with-mapstore-2-intro.md
+++ b/docs/developer-guide/developing-with-mapstore-2-intro.md
@@ -8,13 +8,14 @@ This section is about developing your own application using the MapStore2 framew
  * [Building and Deploying](building-and-deploying)
  * [Code Conventions](code-conventions)
  * [Developers FAQ](dev-faq)
- * [How to customize the Theme](customize-theme.md)
- 
+ * [How to customize the Theme](customize-theme)
+ * [How to add a new language](add-new-language)
+
 ## Developing using plugins
 
  * [Plugins architecture](plugins-architecture)
  * [Plugins documentation](plugins-documentation)
- 
+
 ## Useful references
 
 If you want to create an application based on MapStore2 you can use the [Project Creation Script](project-creation-script).


### PR DESCRIPTION
## Description
Added a piece of documentation describing how to add a new language to MapStore2

## Issues
 - Fix #2271

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:
Just added documentation

**What is the current behavior?** (You can also link to an open issue here)
There is no clear indication on how to add a new language.

**What is the new behavior?**
Now there is.


**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
