### PR TITLE
Fixed #2393 aligned feature text infoFormat value to settings infoFormat value

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -20,6 +20,7 @@ class Toolbar extends React.Component {
     static propTypes = {
         groups: PropTypes.array,
         selectedLayers: PropTypes.array,
+        generalInfoFormat: PropTypes.string,
         selectedGroups: PropTypes.array,
         onToolsActions: PropTypes.object,
         text: PropTypes.object,
@@ -126,6 +127,7 @@ class Toolbar extends React.Component {
                 {...this.props.options.settingsOptions}
                 settings={this.props.settings}
                 element={this.props.selectedLayers[0]}
+                generalInfoFormat={this.props.generalInfoFormat}
                 retrieveLayerData={this.props.onToolsActions.onRetrieveLayerData}
                 updateSettings={this.props.onToolsActions.onUpdateSettings}
                 hideSettings={this.props.onToolsActions.onHideSettings}

--- a/web/client/components/TOC/fragments/SettingsModal.jsx
+++ b/web/client/components/TOC/fragments/SettingsModal.jsx
@@ -34,6 +34,7 @@ class SettingsModal extends React.Component {
         updateNode: PropTypes.func,
         removeNode: PropTypes.func,
         retrieveLayerData: PropTypes.func,
+        generalInfoFormat: PropTypes.string,
         titleText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
         opacityText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
         elevationText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -168,6 +169,7 @@ class SettingsModal extends React.Component {
                 return (<FeatureInfoFormat
                    label= {<Message msgId="layerProperties.featureInfoFormatLbl"/>}
                    element={this.props.element}
+                   generalInfoFormat={this.props.generalInfoFormat}
                    onInfoFormatChange={(key, value) => this.updateParams({[key]: value}, this.props.realtimeUpdate)} />);
             }
         }

--- a/web/client/components/TOC/fragments/settings/FeatureInfoFormat.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfoFormat.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 /**
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
@@ -8,9 +7,22 @@ const PropTypes = require('prop-types');
  */
 
 const React = require('react');
+const PropTypes = require('prop-types');
 const {DropdownList} = require('react-widgets');
 const MapInfoUtils = require('../../../../utils/MapInfoUtils');
 
+
+/**
+ * FeatureInfoFormat shows the infoformat selected for that layer or the default one taken
+ * from the general settings.
+ * @class
+ * @memberof components.toc
+ * @prop {object} [element] the layer options
+ * @prop {object} [label] the label shown for the combobox
+ * @prop {object} [defaultInfoFormat] the object used to show options labels
+ * @prop {string} [generalInfoFormat] the infoFormat value set in the general settings
+ * @prop {function} [onInfoFormatChange] it updates the infoFormat and/or viewer for the given layer
+ */
 module.exports = class extends React.Component {
     static propTypes = {
         element: PropTypes.object,

--- a/web/client/components/TOC/fragments/settings/FeatureInfoFormat.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfoFormat.jsx
@@ -16,18 +16,24 @@ module.exports = class extends React.Component {
         element: PropTypes.object,
         label: PropTypes.object,
         defaultInfoFormat: PropTypes.object,
+        generalInfoFormat: PropTypes.string,
         onInfoFormatChange: PropTypes.func
     };
 
     static defaultProps = {
         defaultInfoFormat: MapInfoUtils.getAvailableInfoFormat(),
+        generalInfoFormat: "text/plain",
         onInfoFormatChange: () => {}
     };
 
-    render() {
-        const data = Object.keys(this.props.defaultInfoFormat).map((infoFormat) => {
+    getInfoFormat = (infoFormats) => {
+        return Object.keys(infoFormats).map((infoFormat) => {
             return infoFormat;
         });
+    }
+    render() {
+        // the selected value if missing on that layer should be set to the general info format value and not the first one.
+        const data = this.getInfoFormat(this.props.defaultInfoFormat);
         const checkDisabled = !!(this.props.element.featureInfo && this.props.element.featureInfo.viewer);
         return (
             <div>
@@ -42,7 +48,7 @@ module.exports = class extends React.Component {
                 (<DropdownList
                     key="format-dropdown"
                     data={data}
-                    value={this.props.element.featureInfo ? this.props.element.featureInfo.format : data[0]}
+                    value={this.props.element.featureInfo ? this.props.element.featureInfo.format : MapInfoUtils.getLabelFromValue(this.props.generalInfoFormat)}
                     defaultValue={data[0]}
                     disabled={checkDisabled}
                     onChange={(value) => {

--- a/web/client/components/TOC/fragments/settings/__tests__/FeatureInfoFormat-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/FeatureInfoFormat-test.jsx
@@ -73,4 +73,22 @@ describe('test Layer Properties FeatureInfoFormat module component', () => {
         li[0].click();
         expect(spy.calls.length).toBe(1);
     });
+    it('tests FeatureInfoFormat component for wms using generalInfoFormat', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const generalInfoFormat = "text/html";
+        const label = "label";
+        const comp = ReactDOM.render(<FeatureInfoFormat element={l} label={label} generalInfoFormat={generalInfoFormat} onInfoFormatChange={() => {}}/>, document.getElementById("container"));
+        expect(comp).toExist();
+        const div = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "div" );
+        expect(div[2]).toExist();
+        expect(div[2].textContent).toBe("HTML");
+
+    });
 });

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -12,7 +12,8 @@ const {createSelector} = require('reselect');
 const {Glyphicon} = require('react-bootstrap');
 
 const {changeLayerProperties, changeGroupProperties, toggleNode, contextNode,
-       sortNode, showSettings, hideSettings, updateSettings, updateNode, removeNode, browseData, selectNode, filterLayers, refreshLayerVersion} = require('../actions/layers');
+       sortNode, showSettings, hideSettings, updateSettings, updateNode, removeNode,
+       browseData, selectNode, filterLayers, refreshLayerVersion} = require('../actions/layers');
 const {getLayerCapabilities} = require('../actions/layerCapabilities');
 const {zoomToExtent} = require('../actions/map');
 const {groupsSelector, layersSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector} = require('../selectors/layers');

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -18,6 +18,7 @@ const {zoomToExtent} = require('../actions/map');
 const {groupsSelector, layersSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector} = require('../selectors/layers');
 const {mapSelector, mapNameSelector} = require('../selectors/map');
 const {currentLocaleSelector} = require("../selectors/locale");
+const {generalInfoFormatSelector} = require("../selectors/mapInfo");
 
 const LayersUtils = require('../utils/LayersUtils');
 const mapUtils = require('../utils/MapUtils');
@@ -68,8 +69,9 @@ const tocSelector = createSelector(
         layerFilterSelector,
         layersSelector,
         mapNameSelector,
-        activeSelector
-    ], (enabled, groups, settings, map, currentLocale, selectedNodes, filterText, layers, mapName, catalogActive) => ({
+        activeSelector,
+        generalInfoFormatSelector
+    ], (enabled, groups, settings, map, currentLocale, selectedNodes, filterText, layers, mapName, catalogActive, generalInfoFormat) => ({
         enabled,
         groups,
         settings,
@@ -81,6 +83,7 @@ const tocSelector = createSelector(
         currentLocale,
         selectedNodes,
         filterText,
+        generalInfoFormat,
         selectedLayers: layers.filter((l) => head(selectedNodes.filter(s => s === l.id))),
         noFilterResults: layers.filter((l) => filterLayersByTitle(l, filterText, currentLocale)).length === 0,
         selectedGroups: selectedNodes.map(n => LayersUtils.getNode(groups, n)).filter(n => n && n.nodes),
@@ -157,6 +160,7 @@ class LayerTree extends React.Component {
         currentLocale: PropTypes.string,
         onFilter: PropTypes.func,
         filterText: PropTypes.string,
+        generalInfoFormat: PropTypes.string,
         selectedLayers: PropTypes.array,
         selectedGroups: PropTypes.array,
         mapName: PropTypes.string,
@@ -287,6 +291,7 @@ class LayerTree extends React.Component {
                             groups={this.props.groups}
                             selectedLayers={this.props.selectedLayers}
                             selectedGroups={this.props.selectedGroups}
+                            generalInfoFormat={this.props.generalInfoFormat}
                             settings={this.props.settings}
                             activateTool={{
                                 activateToolsContainer: this.props.activateToolsContainer,

--- a/web/client/selectors/__tests__/mapinfo-test.js
+++ b/web/client/selectors/__tests__/mapinfo-test.js
@@ -1,0 +1,30 @@
+/*
+* Copyright 2017, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+const expect = require('expect');
+const {
+    generalInfoFormatSelector
+} = require('../mapinfo');
+
+describe('Test mapinfo', () => {
+    it('test generalInfoFormatSelector default value', () => {
+        const mapinfo = generalInfoFormatSelector({});
+        expect(mapinfo).toBe("text/plain");
+    });
+    it('test generalInfoFormatSelector infoFormat: undefined', () => {
+        const mapinfo = generalInfoFormatSelector({mapInfo: {infoFormat: undefined}});
+        expect(mapinfo).toBe("text/plain");
+    });
+    it('test generalInfoFormatSelector ', () => {
+        const mapinfo = generalInfoFormatSelector({mapInfo: {infoFormat: "text/html"}});
+
+        expect(mapinfo).toExist();
+        expect(mapinfo).toBe("text/html");
+    });
+});

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -1,0 +1,27 @@
+/*
+* Copyright 2017, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+const {get} = require('lodash');
+/**
+ * selects mapinfo state
+ * @name mapinfo
+ * @memberof selectors
+ * @static
+ */
+
+/**
+ * selects generalInfoFormat from state
+ * @memberof selectors.mapinfo
+ * @param  {object} state the state
+ * @return {string}       the maptype in the state
+ */
+const generalInfoFormatSelector = (state) => get(state, "mapInfo.infoFormat", "text/plain");
+
+module.exports = {
+    generalInfoFormatSelector
+};

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -32,6 +32,12 @@ const MapInfoUtils = {
         }, {});
     },
     /**
+     * @return the label of an inputformat given the value
+     */
+    getLabelFromValue(value) {
+        return MapInfoUtils.getAvailableInfoFormatLabels().filter(info => INFO_FORMATS[info] === value)[0] || "TEXT";
+    },
+    /**
      * @return like getAvailableInfoFormat but return an array filled with the keys
      */
     getAvailableInfoFormatLabels() {

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -16,7 +16,8 @@ var {
     buildIdentifyRequest,
     getValidator,
     getViewer,
-    setViewer
+    setViewer,
+    getLabelFromValue
 } = require('../MapInfoUtils');
 
 const CoordinatesUtils = require('../CoordinatesUtils');
@@ -328,5 +329,17 @@ describe('MapInfoUtils', () => {
         let validator = getValidator('text/plain');
         let validResponses = validator.getValidResponses(response);
         expect(validResponses.length).toBe(1);
+    });
+    it('get the label given the text/plain value', () => {
+        let label = getLabelFromValue("text/plain");
+        expect(label).toBe("TEXT");
+    });
+    it('get the label given the text/html value', () => {
+        let label = getLabelFromValue("text/html");
+        expect(label).toBe("HTML");
+    });
+    it('get the default label given the wrong value', () => {
+        let label = getLabelFromValue("text_or_something_else");
+        expect(label).toBe("TEXT");
     });
 });


### PR DESCRIPTION
## Description
Now if there is no value set for the layer it takes the infoFormat value from the general settings

## Issues
 - Fix #2393 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Actually there was a misalignement from the infoFormat value

**What is the new behavior?**
Actually if you change the infoFormat value in Settings it does change the selected value in feature text tab in layer properties

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
be sure to test a layer which has not set an infoFormat value.