### PR TITLE
Improve legend image reload policy

### DIFF
--- a/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
+++ b/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
@@ -77,4 +77,27 @@ describe("test the Layer legend", () => {
             done();
         });
     });
+    it('test legend img error reload', (done) => {
+        let layer = {
+            "type": "wms",
+            "url": "base/web/client/test-resources/legendImgError.xml",
+            "visibility": true,
+            "title": "test layer 3 (no group)",
+            "name": "layer3",
+            "format": "image/png"
+        };
+        var tb = ReactDOM.render(<Legend layer={layer} />, document.getElementById("container"));
+        const sub = Rx.Observable.interval(100)
+        .filter(() => tb && tb.state.error)
+        .subscribe(() => {
+            let thumbs = TestUtils.scryRenderedDOMComponentsWithTag(tb, "img");
+            expect(thumbs.length).toBe(0);
+            const newLayer = {...layer, url: "http://test2/reflector/open/service"};
+            tb = ReactDOM.render(<Legend layer={newLayer} />, document.getElementById("container"));
+            thumbs = TestUtils.scryRenderedDOMComponentsWithTag(tb, "img");
+            expect(thumbs.length).toBe(1);
+            sub.unsubscribe();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
## Description
It improves the reload of the legend image. Now when an image download fails, the component will try to reload the image only when the url changes.
## Issues
 - connected to  #2214 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
If the download of a legend image fails, the component tries to reload that images on any render

**What is the new behavior?**
The components will reload a failed image only when url changes


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
