### PR TITLE
Fixes #2322 Custom WMTS gridsets are not supported, Fixes #2342 Tiles errors management

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -16,7 +16,7 @@ const xml2js = require('xml2js');
 
 const capabilitiesCache = {};
 
-const {isArray, castArray, head} = require('lodash');
+const {isArray, castArray} = require('lodash');
 
 const parseUrl = (url) => {
     const parsed = urlUtil.parse(url, true);
@@ -57,19 +57,6 @@ const searchAndPaginate = (json = {}, startPosition, maxRecords, text) => {
             .filter((layer, index) => index >= startPosition - 1 && index < startPosition - 1 + maxRecords)
             .map((layer) => assign({}, layer, {onlineResource, SRS: SRSList}))
     };
-};
-
-const getBoundingBox = (BoundingBox) => {
-    const SRS = 'EPSG:3857';
-    const bbox = BoundingBox && isArray(BoundingBox) && head(BoundingBox.filter(b => {
-        return b && b.$ && b.$.SRS === SRS && b.$.maxx && b.$.maxy && b.$.minx && b.$.miny;
-    }).map(b => b && b.$ && CoordinatesUtils.reprojectBbox([
-        parseFloat(b.$.minx),
-        parseFloat(b.$.miny),
-        parseFloat(b.$.maxx),
-        parseFloat(b.$.maxy)
-    ], SRS, 'EPSG:4326')));
-    return isArray(bbox) && {minx: bbox[0], miny: bbox[1], maxx: bbox[2], maxy: bbox[3]} || null;
 };
 
 const Api = {
@@ -197,10 +184,10 @@ const Api = {
     },
     getBBox: function(record, bounds) {
         let layer = record;
-        let bbox = (layer.EX_GeographicBoundingBox || getBoundingBox(layer.BoundingBox) || (layer.LatLonBoundingBox && layer.LatLonBoundingBox.$) || layer.latLonBoundingBox);
+        let bbox = (layer.EX_GeographicBoundingBox || CoordinatesUtils.getWMSBoundingBox(layer.BoundingBox) || (layer.LatLonBoundingBox && layer.LatLonBoundingBox.$) || layer.latLonBoundingBox);
         while (!bbox && layer.Layer && layer.Layer.length) {
             layer = layer.Layer[0];
-            bbox = (layer.EX_GeographicBoundingBox || getBoundingBox(layer.BoundingBox) || (layer.LatLonBoundingBox && layer.LatLonBoundingBox.$) || layer.latLonBoundingBox);
+            bbox = (layer.EX_GeographicBoundingBox || CoordinatesUtils.getWMSBoundingBox(layer.BoundingBox) || (layer.LatLonBoundingBox && layer.LatLonBoundingBox.$) || layer.latLonBoundingBox);
         }
         if (!bbox) {
             bbox = {

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -189,7 +189,13 @@ describe('Leaflet layer', () => {
             "name": "nurc:Arc_Sample",
             "group": "Meteo",
             "format": "image/png",
-            "tileMatrixSet": "EPSG:900913",
+            "tileMatrixSet": [
+                {
+                    "TileMatrix": [],
+                    "ows:Identifier": "EPSG:4326",
+                    "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::900913"
+                }
+            ],
             "url": "http://sample.server/geoserver/gwc/service/wmts"
         };
         // create layers
@@ -214,7 +220,13 @@ describe('Leaflet layer', () => {
             "name": "nurc:Arc_Sample",
             "group": "Meteo",
             "format": "image/png",
-            "tileMatrixSet": "EPSG:900913",
+            "tileMatrixSet": [
+                {
+                    "TileMatrix": [],
+                    "ows:Identifier": "EPSG:900913",
+                    "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::900913"
+                }
+            ],
             "url": ["http://sample.server/geoserver/gwc/service/wmts", "http://sample.server/geoserver/gwc/service/wmts"]
         };
         // create layers

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -192,7 +192,7 @@ describe('Leaflet layer', () => {
             "tileMatrixSet": [
                 {
                     "TileMatrix": [],
-                    "ows:Identifier": "EPSG:4326",
+                    "ows:Identifier": "EPSG:900913",
                     "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::900913"
                 }
             ],

--- a/web/client/components/map/leaflet/plugins/WMTSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMTSLayer.js
@@ -13,7 +13,7 @@ const assign = require('object-assign');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const WMTSUtils = require('../../../../utils/WMTSUtils');
 const WMTS = require('../../../../utils/leaflet/WMTS');
-const {isArray, isObject} = require('lodash');
+const {isArray, isObject, head} = require('lodash');
 
 L.tileLayer.wmts = function(urls, options, matrixOptions) {
     return new WMTS(urls, options, matrixOptions);
@@ -54,7 +54,8 @@ Layers.registerType('wmts', {
             originY: options.originY || 20037508.3428,
             originX: options.originX || -20037508.3428,
             ignoreErrors: options.ignoreErrors || false,
-            matrixIds: options.matrixIds && getMatrixIds(options.matrixIds, queryParameters.tileMatrixSet || srs) || null
+            matrixIds: options.matrixIds && getMatrixIds(options.matrixIds, queryParameters.tileMatrixSet || srs) || null,
+            matrixSet: head(options.tileMatrixSet.filter(t => t['ows:Identifier'] === queryParameters.tileMatrixSet)) || null
         });
     }
 });

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -154,7 +154,13 @@ describe('Openlayers layer', () => {
             "name": "nurc:Arc_Sample",
             "group": "Meteo",
             "format": "image/png",
-            "tileMatrixSet": "EPSG:900913",
+            "tileMatrixSet": [
+                {
+                    "TileMatrix": [],
+                    "ows:Identifier": "EPSG:900913",
+                    "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::900913"
+                }
+            ],
             "url": "http://sample.server/geoserver/gwc/service/wmts"
         };
         // create layers
@@ -176,7 +182,13 @@ describe('Openlayers layer', () => {
             "name": "nurc:Arc_Sample",
             "group": "Meteo",
             "format": "image/png",
-            "tileMatrixSet": "EPSG:900913",
+            "tileMatrixSet": [
+                {
+                    "TileMatrix": [],
+                    "ows:Identifier": "EPSG:900913",
+                    "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::900913"
+                }
+            ],
             "url": ["http://sample.server/geoserver/gwc/service/wmts", "http://sample.server/geoserver/gwc/service/wmts"]
         };
         // create layers

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -8,7 +8,7 @@
 
 var Layers = require('../../../../utils/openlayers/Layers');
 var ol = require('openlayers');
-const {isArray} = require('lodash');
+const {isArray, head} = require('lodash');
 // const SecurityUtils = require('../../../../utils/SecurityUtils');
 const WMTSUtils = require('../../../../utils/WMTSUtils');
 const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
@@ -19,14 +19,45 @@ function getWMSURLs( urls ) {
     return urls.map((url) => url.split("\?")[0]);
 }
 
+const getTopLeftCorner = (str) => {
+    const coord = str.split(' ');
+    const lng = parseFloat(coord[0]);
+    const lat = parseFloat(coord[1]);
+    return !isNaN(lng) && !isNaN(lat) && {lng, lat} || null;
+};
+
 Layers.registerType('wmts', {
     create: (options) => {
         const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
         const srs = CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS);
-        const tileMatrixSet = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
-        const resolutions = options.resolutions || mapUtils.getResolutions();
-        const matrixIds = WMTSUtils.limitMatrix(options.matrixIds && WMTSUtils.getMatrixIds(options.matrixIds, tileMatrixSet || srs) || WMTSUtils.getDefaultMatrixId(options), resolutions.length);
+        const tilMatrixSetName = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
+        const tileMatrixSet = head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tilMatrixSetName));
+        const scales = tileMatrixSet.TileMatrix.map(t => t.ScaleDenominator);
+        const mapResolutions = mapUtils.getResolutions();
+        const matrixResolutions = options.resolutions || mapUtils.getResolutionsForScales(scales, srs, 96);
+        const resolutions = matrixResolutions && matrixResolutions.map(res => {
+            return head(mapResolutions.map((mRes, i) => {
+                if (i === mapResolutions.length - 1) {
+                    return null;
+                }
+                const isBetween = res <= mapResolutions[i] && res > mapResolutions[i + 1];
+                if (isBetween) {
+                    const delta = res - mapResolutions[i + 1];
+                    return delta > (mapResolutions[i] - mapResolutions[i + 1]) / 2 ? mapResolutions[i] : mapResolutions[i + 1];
+                }
+                return null;
+            }).filter(r => r)) || res;
+        }) || mapResolutions;
+        const matrixIds = WMTSUtils.limitMatrix(options.matrixIds && WMTSUtils.getMatrixIds(options.matrixIds, tilMatrixSetName || srs) || WMTSUtils.getDefaultMatrixId(options), resolutions.length);
+
         const extent = options.bbox ? ol.extent.applyTransform([parseFloat(options.bbox.bounds.minx), parseFloat(options.bbox.bounds.miny), parseFloat(options.bbox.bounds.maxx), parseFloat(options.bbox.bounds.maxy)], ol.proj.getTransform(options.bbox.crs, options.srs)) : null;
+
+        const origin = tileMatrixSet.TileMatrix && tileMatrixSet.TileMatrix[1] && tileMatrixSet.TileMatrix[1].TopLeftCorner && getTopLeftCorner(tileMatrixSet.TileMatrix[1].TopLeftCorner);
+
+        /* remove matrix 0, it doesn't happear correctly on map  */
+        const paramResolutions = resolutions.filter((r, i) => i > 0);
+        const paramMatrixIds = matrixIds.filter((r, i) => i > 0);
+
         // urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters));
         return new ol.layer.Tile({
             opacity: options.opacity !== undefined ? options.opacity : 1,
@@ -35,16 +66,16 @@ Layers.registerType('wmts', {
                 urls: urls,
                 layer: options.name,
                 version: options.version || "1.0.0",
-                matrixSet: tileMatrixSet,
+                matrixSet: tilMatrixSetName,
                 format: options.format || 'image/png',
                 tileGrid: new ol.tilegrid.WMTS({
                     origin: [
-                        options.originX || -20037508.3428,
-                        options.originY || 20037508.3428
+                        origin.lng || -20037508.3428,
+                        origin.lat || 20037508.3428
                     ],
                     extent: extent,
-                    resolutions: resolutions,
-                    matrixIds: matrixIds,
+                    resolutions: paramResolutions,
+                    matrixIds: paramMatrixIds,
                     tileSize: options.tileSize || [256, 256]
                 }),
                 style: options.style || '',

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -88,7 +88,7 @@ Layers.registerType('wmts', {
                 tileGrid: new ol.tilegrid.WMTS({
                     origin: [
                         origin.lng || origin.x || options.originX || -20037508.3428,
-                        origin.lat || origin.y || options.originX || 20037508.3428
+                        origin.lat || origin.y || options.originY || 20037508.3428
                     ],
                     extent: extent,
                     resolutions: paramResolutions,

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -79,6 +79,7 @@ Layers.registerType('wmts', {
         return new ol.layer.Tile({
             opacity: options.opacity !== undefined ? options.opacity : 1,
             zIndex: options.zIndex,
+            extent: extent,
             source: new ol.source.WMTS(assign({
                 urls: urls,
                 layer: options.name,

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -79,7 +79,7 @@ function layers(state = [], action) {
         case LAYER_ERROR: {
             const isError = action.tilesCount === action.tilesErrorCount;
             const newLayers = (state.flat || []).map((layer) => {
-                return layer.id === action.layerId ? assign({}, layer, {loadingError: isError ? 'Error' : 'Warning', visibility: !isError}) : layer;
+                return layer.id === action.layerId ? assign({}, layer, {loadingError: isError ? 'Error' : 'Warning'}) : layer;
             });
             return assign({}, state, {flat: newLayers});
         }

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -574,6 +574,24 @@ const CoordinatesUtils = {
             extent,
             center
         };
+    },
+    parseString: (str) => {
+        const coord = str.split(' ');
+        const x = parseFloat(coord[0]);
+        const y = parseFloat(coord[1]);
+        return !isNaN(x) && !isNaN(y) && {x, y} || null;
+    },
+    getWMSBoundingBox: (BoundingBox, mapSRS) => {
+        const SRS = mapSRS || 'EPSG:3857';
+        const bbox = BoundingBox && isArray(BoundingBox) && head(BoundingBox.filter(b => {
+            return b && b.$ && b.$.SRS === SRS && b.$.maxx && b.$.maxy && b.$.minx && b.$.miny;
+        }).map(b => b && b.$ && CoordinatesUtils.reprojectBbox([
+            parseFloat(b.$.minx),
+            parseFloat(b.$.miny),
+            parseFloat(b.$.maxx),
+            parseFloat(b.$.maxy)
+        ], SRS, 'EPSG:4326')));
+        return isArray(bbox) && {minx: bbox[0], miny: bbox[1], maxx: bbox[2], maxy: bbox[3]} || null;
     }
 };
 

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -400,4 +400,45 @@ describe('CoordinatesUtils', () => {
         });
     });
 
+    it('test parseString number', () => {
+        expect(CoordinatesUtils.parseString("10000 500000")).toEqual({x: 10000, y: 500000});
+    });
+
+    it('test parseString char', () => {
+        expect(CoordinatesUtils.parseString("AAA00 500000")).toBe(null);
+    });
+
+    it('test getWMSBoundingBox no data', () => {
+        expect(CoordinatesUtils.getWMSBoundingBox([])).toBe(null);
+        expect(CoordinatesUtils.getWMSBoundingBox()).toBe(null);
+    });
+
+    it('test getWMSBoundingBox', () => {
+        expect(CoordinatesUtils.getWMSBoundingBox([
+            {
+                $: {
+                    SRS: 'EPSG:3857',
+                    maxx: "1271911.7584765626",
+                    maxy: "5459438.758476563",
+                    minx: "1232776.0",
+                    miny: "5420303.0"
+                }
+            },
+            {
+                $: {
+                    SRS: 'EPSG:4326',
+                    minx: "-180",
+                    miny: "-90",
+                    maxx: "180",
+                    maxy: "90"
+                }
+            }
+        ])).toEqual({
+            minx: 11.074215226957271,
+            miny: 43.70759642778742,
+            maxx: 11.425777726908334,
+            maxy: 43.96119355022118
+        });
+    });
+
 });

--- a/web/client/utils/leaflet/WMTS.js
+++ b/web/client/utils/leaflet/WMTS.js
@@ -82,8 +82,8 @@ var WMTS = L.TileLayer.extend({
         const X0 = topLeftCorner.lng || topLeftCorner.x;
         const Y0 = topLeftCorner.lat || topLeftCorner.y;
 
-        const tilecol = Math.floor((nw.x - X0) / tilewidth);
-        const tilerow = -Math.floor((nw.y - Y0) / tilewidth);
+        const tilecol = Math.round((nw.x - X0) / tilewidth);
+        const tilerow = -Math.round((nw.y - Y0) / tilewidth);
 
         const matrixRanges = matrix.data && matrix.data.MatrixWidth && matrix.data.MatrixHeight && {
             cols: {

--- a/web/client/utils/leaflet/WMTS.js
+++ b/web/client/utils/leaflet/WMTS.js
@@ -85,7 +85,7 @@ var WMTS = L.TileLayer.extend({
         const tilecol = Math.floor((nw.x - X0) / tilewidth);
         const tilerow = -Math.floor((nw.y - Y0) / tilewidth);
 
-        const ranges = matrix.data && matrix.data.MatrixWidth && matrix.data.MatrixHeight ? {
+        const matrixRanges = matrix.data && matrix.data.MatrixWidth && matrix.data.MatrixHeight && {
             cols: {
                 min: 0,
                 max: matrix.data.MatrixWidth - 1
@@ -94,7 +94,9 @@ var WMTS = L.TileLayer.extend({
                 min: 0,
                 max: matrix.data.MatrixHeight - 1
             }
-        } : matrixIds[id].ranges;
+        };
+
+        const ranges = matrixIds[id].ranges || matrixRanges;
 
         if (ranges) {
             if (!isInRange(tilecol, tilerow, ranges)) {

--- a/web/client/utils/leaflet/WMTS.js
+++ b/web/client/utils/leaflet/WMTS.js
@@ -7,7 +7,18 @@
  */
 const L = require('leaflet');
 const MapUtils = require('../MapUtils');
+const CoordinatesUtils = require('../CoordinatesUtils');
 const {head, isNumber} = require('lodash');
+
+const isInRange = function(col, row, ranges) {
+    if (col < ranges.cols.min || col > ranges.cols.max) {
+        return false;
+    }
+    if (row < ranges.rows.min || row > ranges.rows.max) {
+        return false;
+    }
+    return true;
+};
 
 var WMTS = L.TileLayer.extend({
     defaultWmtsParams: {
@@ -42,60 +53,34 @@ var WMTS = L.TileLayer.extend({
         this.ignoreErrors = matrixOptions.ignoreErrors || false;
         L.setOptions(this, options);
     },
-    isInRange: function(col, row, ranges) {
-        if (col < ranges.cols.min || col > ranges.cols.max) {
-            return false;
-        }
-        if (row < ranges.rows.min || row > ranges.rows.max) {
-            return false;
-        }
-        return true;
-    },
-    getTopLeftCorner: (str) => {
-        const coord = str.split(' ');
-        const lng = parseFloat(coord[0]);
-        const lat = parseFloat(coord[1]);
-        return !isNaN(lng) && !isNaN(lat) && {lng, lat} || null;
-    },
-    getTileUrl: function(tilePoint) { // (Point, Number) -> String
-        let map = this._map;
-        let crs = map.options.crs;
-        let tileSize = this.options.tileSize;
-        let nwPoint = tilePoint.multiplyBy(tileSize);
-        nwPoint.x += 1;
-        nwPoint.y -= 1;
-        let sePoint = nwPoint.add([tileSize, tileSize]);
-        let nw = crs.project(map.unproject(nwPoint, tilePoint.z));
-        let se = crs.project(map.unproject(sePoint, tilePoint.z));
-        let tilewidth = se.x - nw.x;
+    getWMTSParams: (matrixSet, matrixIds, zoom, nw, tilewidth) => {
+        const currentScale = MapUtils.getScales()[zoom];
 
-        const currentScale = MapUtils.getScales()[map.getZoom()];
-
-        const matrix = head(this.matrixSet.map((s, i) => {
-            if (i === this.matrixSet.length - 1) {
+        const matrix = head(matrixSet.map((s, i) => {
+            if (i === matrixSet.length - 1) {
                 return null;
             }
             const top = parseFloat(s.ScaleDenominator);
-            const bottom = parseFloat(this.matrixSet[i + 1].ScaleDenominator);
+            const bottom = parseFloat(matrixSet[i + 1].ScaleDenominator);
             const isBetween = top >= currentScale && bottom < currentScale;
             if (isBetween) {
                 const delta = currentScale - bottom;
-                return delta > (top - bottom) / 2 ? {id: i, data: s} : {id: i + 1, data: this.matrixSet[i + 1]};
+                return delta > (top - bottom) / 2 ? {id: i, data: s} : {id: i + 1, data: matrixSet[i + 1]};
             }
             return null;
         }).filter(v => v));
 
-        const id = matrix && isNumber(matrix.id) && matrix.id + '' || this.matrixSet.length === 0 && map.getZoom() || null;
+        const id = matrix && isNumber(matrix.id) && matrix.id + '' || matrixSet.length === 0 && zoom || null;
 
-        if (!this.matrixIds[id]) {
-            return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        if (!matrixIds[id]) {
+            return null;
         }
 
-        const ident = this.matrixIds[id].identifier;
-        const topLeftCorner = matrix.data && matrix.data.TopLeftCorner && this.getTopLeftCorner(matrix.data.TopLeftCorner) || this.matrixIds[id].topLeftCorner;
+        const ident = matrixIds[id].identifier;
+        const topLeftCorner = matrix.data && matrix.data.TopLeftCorner && CoordinatesUtils.parseString(matrix.data.TopLeftCorner) || matrixIds[id].topLeftCorner;
 
-        const X0 = topLeftCorner.lng;
-        const Y0 = topLeftCorner.lat;
+        const X0 = topLeftCorner.lng || topLeftCorner.x;
+        const Y0 = topLeftCorner.lat || topLeftCorner.y;
 
         const tilecol = Math.floor((nw.x - X0) / tilewidth);
         const tilerow = -Math.floor((nw.y - Y0) / tilewidth);
@@ -109,19 +94,40 @@ var WMTS = L.TileLayer.extend({
                 min: 0,
                 max: matrix.data.MatrixHeight - 1
             }
-        } : this.matrixIds[id].ranges;
+        } : matrixIds[id].ranges;
 
         if (ranges) {
-            if (!this.isInRange(tilecol, tilerow, ranges)) {
-                return "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+            if (!isInRange(tilecol, tilerow, ranges)) {
+                return null;
             }
         }
+
+        return {ident, tilecol, tilerow};
+    },
+    getTileUrl: function(tilePoint) { // (Point, Number) -> String
+        let map = this._map;
+        let crs = map.options.crs;
+        let tileSize = this.options.tileSize;
+        let nwPoint = tilePoint.multiplyBy(tileSize);
+        nwPoint.x += 1;
+        nwPoint.y -= 1;
+        let sePoint = nwPoint.add([tileSize, tileSize]);
+        let nw = crs.project(map.unproject(nwPoint, tilePoint.z));
+        let se = crs.project(map.unproject(sePoint, tilePoint.z));
+        let tilewidth = se.x - nw.x;
+
+        const params = this.getWMTSParams([...this.matrixSet], [...this.matrixIds], map.getZoom(), nw, tilewidth);
+
+        if (!params) {
+            return "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+        }
+
         this._urlsIndex++;
         if (this._urlsIndex === this._urls.length) {
             this._urlsIndex = 0;
         }
         const url = L.Util.template(this._urls[this._urlsIndex], {s: this._getSubdomain(tilePoint)});
-        return url + L.Util.getParamString(this.wmtsParams, url, true) + "&tilematrix=" + ident + "&tilerow=" + tilerow + "&tilecol=" + tilecol;
+        return url + L.Util.getParamString(this.wmtsParams, url, true) + "&tilematrix=" + params.ident + "&tilerow=" + params.tilerow + "&tilecol=" + params.tilecol;
     },
     getMatrix: function(matrix, options) {
         return matrix.map((el) => {

--- a/web/client/utils/leaflet/test/WMTS-test.js
+++ b/web/client/utils/leaflet/test/WMTS-test.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const WMTS = require('../WMTS');
+
+describe('Test the leaflet WMTS utils', () => {
+    afterEach((done) => {
+        document.body.innerHTML = '';
+
+        setTimeout(done);
+    });
+    it('test getWMTSParams', () => {
+        const matrixSet = [{
+            MatrixHeight: "1",
+            MatrixWidth: "1",
+            ScaleDenominator: "545978.7733895439",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:0"
+        }, {
+            MatrixHeight: "10",
+            MatrixWidth: "10",
+            ScaleDenominator: "272989.38669477194",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:1"
+        }, {
+            MatrixHeight: "2",
+            MatrixWidth: "4",
+            ScaleDenominator: "136494.69334738597",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:2"
+        }];
+        const matrixIds = [{
+            identifier: "SPHMERC_900913_CoFi:0",
+            ranges: null,
+            topLeftCorner: {lat: 20037508.3428, lng: -20037508.3428}
+        }, {
+            identifier: "SPHMERC_900913_CoFi:1",
+            ranges: null,
+            topLeftCorner: {lat: 20037508.3428, lng: -20037508.3428}
+        }, {
+            identifier: "SPHMERC_900913_CoFi:2",
+            ranges: null,
+            topLeftCorner: {lat: 20037508.3428, lng: -20037508.3428}
+        }];
+        const zoom = 11;
+        const nw = {x: 1252363.3806813988, y: 5434997.568446243};
+        const tilewidth = 4891.969810251379;
+        const layer = new WMTS('http', {}, {
+            tileMatrixPrefix: "SPHMERC_900913_CoFi:",
+            originY: 20037508.3428,
+            originX: -20037508.3428,
+            ignoreErrors: false,
+            matrixIds,
+            matrixSet: null
+        });
+        const params = layer.getWMTSParams(matrixSet, matrixIds, zoom, nw, tilewidth);
+
+        expect(params).toEqual({ ident: 'SPHMERC_900913_CoFi:1', tilecol: 4, tilerow: 1 });
+    });
+
+    it('test getWMTSParams no tile range', () => {
+        const matrixSet = [{
+            MatrixHeight: "1",
+            MatrixWidth: "1",
+            ScaleDenominator: "545978.7733895439",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:0"
+        }, {
+            MatrixHeight: "1",
+            MatrixWidth: "2",
+            ScaleDenominator: "272989.38669477194",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:1"
+        }, {
+            MatrixHeight: "2",
+            MatrixWidth: "4",
+            ScaleDenominator: "136494.69334738597",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:2"
+        }];
+        const matrixIds = [{
+            identifier: "SPHMERC_900913_CoFi:0",
+            ranges: null,
+            topLeftCorner: {lat: 20037508.3428, lng: -20037508.3428}
+        }, {
+            identifier: "SPHMERC_900913_CoFi:1",
+            ranges: null,
+            topLeftCorner: {lat: 20037508.3428, lng: -20037508.3428}
+        }, {
+            identifier: "SPHMERC_900913_CoFi:2",
+            ranges: null,
+            topLeftCorner: {lat: 20037508.3428, lng: -20037508.3428}
+        }];
+        const zoom = 11;
+        const nw = {x: 1252363.3806813988, y: 5434997.568446243};
+        const tilewidth = 4891.969810251379;
+        const layer = new WMTS('http', {}, {
+            tileMatrixPrefix: "SPHMERC_900913_CoFi:",
+            originY: 20037508.3428,
+            originX: -20037508.3428,
+            ignoreErrors: false,
+            matrixIds,
+            matrixSet: null
+        });
+        const params = layer.getWMTSParams(matrixSet, matrixIds, zoom, nw, tilewidth);
+
+        expect(params).toBe(null);
+    });
+
+    it('test getWMTSParams no ids', () => {
+        const matrixSet = [{
+            MatrixHeight: "1",
+            MatrixWidth: "1",
+            ScaleDenominator: "545978.7733895439",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:0"
+        }, {
+            MatrixHeight: "1",
+            MatrixWidth: "2",
+            ScaleDenominator: "272989.38669477194",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:1"
+        }, {
+            MatrixHeight: "2",
+            MatrixWidth: "4",
+            ScaleDenominator: "136494.69334738597",
+            TileHeight: "256",
+            TileWidth: "256",
+            TopLeftCorner: "1232776.0 5439871.0",
+            "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+            "ows:Identifier": "SPHMERC_900913_CoFi:2"
+        }];
+        const matrixIds = [];
+        const zoom = 11;
+        const nw = {x: 1252363.3806813988, y: 5434997.568446243};
+        const tilewidth = 4891.969810251379;
+        const layer = new WMTS('http', {}, {
+            tileMatrixPrefix: "SPHMERC_900913_CoFi:",
+            originY: 20037508.3428,
+            originX: -20037508.3428,
+            ignoreErrors: false,
+            matrixIds,
+            matrixSet: null
+        });
+        const params = layer.getWMTSParams(matrixSet, matrixIds, zoom, nw, tilewidth);
+
+        expect(params).toBe(null);
+    });
+});


### PR DESCRIPTION
## Description
Now custom gridset are loaded an displayed at the right dimension.
About tasmania_test:
I tried this fix with another custom grid set and the world grid set and it works with both (right position and size).
I noticed also an issue with the same layer in WMS (tasmania_test).
Could it be that the gridset isn't configured correctly?
Could it be that on high scale denominator there's a loss of precision in the gridset pyramid?
- About last question I noticed that at small scale denominator the precision increases.

## Issues
 - Fix #2322
 - Fix #2342 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
Cutsom WMTS grids are displayed world wide.
#2322
#2342 

**What is the new behavior?**
Cutsom WMTS grids are displayed at the correct position.
Try to reload layers with errors on zoom.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
