### PR TITLE
Fixes #2428 Going to Home with print tool opened it messes up the layout

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -206,7 +206,7 @@ class OpenlayersMap extends React.Component {
         const attributionContainer = this.props.mapOptions.attribution && this.props.mapOptions.attribution.container
         && document.querySelector(this.props.mapOptions.attribution.container);
         if (attributionContainer && attributionContainer.querySelector('.ol-attribution')) {
-            attributionContainer.removeChild(document.querySelector('.ol-attribution'));
+            attributionContainer.removeChild(attributionContainer.querySelector('.ol-attribution'));
         }
         this.map.setTarget(null);
     }

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -360,9 +360,9 @@ describe('OpenlayersMap', () => {
     });
 
     it('create attribution with container', () => {
-        let map = ReactDOM.render(<OpenlayersMap center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{attribution: {container: 'body'}}}/>, document.getElementById("map"));
+        let map = ReactDOM.render(<OpenlayersMap id="ol-map" center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{attribution: {container: 'body'}}}/>, document.getElementById("map"));
         expect(map).toExist();
-        const domMap = document.getElementById('map');
+        const domMap = document.getElementById('ol-map');
         let attributions = domMap.getElementsByClassName('ol-attribution');
         expect(attributions.length).toBe(0);
         attributions = document.body.getElementsByClassName('ol-attribution');
@@ -370,14 +370,30 @@ describe('OpenlayersMap', () => {
     });
 
     it('remove attribution from container', () => {
-        let map = ReactDOM.render(<OpenlayersMap center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{attribution: {container: 'body'}}}/>, document.getElementById("map"));
+        let map = ReactDOM.render(<OpenlayersMap id="ol-map" center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{attribution: {container: 'body'}}}/>, document.getElementById("map"));
         expect(map).toExist();
-        const domMap = document.getElementById('map');
+        const domMap = document.getElementById('ol-map');
         let attributions = domMap.getElementsByClassName('ol-attribution');
         expect(attributions.length).toBe(0);
         attributions = document.body.getElementsByClassName('ol-attribution');
         document.body.removeChild(attributions[0]);
         attributions = document.body.getElementsByClassName('ol-attribution');
         expect(attributions.length).toBe(0);
+    });
+
+    it('test double attribution on document', () => {
+        let map = ReactDOM.render(
+            <span>
+                <div className="ol-attribution"></div>
+                <div id="map-attribution"></div>
+                <OpenlayersMap id="ol-map" center={{y: 43.9, x: 10.3}} zoom={11} mapOptions={{attribution: {container: '#map-attribution'}}}/>
+            </span>
+        , document.getElementById("map"));
+        expect(map).toExist();
+        const domMap = document.getElementById('ol-map');
+        let attributions = domMap.getElementsByClassName('ol-attribution');
+        expect(attributions.length).toBe(0);
+        attributions = document.getElementsByClassName('ol-attribution');
+        expect(attributions.length).toBe(2);
     });
 });


### PR DESCRIPTION
## Description
Update remove child on unmount component of Map plugin in openlayers.

## Issues
 - Fix #2428 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issue #2428 

**What is the new behavior?**
The homepage doesn't show map viewer in its layout

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
