### PR TITLE
Fixed #2216 disabled GFI in edit mode

### DIFF
--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -114,6 +114,7 @@ const FeatureInfoFormatSelector = connect((state) => ({
 
 module.exports = {
     IdentifyPlugin: assign(IdentifyPlugin, {
+        disablePluginIf: "{state('featuregridmode') === 'EDIT'}",
         Toolbar: {
             name: 'info',
             position: 6,


### PR DESCRIPTION
## Description
Get feature info was closing the feature grid even if the user had changed something (geometry or attributes).

## Issues
 - Fix #2216 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Actually is still possible to enable GFI tool in edit mode

**What is the new behavior?**
removed this possibility

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
