### PR TITLE
Fixes #2374 Print does not localize title in legend

### DIFF
--- a/web/client/actions/__tests__/print-test.js
+++ b/web/client/actions/__tests__/print-test.js
@@ -85,7 +85,7 @@ describe('Test correctness of the print actions', () => {
     });
 
     it('changeMapPrintPreview', () => {
-        const retVal = changeMapPrintPreview({x: 1, y: 1}, 5, {bounds: {}}, {width: 10, height: 50}, 'source', 'EPSG:4326');
+        const retVal = changeMapPrintPreview({x: 1, y: 1}, 5, {bounds: {}}, {width: 10, height: 50}, 'source', 'EPSG:4326', 'en-US');
         expect(retVal).toExist();
         expect(retVal.type).toBe(CHANGE_MAP_PRINT_PREVIEW);
         expect(retVal.center).toExist();
@@ -98,6 +98,7 @@ describe('Test correctness of the print actions', () => {
         expect(retVal.size.height).toBe(50);
         expect(retVal.mapStateSource).toBe('source');
         expect(retVal.projection).toBe('EPSG:4326');
+        expect(retVal.currentLocale).toBe('en-US');
     });
 
     it('printSubmit', (done) => {

--- a/web/client/actions/__tests__/print-test.js
+++ b/web/client/actions/__tests__/print-test.js
@@ -63,7 +63,7 @@ describe('Test correctness of the print actions', () => {
     });
 
     it('configurePrintMap', () => {
-        const retVal = configurePrintMap({x: 1, y: 1}, 5, 6, 2.0, [], 'EPSG:4326');
+        const retVal = configurePrintMap({x: 1, y: 1}, 5, 6, 2.0, [], 'EPSG:4326', 'en-US');
         expect(retVal).toExist();
         expect(retVal.type).toBe(CONFIGURE_PRINT_MAP);
         expect(retVal.center).toExist();
@@ -74,6 +74,7 @@ describe('Test correctness of the print actions', () => {
         expect(retVal.layers).toExist();
         expect(retVal.layers.length).toBe(0);
         expect(retVal.projection).toBe('EPSG:4326');
+        expect(retVal.currentLocale).toBe('en-US');
     });
 
     it('changePrintZoomLevel', () => {
@@ -85,7 +86,7 @@ describe('Test correctness of the print actions', () => {
     });
 
     it('changeMapPrintPreview', () => {
-        const retVal = changeMapPrintPreview({x: 1, y: 1}, 5, {bounds: {}}, {width: 10, height: 50}, 'source', 'EPSG:4326', 'en-US');
+        const retVal = changeMapPrintPreview({x: 1, y: 1}, 5, {bounds: {}}, {width: 10, height: 50}, 'source', 'EPSG:4326');
         expect(retVal).toExist();
         expect(retVal.type).toBe(CHANGE_MAP_PRINT_PREVIEW);
         expect(retVal.center).toExist();
@@ -98,7 +99,6 @@ describe('Test correctness of the print actions', () => {
         expect(retVal.size.height).toBe(50);
         expect(retVal.mapStateSource).toBe('source');
         expect(retVal.projection).toBe('EPSG:4326');
-        expect(retVal.currentLocale).toBe('en-US');
     });
 
     it('printSubmit', (done) => {

--- a/web/client/actions/print.js
+++ b/web/client/actions/print.js
@@ -105,7 +105,7 @@ function setPrintParameter(name, value) {
     };
 }
 
-function configurePrintMap(center, zoom, scaleZoom, scale, layers, projection) {
+function configurePrintMap(center, zoom, scaleZoom, scale, layers, projection, currentLocale) {
     return {
         type: CONFIGURE_PRINT_MAP,
         center,
@@ -113,7 +113,8 @@ function configurePrintMap(center, zoom, scaleZoom, scale, layers, projection) {
         scaleZoom,
         scale,
         layers,
-        projection
+        projection,
+        currentLocale
     };
 }
 

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -30,6 +30,7 @@ const assign = require('object-assign');
 const {head} = require('lodash');
 
 const {scalesSelector} = require('../selectors/map');
+const {currentLocaleSelector} = require('../selectors/locale');
 
 require('./print/print.css');
 
@@ -91,7 +92,8 @@ class Print extends React.Component {
         defaultBackground: PropTypes.string,
         closeGlyph: PropTypes.string,
         submitConfig: PropTypes.object,
-        previewOptions: PropTypes.object
+        previewOptions: PropTypes.object,
+        currentLocale: PropTypes.string
     };
 
     static contextTypes = {
@@ -150,7 +152,8 @@ class Print extends React.Component {
         previewOptions: {
             buttonStyle: "primary"
         },
-        style: {}
+        style: {},
+        currentLocale: 'en-US'
     };
 
     componentWillMount() {
@@ -326,10 +329,10 @@ class Print extends React.Component {
                 const scaleZoom = PrintUtils.getNearestZoom(newMap.zoom, scales);
 
                 this.props.configurePrintMap(newMap.center, mapZoom, scaleZoom, scales[scaleZoom],
-                    this.filterLayers(newPrintSpec), newMap.projection);
+                    this.filterLayers(newPrintSpec), newMap.projection, this.props.currentLocale);
             } else {
                 this.props.configurePrintMap(newMap.center, newMap.zoom, newMap.zoom, this.props.scales[newMap.zoom],
-                    this.filterLayers(newPrintSpec), newMap.projection);
+                    this.filterLayers(newPrintSpec), newMap.projection, this.props.currentLocale);
             }
         }
     };
@@ -351,8 +354,9 @@ const selector = createSelector([
     mapSelector,
     layersSelector,
     scalesSelector,
-    (state) => state.browser && (!state.browser.ie || state.browser.ie11)
-], (open, capabilities, printSpec, pdfUrl, error, map, layers, scales, usePreview) => ({
+    (state) => state.browser && (!state.browser.ie || state.browser.ie11),
+    currentLocaleSelector
+], (open, capabilities, printSpec, pdfUrl, error, map, layers, scales, usePreview, currentLocale) => ({
     open,
     capabilities,
     printSpec,
@@ -361,7 +365,8 @@ const selector = createSelector([
     map,
     layers: layers.filter(l => !l.loadingError),
     scales,
-    usePreview
+    usePreview,
+    currentLocale
 }));
 
 const PrintPlugin = connect(selector, {

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -150,4 +150,30 @@ describe('Test the print reducer', () => {
         });
         expect(state.pdfUrl).toNotExist();
     });
+
+    it('configure print map title with current locale', () => {
+        const state = print({capabilities: {}, spec: {}}, {
+            type: CONFIGURE_PRINT_MAP,
+            center: {x: 1, y: 1},
+            zoom: 5,
+            scaleZoom: 6,
+            scale: 10000,
+            layers: [{
+                title: {
+                    'default': 'Layer',
+                    'it-IT': 'Livello'
+                }
+            }],
+            projection: 'EPSG:4326',
+            currentLocale: 'it-IT'
+        });
+        expect(state.map).toExist();
+        expect(state.map.center).toExist();
+        expect(state.map.center.x).toBe(1);
+        expect(state.map.zoom).toBe(5);
+        expect(state.map.scale).toBe(10000);
+        expect(state.map.layers.length).toBe(1);
+        expect(state.map.layers[0].title).toBe('Livello');
+        expect(state.map.projection).toBe('EPSG:4326');
+    });
 });

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -176,4 +176,53 @@ describe('Test the print reducer', () => {
         expect(state.map.layers[0].title).toBe('Livello');
         expect(state.map.projection).toBe('EPSG:4326');
     });
+
+    it('configure print map title with current locale and no data', () => {
+        const state = print({capabilities: {}, spec: {}}, {
+            type: CONFIGURE_PRINT_MAP,
+            center: {x: 1, y: 1},
+            zoom: 5,
+            scaleZoom: 6,
+            scale: 10000,
+            layers: [{
+                title: {
+                    'default': 'Layer',
+                    'it-IT': 'Livello'
+                }
+            }],
+            projection: 'EPSG:4326',
+            currentLocale: 'en-US'
+        });
+        expect(state.map).toExist();
+        expect(state.map.center).toExist();
+        expect(state.map.center.x).toBe(1);
+        expect(state.map.zoom).toBe(5);
+        expect(state.map.scale).toBe(10000);
+        expect(state.map.layers.length).toBe(1);
+        expect(state.map.layers[0].title).toBe('Layer');
+        expect(state.map.projection).toBe('EPSG:4326');
+    });
+
+    it('configure print map title with current locale and no object title', () => {
+        const state = print({capabilities: {}, spec: {}}, {
+            type: CONFIGURE_PRINT_MAP,
+            center: {x: 1, y: 1},
+            zoom: 5,
+            scaleZoom: 6,
+            scale: 10000,
+            layers: [{
+                title: 'Layer001'
+            }],
+            projection: 'EPSG:4326',
+            currentLocale: 'en-US'
+        });
+        expect(state.map).toExist();
+        expect(state.map.center).toExist();
+        expect(state.map.center.x).toBe(1);
+        expect(state.map.zoom).toBe(5);
+        expect(state.map.scale).toBe(10000);
+        expect(state.map.layers.length).toBe(1);
+        expect(state.map.layers[0].title).toBe('Layer001');
+        expect(state.map.projection).toBe('EPSG:4326');
+    });
 });

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -75,7 +75,7 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
         const layers = action.layers.map((layer) => {
             return layer.title ? assign({}, layer, {
                 title: isObject(layer.title) && action.currentLocale && layer.title[action.currentLocale]
-                || isObject(layer.title) && layer.default
+                || isObject(layer.title) && layer.title.default
                 || layer.title
             }) : layer;
         });

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -73,7 +73,11 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     case CONFIGURE_PRINT_MAP: {
 
         const layers = action.layers.map((layer) => {
-            return layer.title ? assign({}, layer, {title: isObject(layer.title) ? layer.title.default : layer.title}) : layer;
+            return layer.title ? assign({}, layer, {
+                title: isObject(layer.title) && action.currentLocale && layer.title[action.currentLocale]
+                || isObject(layer.title) && layer.default
+                || layer.title
+            }) : layer;
         });
 
         return assign({}, state, {


### PR DESCRIPTION
## Description
Added current translated layer's title on print legend

## Issues
 - Fix #2374

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Title in print legend are not translated

**What is the new behavior?**
Title in print legend are translated with the current locale or if not present with the default value

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
