### PR TITLE
Fix #2382 added a new type check for empty background

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/__tests__/NumberFilter-test.jsx
@@ -30,7 +30,7 @@ const EXPRESSION_TESTS = [
     [" ", "=", undefined],
     ["ZZZ", "=", undefined]
 ];
-const testExperssion = (spyonChange, spyonValueChange, rawValue, expectedOperator, expectedValue) => {
+const testExpression = (spyonChange, spyonValueChange, rawValue, expectedOperator, expectedValue) => {
     const input = document.getElementsByTagName("input")[0];
     input.value = rawValue;
     ReactTestUtils.Simulate.change(input);
@@ -95,6 +95,6 @@ describe('Test for NumberFilter component', () => {
         const spyonChange = expect.spyOn(actions, 'onChange');
         const spyonValueChange = expect.spyOn(actions, 'onValueChange');
         ReactDOM.render(<NumberFilter onChange={actions.onChange} onValueChange={actions.onValueChange} />, document.getElementById("container"));
-        EXPRESSION_TESTS.map( params => testExperssion(spyonChange, spyonValueChange, ...params));
+        EXPRESSION_TESTS.map( params => testExpression(spyonChange, spyonValueChange, ...params));
     });
 });

--- a/web/client/new.json
+++ b/web/client/new.json
@@ -50,6 +50,19 @@
         "source": "OpenTopoMap",
         "group": "background",
         "visibility": false
+      },
+      {
+        "source": "ol",
+        "group": "background",
+        "title": "Empty Background",
+        "fixed": true,
+        "type": "empty",
+        "visibility": false,
+        "args": [
+          "Empty Background", {
+            "visibility": false
+          }
+        ]
       }
 		]
 	}

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -38,6 +38,19 @@ describe('Test the mapConfig reducer', () => {
         expect(state.layers.length).toBe(1);
         expect(state.layers[0].apiKey).toBe(null);
     });
+    it('checks if empty background layer type is changed accordingly', () => {
+        const state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { version: 2, map: { center: {x: 1, y: 1}, zoom: 11, layers: [{type: 'ol', group: "background"}] }}});
+        expect(state.map.zoom).toExist();
+        expect(state.map.center).toExist();
+        expect(state.map.center.crs).toExist();
+        expect(state.layers).toExist();
+        expect(state.layers.length).toBe(1);
+        expect(state.layers[0].type).toBe("empty");
+        const state2 = mapConfig({}, {type: 'MAP_CONFIG_LOADED', config: { version: 2, map: { center: {x: 1, y: 1}, zoom: 11, layers: [{type: 'OpenLayers.Layer', group: "background"}] }}});
+        expect(state2.layers).toExist();
+        expect(state2.layers.length).toBe(1);
+        expect(state2.layers[0].type).toBe("empty");
+    });
 
     it('creates an error on wrongly loaded config', () => {
         var state = mapConfig({}, {type: 'MAP_CONFIG_LOAD_ERROR', error: 'error'});

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -10,7 +10,6 @@ const {MAP_CONFIG_LOADED, MAP_INFO_LOAD_START, MAP_INFO_LOADED, MAP_INFO_LOAD_ER
 const {MAP_CREATED} = require('../actions/maps');
 
 const assign = require('object-assign');
-const {set} = require('lodash');
 const ConfigUtils = require('../utils/ConfigUtils');
 
 function mapConfig(state = null, action) {
@@ -22,14 +21,17 @@ function mapConfig(state = null, action) {
         let hasVersion = action.config.version && action.config.version >= 2;
             // we get from the configuration what will be used as the initial state
         let mapState = action.legacy && !hasVersion ? ConfigUtils.convertFromLegacy(action.config) : ConfigUtils.normalizeConfig(action.config.map);
-        const newMapState = assign({}, set(mapState, "layers", mapState.layers.map( l => {
-            if (l.group === "background" && (l.type === "ol" || l.type === "OpenLayers.Layer")) {
-                l.type = "empty";
-            }
-            return l;
-        })));
+        let newMapState = {
+            ...mapState,
+            layers: mapState.layers.map( l => {
+                if (l.group === "background" && (l.type === "ol" || l.type === "OpenLayers.Layer")) {
+                    l.type = "empty";
+                }
+                return l;
+            })
+        };
         newMapState.map = assign({}, newMapState.map, {mapId: action.mapId, size, version: hasVersion ? action.config.version : 1});
-            // we store the map initial state for future usage
+        // we store the map initial state for future usage
         return assign({}, newMapState, {mapInitialConfig: {...newMapState.map, mapId: action.mapId}});
     case MAP_CONFIG_LOAD_ERROR:
         return {

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -21,7 +21,12 @@ function mapConfig(state = null, action) {
         let hasVersion = action.config.version && action.config.version >= 2;
             // we get from the configuration what will be used as the initial state
         let mapState = action.legacy && !hasVersion ? ConfigUtils.convertFromLegacy(action.config) : ConfigUtils.normalizeConfig(action.config.map);
-
+        mapState.layers = mapState.layers.map( l => {
+            if (l.group === "background" && (l.type === "ol" || l.type === "OpenLayers.Layer")) {
+                l.type = "empty";
+            }
+            return l;
+        });
         mapState.map = assign({}, mapState.map, {mapId: action.mapId, size, version: hasVersion ? action.config.version : 1});
             // we store the map initial state for future usage
         return assign({}, mapState, {mapInitialConfig: {...mapState.map, mapId: action.mapId}});

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -9,8 +9,9 @@
 const {MAP_CONFIG_LOADED, MAP_INFO_LOAD_START, MAP_INFO_LOADED, MAP_INFO_LOAD_ERROR, MAP_CONFIG_LOAD_ERROR} = require('../actions/config');
 const {MAP_CREATED} = require('../actions/maps');
 
-var assign = require('object-assign');
-var ConfigUtils = require('../utils/ConfigUtils');
+const assign = require('object-assign');
+const {set} = require('lodash');
+const ConfigUtils = require('../utils/ConfigUtils');
 
 function mapConfig(state = null, action) {
     let map;
@@ -21,15 +22,15 @@ function mapConfig(state = null, action) {
         let hasVersion = action.config.version && action.config.version >= 2;
             // we get from the configuration what will be used as the initial state
         let mapState = action.legacy && !hasVersion ? ConfigUtils.convertFromLegacy(action.config) : ConfigUtils.normalizeConfig(action.config.map);
-        mapState.layers = mapState.layers.map( l => {
+        const newMapState = assign({}, set(mapState, "layers", mapState.layers.map( l => {
             if (l.group === "background" && (l.type === "ol" || l.type === "OpenLayers.Layer")) {
                 l.type = "empty";
             }
             return l;
-        });
-        mapState.map = assign({}, mapState.map, {mapId: action.mapId, size, version: hasVersion ? action.config.version : 1});
+        })));
+        newMapState.map = assign({}, newMapState.map, {mapId: action.mapId, size, version: hasVersion ? action.config.version : 1});
             // we store the map initial state for future usage
-        return assign({}, mapState, {mapInitialConfig: {...mapState.map, mapId: action.mapId}});
+        return assign({}, newMapState, {mapInitialConfig: {...newMapState.map, mapId: action.mapId}});
     case MAP_CONFIG_LOAD_ERROR:
         return {
             loadingError: {...action.error, mapId: action.mapId}

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, GeoSolutions Sas.
+ * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -64,8 +64,8 @@ const isSupportedLayer = (layer, maptype) => {
     if (layer.type === "mapquest" || layer.type === "bing") {
         return Layers.isSupported(layer.type) && layer.apiKey && layer.apiKey !== "__API_KEY_MAPQUEST__" && !layer.invalid;
     }
-    // type 'ol' represents 'No background' layer
-    if (layer.type === 'ol') {
+    // type 'ol' or 'OpenLayers.Layer' represents 'No background' layer
+    if (layer.type === 'ol' || layer.type === 'OpenLayers.Layer') {
         return maptype === 'openlayers' || maptype === 'leaflet';
     }
     return Layers.isSupported(layer.type) && !layer.invalid;
@@ -355,8 +355,12 @@ const LayersUtils = {
     invalidateUnsupportedLayer(layer, maptype) {
         return isSupportedLayer(layer, maptype) ? checkInvalidParam(layer) : assign({}, layer, {invalid: true});
     },
+    /**
+     * Estasblish if a layer is supported or not
+     * @return {boolean} value
+    */
     isSupportedLayer(layer, maptype) {
-        return isSupportedLayer(layer, maptype);
+        return !!isSupportedLayer(layer, maptype);
     },
     getLayerTitleTranslations: (capabilities) => {
         return !!LayerCustomUtils.getLayerTitleTranslations ? LayerCustomUtils.getLayerTitleTranslations(capabilities) : capabilities.Title;

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -64,8 +64,12 @@ const isSupportedLayer = (layer, maptype) => {
     if (layer.type === "mapquest" || layer.type === "bing") {
         return Layers.isSupported(layer.type) && layer.apiKey && layer.apiKey !== "__API_KEY_MAPQUEST__" && !layer.invalid;
     }
-    // type 'ol' or 'OpenLayers.Layer' represents 'No background' layer
-    if (layer.type === 'ol' || layer.type === 'OpenLayers.Layer') {
+
+    /*
+     * type 'empty' represents 'No background' layer
+     * previously was checking for types
+    */
+    if (layer.type === 'empty') {
         return maptype === 'openlayers' || maptype === 'leaflet';
     }
     return Layers.isSupported(layer.type) && !layer.invalid;

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -390,6 +390,13 @@ describe('LayersUtils', () => {
             const res = LayersUtils.isSupportedLayer(mapquestLayerWithoutApikey, maptype);
             expect(res).toBeFalsy();
         });
+        it('type: bing  maptype: openlayers, with invalid apikey, not supported', () => {
+            const maptype = "openlayers";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('bing', {});
+            const res = LayersUtils.isSupportedLayer(assign({}, bingLayerWithApikey, {apiKey: "__API_KEY_MAPQUEST__"}), maptype);
+            expect(res).toBeFalsy();
+        });
         it('type: bing  maptype: openlayers, with apikey supported', () => {
             const maptype = "openlayers";
             const Layers = require('../' + maptype + '/Layers');

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -8,13 +8,9 @@
 const expect = require('expect');
 const assign = require('object-assign');
 const LayersUtils = require('../LayersUtils');
-const typeV1 = "OpenLayers.Layer";
-const typeV2 = "ol";
-const emptyBackgroundVersion1 = {
+const typeV1 = "empty";
+const emptyBackground = {
     type: typeV1
-};
-const emptyBackgroundVersion2 = {
-    type: typeV2
 };
 const bingLayerWithApikey = {
     type: 'bing',
@@ -332,34 +328,15 @@ describe('LayersUtils', () => {
     });
     describe('isSupportedLayer', () => {
         it('type: ' + typeV1 + '  maptype: leaflet, supported', () => {
-            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion1, "leaflet");
+            const res = LayersUtils.isSupportedLayer(emptyBackground, "leaflet");
             expect(res).toBeTruthy();
         });
         it('type: ' + typeV1 + '  maptype: openlayers, supported', () => {
-            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion1, "openlayers");
+            const res = LayersUtils.isSupportedLayer(emptyBackground, "openlayers");
             expect(res).toBeTruthy();
         });
         it('type: ' + typeV1 + '  maptype: cesium, not supported', () => {
-            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion1, "cesium");
-            expect(res).toBeFalsy();
-        });
-
-        it('type: ' + typeV2 + '  maptype: leaflet, supported', () => {
-            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion2, "leaflet");
-            expect(res).toBeTruthy();
-        });
-        it('type: ' + typeV2 + '  maptype: openlayers, supported', () => {
-            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion2, "openlayers");
-            expect(res).toBeTruthy();
-        });
-        it('type: ' + typeV2 + '  maptype: cesium, not supported', () => {
-            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion2, "cesium");
-            expect(res).toBeFalsy();
-        });
-
-        it('type: newtype  maptype: leaflet, not supported', () => {
-            const maptype = "leaflet";
-            const res = LayersUtils.isSupportedLayer(wmsLayer, maptype);
+            const res = LayersUtils.isSupportedLayer(emptyBackground, "cesium");
             expect(res).toBeFalsy();
         });
         it('type: wms  maptype: leaflet, supported', () => {

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1,13 +1,38 @@
-/**
- * Copyright 2016, GeoSolutions Sas.
+/*
+ * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
 const expect = require('expect');
+const assign = require('object-assign');
 const LayersUtils = require('../LayersUtils');
-
+const typeV1 = "OpenLayers.Layer";
+const typeV2 = "ol";
+const emptyBackgroundVersion1 = {
+    type: typeV1
+};
+const emptyBackgroundVersion2 = {
+    type: typeV2
+};
+const bingLayerWithApikey = {
+    type: 'bing',
+    apiKey: "SOME_APIKEY_VALUE"
+};
+const bingLayerWithoutApikey = {
+    type: 'bing'
+};
+const mapquestLayerWithApikey = {
+    type: 'mapquest',
+    apiKey: "SOME_APIKEY_VALUE"
+};
+const mapquestLayerWithoutApikey = {
+    type: 'mapquest'
+};
+const wmsLayer = {
+    type: 'wms'
+};
 describe('LayersUtils', () => {
     it('splits layers and groups one group', () => {
         const state = LayersUtils.splitMapAndLayers({
@@ -304,6 +329,83 @@ describe('LayersUtils', () => {
         };
 
         expect(LayersUtils.extractTileMatrixFromSources(sources, layer)).toEqual({});
+    });
+    describe('isSupportedLayer', () => {
+        it('type: ' + typeV1 + '  maptype: leaflet, supported', () => {
+            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion1, "leaflet");
+            expect(res).toBeTruthy();
+        });
+        it('type: ' + typeV1 + '  maptype: openlayers, supported', () => {
+            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion1, "openlayers");
+            expect(res).toBeTruthy();
+        });
+        it('type: ' + typeV1 + '  maptype: cesium, not supported', () => {
+            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion1, "cesium");
+            expect(res).toBeFalsy();
+        });
+
+        it('type: ' + typeV2 + '  maptype: leaflet, supported', () => {
+            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion2, "leaflet");
+            expect(res).toBeTruthy();
+        });
+        it('type: ' + typeV2 + '  maptype: openlayers, supported', () => {
+            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion2, "openlayers");
+            expect(res).toBeTruthy();
+        });
+        it('type: ' + typeV2 + '  maptype: cesium, not supported', () => {
+            const res = LayersUtils.isSupportedLayer(emptyBackgroundVersion2, "cesium");
+            expect(res).toBeFalsy();
+        });
+
+        it('type: newtype  maptype: leaflet, not supported', () => {
+            const maptype = "leaflet";
+            const res = LayersUtils.isSupportedLayer(wmsLayer, maptype);
+            expect(res).toBeFalsy();
+        });
+        it('type: wms  maptype: leaflet, supported', () => {
+            const maptype = "leaflet";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('wms', {});
+            const res = LayersUtils.isSupportedLayer(wmsLayer, maptype);
+            expect(res).toBeTruthy();
+        });
+        it('type: wms  maptype: leaflet, not supported because invalid', () => {
+            const maptype = "leaflet";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('wms', {});
+            const res = LayersUtils.isSupportedLayer(assign({}, wmsLayer, {invalid: true}), maptype);
+            expect(res).toBeFalsy();
+        });
+        it('type: mapquest  maptype: openlayers, with apikey supported', () => {
+            const maptype = "openlayers";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('mapquest', {});
+            const res = LayersUtils.isSupportedLayer(mapquestLayerWithApikey, maptype);
+            expect(res).toBeTruthy();
+        });
+        it('type: mapquest  maptype: openlayers, without apikey not supported', () => {
+            const maptype = "openlayers";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('mapquest', {});
+            const res = LayersUtils.isSupportedLayer(mapquestLayerWithoutApikey, maptype);
+            expect(res).toBeFalsy();
+        });
+        it('type: bing  maptype: openlayers, with apikey supported', () => {
+            const maptype = "openlayers";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('bing', {});
+            const res = LayersUtils.isSupportedLayer(bingLayerWithApikey, maptype);
+            expect(res).toBeTruthy();
+        });
+        it('type: bing  maptype: openlayers, without apikey not supported', () => {
+            const maptype = "openlayers";
+            const Layers = require('../' + maptype + '/Layers');
+            Layers.registerType('bing', {});
+            const res = LayersUtils.isSupportedLayer(bingLayerWithoutApikey, maptype);
+            expect(res).toBeFalsy();
+        });
+
+
     });
 
 });


### PR DESCRIPTION
## Description
Added the new type "OpenLayers.Layer" for checking if a layer is a empty background.
Added tests 

## Issues
 - Fix #2382

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Now if a background layer has type "OpenLayers.Layer" is not selectable from backgroundSelector tool.

**What is the new behavior?**
Now it does.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No