### PR TITLE
Added srsName param to the spatial filter configuration

### DIFF
--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -173,12 +173,11 @@ class SpatialFilter extends React.Component {
         const selectedMethod = this.getMethodFromId(this.props.spatialField.method);
         return (<Panel>
             <div className="container-fluid">
-                <Row className="filter-field-row">
-                    <Col xs={5}>
+                <Row className="filter-field-row filter-field-fixed-row">
+                    <Col xs={6}>
                         <span>{this.props.spatialField.method}</span>
                     </Col>
-                    <Col xs={7}>
-                        <div style={{width: "140px"}}>
+                    <Col xs={6}>
                             <AutocompleteWFSCombobox
                                 autocompleteStreamFactory={createWFSFetchStream}
                                 valueField={selectedMethod && selectedMethod.filterProps && selectedMethod.filterProps.valueField}
@@ -188,8 +187,6 @@ class SpatialFilter extends React.Component {
                                 onChangeDrawingStatus={this.props.actions.onChangeDrawingStatus}
                                 filterProps={selectedMethod && selectedMethod.filterProps}
                             />
-                        </div>
-
                     </Col>
                 </Row>
             </div>

--- a/web/client/components/misc/AutocompleteWFSCombobox.jsx
+++ b/web/client/components/misc/AutocompleteWFSCombobox.jsx
@@ -24,6 +24,7 @@ const streamEnhancer = mapPropsStream(props$ => {
         data: isArray(data && data.fetchedData && data.fetchedData.values) ? data.fetchedData.values : [],
         features: isArray(data && data.fetchedData && data.fetchedData.features) ? data.fetchedData.features : [],
         valuesCount: data && data.fetchedData && data.fetchedData.size,
+        srsName: data && data.fetchedData && data.fetchedData.crs,
         busy: data.busy
     }));
 });
@@ -32,13 +33,13 @@ const streamEnhancer = mapPropsStream(props$ => {
 const PagedWFSComboboxEnhanced = streamEnhancer(
     ({ open, toggle, select, focus, change, value, valuesCount, onChangeDrawingStatus,
     loadNextPage, loadPrevPage, maxFeatures, currentPage, itemComponent, features,
-    busy, data, loading = false, valueField, textField, filter }) => {
+    busy, data, loading = false, valueField, textField, filter, srsName }) => {
         const numberOfPages = Math.ceil(valuesCount / maxFeatures);
         // for understanding "numberOfPages <= currentPage" see  https://osgeo-org.atlassian.net/browse/GEOS-7233. can be removed when fixed
         // sometimes on the last page it returns a wrong totalFeatures number
         return (<PagedComboboxWithFeatures
             pagination={{firstPage: currentPage === 1, lastPage: numberOfPages <= currentPage, paginated: true, loadPrevPage, loadNextPage, currentPage}}
-            busy={busy} dropUp={false} data={data} open={open} onChangeDrawingStatus={onChangeDrawingStatus}
+            srsName={srsName} busy={busy} dropUp={false} data={data} open={open} onChangeDrawingStatus={onChangeDrawingStatus}
             valueField={valueField} textField={textField} itemComponent={itemComponent} filter={filter}
             onFocus={focus} onToggle={toggle} onChange={change} onSelect={select} features={features}
             selectedValue={value} loading={loading}/>);

--- a/web/client/components/misc/combobox/PagedComboboxWithFeatures.jsx
+++ b/web/client/components/misc/combobox/PagedComboboxWithFeatures.jsx
@@ -49,6 +49,7 @@ class PagedCombobox extends React.Component {
         nextPageIcon: PropTypes.string,
         prevPageIcon: PropTypes.string,
         selectedValue: PropTypes.string,
+        srsName: PropTypes.string,
         textField: PropTypes.string,
         tooltip: PropTypes.object,
         valueField: PropTypes.string
@@ -79,6 +80,7 @@ class PagedCombobox extends React.Component {
         onChange: () => {},
         onChangeDrawingStatus: () => {},
         onSelect: () => {},
+        srsName: "EPSG:4326",
         textField: "label",
         tooltip: {
             customizedTooltip: undefined,
@@ -155,7 +157,7 @@ class PagedCombobox extends React.Component {
                 const feature = head(this.props.features.filter(f => f.properties[this.props.valueField].toLowerCase() === v[this.props.valueField].toLowerCase()));
                 this.props.onSelect(v, feature);
                 if (feature) {
-                    this.props.onChangeDrawingStatus('drawOrEdit', feature.geometry.type, "queryform", [feature], {editEnabled: false, stopAfterDrawing: true, updateSpatialField: true});
+                    this.props.onChangeDrawingStatus('drawOrEdit', feature.geometry.type, "queryform", [feature], {editEnabled: false, stopAfterDrawing: true, updateSpatialField: true, featureProjection: this.props.srsName});
                 }
             }}
             onToggle={(v) => {
@@ -165,7 +167,7 @@ class PagedCombobox extends React.Component {
                 this.props.onToggle(v, feature, this.props.pagination.currentPage);
                 // if when closing the menu it finds a feature with the text inserted, then update the spatial field
                 if (feature && !v) {
-                    this.props.onChangeDrawingStatus('drawOrEdit', feature.geometry.type, "queryform", [feature], {editEnabled: false, stopAfterDrawing: true, updateSpatialField: true});
+                    this.props.onChangeDrawingStatus('drawOrEdit', feature.geometry.type, "queryform", [feature], {editEnabled: false, stopAfterDrawing: true, updateSpatialField: true, featureProjection: this.props.srsName});
                 }
                 // if when closing the menu it does not find a feature, then clean all
                 // it conflicts with change page which trigger the on toggle twice, one for closing and one for opening

--- a/web/client/observables/autocomplete.js
+++ b/web/client/observables/autocomplete.js
@@ -90,11 +90,12 @@ const createWFSFetchStream = (props$) => props$
                 item: {},
                 timeout: 60000,
                 headers: {'Accept': 'application/json', 'Content-Type': 'application/xml'},
+                srsName: p.filterProps && p.filterProps.srsName || "EPSG:4326",
                 ...parsed.query
             });
             return Rx.Observable.fromPromise((API.Utils.getService("wfs")(p.value, serviceOptions)
                 .then( data => {
-                    return {fetchedData: { values: data.features.map(f => f.properties), size: data.totalFeatures, features: data.features}, busy: false};
+                    return {fetchedData: { values: data.features.map(f => f.properties), size: data.totalFeatures, features: data.features, crs: p.filterProps && p.filterProps.srsName || "EPSG:4326"}, busy: false};
                 }))).catch(() => {
                     return Rx.Observable.of({fetchedData: {values: [], size: 0, features: []}, busy: false});
                 }).startWith({busy: true});

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -301,6 +301,7 @@ class QueryPanel extends React.Component {
  *   - queriableAttributes {string[]} list of attributes to query on.
  *   - typeName {string} the workspace + layer name on geosever
  *   - valueField {string} the attribute from features properties used as value/label in the autocomplete list
+ *   - srsName {string} The projection of the requested features fetched via wfs
  *
  * @prop {object[]} cfg.spatialOperations: The list of geometric operations use to create the spatial filter.<br/>
  *
@@ -329,7 +330,8 @@ class QueryPanel extends React.Component {
  *            "predicate": "LIKE",
  *            "queriableAttributes": ["ATTRIBUTE_X"],
  *            "typeName": "workspace:typeName",
- *            "valueField": "ATTRIBUTE_Y"
+ *            "valueField": "ATTRIBUTE_Y",
++ *            "srsName": "ESPG:3857"
  *        },
  *        "customItemClassName": "customItemClassName"
  *    }


### PR DESCRIPTION
## Description
This pr introduce a fix on the crs used to query the features via wvs in the spatialFilter custom.

## Issues
 - Fix #2418

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
without this srsParam it was using the default one for which was not working for certain layers which had a different crs.

**What is the new behavior?**
Actually the srsParam name is added to the wfs requests and used by openlayers in order to reproject them correctly.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
