### PR TITLE
Add a selector to set button visibility based on layer/group properties in TOC plugin

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -183,7 +183,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.toolbarButtonSelector('feature grid', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateQueryTool && status === 'LAYER' && this.props.selectedLayers[0].search && !this.props.settings.expanded ?
+                {this.props.toolbarButtonSelector('features grid', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateQueryTool && status === 'LAYER' && this.props.selectedLayers[0].search && !this.props.settings.expanded ?
                     <OverlayTrigger
                         key="featuresGrid"
                         placement="top"

--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -26,13 +26,15 @@ class Toolbar extends React.Component {
         activateTool: PropTypes.object,
         options: PropTypes.object,
         style: PropTypes.object,
-        settings: PropTypes.object
+        settings: PropTypes.object,
+        toolbarButtonSelector: PropTypes.func
     };
 
     static defaultProps = {
         groups: [],
         selectedLayers: [],
         selectedGroups: [],
+        toolbarButtonSelector: () => true,
         onToolsActions: {
             onZoom: () => {},
             onBrowseData: () => {},
@@ -161,7 +163,7 @@ class Toolbar extends React.Component {
                         {this.props.text.addLayer}
                     </Button>
                 : null}
-                {this.props.activateTool.activateZoomTool && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS') && this.checkBbox() ?
+                {this.props.toolbarButtonSelector('zoom to', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateZoomTool && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS') && this.checkBbox() ?
                     <OverlayTrigger
                         key="zoomTo"
                         placement="top"
@@ -171,7 +173,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.activateTool.activateSettingsTool && (status === 'LAYER' || status === 'GROUP') ?
+                {this.props.toolbarButtonSelector('settings', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateSettingsTool && (status === 'LAYER' || status === 'GROUP') ?
                     <OverlayTrigger
                         key="settings"
                         placement="top"
@@ -181,7 +183,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.activateTool.activateQueryTool && status === 'LAYER' && this.props.selectedLayers[0].search && !this.props.settings.expanded ?
+                {this.props.toolbarButtonSelector('feature grid', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateQueryTool && status === 'LAYER' && this.props.selectedLayers[0].search && !this.props.settings.expanded ?
                     <OverlayTrigger
                         key="featuresGrid"
                         placement="top"
@@ -191,7 +193,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.activateTool.activateRemoveLayer && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS' || status === 'LAYERS_LOAD_ERROR') && this.props.selectedLayers.length > 0 && !this.props.settings.expanded ?
+                {this.props.toolbarButtonSelector('remove', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateRemoveLayer && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS' || status === 'LAYERS_LOAD_ERROR') && this.props.selectedLayers.length > 0 && !this.props.settings.expanded ?
                     <OverlayTrigger
                         key="removeNode"
                         placement="top"

--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -14,6 +14,7 @@ const {head} = require('lodash');
 const ConfirmModal = require('../maps/modals/ConfirmModal');
 const SettingsModal = require('./fragments/SettingsModal');
 const GroupSettingsModal = require('./fragments/GroupSettingsModal');
+const assign = require('object-assign');
 
 class Toolbar extends React.Component {
 
@@ -23,18 +24,17 @@ class Toolbar extends React.Component {
         selectedGroups: PropTypes.array,
         onToolsActions: PropTypes.object,
         text: PropTypes.object,
-        activateTool: PropTypes.object,
         options: PropTypes.object,
         style: PropTypes.object,
         settings: PropTypes.object,
-        toolbarButtonSelector: PropTypes.func
+        activateSelector: PropTypes.func
     };
 
     static defaultProps = {
         groups: [],
         selectedLayers: [],
         selectedGroups: [],
-        toolbarButtonSelector: () => true,
+        activateSelector: () => true,
         onToolsActions: {
             onZoom: () => {},
             onBrowseData: () => {},
@@ -75,15 +75,6 @@ class Toolbar extends React.Component {
                 LAYER: '',
                 LAYERS: ''
             }
-        },
-        activateTool: {
-            activateToolsContainer: true,
-            activateRemoveLayer: true,
-            activateZoomTool: true,
-            activateQueryTool: true,
-            activateSettingsTool: true,
-            activateAddLayer: true,
-            includeDeleteButtonInSettings: false
         },
         options: {
             modalOptions: {},
@@ -133,7 +124,7 @@ class Toolbar extends React.Component {
                 hideSettings={this.props.onToolsActions.onHideSettings}
                 updateNode={this.props.onToolsActions.onUpdate}
                 removeNode={this.props.onToolsActions.onRemove}
-                includeDeleteButton={this.props.activateTool.includeDeleteButtonInSettings}
+                includeDeleteButton={this.props.activateSelector('settings delete', assign({}, {selectedLayers: [...this.props.selectedLayers], selectedGroups: [...this.props.selectedGroups]}))}
                 chartStyle={this.props.style.chartStyle}
                 titleText={this.props.text.settingsText}
                 opacityText={this.props.text.opacityText}
@@ -152,18 +143,19 @@ class Toolbar extends React.Component {
     render() {
         const status = this.getStatus();
         const settingModal = status === 'GROUP' || status === 'LAYER' ? this.getSettingsModal(status) : null;
-        return this.props.activateTool.activateToolsContainer ? (
+        const selected = assign({}, {selectedLayers: [...this.props.selectedLayers], selectedGroups: [...this.props.selectedGroups]});
+        return this.props.activateSelector('tools container', selected) ? (
         <ButtonGroup>
             <ReactCSSTransitionGroup
                 transitionName="toc-toolbar-btn-transition"
                 transitionEnterTimeout={300}
                 transitionLeaveTimeout={300}>
-                {this.props.activateTool.activateAddLayer && status === 'DESELECT' ?
+                {this.props.activateSelector('add layer', selected) && status === 'DESELECT' ?
                     <Button key="addLayer" bsStyle="primary" bsSize="small" onClick={this.props.onToolsActions.onAddLayer}>
                         {this.props.text.addLayer}
                     </Button>
                 : null}
-                {this.props.toolbarButtonSelector('zoom to', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateZoomTool && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS') && this.checkBbox() ?
+                {this.props.activateSelector('zoom to', selected) && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS') && this.checkBbox() ?
                     <OverlayTrigger
                         key="zoomTo"
                         placement="top"
@@ -173,7 +165,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.toolbarButtonSelector('settings', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateSettingsTool && (status === 'LAYER' || status === 'GROUP') ?
+                {this.props.activateSelector('settings', selected) && (status === 'LAYER' || status === 'GROUP') ?
                     <OverlayTrigger
                         key="settings"
                         placement="top"
@@ -183,7 +175,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.toolbarButtonSelector('features grid', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateQueryTool && status === 'LAYER' && this.props.selectedLayers[0].search && !this.props.settings.expanded ?
+                {this.props.activateSelector('features grid', selected) && status === 'LAYER' && this.props.selectedLayers[0].search && !this.props.settings.expanded ?
                     <OverlayTrigger
                         key="featuresGrid"
                         placement="top"
@@ -193,7 +185,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                {this.props.toolbarButtonSelector('remove', {selectedLayers: this.props.selectedLayers, selectedGroups: this.props.selectedGroups}) && this.props.activateTool.activateRemoveLayer && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS' || status === 'LAYERS_LOAD_ERROR') && this.props.selectedLayers.length > 0 && !this.props.settings.expanded ?
+                {this.props.activateSelector('remove', selected) && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS' || status === 'LAYERS_LOAD_ERROR') && this.props.selectedLayers.length > 0 && !this.props.settings.expanded ?
                     <OverlayTrigger
                         key="removeNode"
                         placement="top"

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -327,4 +327,46 @@ describe('TOC Toolbar', () => {
         expect(removeModal).toExist();
     });
 
+    it('toolbar button selector', () => {
+        const selectedLayers = [{
+            id: 'l001',
+            title: 'layer001',
+            name: 'layer001name',
+            bbox: {
+                bounds: {
+                    maxx: 10,
+                    maxy: 9,
+                    minx: -10,
+                    miny: -9
+                }, crs: 'EPSG'
+            },
+            search: {
+                url: 'l001url'
+            }
+        }];
+
+        const toolbarButtonSelector = (type, props) => {
+            switch (type) {
+                case 'zoom to':
+                    return props && props.selectedLayers && props.selectedLayers[0].zoomToBtn;
+                case 'settings':
+                    return props && props.selectedLayers && props.selectedLayers[0].settingsBtn;
+                case 'features grid':
+                    return props && props.selectedLayers && props.selectedLayers[0].featuresGridBtn;
+                case 'remove':
+                    return props && props.selectedLayers && props.selectedLayers[0].removeBtn;
+                default:
+                    return true;
+            }
+        };
+
+        const cmp = ReactDOM.render(<Toolbar toolbarButtonSelector={toolbarButtonSelector} selectedLayers={selectedLayers} selectedGroups={[]}/>, document.getElementById("container"));
+
+        const el = ReactDOM.findDOMNode(cmp);
+        expect(el).toExist();
+
+        const btn = el.getElementsByClassName("btn");
+        expect(btn.length).toBe(0);
+    });
+
 });

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -345,22 +345,28 @@ describe('TOC Toolbar', () => {
             }
         }];
 
-        const toolbarButtonSelector = (type, props) => {
+        const activateSelector = (type, selected) => {
             switch (type) {
+                case 'tools container':
+                    return true;
+                case 'add layer':
+                    return true;
                 case 'zoom to':
-                    return props && props.selectedLayers && props.selectedLayers[0].zoomToBtn;
+                    return selected && selected.selectedLayers && selected.selectedLayers[0].zoomToBtn;
                 case 'settings':
-                    return props && props.selectedLayers && props.selectedLayers[0].settingsBtn;
+                    return selected && selected.selectedLayers && selected.selectedLayers[0].settingsBtn;
+                case 'settings delete':
+                    return false;
                 case 'features grid':
-                    return props && props.selectedLayers && props.selectedLayers[0].featuresGridBtn;
+                    return selected && selected.selectedLayers && selected.selectedLayers[0].featuresGridBtn;
                 case 'remove':
-                    return props && props.selectedLayers && props.selectedLayers[0].removeBtn;
+                    return selected && selected.selectedLayers && selected.selectedLayers[0].removeBtn;
                 default:
                     return true;
             }
         };
 
-        const cmp = ReactDOM.render(<Toolbar toolbarButtonSelector={toolbarButtonSelector} selectedLayers={selectedLayers} selectedGroups={[]}/>, document.getElementById("container"));
+        const cmp = ReactDOM.render(<Toolbar activateSelector={activateSelector} selectedLayers={selectedLayers} selectedGroups={[]}/>, document.getElementById("container"));
 
         const el = ReactDOM.findDOMNode(cmp);
         expect(el).toExist();

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -125,6 +125,7 @@ class LayerTree extends React.Component {
         onContextMenu: PropTypes.func,
         onBrowseData: PropTypes.func,
         onSelectNode: PropTypes.func,
+        toolbarButtonSelector: PropTypes.func,
         selectedNodes: PropTypes.array,
         onZoomToExtent: PropTypes.func,
         retrieveLayerData: PropTypes.func,
@@ -181,6 +182,7 @@ class LayerTree extends React.Component {
         updateNode: () => {},
         removeNode: () => {},
         onSelectNode: () => {},
+        toolbarButtonSelector: () => true,
         selectedNodes: [],
         activateSortLayer: true,
         activateFilterLayer: true,
@@ -283,6 +285,7 @@ class LayerTree extends React.Component {
                             selectedLayers={this.props.selectedLayers}
                             selectedGroups={this.props.selectedGroups}
                             settings={this.props.settings}
+                            toolbarButtonSelector={this.props.toolbarButtonSelector}
                             activateTool={{
                                 activateToolsContainer: this.props.activateToolsContainer,
                                 activateRemoveLayer: this.props.activateRemoveLayer,

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -125,7 +125,7 @@ class LayerTree extends React.Component {
         onContextMenu: PropTypes.func,
         onBrowseData: PropTypes.func,
         onSelectNode: PropTypes.func,
-        toolbarButtonSelector: PropTypes.func,
+        activateSelector: PropTypes.func,
         selectedNodes: PropTypes.array,
         onZoomToExtent: PropTypes.func,
         retrieveLayerData: PropTypes.func,
@@ -182,7 +182,7 @@ class LayerTree extends React.Component {
         updateNode: () => {},
         removeNode: () => {},
         onSelectNode: () => {},
-        toolbarButtonSelector: () => true,
+        activateSelector: null,
         selectedNodes: [],
         activateSortLayer: true,
         activateFilterLayer: true,
@@ -285,15 +285,27 @@ class LayerTree extends React.Component {
                             selectedLayers={this.props.selectedLayers}
                             selectedGroups={this.props.selectedGroups}
                             settings={this.props.settings}
-                            toolbarButtonSelector={this.props.toolbarButtonSelector}
-                            activateTool={{
-                                activateToolsContainer: this.props.activateToolsContainer,
-                                activateRemoveLayer: this.props.activateRemoveLayer,
-                                activateZoomTool: this.props.activateZoomTool,
-                                activateQueryTool: this.props.activateQueryTool,
-                                activateSettingsTool: this.props.activateSettingsTool,
-                                activateAddLayer: this.props.activateAddLayerButton && !this.props.catalogActive,
-                                includeDeleteButtonInSettings: false
+                            activateSelector={this.props.activateSelector ?
+                                this.props.activateSelector
+                            : (type) => {
+                                switch (type) {
+                                    case 'tools container':
+                                        return this.props.activateToolsContainer;
+                                    case 'add layer':
+                                        return this.props.activateAddLayerButton && !this.props.catalogActive;
+                                    case 'zoom to':
+                                        return this.props.activateZoomTool;
+                                    case 'settings':
+                                        return this.props.activateSettingsTool;
+                                    case 'settings delete':
+                                        return false;
+                                    case 'features grid':
+                                        return this.props.activateQueryTool;
+                                    case 'remove':
+                                        return this.props.activateRemoveLayer;
+                                    default:
+                                        return true;
+                                }
                             }}
                             options={{
                                 modalOptions: {},


### PR DESCRIPTION
## Description
Added a selector to set button visibility based on layer properties

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
Cannot set a custom selector on toolbar in TOC

**What is the new behavior?**
A new function has been added to Toolbar of TOC.
Now the button visibility can be customize based on layer/group properties
e.g
```
        const toolbarButtonSelector = (type, props) => {
            switch (type) {
                case 'zoom to':
                    return props && props.selectedLayers && props.selectedLayers[0].zoomToBtn;
                case 'settings':
                    return props && props.selectedLayers && props.selectedLayers[0].settingsBtn;
                case 'features grid':
                    return props && props.selectedLayers && props.selectedLayers[0].featuresGridBtn;
                case 'remove':
                    return props && props.selectedLayers && props.selectedLayers[0].removeBtn;
                default:
                    return true;
            }
        };
```

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
