### PR TITLE
Issue #2337. Make FeatureInfo viewer pluggable

### DIFF
--- a/web/client/api/WFS.js
+++ b/web/client/api/WFS.js
@@ -17,7 +17,7 @@ const Api = {
     getFeatureSimple: function(baseUrl, params) {
         return axios.get(baseUrl + '?service=WFS&version=1.1.0&request=GetFeature', {
             params: assign({
-                format: "application/json"
+                outputFormat: "application/json"
             }, params)
         }).then((response) => {
             if (typeof response.data !== 'object') {

--- a/web/client/components/TOC/fragments/settings/FeatureInfoFormat.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfoFormat.jsx
@@ -14,7 +14,7 @@ const MapInfoUtils = require('../../../../utils/MapInfoUtils');
 module.exports = class extends React.Component {
     static propTypes = {
         element: PropTypes.object,
-        label: PropTypes.string,
+        label: PropTypes.object,
         defaultInfoFormat: PropTypes.object,
         onInfoFormatChange: PropTypes.func
     };
@@ -28,6 +28,7 @@ module.exports = class extends React.Component {
         const data = Object.keys(this.props.defaultInfoFormat).map((infoFormat) => {
             return infoFormat;
         });
+        const checkDisabled = !!(this.props.element.featureInfo && this.props.element.featureInfo.viewer);
         return (
             <div>
                 {this.props.element.type === "wms" ?
@@ -43,9 +44,11 @@ module.exports = class extends React.Component {
                     data={data}
                     value={this.props.element.featureInfo ? this.props.element.featureInfo.format : data[0]}
                     defaultValue={data[0]}
+                    disabled={checkDisabled}
                     onChange={(value) => {
                         this.props.onInfoFormatChange("featureInfo", Object.assign({}, {
-                            ['format']: value
+                            ['format']: value,
+                            ['viewer']: this.props.element.featureInfo ? this.props.element.featureInfo.viewer : undefined
                         }));
                     }} />
                 )] : null}

--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -111,6 +111,10 @@ class DefaultViewer extends React.Component {
                 infoFormat = queryParams.info_format;
             }
             const PageHeader = this.props.header;
+            let customViewer;
+            if (layerMetadata.viewer && layerMetadata.viewer.type) {
+                customViewer = MapInfoUtils.getViewer(layerMetadata.viewer.type);
+            }
             return (
                 <Panel
                     eventKey={i}
@@ -125,7 +129,7 @@ class DefaultViewer extends React.Component {
                         onPrevious={() => this.previous()}/></span>
                     }
                     style={this.props.style}>
-                    <ViewerPage response={response} format={infoFormat || this.props.format} viewers={this.props.viewers} layer={layerMetadata}/>
+                    <ViewerPage response={response} format={infoFormat || this.props.format} viewers={customViewer || this.props.viewers} layer={layerMetadata}/>
                 </Panel>
             );
         });

--- a/web/client/components/data/identify/viewers/ViewerPage.jsx
+++ b/web/client/components/data/identify/viewers/ViewerPage.jsx
@@ -12,7 +12,7 @@ const React = require('react');
 module.exports = class extends React.Component {
     static propTypes = {
         format: PropTypes.string,
-        viewers: PropTypes.object,
+        viewers: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
         response: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.node]),
         layer: PropTypes.object
     };
@@ -58,7 +58,7 @@ module.exports = class extends React.Component {
     };
 
     renderPage = () => {
-        const Viewer = this.props.viewers[this.props.format];
+        const Viewer = typeof this.props.viewers === 'function' ? this.props.viewers : this.props.viewers[this.props.format];
         if (Viewer) {
             return <Viewer response={this.props.response} layer={this.props.layer}/>;
         }

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -161,9 +161,21 @@ const MapInfoUtils = {
         wmts: require('./mapinfo/wmts'),
         vector: require('./mapinfo/vector')
     },
+    /**
+     * To get the custom viewer with the given type
+     * This way you can extend the featureinfo with your custom viewers in external projects.
+     * @param type {string} the string the component was registered with
+     * @return {object} the registered component
+     */
     getViewer: (type) => {
         return !!MapInfoUtils.VIEWERS[type] ? MapInfoUtils.VIEWERS[type] : null;
     },
+    /**
+     * To register a custom viewer
+     * This way you can extend the featureinfo with your custom viewers in external projects.
+     * @param type {string} the string you want to register the component with
+     * @param viewer {object} the component to register
+     */
     setViewer: (type, viewer) => {
         MapInfoUtils.VIEWERS[type] = viewer;
     }

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -18,6 +18,7 @@ const MapInfoUtils = {
     //           default format ↴
     AVAILABLE_FORMAT: ['TEXT', 'JSON', 'HTML'],
 
+    VIEWERS: {},
     /**
      * @return a filtered version of INFO_FORMATS object.
      * the returned object contains only keys that AVAILABLE_FORMAT contains.
@@ -61,6 +62,13 @@ const MapInfoUtils = {
         }
         return props.format || 'application/json';
     },
+    getLayerFeatureInfoViewer(layer) {
+        if (layer.featureInfo
+            && layer.featureInfo.viewer) {
+            return layer.featureInfo.viewer;
+        }
+        return {};
+    },
     clickedPointToGeoJson(clickedPoint) {
         if (!clickedPoint) {
             return [];
@@ -101,7 +109,8 @@ const MapInfoUtils = {
     buildIdentifyRequest(layer, props) {
         if (MapInfoUtils.services[layer.type]) {
             let infoFormat = MapInfoUtils.getDefaultInfoFormatValueFromLayer(layer, props);
-            return MapInfoUtils.services[layer.type].buildRequest(layer, props, infoFormat);
+            let viewer = MapInfoUtils.getLayerFeatureInfoViewer(layer);
+            return MapInfoUtils.services[layer.type].buildRequest(layer, props, infoFormat, viewer);
         }
         return {};
     },
@@ -151,6 +160,12 @@ const MapInfoUtils = {
         wms: require('./mapinfo/wms'),
         wmts: require('./mapinfo/wmts'),
         vector: require('./mapinfo/vector')
+    },
+    getViewer: (type) => {
+        return !!MapInfoUtils.VIEWERS[type] ? MapInfoUtils.VIEWERS[type] : null;
+    },
+    setViewer: (type, viewer) => {
+        MapInfoUtils.VIEWERS[type] = viewer;
     }
 };
 

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -6,16 +6,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const React = require('react');
 var expect = require('expect');
 var {
     getAvailableInfoFormat,
     getAvailableInfoFormatLabels,
     getAvailableInfoFormatValues,
     getDefaultInfoFormatValue,
-    buildIdentifyRequest
+    buildIdentifyRequest,
+    getViewer,
+    setViewer
 } = require('../MapInfoUtils');
 
 const CoordinatesUtils = require('../CoordinatesUtils');
+
+class App extends React.Component {
+    render() {
+        return (<div></div>);
+    }
+}
 
 describe('MapInfoUtils', () => {
 
@@ -137,6 +146,66 @@ describe('MapInfoUtils', () => {
         expect(req1.request.service).toBe('WMS');
     });
 
+    it('buildIdentifyRequest works for wms layer with config featureInfo info_format', () => {
+        let props = {
+            map: {
+                zoom: 0,
+                projection: 'EPSG:4326'
+            },
+            point: {
+                latlng: {
+                    lat: 0,
+                    lng: 0
+                }
+            }
+        };
+        let layer1 = {
+            type: "wms",
+            queryLayers: ["sublayer1", "sublayer2"],
+            name: "layer",
+            url: "http://localhost",
+            featureInfo: {
+                format: "HTML"
+            }
+        };
+        let req1 = buildIdentifyRequest(layer1, props);
+        expect(req1.request).toExist();
+        expect(req1.request.service).toBe('WMS');
+        expect(req1.request.info_format).toBe('text/html');
+    });
+
+    it('buildIdentifyRequest works for wms layer with config featureInfo viewer', () => {
+        let props = {
+            map: {
+                zoom: 0,
+                projection: 'EPSG:4326'
+            },
+            point: {
+                latlng: {
+                    lat: 0,
+                    lng: 0
+                }
+            }
+        };
+        let layer1 = {
+            type: "wms",
+            queryLayers: ["sublayer1", "sublayer2"],
+            name: "layer",
+            url: "http://localhost",
+            featureInfo: {
+                format: "JSON",
+                viewer: {
+                    type: 'customViewer'
+                }
+            }
+        };
+        let req1 = buildIdentifyRequest(layer1, props);
+        expect(req1.request).toExist();
+        expect(req1.request.service).toBe('WMS');
+        expect(req1.request.info_format).toBe('application/json');
+        expect(req1.metadata.viewer.type).toBe('customViewer');
+    });
+
     it('buildIdentifyRequest works for wmts layer', () => {
         let props = {
             map: {
@@ -181,5 +250,43 @@ describe('MapInfoUtils', () => {
         let req1 = buildIdentifyRequest(layer1, props);
         expect(req1.request).toExist();
         expect(req1.request.lat).toBe(43);
+    });
+
+    it('getViewer and setViewer test', () => {
+        let props = {
+            map: {
+                zoom: 0,
+                projection: 'EPSG:4326'
+            },
+            point: {
+                latlng: {
+                    lat: 0,
+                    lng: 0
+                }
+            }
+        };
+        let layer1 = {
+            type: "wms",
+            queryLayers: ["sublayer1", "sublayer2"],
+            name: "layer",
+            url: "http://localhost",
+            featureInfo: {
+                format: "JSON",
+                viewer: {
+                    type: 'customViewer'
+                }
+            }
+        };
+        let req1 = buildIdentifyRequest(layer1, props);
+        expect(req1.request).toExist();
+        expect(req1.request.service).toBe('WMS');
+        expect(req1.request.info_format).toBe('application/json');
+        expect(req1.metadata.viewer.type).toBe('customViewer');
+
+        let get = getViewer(req1.metadata.viewer.type);
+        expect(get).toNotExist();
+        setViewer('customViewer', <App/>);
+        let newGet = getViewer(req1.metadata.viewer.type);
+        expect(newGet).toExist();
     });
 });

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -13,7 +13,7 @@ const FilterUtils = require('../FilterUtils');
 const assign = require('object-assign');
 
 module.exports = {
-    buildRequest: (layer, props, infoFormat) => {
+    buildRequest: (layer, props, infoFormat, viewer) => {
         /* In order to create a valid feature info request
          * we create a bbox of 101x101 pixel that wrap the point.
          * center point is repojected then is built a box of 101x101pixel around it
@@ -63,7 +63,8 @@ module.exports = {
             },
             metadata: {
                 title: isObject(layer.title) ? layer.title[props.currentLocale] || layer.title.default : layer.title,
-                regex: layer.featureInfoRegex
+                regex: layer.featureInfoRegex,
+                viewer
             },
             url: isArray(layer.url) ?
                 layer.url[0] :


### PR DESCRIPTION
## Description
Enable MapStore2 to extend the available viewers for FeatureInfo. Map can be configured to use a custom viewer for certain layers.

The MapInfoUtils now expose 2 :

setViewer - to register a viewer
getViewer - to get the viewer with the given id

Example layer config:

`"featureInfo": {
	"format": "JSON",
	"viewer": {
		"type": "Geocollect"
	}
}`

## Issues
 - Fix #2337 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Now isn't possible to extend the featureinfo with your custom viewers in external projects.

**What is the new behavior?**
This way you can extend the featureinfo with your custom viewers in external projects.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
