### PR TITLE
Fix #2211. Unsupported message also for geometry collection

### DIFF
--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -433,5 +433,12 @@ describe('Test featuregrid selectors', () => {
         initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:Geometry';
         initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'Geometry';
         expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:GeometryCollection';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'GeometryCollection';
+        expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:Polygon';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'Polygon';
+        expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(true);
+
     });
 });

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -56,7 +56,7 @@ const hasGeometrySelectedFeature = (state) => {
     return false;
 };
 
-const notSupportedGeometries = ['Geometry'];
+const notSupportedGeometries = ['Geometry', 'GeometryCollection'];
 
 const hasSupportedGeometry = state => head(notSupportedGeometries.filter(g => geomTypeSelectedFeatureSelector(state) === g)) ? false : true;
 const hasChangesSelector = state => changesSelector(state) && changesSelector(state).length > 0;


### PR DESCRIPTION
## Description
Provided unsupported message and disable proper tools for "GeometryCollection" as well as with "Geometry"
## Issues
 - Fix #2211

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
A layer with geometry type "gml:GeometryCollection" do not work when you try to edit.

**What is the new behavior?**
The user receives a message for the geometry type that is not supported. The edit geometry and create buttons are disabled. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
