### PR TITLE
Fixes #2131 added test and default in catalog services reducer

### DIFF
--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -171,7 +171,8 @@ describe('Test the catalog reducer', () => {
         const state = catalog({mode: "edit"}, {type: "default"});
         expect(state.mode).toBe("edit");
     });
-    it('CHANGE_CATALOG_MODE', () => {
+    // it should return an empty service as a new service
+    it('CHANGE_CATALOG_MODE with no configured services, new service', () => {
         const mode = "edit";
         let isNew = true;
         const state = catalog({}, {type: CHANGE_CATALOG_MODE, mode, isNew});
@@ -182,6 +183,26 @@ describe('Test the catalog reducer', () => {
         expect(state.newService.type).toBe(emptyService.type);
         expect(state.newService.title).toBe(emptyService.title);
         expect(state.newService.url).toBe(emptyService.url);
+        isNew = false;
+        const state2 = catalog({selectedService: "serv", services: {
+            "serv": {
+                title: "tit"
+            }
+        }}, {type: CHANGE_CATALOG_MODE, mode, isNew});
+        expect(state2.newService.title).toBe("tit");
+    });
+    it('CHANGE_CATALOG_MODE with no configured services, not new', () => {
+        const mode = "edit";
+        let isNew = false;
+        const state = catalog({}, {type: CHANGE_CATALOG_MODE, mode, isNew});
+        expect(state.result).toBe(null);
+        expect(state.loadingError).toBe(null);
+        expect(state.layerError).toBe(null);
+        expect(state.mode).toBe(mode);
+        expect(state.newService.oldService).toBe('');
+        expect(state.newService.type).toBe(undefined);
+        expect(state.newService.title).toBe(undefined);
+        expect(state.newService.url).toBe(undefined);
         isNew = false;
         const state2 = catalog({selectedService: "serv", services: {
             "serv": {

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -26,6 +26,7 @@ const {
 const {
     MAP_CONFIG_LOADED
 } = require('../actions/config');
+const {isNil} = require('lodash');
 const assign = require('object-assign');
 const emptyService = {
     url: "",
@@ -35,7 +36,16 @@ const emptyService = {
     autoload: false
 };
 
-function catalog(state = {}, action) {
+function catalog(state = {
+    "default": {
+        services: {},
+        selectedService: "",
+        newService: {}
+    },
+    services: {},
+    selectedService: "",
+    newService: {}
+}, action) {
     switch (action.type) {
     case SAVING_SERVICE:
         return assign({}, state, {
@@ -77,14 +87,14 @@ function catalog(state = {}, action) {
         return assign({}, state, {layerError: action.error});
     case CHANGE_CATALOG_MODE:
         return assign({}, state, {
-            newService: action.isNew ? emptyService : assign({}, state.services[state.selectedService], {oldService: state.selectedService}),
+            newService: action.isNew ? emptyService : assign({}, state.services && state.services[state.selectedService || ""] || {}, {oldService: state.selectedService || ""}),
             mode: action.mode,
             result: null,
             loadingError: null,
             layerError: null});
     case MAP_CONFIG_LOADED: {
-        if (state && state.default) {
-            if (action.config && action.config.catalogServices) {
+        if (state && !isNil(state.default)) {
+            if (action.config && !isNil(action.config.catalogServices)) {
                 return assign({}, state, {services: action.config.catalogServices.services, selectedService: action.config.catalogServices.selectedService });
             }
             return assign({}, state, {services: state.default.services, selectedService: state.default.selectedService });


### PR DESCRIPTION
## Description
If no configuration an empty default is used avoding the generation of errors.

## Issues
 - Fix #2131


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
#2131 there is an error in the console if a not proper configuration of initialState is provided.

**What is the new behavior?**
If no services are set in the config an empty default is used.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
