### PR TITLE
 Added control on annotation thumbnail

### DIFF
--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -108,7 +108,7 @@ class Annotations extends React.Component {
 
     renderThumbnail = (style) => {
         const marker = this.getConfig().getMarkerFromStyle(style);
-        return (<div className={"mapstore-annotations-panel-card-thumbnail-" + marker.name} style={marker.thumbnailStyle}>
+        return (<div className={"mapstore-annotations-panel-card-thumbnail-" + (marker && marker.name)} style={marker && marker.thumbnailStyle || {}}>
             <span className={"mapstore-annotations-panel-card-thumbnail " + this.getConfig().getGlyphClassName(style)}>
         </span></div>);
     };

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -108,7 +108,7 @@ class Annotations extends React.Component {
 
     renderThumbnail = (style) => {
         const marker = this.getConfig().getMarkerFromStyle(style);
-        return (<div className={"mapstore-annotations-panel-card-thumbnail-" + (marker && marker.name)} style={marker && marker.thumbnailStyle || {}}>
+        return (<div className={"mapstore-annotations-panel-card-thumbnail-" + (marker && marker.name || '')} style={marker && marker.thumbnailStyle || {}}>
             <span className={"mapstore-annotations-panel-card-thumbnail " + this.getConfig().getGlyphClassName(style)}>
         </span></div>);
     };


### PR DESCRIPTION
## Description
To prevent errors if marker return null

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
If marker is null throws error

**What is the new behavior?**
If marker is null the thumbnail is empty without style

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
