### PR TITLE
Fix WMS issue from GWC or w/missing DescribeLayer

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -118,6 +118,11 @@
             "web/client/components/mapcontrols/annotations/Annotations.jsx",
             "web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx",
             "web/client/components/mapcontrols/annotations/AnnotationsConfig.js",
+            "web/client/components/misc/enhancers/emptyState.jsx",
+            "web/client/components/misc/enhancers/tooltip.jsx",
+            "web/client/components/misc/sidebar/Sidebar.jsx",
+            "web/client/components/misc/toolbar/Toolbar.jsx",
+            "web/client/components/misc/EmptyView.jsx",
 
             "web/client/actions/index.jsdoc",
             "web/client/actions/controls.js",

--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -18,7 +18,7 @@ const LayersUtils = require('../../utils/LayersUtils');
 const {getRecords, addLayerError, addLayer, ADD_LAYER_ERROR, changeCatalogFormat, CHANGE_CATALOG_FORMAT, changeSelectedService, CHANGE_SELECTED_SERVICE,
      focusServicesList, FOCUS_SERVICES_LIST, changeCatalogMode, CHANGE_CATALOG_MODE, changeTitle, CHANGE_TITLE,
     changeUrl, CHANGE_URL, changeType, CHANGE_TYPE, addService, ADD_SERVICE, addCatalogService, ADD_CATALOG_SERVICE, resetCatalog, RESET_CATALOG,
-    changeAutoload, CHANGE_AUTOLOAD, deleteCatalogService, DELETE_CATALOG_SERVICE, deleteService, DELETE_SERVICE, savingService, SAVING_SERVICE} = require('../catalog');
+    changeAutoload, CHANGE_AUTOLOAD, deleteCatalogService, DELETE_CATALOG_SERVICE, deleteService, DELETE_SERVICE, savingService, SAVING_SERVICE, DESCRIBE_ERROR} = require('../catalog');
 const {CHANGE_LAYER_PROPERTIES, ADD_LAYER} = require('../layers');
 describe('Test correctness of the catalog actions', () => {
 
@@ -176,13 +176,33 @@ describe('Test correctness of the catalog actions', () => {
                 expect(action.layer).toExist();
                 expect(action.newProperties).toExist();
                 expect(action.newProperties.search).toExist();
-                expect(action.newProperties.search.type ).toBe('wfs');
+                expect(action.newProperties.search.type).toBe('wfs');
                 expect(action.newProperties.search.url).toBe("http://some.geoserver.org:80/geoserver/wfs?");
                 done();
             }
         };
         const callback = addLayer({
             url: 'base/web/client/test-resources/wms/DescribeLayers.xml',
+            type: 'wms',
+            name: 'workspace:vector_layer'
+        });
+        callback(verify, () => ({ layers: []}));
+    });
+    it('add layer with no describe layer', (done) => {
+        const verify = (action) => {
+            if (action.type === ADD_LAYER) {
+                expect(action.layer).toExist();
+                const layer = action.layer;
+                expect(layer.id).toExist();
+                expect(layer.id).toBe(LayersUtils.getLayerId(action.layer, []));
+            } else if (action.type === DESCRIBE_ERROR) {
+                expect(action.layer).toExist();
+                expect(action.error).toExist();
+                done();
+            }
+        };
+        const callback = addLayer({
+            url: 'base/web/client/test-resources/wms/Missing.xml',
             type: 'wms',
             name: 'workspace:vector_layer'
         });

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -22,6 +22,7 @@ const RESET_CATALOG = 'CATALOG:RESET_CATALOG';
 const RECORD_LIST_LOAD_ERROR = 'CATALOG:RECORD_LIST_LOAD_ERROR';
 const CHANGE_CATALOG_FORMAT = 'CATALOG:CHANGE_CATALOG_FORMAT';
 const ADD_LAYER_ERROR = 'CATALOG:ADD_LAYER_ERROR';
+const DESCRIBE_ERROR = "CATALOG:DESCRIBE_ERROR";
 const CHANGE_SELECTED_SERVICE = 'CATALOG:CHANGE_SELECTED_SERVICE';
 const CHANGE_CATALOG_MODE = 'CATALOG:CHANGE_CATALOG_MODE';
 const CHANGE_TITLE = 'CATALOG:CHANGE_TITLE';
@@ -170,6 +171,13 @@ function textSearch(format, url, startPosition, maxRecords, text, options) {
         });
     };
 }
+function describeError(layer, error) {
+    return {
+        type: DESCRIBE_ERROR,
+        layer,
+        error
+    };
+}
 function addLayerAndDescribe(layer) {
     return (dispatch, getState) => {
         const state = getState();
@@ -191,7 +199,7 @@ function addLayerAndDescribe(layer) {
                     }
                 }
 
-            });
+            }).catch((e) => dispatch(describeError(layer, e)));
         }
 
     };
@@ -203,11 +211,13 @@ function addLayerError(error) {
     };
 }
 
+
 module.exports = {
     RECORD_LIST_LOADED,
     RECORD_LIST_LOAD_ERROR,
     CHANGE_CATALOG_FORMAT, changeCatalogFormat,
     ADD_LAYER_ERROR, addLayerError,
+    DESCRIBE_ERROR,
     RESET_CATALOG, resetCatalog,
     CHANGE_SELECTED_SERVICE, changeSelectedService,
     CHANGE_CATALOG_MODE, changeCatalogMode,

--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -38,8 +38,9 @@ const flatLayers = (root) => {
 const getOnlineResource = (c) => {
     return c.Request && c.Request.GetMap && c.Request.GetMap.DCPType && c.Request.GetMap.DCPType.HTTP && c.Request.GetMap.DCPType.HTTP.Get && c.Request.GetMap.DCPType.HTTP.Get.OnlineResource && c.Request.GetMap.DCPType.HTTP.Get.OnlineResource.$ || undefined;
 };
-const searchAndPaginate = (json, startPosition, maxRecords, text) => {
-    const root = (json.WMS_Capabilities || json.WMT_MS_Capabilities).Capability;
+const searchAndPaginate = (json = {}, startPosition, maxRecords, text) => {
+    const root = (json.WMS_Capabilities || json.WMT_MS_Capabilities || {}).Capability;
+    const service = (json.WMS_Capabilities || json.WMT_MS_Capabilities || {}).Service;
     const onlineResource = getOnlineResource(root);
     const SRSList = root.Layer && (root.Layer.SRS || root.Layer.CRS) || [];
     const layersObj = flatLayers(root);
@@ -50,7 +51,7 @@ const searchAndPaginate = (json, startPosition, maxRecords, text) => {
         numberOfRecordsMatched: filteredLayers.length,
         numberOfRecordsReturned: Math.min(maxRecords, filteredLayers.length),
         nextRecord: startPosition + Math.min(maxRecords, filteredLayers.length) + 1,
-        service: json.WMS_Capabilities.Service,
+        service,
         records: filteredLayers
             .filter((layer, index) => index >= startPosition - 1 && index < startPosition - 1 + maxRecords)
             .map((layer) => assign({}, layer, {onlineResource, SRS: SRSList}))
@@ -157,7 +158,7 @@ const Api = {
             // make it compatible with json format of describe layer
             return decriptions.map(desc => ({
                 ...desc && desc.$ || {},
-                layerName: desc.$ && desc.$.name,
+                layerName: desc && desc.$ && desc.$.name,
                 query: {
                     ...desc && desc.query && desc.query.$ || {}
                 }

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -123,7 +123,20 @@ describe('Test correctness of the WMS APIs', () => {
         API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.3.0.xml', 0, 1, '').then((result) => {
             try {
                 expect(result).toExist();
+                expect(result.service).toExist();
                 expect(result.numberOfRecordsMatched).toBe(5);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+    it('GetRecords 1.1.1', (done) => {
+        API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml', 0, 1, '').then((result) => {
+            try {
+                expect(result).toExist();
+                expect(result.service).toExist();
+                expect(result.numberOfRecordsMatched).toBe(7);
                 done();
             } catch (ex) {
                 done(ex);

--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -35,6 +35,7 @@ class FeatureGrid extends React.PureComponent {
         gridOpts: PropTypes.object,
         changes: PropTypes.object,
         selectBy: PropTypes.object,
+        customEditorsOptions: PropTypes.object,
         features: PropTypes.array,
         showDragHandle: PropTypes.bool,
         gridComponent: PropTypes.func,

--- a/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+const React = require('react');
+const PropTypes = require('prop-types');
+const AttributeEditor = require('./AttributeEditor');
+const ControlledCombobox = require('../../../misc/combobox/ControlledCombobox');
+const {head} = require('lodash');
+const assign = require('object-assign');
+
+class DropDownEditor extends AttributeEditor {
+    static propTypes = {
+        column: PropTypes.object,
+        dataType: PropTypes.string,
+        defaultOption: PropTypes.string,
+        forceSelection: PropTypes.bool,
+        allowEmpty: PropTypes.bool,
+        inputProps: PropTypes.object,
+        isValid: PropTypes.func,
+        onBlur: PropTypes.func,
+        typeName: PropTypes.string,
+        url: PropTypes.string,
+        value: PropTypes.string,
+        values: PropTypes.array
+    };
+    static defaultProps = {
+        isValid: () => true,
+        dataType: "string",
+        values: [],
+        forceSelection: true,
+        allowEmpty: true
+    };
+    constructor(props) {
+        super(props);
+        this.validate = (value) => {
+            try {
+                return this.props.isValid(value[this.props.column && this.props.column.key]);
+            } catch (e) {
+                return false;
+            }
+        };
+        this.getValue = () => {
+            const updated = super.getValue();
+            const {forceSelection} = require('../../../../utils/featuregrid/EditorRegistry');
+
+            if (this.props.forceSelection) {
+                return {[this.props.column.key]: forceSelection({
+                    oldValue: this.props.defaultOption,
+                    changedValue: updated[this.props.column && this.props.column.key],
+                    data: this.props.values,
+                    allowEmpty: this.props.allowEmpty})};
+            }
+            if (this.props.allowEmpty) {
+                return updated;
+            }
+            // this case is only when forceSelection and allowEmpty are falsy, but this is contractidtory!! so the default option is used
+            return {[this.props.column.key]: forceSelection({
+                oldValue: this.props.defaultOption,
+                changedValue: updated[this.props.column && this.props.column.key],
+                data: this.props.values,
+                allowEmpty: this.props.allowEmpty})};
+        };
+    }
+    render() {
+        const data = this.props.values.map(v => {return {label: v, value: v}; });
+
+        const props = assign({}, {...this.props}, {
+            data,
+            defaultOption: this.props.defaultOption || head(this.props.values)
+        });
+        return <ControlledCombobox {...props} filter="contains"/>;
+    }
+}
+
+module.exports = DropDownEditor;

--- a/web/client/components/data/featuregrid/editors/customEditors.jsx
+++ b/web/client/components/data/featuregrid/editors/customEditors.jsx
@@ -1,0 +1,11 @@
+const React = require('react');
+const DropDownEditor = require('./DropDownEditor');
+
+const Editors = {
+    "DropDownEditor": {
+        "string": (props) => <DropDownEditor dataType="string" {...props}/>
+    }
+};
+
+
+module.exports = Editors;

--- a/web/client/components/data/featuregrid/editors/index.jsx
+++ b/web/client/components/data/featuregrid/editors/index.jsx
@@ -2,7 +2,6 @@ const React = require('react');
 const Editor = require('./AttributeEditor');
 const NumberEditor = require('./NumberEditor');
 const AutocompleteEditor = require('./AutocompleteEditor');
-
 const types = {
     "defaultEditor": (props) => <Editor {...props}/>,
     "int": (props) => <NumberEditor dataType="int" inputProps={{step: 1, type: "number"}} {...props}/>,
@@ -10,5 +9,5 @@ const types = {
     "string": (props) => props.autocompleteEnabled ?
         <AutocompleteEditor dataType="string" {...props}/> :
         <Editor dataType="string" {...props}/>
- };
+};
 module.exports = (type, props) => types[type] ? types[type](props) : types.defaultEditor(props);

--- a/web/client/components/data/query/AutocompleteFieldHOC.jsx
+++ b/web/client/components/data/query/AutocompleteFieldHOC.jsx
@@ -11,7 +11,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const assign = require('object-assign');
 const AutocompleteListItem = require('./AutocompleteListItem');
-const PagedCombobox = require('../../misc/PagedCombobox');
+const PagedCombobox = require('../../misc/combobox/PagedCombobox');
 const {isLikeOrIlike} = require('../../../utils/FilterUtils');
 const HTML = require('../../../components/I18N/HTML');
 

--- a/web/client/components/data/query/__tests__/AutocompleteFieldHOC-test.jsx
+++ b/web/client/components/data/query/__tests__/AutocompleteFieldHOC-test.jsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const AutocompleteFieldHOC = require('../AutocompleteFieldHOC');
+
+describe('AutocompleteFieldHOC', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('create a AutocompleteFieldHOC component without any props', () => {
+        const cmp = ReactDOM.render(<AutocompleteFieldHOC/>, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
+    it('create a AutocompleteFieldHOC with 2 options', () => {
+        let conf = {
+            filterField: {
+                attribute: "NAME",
+                options: {
+                    "NAME": [{
+                        value: "val1",
+                        label: "val1"
+                    }, {
+                        value: "val2",
+                        label: "val2"
+                    }]
+                },
+                value: "someVAlue",
+                fieldOptions: {
+                    valuesCount: 2,
+                    currentPage: 1
+                }
+            },
+            maxFeaturesWPS: 5
+        };
+        const cmp = ReactDOM.render(<AutocompleteFieldHOC {...conf} />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+    });
+    it('create a AutocompleteFieldHOC with pagination', () => {
+        let conf = {
+            filterField: {
+                attribute: "NAME",
+                options: {
+                    "NAME": [{
+                        value: "val1",
+                        label: "val1"
+                    }, {
+                        value: "val2",
+                        label: "val2"
+                    }]
+                },
+                value: "someVAlue",
+                fieldOptions: {
+                    valuesCount: 2,
+                    currentPage: 1
+                }
+            },
+            maxFeaturesWPS: 5,
+            pagination: {
+                paginated: true
+            }
+        };
+        const cmp = ReactDOM.render(<AutocompleteFieldHOC {...conf} />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+    });
+});

--- a/web/client/components/misc/AutocompleteCombobox.jsx
+++ b/web/client/components/misc/AutocompleteCombobox.jsx
@@ -8,7 +8,7 @@
 
 const React = require('react');
 const {isArray} = require('lodash');
-const PagedCombobox = require('./PagedCombobox');
+const PagedCombobox = require('./combobox/PagedCombobox');
 const {setObservableConfig, mapPropsStreamWithConfig, compose, withStateHandlers} = require('recompose');
 const rxjsConfig = require('recompose/rxjsObservableConfig').default;
 setObservableConfig(rxjsConfig);

--- a/web/client/components/misc/EmptyView.jsx
+++ b/web/client/components/misc/EmptyView.jsx
@@ -1,0 +1,41 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const React = require('react');
+
+const FullWidthIcon = require('./FullWidthGlyph');
+
+/**
+ * A component to display an empty page.
+ * It allows to display a big icon with some information centered. As an option some additiona content can be provided via props. (e.g. add buttons, tools or info)
+ * It is very similar to material design concept for [empty state](https://material.io/guidelines/patterns/empty-states.html)
+ *
+ * @class EmptyView
+ * @memberof components.misc
+ * @param  {object} [mainViewStyle]     Style for the main view
+ * @param  {object} [contentStyle]      Style for the container view
+ * @param  {String} [glyph="info-sign"] The icon glyph
+ * @param  {string|node} [title]               The title of the advice to display
+ * @param  {string|node} [description]         The description to display
+ * @param  {string|node} [content]             Additional content for the empty view (e.g. buttons...)
+ */
+module.exports = ({
+        mainViewStyle,
+        contentStyle,
+        glyph="info-sign",
+        title,
+        description,
+        content
+    } = {}) =>
+        (<div className="empty-state-container">
+            <div key="main-view" className="empty-state-main-view" style={mainViewStyle}>
+                {glyph ? <div key="glyph" className="empty-state-image"><FullWidthIcon glyph={glyph} /></div> : null}
+                {title ? <h1 key="title" >{title}</h1> : null}
+                {description ? <p key="description">{description}</p> : null}
+            </div>
+            <div key="content" className="empty-state-content" style={contentStyle}>{content}</div>
+        </div>);

--- a/web/client/components/misc/FullWidthGlyph.jsx
+++ b/web/client/components/misc/FullWidthGlyph.jsx
@@ -1,0 +1,20 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+
+
+const React = require('react');
+const {Glyphicon} = require('react-bootstrap');
+const ContainerDimensions = require('react-container-dimensions').default;
+
+/**
+ * An icon that fits to the width of the container
+ * @param {string} glyph icon glyph
+ */
+module.exports = ({glyph = "info-sign"}) => (<ContainerDimensions>
+    { ({ width }) => (<Glyphicon glyph={glyph} style={{fontSize: width}} />)}
+</ContainerDimensions>);

--- a/web/client/components/misc/__tests__/AutocompleteCombobox-test.jsx
+++ b/web/client/components/misc/__tests__/AutocompleteCombobox-test.jsx
@@ -26,4 +26,12 @@ describe("This test for AutocompleteCombobox component", () => {
         expect(comp).toExist();
     });
 
+    it('creates AutocompleteCombobox with change', () => {
+        const comp = ReactDOM.render(<AutocompleteCombobox value="old" autocompleteStreamFactory={createPagedUniqueAutompleteStream}/>, document.getElementById("container"));
+        expect(comp).toExist();
+        const input = document.getElementsByTagName("input")[0];
+        input.value = "newValue";
+
+    });
+
 });

--- a/web/client/components/misc/__tests__/EmptyView-test.jsx
+++ b/web/client/components/misc/__tests__/EmptyView-test.jsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const EmptyView = require('../EmptyView');
+
+describe("EmptyView component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('create EmptyView with defaults', () => {
+        ReactDOM.render(<EmptyView />, document.getElementById("container"));
+        const el = document.getElementsByClassName('glyphicon')[0];
+        expect(el).toExist();
+    });
+    it('create EmptyView title, description and content', () => {
+        ReactDOM.render(<EmptyView title="Title" description="description" content={<div id="content" >TEST</div>}/>, document.getElementById("container"));
+        const description = document.getElementsByTagName('p')[0];
+        expect(description).toExist();
+        const content = document.getElementById("content");
+        expect(content).toExist();
+    });
+
+});

--- a/web/client/components/misc/__tests__/PagedCombobox-test.jsx
+++ b/web/client/components/misc/__tests__/PagedCombobox-test.jsx
@@ -8,7 +8,7 @@
 const expect = require('expect');
 const React = require('react');
 const ReactDOM = require('react-dom');
-const PagedCombobox = require('../PagedCombobox');
+const PagedCombobox = require('../combobox/PagedCombobox');
 const TestUtils = require('react-dom/test-utils');
 const {Tooltip} = require('react-bootstrap');
 

--- a/web/client/components/misc/combobox/ControlledCombobox.jsx
+++ b/web/client/components/misc/combobox/ControlledCombobox.jsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const React = require('react');
+const PagedCombobox = require('./PagedCombobox');
+
+// state enhancer for local props
+const addState = require('./addState');
+
+const ControlledCombobox = addState(({ toggle, select, focus, change, value, busy, data, loading = false, filter, open }) => {
+    return (<PagedCombobox
+        pagination={{paginated: false}}
+        onFocus={focus}
+        onToggle={toggle}
+        onChange={change}
+        onSelect={select}
+        selectedValue={value}
+        dropUp={false}
+        busy={busy}
+        data={data}
+        open={open}
+        loading={loading}
+        filter={filter}
+        />);
+});
+
+module.exports = ControlledCombobox;

--- a/web/client/components/misc/combobox/PagedCombobox.jsx
+++ b/web/client/components/misc/combobox/PagedCombobox.jsx
@@ -10,9 +10,9 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const Combobox = require('react-widgets').Combobox;
 const {Glyphicon, Tooltip} = require('react-bootstrap');
-const LocaleUtils = require('../../utils/LocaleUtils');
-const OverlayTrigger = require('./OverlayTrigger');
-const AutocompleteListItem = require('../data/query/AutocompleteListItem');
+const LocaleUtils = require('../../../utils/LocaleUtils');
+const OverlayTrigger = require('../OverlayTrigger');
+const AutocompleteListItem = require('../../data/query/AutocompleteListItem');
 
 /**
  * Combobox with remote autocomplete functionality.
@@ -35,6 +35,7 @@ class PagedCombobox extends React.Component {
         itemComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
         label: PropTypes.string,
         loading: PropTypes.bool,
+        filter: PropTypes.string,
         messages: PropTypes.object,
         onChange: PropTypes.func,
         onFocus: PropTypes.func,
@@ -59,6 +60,7 @@ class PagedCombobox extends React.Component {
         itemComponent: AutocompleteListItem,
         loading: false,
         label: null,
+        filter: "",
         pagination: {
             paginated: true,
             firstPage: false,
@@ -135,6 +137,7 @@ class PagedCombobox extends React.Component {
             itemComponent={this.props.itemComponent}
             messages={this.props.messages || messages}
             open={this.props.open}
+            filter={this.props.filter}
             onChange={(val) => this.props.onChange(val)}
             onFocus={() => this.props.onFocus(this.props.data)}
             onSelect={(v) => this.props.onSelect(v)}

--- a/web/client/components/misc/combobox/addState.js
+++ b/web/client/components/misc/combobox/addState.js
@@ -1,0 +1,54 @@
+const {compose, withStateHandlers} = require('recompose');
+
+const addState = compose(
+    withStateHandlers((props) => ({
+        open: false,
+        currentPage: 1,
+        value: props.value,
+        data: props.data,
+        textValue: props.textValue,
+        textLabel: props.textLabel
+    }), {
+        select: (state) => () => ({
+            ...state,
+            selected: true
+        }),
+        change: (state) => (v) => {
+            if (state.selected && state.changingPage) {
+                return ({
+                    ...state,
+                    selected: false,
+                    changingPage: false,
+                    value: state.value,
+                    currentPage: !state.changingPage ? 1 : state.currentPage
+                });
+            }
+            const value = typeof v === "string" ? v : v.value;
+            return ({
+                ...state,
+                selected: false,
+                changingPage: false,
+                value: value,
+                currentPage: !state.changingPage ? 1 : state.currentPage
+            });
+        },
+        focus: (state) => (options) => {
+            if (options && options.length === 0 && state.value === "") {
+                return ({
+                    ...state,
+                    currentPage: 1,
+                    isToggled: false,
+                    open: true
+                });
+            }
+            return (state);
+        },
+        toggle: (state) => () => ({
+            ...state,
+            open: state.changingPage ? true : !state.open
+        })
+    })
+);
+
+
+module.exports = addState;

--- a/web/client/components/misc/enhancers/__tests__/tooltip-test.jsx
+++ b/web/client/components/misc/enhancers/__tests__/tooltip-test.jsx
@@ -1,0 +1,42 @@
+ /**
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+
+var expect = require('expect');
+var React = require('react');
+var ReactDOM = require('react-dom');
+var tooltip = require('../tooltip');
+
+const {Button} = require('react-bootstrap');
+describe("tooltip enhancer", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates component with defaults', () => {
+        const CMP = tooltip(({id}) => <div id={id} />);
+        ReactDOM.render(<CMP id="text-cmp"/>, document.getElementById("container"));
+        const el = document.getElementById("text-cmp");
+        expect(el).toExist();
+    });
+    it('creates component with tooltip props', () => {
+        const CMP = tooltip(Button);
+        ReactDOM.render(<CMP tooltip={<div>Hello</div>} tooltipTrigger={['click', 'focus', 'hover']} id="text-cmp">TEXT</CMP>, document.getElementById("container"));
+        const el = document.getElementById("text-cmp");
+        expect(el).toExist();
+        el.click();
+        expect(el.getAttribute('aria-describedby')).toExist();
+    });
+
+});

--- a/web/client/components/misc/enhancers/emptyState.jsx
+++ b/web/client/components/misc/enhancers/emptyState.jsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const {branch} = require('recompose');
+const DefaultEmptyComponent = require("../EmptyView");
+
+
+/**
+* Empty State enhancer. Enhances an object displaying an empty state view under a given condition
+* @type {function}
+* @name emptyState
+* @memberof components.misc.enhancers
+* @param {function} test The test for the properties. If it is true, use empty view
+* @param {object} [emptyComponentProps] parameters for the empty components. The structure must reflect the props of the EmptyComponent(3rd) parameter (or its default @see [EmptyView](#components.misc.EmptyView))
+* @param {Component} [EmptyComponent=EmptyView] the component to use for empty view. By default [EmptyView](#components.misc.EmptyView)
+* @example
+* emptyState(({data=[]}) => data.length === 0)(ComponentToEnhance);
+*
+*/
+module.exports = (test, emptyComponentProps, EmptyComponent = DefaultEmptyComponent) => branch(
+    test,
+   // TODO return proper HOC
+   () => () => <EmptyComponent {...emptyComponentProps} />);

--- a/web/client/components/misc/enhancers/tooltip.jsx
+++ b/web/client/components/misc/enhancers/tooltip.jsx
@@ -1,0 +1,37 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const React = require('react');
+const {branch} = require('recompose');
+const { Tooltip, OverlayTrigger} = require('react-bootstrap');
+const Message = require('../../I18N/Message');
+
+/**
+ * Tooltip enhancer. Enhances an object adding a (localizable) tooltip.
+ * It is applied only if props contains `tooltip` or `tooltipId`. It have to be applied to a React (functional) component
+ * @type {function}
+ * @name tooltip
+ * @memberof components.misc.enhancers
+ * @prop {string|node} [tooltip] if present will add the tooltip. This is the full tooltip content
+ * @prop {string} [tooltipId] if present will show a localized tooltip using the tooltipId as msgId
+ * @prop {string} [tooltipPosition="top"]
+ * @prop {string} tooltipTrigger see react overlay trigger
+ * @example
+ * render() {
+ *   const Cmp = tooltip((props) =><El {...props}></El>); // or simply tooltip(El);
+ *   return <Cmp tooltipId="Hello" tooltipPosition="left" /> // => render the component with tooltip
+ * }
+ *
+ */
+module.exports = branch(
+    ({tooltip, tooltipId} = {}) => tooltip || tooltipId,
+    // TODO return proper HOC
+    (Wrapped) => ({tooltip, tooltipId, tooltipPosition = "top", tooltipTrigger, key, ...props} = {}) => (<OverlayTrigger
+        trigger={tooltipTrigger}
+        key={key}
+        placement={tooltipPosition}
+        overlay={<Tooltip id={"tooltip-" + {key}}>{tooltipId ? <Message msgId={tooltipId} /> : tooltip}</Tooltip>}><Wrapped {...props}/></OverlayTrigger>));

--- a/web/client/components/misc/sidebar/Sidebar.jsx
+++ b/web/client/components/misc/sidebar/Sidebar.jsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const Sidebar = require('react-sidebar').default;
+/**
+ * MapStore generic sidebar component with good defaults
+ * @class Sidebar
+ * @memberof components.misc.sidebar
+ * @param  {boolean} open       Open flag
+ * @param  {Number} [width=600] Width of the sidebar
+ * @param  {node} children      Content
+ */
+module.exports = ({open, width = 600, children} = {}) => (<Sidebar
+   open={open}
+   sidebarClassName="sidepanel-content"
+   sidebar={children}
+   styles={{
+       sidebar: {
+           zIndex: 1024,
+           width
+       },
+       overlay: {
+           zIndex: 1023,
+           width: 0
+       },
+       root: {
+           right: open ? 0 : 'auto',
+           width: '0',
+           overflow: 'visible'
+       },
+       content: {
+           overflowY: 'auto'
+       }
+   }}
+   >
+   <div/>
+</Sidebar>);

--- a/web/client/components/misc/sidebar/SidebarHeader.jsx
+++ b/web/client/components/misc/sidebar/SidebarHeader.jsx
@@ -1,0 +1,9 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const React = require('react');
+module.exports = ({title} = {}) => <div className="sidebar-title"><h3 className="sidebar-title ">{title}</h3></div>;

--- a/web/client/components/misc/sidebar/__tests__/Sidebar-test.jsx
+++ b/web/client/components/misc/sidebar/__tests__/Sidebar-test.jsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Sidebar = require('../Sidebar');
+const SidebarHeader = require('../SidebarHeader');
+
+describe("Sidebar component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('create Sidebar with content', () => {
+        ReactDOM.render(<Sidebar open>
+           <div id="content" />
+        </Sidebar>, document.getElementById("container"));
+        const el = document.getElementById('content');
+        expect(el).toExist();
+    });
+    it('create Sidebar wjth title and content', () => {
+        ReactDOM.render(<Sidebar open>
+           <SidebarHeader title={<span id="content">content</span>} />
+        </Sidebar>, document.getElementById("container"));
+        const titleContainer = document.getElementsByClassName('sidebar-title')[0];
+        expect(titleContainer).toExist();
+        const content = document.getElementById("content");
+        expect(content).toExist();
+    });
+
+});

--- a/web/client/components/misc/sidebar/index.js
+++ b/web/client/components/misc/sidebar/index.js
@@ -1,0 +1,15 @@
+ /**
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+
+const Sidebar = require('./Sidebar');
+const SidebarHeader = require('./SidebarHeader');
+
+module.exports = {
+    Sidebar,
+    SidebarHeader
+};

--- a/web/client/components/misc/toolbar/Toolbar.jsx
+++ b/web/client/components/misc/toolbar/Toolbar.jsx
@@ -1,0 +1,41 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const React = require('react');
+const {ButtonGroup} = require('react-bootstrap');
+const ToolbarButton = require('./ToolbarButton');
+
+const ReactCSSTransitionGroup = require('react-addons-css-transition-group');
+/**
+ * A Generic Reusable Toolbar. Build in animations.
+ * @class Toolbar
+ * @memberof components.misc.toolbar
+ * @param  {Array}  [buttons=[]]       Array of buttons. Button objects support the follwing properties:
+ *  - *visible*: true by default, set to `false` to make the button disappear
+ *  - All the react-bootstrap buttons properties.
+ *  - All the properties for @see components.misc.enhancers
+ *  . All properties for @see components.misc.toolbar.ToolbarButton and react-bootstrap button
+ * @param  {Object} [btnDefaultProps] A serie of default Props for buttons
+ * @param  {Object} [transitionProps] properties of ReactCSSTransitionGroup
+ */
+module.exports = ({
+    buttons = [],
+    btnDefaultProps = {},
+    transitionProps = {
+        transitionName: "toolbar-btn-transition",
+        transitionEnterTimeout: 300,
+        transitionLeaveTimeout: 300
+    }} = {}) =>
+(<ButtonGroup>
+  <ReactCSSTransitionGroup {...transitionProps}>
+    {buttons.map(
+        ({visible= true, ...props}, index) => visible
+            ? (<ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />)
+            : null
+    )}
+  </ReactCSSTransitionGroup>
+  </ButtonGroup>);

--- a/web/client/components/misc/toolbar/ToolbarButton.jsx
+++ b/web/client/components/misc/toolbar/ToolbarButton.jsx
@@ -1,0 +1,22 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const React = require('react');
+const {Button, Glyphicon} = require('react-bootstrap');
+const tooltip = require('../enhancers/tooltip');
+/**
+ * Button for @see components.misc.toolbar.Toolbar. Exposes all the props of a react-bootstrap button, plus glyph and text
+ * @class TooltipButton
+ * @memberof components.misc.toolbar
+ * @prop glyph [glyph] the icon to use
+ * @prop text [text] the text to display
+ */
+module.exports = tooltip(({glyph, text="", ...props} = {}) =>
+    <Button {...props}>
+        {glyph ? <Glyphicon glyph={glyph}/> : null}
+        {text}
+    </Button>);

--- a/web/client/components/misc/toolbar/__tests__/Toolbar-test.jsx
+++ b/web/client/components/misc/toolbar/__tests__/Toolbar-test.jsx
@@ -1,0 +1,61 @@
+ /**
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+
+var expect = require('expect');
+var React = require('react');
+var ReactDOM = require('react-dom');
+var Toolbar = require('../Toolbar');
+
+
+describe("Toolbar component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates component with defaults', () => {
+        ReactDOM.render(<Toolbar />, document.getElementById("container"));
+        const el = document.getElementsByClassName("btn-group");
+        expect(el).toExist();
+    });
+    it('creates component with buttons and defaultProps', () => {
+        ReactDOM.render(<Toolbar key={"toolbar"} btnDefaultProps={{className: "TEST_CLASS"}} buttons={[{
+            id: "button",
+            tooltip: "hello",
+            text: "hello",
+            tooltipPosition: "right",
+            glyph: "plus"
+        }]}/>, document.getElementById("container"));
+        const el = document.getElementsByClassName("btn-group");
+        expect(el).toExist();
+        const btn = document.getElementById("button");
+        expect(btn).toExist();
+        expect(document.getElementsByClassName("TEST_CLASS").length > 0).toBe(true);
+    });
+    it('test button visibility', () => {
+        ReactDOM.render(<Toolbar key={"toolbar"} buttons={[{
+            id: "button",
+            visible: false,
+            tooltip: "hello",
+            text: "hello",
+            tooltipPosition: "right",
+            glyph: "plus"
+        }]}/>, document.getElementById("container"));
+        const el = document.getElementsByClassName("btn-group");
+        expect(el).toExist();
+        const btn = document.getElementById("button");
+        expect(btn).toNotExist();
+    });
+
+
+});

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -22,7 +22,7 @@ const {query, QUERY_CREATE, QUERY_RESULT, LAYER_SELECTED_FOR_SEARCH, FEATURE_TYP
 const {reset, QUERY_FORM_RESET} = require('../actions/queryform');
 const {zoomToExtent} = require('../actions/map');
 
-const {BROWSE_DATA, changeLayerProperties} = require('../actions/layers');
+const {BROWSE_DATA, changeLayerProperties, refreshLayerVersion} = require('../actions/layers');
 const {purgeMapInfoResults} = require('../actions/mapInfo');
 
 const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURES, featureSaving, changePage,
@@ -35,7 +35,6 @@ const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURE
 
 const {TOGGLE_CONTROL, resetControls} = require('../actions/controls');
 const {setHighlightFeaturesPath} = require('../actions/highlight');
-const {refreshLayerVersion} = require('../actions/layers');
 
 const {selectedFeaturesSelector, changesMapSelector, newFeaturesSelector, hasChangesSelector, hasNewFeaturesSelector,
     selectedFeatureSelector, selectedFeaturesCount, selectedLayerIdSelector, isDrawingSelector, modeSelector,
@@ -551,14 +550,14 @@ module.exports = {
     /**
      * stop sync filter with wms layer
      */
-     stopSyncWmsFilter: (action$, store) =>
+    stopSyncWmsFilter: (action$, store) =>
         action$.ofType(TOGGLE_SYNC_WMS)
         .filter( () => !isSyncWmsActive(store.getState()))
         .switchMap(() => Rx.Observable.from([removeFilterFromWMSLayer(store.getState()), {type: STOP_SYNC_WMS}])),
     /**
      * Sync map with filter
      */
-     syncMapWmsFilter: (action$, store) =>
+    syncMapWmsFilter: (action$, store) =>
         action$.ofType(QUERY_CREATE, UPDATE_QUERY).
             filter((a) => {
                 const {disableQuickFilterSync} = (store.getState()).featuregrid;

--- a/web/client/examples/featuregrid/localConfig.json
+++ b/web/client/examples/featuregrid/localConfig.json
@@ -25,8 +25,26 @@
                   ]
               }
 
+            }, {
+              "name":"FeatureEditor",
+              "cfg": {
+                "customEditorsOptions": {
+                  "rules": [{
+                    "regex": {
+                      "attribute": "type",
+                      "typeName": "atlantis:landmarks"
+                    },
+                    "editor": "DropDownEditor",
+                    "editorProps": {
+                      "values": ["FOREST", "MOUNTAIN", "DESERT", "LAKE"],
+                      "forceSelection": true,
+                      "defaultOption": "FOREST",
+                      "allowEmpty": true
+                    }
+                  }]
+                }
+              }
             },
-            "FeatureEditor",
             "WFSDownload",
             "LayerSelector",
             "Notifications"

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -34,7 +34,7 @@
     "projectionDefs": [],
     "initialState": {
       "defaultState": {
-        "catalog":{
+        "catalog": {
           "default": {
             "newService": {
                 "url": "",

--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -49,7 +49,8 @@ require('./drawer/drawer.css');
  * {
  *   "name": "DrawerMenu",
  *   "cfg": {
- *   "hideButton": true
+ *     "hideButton": true
+ *   }
  * }
  */
 class DrawerMenu extends React.Component {

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -23,6 +23,42 @@ const {gridTools, gridEvents, pageEvents, toolbarEvents} = require('./featuregri
 const ContainerDimensions = require('react-container-dimensions').default;
 const {getParsedUrl} = require('../utils/ConfigUtils');
 
+/**
+  * @name FeatureEditor
+  * @memberof plugins
+  * @class
+  * @prop {object} cfg.customEditorsOptions Set of options used to connect the custom editors to the featuregrid
+  * @classdesc
+  * FeatureEditor Plugin Provides functionalities to browse/edit data via WFS. It can be configured passing custom editors
+  * <br/>Rules are applied in order and the first rule that match the regex wins.
+  * <br/>That means that for those conditions it is used the custom editor specified in the editor param.
+  * <br/>All the conditions inside a rule must match to apply the editor.
+  * <br/>If no rule is applied then it will be used the default editor based on the dataType of that column.
+  * <br/>At least one of the three kind of regex must be specified.
+  * <br/>Editor props are optionally.
+  * <br/>Inside localConfig you can specify different rules in an array.
+  * @example
+  * {
+  *   "name": "FeatureEditor",
+  *   "cfg": {
+  *     "customEditorsOptions": {
+  *       "rules": [{
+  *         "regex": {
+  *           "attribute": "NAME_OF_THE_ATTRIBUTE",
+  *           "url": "regex to match a specific url",
+  *           "typeName": "layerName"
+  *         },
+  *         "editor": "DropDownEditor",
+  *         "editorProps": {
+  *           "values": ["Opt1", "Opt2"],
+  *           "forceSelection": true
+  *         }
+  *       }]
+  *     }
+  *   }
+  * }
+  *
+*/
 const FeatureDock = (props = {
     tools: EMPTY_OBJ,
     dialogs: EMPTY_OBJ,
@@ -53,6 +89,7 @@ const FeatureDock = (props = {
             footer={getFooter(props)}>
             {getDialogs(props.tools)}
             <Grid
+                customEditorsOptions={props.customEditorsOptions}
                 autocompleteEnabled={props.autocompleteEnabled}
                 url={props.url}
                 typeName={props.typeName}
@@ -121,14 +158,6 @@ const EditorPlugin = connect(selector, (dispatch) => ({
     }))
 }))(FeatureDock);
 
-
-/**
-  * FeatureEditor Plugin. Provides functionalities to browse/edit data via WFS.
-  * @class  FeatureEditor
-  * @memberof plugins
-  * @static
-  *
-  */
 module.exports = {
      FeatureEditorPlugin: EditorPlugin,
      epics: require('../epics/featuregrid'),

--- a/web/client/plugins/MousePosition.jsx
+++ b/web/client/plugins/MousePosition.jsx
@@ -74,32 +74,35 @@ class MousePosition extends React.Component {
 }
 
 /**
-  * MousePositionPlugin is a plugin that shows the coordinate of the mouse position in a selected crs.
+  * MousePosition Plugin is a plugin that shows the coordinate of the mouse position in a selected crs.
   * it gets displayed into the mapFooter plugin
-  * @name MousePositionPlugin
+  * @name MousePosition
+  * @memberof plugins
   * @class
+  * @prop {object[]} projectionDefs list of additional project definitions
   * @prop {string[]} cfg.filterAllowedCRS list of allowed crs in the combobox list to used as filter for the one of retrieved proj4.defs()
-  * @prop {object[]} cfg.projectionDefs list of additional project definitions
-  * @prop {object} cfg.additionalCRS additional crs to be added to the list
-  * If you want to add some crs you need to provide a definition and adding it in the additionalCRS property
-  * example
-  *
-  * ```
-  * inside the localconfig put
-  * "projectionDefs": [{
-  *            "code": "EPSG:3003",
-  *            "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl
-  *                    +towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
-  *            "extent": [1241482.0019, 973563.1609, 1830078.9331, 5215189.0853],
-  *            "worldExtent": [6.6500, 8.8000, 12.0000, 47.0500]
-  *        },{...},{...}]
-  *
-  * and inside mouseposition cfg put:
-  *  "additionalCRS": {
-  *    "EPSG:3003": { "label": "EPSG:3003" }
-  *  },
-  *  "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
- ```
+  * @prop {object} cfg.additionalCRS additional crs added to the list. The label param is used after in the combobox.
+  * @example
+  * // If you want to add some crs you need to provide a definition and adding it in the additionalCRS property
+  * // Put the following lines at the first level of the localconfig
+  * {
+  *   "projectionDefs": [{
+  *     "code": "EPSG:3003",
+  *     "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+  *     "extent": [1241482.0019, 973563.1609, 1830078.9331, 5215189.0853],
+  *     "worldExtent": [6.6500, 8.8000, 12.0000, 47.0500]
+  *   }]
+  * }
+  * @example
+  * // And configure the mouse position plugin as below:
+  * {
+  *   "cfg": {
+  *     "additionalCRS": {
+  *       "EPSG:3003": { "label": "EPSG:3003" }
+  *     },
+  *     "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"]
+  *   }
+  * }
 */
 const MousePositionPlugin = connect(selector, {
     onCRSChange: changeMousePositionCrs

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -126,70 +126,7 @@ const SearchPlugin = connect((state) => ({
     selectedServices: state && state.search && state.search.selectedServices,
     selectedItems: state && state.search && state.search.selectedItems,
     textSearchConfig: state && state.searchconfig && state.searchconfig.textSearchConfig
-}))(/**
- * Search plugin. Provides search functionalities for the map.
- * Allows to display results and place them on the map. Supports nominatim and WFS as search protocols
- * You can configure the services and each service can trigger a nested search.
- *
- * @example
- * {
- *  "name": "Search",
- *  "cfg": {
- *    "withToggle": ["max-width: 768px", "min-width: 768px"]
- *  }
- * }
- * @class Search
- * @memberof plugins
- * @prop {object} cfg.searchOptions initial search options
- * @prop {bool} cfg.fitResultsToMapSize true by default, fits the result list to the mapSize (can be disabled, for custom uses)
- * @prop {searchService[]} cfg.searchOptions.services a list of services to perform search.
- * a **nominatim** search service look like this:
- * ```
- * {
- *  "type": "nominatim",
- *  "searchTextTemplate": "${properties.display_name}", // text to use as searchText when an item is selected. Gets the result properties.
- *  "options": {
- *    "polygon_geojson": 1,
- *    "limit": 3
- *  }
- * ```
- *
- * a **wfs** service look like this:
- * ```
- * {
- *      "type": "wfs",
- *      "priority": 2,
- *      "displayName": "${properties.propToDisplay}",
- *      "subTitle": " (a subtitle for the results coming from this service [ can contain expressions like ${properties.propForSubtitle}])",
- *      "options": {
- *        "url": "/geoserver/wfs",
- *        "typeName": "workspace:layer",
- *        "queriableAttributes": ["attribute_to_query"],
- *        "sortBy": "ID",
- *        "srsName": "EPSG:4326",
- *        "maxFeatures": 4,
- *        "blackist": [... an array of strings to exclude from the final search filter ]
- *      },
- *      "nestedPlaceholder": "Write other text to refine the search...",
- *      "nestedPlaceholderMsgId": "id contained in the localization files i.e. search.nestedplaceholder",
- *      "then": [ ... an array of services to use when one item of this service is selected],
- *      "geomService": { optional service to retrieve the geometry}
- *  }
- *
- * ```
- * The typical nested service needs to have some additional parameters:
- * ```
- * {
- *     "type": "wfs",
- *     "filterTemplate": " AND SOMEPROP = '${properties.OLDPROP}'", // will be appended to the original filter, it gets the properties of the current selected item (of the parent service)
- *     "options": {
- *       ...
- *     }
- * }
- * ```
- * **note:** `searchTextTemplate` is useful to populate the search text input when a search result is selected, typically with "leaf" services.
- * @prop {array|boolean} cfg.withToggle when boolean, true uses a toggle to display the searchbar. When array, e.g  `["max-width: 768px", "min-width: 768px"]`, `max-width` and `min-width` are the limits where to show/hide the toggle (useful for mobile)
- */
+}))(
 class extends React.Component {
     static propTypes = {
         fitResultsToMapSize: PropTypes.bool,

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -72,3 +72,57 @@ textarea {
 .portal-dialog {
     background-color: @ms2-color-background !important;
 }
+
+.sidepanel-content {
+    background-color: @ms2-color-background;
+   .sidebar-title {
+        font-size: 20px;
+        margin: 11px 11px 11px 20px;
+    }
+}
+
+.toolbar-btn-transition-enter {
+    width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    overflow: hidden;
+    &.toolbar-btn-transition-enter-active {
+        .square-btn-size {
+            width: @square-btn-medium-size;
+        }
+
+        transition: all 0.3s;
+        padding-left: @padding-left-square-md;
+        padding-right: @padding-left-square-md;
+        overflow: hidden;
+    }
+}
+
+.toolbar-btn-transition-leave {
+    .square-btn-size {
+        width: @square-btn-medium-size;
+    }
+    transition: all 0.3s;
+    padding-left: @padding-left-square-md;
+    padding-right: @padding-left-square-md;
+    overflow: hidden;
+    &.toolbar-btn-transition-leave-active {
+        width: 0;
+        padding-left: 0;
+        padding-right: 0;
+        overflow: hidden;
+    }
+}
+.empty-state-container {
+    text-align: center;
+    position: absolute;
+    width: 100%;
+    .empty-state-main-view {
+        opacity: 0.45;
+        .empty-state-image {
+            width: 40%;
+            margin-left: 30%;
+            text-align: center;
+        }
+    }
+}

--- a/web/client/utils/featuregrid/EditorRegistry.jsx
+++ b/web/client/utils/featuregrid/EditorRegistry.jsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const {find} = require('lodash');
+const assign = require('object-assign');
+let Editors = assign({}, require('../../components/data/featuregrid/editors/customEditors'));
+
+const isPresent = (editorName) => {
+    return Object.keys(Editors).indexOf(editorName) !== -1;
+};
+const testRule = (rule = {}, values = {}) => {
+    if (Object.keys(rule).length > 0) {
+        return Object.keys(rule).reduce( (p, c) => {
+            const r = new RegExp(rule[c]);
+            return p && r.test(values[c]);
+        }, true);
+    }
+    return false;
+};
+const getEditor = (type, name, props) => {
+    if (Editors[name]) {
+        if (Editors[name][type]) {
+            return Editors[name][type](props);
+        }
+        if (Editors[name].defaultEditor) {
+            return Editors[name].defaultEditor(props);
+        }
+    }
+    return null;
+};
+module.exports = {
+    get: () => Editors,
+    register: ({name, editors}) => {
+        if (!!editors) {
+            Editors[name] = editors;
+        }
+    },
+    remove: (name) => {
+        if (isPresent(name)) {
+            try {
+                delete Editors[name];
+                return true;
+            } catch (e) {
+                return false;
+            }
+        }
+        return false;
+    },
+    clean: () => {
+        Editors = {};
+    },
+    getCustomEditor: ({attribute, url, typeName}, rules = [], {type, props}) => {
+        const editor = find(rules, (r) => testRule(r.regex, {attribute, url, typeName }));
+        if (!!editor) {
+            return getEditor(type, editor.editor, {...props, ...editor.editorProps || {}});
+        }
+        return null;
+    },
+    forceSelection: ( {oldValue, changedValue, data, allowEmpty}) => {
+        if (allowEmpty && changedValue === "") {
+            return "";
+        }
+        return data.indexOf(changedValue) !== -1 ? changedValue : oldValue;
+    }
+};

--- a/web/client/utils/featuregrid/__tests__/EditorRegistry-test.js
+++ b/web/client/utils/featuregrid/__tests__/EditorRegistry-test.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+const ReactDOM = require('react-dom');
+const React = require('react');
+const expect = require('expect');
+const DropDownEditor = require('../../../components/data/featuregrid/editors/DropDownEditor');
+
+const assign = require('object-assign');
+const {
+    register,
+    clean,
+    get,
+    getCustomEditor,
+    forceSelection,
+    remove
+} = require('../EditorRegistry');
+const attribute = "STATE_NAME";
+const url = "https://demo.geo-solutions.it/geoserver/wfs";
+const typeName = "topp:states";
+const rules = [{
+    "regex": {
+        "attribute": "STATE_NAME"
+    },
+    "editor": "DropDownEditor",
+    "editorProps": {
+        "values": ["Opt1", "Opt2"],
+        "forceSelection": true
+    }
+}];
+const Editor = require('../../../components/data/featuregrid/editors/AttributeEditor');
+const NumberEditor = require('../../../components/data/featuregrid/editors/NumberEditor');
+const testEditors = {
+    "defaultEditor": (props) => <Editor {...props}/>,
+    "string": (props) => <DropDownEditor dataType="string" {...props}/>,
+    "int": (props) => <NumberEditor dataType="int" inputProps={{step: 1, type: "number"}} {...props}/>,
+    "number": (props) => <NumberEditor dataType="number" inputProps={{step: 1, type: "number"}} {...props}/>
+};
+describe('EditorRegistry tests ', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="container"></div>';
+        clean();
+    });
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+    });
+    it('clean', () => {
+        let Editors = get();
+        clean();
+        expect(Object.keys(Editors).length).toBe(0);
+    });
+    it('get', () => {
+        let Editors = get();
+        expect(Object.keys(Editors).length).toBe(0);
+    });
+    it('register using defaults', () => {
+        const name = "custom_name_editor";
+        register({name});
+        let Editors = get();
+        expect(Object.keys(Editors).length).toBe(0);
+    });
+    it('register using custom editors', () => {
+        const name = "custom_name_editor2";
+        const customEditors = assign({}, testEditors);
+        delete customEditors.string;
+        register({name, editors: customEditors});
+        let Editors = get();
+        expect(Object.keys(Editors).length).toBe(1);
+        expect(Editors[name]).toBe(customEditors);
+        expect(Object.keys(Editors[name]).length).toBe(3);
+    });
+    it('remove with name NOT PRESENT in the list', () => {
+        const name = "non present editor";
+        const result = remove(name);
+        expect(result).toBe(false);
+    });
+    it('remove with name PRESENT in the list', () => {
+        const name = "custom_name_editor2";
+        const customEditors = assign({}, testEditors);
+        register({name, editors: customEditors});
+
+        const result = remove(name);
+        expect(result).toBe(true);
+    });
+    it('getCustomEditor with positive match', () => {
+        const name = "DropDownEditor";
+        const customEditors = assign({}, testEditors);
+        register({name, editors: customEditors});
+        const editor = getCustomEditor({attribute, url, typeName}, rules, {type: "string", props: {}});
+        expect(editor).toExist();
+    });
+    it('getCustomEditor with positive match but not supported type, i.e. default editor', () => {
+        const name = "DropDownEditor";
+        const customEditors = assign({}, testEditors);
+        register({name, editors: customEditors});
+        const editor = getCustomEditor({attribute, url, typeName}, rules, {type: "varchar", props: {}});
+        expect(editor).toExist();
+    });
+    it('getCustomEditor with positive match but not supported type, return null', () => {
+        const name = "DropDownEditor";
+        let customEditors = assign({}, testEditors);
+        delete customEditors.defaultEditor;
+        register({name, editors: customEditors});
+        const editor = getCustomEditor({attribute, url, typeName}, rules, {type: "varchar", props: {}});
+        expect(editor).toBe(null);
+    });
+    it('getCustomEditor with negative match', () => {
+        const attr = "STAsTE_NAME";
+        const name = "DropDownEditor";
+        const customEditors = assign({}, testEditors);
+        register({name, editors: customEditors});
+        const editor = getCustomEditor({attribute: attr, url, typeName}, rules, {type: "string", props: {}});
+        expect(editor).toBe(null);
+    });
+    it('getCustomEditor with no rules', () => {
+        const name = "DropDownEditor";
+        const customEditors = assign({}, testEditors);
+        register({name, editors: customEditors});
+
+        const rulesempty = [{}];
+        const editor = getCustomEditor({attribute, url, typeName}, rulesempty, {type: "string", props: {}});
+        expect(editor).toBe(null);
+    });
+
+    it('testing fetch of custom editors', () => {
+        const name = "DropDownEditor";
+        const customEditors = assign({}, testEditors);
+        register({name, editors: customEditors});
+
+        const AutocompleteEditor = getCustomEditor({attribute, url, typeName}, rules, {type: "string", props: {autocompleteEnabled: true}});
+        expect(AutocompleteEditor).toExist();
+
+        const IntEditor = getCustomEditor({attribute, url, typeName}, rules, {type: "int", props: {}});
+        expect(IntEditor).toExist();
+
+        const NumbEditor = getCustomEditor({attribute, url, typeName}, rules, {type: "number", props: {}});
+        expect(NumbEditor).toExist();
+
+    });
+
+    it('forceSelection allowEmpty=true', () => {
+        const oldValue = "old";
+        const changedValue = "new";
+        const data = ["new", "old", "agile"];
+        const allowEmpty = true;
+        const newVal = forceSelection({oldValue, changedValue, data, allowEmpty});
+        expect(newVal).toBe("new");
+    });
+    it('forceSelection allowEmpty=true with "" value', () => {
+        const oldValue = "old";
+        const changedValue = "";
+        const data = ["new", "old", "agile"];
+        const allowEmpty = true;
+        const newVal = forceSelection({oldValue, changedValue, data, allowEmpty});
+        expect(newVal).toBe("");
+    });
+    it('forceSelection allowEmpty=false with "" value', () => {
+        const oldValue = "old";
+        const changedValue = "";
+        const data = ["new", "old", "agile"];
+        const allowEmpty = false;
+        const newVal = forceSelection({oldValue, changedValue, data, allowEmpty});
+        expect(newVal).toBe("old");
+    });
+    it('forceSelection allowEmpty=false with "agile" value', () => {
+        const oldValue = "old";
+        const changedValue = "agile";
+        const data = ["new", "old", "agile"];
+        const allowEmpty = false;
+        const newVal = forceSelection({oldValue, changedValue, data, allowEmpty});
+        expect(newVal).toBe("agile");
+    });
+});


### PR DESCRIPTION
## Description
 - Made MS2 Resilient on missing describe layer.
 - Allow getRecords to work with 1.1.1 WMS coming from GWC..

## Issues
 - Fix #2273

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)



**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Access on WMS from GWC (e.g. `tms.comune.fi.it/geowebcache/service/wms` ) or to services that do not expose DescribeLayer( e.g. datigis.comune.fi.it/geoserver/wms). The layer can not be added and and you have an error in console.

**What is the new behavior?**
The layer can be added anyway. Of course the if the layer is somehow broken, you will receive the error in TOC, but describeLayer is not blocking anymore. For the GWC WMS response, the layer now will work correctly. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
