### PR TITLE
Add MapBoxStyle tile provider

### DIFF
--- a/web/client/utils/ConfigProvider.js
+++ b/web/client/utils/ConfigProvider.js
@@ -182,6 +182,13 @@ const CONFIGPROVIDER = {
             subdomains: 'abcd'
         }
     },
+    MapBoxStyle: {
+        url: 'https://api.mapbox.com/styles/v1/mapbox/{source}/tiles/{z}/{x}/{y}?access_token={accessToken}',
+        options: {
+            attribution: 'Imagery from <a href="http://mapbox.com/about/maps/">MapBox</a>',
+            subdomains: 'abcd'
+        }
+    },
     Stamen: {
         url: '//stamen-tiles-{s}.a.ssl.fastly.net/{variant}/{z}/{x}/{y}.{ext}',
         options: {


### PR DESCRIPTION
## Description
Adds a tile provider for tiles from MapBox's Style API.

## Issues
 - Related to #2309

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe: Add support for MapBox Styles API tileprovider


**What is the current behavior?** (You can also link to an open issue here)
MapBoxStyle tile provider was not available

**What is the new behavior?**
MapBoxStyle tile provider is now available

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Related to #2309 