### PR TITLE
Fixes #2401 If authkey has been saved on map configuration generates a wps/wfs query request with two authkey 

### DIFF
--- a/web/client/epics/autocomplete.js
+++ b/web/client/epics/autocomplete.js
@@ -16,6 +16,7 @@ const {error} = require('../actions/notifications');
 const {typeNameSelector} = require('../selectors/query');
 const {maxFeaturesWPSSelector} = require('../selectors/queryform');
 const {getParsedUrl} = require('../utils/ConfigUtils');
+const {authkeyParamNameSelector} = require('../selectors/catalog');
 
    /**
     * Epics for WFS query requests
@@ -25,13 +26,13 @@ const {getParsedUrl} = require('../utils/ConfigUtils');
 
 module.exports = {
 
-    isAutoCompleteEnabled: (action$) =>
+    isAutoCompleteEnabled: (action$, store) =>
     action$.ofType(FEATURE_TYPE_SELECTED)
         .switchMap((action) => {
             const parsedUrl = getParsedUrl(action.url, {
                 "version": "1.0.0",
                 "REQUEST": "DescribeProcess",
-                "IDENTIFIER": "gs:PagedUnique" });
+                "IDENTIFIER": "gs:PagedUnique" }, authkeyParamNameSelector(store.getState()));
             if (parsedUrl === null) {
                 return Rx.Observable.of(setAutocompleteMode(false));
             }
@@ -70,7 +71,7 @@ module.exports = {
                         startIndex: (action.fieldOptions.currentPage - 1) * maxFeaturesWPS,
                         value: action.fieldValue
                     });
-                const parsedUrl = getParsedUrl(state.query.url, {"outputFormat": "json"});
+                const parsedUrl = getParsedUrl(state.query.url, {"outputFormat": "json"}, authkeyParamNameSelector(store.getState()));
                 if (parsedUrl === null) {
                     return Rx.Observable.of(setAutocompleteMode(false));
                 }

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -14,8 +14,10 @@ const {CHANGE_MAP_VIEW} = require('../actions/map');
 const {FEATURE_TYPE_SELECTED, QUERY, UPDATE_QUERY, featureLoading, featureTypeLoaded, featureTypeError, querySearchResponse, queryError} = require('../actions/wfsquery');
 const {paginationInfo, isDescribeLoaded, describeSelector} = require('../selectors/query');
 const {mapSelector} = require('../selectors/map');
+const {authkeyParamNameSelector} = require('../selectors/catalog');
 const FilterUtils = require('../utils/FilterUtils');
 const CoordinatesUtils = require('../utils/CoordinatesUtils');
+const ConfigUtils = require('../utils/ConfigUtils');
 const assign = require('object-assign');
 const {spatialFieldMethodSelector, spatialFieldSelector, spatialFieldGeomTypeSelector, spatialFieldGeomCoordSelector, spatialFieldGeomSelector, spatialFieldGeomProjSelector} = require('../selectors/queryform');
 const {changeDrawingStatus} = require('../actions/draw');
@@ -144,10 +146,10 @@ const getWFSFilterData = (filterObj) => {
     return data;
 };
 
-const getWFSFeature = (searchUrl, filterObj) => {
+const getWFSFeature = (searchUrl, filterObj, state) => {
     const data = getWFSFilterData(filterObj);
 
-    const urlParsedObj = Url.parse(searchUrl, true);
+    const urlParsedObj = Url.parse(ConfigUtils.filterUrlParams(searchUrl, authkeyParamNameSelector(state)), true);
     let params = isObject(urlParsedObj.query) ? urlParsedObj.query : {};
     params.service = 'WFS';
     params.outputFormat = 'json';
@@ -177,7 +179,7 @@ const retryWithForcedSortOptions = (action, store) => {
     const sortOptions = getDefaultSortOptions(getFirstAttribute(store.getState()));
     return getWFSFeature(action.searchUrl, assign(action.filterObj, {
         sortOptions
-    }))
+    }), store.getState())
         .let(interceptOGCError)
         .map((newResponse) => {
             const state = store.getState();
@@ -206,7 +208,7 @@ const featureTypeSelectedEpic = (action$, store) =>
                 const geometry = info.geometry[0] && info.geometry[0].attribute ? info.geometry[0].attribute : 'the_geom';
                 return Rx.Observable.of(changeSpatialAttribute(geometry));
             }
-            return Rx.Observable.defer( () => axios.get(action.url + '?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=' + action.typeName + '&outputFormat=application/json'))
+            return Rx.Observable.defer( () => axios.get(ConfigUtils.filterUrlParams(action.url, authkeyParamNameSelector(store.getState())) + '?service=WFS&version=1.1.0&request=DescribeFeatureType&typeName=' + action.typeName + '&outputFormat=application/json'))
                 .map((response) => {
                     if (typeof response.data === 'object' && response.data.featureTypes && response.data.featureTypes[0]) {
                         const info = extractInfo(response.data);
@@ -236,7 +238,7 @@ const wfsQueryEpic = (action$, store) =>
     action$.ofType(QUERY)
         .switchMap(action => {
             return Rx.Observable.merge(
-                getWFSFeature(action.searchUrl, action.filterObj)
+                getWFSFeature(action.searchUrl, action.filterObj, store.getState())
                     .let(interceptOGCError)
                     .switchMap((response) => {
                         const state = store.getState();

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -106,9 +106,9 @@ var ConfigUtils = {
         }),
         mapStateSource: PropTypes.string
     },
-    getParsedUrl: (urlToParse, options) => {
+    getParsedUrl: (urlToParse, options, params = []) => {
         if (urlToParse) {
-            const parsed = url.parse(urlToParse, true);
+            const parsed = url.parse(ConfigUtils.filterUrlParams(urlToParse, params), true);
             let newPathname = null;
             if (endsWith(parsed.pathname, "wfs") || endsWith(parsed.pathname, "wms") || endsWith(parsed.pathname, "ows")) {
                 newPathname = parsed.pathname.replace(/(wms|ows|wfs|wps)$/, "wps");


### PR DESCRIPTION
## Description
Added filterUrlParams to query requests wfs/wps.
as in #2372  

## Issues
 - Fix #2401 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
 - issue #2401 

**What is the new behavior?**
- parse the url link before query and remove authkey

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
