### PR TITLE
Issue #2443. Load locally available KML/KMZ, GPX files into the map a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "//": "replace react-sortable-items with official on npm when it will support React 15",
   "dependencies": {
     "@carnesen/redux-add-action-listener-enhancer": "0.0.1",
+    "@mapbox/togeojson": "0.16.0",
     "@turf/bbox": "4.1.0",
     "@turf/inside": "4.1.0",
     "@turf/line-intersect": "4.1.0",
@@ -106,6 +107,7 @@
     "json-2-csv": "2.1.2",
     "json-loader": "0.5.4",
     "jsonix": "2.4.1",
+    "jszip": "3.1.5",
     "keymirror": "0.1.1",
     "leaflet": "0.7.7",
     "leaflet-draw": "0.2.4",

--- a/web/client/components/shapefile/SelectShape.jsx
+++ b/web/client/components/shapefile/SelectShape.jsx
@@ -57,9 +57,8 @@ class SelectShape extends React.Component {
     checkFileType = (file) => {
         return new Promise((resolve, reject) => {
             const ext = FileUtils.recognizeExt(file.name);
-            const type = file.type || FileUtils.MIME_LOOKUPS[ext];
-            if (type instanceof Array ||
-                type === 'application/x-zip-compressed' ||
+            const type = FileUtils.MIME_LOOKUPS[ext];
+            if (type === 'application/x-zip-compressed' ||
                 type === 'application/zip' ||
                 type === 'application/vnd.google-earth.kml+xml' ||
                 type === 'application/vnd.google-earth.kmz' ||

--- a/web/client/components/shapefile/SelectShape.jsx
+++ b/web/client/components/shapefile/SelectShape.jsx
@@ -56,12 +56,13 @@ class SelectShape extends React.Component {
 
     checkFileType = (file) => {
         return new Promise((resolve, reject) => {
-            const ext = file.name.split('.').slice(-1)[0];
+            const ext = FileUtils.recognizeExt(file.name);
             const type = file.type || FileUtils.MIME_LOOKUPS[ext];
-            if (file.type === 'application/zip' ||
-                file.type === 'application/x-zip-compressed' ||
-                file.type === 'application/vnd.google-earth.kml+xml' ||
-                file.type === 'application/vnd.google-earth.kmz' ||
+            if (type instanceof Array ||
+                type === 'application/x-zip-compressed' ||
+                type === 'application/zip' ||
+                type === 'application/vnd.google-earth.kml+xml' ||
+                type === 'application/vnd.google-earth.kmz' ||
                 type === 'application/gpx+xml') {
                 resolve();
             } else {

--- a/web/client/components/shapefile/SelectShape.jsx
+++ b/web/client/components/shapefile/SelectShape.jsx
@@ -57,7 +57,7 @@ class SelectShape extends React.Component {
     checkFileType = (file) => {
         return new Promise((resolve, reject) => {
             const ext = FileUtils.recognizeExt(file.name);
-            const type = FileUtils.MIME_LOOKUPS[ext];
+            const type = file.type || FileUtils.MIME_LOOKUPS[ext];
             if (type === 'application/x-zip-compressed' ||
                 type === 'application/zip' ||
                 type === 'application/vnd.google-earth.kml+xml' ||

--- a/web/client/components/shapefile/SelectShape.jsx
+++ b/web/client/components/shapefile/SelectShape.jsx
@@ -49,13 +49,20 @@ class SelectShape extends React.Component {
 
     tryUnzip = (file) => {
         return FileUtils.readZip(file).then((buffer) => {
-            return new JSZip(buffer);
+            var zip = new JSZip();
+            return zip.loadAsync(buffer);
         });
     };
 
-    isZip = (file) => {
+    checkFileType = (file) => {
         return new Promise((resolve, reject) => {
-            if (file.type === 'application/zip' || file.type === 'application/x-zip-compressed') {
+            const ext = file.name.split('.').slice(-1)[0];
+            const type = file.type || FileUtils.MIME_LOOKUPS[ext];
+            if (file.type === 'application/zip' ||
+                file.type === 'application/x-zip-compressed' ||
+                file.type === 'application/vnd.google-earth.kml+xml' ||
+                file.type === 'application/vnd.google-earth.kmz' ||
+                type === 'application/gpx+xml') {
                 resolve();
             } else {
                 this.tryUnzip(file).then(resolve).catch(reject);
@@ -64,7 +71,7 @@ class SelectShape extends React.Component {
     };
 
     checkfile = (files) => {
-        Promise.all(files.map(file => this.isZip(file))).then(() => {
+        Promise.all(files.map(file => this.checkFileType(file))).then(() => {
             if (this.props.error) {
                 this.props.onShapeError(null);
             }

--- a/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
+++ b/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
@@ -60,7 +60,7 @@ class ShapeFileUploadAndStyle extends React.Component {
         shapeLoading: () => {},
         readFiles: (files) => files.map((file) => {
             const ext = FileUtils.recognizeExt(file.name);
-            const type = file.type || FileUtils.MIME_LOOKUPS[ext];
+            const type = FileUtils.MIME_LOOKUPS[ext];
             if (type === 'application/vnd.google-earth.kml+xml') {
                 return FileUtils.readKml(file).then((xml) => {
                     return FileUtils.kmlToGeoJSON(xml);
@@ -82,8 +82,7 @@ class ShapeFileUploadAndStyle extends React.Component {
                     return e.message;
                 });
             }
-            if (type instanceof Array ||
-                type === 'application/x-zip-compressed' ||
+            if (type === 'application/x-zip-compressed' ||
                 type === 'application/zip' ) {
                 return FileUtils.readZip(file).then((buffer) => {
                     return FileUtils.shpToGeoJSON(buffer);

--- a/web/client/components/shapefile/__tests__/SelectShape-test.jsx
+++ b/web/client/components/shapefile/__tests__/SelectShape-test.jsx
@@ -61,6 +61,57 @@ describe("Test the select shapefile component", () => {
         TestUtils.Simulate.drop(content, { dataTransfer: { files } });
     });
 
+    it('upload KML file', (done) => {
+        const handler = () => {
+            done();
+        };
+        const cmp = ReactDOM.render(<SelectShape onShapeChoosen={handler}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        const dom = ReactDOM.findDOMNode(cmp);
+        expect(dom.getElementsByTagName('input').length).toBe(1);
+        const content = TestUtils.findRenderedDOMComponentWithClass(cmp, 'dropzone-content');
+        const files = [{
+            name: 'file1.kml',
+            size: 1111,
+            type: 'application/vnd.google-earth.kml+xml'
+        }];
+        TestUtils.Simulate.drop(content, { dataTransfer: { files } });
+    });
+
+    it('upload KMZ file', (done) => {
+        const handler = () => {
+            done();
+        };
+        const cmp = ReactDOM.render(<SelectShape onShapeChoosen={handler}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        const dom = ReactDOM.findDOMNode(cmp);
+        expect(dom.getElementsByTagName('input').length).toBe(1);
+        const content = TestUtils.findRenderedDOMComponentWithClass(cmp, 'dropzone-content');
+        const files = [{
+            name: 'file1.kmz',
+            size: 1111,
+            type: 'application/vnd.google-earth.kmz'
+        }];
+        TestUtils.Simulate.drop(content, { dataTransfer: { files } });
+    });
+
+    it('upload GPX file', (done) => {
+        const handler = () => {
+            done();
+        };
+        const cmp = ReactDOM.render(<SelectShape onShapeChoosen={handler}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        const dom = ReactDOM.findDOMNode(cmp);
+        expect(dom.getElementsByTagName('input').length).toBe(1);
+        const content = TestUtils.findRenderedDOMComponentWithClass(cmp, 'dropzone-content');
+        const files = [{
+            name: 'file1.gpx',
+            size: 1111,
+            type: ''
+        }];
+        TestUtils.Simulate.drop(content, { dataTransfer: { files } });
+    });
+
     it('upload wrong mime, right file', (done) => {
         const handler = () => {
             done();
@@ -71,6 +122,7 @@ describe("Test the select shapefile component", () => {
         expect(dom.getElementsByTagName('input').length).toBe(1);
         const content = TestUtils.findRenderedDOMComponentWithClass(cmp, 'dropzone-content');
         const files = [b64toBlob('UEsDBAoAAAAAACGPaktDvrfoAQAAAAEAAAAKAAAAc2FtcGxlLnR4dGFQSwECPwAKAAAAAAAhj2pLQ7636AEAAAABAAAACgAkAAAAAAAAACAAAAAAAAAAc2FtcGxlLnR4dAoAIAAAAAAAAQAYAGILh+1EWtMBy3f86URa0wHLd/zpRFrTAVBLBQYAAAAAAQABAFwAAAApAAAAAAA=', 'application/pdf')];
+        files[0].name = 'test.zip';
         TestUtils.Simulate.drop(content, { dataTransfer: { files } });
     });
 

--- a/web/client/plugins/shapefile/ShapeFile.jsx
+++ b/web/client/plugins/shapefile/ShapeFile.jsx
@@ -67,6 +67,7 @@ class ShapeFile extends React.Component {
         const stylers = {
             Polygon: <StylePolygon/>,
             MultiPolygon: <StylePolygon/>,
+            GeometryCollection: <StylePolygon/>,
             LineString: <StylePolyline/>,
             MultiLineString: <StylePolyline/>,
             MultiPoint: <StylePoint/>,

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -706,13 +706,13 @@
             "taintedMessage": "Die Snapshot Speichern Funktionalität ist aufgrund von Browser Sicherheits Beschränkungen eingeschränkt. Für ein besseres Ergebnis klicke mit der rechten Maustaste auf die Vorschau und wähle 'Bild speichern unter'(unterstützt von Firefox und Chrome)"
         },
         "shapefile": {
-            "title": "Shapefile hochladen",
-            "tooltip": "Füge der Karte ein Shapefile hinzu.",
-            "placeholder": "Ziehe deine Dateien hierher oder klicke Shapefile(s) die importiert werden sollen.(Shapefiles müssen in Zip-Archiven enthalten sein)",
+            "title": "Vektor-Dateien hochladen",
+            "tooltip": "Füge der Karte ein Vektor-Dateien hinzu.",
+            "placeholder": "Ziehe deine Dateien hierher oder klicke Vektor-Dateien die importiert werden sollen.(Shapefiles müssen in Zip-Archiven enthalten sein, KML/KMZ e GPX)",
             "defaultStyle": "Standardstil",
             "zoom": "Zoome auf Shapefiles",
             "error": {
-                "select": "Wähle ein oder mehrere Zip Archive",
+                "select": "Wählen Sie die richtige Datei aus",
                 "shapeFileParsingError": "Das Shapefile kann nicht geladen werden. Die Datei könnte beschädigt oder nicht gut geformt sein",
                 "genericLoadError": "Das Shapefile kann nicht auf der Karte geladen werden"
             },

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -705,15 +705,15 @@
             "taintedMessage": "Save snapshot functionality is limited due to some browser security rules. For better results right-click on the preview and select 'Save image as' (supported by Firefox and Chrome)."
         },
         "shapefile": {
-            "title": "Add Local Shapefile",
-            "tooltip": "Add a local shapefile to the map.",
-            "placeholder": "Drop your files here or click to select the shapefiles to import. (shapefiles must be contained in zip archives)",
+            "title": "Add Local Vector Files",
+            "tooltip": "Add a local Vector Files to the map.",
+            "placeholder": "Drop your files here or click to select the Vector Files to import. (supported files: shapefiles must be contained in zip archives, KML/KMZ e GPX)",
             "defaultStyle": "Default style",
-            "zoom": "Zoom on the shapefiles",
+            "zoom": "Zoom on the vector files",
             "error": {
-                "select": "Select one or more zip files",
-                "shapeFileParsingError": "Cannot load the shapefile. The file could be damaged or not well formed",
-                "genericLoadError": "Cannot load the shapefile on map"
+                "select": "Select one or more files. (supported files: shapefiles must be contained in zip archives, KML/KMZ e GPX)",
+                "shapeFileParsingError": "Cannot load the vector file. The file could be damaged or not well formed",
+                "genericLoadError": "Cannot load the vector file on map"
             },
             "add": "Add",
             "cancel": "Cancel",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -707,15 +707,15 @@
             "taintedMessage": "La funcionalidad de guardar está limitada por las restricciones de seguridad del navegador. Para un mejor resultado, clique con el botón derecho del ratón en la vista previa y selecionar 'Guardar como ...' (en firefox y chrome)"
         },
         "shapefile": {
-            "title": "Añadir fichero shape local",
-            "tooltip": "Añadir fichero shape local al mapa.",
-            "placeholder": "Ponga aqui sus fichero  o clique  para selecionar los shapefile  a importar. (Shapefiles deben estar dentro de un zip)",
+            "title": "Añadir fichero archivo local",
+            "tooltip": "Añadir fichero archivo local al mapa.",
+            "placeholder": "Ponga aqui sus fichero  o clique  para selecionar los archivo local a importar. (archivos compatibles: Shapefiles deben estar dentro de un zip, KML/KMZ e GPX)",
             "defaultStyle": "Estilo por defecto",
             "zoom": "Zoom sobre el fichero shape",
             "error": {
-                "select": "Seleccionar uno o más ficheros zip",
-                "shapeFileParsingError": "No se puede cargar el shapefile El archivo podría dañarse o no estar bien formado",
-                "genericLoadError": "No se puede cargar el shapefile en el mapa"
+                "select": "Seleccionar uno o más archivo local. (archivos compatibles: Shapefiles deben estar dentro de un zip, KML/KMZ e GPX)",
+                "shapeFileParsingError": "No se puede cargar el archivo local El archivo podría dañarse o no estar bien formado",
+                "genericLoadError": "No se puede cargar el archivo local en el mapa"
             },
             "add": "Añadir",
             "cancel": "Cancelar",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -710,13 +710,13 @@
             "taintedMessage": "La fonctionnalité de sauvegarde est limitée pour les limitations de sécurité du navigateur. Pour un meilleur résultat, cliquez avec le bouton droit de la souris sur l'aperçu et sélectionnez 'Enregistrer l'image sous...' (prise en charge par Firefox et Chrome)"
         },
         "shapefile": {
-            "title": "Ajouter un fichier Shape local",
-            "tooltip": "Ajouter un fichier Shape local à la carte.",
-            "placeholder": "Déposez vos fichiers ici ou cliquez sur pour sélectionner les shapefiles à importer. (Shapefiles doivent être contenus dans des archives zip)",
+            "title": "Ajouter un fichier fichiers vectoriels",
+            "tooltip": "Ajouter un fichier fichiers vectoriels à la carte.",
+            "placeholder": "Déposez vos fichiers ici ou cliquez sur pour sélectionner les fichiers vectoriels à importer. (Shapefiles doivent être contenus dans des archives zip, KML/KMZ e GPX)",
             "defaultStyle": "Style par défaut",
             "zoom": "Zoomer sur le fichier shape",
             "error": {
-                "select": "Sélectionner un ou plusieurs fichiers zip",
+                "select": "Sélectionnez le bon fichier. (Shapefiles doivent être contenus dans des archives zip, KML/KMZ e GPX)",
                 "shapeFileParsingError": "Impossible de charger le fichier de formes. Le fichier pourrait être endommagé ou mal formé",
                 "genericLoadError": "Impossible de charger le fichier de formes sur la carte"
             },

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -706,15 +706,15 @@
             "taintedMessage": "La funzionalità di salvataggio dell'istantanea è limitata a causa di alcune regole di sicurezza. Per un risultato migliore cliccare con il tasto destro sull'anteprima e selezionare  'Salva immagine con nome' (supportato solo da Mozilla Firefox e Google Chrome)"
         },
         "shapefile": {
-            "title": "Carica Shapefile",
-            "tooltip": "Aggiungi uno shapefile alla mappa.",
-            "placeholder": "Trascina qui i file o fai click per selezionare gli shapefile da importare.(gli shapefiles devono essere contenuti in archivi zip)",
+            "title": "Carica files vettoriali",
+            "tooltip": "Aggiungi uno file vettoriale alla mappa.",
+            "placeholder": "Trascina qui i file o fai click per selezionare i file vettoriali da importare.(file supportati: SHAPEFILES contenuti in archivi zip, KML/KMZ e GPX)",
             "defaultStyle": "Stile di default",
-            "zoom": "Zoom sugli shapefile",
+            "zoom": "Zoom sui file",
             "error": {
-                "select": "Seleziona Shapefile compresso",
-                "shapeFileParsingError": "Non è stato possibile caricare lo shapefile. Il file potrebbe essere danneggiato o non corretto",
-                "genericLoadError": "Lo shapefile non è stato caricato correttamente sulla mappa"
+                "select": "Seleziona file corretto. File supportati: SHAPEFILES contenuti in archivi zip, KML/KMZ e GPX)",
+                "shapeFileParsingError": "Non è stato possibile caricare il file. Il file potrebbe essere danneggiato o non corretto",
+                "genericLoadError": "Il file non è stato caricato correttamente sulla mappa"
             },
             "add": "Importa",
             "cancel": "Annulla",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -643,12 +643,12 @@
             "taintedMessage": "De opslagfunctie is beperkt omwille van beveiligingsbeperkingen van de browser. Klik met de rechtermuisknop op het voorbeeld en selecteer 'Afbeelding opslaan als ...' om een beter resultaat te bekomen (ondersteund door Firefox en Chrome)"
         },
         "shapefile": {
-            "title": "Voeg een lokaal Shape-bestand toe",
-            "tooltip": "Voeg een lokaal Shape-bestand toe aan de kaart.",
+            "title": "Voeg een lokaal bestand",
+            "tooltip": "Voeg een lokaal bestand toe aan de kaart.",
             "placeholder": "Drop je bestanden hier of klik hier op om de shapefiles te selecteren die u wilt importeren. (Shapefiles moeten in zip-archieven zijn opgenomen)",
             "defaultStyle": "Standaard stijl",
-            "zoom": "Zoomer op het Shape-bestand",
-            "error": {"select": "Kies één of meerdere zip-bestanden"},
+            "zoom": "Zoomer op het bestand",
+            "error": {"select": "Kies één of meerdere zip-bestanden. (Shapefiles moeten in zip-archieven zijn opgenomen, KML/KMZ e GPX)"},
             "add": "Voeg toe",
             "cancel": "Annuleer",
             "success": " Import geslaagd"

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -20,7 +20,7 @@ const FileUtils = {
         'gpx': 'application/gpx+xml',
         'kmz': 'application/vnd.google-earth.kmz',
         'kml': 'application/vnd.google-earth.kml+xml',
-        'zip': ['application/x-zip-compressed', 'application/zip']
+        'zip': 'application/zip'
     },
     recognizeExt: function(fileName) {
         return fileName.split('.').slice(-1)[0];

--- a/web/client/utils/FileUtils.js
+++ b/web/client/utils/FileUtils.js
@@ -9,9 +9,18 @@
 const FileSaver = require('file-saver');
 const toBlob = require('canvas-to-blob');
 const shp = require('shpjs');
+const tj = require('@mapbox/togeojson');
+const JSZip = require('jszip');
 const {Promise} = require('es6-promise');
+const parser = new DOMParser();
 
 const FileUtils = {
+    MIME_LOOKUPS: {
+        'gpx': 'application/gpx+xml',
+        'kmz': 'application/vnd.google-earth.kmz',
+        'kml': 'application/vnd.google-earth.kml+xml',
+        'zip': ['application/x-zip-compressed', 'application/zip']
+    },
     download: function(blob, name, mimetype) {
         let file = new Blob([blob], {type: mimetype});
         // a.href = URL.createObjectURL(file);
@@ -23,6 +32,20 @@ const FileUtils = {
     shpToGeoJSON: function(zipBuffer) {
         return [].concat(shp.parseZip(zipBuffer));
     },
+    kmlToGeoJSON: function(xml) {
+        let geoJSON = [].concat(tj.kml(xml));
+        geoJSON.forEach(function(item) {
+            item.fileName = xml.getElementsByTagName('name')[0].innerHTML;
+        });
+        return geoJSON;
+    },
+    gpxToGeoJSON: function(xml) {
+        let geoJSON = [].concat(tj.gpx(xml));
+        geoJSON.forEach(function(item) {
+            item.fileName = xml.getElementsByTagName('name')[0].innerHTML;
+        });
+        return geoJSON;
+    },
     readZip: function(file) {
         return new Promise((resolve, reject) => {
             let reader = new FileReader();
@@ -30,7 +53,34 @@ const FileUtils = {
             reader.onerror = function() { reject(reader.error.name); };
             reader.readAsArrayBuffer(file);
         });
-
+    },
+    readKml: function(file) {
+        return new Promise((resolve, reject) => {
+            let reader = new FileReader();
+            reader.onload = function() {
+                 resolve(parser.parseFromString(reader.result, "text/xml"));
+             };
+            reader.onerror = function() {
+                reject(reader.error.name);
+            };
+            reader.readAsText(file);
+        });
+    },
+    readKmz: function(file) {
+        const zip = new JSZip();
+        return new Promise((resolve, reject) => {
+            zip.loadAsync(file).then(files => {
+                files.filter(elem => {
+                    return elem.indexOf('kml') !== -1;
+                }).map(elem => {
+                    return elem.async("string").then((response) => {
+                        resolve(parser.parseFromString(response, "text/xml"));
+                    }).catch((e) => {
+                        reject(e.message);
+                    });
+                });
+            });
+        });
     }
 };
 module.exports = FileUtils;

--- a/web/client/utils/openlayers/StyleUtils.js
+++ b/web/client/utils/openlayers/StyleUtils.js
@@ -62,6 +62,19 @@ const toVectorStyle = function(layer, style) {
                 })});
             break;
         }
+        case 'GeometryCollection': {
+            newLayer.nativeStyle = new ol.style.Style({
+                radius: style.radius,
+                stroke: stroke,
+                fill: fill,
+                image: new ol.style.Circle({
+                    radius: style.radius,
+                    fill: fill,
+                    stroke: stroke
+                })
+            });
+            break;
+        }
         default: {
             newLayer.style = null;
         }


### PR DESCRIPTION
…nd show the data (geometry and attributes)

## Description
The users shall be able to upload KML/KMZ, GPX data to the UI and the data shall be displayed in the map.
The result of the import will be a (vector) layer in the map, with all the usual functionalities (included the ability to do an identify and show attributes of the vector data).

## Issues
 - #2443 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Feature


**What is the current behavior?** (You can also link to an open issue here)
You can only upload Shapefiles in zip archive

**What is the new behavior?**
Now you can upload also KML/KMZ, GPX vector files.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [X] No
