### PR TITLE
Fixes #2284: ol vector style not applied correctly on update

### DIFF
--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -30,6 +30,7 @@ class Feature extends React.Component {
     };
 
     componentDidMount() {
+        this.addFeatures(this.props);
         const format = new ol.format.GeoJSON();
         const geometry = this.props.geometry && this.props.geometry.coordinates;
 
@@ -54,19 +55,7 @@ class Feature extends React.Component {
     componentWillUpdate(newProps) {
         if (!isEqual(newProps.properties, this.props.properties) || !isEqual(newProps.geometry, this.props.geometry) || !isEqual(newProps.style, this.props.style)) {
             this.removeFromContainer();
-            const format = new ol.format.GeoJSON();
-            const geometry = newProps.geometry && newProps.geometry.coordinates;
-
-            if (newProps.container && geometry) {
-                this._feature = format.readFeatures({type: newProps.type, properties: newProps.properties, geometry: newProps.geometry, id: this.props.msId});
-                this._feature.forEach((f) => f.getGeometry().transform(newProps.featuresCrs, this.props.crs || 'EPSG:3857'));
-                this._feature.forEach((f) => {
-                    if (newProps.layerStyle !== newProps.style) {
-                        f.setStyle(getStyle({style: newProps.style}));
-                    }
-                });
-                newProps.container.getSource().addFeatures(this._feature);
-            }
+            this.addFeatures(newProps);
         }
     }
 
@@ -77,6 +66,25 @@ class Feature extends React.Component {
     render() {
         return null;
     }
+
+    addFeatures = (props) => {
+        const format = new ol.format.GeoJSON();
+        const geometry = props.geometry && props.geometry.coordinates;
+
+        if (props.container && geometry) {
+            this._feature = format.readFeatures({
+                type: props.type,
+                properties: props.properties,
+                geometry: props.geometry,
+                id: this.props.msId});
+            this._feature.forEach((f) => f.getGeometry().transform(props.featuresCrs, props.crs || 'EPSG:3857'));
+            if (props.style && (props.style !== props.layerStyle)) {
+                this._feature.forEach((f) => { f.setStyle(getStyle({style: props.style})); });
+            }
+            props.container.getSource().addFeatures(this._feature);
+        }
+    };
+
 
     removeFromContainer = () => {
         if (this._feature) {

--- a/web/client/components/map/openlayers/__tests__/Feature-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Feature-test.jsx
@@ -103,4 +103,102 @@ describe('Test Feature', () => {
         // count layers
         expect(container.getSource().getFeatures().length === 1 );
     });
+
+    it('updating a feature', () => {
+        var options = {
+            crs: 'EPSG:4326',
+            features: {
+                type: 'FeatureCollection',
+                crs: {
+                    'type': 'name',
+                    'properties': {
+                        'name': 'EPSG:4326'
+                    }
+                },
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Polygon',
+                            coordinates: [[
+                              [13, 43],
+                              [15, 43],
+                              [15, 44],
+                              [13, 44]
+                            ]]
+                        },
+                        properties: {
+                            'name': "some name"
+                        }
+                    }
+                ]
+            }
+        };
+        const source = new ol.source.Vector({
+            features: []
+        });
+        const msId = "some value";
+        let container = new ol.layer.Vector({
+            msId,
+            source: source,
+            visible: true,
+            zIndex: 1
+        });
+        const geometry = options.features.features[0].geometry;
+        const type = options.features.features[0].type;
+        const properties = options.features.features[0].properties;
+
+        // create layers
+        let layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 msId={msId}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(container.getSource().getFeatures().length === 1 );
+
+        let style = layer._feature[0].getStyle();
+        expect(style).toNotExist();
+
+        options.features.features[0].properties.name = 'other name';
+
+        layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 msId={msId}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 />, document.getElementById("container"));
+
+        style = layer._feature[0].getStyle();
+        expect(style).toNotExist();
+
+        layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 msId={msId}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 style={{}}
+                 />, document.getElementById("container"));
+
+        style = layer._feature[0].getStyle();
+        expect(style).toExist();
+    });
 });


### PR DESCRIPTION
## Description
Fixed style update on openlayers vector features.

## Issues
 - Fix #2284

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
On feature update a wrong style can be  applied if by feature style is not configured.

**What is the new behavior?**
On feature update layer style is applied if by feature style is not configured.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
