### PR TITLE
Fixed issues with GeoWebCache Capabilities

### DIFF
--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -18,7 +18,7 @@ const LayersUtils = require('../../utils/LayersUtils');
 const {getRecords, addLayerError, addLayer, ADD_LAYER_ERROR, changeCatalogFormat, CHANGE_CATALOG_FORMAT, changeSelectedService, CHANGE_SELECTED_SERVICE,
      focusServicesList, FOCUS_SERVICES_LIST, changeCatalogMode, CHANGE_CATALOG_MODE, changeTitle, CHANGE_TITLE,
     changeUrl, CHANGE_URL, changeType, CHANGE_TYPE, addService, ADD_SERVICE, addCatalogService, ADD_CATALOG_SERVICE, resetCatalog, RESET_CATALOG,
-    changeAutoload, CHANGE_AUTOLOAD, deleteCatalogService, DELETE_CATALOG_SERVICE, deleteService, DELETE_SERVICE, savingService, SAVING_SERVICE} = require('../catalog');
+    changeAutoload, CHANGE_AUTOLOAD, deleteCatalogService, DELETE_CATALOG_SERVICE, deleteService, DELETE_SERVICE, savingService, SAVING_SERVICE, DESCRIBE_ERROR} = require('../catalog');
 const {CHANGE_LAYER_PROPERTIES, ADD_LAYER} = require('../layers');
 describe('Test correctness of the catalog actions', () => {
 
@@ -176,13 +176,33 @@ describe('Test correctness of the catalog actions', () => {
                 expect(action.layer).toExist();
                 expect(action.newProperties).toExist();
                 expect(action.newProperties.search).toExist();
-                expect(action.newProperties.search.type ).toBe('wfs');
+                expect(action.newProperties.search.type).toBe('wfs');
                 expect(action.newProperties.search.url).toBe("http://some.geoserver.org:80/geoserver/wfs?");
                 done();
             }
         };
         const callback = addLayer({
             url: 'base/web/client/test-resources/wms/DescribeLayers.xml',
+            type: 'wms',
+            name: 'workspace:vector_layer'
+        });
+        callback(verify, () => ({ layers: []}));
+    });
+    it('add layer with no describe layer', (done) => {
+        const verify = (action) => {
+            if (action.type === ADD_LAYER) {
+                expect(action.layer).toExist();
+                const layer = action.layer;
+                expect(layer.id).toExist();
+                expect(layer.id).toBe(LayersUtils.getLayerId(action.layer, []));
+            } else if (action.type === DESCRIBE_ERROR) {
+                expect(action.layer).toExist();
+                expect(action.error).toExist();
+                done();
+            }
+        };
+        const callback = addLayer({
+            url: 'base/web/client/test-resources/wms/Missing.xml',
             type: 'wms',
             name: 'workspace:vector_layer'
         });

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -22,6 +22,7 @@ const RESET_CATALOG = 'CATALOG:RESET_CATALOG';
 const RECORD_LIST_LOAD_ERROR = 'CATALOG:RECORD_LIST_LOAD_ERROR';
 const CHANGE_CATALOG_FORMAT = 'CATALOG:CHANGE_CATALOG_FORMAT';
 const ADD_LAYER_ERROR = 'CATALOG:ADD_LAYER_ERROR';
+const DESCRIBE_ERROR = "CATALOG:DESCRIBE_ERROR";
 const CHANGE_SELECTED_SERVICE = 'CATALOG:CHANGE_SELECTED_SERVICE';
 const CHANGE_CATALOG_MODE = 'CATALOG:CHANGE_CATALOG_MODE';
 const CHANGE_TITLE = 'CATALOG:CHANGE_TITLE';
@@ -170,6 +171,13 @@ function textSearch(format, url, startPosition, maxRecords, text, options) {
         });
     };
 }
+function describeError(layer, error) {
+    return {
+        type: DESCRIBE_ERROR,
+        layer,
+        error
+    };
+}
 function addLayerAndDescribe(layer) {
     return (dispatch, getState) => {
         const state = getState();
@@ -191,7 +199,7 @@ function addLayerAndDescribe(layer) {
                     }
                 }
 
-            });
+            }).catch((e) => dispatch(describeError(layer, e)));
         }
 
     };
@@ -203,11 +211,13 @@ function addLayerError(error) {
     };
 }
 
+
 module.exports = {
     RECORD_LIST_LOADED,
     RECORD_LIST_LOAD_ERROR,
     CHANGE_CATALOG_FORMAT, changeCatalogFormat,
     ADD_LAYER_ERROR, addLayerError,
+    DESCRIBE_ERROR,
     RESET_CATALOG, resetCatalog,
     CHANGE_SELECTED_SERVICE, changeSelectedService,
     CHANGE_CATALOG_MODE, changeCatalogMode,

--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -38,8 +38,9 @@ const flatLayers = (root) => {
 const getOnlineResource = (c) => {
     return c.Request && c.Request.GetMap && c.Request.GetMap.DCPType && c.Request.GetMap.DCPType.HTTP && c.Request.GetMap.DCPType.HTTP.Get && c.Request.GetMap.DCPType.HTTP.Get.OnlineResource && c.Request.GetMap.DCPType.HTTP.Get.OnlineResource.$ || undefined;
 };
-const searchAndPaginate = (json, startPosition, maxRecords, text) => {
-    const root = (json.WMS_Capabilities || json.WMT_MS_Capabilities).Capability;
+const searchAndPaginate = (json = {}, startPosition, maxRecords, text) => {
+    const root = (json.WMS_Capabilities || json.WMT_MS_Capabilities || {}).Capability;
+    const service = (json.WMS_Capabilities || json.WMT_MS_Capabilities || {}).Service;
     const onlineResource = getOnlineResource(root);
     const SRSList = root.Layer && (root.Layer.SRS || root.Layer.CRS) || [];
     const layersObj = flatLayers(root);
@@ -50,7 +51,7 @@ const searchAndPaginate = (json, startPosition, maxRecords, text) => {
         numberOfRecordsMatched: filteredLayers.length,
         numberOfRecordsReturned: Math.min(maxRecords, filteredLayers.length),
         nextRecord: startPosition + Math.min(maxRecords, filteredLayers.length) + 1,
-        service: json.WMS_Capabilities.Service,
+        service,
         records: filteredLayers
             .filter((layer, index) => index >= startPosition - 1 && index < startPosition - 1 + maxRecords)
             .map((layer) => assign({}, layer, {onlineResource, SRS: SRSList}))
@@ -157,7 +158,7 @@ const Api = {
             // make it compatible with json format of describe layer
             return decriptions.map(desc => ({
                 ...desc && desc.$ || {},
-                layerName: desc.$ && desc.$.name,
+                layerName: desc && desc.$ && desc.$.name,
                 query: {
                     ...desc && desc.query && desc.query.$ || {}
                 }

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -123,7 +123,20 @@ describe('Test correctness of the WMS APIs', () => {
         API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.3.0.xml', 0, 1, '').then((result) => {
             try {
                 expect(result).toExist();
+                expect(result.service).toExist();
                 expect(result.numberOfRecordsMatched).toBe(5);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+    it('GetRecords 1.1.1', (done) => {
+        API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml', 0, 1, '').then((result) => {
+            try {
+                expect(result).toExist();
+                expect(result.service).toExist();
+                expect(result.numberOfRecordsMatched).toBe(7);
                 done();
             } catch (ex) {
                 done(ex);


### PR DESCRIPTION
## Description
 - Made MS2 Resilient on missing describe layer.
 - Allow getRecords to work with 1.1.1 WMS coming from GWC..

## Issues
 - Fix #2273

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Access on WMS from GWC (e.g. `tms.comune.fi.it/geowebcache/service/wms` ) or to services that do not expose DescribeLayer( e.g. datigis.comune.fi.it/geoserver/wms). The layer can not be added and and you have an error in console.

**What is the new behavior?**
The layer can be added anyway. Of course the if the layer is somehow broken, you will receive the error in TOC, but describeLayer is not blocking anymore. For the GWC WMS response, the layer now will work correctly. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
