### PR TITLE
Fixes #2294: reloading saved shapefile set wrong style in openlayers

### DIFF
--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -117,18 +117,21 @@ function getMarkerStyle(options) {
 
 function getStyle(options) {
     let style = options.nativeStyle;
+    const geomType = (options.style && options.style.type) || (options.features && options.features[0] ? options.features[0].geometry.type : undefined);
     if (!style && options.style) {
         style = {
             stroke: new ol.style.Stroke( options.style.stroke ? options.style.stroke : {
-                color: 'blue',
-                width: 1
+                color: options.style.color || 'blue',
+                width: options.style.weight || 1,
+                opacity: options.style.opacity || 1
             }),
             fill: new ol.style.Fill(options.style.fill ? options.style.fill : {
-                color: 'blue'
+                color: options.style.fillColor || 'blue',
+                opacity: options.style.fillOpacity || 1
             })
         };
 
-        if (options.style.type === "Point") {
+        if (geomType === "Point") {
             style = {
                 image: new ol.style.Circle(assign({}, style, {radius: options.style.radius || 5}))
             };

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -52,4 +52,23 @@ describe('Test VectorStyle', () => {
         });
         expect(style).toExist();
     });
+
+    it('guess image point style', () => {
+        const feature = {
+              geometry: {
+                  type: 'Point',
+                  coordinates: [13.0, 43.0]
+              },
+              name: 'My Point'
+        };
+        const style = VectorStyle.getStyle({
+            features: [feature],
+            style: {
+                radius: 10,
+                color: 'blue'
+            }
+        });
+        expect(style).toExist();
+        expect(style.getImage()).toExist();
+    });
 });


### PR DESCRIPTION
## Description
Saved shapefile were not correctly reloaded with OpenLayers (wrong style set)

## Issues
 - Fix #2294
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Saved shapefile are not correctly reloaded with OpenLayers (wrong style set)

**What is the new behavior?**
Saved shapefile are correctly reloaded with OpenLayers (right style set)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
