### PR TITLE
Fixes #2315: check if point is null on Identify and avoids exception

### DIFF
--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -262,11 +262,12 @@ class Identify extends React.Component {
 
     needsRefresh = (props) => {
         if (props.enabled && props.point && props.point.pixel) {
-            if (!this.props.point.pixel || this.props.point.pixel.x !== props.point.pixel.x ||
-                    this.props.point.pixel.y !== props.point.pixel.y ) {
+            if (!this.props.point || !this.props.point.pixel ||
+                this.props.point.pixel.x !== props.point.pixel.x ||
+                this.props.point.pixel.y !== props.point.pixel.y ) {
                 return true;
             }
-            if (!this.props.point.pixel || props.point.pixel && this.props.format !== props.format) {
+            if (!this.props.point || !this.props.point.pixel || props.point.pixel && this.props.format !== props.format) {
                 return true;
             }
         }

--- a/web/client/components/data/identify/__tests__/Identify-test.jsx
+++ b/web/client/components/data/identify/__tests__/Identify-test.jsx
@@ -397,4 +397,13 @@ describe('Identify', () => {
         expect(params.WMS_OPTION).toBe(true);
 
     });
+
+    it('test need refresh with null point', () => {
+        const identify = ReactDOM.render(
+            <Identify point={null}/>,
+            document.getElementById("container")
+        );
+        expect(identify).toExist();
+        expect(identify.needsRefresh({ enabled: true, point: { pixel: {x: 0, y: 0}}})).toBe(true);
+    });
 });


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #2315

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
if point is null Identify throws an exception

**What is the new behavior?**
if point is null Identify does not throw an exception

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
