### PR TITLE
Fix #2345. Autohide download when WFSDownload plugin not available

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,7 +16,7 @@ const getSaveMessageId = ({saving, saved}) => {
     return "featuregrid.toolbar.saveChanges";
 };
 
-module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, isSyncActive = false, hasSupportedGeometry = true} = {}) =>
+module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true} = {}) =>
 
     (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
@@ -96,7 +96,7 @@ module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeo
             tooltip={<Message msgId="featuregrid.toolbar.downloadGridData"/>}
             disabled={disableToolbar || disableDownload}
             active={isDownloadOpen}
-            visible={mode === "VIEW"}
+            visible={displayDownload && mode === "VIEW"}
             onClick={events.download}
             glyph="features-grid-download"/>
         <TButton

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -33,6 +33,15 @@ describe('Featuregrid toolbar component', () => {
         expect(el).toExist();
         const downloadBtn = document.getElementById("fg-download-grid");
         const editButton = document.getElementById("fg-edit-mode");
+        expect(isVisibleButton(downloadBtn)).toBe(false);
+        expect(isVisibleButton(editButton)).toBe(false);
+    });
+    it('check download displayDownload', () => {
+        ReactDOM.render(<Toolbar displayDownload />, document.getElementById("container"));
+        const el = document.getElementsByClassName("featuregrid-toolbar")[0];
+        expect(el).toExist();
+        const downloadBtn = document.getElementById("fg-download-grid");
+        const editButton = document.getElementById("fg-edit-mode");
         expect(isVisibleButton(downloadBtn)).toBe(true);
         expect(isVisibleButton(editButton)).toBe(false);
     });

--- a/web/client/components/data/featuregrid_ag/DockedFeatureGrid.jsx
+++ b/web/client/components/data/featuregrid_ag/DockedFeatureGrid.jsx
@@ -259,6 +259,7 @@ class DockedFeatureGrid extends React.Component {
                         }}>
                             <FeatureGrid
                                 useIcons
+                                exportEnabled={this.actions.exportEnabled}
                                 exportAction={this.props.exportEnabled && this.props.exportAction}
                                 tools={[<Button onClick={this.props.onBackToSearch} ><Glyphicon glyph="arrow-left" /><I18N.Message msgId="featuregrid.backtosearch"/></Button>]}
                                 key={"search-results-" + (this.state && this.state.searchN)}
@@ -281,7 +282,7 @@ class DockedFeatureGrid extends React.Component {
                                 zoomToFeatureAction={this.props.zoomToFeatureAction}
                                 toolbar={{
                                     zoom: this.props.withMap,
-                                    exporter: true,
+                                    exporter: this.props.exportEnabled,
                                     toolPanel: true,
                                     selectAll: false
                                 }}

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -114,7 +114,7 @@ describe('OpenlayersMap', () => {
             });
             expect(spy.calls.length).toEqual(1);
             done();
-        }, 0);
+        }, 500);
     });
 
     it('check layers init', () => {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -222,6 +222,7 @@
                     }
                 }
             }, "Home", "FeatureEditor",
+            "WFSDownload",
             {
               "name": "QueryPanel",
               "cfg": {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -222,7 +222,6 @@
                     }
                 }
             }, "Home", "FeatureEditor",
-            "WFSDownload",
             {
               "name": "QueryPanel",
               "cfg": {

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -10,6 +10,7 @@ const React = require('react');
 const {connect} = require('react-redux');
 const {bindActionCreators} = require('redux');
 const {createSelector, createStructuredSelector} = require('reselect');
+const {wfsDownloadAvailable} = require('../../../selectors/controls');
 const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive} = require('../../../selectors/query');
 const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter, hasSupportedGeometry, editingAllowedRolesSelector} = require('../../../selectors/featuregrid');
 const {userRoleSelector} = require('../../../selectors/security');
@@ -37,6 +38,7 @@ const Toolbar = connect(
         isSimpleGeom: isSimpleGeomSelector,
         selectedCount: selectedFeaturesCount,
         disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar,
+        displayDownload: wfsDownloadAvailable,
         disableDownload: state => (resultsSelector(state) || []).length === 0,
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
         isSyncActive: isSyncWmsActive,

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -8,13 +8,17 @@
 
 const expect = require('expect');
 const {
-    queryPanelSelector
+    queryPanelSelector,
+    wfsDownloadAvailable
 } = require("../controls");
 
 const state = {
     controls: {
         queryPanel: {
             enabled: true
+        },
+        wfsdownload: {
+            available: true
         }
     }
 };
@@ -22,6 +26,11 @@ const state = {
 describe('Test controls selectors', () => {
     it('test queryPanelSelector', () => {
         const retVal = queryPanelSelector(state);
+        expect(retVal).toExist();
+        expect(retVal).toBe(true);
+    });
+    it('test wfsDownloadAvailable', () => {
+        const retVal = wfsDownloadAvailable(state);
         expect(retVal).toExist();
         expect(retVal).toBe(true);
     });

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -1,5 +1,6 @@
 const {get} = require('lodash');
 
 module.exports = {
-    queryPanelSelector: (state) => get(state, "controls.queryPanel.enabled")
+    queryPanelSelector: (state) => get(state, "controls.queryPanel.enabled"),
+    wfsDownloadAvailable: state => !!get(state, "controls.wfsdownload.available")
 };


### PR DESCRIPTION
## Description
Autohide download button in FeatureEditor/FeatureGrid when WFSDownload plugin not available.

## Issues
 - Fix #2345

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
If you remove the WFSDownload plugin, the download button in FeatureGrid is still present

**What is the new behavior?**
The button is present only if the WFSDownload plugins is loaded

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
