### PR TITLE
Fixed a couple of typos in translations

### DIFF
--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -82,7 +82,6 @@
             "leave": "Quitter",
             "accept": "Accepter"
         },
-        "enable": "Activer",
         "background": "Fond de plan",
         "language": "langue",
         "mousePositionCoordinates": "Coordonnées",
@@ -251,7 +250,7 @@
             "toolReloadLayerTooltip": "Forcer la recharge de la couche sélectionnée",
             "toolReloadLayersTooltip": "Forcer la recharge des couches sélectionnées",
             "statusIconOpen": "Fermer le groupe de couches",
-            "statusIconClose": Ouvrir le groupe de couches",
+            "statusIconClose": "Ouvrir le groupe de couches",
             "grabLayerIcon": "Attraper et déplacer la couche",
             "grabGroupIcon": "Attraper et déplacer le groupe",
             "toggleLayerVisibilityWarning": "Inverser la visibilité de la couche, attention: la couche ne s'est pas chargée correctement",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -80,7 +80,6 @@
             "leave": "Verlaten",
             "accept": "Aanvaarden"
         },
-        "enable": "Activeren",
         "background": "Achtergrondkaart",
         "language": "Taal",
         "mousePositionCoordinates": "Coördinaten",


### PR DESCRIPTION
## Description
Fixed typos in https://github.com/geosolutions-it/MapStore2/pull/2442
## Issues

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Doesn't load fr and nl translations due to malformed JSON

**What is the new behavior?**
Loads fr and nl translations due to malformed JSON

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
