### PR TITLE
Fixes #2354 TilematrixSet and TilematrixIds stored in WMTS layers could cause errors on save request

### DIFF
--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -112,4 +112,198 @@ describe('LayersUtils', () => {
         const newGroupsNull = LayersUtils.getNode(nestedGroups, 'nested010');
         expect(newGroupsNull).toNotExist();
     });
+
+    it('extract data from sources no state', () => {
+        expect( LayersUtils.extractDataFromSources()).toBe(null);
+        expect( LayersUtils.extractDataFromSources({})).toBe(null);
+    });
+
+    it('extract data from sources no sources object', () => {
+
+        const mapState = {
+            layers: [{
+                id: 'layer:001',
+                url: 'http:url001'
+            }]
+        };
+
+        const layers = LayersUtils.extractDataFromSources(mapState);
+        expect(layers).toEqual([
+            {
+                id: 'layer:001',
+                url: 'http:url001'
+            }
+        ]);
+    });
+
+    it('extract data from sources', () => {
+        const sources = {
+            'http:url001': {
+                tileMatrixSet: {
+                    'EPSG:4326': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    },
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            }
+        };
+
+        const mapState = {
+            mapInitialConfig: {
+                sources
+            },
+            layers: [{
+                id: 'layer:001',
+                url: 'http:url001',
+                tileMatrixSet: true,
+                matrixIds: ['EPSG:4326', 'custom']
+            }]
+        };
+
+        const layers = LayersUtils.extractDataFromSources(mapState);
+        expect(layers).toEqual([
+            {
+                id: 'layer:001',
+                url: 'http:url001',
+                matrixIds: {
+                    'EPSG:4326': [{
+                        identifier: 'EPSG:4326:0',
+                        ranges: undefined
+                    }],
+                    'custom': [{
+                        identifier: 'custom:0',
+                        ranges: undefined
+                    }]
+                },
+                tileMatrixSet: [{
+                    TileMatrix: [{
+                        'ows:Identifier': 'EPSG:4326:0'
+                    }],
+                    'ows:Identifier': "EPSG:4326",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                }, {
+                    TileMatrix: [{
+                        'ows:Identifier': 'custom:0'
+                    }],
+                    'ows:Identifier': "custom",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                }]
+            }
+        ]);
+    });
+
+    it('extract matrix from sources no arguments', () => {
+        expect( LayersUtils.extractTileMatrixFromSources()).toEqual({});
+        expect( LayersUtils.extractTileMatrixFromSources(null, {})).toEqual({});
+        expect( LayersUtils.extractTileMatrixFromSources({}, null)).toEqual({});
+        expect( LayersUtils.extractTileMatrixFromSources({}, {})).toEqual({});
+    });
+
+    it('extract matrix from sources', () => {
+        const sources = {
+            'http:url001': {
+                tileMatrixSet: {
+                    'EPSG:4326': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    },
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            }
+        };
+
+        const layer = {
+            id: 'layer:001',
+            url: 'http:url001',
+            tileMatrixSet: true,
+            matrixIds: ['EPSG:4326', 'custom']
+        };
+
+        const {matrixIds, tileMatrixSet} = LayersUtils.extractTileMatrixFromSources(sources, layer);
+
+        expect(matrixIds).toEqual({
+            'EPSG:4326': [
+                {
+                    identifier: 'EPSG:4326:0',
+                    ranges: undefined
+                }
+            ],
+            'custom': [
+                {
+                    identifier: 'custom:0',
+                    ranges: undefined
+                }
+            ]
+        });
+
+        expect(tileMatrixSet).toEqual([
+            {
+                TileMatrix: [
+                    {
+                        'ows:Identifier': 'EPSG:4326:0'
+                    }
+                ],
+                'ows:Identifier': "EPSG:4326",
+                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+            }, {
+                TileMatrix: [
+                    {
+                        'ows:Identifier': 'custom:0'
+                    }
+                ],
+                'ows:Identifier': "custom",
+                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+            }
+        ]);
+    });
+
+    it('extract matrix from sources no wmts layer', () => {
+        const sources = {
+            'http:url001': {
+                tileMatrixSet: {
+                    'EPSG:4326': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    },
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            }
+        };
+
+        const layer = {
+            id: 'layer:001',
+            url: 'http:url001'
+        };
+
+        expect(LayersUtils.extractTileMatrixFromSources(sources, layer)).toEqual({});
+    });
+
 });

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -25,7 +25,8 @@ var {
     getCenterForExtent,
     getBbox,
     getCurrentResolution,
-    saveMapConfiguration
+    saveMapConfiguration,
+    extractTileMatrixSetFromLayers
 } = require('../MapUtils');
 
 describe('Test the MapUtils', () => {
@@ -330,6 +331,528 @@ describe('Test the MapUtils', () => {
             },
             version: 2
         });
+    });
+
+    it('save map configuration with tile matrix', () => {
+
+        const flat = [
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer001",
+                loading: true,
+                name: "layer001",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer001",
+                type: "wms",
+                url: "http:url001",
+                visibility: true,
+                matrixIds: {
+                    'EPSG:4326': [{
+                        identifier: 'EPSG:4326:0'
+                    }]
+                },
+                tileMatrixSet: [{
+                    TileMatrix: [{
+                        'ows:Identifier': 'EPSG:4326:0'
+                    }],
+                    'ows:Identifier': "EPSG:4326",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                }, {
+                    TileMatrix: [{
+                        'ows:Identifier': 'custom:0'
+                    }],
+                    'ows:Identifier': "custom",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                }]
+            },
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer002",
+                loading: true,
+                name: "layer002",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer002",
+                type: "wms",
+                url: "http:url001",
+                visibility: true
+            },
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer003",
+                loading: true,
+                name: "layer003",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer003",
+                type: "wms",
+                url: "http:url001",
+                visibility: true
+            }
+        ];
+
+        const groups = [
+            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+            ]}
+        ];
+
+        const mapConfig = {
+            center: {x: 0, y: 0, crs: 'EPSG:4326'},
+            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+            projection: 'EPSG:900913',
+            units: 'm',
+            zoom: 10
+        };
+
+        const saved = saveMapConfiguration(mapConfig, flat, groups, '', {});
+        expect(saved).toEqual({
+            catalogServices: {},
+            map: {
+                center: {crs: 'EPSG:4326', x: 0, y: 0},
+                groups: [{
+                    id: 'Default',
+                    expanded: true
+                }, {
+                    id: 'custom',
+                    expanded: false
+                }, {
+                    id: 'custom.nested001',
+                    expanded: true
+                }],
+                layers: [{
+                    allowedSRS: {},
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    dimensions: [],
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer001",
+                    matrixIds: ['EPSG:4326'],
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer001",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: true,
+                    tiled: undefined,
+                    title: "layer001",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "http:url001",
+                    visibility: true
+                },
+                {
+                    allowedSRS: {},
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    dimensions: [],
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer002",
+                    matrixIds: undefined,
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer002",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: undefined,
+                    tiled: undefined,
+                    title: "layer002",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "http:url001",
+                    visibility: true
+                },
+                {
+                    allowedSRS: {},
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    dimensions: [],
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer003",
+                    matrixIds: undefined,
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer003",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: undefined,
+                    tiled: undefined,
+                    title: "layer003",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "http:url001",
+                    visibility: true
+                }],
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                text_serch_config: '',
+                units: 'm',
+                zoom: 10,
+                sources: {
+                    'http:url001': {
+                        tileMatrixSet: {
+                            'EPSG:4326': {
+                                TileMatrix: [{
+                                    'ows:Identifier': 'EPSG:4326:0'
+                                }],
+                                'ows:Identifier': "EPSG:4326",
+                                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                            }
+                        }
+                    }
+                }
+            },
+            version: 2
+        });
+    });
+
+    it('extract TileMatrixSet from layers without sources and grouped layers', () => {
+        expect(extractTileMatrixSetFromLayers()).toEqual({});
+    });
+
+    it('extract TileMatrixSet from layers without sources and empty grouped layers', () => {
+        expect(extractTileMatrixSetFromLayers({})).toEqual({});
+    });
+
+    it('extract TileMatrixSet from layers with sources and empty grouped layers', () => {
+        expect(extractTileMatrixSetFromLayers(null, {data: 'data'})).toEqual({data: 'data'});
+    });
+
+    it('extract TileMatrixSet from layers without sources', () => {
+
+        const groupedLayersByUrl = {
+            'http:url001': [
+                {
+                    id: "layer001",
+                    matrixIds: {
+                        'EPSG:4326': [{
+                            identifier: 'EPSG:4326:0'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                },
+                {
+                    id: "layer003",
+                    matrixIds: {
+                        'custom': [{
+                            identifier: 'custom'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                }
+            ],
+            'http:url002': [
+                {
+                    id: "layer002",
+                    matrixIds: {
+                        'custom': [
+                            {
+                                identifier: 'custom:0',
+                                ranges: {
+                                    cols: {
+                                        min: 0,
+                                        max: 1
+                                    },
+                                    rows: {
+                                        min: 0,
+                                        max: 1
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                }
+            ]
+        };
+
+        const newSources = extractTileMatrixSetFromLayers(groupedLayersByUrl);
+
+        expect(newSources).toEqual({
+            'http:url001': {
+                tileMatrixSet: {
+                    'EPSG:4326': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    },
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            },
+            'http:url002': {
+                tileMatrixSet: {
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0',
+                            ranges: {
+                                cols: {
+                                    min: 0,
+                                    max: 1
+                                },
+                                rows: {
+                                    min: 0,
+                                    max: 1
+                                }
+                            }
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            }
+        });
+
+    });
+
+    it('extract TileMatrixSet from layers with sources', () => {
+
+        const groupedLayersByUrl = {
+            'http:url001': [
+                {
+                    id: "layer001",
+                    matrixIds: {
+                        'EPSG:4326': [{
+                            identifier: 'EPSG:4326:0'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                },
+                {
+                    id: "layer003",
+                    matrixIds: {
+                        'custom': [{
+                            identifier: 'custom'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                }
+            ],
+            'http:url002': [
+                {
+                    id: "layer002",
+                    matrixIds: {
+                        'custom': [
+                            {
+                                identifier: 'custom:0',
+                                ranges: {
+                                    cols: {
+                                        min: 0,
+                                        max: 1
+                                    },
+                                    rows: {
+                                        min: 0,
+                                        max: 1
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                }
+            ]
+        };
+
+        const sources = {
+            'http:url003': {
+                data: 'data'
+            },
+            'http:url002': {
+                tileMatrixSet: {
+                    'fromsources': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'fromsources:0'
+                        }],
+                        'ows:Identifier': "fromsources",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            }
+        };
+
+        const newSources = extractTileMatrixSetFromLayers(groupedLayersByUrl, sources);
+
+        expect(newSources).toEqual({
+            'http:url001': {
+                tileMatrixSet: {
+                    'EPSG:4326': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    },
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            },
+            'http:url002': {
+                tileMatrixSet: {
+                    'custom': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0',
+                            ranges: {
+                                cols: {
+                                    min: 0,
+                                    max: 1
+                                },
+                                rows: {
+                                    min: 0,
+                                    max: 1
+                                }
+                            }
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    },
+                    'fromsources': {
+                        TileMatrix: [{
+                            'ows:Identifier': 'fromsources:0'
+                        }],
+                        'ows:Identifier': "fromsources",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }
+                }
+            },
+            'http:url003': {
+                data: 'data'
+            }
+        });
+
     });
 
 });


### PR DESCRIPTION
## Description
Improved TileMatrixSet management on save and load of configuration.
Now if TileMatrixSet is a properties of layer, a new source object on configuration will be created
``` js
{
 ...
 map: {
  ...
  layers: [...],
  sources: {
   "http:url": {
    tileMatrixSet: {
    ...
    }
   }
  }
  ...
 }
 version: 2
}  
```

## Issues
 - Fix #2354 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issue #2354 
16 WMTS topp:states layers produce a configuration body with a content-length of 516694 chars

**What is the new behavior?**
Now 16 WMTS topp:states layers produce a configuration body with a content-length of 25202 chars (max 500000)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications:
layers saved after this commit will lose tileMatrixSet array and matrixIds object properties, replaced with a boolean for tileMatrixSet and an array of string for matrixIds.
So we make sure that the save and load functions contain this fix to parse correctly the configuration.

**Other information**:
