### PR TITLE
Fix #2378 removed translate interaction for polygons in ol

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -422,7 +422,7 @@ class DrawSupport extends React.Component {
         if (newProps.options.editEnabled) {
             this.addModifyInteraction();
         }
-        if (isSimpleGeomType(newProps.drawMethod) && getSimpleGeomType(newProps.drawMethod) === "Point") {
+        if (getSimpleGeomType(newProps.drawMethod) !== "Polygon") {
             this.addTranslateInteraction();
         }
         if (newProps.options.drawEnabled) {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -421,7 +421,6 @@ class DrawSupport extends React.Component {
         }
         if (newProps.options.editEnabled) {
             this.addModifyInteraction();
-            this.addTranslateInteraction();
         }
         if (newProps.options.drawEnabled) {
             this.handleDrawAndEdit(newProps.drawMethod, newProps.options.startingPoint, newProps.options.maxPoints);

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -422,6 +422,9 @@ class DrawSupport extends React.Component {
         if (newProps.options.editEnabled) {
             this.addModifyInteraction();
         }
+        if (isSimpleGeomType(newProps.drawMethod) && getSimpleGeomType(newProps.drawMethod) === "Point") {
+            this.addTranslateInteraction();
+        }
         if (newProps.options.drawEnabled) {
             this.handleDrawAndEdit(newProps.drawMethod, newProps.options.startingPoint, newProps.options.maxPoints);
         }

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -422,6 +422,7 @@ class DrawSupport extends React.Component {
         if (newProps.options.editEnabled) {
             this.addModifyInteraction();
         }
+        // removed for polygon because of the issue https://github.com/geosolutions-it/MapStore2/issues/2378
         if (getSimpleGeomType(newProps.drawMethod) !== "Polygon") {
             this.addTranslateInteraction();
         }

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -825,7 +825,7 @@ describe('Test DrawSupport', () => {
                 }}
                 />, document.getElementById("container"));
         expect(spyAddLayer.calls.length).toBe(1);
-        expect(spyAddInteraction.calls.length).toBe(3);
+        expect(spyAddInteraction.calls.length).toBe(2);
     });
 
     it('draw or edit, endevent', () => {


### PR DESCRIPTION
## Description
Removed translate interaction in order to avoid conflict when a polygon is being edited.
I also tested that a point is anyway moved eithout this interaction.

## Issues
 - Fix #2378

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue #2378 for details

**What is the new behavior?**
Actually it does not anymore move the polygon, only add or remove vertices.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
