### PR TITLE
Fix #2214. Improved error management for layer's legend

### DIFF
--- a/web/client/components/TOC/fragments/legend/Legend.jsx
+++ b/web/client/components/TOC/fragments/legend/Legend.jsx
@@ -3,6 +3,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const {isArray} = require('lodash');
 
+const Message = require('../../../I18N/Message');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 
 const assign = require('object-assign');
@@ -24,9 +25,19 @@ class Legend extends React.Component {
         legendOptions: "forceLabels:on;fontSize:10",
         style: {maxWidth: "100%"}
     };
-
+    state = {
+        error: false
+    }
+    componentWillReceiveProps() {
+        if (this.state.error) {
+            this.setState(() => ({error: false}));
+        }
+    }
+    onImgError = () => {
+        this.setState(() => ({error: true}));
+    }
     render() {
-        if (this.props.layer && this.props.layer.type === "wms" && this.props.layer.url) {
+        if (!this.state.error && this.props.layer && this.props.layer.type === "wms" && this.props.layer.url) {
             let layer = this.props.layer;
             const url = isArray(layer.url) ?
                 layer.url[Math.floor(Math.random() * layer.url.length)] :
@@ -56,9 +67,9 @@ class Legend extends React.Component {
                 pathname: urlObj.pathname,
                 query: query
             });
-            return <img src={legendUrl} style={this.props.style}/>;
+            return <img onError={this.onImgError} src={legendUrl} style={this.props.style}/>;
         }
-        return null;
+        return <Message msgId="layerProperties.legenderror" />;
     }
 }
 

--- a/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
+++ b/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
@@ -10,6 +10,7 @@ var expect = require('expect');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var Legend = require('../Legend');
+const Rx = require('rxjs');
 
 const TestUtils = require('react-dom/test-utils');
 
@@ -44,7 +45,6 @@ describe("test the Layer legend", () => {
         expect(tb).toExist();
 
     });
-
     it('test legend content', () => {
         let layer = {
             "type": "wms",
@@ -58,5 +58,23 @@ describe("test the Layer legend", () => {
         let thumbs = TestUtils.scryRenderedDOMComponentsWithTag(tb, "img");
         expect(thumbs.length).toBe(1);
     });
-
+    it('test legend img error content', (done) => {
+        let layer = {
+            "type": "wms",
+            "url": "base/web/client/test-resources/legendImgError.xml",
+            "visibility": true,
+            "title": "test layer 3 (no group)",
+            "name": "layer3",
+            "format": "image/png"
+        };
+        var tb = ReactDOM.render(<Legend layer={layer} />, document.getElementById("container"));
+        const sub = Rx.Observable.interval(100)
+        .filter(() => tb && tb.state.error)
+        .subscribe(() => {
+            let thumbs = TestUtils.scryRenderedDOMComponentsWithTag(tb, "img");
+            expect(thumbs.length).toBe(0);
+            sub.unsubscribe();
+            done();
+        });
+    });
 });

--- a/web/client/test-resources/legendImgError.xml
+++ b/web/client/test-resources/legendImgError.xml
@@ -1,0 +1,5 @@
+<ServiceExceptionReport xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3.0" xsi:schemaLocation="http://www.opengis.net/ogc http://mappe.comune.genova.it:80/geoserver/schemas/wms/1.3.0/exceptions_1_3_0.xsd">
+<ServiceException>
+java.lang.IllegalArgumentException: no legend passed no legend passed
+</ServiceException>
+</ServiceExceptionReport>

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -54,7 +54,8 @@
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
             "featureInfo": "Feature Info",
-            "featureInfoFormatLbl": "Identifiziere das Antwortformat"
+            "featureInfoFormatLbl": "Identifiziere das Antwortformat",
+            "legenderror": "Legende ist nicht verfügbar"
         },
         "notification": {
             "update": "Update",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -54,7 +54,8 @@
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
             "featureInfo": "Feature Info",
-            "featureInfoFormatLbl": "Identify response format"
+            "featureInfoFormatLbl": "Identify response format",
+            "legenderror": "Legend is not available"
         },
         "notification": {
             "update": "Update",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -55,7 +55,8 @@
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
             "featureInfo": "Feature Info",
-            "featureInfoFormatLbl": "Indentificar el formato de respuesta"
+            "featureInfoFormatLbl": "Indentificar el formato de respuesta",
+            "legenderror": "La leyenda no está disponible"
         },
         "notification": {
             "update": "Update",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -55,7 +55,8 @@
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
             "featureInfo": "Feature Info",
-            "featureInfoFormatLbl": "Information, format de la réponse"
+            "featureInfoFormatLbl": "Information, format de la réponse",
+            "legenderror": "La légende n'est pas disponible"
         },
         "notification": {
             "update": "Update",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -54,7 +54,8 @@
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
             "featureInfo": "Feature Info",
-            "featureInfoFormatLbl": "Formato risposta interrogazioni su mappa"
+            "featureInfoFormatLbl": "Formato risposta interrogazioni su mappa",
+            "legenderror": "Legenda non disponibile"
         },
         "notification": {
             "update": "Aggiorna",


### PR DESCRIPTION
## Description
It adds error management for legend's img. On error It' shows a message.
When the component recivies new props It attempts to reload the legend img.

## Issues
 - Fix #2214 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
A broken img icon is shown

**What is the new behavior?**
An Error msg is shown

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
