### PR TITLE
Added optional extraClass style to add extra style to marker icons

### DIFF
--- a/web/client/utils/leaflet/Icons.js
+++ b/web/client/utils/leaflet/Icons.js
@@ -20,7 +20,7 @@ module.exports = {
                 markerColor: style.iconColor || 'blue',
                 shape: style.iconShape || 'square',
                 prefix,
-                extraClasses: style.highlight ? 'marker-selected' : ''
+                extraClasses: (style.highlight ? 'marker-selected' : '') + ' ' + (style.extraClass)
             });
         }
     },


### PR DESCRIPTION
## Description
Added optional extraClass style to add extra style to marker icons

## Issues

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
extraClasses applied only for highlight attribute

**What is the new behavior?**
added possibility to specify an extra css class explicitly for marker icons through style

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
