### PR TITLE
Fixed #2219 zoom to page

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,7 +16,7 @@ const getSaveMessageId = ({saving, saved}) => {
     return "featuregrid.toolbar.saveChanges";
 };
 
-module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true} = {}) =>
+module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, allFeaturesWithNoGeometry = false} = {}) =>
 
     (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
@@ -36,7 +36,7 @@ module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeo
         <TButton
             id="zoom-all"
             tooltip={<Message msgId="featuregrid.toolbar.zoomAll"/>}
-            disabled={disableToolbar}
+            disabled={disableToolbar || allFeaturesWithNoGeometry}
             visible={mode === "VIEW"}
             onClick={events.zoomAll}
             glyph="zoom-to"/>

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,7 +16,7 @@ const getSaveMessageId = ({saving, saved}) => {
     return "featuregrid.toolbar.saveChanges";
 };
 
-module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, allFeaturesWithNoGeometry = false} = {}) =>
+module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, disableZoomAll = false} = {}) =>
 
     (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
@@ -36,7 +36,7 @@ module.exports = ({events = {}, mode = "VIEW", selectedCount, hasChanges, hasGeo
         <TButton
             id="zoom-all"
             tooltip={<Message msgId="featuregrid.toolbar.zoomAll"/>}
-            disabled={disableToolbar || allFeaturesWithNoGeometry}
+            disabled={disableToolbar || disableZoomAll}
             visible={mode === "VIEW"}
             onClick={events.zoomAll}
             glyph="zoom-to"/>

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -306,13 +306,13 @@ describe('Featuregrid toolbar component', () => {
             switchEditMode: () => {}
         };
         spyOn(events, "switchEditMode");
-        ReactDOM.render(<Toolbar events={events} mode="VIEW" allFeaturesWithNoGeometry/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" disableZoomAll/>, document.getElementById("container"));
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
         let zoomAllButton = document.getElementById("fg-zoom-all");
         expect(isVisibleButton(zoomAllButton)).toBe(true);
         expect(el.children[2].disabled).toBe(true);
-        ReactDOM.render(<Toolbar events={events} mode="VIEW" allFeaturesWithNoGeometry={false}/>, document.getElementById("container"));
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" disableZoomAll={false}/>, document.getElementById("container"));
         zoomAllButton = document.getElementById("fg-zoom-all");
         expect(el.children[2].disabled).toBe(false);
     });

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -300,4 +300,19 @@ describe('Featuregrid toolbar component', () => {
         expect(isVisibleButton(document.getElementById("fg-save-feature"))).toBe(true);
         expect(isVisibleButton(document.getElementById("fg-cancel-editing"))).toBe(true);
     });
+
+    it('check zoom-all button if all features has no geom', () => {
+        const events = {
+            switchEditMode: () => {}
+        };
+        spyOn(events, "switchEditMode");
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" allFeaturesWithNoGeometry/>, document.getElementById("container"));
+        const el = document.getElementsByClassName("featuregrid-toolbar")[0];
+        expect(el).toExist();
+        let zoomAllButton = document.getElementById("fg-zoom-all");
+        expect(isVisibleButton(zoomAllButton)).toBe(false);
+        ReactDOM.render(<Toolbar events={events} mode="EDIT" isEditingAllowed={false}/>, document.getElementById("container"));
+        zoomAllButton = document.getElementById("fg-zoom-all");
+        expect(isVisibleButton(zoomAllButton)).toBe(true);
+    });
 });

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -310,9 +310,10 @@ describe('Featuregrid toolbar component', () => {
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
         let zoomAllButton = document.getElementById("fg-zoom-all");
-        expect(isVisibleButton(zoomAllButton)).toBe(false);
-        ReactDOM.render(<Toolbar events={events} mode="EDIT" isEditingAllowed={false}/>, document.getElementById("container"));
-        zoomAllButton = document.getElementById("fg-zoom-all");
         expect(isVisibleButton(zoomAllButton)).toBe(true);
+        expect(el.children[2].disabled).toBe(true);
+        ReactDOM.render(<Toolbar events={events} mode="VIEW" allFeaturesWithNoGeometry={false}/>, document.getElementById("container"));
+        zoomAllButton = document.getElementById("fg-zoom-all");
+        expect(el.children[2].disabled).toBe(false);
     });
 });

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -43,7 +43,7 @@ const Toolbar = connect(
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
         isSyncActive: isSyncWmsActive,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
-        allFeaturesWithNoGeometry: (state) => featureCollectionResultSelector(state).features.length === 0,
+        disableZoomAll: (state) => featureCollectionResultSelector(state).features.length === 0,
         isSearchAllowed: (state) => !isCesium(state),
         isEditingAllowed: (state) => (filterEditingAllowedUser(userRoleSelector(state), editingAllowedRolesSelector(state)) || canEditSelector(state)) && !isCesium(state),
         hasSupportedGeometry

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 const {bindActionCreators} = require('redux');
 const {createSelector, createStructuredSelector} = require('reselect');
 const {wfsDownloadAvailable} = require('../../../selectors/controls');
-const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive} = require('../../../selectors/query');
+const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive, featureCollectionResultSelector} = require('../../../selectors/query');
 const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter, hasSupportedGeometry, editingAllowedRolesSelector} = require('../../../selectors/featuregrid');
 const {userRoleSelector} = require('../../../selectors/security');
 const {isCesium} = require('../../../selectors/maptype');
@@ -43,6 +43,7 @@ const Toolbar = connect(
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
         isSyncActive: isSyncWmsActive,
         isColumnsOpen: state => state && state.featuregrid && state.featuregrid.tools && state.featuregrid.tools.settings,
+        allFeaturesWithNoGeometry: (state) => featureCollectionResultSelector(state).features.length === 0,
         isSearchAllowed: (state) => !isCesium(state),
         isEditingAllowed: (state) => (filterEditingAllowedUser(userRoleSelector(state), editingAllowedRolesSelector(state)) || canEditSelector(state)) && !isCesium(state),
         hasSupportedGeometry

--- a/web/client/selectors/__tests__/query-test.js
+++ b/web/client/selectors/__tests__/query-test.js
@@ -235,7 +235,16 @@ const initialState = {
           properties: {
             name: 'vvvv'
           }
+      },
+      {
+        type: 'Feature',
+        id: 'poligoni.8',
+        geometry: null,
+        geometry_name: 'geometry',
+        properties: {
+          name: 'no geom'
         }
+      }
       ],
       crs: {
         type: 'name',
@@ -317,7 +326,7 @@ describe('Test query selectors', () => {
     it('test resultsSelector selector', () => {
         const res = resultsSelector(initialState);
         expect(res).toExist();
-        expect(res.length).toBe(4);
+        expect(res.length).toBe(5);
     });
     it('test paginationInfo.startIndex selector', () => {
         const startIndex = paginationInfo.startIndex(initialState);
@@ -329,7 +338,7 @@ describe('Test query selectors', () => {
     });
     it('test paginationInfo.resultSize selector', () => {
         const featuresLength = paginationInfo.resultSize(initialState);
-        expect(featuresLength).toBe(4);
+        expect(featuresLength).toBe(5);
     });
     it('test paginationInfo.totalFeatures selector', () => {
         const totalFeatures = paginationInfo.totalFeatures(initialState);

--- a/web/client/selectors/__tests__/queryform-test.js
+++ b/web/client/selectors/__tests__/queryform-test.js
@@ -73,7 +73,7 @@ const initialState = {
     }
 };
 
-describe('Test query selectors', () => {
+describe('Test queryform selectors', () => {
     it(' 1) - spatialFieldSelector', () => {
         const spatialfield = spatialFieldSelector(initialState);
         expect(spatialfield).toExist();

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -1,4 +1,4 @@
-const {get, head} = require('lodash');
+const {isNil, get, head} = require('lodash');
 module.exports = {
     wfsURL: state => state && state.query && state.query.searchUrl,
     wfsURLSelector: state => state && state.query && state.query.url,
@@ -6,7 +6,13 @@ module.exports = {
     attributesSelector: state => get(state, `query.featureTypes.${get(state, "query.filterObj.featureTypeName")}.attributes`),
     typeNameSelector: state => get(state, "query.typeName"),
     resultsSelector: (state) => get(state, "query.result.features"),
-    featureCollectionResultSelector: state => get(state, "query.result"),
+    featureCollectionResultSelector: state => {
+        const results = get(state, "query.result");
+        return {
+            ...results,
+            features: results.features.filter(f => !isNil(f.geometry))
+        };
+    },
     getFeatureById: (state, id) => {
         let features = state && state.query && state.query.result && state.query.result.features;
         return head(features.filter(f => f.id === id));

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -10,7 +10,7 @@ module.exports = {
         const results = get(state, "query.result");
         return {
             ...results,
-            features: results.features.filter(f => !isNil(f.geometry))
+            features: (results && results.features || []).filter(f => !isNil(f.geometry))
         };
     },
     getFeatureById: (state, id) => {


### PR DESCRIPTION
## Description
Zoom to page fails if a feature in the pages has no geometry

## Issues
 - Fix #2219 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
actually it does not soozm because it fails internally to create the bbox

**What is the new behavior?**
now it does not fails and it zooms to the page

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No