### PR TITLE
Identify throws error on update if point prop is null

### DIFF
--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -262,7 +262,7 @@ class Identify extends React.Component {
 
     needsRefresh = (props) => {
         if (props.enabled && props.point && props.point.pixel) {
-            if (!this.props.point.pixel || this.props.point.pixel.x !== props.point.pixel.x ||
+            if (!this.props.point || !this.props.point.pixel || this.props.point.pixel.x !== props.point.pixel.x ||
                     this.props.point.pixel.y !== props.point.pixel.y ) {
                 return true;
             }

--- a/web/client/components/data/identify/__tests__/Identify-test.jsx
+++ b/web/client/components/data/identify/__tests__/Identify-test.jsx
@@ -397,4 +397,13 @@ describe('Identify', () => {
         expect(params.WMS_OPTION).toBe(true);
 
     });
+
+    it('test need refresh with null point', () => {
+        const identify = ReactDOM.render(
+            <Identify point={null}/>,
+            document.getElementById("container")
+        );
+        expect(identify).toExist();
+        expect(identify.needsRefresh({ enabled: true, point: { pixel: {x: 0, y: 0}}})).toBe(true);
+    });
 });


### PR DESCRIPTION
## Description
Added a control to Identify plugin to check if point prop is null  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
![screenshot from 2017-10-19 15-47-39](https://user-images.githubusercontent.com/19175505/31822889-81c3eb44-b5aa-11e7-907d-764863a515d7.png)

**What is the new behavior?**
If point is null and new props has pixel attribute, Identify refreshes

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
