### PR TITLE
Fixes #2317: custom css class for annotations cards

### DIFF
--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -52,6 +52,8 @@ const defaultConfig = require('./AnnotationsConfig');
  * @prop {function} onCleanHighlight triggered when the mouse is out of any annotation card
  * @prop {function} onDetail triggered when the user clicks on an annotation card
  * @prop {function} onFilter triggered when the user enters some text in the filtering widget
+ * @prop {function} classNameSelector optional selector to assign custom a CSS class to annotations, based on
+ * the annotation's attributes.
  */
 class Annotations extends React.Component {
     static propTypes = {
@@ -72,7 +74,8 @@ class Annotations extends React.Component {
         current: PropTypes.string,
         config: PropTypes.object,
         filter: PropTypes.string,
-        onFilter: PropTypes.func
+        onFilter: PropTypes.func,
+        classNameSelector: PropTypes.func
     };
 
     static contextTypes = {
@@ -81,7 +84,8 @@ class Annotations extends React.Component {
 
     static defaultProps = {
         mode: 'list',
-        config: defaultConfig
+        config: defaultConfig,
+        classNameSelector: () => ''
     };
 
     getConfig = () => {
@@ -112,7 +116,7 @@ class Annotations extends React.Component {
     };
 
     renderCard = (annotation) => {
-        return (<div className="mapstore-annotations-panel-card" onMouseOver={() => this.props.onHighlight(annotation.properties.id)} onMouseOut={this.props.onCleanHighlight} onClick={() => this.props.onDetail(annotation.properties.id)}>
+        return (<div className={"mapstore-annotations-panel-card " + this.props.classNameSelector(annotation)} onMouseOver={() => this.props.onHighlight(annotation.properties.id)} onMouseOut={this.props.onCleanHighlight} onClick={() => this.props.onDetail(annotation.properties.id)}>
             <span className="mapstore-annotations-panel-card-thumbnail">{this.renderThumbnail(annotation.style)}</span>
             {this.getConfig().fields.map(f => this.renderField(f, annotation))}
         </div>);

--- a/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.jsx
+++ b/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.jsx
@@ -186,4 +186,44 @@ describe("test the Annotations Panel", () => {
         expect(TestUtils.scryRenderedDOMComponentsWithClass(annotations, "mapstore-annotations-panel-card").length).toBe(0);
         expect(TestUtils.scryRenderedDOMComponentsWithClass(annotations, "myeditor").length).toBe(1);
     });
+
+    it('test rendering custom class', () => {
+        const annotationsList = [{
+            properties: {
+                title: 'a',
+                description: 'b'
+            },
+            style: {
+                iconShape: 'square',
+                iconColor: 'blue'
+            }
+        }, {
+            properties: {
+                external: true,
+                title: 'c',
+                description: 'd'
+            },
+            style: {
+                iconShape: 'square',
+                iconColor: 'blue'
+            }
+        }];
+
+        const classNameSelector = (annotation) => {
+            if (annotation && annotation.properties && annotation.properties.external) {
+                return 'external';
+            }
+            return '';
+        };
+
+        const annotations = ReactDOM.render(<Annotations mode="list" classNameSelector={classNameSelector} annotations={annotationsList} />, document.getElementById("container"));
+
+        expect(annotations).toExist();
+
+        const cards = TestUtils.scryRenderedDOMComponentsWithClass(annotations, "mapstore-annotations-panel-card");
+        expect(cards.length).toBe(2);
+
+        const cardsExternal = TestUtils.scryRenderedDOMComponentsWithClass(annotations, "mapstore-annotations-panel-card external");
+        expect(cardsExternal.length).toBe(1);
+    });
 });


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #2317

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
All annotations cards have the same css classes

**What is the new behavior?**
It is possible to define (through a selector) by annotation css class(es)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
