### PR TITLE
Fix #2369 correct parsing of url fetched from GS removing authkey param

### DIFF
--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -177,7 +177,7 @@ describe('Test correctness of the catalog actions', () => {
                 expect(action.newProperties).toExist();
                 expect(action.newProperties.search).toExist();
                 expect(action.newProperties.search.type).toBe('wfs');
-                expect(action.newProperties.search.url).toBe("http://some.geoserver.org:80/geoserver/wfs?");
+                expect(action.newProperties.search.url).toBe("http://some.geoserver.org:80/geoserver/wfs");
                 done();
             }
         };

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -15,7 +15,9 @@ var API = {
 const {addLayer, changeLayerProperties} = require('./layers');
 
 const LayersUtils = require('../utils/LayersUtils');
+const ConfigUtils = require('../utils/ConfigUtils');
 const {find} = require('lodash');
+const {authkeyParamNameSelector} = require('../selectors/catalog');
 
 const RECORD_LIST_LOADED = 'CATALOG:RECORD_LIST_LOADED';
 const RESET_CATALOG = 'CATALOG:RESET_CATALOG';
@@ -178,6 +180,7 @@ function describeError(layer, error) {
         error
     };
 }
+
 function addLayerAndDescribe(layer) {
     return (dispatch, getState) => {
         const state = getState();
@@ -190,9 +193,10 @@ function addLayerAndDescribe(layer) {
                 if (results) {
                     let description = find(results, (desc) => desc.name === layer.name );
                     if (description && description.owsType === 'WFS') {
+                        const filteredUrl = ConfigUtils.filterUrlParams(ConfigUtils.normalizeUrl(description.owsURL), authkeyParamNameSelector(state));
                         dispatch(changeLayerProperties(id, {
                             search: {
-                                url: description.owsURL,
+                                url: filteredUrl,
                                 type: 'wfs'
                             }
                         }));

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -193,7 +193,7 @@ function addLayerAndDescribe(layer) {
                 if (results) {
                     let description = find(results, (desc) => desc.name === layer.name );
                     if (description && description.owsType === 'WFS') {
-                        const filteredUrl = ConfigUtils.filterUrlParams(ConfigUtils.normalizeUrl(description.owsURL), authkeyParamNameSelector(state));
+                        const filteredUrl = ConfigUtils.filterUrlParams(ConfigUtils.cleanDuplicatedQuestionMarks(description.owsURL), authkeyParamNameSelector(state));
                         dispatch(changeLayerProperties(id, {
                             search: {
                                 url: filteredUrl,

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -10,6 +10,7 @@ const axios = require('../libs/ajax');
 const _ = require('lodash');
 
 const urlUtil = require('url');
+const ConfigUtils = require('../utils/ConfigUtils');
 const assign = require('object-assign');
 
 const parseUrl = (url) => {
@@ -98,12 +99,12 @@ var Api = {
                                                 let dcel = dcElement[j];
                                                 let elName = dcel.name.localPart;
                                                 let finalEl = {};
-                                                /* Some services (e.g. GeoServer ) support http://schemas.opengis.net/csw/2.0.2/record.xsd only
+                                                /* Some services (e.g. GeoServer) support http://schemas.opengis.net/csw/2.0.2/record.xsd only
                                                 * Usually they publish the WMS URL at dct:"references" with scheme=OGC:WMS
                                                 * So we place references as they are.
                                                 */
                                                 if (elName === "references" && dcel.value) {
-                                                    let urlString = dcel.value.content && dcel.value.content[0] || dcel.value.content || dcel.value;
+                                                    let urlString = dcel.value.content && ConfigUtils.normalizeUrl(dcel.value.content[0]) || dcel.value.content || dcel.value;
                                                     finalEl = {
                                                         value: urlString,
                                                         scheme: dcel.value.scheme

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -104,7 +104,7 @@ var Api = {
                                                 * So we place references as they are.
                                                 */
                                                 if (elName === "references" && dcel.value) {
-                                                    let urlString = dcel.value.content && ConfigUtils.normalizeUrl(dcel.value.content[0]) || dcel.value.content || dcel.value;
+                                                    let urlString = dcel.value.content && ConfigUtils.cleanDuplicatedQuestionMarks(dcel.value.content[0]) || dcel.value.content || dcel.value;
                                                     finalEl = {
                                                         value: urlString,
                                                         scheme: dcel.value.scheme

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -50,6 +50,7 @@ class Catalog extends React.Component {
         onZoomToExtent: PropTypes.func,
         pageSize: PropTypes.number,
         records: PropTypes.array,
+        authkeyParamNames: PropTypes.array,
         recordItem: PropTypes.element,
         result: PropTypes.object,
         saving: PropTypes.bool,
@@ -203,6 +204,7 @@ class Catalog extends React.Component {
         return (<div className="catalog-results">
                 <RecordGrid {...this.props.gridOptions} key="records"
                     records={this.props.records}
+                    authkeyParamNames={this.props.authkeyParamNames}
                     catalogURL={this.isValidServiceSelected() && this.props.services[this.props.selectedService].url || ""}
                     onLayerAdd={this.props.onLayerAdd}
                     onZoomToExtent={this.props.onZoomToExtent}

--- a/web/client/components/catalog/RecordGrid.jsx
+++ b/web/client/components/catalog/RecordGrid.jsx
@@ -22,6 +22,7 @@ class RecordGrid extends React.Component {
         onLayerAdd: PropTypes.func,
         onError: PropTypes.func,
         records: PropTypes.array,
+        authkeyParamNames: PropTypes.array,
         style: PropTypes.object,
         showGetCapLinks: PropTypes.bool,
         addAuthentication: PropTypes.bool,
@@ -49,6 +50,7 @@ class RecordGrid extends React.Component {
                     onError={this.props.onError}
                     catalogURL={this.props.catalogURL}
                     record={record}
+                    authkeyParamNames={this.props.authkeyParamNames}
                     style={{height: "215px", maxHeight: "215px"}}
                     showGetCapLinks={this.props.showGetCapLinks}
                     addAuthentication={this.props.addAuthentication}

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -14,6 +14,7 @@ const {head, memoize, isObject} = require('lodash');
 const assign = require('object-assign');
 
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
+const ConfigUtils = require('../../utils/ConfigUtils');
 
 const defaultThumb = require('./img/default.jpg');
 
@@ -51,6 +52,7 @@ class RecordItem extends React.Component {
         onLayerAdd: PropTypes.func,
         onZoomToExtent: PropTypes.func,
         record: PropTypes.object,
+        authkeyParamNames: PropTypes.array,
         showGetCapLinks: PropTypes.bool,
         zoomToLayer: PropTypes.bool
     };
@@ -211,7 +213,7 @@ class RecordItem extends React.Component {
     };
 
     addLayer = (wms) => {
-        const {url, params} = removeParameters(wms.url, ["request", "layer", "service", "version"]);
+        const {url, params} = removeParameters(ConfigUtils.normalizeUrl(wms.url), ["request", "layer", "service", "version"].concat(this.props.authkeyParamNames));
         const allowedSRS = buildSRSMap(wms.SRS);
         if (wms.SRS.length > 0 && !CoordinatesUtils.isAllowedSRS(this.props.crs, allowedSRS)) {
             this.props.onError('catalog.srs_not_allowed');
@@ -245,7 +247,7 @@ class RecordItem extends React.Component {
     };
 
     addwmtsLayer = (wmts) => {
-        const {url, params} = removeParameters(wmts.url, ["request", "layer"]);
+        const {url, params} = removeParameters(ConfigUtils.normalizeUrl(wmts.url), ["request", "layer"].concat(this.props.authkeyParamNames));
         const allowedSRS = buildSRSMap(wmts.SRS);
         if (wmts.SRS.length > 0 && !CoordinatesUtils.isAllowedSRS(this.props.crs, allowedSRS)) {
             this.props.onError('catalog.srs_not_allowed');

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -213,7 +213,7 @@ class RecordItem extends React.Component {
     };
 
     addLayer = (wms) => {
-        const {url, params} = removeParameters(ConfigUtils.normalizeUrl(wms.url), ["request", "layer", "service", "version"].concat(this.props.authkeyParamNames));
+        const {url, params} = removeParameters(ConfigUtils.cleanDuplicatedQuestionMarks(wms.url), ["request", "layer", "service", "version"].concat(this.props.authkeyParamNames));
         const allowedSRS = buildSRSMap(wms.SRS);
         if (wms.SRS.length > 0 && !CoordinatesUtils.isAllowedSRS(this.props.crs, allowedSRS)) {
             this.props.onError('catalog.srs_not_allowed');
@@ -247,7 +247,7 @@ class RecordItem extends React.Component {
     };
 
     addwmtsLayer = (wmts) => {
-        const {url, params} = removeParameters(ConfigUtils.normalizeUrl(wmts.url), ["request", "layer"].concat(this.props.authkeyParamNames));
+        const {url, params} = removeParameters(ConfigUtils.cleanDuplicatedQuestionMarks(wmts.url), ["request", "layer"].concat(this.props.authkeyParamNames));
         const allowedSRS = buildSRSMap(wmts.SRS);
         if (wmts.SRS.length > 0 && !CoordinatesUtils.isAllowedSRS(this.props.crs, allowedSRS)) {
             this.props.onError('catalog.srs_not_allowed');

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -221,7 +221,7 @@ const featureTypeSelectedEpic = (action$, store) =>
                     return Rx.Observable.from([featureTypeError(action.typeName, 'Error: feature types are empty')]);
                 })
                 .mergeAll()
-                .catch(e => Rx.Observable.of(featureTypeError(action.typeName, e.message)));
+                .catch(e => Rx.Observable.of(featureTypeError(action.typeName, e.message || e.statusText)));
         });
 
 /**

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -25,7 +25,7 @@ const {setControlProperty, toggleControl} = require("../actions/controls");
 const {resultSelector, serviceListOpenSelector, newServiceSelector,
     newServiceTypeSelector, selectedServiceTypeSelector, searchOptionsSelector,
     servicesSelector, formatsSelector, loadingErrorSelector, selectedServiceSelector,
-    modeSelector, layerErrorSelector, activeSelector, savingSelector
+    modeSelector, layerErrorSelector, activeSelector, savingSelector, authkeyParamNameSelector
 } = require("../selectors/catalog");
 const Message = require("../components/I18N/Message");
 require('./metadataexplorer/css/style.css');
@@ -33,6 +33,7 @@ require('./metadataexplorer/css/style.css');
 const CatalogUtils = require('../utils/CatalogUtils');
 
 const catalogSelector = createSelector([
+    (state) => authkeyParamNameSelector(state),
     (state) => resultSelector(state),
     (state) => savingSelector(state),
     (state) => serviceListOpenSelector(state),
@@ -41,7 +42,8 @@ const catalogSelector = createSelector([
     (state) => selectedServiceTypeSelector(state),
     (state) => searchOptionsSelector(state),
     (state) => currentLocaleSelector(state)
-], (result, saving, openCatalogServiceList, newService, newformat, selectedFormat, options, currentLocale) =>({
+], (authkeyParamNames, result, saving, openCatalogServiceList, newService, newformat, selectedFormat, options, currentLocale) =>({
+    authkeyParamNames,
     saving,
     openCatalogServiceList,
     format: newformat,

--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -20,7 +20,8 @@ const {
     selectedServiceSelector,
     modeSelector,
     layerErrorSelector,
-    activeSelector
+    activeSelector,
+    authkeyParamNameSelector
 } = require("../catalog");
 const url = "https://demo.geo-solutions.it/geoserver/wms";
 const state = {
@@ -68,6 +69,13 @@ const state = {
             maxRecords: 4,
             text: ''
         }
+    },
+    localConfig: {
+        authenticationRules: [{
+        "urlPattern": "\\/geoserver.*",
+        "authkeyParamName": "ms2-authkey",
+        "method": "authkey"
+      }]
     }
 };
 
@@ -135,6 +143,17 @@ describe('Test catalog selectors', () => {
         const retVal = activeSelector(state);
         expect(retVal).toExist();
         expect(retVal).toBeTruthy();
+    });
+    it('test authkeyParamNameSelector with authkey params set', () => {
+        const authkeyParamNames = authkeyParamNameSelector(state);
+        expect(authkeyParamNames).toExist();
+        expect(authkeyParamNames.length).toBe(1);
+        expect(authkeyParamNames[0]).toBe("ms2-authkey");
+    });
+    it('test authkeyParamNameSelector without authkey params set', () => {
+        const authkeyParamNames = authkeyParamNameSelector({});
+        expect(authkeyParamNames).toExist();
+        expect(authkeyParamNames.length).toBe(0);
     });
 
 });

--- a/web/client/selectors/__tests__/query-test.js
+++ b/web/client/selectors/__tests__/query-test.js
@@ -347,6 +347,22 @@ describe('Test query selectors', () => {
         const isLoaded = isDescribeLoaded(initialState, "editing:polygons");
         expect(isLoaded).toBe(true);
     });
+    it('test isDescribeLoaded with missing describe', () => {
+        const isLoaded = isDescribeLoaded(initialState, "editing:polygosns");
+        expect(isLoaded).toBe(false);
+    });
+    it('test isDescribeLoaded with error in describe', () => {
+        const isLoaded = isDescribeLoaded({
+            query: {
+                featureTypes: {
+                    "editing:polygons": {
+                        error: "500 internal server error"
+                    }
+                }
+            }
+        }, "editing:polygons");
+        expect(isLoaded).toBe(false);
+    });
     it('test getFeatureById selector', () => {
         const ft = getFeatureById(initialState, "poligoni.7");
         expect(ft).toExist();

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -14,5 +14,8 @@ module.exports = {
     selectedServiceSelector: (state) => get(state, "catalog.selectedService"),
     modeSelector: (state) => get(state, "catalog.mode", "view"),
     layerErrorSelector: (state) => get(state, "catalog.layerError"),
-    activeSelector: (state) => get(state, "controls.toolbar.active") === "metadataexplorer" || get(state, "controls.metadataexplorer.enabled")
+    activeSelector: (state) => get(state, "controls.toolbar.active") === "metadataexplorer" || get(state, "controls.metadataexplorer.enabled"),
+    authkeyParamNameSelector: (state) => {
+        return (get(state, "localConfig.authenticationRules") || []).filter(a => a.method === "authkey").map(r => r.authkeyParamName) || [];
+    }
 };

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -17,7 +17,13 @@ module.exports = {
         resultSize: (state) =>get(state, "query.result.features.length"),
         totalFeatures: (state) => get(state, "query.result.totalFeatures")
     },
-    isDescribeLoaded: (state, name) => !!get(state, `query.featureTypes.${name}`),
+    isDescribeLoaded: (state, name) => {
+        const ft = get(state, `query.featureTypes.${name}`);
+        if (ft && ft.attributes && ft.geometry && ft.original) {
+            return true;
+        }
+        return false;
+    },
     describeSelector: (state) => get(state, `query.featureTypes.${get(state, "query.filterObj.featureTypeName")}.original`),
     featureLoadingSelector: (state) => get(state, "query.featureLoading"),
     isSyncWmsActive: (state) => get(state, "query.syncWmsFilter", false)

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -10,7 +10,7 @@ const PropTypes = require('prop-types');
 var url = require('url');
 
 var axios = require('axios');
-const {isArray, isObject, endsWith} = require('lodash');
+const {isArray, isObject, endsWith, isNil} = require('lodash');
 const assign = require('object-assign');
 const {Promise} = require('es6-promise');
 
@@ -50,6 +50,38 @@ const getConfigurationOptions = function(query, defaultName, extension, geoStore
     };
 };
 
+/**
+ * it removes some params from the query string
+ * return the shrinked url
+*/
+const removeParameters = (urlToFilter, skip) => {
+    const urlparts = urlToFilter.split('?');
+    let paramsFiltered = "";
+    if (urlparts.length >= 2 && urlparts[1]) {
+        const pars = urlparts[1].split(/[&;]/g).filter( p => !!p);
+        pars.forEach((par, i) => {
+            const param = par.split('=');
+            if (skip.indexOf(param[0].toLowerCase()) === -1) {
+                let addAnd = i === (pars.length - 1) ? "" : "&";
+                paramsFiltered += param.join("=") + addAnd;
+            }
+        });
+    }
+    return !!paramsFiltered ? urlparts[0] + "?" + paramsFiltered : urlparts[0];
+};
+/**
+ * WORKAROUND: it removes the extra ? when the authkey param is present
+ * the url was like         http......?authkey=....?service=....&otherparam
+ * that should become like  http......?authkey=....&service=....&otherparam
+*/
+const normalizeUrl = (urlToNormalize) => {
+    const urlParts = urlToNormalize.split("?");
+    if (urlParts.length > 2) {
+        let newUrlParts = urlParts.slice(1);
+        return urlParts[0] + "?" + newUrlParts.join("&");
+    }
+    return urlToNormalize;
+};
 var ConfigUtils = {
     defaultSourceType: "gxp_wmssource",
     backgroundGroup: "background",
@@ -266,6 +298,14 @@ var ConfigUtils = {
     },
     getProxyUrl: function(config) {
         return config.proxyUrl ? config.proxyUrl : defaultConfig.proxyUrl;
+    },
+    normalizeUrl,
+    removeParameters,
+    filterUrlParams: (urlToFilter, params = []) => {
+        if (isNil(urlToFilter) || urlToFilter === "") {
+            return null;
+        }
+        return removeParameters(normalizeUrl(urlToFilter), params);
     },
     getProxiedUrl: function(uri, config = {}) {
         let sameOrigin = !(uri.indexOf("http") === 0);

--- a/web/client/utils/__tests__/ConfigUtils-test.js
+++ b/web/client/utils/__tests__/ConfigUtils-test.js
@@ -308,33 +308,33 @@ describe('ConfigUtils', () => {
         expect(ConfigUtils.getConfigProp('testProperty')).toNotExist();
     });
 
-    it('testing normalizeUrl', () => {
+    it('testing cleanDuplicatedQuestionMarks', () => {
         const urlDoubleQuestionMark = "http.../wms?authkey=...?service=...&otherparam";
         const match = "http.../wms?authkey=...&service=...&otherparam";
         const noQuestionMark = "http.../wmsauthkey=...&service=...&otherparam";
-        // with 2 ? it returns the normalizeUrl
-        let normalizedUrl = ConfigUtils.normalizeUrl(urlDoubleQuestionMark);
+        // with 2 ? it returns the cleanDuplicatedQuestionMarks
+        let normalizedUrl = ConfigUtils.cleanDuplicatedQuestionMarks(urlDoubleQuestionMark);
         expect(normalizedUrl).toBe(match);
         // with 1 ? it returns the url passed as argument
-        let normalizedUrl2 = ConfigUtils.normalizeUrl(match);
+        let normalizedUrl2 = ConfigUtils.cleanDuplicatedQuestionMarks(match);
         expect(normalizedUrl2).toBe(match);
         // with 0 ? it returns the url passed as argument
-        let normalizedUrl3 = ConfigUtils.normalizeUrl(noQuestionMark);
+        let normalizedUrl3 = ConfigUtils.cleanDuplicatedQuestionMarks(noQuestionMark);
         expect(normalizedUrl3).toBe(noQuestionMark);
     });
-    it('removeParameters from a normalized url with single ?', () => {
+    it('getUrlWithoutParameters from a normalized url with single ?', () => {
         const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
-        let shrinkedUrl = ConfigUtils.removeParameters(match, ["authkey"]);
+        let shrinkedUrl = ConfigUtils.getUrlWithoutParameters(match, ["authkey"]);
         expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms?service=WMS&otherparam=OTHERVALUE");
     });
-    it('removeParameters from a normalized url without passing params ', () => {
+    it('getUrlWithoutParameters from a normalized url without passing params ', () => {
         const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
-        let shrinkedUrl = ConfigUtils.removeParameters(match, []);
+        let shrinkedUrl = ConfigUtils.getUrlWithoutParameters(match, []);
         expect(shrinkedUrl).toBe(match);
     });
-    it('removeParameters from a normalized url, removing all the params ', () => {
+    it('getUrlWithoutParameters from a normalized url, removing all the params ', () => {
         const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
-        let shrinkedUrl = ConfigUtils.removeParameters(match, ["authkey", "service", "otherparam"]);
+        let shrinkedUrl = ConfigUtils.getUrlWithoutParameters(match, ["authkey", "service", "otherparam"]);
         expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms");
     });
     it('filterUrlParams with normalized url', () => {

--- a/web/client/utils/__tests__/ConfigUtils-test.js
+++ b/web/client/utils/__tests__/ConfigUtils-test.js
@@ -307,4 +307,50 @@ describe('ConfigUtils', () => {
         ConfigUtils.removeConfigProp('testProperty');
         expect(ConfigUtils.getConfigProp('testProperty')).toNotExist();
     });
+
+    it('testing normalizeUrl', () => {
+        const urlDoubleQuestionMark = "http.../wms?authkey=...?service=...&otherparam";
+        const match = "http.../wms?authkey=...&service=...&otherparam";
+        const noQuestionMark = "http.../wmsauthkey=...&service=...&otherparam";
+        // with 2 ? it returns the normalizeUrl
+        let normalizedUrl = ConfigUtils.normalizeUrl(urlDoubleQuestionMark);
+        expect(normalizedUrl).toBe(match);
+        // with 1 ? it returns the url passed as argument
+        let normalizedUrl2 = ConfigUtils.normalizeUrl(match);
+        expect(normalizedUrl2).toBe(match);
+        // with 0 ? it returns the url passed as argument
+        let normalizedUrl3 = ConfigUtils.normalizeUrl(noQuestionMark);
+        expect(normalizedUrl3).toBe(noQuestionMark);
+    });
+    it('removeParameters from a normalized url with single ?', () => {
+        const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
+        let shrinkedUrl = ConfigUtils.removeParameters(match, ["authkey"]);
+        expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms?service=WMS&otherparam=OTHERVALUE");
+    });
+    it('removeParameters from a normalized url without passing params ', () => {
+        const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
+        let shrinkedUrl = ConfigUtils.removeParameters(match, []);
+        expect(shrinkedUrl).toBe(match);
+    });
+    it('removeParameters from a normalized url, removing all the params ', () => {
+        const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
+        let shrinkedUrl = ConfigUtils.removeParameters(match, ["authkey", "service", "otherparam"]);
+        expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms");
+    });
+    it('filterUrlParams with normalized url', () => {
+        const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
+        let shrinkedUrl = ConfigUtils.filterUrlParams(match, ["authkey", "service", "otherparam"]);
+        expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms");
+    });
+    it('filterUrlParams with non normalized url', () => {
+        const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue?service=WMS&otherparam=OTHERVALUE";
+        let shrinkedUrl = ConfigUtils.filterUrlParams(match, ["authkey", "service", "otherparam"]);
+        expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms");
+    });
+    it('filterUrlParams with empty string as url', () => {
+        const match = "";
+        let shrinkedUrl = ConfigUtils.filterUrlParams(match, ["authkey", "service", "otherparam"]);
+        expect(shrinkedUrl).toBe(null);
+    });
+
 });


### PR DESCRIPTION
## Description
Added some utils to parse the url that allow to filter out some params.
When adding a new layer from the catalog now it parses the url filtering out the authkey specified in the configuration.
Also when the featuregrid is opened and a describelayer is performed

## Issues
- Fix #2369 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Now if using csw service geoserver returns a url containing a double ? it contains an old authkey that make fail the wfs request when opening the featuregrid.

**What is the new behavior?**
now the urls is parsed correctly

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
