### PR TITLE
Closed #2404 added tiled true by default in openlayers wms layers

### DIFF
--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -17,6 +17,11 @@ const FilterUtils = require('../../../../utils/FilterUtils');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const mapUtils = require('../../../../utils/MapUtils');
 
+/**
+    @param {object} options of the layer
+    @return the Openlayers options from the layers ones and/or default.
+    tiled params must be tru if not defined
+*/
 function wmsToOpenlayersOptions(options) {
     const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     // NOTE: can we use opacity to manage visibility?

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -6,9 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var Layers = require('../../../../utils/openlayers/Layers');
-var ol = require('openlayers');
-var objectAssign = require('object-assign');
+const Layers = require('../../../../utils/openlayers/Layers');
+const ol = require('openlayers');
+const {isNil} = require('lodash');
+const objectAssign = require('object-assign');
 const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
 const ProxyUtils = require('../../../../utils/ProxyUtils');
 const {isArray} = require('lodash');
@@ -26,7 +27,7 @@ function wmsToOpenlayersOptions(options) {
         TRANSPARENT: options.transparent !== undefined ? options.transparent : true,
         SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
-        TILED: options.tiled || false,
+        TILED: !isNil(options.tiled) ? options.tiled : true,
         VERSION: options.version || "1.3.0",
         CQL_FILTER
     }, objectAssign(


### PR DESCRIPTION
## Description
Added tiled true by default to wms layer for openlayers

## Issues
 - Fix #2404

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
The tiled param in wms request was set to false by default in openlayers for layers added from catalog.
see #2404 for details

**What is the new behavior?**
now the value is set to true if it is missing

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
