### PR TITLE
Add read only mode on annotations

### DIFF
--- a/web/client/components/data/identify/viewers/JSONViewer.jsx
+++ b/web/client/components/data/identify/viewers/JSONViewer.jsx
@@ -25,7 +25,7 @@ class JSONViewer extends React.Component {
         const RowViewer = (this.props.layer && this.props.layer.rowViewer) || this.props.rowViewer || PropertiesViewer;
         return (<div className="mapstore-json-viewer">
                 {(this.props.response.features || []).map((feature, i) => {
-                    return <RowViewer key={i} readOnly={feature.readOnly} title={feature.id} exclude={["bbox"]} {...feature.properties}/>;
+                    return <RowViewer key={i} feature={feature} title={feature.id} exclude={["bbox"]} {...feature.properties}/>;
                 })}
             </div>)
         ;

--- a/web/client/components/data/identify/viewers/JSONViewer.jsx
+++ b/web/client/components/data/identify/viewers/JSONViewer.jsx
@@ -25,7 +25,7 @@ class JSONViewer extends React.Component {
         const RowViewer = (this.props.layer && this.props.layer.rowViewer) || this.props.rowViewer || PropertiesViewer;
         return (<div className="mapstore-json-viewer">
                 {(this.props.response.features || []).map((feature, i) => {
-                    return <RowViewer key={i} title={feature.id} exclude={["bbox"]} {...feature.properties}/>;
+                    return <RowViewer key={i} readOnly={feature.readOnly} title={feature.id} exclude={["bbox"]} {...feature.properties}/>;
                 })}
             </div>)
         ;

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -112,14 +112,16 @@ class Annotations extends React.Component {
     };
 
     renderCard = (annotation) => {
-        return (<div className="mapstore-annotations-panel-card" onMouseOver={() => this.props.onHighlight(annotation.properties.id)} onMouseOut={this.props.onCleanHighlight} onClick={() => this.props.onDetail(annotation.properties.id)}>
+        const readOnly = annotation.readOnly ? ' m-read-only' : '';
+        return (<div className={"mapstore-annotations-panel-card" + readOnly} onMouseOver={() => this.props.onHighlight(annotation.properties.id)} onMouseOut={this.props.onCleanHighlight} onClick={annotation.readOnly ? () => {} : () => this.props.onDetail(annotation.properties.id)}>
             <span className="mapstore-annotations-panel-card-thumbnail">{this.renderThumbnail(annotation.style)}</span>
             {this.getConfig().fields.map(f => this.renderField(f, annotation))}
         </div>);
     };
 
     renderCards = () => {
-        if (this.props.mode === 'list') {
+        const annotation = head(this.props.annotations.filter(a => a.properties.id === this.props.current));
+        if (this.props.mode === 'list' || (!annotation && !this.props.editing)) {
             return [<ButtonGroup id="mapstore-annotations-panel-buttons">
                 <Button bsStyle="primary" onClick={() => this.props.onAdd(this.props.config.multiGeometry ? 'MultiPoint' : 'Point')}><Glyphicon glyph="plus"/>&nbsp;<Message msgId="annotations.add"/></Button>
             </ButtonGroup>,
@@ -131,8 +133,7 @@ class Annotations extends React.Component {
             ];
         }
         const Editor = this.props.editor;
-        if (this.props.mode === 'detail') {
-            const annotation = head(this.props.annotations.filter(a => a.properties.id === this.props.current));
+        if (this.props.mode === 'detail' && annotation && annotation.properties) {
             return <Editor showBack id={this.props.current} {...annotation.properties}/>;
         }
         // mode = editing

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -120,7 +120,7 @@ class Annotations extends React.Component {
     };
 
     renderCards = () => {
-        const annotation = head(this.props.annotations.filter(a => a.properties.id === this.props.current));
+        const annotation = this.props.annotations && head(this.props.annotations.filter(a => a.properties.id === this.props.current));
         if (this.props.mode === 'list' || (!annotation && !this.props.editing)) {
             return [<ButtonGroup id="mapstore-annotations-panel-buttons">
                 <Button bsStyle="primary" onClick={() => this.props.onAdd(this.props.config.multiGeometry ? 'MultiPoint' : 'Point')}><Glyphicon glyph="plus"/>&nbsp;<Message msgId="annotations.add"/></Button>

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -90,7 +90,6 @@ class AnnotationsEditor extends React.Component {
     };
 
     componentWillReceiveProps(newProps) {
-
         if (newProps.id !== this.props.id) {
             this.setState({
                 editedFields: {}
@@ -103,10 +102,11 @@ class AnnotationsEditor extends React.Component {
         const newEditing = newProps.editing && (newProps.editing.properties.id === newProps.id);
 
         if (!editing && newEditing) {
+            const newConfig = assign({}, defaultConfig, newProps.config);
             this.setState({
-                editedFields: this.getConfig().fields
+                editedFields: newConfig.fields
                     .reduce((a, field) => {
-                        return assign({}, a, { [field.name]: this.props[field.name]});
+                        return assign({}, a, { [field.name]: newProps[field.name]});
                     }, {})
             });
         }

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -74,13 +74,15 @@ class AnnotationsEditor extends React.Component {
         styling: PropTypes.bool,
         errors: PropTypes.object,
         showBack: PropTypes.bool,
-        config: PropTypes.object
+        config: PropTypes.object,
+        readOnly: PropTypes.bool
     };
 
     static defaultProps = {
         config: defaultConfig,
         errors: {},
-        showBack: false
+        showBack: false,
+        readOnly: false
     };
 
     state = {
@@ -88,9 +90,24 @@ class AnnotationsEditor extends React.Component {
     };
 
     componentWillReceiveProps(newProps) {
+
         if (newProps.id !== this.props.id) {
             this.setState({
                 editedFields: {}
+            });
+        }
+    }
+
+    componentWillUpdate(newProps) {
+        const editing = this.props.editing && (this.props.editing.properties.id === this.props.id);
+        const newEditing = newProps.editing && (newProps.editing.properties.id === newProps.id);
+
+        if (!editing && newEditing) {
+            this.setState({
+                editedFields: this.getConfig().fields
+                    .reduce((a, field) => {
+                        return assign({}, a, { [field.name]: this.props[field.name]});
+                    }, {})
             });
         }
     }
@@ -255,7 +272,7 @@ class AnnotationsEditor extends React.Component {
         const editing = this.props.editing && (this.props.editing.properties.id === this.props.id);
         return (
             <div className="mapstore-annotations-info-viewer">
-                {this.renderButtons(editing)}
+                {this.props.readOnly ? null : this.renderButtons(editing)}
                 {this.renderError(editing)}
                 {this.renderBody(editing)}
             </div>

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -75,14 +75,14 @@ class AnnotationsEditor extends React.Component {
         errors: PropTypes.object,
         showBack: PropTypes.bool,
         config: PropTypes.object,
-        readOnly: PropTypes.bool
+        feature: PropTypes.object
     };
 
     static defaultProps = {
         config: defaultConfig,
         errors: {},
         showBack: false,
-        readOnly: false
+        feature: {}
     };
 
     state = {
@@ -272,7 +272,7 @@ class AnnotationsEditor extends React.Component {
         const editing = this.props.editing && (this.props.editing.properties.id === this.props.id);
         return (
             <div className="mapstore-annotations-info-viewer">
-                {this.props.readOnly ? null : this.renderButtons(editing)}
+                {this.props.feature.readOnly ? null : this.renderButtons(editing)}
                 {this.renderError(editing)}
                 {this.renderBody(editing)}
             </div>

--- a/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.jsx
+++ b/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.jsx
@@ -186,4 +186,47 @@ describe("test the Annotations Panel", () => {
         expect(TestUtils.scryRenderedDOMComponentsWithClass(annotations, "mapstore-annotations-panel-card").length).toBe(0);
         expect(TestUtils.scryRenderedDOMComponentsWithClass(annotations, "myeditor").length).toBe(1);
     });
+
+    it('test rendering in read only', () => {
+        const annotationsList = [{
+            readOnly: true,
+            properties: {
+                title: 'a',
+                description: 'b'
+            },
+            style: {
+                iconShape: 'square',
+                iconColor: 'blue'
+            }
+        }, {
+            readOnly: true,
+            properties: {
+                title: 'c',
+                description: 'd'
+            },
+            style: {
+                iconShape: 'square',
+                iconColor: 'blue'
+            }
+        }];
+
+        const testHandlers = {
+            onDetail: () => {}
+        };
+
+        const spyDetail = expect.spyOn(testHandlers, 'onDetail');
+
+        const annotations = ReactDOM.render(<Annotations mode="list" onDetail={testHandlers.onDetail} annotations={annotationsList} />, document.getElementById("container"));
+
+        expect(annotations).toExist();
+
+        const cards = TestUtils.scryRenderedDOMComponentsWithClass(annotations, "mapstore-annotations-panel-card m-read-only");
+        expect(cards.length).toBe(2);
+
+        TestUtils.Simulate.click(ReactDOM.findDOMNode(cards[0]));
+        TestUtils.Simulate.click(ReactDOM.findDOMNode(cards[1]));
+
+        expect(spyDetail).toNotHaveBeenCalled();
+
+    });
 });

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -421,4 +421,38 @@ describe("test the AnnotationsEditor Panel", () => {
         expect(spySetStyle.calls.length).toEqual(1);
         expect(spySetStyle.calls[0].arguments[0]).toExist();
     });
+
+    it('test faeture read only', () => {
+        const feature = {
+            id: "1",
+            title: 'mytitle',
+            description: '<span><i>desc</i></span>'
+        };
+
+        const viewer = ReactDOM.render(<AnnotationsEditor feature={{
+            readOnly: true
+        }} {...feature} editing={{
+            readOnly: true,
+            properties: feature,
+            style: {
+                iconGlyph: 'comment',
+                iconColor: 'red',
+                iconShape: 'square'
+            }
+        }}/>, document.getElementById("container"));
+        expect(viewer).toExist();
+
+        const editingBtnLength = TestUtils.scryRenderedDOMComponentsWithClass(viewer, "mapstore-annotations-info-viewer-buttons").length;
+        expect(editingBtnLength).toBe(0);
+
+        const viewBtnLength = TestUtils.scryRenderedDOMComponentsWithClass(viewer, "mapstore-annotations-info-viewer-buttons").length;
+        expect(viewBtnLength).toBe(0);
+
+    });
+
+    it('test faeture update editing', () => {
+        const viewer = ReactDOM.render(<AnnotationsEditor id="1"/>, document.getElementById("container"));
+        viewer.componentWillUpdate({id: '2', editing: {properties: {id: '2'}}, description: '<p>desc</p>', title: 'title'});
+        expect(viewer.state).toEqual({ editedFields: { description: '<p>desc</p>', title: 'title' } });
+    });
 });

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -190,3 +190,10 @@
 .mapstore-annotations-info-viewer-styler-buttons {
     text-align: right;
 }
+
+.mapstore-annotations-panel-card {
+    &.m-read-only {
+        border: none;
+        cursor: default;
+    }
+}


### PR DESCRIPTION
## Description
Added read only mode on annotations

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
annotations cannot be disabled

**What is the new behavior?**
annotations can be disabled with readOnly flag

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
