### PR TITLE
Fixed #2234 FeatureEditor manages/shows boolean values

### DIFF
--- a/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
@@ -25,11 +25,13 @@ class DropDownEditor extends AttributeEditor {
         typeName: PropTypes.string,
         url: PropTypes.string,
         value: PropTypes.string,
+        filter: PropTypes.string,
         values: PropTypes.array
     };
     static defaultProps = {
         isValid: () => true,
         dataType: "string",
+        filter: "contains",
         values: [],
         forceSelection: true,
         allowEmpty: true
@@ -72,7 +74,7 @@ class DropDownEditor extends AttributeEditor {
             data,
             defaultOption: this.props.defaultOption || head(this.props.values)
         });
-        return <ControlledCombobox {...props} filter="contains"/>;
+        return <ControlledCombobox {...props} filter={this.props.filter}/>;
     }
 }
 

--- a/web/client/components/data/featuregrid/editors/index.jsx
+++ b/web/client/components/data/featuregrid/editors/index.jsx
@@ -2,12 +2,15 @@ const React = require('react');
 const Editor = require('./AttributeEditor');
 const NumberEditor = require('./NumberEditor');
 const AutocompleteEditor = require('./AutocompleteEditor');
+const DropDownEditor = require('./DropDownEditor');
+
 const types = {
     "defaultEditor": (props) => <Editor {...props}/>,
     "int": (props) => <NumberEditor dataType="int" inputProps={{step: 1, type: "number"}} {...props}/>,
     "number": (props) => <NumberEditor dataType="number" inputProps={{step: 1, type: "number"}} {...props}/>,
     "string": (props) => props.autocompleteEnabled ?
         <AutocompleteEditor dataType="string" {...props}/> :
-        <Editor dataType="string" {...props}/>
+        <Editor dataType="string" {...props}/>,
+    "boolean": (props) => <DropDownEditor dataType="string" {...props} value={props.value && props.value.toString()} filter={false} values={["true", "false"]}/>
 };
 module.exports = (type, props) => types[type] ? types[type](props) : types.defaultEditor(props);

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -3,6 +3,7 @@ const EditorRegistry = require('../../../../utils/featuregrid/EditorRegistry');
 const {compose, withPropsOnChange, withHandlers, defaultProps} = require('recompose');
 const {isNil} = require('lodash');
 const {getFilterRenderer} = require('../filterRenderers');
+const {getFormatter} = require('../formatters');
 const {manageFilterRendererState} = require('../enhancers/filterRenderers');
 
 const editors = require('../editors');
@@ -103,7 +104,8 @@ const featuresToGrid = compose(
                             return props.filterRenderers[name];
                         }
                         return manageFilterRendererState(getFilterRenderer(localType));
-                    }
+                    },
+                    getFormatter: (desc) => getFormatter(desc)
                 }))
             })
     ),

--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {getFormatter} = require('../index');
+var expect = require('expect');
+
+describe('Tests for the formatter functions', () => {
+    it('test getFormatter for strings', () => {
+        const formatter = getFormatter({localType: "string"});
+        expect(formatter).toBe(undefined);
+    });
+    it('test getFormatter for booleans', () => {
+        const formatter = getFormatter({localType: "boolean"});
+        expect(typeof formatter).toBe("function");
+        expect(formatter()).toBe(undefined);
+        expect(formatter({value: true}).type).toBe("span");
+        expect(formatter({value: true}).props.children).toBe("true");
+
+    });
+});

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+const React = require('react');
+
+module.exports = {
+    getFormatter: (desc) => desc.localType === 'boolean' ? (({value} = {}) => value !== undefined ? <span>{value.toString()}</span> : undefined) : undefined
+};

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -62,7 +62,7 @@ module.exports = {
             describe,
             columnSettings = {},
             {editable=false, sortable=true, resizable=true, filterable = true} = {},
-            {getEditor = () => {}, getFilterRenderer = () => {}} = {}) =>
+            {getEditor = () => {}, getFilterRenderer = () => {}, getFormatter = () => {}} = {}) =>
         getAttributeFields(describe).filter(e => !(columnSettings[e.name] && columnSettings[e.name].hide)).map( (desc) => ({
                 sortable,
                 key: desc.name,
@@ -72,6 +72,7 @@ module.exports = {
                 editable,
                 filterable,
                 editor: getEditor(desc),
+                formatter: getFormatter(desc),
                 filterRenderer: getFilterRenderer(desc, desc.name)
         })),
     getRow,

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -807,4 +807,39 @@ describe('FilterUtils', () => {
 
         expect(FilterUtils.toOGCFilter(filterObj.featureTypeName, filterObj, filterObj.ogcVersion, filterObj.sortOptions, filterObj.hits)).toEqual(expected);
     });
+    it('Check if cqlBooleanField(attribute, operator, value)', () => {
+        // testing operators
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", true)).toBe("\"attribute_1\"='true'");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", false)).toBe("\"attribute_1\"='false'");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", "true")).toBe("\"attribute_1\"='true'");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", "false")).toBe("\"attribute_1\"='false'");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "<", true)).toBe("");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "like", true)).toBe("");
+        // testing falsy values
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", "")).toBe("");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", undefined)).toBe("");
+        expect(FilterUtils.cqlBooleanField("attribute_1", "=", null)).toBe("");
+    });
+    it('Check if ogcBooleanField(attribute, operator, value, nsplaceholder)', () => {
+        // testing operators
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", true, "ogc"))
+            .toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>true</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", false, "ogc"))
+            .toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>false</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", "true", "ogc"))
+            .toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>true</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", "false", "ogc"))
+            .toBe("<ogc:PropertyIsEqualTo><ogc:PropertyName>attribute_1</ogc:PropertyName><ogc:Literal>false</ogc:Literal></ogc:PropertyIsEqualTo>");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "<", true, "ogc")).toBe("");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "<", false, "ogc")).toBe("");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "<", true, "ogc")).toBe("");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "like", true, "ogc")).toBe("");
+            // testing falsy values
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", "", "ogc")).toBe("");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", undefined, "ogc")).toBe("");
+        expect(FilterUtils.ogcBooleanField("attribute_1", "=", null, "ogc")).toBe("");
+
+    });
+
+
 });


### PR DESCRIPTION
## Description
Added support for boolean values for the cql and ogc filter and for the feature grid

## Issues
 - Fix #2234

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
empty values, and filter does not work

**What is the new behavior?**
it shows true or false instead of empty value.
it filters correctly if sync is active

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No