### PR TITLE
Fix #2321. Keep circle on change

### DIFF
--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -144,12 +144,20 @@ class GeometryDetails extends React.Component {
                 center.x - this.circle.radius, center.y - this.circle.radius,
                 center.x + this.circle.radius, center.y + this.circle.radius
             ];
-
+            let coordinates = CoordinatesUtils.calculateCircleCoordinates(center, this.circle.radius, 100);
+            if (!this.props.useMapProjection) {
+                // reproject into "EPSG:3857" to draw and circle coordinates
+                const projection = "EPSG:3857";
+                const tempCenter = CoordinatesUtils.reproject(center, "EPSG:4326", projection);
+                const tempCoordinates = CoordinatesUtils.calculateCircleCoordinates(tempCenter, this.circle.radius, 100);
+                const tempPolygon = CoordinatesUtils.reprojectGeoJson({type: "Feature", geometry: {type: "Polygon", coordinates: tempCoordinates}}, projection, "EPSG:4326");
+                coordinates = tempPolygon.geometry.coordinates;
+            }
             geometry = {
                 type: this.props.geometry.type,
                 extent: extent,
                 center: center,
-                coordinates: CoordinatesUtils.calculateCircleCoordinates(center, this.circle.radius, 100),
+                coordinates,
                 radius: this.circle.radius,
                 projection: this.props.geometry.projection
             };

--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -145,7 +145,7 @@ class GeometryDetails extends React.Component {
                 center.x + this.circle.radius, center.y + this.circle.radius
             ];
             let coordinates = CoordinatesUtils.calculateCircleCoordinates(center, this.circle.radius, 100);
-            if (!this.props.useMapProjection) {
+            if (this.props.geometry && this.props.geometry.projection === "EPSG:4326") {
                 // reproject into "EPSG:3857" to draw and circle coordinates
                 const projection = "EPSG:3857";
                 const tempCenter = CoordinatesUtils.reproject(center, "EPSG:4326", projection);

--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -145,12 +145,12 @@ class GeometryDetails extends React.Component {
                 center.x + this.circle.radius, center.y + this.circle.radius
             ];
             let coordinates = CoordinatesUtils.calculateCircleCoordinates(center, this.circle.radius, 100);
-            if (this.props.geometry && this.props.geometry.projection === "EPSG:4326") {
+            if (this.props.geometry && this.props.geometry.projection) {
                 // reproject into "EPSG:3857" to draw and circle coordinates
-                const projection = "EPSG:3857";
-                const tempCenter = CoordinatesUtils.reproject(center, "EPSG:4326", projection);
+                const METRIC = "EPSG:3857";
+                const tempCenter = CoordinatesUtils.reproject(center, this.props.geometry.projection, METRIC);
                 const tempCoordinates = CoordinatesUtils.calculateCircleCoordinates(tempCenter, this.circle.radius, 100);
-                const tempPolygon = CoordinatesUtils.reprojectGeoJson({type: "Feature", geometry: {type: "Polygon", coordinates: tempCoordinates}}, projection, "EPSG:4326");
+                const tempPolygon = CoordinatesUtils.reprojectGeoJson({type: "Feature", geometry: {type: "Polygon", coordinates: tempCoordinates}}, METRIC, this.props.geometry.projection);
                 coordinates = tempPolygon.geometry.coordinates;
             }
             geometry = {

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -7,6 +7,8 @@
  */
 const React = require('react');
 const ReactDOM = require('react-dom');
+const ReactTestUtils = require('react-dom/test-utils');
+
 
 const GeometryDetails = require('../GeometryDetails.jsx');
 
@@ -64,6 +66,65 @@ describe('GeometryDetails', () => {
         expect(panelBodyRows.length).toBe(4);
 
         expect(panelBodyRows[0].childNodes.length).toBe(4);
+    });
+    it('Test GeometryDetails onEndDrawing', () => {
+        const actions = {
+            onEndDrawing: () => {}
+        };
+        let geometry = {
+            center: {
+                srs: "EPSG:900913",
+                x: -1761074.344349588,
+                y: 5852757.632510748
+            },
+            projection: "EPSG:900913",
+            radius: 836584.05,
+            type: "Polygon"
+        };
+
+        let type = "Circle";
+
+        const spyonEndDrawing = expect.spyOn(actions, 'onEndDrawing');
+        const cmp = ReactDOM.render(<GeometryDetails geometry={geometry} type={type} onEndDrawing={actions.onEndDrawing} />, document.getElementById("container"));
+        expect(cmp).toExist();
+        ReactTestUtils.Simulate.click(document.getElementById('save-radius')); // <-- trigger event callback
+        expect(spyonEndDrawing).toHaveBeenCalled();
+        expect(spyonEndDrawing.calls[0].arguments.length).toBe(2);
+        const geom = spyonEndDrawing.calls[0].arguments[0];
+        expect(geom).toExist();
+
+    });
+
+    it('Test GeometryDetails onEndDrawing without using map projection', () => {
+        const actions = {
+            onEndDrawing: () => {}
+        };
+        let geometry = {
+            center: {
+                srs: "EPSG:4326",
+                x: 0,
+                y: 0
+            },
+            projection: "EPSG:4326",
+            radius: 1,
+            type: "Polygon"
+        };
+
+        let type = "Circle";
+
+        const spyonEndDrawing = expect.spyOn(actions, 'onEndDrawing');
+        const cmp = ReactDOM.render(<GeometryDetails geometry={geometry} type={type} onEndDrawing={actions.onEndDrawing} />, document.getElementById("container"));
+        expect(cmp).toExist();
+        ReactTestUtils.Simulate.click(document.getElementById('save-radius')); // <-- trigger event callback
+        expect(spyonEndDrawing).toHaveBeenCalled();
+        const geom = spyonEndDrawing.calls[0].arguments[0];
+        const coords = geom.coordinates[0];
+        // verify that the geometry is not bigger than radious
+        for (let i = 0; i < coords.length; i++) {
+            expect(Math.abs(coords[i][0]) <= 1).toBe(true);
+            expect(Math.abs(coords[i][1]) <= 1).toBe(true);
+        }
+
     });
 
     it('creates the GeometryDetails component with BBOX selection', () => {

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -95,7 +95,7 @@ describe('GeometryDetails', () => {
 
     });
 
-    it('Test GeometryDetails onEndDrawing without using map projection', () => {
+    it('Test GeometryDetails onEndDrawing with 4326 (leaflet)', () => {
         const actions = {
             onEndDrawing: () => {}
         };

--- a/web/client/components/map/leaflet/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/DrawSupport-test.jsx
@@ -173,6 +173,60 @@ describe('Leaflet DrawSupport', () => {
             />
         , msNode);
     });
+    it('test draw replace with circle', () => {
+        const RADIUS = 1;
+        let bounds = L.latLngBounds(L.latLng(40.712, -74.227), L.latLng(40.774, -74.125));
+        let layer = {
+            getBounds: function() { return bounds; },
+            toGeoJSON: function() {return {geometry: {coordinates: [0, 0]}}; }
+        };
+        let map = L.map("map", {
+            center: [51.505, -0.09],
+            zoom: 13
+        });
+        let cmp = ReactDOM.render(
+            <DrawSupport
+                map={map}
+                drawOwner="me"
+                drawStatus="create"
+                drawMethod="Circle"
+                options={{editEnabled: true}}
+            />
+        , msNode);
+        let featureData;
+        cmp.drawLayer = { options: {}, addData: function(data) {featureData = data; return true; }, toGeoJSON: function() { return featureData; }, clearLayers: () => {}};
+        cmp.onDrawCreated.call(cmp, {layer: layer, layerType: "circle"});
+        cmp = ReactDOM.render(
+            <DrawSupport
+                map={map}
+                drawOwner="me"
+                drawStatus="create"
+                drawMethod="Circle"
+                options={{editEnabled: false}}
+            />
+        , msNode);
+        expect(cmp).toExist();
+        cmp = ReactDOM.render(
+            <DrawSupport
+                map={map}
+                drawOwner="me"
+                drawStatus="replace"
+                drawMethod="Circle"
+                features={[{
+                    projection: "EPSG:4326",
+                    coordinates: [[ -21150.703250721977, 5855989.620460]],
+                    type: "Circle"}
+                ]}
+                options={{featureProjection: "EPSG:4326"}}
+            />
+        , msNode);
+        expect(cmp.drawLayer.options).toExist();
+        expect(cmp.drawLayer.options.pointToLayer).toExist();
+        // verify the pointToLayer still exists and creates circle after replace
+        const circle = cmp.drawLayer.options.pointToLayer({radius: RADIUS}, {lng: 0, lat: 0});
+        expect(circle).toExist();
+        expect(circle._mRadius).toBe(RADIUS);
+    });
     it('test editEnabled=true', () => {
         let map = L.map("map", {
             center: [51.505, -0.09],


### PR DESCRIPTION
## Description
This pull request fixes 2 kind of issues in Advanced Search circle spatial filter: 
 - When you edit the circle's details the style doesn't change to marker
 - When you save the edited circle, the geometry is valid. 
## Issues
 - Fix #2321

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
In advanced search, when you try to edit the circle's details, a marker appears on the map instead of circle. When save the changes, the geometry is not valid and so the search produces no results.

**What is the new behavior?**
Now you can change the details and the geometry remains a circle. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
The #2222 still exists. So the real geometry used for the filter is not the same of the one drown on the map. 