### PR TITLE
Fix #2211. Add warning and disable editing for GeometryCollection

### DIFF
--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -303,12 +303,12 @@ class Catalog extends React.Component {
                                 </FormGroup>
                                 <FormGroup controlId="buttons" key="buttons">
                                     {this.renderButtons()}
+                                    {this.props.layerError ? this.renderError(this.props.layerError) : null}
                                 </FormGroup>
                             </Form>)}
                     footer={this.renderPagination()}>
                             <div>
                                 {this.renderResult()}
-                                {this.props.layerError ? this.renderError(this.props.layerError) : null}
                             </div>
                         </BorderLayout>
             ) : (

--- a/web/client/components/map/leaflet/plugins/WMTSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMTSLayer.js
@@ -13,7 +13,7 @@ const assign = require('object-assign');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const WMTSUtils = require('../../../../utils/WMTSUtils');
 const WMTS = require('../../../../utils/leaflet/WMTS');
-const {isObject, isArray} = require('lodash');
+const {isArray, isObject} = require('lodash');
 
 L.tileLayer.wmts = function(urls, options, matrixOptions) {
     return new WMTS(urls, options, matrixOptions);

--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -30,6 +30,7 @@ class Feature extends React.Component {
     };
 
     componentDidMount() {
+        this.addFeatures(this.props);
         const format = new ol.format.GeoJSON();
         const geometry = this.props.geometry && this.props.geometry.coordinates;
 
@@ -54,19 +55,7 @@ class Feature extends React.Component {
     componentWillUpdate(newProps) {
         if (!isEqual(newProps.properties, this.props.properties) || !isEqual(newProps.geometry, this.props.geometry) || !isEqual(newProps.style, this.props.style)) {
             this.removeFromContainer();
-            const format = new ol.format.GeoJSON();
-            const geometry = newProps.geometry && newProps.geometry.coordinates;
-
-            if (newProps.container && geometry) {
-                this._feature = format.readFeatures({type: newProps.type, properties: newProps.properties, geometry: newProps.geometry, id: this.props.msId});
-                this._feature.forEach((f) => f.getGeometry().transform(newProps.featuresCrs, this.props.crs || 'EPSG:3857'));
-                this._feature.forEach((f) => {
-                    if (newProps.layerStyle !== newProps.style) {
-                        f.setStyle(getStyle({style: newProps.style}));
-                    }
-                });
-                newProps.container.getSource().addFeatures(this._feature);
-            }
+            this.addFeatures(newProps);
         }
     }
 
@@ -77,6 +66,25 @@ class Feature extends React.Component {
     render() {
         return null;
     }
+
+    addFeatures = (props) => {
+        const format = new ol.format.GeoJSON();
+        const geometry = props.geometry && props.geometry.coordinates;
+
+        if (props.container && geometry) {
+            this._feature = format.readFeatures({
+                type: props.type,
+                properties: props.properties,
+                geometry: props.geometry,
+                id: this.props.msId});
+            this._feature.forEach((f) => f.getGeometry().transform(props.featuresCrs, props.crs || 'EPSG:3857'));
+            if (props.style && (props.style !== props.layerStyle)) {
+                this._feature.forEach((f) => { f.setStyle(getStyle({style: props.style})); });
+            }
+            props.container.getSource().addFeatures(this._feature);
+        }
+    };
+
 
     removeFromContainer = () => {
         if (this._feature) {

--- a/web/client/components/map/openlayers/__tests__/Feature-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Feature-test.jsx
@@ -103,4 +103,102 @@ describe('Test Feature', () => {
         // count layers
         expect(container.getSource().getFeatures().length === 1 );
     });
+
+    it('updating a feature', () => {
+        var options = {
+            crs: 'EPSG:4326',
+            features: {
+                type: 'FeatureCollection',
+                crs: {
+                    'type': 'name',
+                    'properties': {
+                        'name': 'EPSG:4326'
+                    }
+                },
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Polygon',
+                            coordinates: [[
+                              [13, 43],
+                              [15, 43],
+                              [15, 44],
+                              [13, 44]
+                            ]]
+                        },
+                        properties: {
+                            'name': "some name"
+                        }
+                    }
+                ]
+            }
+        };
+        const source = new ol.source.Vector({
+            features: []
+        });
+        const msId = "some value";
+        let container = new ol.layer.Vector({
+            msId,
+            source: source,
+            visible: true,
+            zIndex: 1
+        });
+        const geometry = options.features.features[0].geometry;
+        const type = options.features.features[0].type;
+        const properties = options.features.features[0].properties;
+
+        // create layers
+        let layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 msId={msId}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(container.getSource().getFeatures().length === 1 );
+
+        let style = layer._feature[0].getStyle();
+        expect(style).toNotExist();
+
+        options.features.features[0].properties.name = 'other name';
+
+        layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 msId={msId}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 />, document.getElementById("container"));
+
+        style = layer._feature[0].getStyle();
+        expect(style).toNotExist();
+
+        layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 msId={msId}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 style={{}}
+                 />, document.getElementById("container"));
+
+        style = layer._feature[0].getStyle();
+        expect(style).toExist();
+    });
 });

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -36,7 +36,8 @@ class MapPreview extends React.Component {
         resolutions: PropTypes.array,
         printRatio: PropTypes.number,
         layout: PropTypes.string,
-        layoutSize: PropTypes.object
+        layoutSize: PropTypes.object,
+        useFixedScales: PropTypes.bool
     };
 
     static defaultProps = {
@@ -51,7 +52,8 @@ class MapPreview extends React.Component {
         height: 270,
         enableRefresh: true,
         enableScalebox: true,
-        printRatio: 96.0 / 72.0
+        printRatio: 96.0 / 72.0,
+        useFixedScales: false
     };
 
     componentWillMount() {
@@ -121,7 +123,7 @@ class MapPreview extends React.Component {
                 interactive={false}
                 onMapViewChanges={this.props.onMapViewChanges}
                 zoomControl={false}
-                zoom={this.props.scales ? PrintUtils.getMapZoom(this.props.map.scaleZoom, this.props.scales) : this.props.map.zoom}
+                zoom={this.props.useFixedScales && this.props.scales ? PrintUtils.getMapZoom(this.props.map.scaleZoom, this.props.scales) : this.props.map.zoom}
                 center={this.props.map.center}
                 id="print_preview"
                 registerHooks={false}

--- a/web/client/components/print/__tests__/MapPreview-test.jsx
+++ b/web/client/components/print/__tests__/MapPreview-test.jsx
@@ -82,4 +82,44 @@ describe("Test the MapPreview component", () => {
         expect(node).toExist();
         expect(node.getElementsByClassName('leaflet-layer').length).toBe(2);
     });
+
+    it('uses map zoom when useFixedScales is false', () => {
+        const layers = [{
+            name: 'layer1',
+            type: "wms",
+            visibility: false,
+            url: "http://fake"
+        }, {
+            name: 'layer2',
+            visibility: true,
+            type: "osm"
+        }, {
+            name: 'layer3',
+            visibility: true,
+            type: "wms",
+            url: "http://fake"
+        }];
+        const cmp = ReactDOM.render(<MapPreview layers={layers} map={{center: {x: 10.0, y: 40.0}, zoom: 5}}/>, document.getElementById("container"));
+        expect(cmp.refs.mappa.props.zoom).toBe(5);
+    });
+
+    it('calculate zoom on given scales when useFixedScales is true', () => {
+        const layers = [{
+            name: 'layer1',
+            type: "wms",
+            visibility: false,
+            url: "http://fake"
+        }, {
+            name: 'layer2',
+            visibility: true,
+            type: "osm"
+        }, {
+            name: 'layer3',
+            visibility: true,
+            type: "wms",
+            url: "http://fake"
+        }];
+        const cmp = ReactDOM.render(<MapPreview layers={layers} map={{center: {x: 10.0, y: 40.0}, zoom: 5, scaleZoom: 3}} useFixedScales scales={[100, 1000, 10000, 100000]}/>, document.getElementById("container"));
+        expect(cmp.refs.mappa.props.zoom).toBe(13);
+    });
 });

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -248,6 +248,7 @@ class Print extends React.Component {
                         layout={layoutName}
                         layoutSize={layout && layout.map || {width: 10, height: 10}}
                         resolutions={MapUtils.getResolutions()}
+                        useFixedScales={this.props.useFixedScales}
                         {...this.props.mapPreviewOptions}
                         />
                     {this.isBackgroundIgnored() ? <DefaultBackgroundOption label={LocaleUtils.getMessageById(this.context.messages, "print.defaultBackground")}/> : null}

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -433,5 +433,12 @@ describe('Test featuregrid selectors', () => {
         initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:Geometry';
         initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'Geometry';
         expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:GeometryCollection';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'GeometryCollection';
+        expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:Polygon';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'Polygon';
+        expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(true);
+
     });
 });

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -56,7 +56,7 @@ const hasGeometrySelectedFeature = (state) => {
     return false;
 };
 
-const notSupportedGeometries = ['Geometry'];
+const notSupportedGeometries = ['Geometry', 'GeometryCollection'];
 
 const hasSupportedGeometry = state => head(notSupportedGeometries.filter(g => geomTypeSelectedFeatureSelector(state) === g)) ? false : true;
 const hasChangesSelector = state => changesSelector(state) && changesSelector(state).length > 0;

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -20,7 +20,7 @@ const WMTSUtils = {
         return matrixIds;
     },
     getMatrixIds: (matrix, srs) => {
-        return (isObject(matrix) && matrix[srs] || matrix).map((el) => el.identifier);
+        return ((isObject(matrix) && isArray(matrix[srs]) && matrix[srs]) || (isArray(matrix) && matrix) || []).map((el) => el.identifier);
     },
     limitMatrix: (matrix, len) => {
         if (matrix.length > len) {
@@ -31,7 +31,7 @@ const WMTSUtils = {
         }
         return matrix;
     },
-    getTileMatrixSet: (tileMatrixSet, srs, allowedSRS, matrixIds = {}) => {
+    getTileMatrixSet: (tileMatrixSet, srs, allowedSRS, matrixIds = {}, defaultMatrix = srs) => {
         if (tileMatrixSet && isString(tileMatrixSet)) {
             return tileMatrixSet;
         }
@@ -44,10 +44,10 @@ const WMTSUtils = {
                     return tileMatrixSet[current] || previous;
                 }
                 return previous;
-            }, srs);
+            }, defaultMatrix);
         }
 
-        return srs;
+        return defaultMatrix;
     }
 };
 

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -77,6 +77,82 @@ describe('Test the CatalogUtils', () => {
 
     });
 
+    it('wmts with tilematrix filtered', () => {
+        const records = CatalogUtils.getCatalogRecords('wmts', {
+            records: [{
+                "ows:WGS84BoundingBox": {
+                    "ows:LowerCorner": "-180.0 -90.0",
+                    "ows:UpperCorner": "180.0 90.0"
+                },
+                TileMatrixSetLink: [{
+                    TileMatrixSet: 'EPSG:4326',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:4326:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }],
+                TileMatrixSet: [{
+                    "ows:Identifier": "EPSG:4326",
+                    "ows:SupportedCRS": "EPSG:4326"
+                }],
+                SRS: ['EPSG:4326', 'EPSG:3857']
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].references.length).toBe(1);
+        expect(records[0].references[0].SRS.length).toBe(1);
+    });
+
+    it('wmts with tilematrix not filtered', () => {
+        const records = CatalogUtils.getCatalogRecords('wmts', {
+            records: [{
+                "ows:WGS84BoundingBox": {
+                    "ows:LowerCorner": "-180.0 -90.0",
+                    "ows:UpperCorner": "180.0 90.0"
+                },
+                TileMatrixSetLink: [{
+                    TileMatrixSet: 'EPSG:4326',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:4326:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }, {
+                    TileMatrixSet: 'EPSG:3857',
+                    TileMatrixSetLimits: {
+                        TileMatrixSetLimits: [{
+                            TileMatrix: 'EPSG:3857:0',
+                            MinTileCol: 0,
+                            MaxTileCol: 10,
+                            MinTileRow: 0,
+                            MaxTileRow: 10
+                        }]
+                    }
+                }],
+                TileMatrixSet: [{
+                    "ows:Identifier": "EPSG:4326",
+                    "ows:SupportedCRS": "EPSG:4326"
+                }, {
+                    "ows:Identifier": "EPSG:3857",
+                    "ows:SupportedCRS": "EPSG:3857"
+                }],
+                SRS: ['EPSG:4326', 'EPSG:3857']
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].references.length).toBe(1);
+        expect(records[0].references[0].SRS.length).toBe(2);
+    });
+
     it('csw empty', () => {
         const records = CatalogUtils.getCatalogRecords('csw', {
             records: [{}]

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const WMTSUtils = require('../WMTSUtils');
+
+describe('Test the WMTSUtils', () => {
+    it('get matrix ids with object', () => {
+        const ids = WMTSUtils.getMatrixIds({
+            "EPSG:4326": [{
+                identifier: 'EPSG:4326'
+            }]
+        }, 'EPSG:4326');
+        expect(ids.length).toBe(1);
+        expect(ids[0]).toBe('EPSG:4326');
+    });
+
+    it('get matrix ids with array', () => {
+        const ids = WMTSUtils.getMatrixIds([{
+                identifier: 'EPSG:4326'
+            }], 'EPSG:4326');
+        expect(ids.length).toBe(1);
+        expect(ids[0]).toBe('EPSG:4326');
+    });
+});

--- a/web/client/utils/leaflet/WMTS.js
+++ b/web/client/utils/leaflet/WMTS.js
@@ -60,6 +60,9 @@ var WMTS = L.TileLayer.extend({
         let se = crs.project(map.unproject(sePoint, tilePoint.z));
         let tilewidth = se.x - nw.x;
         let t = map.getZoom();
+        if (!this.matrixIds[t]) {
+            return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        }
         let ident = this.matrixIds[t].identifier;
         let X0 = this.matrixIds[t].topLeftCorner.lng;
         let Y0 = this.matrixIds[t].topLeftCorner.lat;


### PR DESCRIPTION
## Description
Provided unsupported message and disable proper tools for "GeometryCollection" as well as with "Geometry"
## Issues
 - Fix #2211
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
A layer with geometry type "gml:GeometryCollection" do not work when you try to edit.

**What is the new behavior?**
The user receives a message for the geometry type that is not supported. The edit geometry and create buttons are disabled. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
