### PR TITLE
Fix #2282. Set Standard epics for StandardStore

### DIFF
--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -178,6 +178,6 @@ module.exports = {
     reducers: {
         annotations: require('../reducers/annotations')
     },
-    epics: assign({}, require('../epics/annotations')(AnnotationsInfoViewer),
-        require('../epics/controls'))
+    epics: require('../epics/annotations'
+)(AnnotationsInfoViewer)
 };

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -30,7 +30,9 @@ const history = routerCreateHistory();
 
 // Build the middleware for intercepting and dispatching navigation actions
 const reduxRouterMiddleware = routerMiddleware(history);
-
+const standardEpics = {
+    ...require('../epics/controls')
+};
 
 module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {}, appEpics = {}, plugins, storeOpts = {}) => {
     const allReducers = combineReducers(plugins, {
@@ -46,7 +48,7 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
         layers: () => {return null; },
         routing: routerReducer
     });
-    const rootEpic = combineEpics(plugins, appEpics);
+    const rootEpic = combineEpics(plugins, {...appEpics, ...standardEpics});
     const optsState = storeOpts.initialState || {defaultState: {}, mobile: {}};
     const defaultState = assign({}, initialState.defaultState, optsState.defaultState);
     const mobileOverride = assign({}, initialState.mobile, optsState.mobile);


### PR DESCRIPTION
## Description
Add a standardEpics object to the StandardStore to include common epics, not related to any epic.
Moved the controls epics from Annotations to Standard Store 
## Issues
 - Fix #2282

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
When the Annotation plugin is not present at build time, the feature info can not be closed. 

**What is the new behavior?**
The FeatureInfo can be closed anyway. 


**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Now you should register or generic epics into the StandardStore