### PR TITLE
Fix #2304 Allowed authenticated user to enter in edit mode using FeatureEditor plugin

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -7,6 +7,7 @@
  */
 
 const expect = require('expect');
+const {isEmpty, isEqual} = require('lodash');
 const {
     SELECT_FEATURES, selectFeatures,
     changePage, CHANGE_PAGE,
@@ -34,7 +35,8 @@ const {
     closeFeatureGridConfirmed, FEATURE_GRID_CLOSE_CONFIRMED,
     updateFilter, UPDATE_FILTER,
     zoomAll, ZOOM_ALL,
-    openAdvancedSearch, OPEN_ADVANCED_SEARCH
+    openAdvancedSearch, OPEN_ADVANCED_SEARCH,
+    initPlugin, INIT_PLUGIN
 } = require('../featuregrid');
 
 const idFeature = "2135";
@@ -64,6 +66,20 @@ describe('Test correctness of featurgrid actions', () => {
         const retval = deleteGeometry();
         expect(retval).toExist();
         expect(retval.type).toBe(DELETE_GEOMETRY);
+    });
+    it('Test initPlugin action creator', () => {
+        const someOption = "someValue";
+        const retval = initPlugin({someOption});
+        expect(retval).toExist();
+        expect(retval.type).toBe(INIT_PLUGIN);
+        expect(retval.options.someOption).toBe(someOption);
+
+        // test with empty value, returns empty options
+        const retval2 = initPlugin();
+        expect(retval2).toExist();
+        expect(retval2.type).toBe(INIT_PLUGIN);
+        expect(isEmpty(retval2.options)).toBe(true);
+        expect(isEqual(retval2.options, {})).toBe(true);
     });
     it('Test closeFeatureGridConfirmed action creator', () => {
         const retval = closeFeatureGridConfirmed();

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -43,6 +43,7 @@ const SET_PERMISSION = 'FEATUREGRID:SET_PERMISSION';
 const DISABLE_TOOLBAR = 'FEATUREGRID:DISABLE_TOOLBAR';
 const OPEN_ADVANCED_SEARCH = 'FEATUREGRID:ADVANCED_SEARCH';
 const ZOOM_ALL = 'FEATUREGRID:ZOOM_ALL';
+const INIT_PLUGIN = 'FEATUREGRID:INIT_PLUGIN';
 
 const MODES = {
     EDIT: "EDIT",
@@ -52,6 +53,12 @@ const START_SYNC_WMS = 'FEATUREGRID:START_SYNC_WMS';
 const STOP_SYNC_WMS = 'FEATUREGRID:STOP_SYNC_WMS';
 
 
+function initPlugin(options) {
+    return {
+        type: INIT_PLUGIN,
+        options
+    };
+}
 function clearChangeConfirmed() {
     return {
         type: CLEAR_CHANGES_CONFIRMED
@@ -336,6 +343,7 @@ module.exports = {
     customizeAttribute,
     toggleEditMode,
     toggleViewMode,
+    initPlugin, INIT_PLUGIN,
     START_SYNC_WMS,
     STOP_SYNC_WMS
 };

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -53,7 +53,7 @@ const START_SYNC_WMS = 'FEATUREGRID:START_SYNC_WMS';
 const STOP_SYNC_WMS = 'FEATUREGRID:STOP_SYNC_WMS';
 
 
-function initPlugin(options) {
+function initPlugin(options = {}) {
     return {
         type: INIT_PLUGIN,
         options

--- a/web/client/api/searchText.js
+++ b/web/client/api/searchText.js
@@ -30,16 +30,16 @@ const defaultFromTextToFilter = ({searchText, staticFilter, blacklist, item, que
 /*
  * The API returns a promise for each search service.
  * These search services have a particular option that specify how the response is returned.
- * 'returnFullResponse' is a boolean option that if true a the full reponse is returned, otherwise an array o fearures.
+ * 'returnFullData' is a boolean option that if true a the full data is returned, otherwise an array o fearures.
 */
 let Services = {
     nominatim: (searchText, options = {
-        returnFullResponse: false
+        returnFullData: false
     }) =>
         require('./Nominatim')
         .geocode(searchText, options)
-        .then( res => {return options.returnFullResponse ? res : GeoCodeUtils.nominatimToGeoJson(res.data); }),
-    wfs: (searchText, {url, typeName, queriableAttributes = [], outputFormat = "application/json", predicate = "ILIKE", staticFilter = "", blacklist = [], item, fromTextToFilter = defaultFromTextToFilter, returnFullResponse = false, ...params }) => {
+        .then( res => {return options.returnFullData ? res : GeoCodeUtils.nominatimToGeoJson(res.data); }),
+    wfs: (searchText, {url, typeName, queriableAttributes = [], outputFormat = "application/json", predicate = "ILIKE", staticFilter = "", blacklist = [], item, fromTextToFilter = defaultFromTextToFilter, returnFullData = false, ...params }) => {
         const filter = fromTextToFilter({searchText, staticFilter, blacklist, item, queriableAttributes, predicate});
         return WFS
             .getFeatureSimple(url, assign({
@@ -49,7 +49,7 @@ let Services = {
                 // create a filter like : `(ATTR ilike '%word1%') AND (ATTR ilike '%word2%')`
                 cql_filter: filter
             }, params))
-            .then( response => {return returnFullResponse ? response : response.features; } );
+            .then( response => {return returnFullData ? response : response.features; } );
     }
 };
 

--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -32,7 +32,7 @@ require("./featuregrid.css");
 class FeatureGrid extends React.PureComponent {
     static propTypes = {
         autocompleteEnabled: PropTypes.bool,
-        allowedRoles: PropTypes.array,
+        editingAllowedRoles: PropTypes.array,
         gridOpts: PropTypes.object,
         changes: PropTypes.object,
         selectBy: PropTypes.object,
@@ -54,7 +54,7 @@ class FeatureGrid extends React.PureComponent {
         isProperty: PropTypes.func
     };
     static defaultProps = {
-        allowedRoles: ["ADMIN"],
+        editingAllowedRoles: ["ADMIN"],
         autocompleteEnabled: false,
         gridComponent: AdaptiveGrid,
         changes: {},
@@ -70,7 +70,7 @@ class FeatureGrid extends React.PureComponent {
         super(props);
     }
     componentDidMount() {
-        this.props.initPlugin({allowedRoles: this.props.allowedRoles});
+        this.props.initPlugin({editingAllowedRoles: this.props.editingAllowedRoles});
     }
     getChildContext() {
         return {

--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -32,6 +32,7 @@ require("./featuregrid.css");
 class FeatureGrid extends React.PureComponent {
     static propTypes = {
         autocompleteEnabled: PropTypes.bool,
+        allowedRoles: PropTypes.array,
         gridOpts: PropTypes.object,
         changes: PropTypes.object,
         selectBy: PropTypes.object,
@@ -43,6 +44,7 @@ class FeatureGrid extends React.PureComponent {
         columnSettings: PropTypes.object,
         gridOptions: PropTypes.object,
         actionOpts: PropTypes.object,
+        initPlugin: PropTypes.func,
         tools: PropTypes.array,
         gridEvents: PropTypes.object
     };
@@ -52,6 +54,7 @@ class FeatureGrid extends React.PureComponent {
         isProperty: PropTypes.func
     };
     static defaultProps = {
+        allowedRoles: ["ADMIN"],
         autocompleteEnabled: false,
         gridComponent: AdaptiveGrid,
         changes: {},
@@ -65,6 +68,9 @@ class FeatureGrid extends React.PureComponent {
     };
     constructor(props) {
         super(props);
+    }
+    componentDidMount() {
+        this.props.initPlugin({allowedRoles: this.props.allowedRoles});
     }
     getChildContext() {
         return {

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -9,6 +9,8 @@ const editors = require('../editors');
 const featuresToGrid = compose(
     defaultProps({
         autocompleteEnabled: false,
+        allowedRoles: [],
+        initPlugin: () => {},
         url: "",
         typeName: "",
         enableColumnFilters: false,
@@ -26,6 +28,13 @@ const featuresToGrid = compose(
     withPropsOnChange(
         ["enableColumnFilters"],
         props => ({displayFilters: props.enableColumnFilters})
+    ),
+    withPropsOnChange(
+        ["allowedRoles"],
+        props => ({
+            allowedRoles: props.allowedRoles,
+            initPlugin: props.initPlugin
+        })
     ),
     withPropsOnChange(
         ["autocompleteEnabled"],

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -9,7 +9,6 @@ const editors = require('../editors');
 const featuresToGrid = compose(
     defaultProps({
         autocompleteEnabled: false,
-        allowedRoles: [],
         initPlugin: () => {},
         url: "",
         typeName: "",
@@ -30,9 +29,9 @@ const featuresToGrid = compose(
         props => ({displayFilters: props.enableColumnFilters})
     ),
     withPropsOnChange(
-        ["allowedRoles"],
+        ["editingAllowedRoles"],
         props => ({
-            allowedRoles: props.allowedRoles,
+            editingAllowedRoles: props.editingAllowedRoles,
             initPlugin: props.initPlugin
         })
     ),

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -68,7 +68,7 @@ describe('search Epics', () => {
                     url: 'base/web/client/test-resources/wfs/Wyoming.json',
                     typeName: 'topp:states',
                     queriableAttributes: [STATE_NAME],
-                    returnFullResponse: false
+                    returnFullData: false
                 }
             }]
         };
@@ -167,7 +167,7 @@ describe('search Epics', () => {
                         url: 'base/web/client/test-resources/wfs/Wyoming.json',
                         typeName: 'topp:states',
                         queriableAttributes: [STATE_NAME],
-                        returnFullResponse: false
+                        returnFullData: false
                     }
                 }
             }

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -225,7 +225,7 @@
             {
               "name": "FeatureEditor",
               "cfg": {
-                "allowedRoles": ["ADMIN", "USER"]
+                "editingAllowedRoles": ["ADMIN"]
               }
             },
             "WFSDownload",

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -221,13 +221,7 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home",
-            {
-              "name": "FeatureEditor",
-              "cfg": {
-                "editingAllowedRoles": ["ADMIN"]
-              }
-            },
+            }, "Home", "FeatureEditor",
             "WFSDownload",
             {
               "name": "QueryPanel",

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -221,7 +221,14 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home", "FeatureEditor", "WFSDownload",
+            }, "Home",
+            {
+              "name": "FeatureEditor",
+              "cfg": {
+                "allowedRoles": ["ADMIN", "USER"]
+              }
+            },
+            "WFSDownload",
             {
               "name": "QueryPanel",
               "cfg": {

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -89,7 +89,7 @@ const FeatureDock = (props = {
             footer={getFooter(props)}>
             {getDialogs(props.tools)}
             <Grid
-                allowedRoles={props.allowedRoles}
+                editingAllowedRoles={props.editingAllowedRoles}
                 initPlugin={props.initPlugin}
                 customEditorsOptions={props.customEditorsOptions}
                 autocompleteEnabled={props.autocompleteEnabled}
@@ -153,7 +153,7 @@ const selector = createSelector(
 const EditorPlugin = connect(selector, (dispatch) => ({
     gridEvents: bindActionCreators(gridEvents, dispatch),
     pageEvents: bindActionCreators(pageEvents, dispatch),
-    initPlugin: bindActionCreators((allowedRoles) => initPlugin(allowedRoles), dispatch),
+    initPlugin: bindActionCreators((options) => initPlugin(options), dispatch),
     toolbarEvents: bindActionCreators(toolbarEvents, dispatch),
     gridTools: gridTools.map((t) => ({
         ...t,

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -20,6 +20,7 @@ const BorderLayout = require('../components/layout/BorderLayout');
 const EMPTY_ARR = [];
 const EMPTY_OBJ = {};
 const {gridTools, gridEvents, pageEvents, toolbarEvents} = require('./featuregrid/index');
+const {initPlugin} = require('../actions/featuregrid');
 const ContainerDimensions = require('react-container-dimensions').default;
 
 /**
@@ -88,6 +89,8 @@ const FeatureDock = (props = {
             footer={getFooter(props)}>
             {getDialogs(props.tools)}
             <Grid
+                allowedRoles={props.allowedRoles}
+                initPlugin={props.initPlugin}
                 customEditorsOptions={props.customEditorsOptions}
                 autocompleteEnabled={props.autocompleteEnabled}
                 url={props.url}
@@ -150,6 +153,7 @@ const selector = createSelector(
 const EditorPlugin = connect(selector, (dispatch) => ({
     gridEvents: bindActionCreators(gridEvents, dispatch),
     pageEvents: bindActionCreators(pageEvents, dispatch),
+    initPlugin: bindActionCreators((allowedRoles) => initPlugin(allowedRoles), dispatch),
     toolbarEvents: bindActionCreators(toolbarEvents, dispatch),
     gridTools: gridTools.map((t) => ({
         ...t,

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -53,7 +53,7 @@ const ContainerDimensions = require('react-container-dimensions').default;
   *         <li> predicate: predicate used to create the cql_filter </li>
   *         <li> typeName: layer on which the wfs search is performed </li>
   *         <li> valueField: property used as value based on the data passed to the editors (from stream)
-  *         <li> returnFullResponse: if true it returns the full data given from the response </li>
+  *         <li> returnFullData: if true it returns the full data given from the response </li>
   *     </ul>
   * </ul>
   * @example
@@ -76,11 +76,11 @@ const ContainerDimensions = require('react-container-dimensions').default;
   *           "filterProps": {
   *             "blacklist": ["via", "piazza", "viale"],
   *             "maxFeatures": 3,
-  *             "queriableAttributes": ["DESVIA"],
+  *             "queriableAttributes": ["ATTRIBUTE1"],
   *             "predicate": "ILIKE",
-  *             "typeName": "SITGEO:CIVICI_COD_TOPON",
-  *             "valueField": "CODICE_CONTROLLO",
-  *             "returnFullResponse": true
+  *             "typeName": "WORKSPACE:LAYER",
+  *             "valueField": "VALUE",
+  *             "returnFullData": true
   *           }
   *         }
   *       }]

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -28,6 +28,7 @@ const ContainerDimensions = require('react-container-dimensions').default;
   * @memberof plugins
   * @class
   * @prop {object} cfg.customEditorsOptions Set of options used to connect the custom editors to the featuregrid
+  * @prop {object} cfg.editingAllowedRoles array of user roles allowed to enter in edit mode
   * @classdesc
   * FeatureEditor Plugin Provides functionalities to browse/edit data via WFS. It can be configured passing custom editors
   * <br/>Rules are applied in order and the first rule that match the regex wins.
@@ -37,6 +38,24 @@ const ContainerDimensions = require('react-container-dimensions').default;
   * <br/>At least one of the three kind of regex must be specified.
   * <br/>Editor props are optionally.
   * <br/>Inside localConfig you can specify different rules in an array.
+  * <br/> <li> editor: name of the editor used</li>
+  * <br/> editorProps are props passed to the custom editor and used also to create a custom cqlFilter:
+  * <ul>
+  *     <li> values: force an editor to use a specific list of values </li>
+  *     <li> forceSelection: force the editor to use a defaultOption as value </li>
+  *     <li> defaultOption: value used as default if forceSelection is true </li>
+  *     <li> allowEmpty: if true it accept empty string as value </li>
+  *     <li> filterProps: </li>
+  *     <ul>
+  *         <li> blacklist: array used to exclude some word for the wfs call </li>
+  *         <li> maxFeatures:max number of features fetched for each wfs request </li>
+  *         <li> queriableAttributes: attributes used to create the cql filter </li>
+  *         <li> predicate: predicate used to create the cql_filter </li>
+  *         <li> typeName: layer on which the wfs search is performed </li>
+  *         <li> valueField: property used as value based on the data passed to the editors (from stream)
+  *         <li> returnFullResponse: if true it returns the full data given from the response </li>
+  *     </ul>
+  * </ul>
   * @example
   * {
   *   "name": "FeatureEditor",
@@ -51,10 +70,22 @@ const ContainerDimensions = require('react-container-dimensions').default;
   *         "editor": "DropDownEditor",
   *         "editorProps": {
   *           "values": ["Opt1", "Opt2"],
-  *           "forceSelection": true
+  *           "forceSelection": false,
+  *           "defaultOption": "Opt1",
+  *           "allowEmpty": true,
+  *           "filterProps": {
+  *             "blacklist": ["via", "piazza", "viale"],
+  *             "maxFeatures": 3,
+  *             "queriableAttributes": ["DESVIA"],
+  *             "predicate": "ILIKE",
+  *             "typeName": "SITGEO:CIVICI_COD_TOPON",
+  *             "valueField": "CODICE_CONTROLLO",
+  *             "returnFullResponse": true
+  *           }
   *         }
   *       }]
-  *     }
+  *     },
+  *   "editingAllowedRoles": ["ADMIN"]
   *   }
   * }
   *

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 const {bindActionCreators} = require('redux');
 const {createSelector, createStructuredSelector} = require('reselect');
 const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive} = require('../../../selectors/query');
-const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter, hasSupportedGeometry} = require('../../../selectors/featuregrid');
+const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter, hasSupportedGeometry, editingAllowedRolesSelector} = require('../../../selectors/featuregrid');
 const {userRoleSelector} = require('../../../selectors/security');
 const {isCesium} = require('../../../selectors/maptype');
 const {deleteFeatures, toggleTool, clearChangeConfirmed, closeFeatureGridConfirmed, closeFeatureGrid} = require('../../../actions/featuregrid');
@@ -19,8 +19,8 @@ const {toolbarEvents, pageEvents} = require('../index');
 const {getAttributeFields} = require('../../../utils/FeatureGridUtils');
 const {getFilterRenderer} = require('../../../components/data/featuregrid/filterRenderers');
 
-const filterAllowedUser = (role, allowedRoles = ["ADMIN"]) => {
-    return allowedRoles.indexOf(role) !== -1;
+const filterEditingAllowedUser = (role, editingAllowedRoles = ["ADMIN"]) => {
+    return editingAllowedRoles.indexOf(role) !== -1;
 };
 const EmptyRowsView = connect(createStructuredSelector({
     loading: featureLoadingSelector
@@ -42,7 +42,7 @@ const Toolbar = connect(
         isSyncActive: isSyncWmsActive,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
         isSearchAllowed: (state) => !isCesium(state),
-        isEditingAllowed: (state) => (filterAllowedUser(userRoleSelector(state), state && state.featuregrid && state.featuregrid.allowedRoles) || canEditSelector(state)) && !isCesium(state),
+        isEditingAllowed: (state) => (filterEditingAllowedUser(userRoleSelector(state), editingAllowedRolesSelector(state)) || canEditSelector(state)) && !isCesium(state),
         hasSupportedGeometry
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -12,12 +12,16 @@ const {bindActionCreators} = require('redux');
 const {createSelector, createStructuredSelector} = require('reselect');
 const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive} = require('../../../selectors/query');
 const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter, hasSupportedGeometry} = require('../../../selectors/featuregrid');
-const {isAdminUserSelector} = require('../../../selectors/security');
+const {userRoleSelector} = require('../../../selectors/security');
 const {isCesium} = require('../../../selectors/maptype');
 const {deleteFeatures, toggleTool, clearChangeConfirmed, closeFeatureGridConfirmed, closeFeatureGrid} = require('../../../actions/featuregrid');
 const {toolbarEvents, pageEvents} = require('../index');
 const {getAttributeFields} = require('../../../utils/FeatureGridUtils');
 const {getFilterRenderer} = require('../../../components/data/featuregrid/filterRenderers');
+
+const filterAllowedUser = (role, allowedRoles = ["ADMIN"]) => {
+    return allowedRoles.indexOf(role) !== -1;
+};
 const EmptyRowsView = connect(createStructuredSelector({
     loading: featureLoadingSelector
 }))(require('../../../components/data/featuregrid/EmptyRowsView'));
@@ -38,7 +42,7 @@ const Toolbar = connect(
         isSyncActive: isSyncWmsActive,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
         isSearchAllowed: (state) => !isCesium(state),
-        isEditingAllowed: (state) => (isAdminUserSelector(state) || canEditSelector(state)) && !isCesium(state),
+        isEditingAllowed: (state) => (filterAllowedUser(userRoleSelector(state), state && state.featuregrid && state.featuregrid.allowedRoles) || canEditSelector(state)) && !isCesium(state),
         hasSupportedGeometry
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -46,7 +46,7 @@ const expect = require('expect');
 const featuregrid = require('../featuregrid');
 const {setFeatures, dockSizeFeatures, setLayer, toggleTool, customizeAttribute, selectFeatures, deselectFeatures, createNewFeatures, updateFilter,
     featureSaving, toggleSelection, clearSelection, MODES, toggleEditMode, toggleViewMode, saveSuccess, clearChanges, saveError, startDrawingFeature,
-    deleteGeometryFeature, geometryChanged, setSelectionOptions, changePage, featureModified, setPermission, disableToolbar, openFeatureGrid, closeFeatureGrid} = require('../../actions/featuregrid');
+    deleteGeometryFeature, geometryChanged, setSelectionOptions, changePage, featureModified, setPermission, disableToolbar, openFeatureGrid, closeFeatureGrid, initPlugin} = require('../../actions/featuregrid');
 const {featureTypeLoaded, createQuery} = require('../../actions/wfsquery');
 
 const {changeDrawingStatus} = require('../../actions/draw');
@@ -64,6 +64,14 @@ describe('Test the featuregrid reducer', () => {
         expect(state.pagination).toExist();
         expect(state.select).toExist();
         expect(state.features).toExist();
+    });
+    it('initPlugin', () => {
+        const someValue = "someValue";
+        const editingAllowedRoles = [someValue];
+        let state = featuregrid({}, initPlugin({editingAllowedRoles}));
+        expect(state).toExist();
+        expect(state.editingAllowedRoles.length).toBe(1);
+        expect(state.editingAllowedRoles[0]).toBe(someValue);
     });
     it('openFeatureGrid', () => {
         let state = featuregrid(undefined, openFeatureGrid());

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -47,7 +47,7 @@ const uuid = require('uuid');
 
 const emptyResultsState = {
     filters: {},
-    allowedRoles: ["ADMIN"],
+    editingAllowedRoles: ["ADMIN"],
     enableColumnFilters: true,
     open: false,
     canEdit: false,
@@ -90,7 +90,7 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
 /**
  * Manages the state of the featuregrid
  * The properties represent the shape of the state
- * @prop {string[]} allowedRoles array of user roles allowed to enter in edit mode
+ * @prop {string[]} editingAllowedRoles array of user roles allowed to enter in edit mode
  * @prop {boolean} canEdit flag used to enable editing on the feature grid
  * @prop {object} filters filters for quick search. `{attribute: "name", value: "filter_value", opeartor: "=", rawValue: "the fitler raw value"}`
  * @prop {boolan} enableColumnFilters enables column filter. [configurable]
@@ -105,7 +105,7 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
  * @prop {array} features list of the features currently loaded in the feature grid
  * @example
  *  {
- *     allowedRoles: ["ADMIN"],
+ *     editingAllowedRoles: ["ADMIN"],
  *     filters: {},
  *     enableColumnFilters: true,
  *     open: false,
@@ -131,7 +131,7 @@ function featuregrid(state = emptyResultsState, action) {
     switch (action.type) {
     case INIT_PLUGIN: {
         return assign({}, state, {
-            allowedRoles: action.options.allowedRoles || state.allowedRoles || ["ADMIN"]
+            editingAllowedRoles: action.options.editingAllowedRoles || state.editingAllowedRoles || ["ADMIN"]
         });
     }
     case CHANGE_PAGE: {

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -33,7 +33,8 @@ const {
     DISABLE_TOOLBAR,
     OPEN_FEATURE_GRID,
     CLOSE_FEATURE_GRID,
-    UPDATE_FILTER
+    UPDATE_FILTER,
+    INIT_PLUGIN
 } = require('../actions/featuregrid');
 const{
     FEATURE_TYPE_LOADED,
@@ -46,6 +47,7 @@ const uuid = require('uuid');
 
 const emptyResultsState = {
     filters: {},
+    allowedRoles: ["ADMIN"],
     enableColumnFilters: true,
     open: false,
     canEdit: false,
@@ -88,6 +90,8 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
 /**
  * Manages the state of the featuregrid
  * The properties represent the shape of the state
+ * @prop {string[]} allowedRoles array of user roles allowed to enter in edit mode
+ * @prop {boolean} canEdit flag used to enable editing on the feature grid
  * @prop {object} filters filters for quick search. `{attribute: "name", value: "filter_value", opeartor: "=", rawValue: "the fitler raw value"}`
  * @prop {boolan} enableColumnFilters enables column filter. [configurable]
  * @prop {boolean} open feature grid open or close
@@ -101,6 +105,7 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
  * @prop {array} features list of the features currently loaded in the feature grid
  * @example
  *  {
+ *     allowedRoles: ["ADMIN"],
  *     filters: {},
  *     enableColumnFilters: true,
  *     open: false,
@@ -124,6 +129,11 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
  */
 function featuregrid(state = emptyResultsState, action) {
     switch (action.type) {
+    case INIT_PLUGIN: {
+        return assign({}, state, {
+            allowedRoles: action.options.allowedRoles || state.allowedRoles || ["ADMIN"]
+        });
+    }
     case CHANGE_PAGE: {
         return assign({}, state, {
             pagination: {

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -22,6 +22,7 @@ const {
     changesSelector,
     isDrawingSelector,
     isSimpleGeomSelector,
+    editingAllowedRolesSelector,
     getCustomizedAttributes,
     isSavingSelector,
     isSavedSelector,
@@ -417,6 +418,11 @@ describe('Test featuregrid selectors', () => {
     it('test isSavingSelector', () => {
         expect(isSavingSelector(initialState)).toBe(false);
         expect(isSavingSelector({...initialState, featuregrid: { saving: true}})).toBe(true);
+    });
+    it('test editingAllowedRolesSelector', () => {
+        expect(editingAllowedRolesSelector(initialState).length).toBe(1);
+        expect(editingAllowedRolesSelector(initialState)[0]).toBe("ADMIN");
+        expect(editingAllowedRolesSelector({...initialState, featuregrid: { editingAllowedRoles: ["USER", "ADMIN"]}}).length).toBe(2);
     });
     it('test isSavedSelector', () => {
         expect(isSavedSelector(initialState)).toBe(false);

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -122,6 +122,7 @@ module.exports = {
     newFeaturesSelector,
     hasNewFeaturesSelector,
     isSavingSelector: state => state && state.featuregrid && state.featuregrid.saving,
+    editingAllowedRolesSelector: state => get(state, "featuregrid.editingAllowedRoles", ["ADMIN"]),
     isSavedSelector: state => state && state.featuregrid && state.featuregrid.saved,
     isDrawingSelector: state => state && state.featuregrid && state.featuregrid.drawing,
     geomTypeSelectedFeatureSelector,


### PR DESCRIPTION
## Description
It has been added a flag in the FeatureEditor plugin configuration which is used to check if the user role is allowed to enter in edit mode.

## Issues
 - Fix #2304

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:
Introduced a new option to pilot the edit mode

**What is the current behavior?** (You can also link to an open issue here)
it was checking only if the user is authenticated and his role was ADMIN.

**What is the new behavior?**
now it checks if the user role is among the configured allowed roles, (only ADMIN by default)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
