### PR TITLE
Access detail panel if read only is activated on annotations

### DIFF
--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -11,7 +11,7 @@ const PropTypes = require('prop-types');
 const ConfirmDialog = require('../../misc/ConfirmDialog');
 const Message = require('../../I18N/Message');
 const LocaleUtils = require('../../../utils/LocaleUtils');
-const {Glyphicon, Button, ButtonGroup} = require('react-bootstrap');
+const {ButtonGroup} = require('react-bootstrap');
 const {head} = require('lodash');
 const assign = require('object-assign');
 const Filter = require('../../misc/Filter');
@@ -126,10 +126,6 @@ class Annotations extends React.Component {
         const annotation = this.props.annotations && head(this.props.annotations.filter(a => a.properties.id === this.props.current));
         if (this.props.mode === 'list' || (!annotation && !this.props.editing)) {
             return [
-            <Filter
-                filterPlaceholder={LocaleUtils.getMessageById(this.context.messages, "annotations.filter")}
-                filterText={this.props.filter}
-                onFilter={this.props.onFilter}/>,
             <ButtonGroup id="mapstore-annotations-panel-buttons">
                 <TButton
                     id="add-annotation"
@@ -139,6 +135,10 @@ class Annotations extends React.Component {
                     className="square-button-md"
                     glyph="plus"/>
             </ButtonGroup>,
+            <Filter
+                filterPlaceholder={LocaleUtils.getMessageById(this.context.messages, "annotations.filter")}
+                filterText={this.props.filter}
+                onFilter={this.props.onFilter}/>,
             <div className="mapstore-annotations-panel-cards">{this.props.annotations.filter(this.applyFilter).map(a => this.renderCard(a))}</div>
             ];
         }

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -15,6 +15,7 @@ const {Glyphicon, Button, ButtonGroup} = require('react-bootstrap');
 const {head} = require('lodash');
 const assign = require('object-assign');
 const Filter = require('../../misc/Filter');
+const TButton = require('../../data/featuregrid/toolbars/TButton');
 
 const defaultConfig = require('./AnnotationsConfig');
 
@@ -115,7 +116,7 @@ class Annotations extends React.Component {
 
     renderCard = (annotation) => {
         const readOnly = annotation.readOnly ? ' m-read-only' : '';
-        return (<div className={"mapstore-annotations-panel-card" + this.props.classNameSelector(annotation) + readOnly} onMouseOver={() => this.props.onHighlight(annotation.properties.id)} onMouseOut={this.props.onCleanHighlight} onClick={annotation.readOnly ? () => {} : () => this.props.onDetail(annotation.properties.id)}>
+        return (<div className={"mapstore-annotations-panel-card" + this.props.classNameSelector(annotation) + readOnly} onMouseOver={() => this.props.onHighlight(annotation.properties.id)} onMouseOut={this.props.onCleanHighlight} onClick={() => this.props.onDetail(annotation.properties.id)}>
             <span className="mapstore-annotations-panel-card-thumbnail">{this.renderThumbnail(annotation.style)}</span>
             {this.getConfig().fields.map(f => this.renderField(f, annotation))}
         </div>);
@@ -124,22 +125,29 @@ class Annotations extends React.Component {
     renderCards = () => {
         const annotation = this.props.annotations && head(this.props.annotations.filter(a => a.properties.id === this.props.current));
         if (this.props.mode === 'list' || (!annotation && !this.props.editing)) {
-            return [<ButtonGroup id="mapstore-annotations-panel-buttons">
-                <Button bsStyle="primary" onClick={() => this.props.onAdd(this.props.config.multiGeometry ? 'MultiPoint' : 'Point')}><Glyphicon glyph="plus"/>&nbsp;<Message msgId="annotations.add"/></Button>
-            </ButtonGroup>,
+            return [
             <Filter
                 filterPlaceholder={LocaleUtils.getMessageById(this.context.messages, "annotations.filter")}
                 filterText={this.props.filter}
                 onFilter={this.props.onFilter}/>,
+            <ButtonGroup id="mapstore-annotations-panel-buttons">
+                <TButton
+                    id="add-annotation"
+                    tooltip={<Message msgId="annotations.add"/>}
+                    onClick={() => this.props.onAdd(this.props.config.multiGeometry ? 'MultiPoint' : 'Point')}
+                    visible
+                    className="square-button-md"
+                    glyph="plus"/>
+            </ButtonGroup>,
             <div className="mapstore-annotations-panel-cards">{this.props.annotations.filter(this.applyFilter).map(a => this.renderCard(a))}</div>
             ];
         }
         const Editor = this.props.editor;
         if (this.props.mode === 'detail' && annotation && annotation.properties) {
-            return <Editor showBack config={this.props.config} id={this.props.current} {...annotation.properties}/>;
+            return <Editor feature={annotation} showBack config={this.props.config} id={this.props.current} {...annotation.properties}/>;
         }
         // mode = editing
-        return this.props.editing && <Editor config={this.props.config} id={this.props.editing.properties.id} {...this.props.editing.properties}/>;
+        return this.props.editing && <Editor feature={annotation} config={this.props.config} id={this.props.editing.properties.id} {...this.props.editing.properties}/>;
     };
 
     render() {

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -142,16 +142,39 @@ class AnnotationsEditor extends React.Component {
 
     renderViewButtons = () => {
         return (<ButtonGroup className="mapstore-annotations-info-viewer-buttons">
-                <Button bsStyle="primary" onClick={() => this.props.onEdit(this.props.id, this.props.config.multiGeometry ? 'MultiPoint' : 'Point')}><Glyphicon glyph="pencil"/>&nbsp;<Message msgId="annotations.edit"/></Button>
-                <Button bsStyle="primary" onClick={() => this.props.onRemove(this.props.id)}><Glyphicon glyph="ban-circle"/>&nbsp;<Message msgId="annotations.remove"/></Button>
-                {this.props.showBack ? <Button bsStyle="primary" onClick={() => this.props.onCancel()}><Glyphicon glyph="back"/>&nbsp;<Message msgId="annotations.back"/></Button> : null }
+                {!this.props.feature.readOnly &&
+                    <span>
+                    <TButton
+                        id="annotation-edit"
+                        tooltip={<Message msgId="annotations.edit"/>}
+                        onClick={() => this.props.onEdit(this.props.id, this.props.config.multiGeometry ? 'MultiPoint' : 'Point')}
+                        visible
+                        className="square-button-md"
+                        glyph="pencil"/>
+                    <TButton
+                        id="annotation-remove"
+                        tooltip={<Message msgId="annotations.remove"/>}
+                        onClick={() => this.props.onRemove(this.props.id)}
+                        visible
+                        className="square-button-md"
+                        glyph="trash"/>
+                    </span>}
+                {this.props.showBack ?
+                    <TButton
+                        id="annotation-back"
+                        tooltip={<Message msgId="annotations.back"/>}
+                        onClick={() => this.props.onCancel()}
+                        visible
+                        className="square-button-md"
+                        glyph="arrow-left"/>
+                : null }
             </ButtonGroup>);
     };
 
     renderEditingButtons = () => {
         return (<Grid className="mapstore-annotations-info-viewer-buttons" fluid>
                     <Row>
-                        <Col xs={7}>
+                        <Col xs={12}>
                             <TButton
                                 id="edit-geometry"
                                 tooltip={<Message msgId="annotations.addMarker"/>}
@@ -175,12 +198,20 @@ class AnnotationsEditor extends React.Component {
                                 visible
                                 className="square-button-md"
                                 glyph="trash"/>
-                        </Col>
-                        <Col xs={5}>
-                            <ButtonGroup id="mapstore-annotations-info-viewer-edit-buttons">
-                                <Button bsStyle="primary" onClick={this.save}><Glyphicon glyph="floppy-disk"/>&nbsp;<Message msgId="annotations.save"/></Button>
-                                <Button bsStyle="primary" onClick={this.cancelEdit}><Glyphicon glyph="remove"/>&nbsp;<Message msgId="annotations.cancel"/></Button>
-                            </ButtonGroup>
+                            <TButton
+                                id="save-annotation"
+                                tooltip={<Message msgId="annotations.save"/>}
+                                onClick={this.save}
+                                visible
+                                className="square-button-md"
+                                glyph="floppy-disk"/>
+                            <TButton
+                                id="cancel-edit-annotation"
+                                tooltip={<Message msgId="annotations.cancel"/>}
+                                onClick={this.cancelEdit}
+                                visible
+                                className="square-button-md"
+                                glyph="remove"/>
                         </Col>
             </Row>
         </Grid>);
@@ -237,8 +268,20 @@ class AnnotationsEditor extends React.Component {
         const glyphRenderer = (option) => (<div><span className={"fa fa-" + option.value}/><span> {option.label}</span></div>);
         return (<div className="mapstore-annotations-info-viewer-styler">
             <div className="mapstore-annotations-info-viewer-styler-buttons">
-                <Button bsStyle="primary" onClick={this.props.onSaveStyle}><Glyphicon glyph="floppy-disk"/>&nbsp;<Message msgId="annotations.save"/></Button>
-                <Button bsStyle="primary" onClick={this.props.onCancelStyle}><Glyphicon glyph="remove"/>&nbsp;<Message msgId="annotations.cancel"/></Button>
+                <TButton
+                    id="save-annotation"
+                    tooltip={<Message msgId="annotations.save"/>}
+                    onClick={this.props.onSaveStyle}
+                    visible
+                    className="square-button-md"
+                    glyph="floppy-disk"/>
+                <TButton
+                    id="cancel-edit-annotation"
+                    tooltip={<Message msgId="annotations.cancel"/>}
+                    onClick={this.props.onCancelStyle}
+                    visible
+                    className="square-button-md"
+                    glyph="remove"/>
             </div>
             <div className="mapstore-annotations-info-viewer-markers">{this.renderMarkers(this.getConfig().markers)}</div>
             <Select
@@ -279,7 +322,7 @@ class AnnotationsEditor extends React.Component {
         const editing = this.props.editing && (this.props.editing.properties.id === this.props.id);
         return (
             <div className="mapstore-annotations-info-viewer">
-                {this.props.feature.readOnly ? null : this.renderButtons(editing)}
+                {this.renderButtons(editing)}
                 {this.renderError(editing)}
                 {this.renderBody(editing)}
             </div>

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -9,7 +9,6 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 
-const {Button, Glyphicon} = require('react-bootstrap');
 const TButton = require('../../data/featuregrid/toolbars/TButton');
 
 const Message = require('../../I18N/Message');

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -196,7 +196,7 @@ class AnnotationsEditor extends React.Component {
                                 onClick={this.props.onDeleteGeometry}
                                 visible
                                 className="square-button-md"
-                                glyph="trash"/>
+                                glyph="polygon-trash"/>
                             <TButton
                                 id="save-annotation"
                                 tooltip={<Message msgId="annotations.save"/>}

--- a/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.jsx
+++ b/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.jsx
@@ -226,7 +226,7 @@ describe("test the Annotations Panel", () => {
         TestUtils.Simulate.click(ReactDOM.findDOMNode(cards[0]));
         TestUtils.Simulate.click(ReactDOM.findDOMNode(cards[1]));
 
-        expect(spyDetail).toNotHaveBeenCalled();
+        expect(spyDetail).toHaveBeenCalled();
 
     });
 

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -429,24 +429,15 @@ describe("test the AnnotationsEditor Panel", () => {
             description: '<span><i>desc</i></span>'
         };
 
-        const viewer = ReactDOM.render(<AnnotationsEditor feature={{
+        const viewer = ReactDOM.render(<AnnotationsEditor showBack feature={{
             readOnly: true
-        }} {...feature} editing={{
-            readOnly: true,
-            properties: feature,
-            style: {
-                iconGlyph: 'comment',
-                iconColor: 'red',
-                iconShape: 'square'
-            }
-        }}/>, document.getElementById("container"));
+        }} {...feature} />, document.getElementById("container"));
         expect(viewer).toExist();
 
-        const editingBtnLength = TestUtils.scryRenderedDOMComponentsWithClass(viewer, "mapstore-annotations-info-viewer-buttons").length;
-        expect(editingBtnLength).toBe(0);
+        const viewBtn = TestUtils.scryRenderedDOMComponentsWithClass(viewer, "mapstore-annotations-info-viewer-buttons");
+        expect(viewBtn.length).toBe(1);
 
-        const viewBtnLength = TestUtils.scryRenderedDOMComponentsWithClass(viewer, "mapstore-annotations-info-viewer-buttons").length;
-        expect(viewBtnLength).toBe(0);
+        expect(TestUtils.scryRenderedDOMComponentsWithClass(viewer, "glyphicon glyphicon-arrow-left")).toExist();
 
     });
 

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -185,10 +185,9 @@
 
 .mapstore-annotations-info-viewer-buttons {
     min-height: 45px;
-}
-
-.mapstore-annotations-info-viewer-styler-buttons {
-    text-align: right;
+    .col-xs-12 {
+        padding: 0;
+    }
 }
 
 .mapstore-annotations-panel-card {


### PR DESCRIPTION
## Description
Changed current buttons with the square medium of mapstore and modified read only behaviour.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
can't access detail panel of annotations if read only is activated 

**What is the new behavior?**
can access detail panel of annotations if read only is activated and the edit buttons aren't displayed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
