### PR TITLE
Issue #2448. Download WFS data (KML, SHP, CSV, GML, etc.)

### DIFF
--- a/web/client/actions/__tests__/wfsdownload-test.js
+++ b/web/client/actions/__tests__/wfsdownload-test.js
@@ -11,9 +11,13 @@ var {
     DOWNLOAD_FEATURES,
     DOWNLOAD_OPTIONS_CHANGE,
     DOWNLOAD_FINISHED,
+    FORMAT_OPTIONS_FETCH,
+    FORMAT_OPTIONS_UPDATE,
     downloadFeatures,
     onDownloadOptionChange,
-    onDownloadFinished
+    onDownloadFinished,
+    onFormatOptionsFetch,
+    updateFormats
 } = require('../wfsdownload');
 
 describe('Test correctness of the wfsdownload actions', () => {
@@ -34,6 +38,15 @@ describe('Test correctness of the wfsdownload actions', () => {
         let {type} = onDownloadFinished();
         expect(type).toBe(DOWNLOAD_FINISHED);
     });
-
+    it('test onFormatOptionsFetch action', () => {
+        let {type, layer} = onFormatOptionsFetch("layer");
+        expect(type).toBe(FORMAT_OPTIONS_FETCH);
+        expect(layer).toBe("layer");
+    });
+    it('test onFormatOptionsFetch action', () => {
+        let {type, formats} = updateFormats("formats");
+        expect(type).toBe(FORMAT_OPTIONS_UPDATE);
+        expect(formats).toBe("formats");
+    });
 
 });

--- a/web/client/actions/__tests__/wfsdownload-test.js
+++ b/web/client/actions/__tests__/wfsdownload-test.js
@@ -43,10 +43,10 @@ describe('Test correctness of the wfsdownload actions', () => {
         expect(type).toBe(FORMAT_OPTIONS_FETCH);
         expect(layer).toBe("layer");
     });
-    it('test onFormatOptionsFetch action', () => {
-        let {type, formats} = updateFormats("formats");
+    it('test updateFormats action', () => {
+        let {type, wfsFormats} = updateFormats("wfsFormats");
         expect(type).toBe(FORMAT_OPTIONS_UPDATE);
-        expect(formats).toBe("formats");
+        expect(wfsFormats).toBe("wfsFormats");
     });
 
 });

--- a/web/client/actions/wfsdownload.js
+++ b/web/client/actions/wfsdownload.js
@@ -56,9 +56,10 @@ module.exports = {
      * @param  {object} layer           selected layer
      * @return {action}                 the action of type `FORMAT_OPTIONS_FETCH`
      */
-    onFormatOptionsFetch: (layer) => ({
+    onFormatOptionsFetch: (layer, formatFilter) => ({
         type: FORMAT_OPTIONS_FETCH,
-        layer
+        layer,
+        formatFilter
     }),
     /**
      * action for update list of formats

--- a/web/client/actions/wfsdownload.js
+++ b/web/client/actions/wfsdownload.js
@@ -56,20 +56,19 @@ module.exports = {
      * @param  {object} layer           selected layer
      * @return {action}                 the action of type `FORMAT_OPTIONS_FETCH`
      */
-    onFormatOptionsFetch: (layer, formatFilter) => ({
+    onFormatOptionsFetch: (layer) => ({
         type: FORMAT_OPTIONS_FETCH,
-        layer,
-        formatFilter
+        layer
     }),
     /**
      * action for update list of formats
      * @memberof actions.wfsdownload
-     * @param  {array} formats          available formats for download
+     * @param  {array} wfsFormats          available wfsFormats for download
      * @return {action}                 the action of type `FORMAT_OPTIONS_UPDATE`
      */
-    updateFormats: (formats) => ({
+    updateFormats: (wfsFormats) => ({
         type: FORMAT_OPTIONS_UPDATE,
-        formats
+        wfsFormats
     }),
     /**
      * action that notifies the end of the downloadOptions

--- a/web/client/actions/wfsdownload.js
+++ b/web/client/actions/wfsdownload.js
@@ -9,6 +9,8 @@
 const DOWNLOAD_FEATURES = "WFSDOWNLOAD::DOWNLOAD_FEATURES";
 const DOWNLOAD_FINISHED = "WFSDOWNLOAD::DOWNLOAD_FINISHED";
 const DOWNLOAD_OPTIONS_CHANGE = "WFSDOWNLOAD::FORMAT_SELECTED";
+const FORMAT_OPTIONS_FETCH = "WFSDOWNLOAD::FORMAT_FETCH";
+const FORMAT_OPTIONS_UPDATE = "WFSDOWNLOAD::FORMAT_UPDATE";
 
 /**
  * Actions for WFS Download
@@ -20,6 +22,8 @@ module.exports = {
     DOWNLOAD_FEATURES,
     DOWNLOAD_OPTIONS_CHANGE,
     DOWNLOAD_FINISHED,
+    FORMAT_OPTIONS_FETCH,
+    FORMAT_OPTIONS_UPDATE,
     /**
      * action to download features
      * @memberof actions.wfsdownload
@@ -45,6 +49,26 @@ module.exports = {
         type: DOWNLOAD_OPTIONS_CHANGE,
         key,
         value
+    }),
+    /**
+     * action for fetch format options WFS download
+     * @memberof actions.wfsdownload
+     * @param  {object} layer           selected layer
+     * @return {action}                 the action of type `FORMAT_OPTIONS_FETCH`
+     */
+    onFormatOptionsFetch: (layer) => ({
+        type: FORMAT_OPTIONS_FETCH,
+        layer
+    }),
+    /**
+     * action for update list of formats
+     * @memberof actions.wfsdownload
+     * @param  {array} formats          available formats for download
+     * @return {action}                 the action of type `FORMAT_OPTIONS_UPDATE`
+     */
+    updateFormats: (formats) => ({
+        type: FORMAT_OPTIONS_UPDATE,
+        formats
     }),
     /**
      * action that notifies the end of the downloadOptions

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -22,8 +22,8 @@ class DownloadDialog extends React.Component {
         onDownloadOptionChange: PropTypes.func,
         onFormatOptionsFetch: PropTypes.func,
         downloadOptions: PropTypes.object,
+        wfsFormats: PropTypes.array,
         formats: PropTypes.array,
-        formatFilter: PropTypes.object,
         srsList: PropTypes.array,
         defaultSrs: PropTypes.string,
         layer: PropTypes.object,
@@ -39,8 +39,8 @@ class DownloadDialog extends React.Component {
         onFormatOptionsFetch: () => {},
         layer: {},
         closeGlyph: "1-close",
+        wfsFormats: [],
         formats: [],
-        formatFilter: {},
         formatsLoading: false,
         srsList: [
             {name: "native", label: "Native"},
@@ -76,8 +76,8 @@ class DownloadDialog extends React.Component {
                     onChange={this.props.onDownloadOptionChange}
                     formatOptionsFetch={this.props.onFormatOptionsFetch}
                     formatsLoading={this.props.formatsLoading}
+                    wfsFormats={this.props.wfsFormats}
                     formats={this.props.formats}
-                    formatFilter={this.props.formatFilter}
                     srsList={this.props.srsList}
                     defaultSrs={this.props.defaultSrs}
                     layer={this.props.layer}/>

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -23,6 +23,7 @@ class DownloadDialog extends React.Component {
         onFormatOptionsFetch: PropTypes.func,
         downloadOptions: PropTypes.object,
         formats: PropTypes.array,
+        formatFilter: PropTypes.object,
         srsList: PropTypes.array,
         defaultSrs: PropTypes.string,
         layer: PropTypes.object,
@@ -39,6 +40,7 @@ class DownloadDialog extends React.Component {
         layer: {},
         closeGlyph: "1-close",
         formats: [],
+        formatFilter: {},
         formatsLoading: false,
         srsList: [
             {name: "native", label: "Native"},
@@ -75,6 +77,7 @@ class DownloadDialog extends React.Component {
                     formatOptionsFetch={this.props.onFormatOptionsFetch}
                     formatsLoading={this.props.formatsLoading}
                     formats={this.props.formats}
+                    formatFilter={this.props.formatFilter}
                     srsList={this.props.srsList}
                     defaultSrs={this.props.defaultSrs}
                     layer={this.props.layer}/>

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -20,10 +20,13 @@ class DownloadDialog extends React.Component {
         onClose: PropTypes.func,
         onExport: PropTypes.func,
         onDownloadOptionChange: PropTypes.func,
+        onFormatOptionsFetch: PropTypes.func,
         downloadOptions: PropTypes.object,
         formats: PropTypes.array,
         srsList: PropTypes.array,
-        defaultSrs: PropTypes.string
+        defaultSrs: PropTypes.string,
+        layer: PropTypes.object,
+        formatsLoading: PropTypes.bool
     };
 
     static defaultProps = {
@@ -32,11 +35,11 @@ class DownloadDialog extends React.Component {
         onExport: () => {},
         onClose: () => {},
         onDownloadOptionChange: () => {},
+        onFormatOptionsFetch: () => {},
+        layer: {},
         closeGlyph: "1-close",
-        formats: [
-            {name: "csv", label: "csv"},
-            {name: "shape-zip", label: "shape-zip"}
-        ],
+        formats: [],
+        formatsLoading: false,
         srsList: [
             {name: "native", label: "Native"},
             {name: "EPSG:4326", label: "WGS84"}
@@ -69,9 +72,12 @@ class DownloadDialog extends React.Component {
                 <DownloadOptions
                     downloadOptions={this.props.downloadOptions}
                     onChange={this.props.onDownloadOptionChange}
+                    formatOptionsFetch={this.props.onFormatOptionsFetch}
+                    formatsLoading={this.props.formatsLoading}
                     formats={this.props.formats}
                     srsList={this.props.srsList}
-                    defaultSrs={this.props.defaultSrs}/>
+                    defaultSrs={this.props.defaultSrs}
+                    layer={this.props.layer}/>
                 </div>
             <div role="footer">
                 <Button

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -26,8 +26,8 @@ module.exports = class extends React.Component {
     static propTypes = {
             downloadOptions: PropTypes.object,
             formatOptionsFetch: PropTypes.func,
+            wfsFormats: PropTypes.array,
             formats: PropTypes.array,
-            formatFilter: PropTypes.object,
             srsList: PropTypes.array,
             onChange: PropTypes.func,
             defaultSrs: PropTypes.string,
@@ -38,8 +38,8 @@ module.exports = class extends React.Component {
     static defaultProps = {
         downloadOptions: {},
         formatsLoading: false,
+        wfsFormats: [],
         formats: [],
-        formatFilter: {},
         srsList: []
     };
 
@@ -49,17 +49,31 @@ module.exports = class extends React.Component {
     getSelectedSRS = () => {
         return get(this.props, "downloadOptions.selectedSrs") || this.props.defaultSrs || get(head(this.props.srsList), "name");
     };
+    setSelectMethod = (formats) => {
+        if (formats && !formats.length) {
+            return (
+                <Select
+                    clearable={false}
+                    isLoading={this.props.formatsLoading}
+                    onOpen={() => this.props.formatOptionsFetch(this.props.layer)}
+                    value={this.getSelectedFormat()}
+                    noResultsText={<Message msgId="wfsdownload.format" />}
+                    onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
+                    options={this.props.wfsFormats.map(f => ({value: f.name, label: f.label || f.name}))} />
+            );
+        }
+        return (
+            <Select
+                clearable={false}
+                value={this.getSelectedFormat()}
+                onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
+                options={formats.map(f => ({value: f.name, label: f.label || f.name}))} />
+        );
+    };
     render() {
         return (<form>
             <label><Message msgId="wfsdownload.format" /></label>
-            <Select
-                clearable={false}
-                isLoading={this.props.formatsLoading}
-                onOpen={() => this.props.formatOptionsFetch(this.props.layer, this.props.formatFilter)}
-                value={this.getSelectedFormat()}
-                noResultsText={<Message msgId="wfsdownload.format" />}
-                onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
-                options={this.props.formats.map(f => ({value: f.name, label: f.label || f.name}))} />
+            {this.setSelectMethod(this.props.formats)}
             <label><Message msgId="wfsdownload.srs" /></label>
             <Select
                 clearable={false}

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -27,6 +27,7 @@ module.exports = class extends React.Component {
             downloadOptions: PropTypes.object,
             formatOptionsFetch: PropTypes.func,
             formats: PropTypes.array,
+            formatFilter: PropTypes.object,
             srsList: PropTypes.array,
             onChange: PropTypes.func,
             defaultSrs: PropTypes.string,
@@ -38,6 +39,7 @@ module.exports = class extends React.Component {
         downloadOptions: {},
         formatsLoading: false,
         formats: [],
+        formatFilter: {},
         srsList: []
     };
 
@@ -53,7 +55,7 @@ module.exports = class extends React.Component {
             <Select
                 clearable={false}
                 isLoading={this.props.formatsLoading}
-                onOpen={() => this.props.formatOptionsFetch(this.props.layer)}
+                onOpen={() => this.props.formatOptionsFetch(this.props.layer, this.props.formatFilter)}
                 value={this.getSelectedFormat()}
                 noResultsText={<Message msgId="wfsdownload.format" />}
                 onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -12,6 +12,7 @@ require('react-select/dist/react-select.css');
 const {Checkbox} = require('react-bootstrap');
 const {get, head} = require('lodash');
 const Message = require('../../I18N/Message');
+
 /**
  * Download Options Form. Shows a selector of the options to perform a WFS download
  * @memberof components.data.download
@@ -24,14 +25,18 @@ const Message = require('../../I18N/Message');
 module.exports = class extends React.Component {
     static propTypes = {
             downloadOptions: PropTypes.object,
+            formatOptionsFetch: PropTypes.func,
             formats: PropTypes.array,
             srsList: PropTypes.array,
             onChange: PropTypes.func,
-            defaultSrs: PropTypes.string
+            defaultSrs: PropTypes.string,
+            layer: PropTypes.object,
+            formatsLoading: PropTypes.bool
     };
 
     static defaultProps = {
         downloadOptions: {},
+        formatsLoading: false,
         formats: [],
         srsList: []
     };
@@ -47,7 +52,10 @@ module.exports = class extends React.Component {
             <label><Message msgId="wfsdownload.format" /></label>
             <Select
                 clearable={false}
+                isLoading={this.props.formatsLoading}
+                onOpen={() => this.props.formatOptionsFetch(this.props.layer)}
                 value={this.getSelectedFormat()}
+                noResultsText={<Message msgId="wfsdownload.format" />}
                 onChange={(sel) => this.props.onChange("selectedFormat", sel.value)}
                 options={this.props.formats.map(f => ({value: f.name, label: f.label || f.name}))} />
             <label><Message msgId="wfsdownload.srs" /></label>

--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -15,7 +15,7 @@ const DOWNLOAD_FORMATS_LOOKUP = {
 	"application/vnd.google-earth.kml+xml": "KML",
 	"OGR-CSV": "OGR-CSV",
 	"OGR-FileGDB": "OGR-GeoDatabase",
-	"OGR-GPKG": "OGR-OGR-GeoPackage",
+	"OGR-GPKG": "OGR-GeoPackage",
 	"OGR-KML": "OGR-KML",
 	"OGR-MIF": "OGR-MIF",
 	"OGR-TAB": "OGR-TAB",

--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -2,7 +2,7 @@ const {FORMAT_OPTIONS_FETCH, DOWNLOAD_FEATURES, onDownloadFinished, updateFormat
 const {TOGGLE_CONTROL, toggleControl} = require('../actions/controls');
 const {error} = require('../actions/notifications');
 const Rx = require('rxjs');
-const {get, find, pick, toPairs, isEmpty} = require('lodash');
+const {get, find, pick, toPairs} = require('lodash');
 const {saveAs} = require('file-saver');
 const axios = require('axios');
 const FilterUtils = require('../utils/FilterUtils');
@@ -26,12 +26,12 @@ const DOWNLOAD_FORMATS_LOOKUP = {
 	"application/x-gpkg": "GeoPackage"
 };
 
-const hasOutputFormat = (data, formatFilter) => {
+const hasOutputFormat = (data) => {
     const operation = get(data, "WFS_Capabilities.OperationsMetadata.Operation");
     const getFeature = find(operation, function(o) { return o.name === 'GetFeature'; });
     const parameter = get(getFeature, "Parameter");
     const outputFormatValue = find(parameter, function(o) { return o.name === 'outputFormat'; }).Value;
-    const pickedObj = pick(!isEmpty(formatFilter) ? formatFilter : DOWNLOAD_FORMATS_LOOKUP, outputFormatValue);
+    const pickedObj = pick(DOWNLOAD_FORMATS_LOOKUP, outputFormatValue);
     return toPairs(pickedObj).map(([prop, value]) => ({ name: prop, label: value }));
 };
 
@@ -73,7 +73,7 @@ module.exports = {
             .switchMap( action => {
                 return getLayerWFSCapabilities(action)
                 .map((data) => {
-                    return updateFormats(hasOutputFormat(data, action.formatFilter));
+                    return updateFormats(hasOutputFormat(data));
                 });
             }),
     startFeatureExportDownload: (action$, store) =>

--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -1,12 +1,42 @@
-const {DOWNLOAD_FEATURES, onDownloadFinished} = require('../actions/wfsdownload');
+const {FORMAT_OPTIONS_FETCH, DOWNLOAD_FEATURES, onDownloadFinished, updateFormats} = require('../actions/wfsdownload');
 const {TOGGLE_CONTROL, toggleControl} = require('../actions/controls');
 const {error} = require('../actions/notifications');
 const Rx = require('rxjs');
-const {get} = require('lodash');
+const {get, find, pick, toPairs} = require('lodash');
 const {saveAs} = require('file-saver');
 const axios = require('axios');
 const FilterUtils = require('../utils/FilterUtils');
 const {getByOutputFormat} = require('../utils/FileFormatUtils');
+const {getLayerWFSCapabilities} = require('../observables/wfs');
+
+const DOWNLOAD_FORMATS_LOOKUP = {
+	"gml3": "GML3.1",
+	"GML2": "GML2",
+	"application/vnd.google-earth.kml+xml": "KML",
+	"OGR-CSV": "OGR-CSV",
+	"OGR-FileGDB": "OGR-FileGDB",
+	"OGR-GPKG": "OGR-GPKG",
+	"OGR-KML": "OGR-KML",
+	"OGR-MIF": "OGR-MIF",
+	"OGR-TAB": "OGR-TAB",
+	"SHAPE-ZIP": "Shapefile",
+	"gml32": "GML3.2",
+	"application/json": "GeoJSON",
+	"csv": "CSV",
+	"application/x-gpkg": "application/x-gpkg",
+	"geopackage": "geopackage",
+	"geopkg": "geopkg",
+	"gpkg": "gpkg"
+};
+
+const hasOutputFormat = (data) => {
+    const operation = get(data, "WFS_Capabilities.OperationsMetadata.Operation");
+    const getFeature = find(operation, function(o) { return o.name === 'GetFeature'; });
+    const parameter = get(getFeature, "Parameter");
+    const outputFormatValue = find(parameter, function(o) { return o.name === 'outputFormat'; }).Value;
+    const pickedObj = pick(DOWNLOAD_FORMATS_LOOKUP, outputFormatValue);
+    return toPairs(pickedObj).map(([prop, value]) => ({ name: prop, label: value }));
+};
 
 const getWFSFeature = ({url, filterObj = {}, downloadOptions= {}} = {}) => {
     const data = FilterUtils.toOGCFilter(filterObj.featureTypeName, filterObj, filterObj.ogcVersion, filterObj.sortOptions, false, null, null, downloadOptions.selectedSrs);
@@ -41,6 +71,14 @@ const str2bytes = (str) => {
 };
 */
 module.exports = {
+    fetchFormatsWFSDownload: (action$) =>
+        action$.ofType(FORMAT_OPTIONS_FETCH)
+            .switchMap( action => {
+                return getLayerWFSCapabilities(action)
+                .map((data) => {
+                    return updateFormats(hasOutputFormat(data));
+                });
+            }),
     startFeatureExportDownload: (action$, store) =>
         action$.ofType(DOWNLOAD_FEATURES).switchMap(action =>
             getWFSFeature({

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -6,11 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {connect} = require('react-redux');
-const {downloadFeatures, onDownloadOptionChange} = require('../actions/wfsdownload');
+const {downloadFeatures, onDownloadOptionChange, onFormatOptionsFetch} = require('../actions/wfsdownload');
 const {toggleControl, setControlProperty} = require('../actions/controls');
 
 const {createSelector} = require('reselect');
 const {wfsURL, wfsFilter} = require('../selectors/query');
+const {getSelectedLayer} = require('../selectors/layers');
 
 const DownloadDialog = require('../components/data/download/DownloadDialog');
 /**
@@ -48,16 +49,23 @@ module.exports = {
             state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
             state => state && state.wfsdownload && state.wfsdownload.downloadOptions,
             state => state && state.wfsdownload && state.wfsdownload.loading,
-            (url, filterObj, enabled, downloadOptions, loading) => ({
+            state => state && state.wfsdownload && state.wfsdownload.formats,
+            state => state && state.wfsdownload && state.wfsdownload.formatsLoading,
+            getSelectedLayer,
+            (url, filterObj, enabled, downloadOptions, loading, formats, formatsLoading, layer) => ({
                 url,
                 filterObj,
                 enabled,
                 downloadOptions,
-                loading
+                loading,
+                formats,
+                formatsLoading,
+                layer
             })
     ), {
         onExport: downloadFeatures,
         onDownloadOptionChange,
+        onFormatOptionsFetch,
         onMount: () => setControlProperty("wfsdownload", "available", true),
         onUnmount: () => setControlProperty("wfsdownload", "available", false),
         onClose: () => toggleControl("wfsdownload")

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -19,18 +19,21 @@ const DownloadDialog = require('../components/data/download/DownloadDialog');
  * @memberof plugins
  * @name WFSDownload
  * @class
- * @prop {object[]} formatFilter An object of "Name": "label" objects for the allowed format available. Now the list of available format is always fetched by server. This prop filter the result list. Use the example below
- * @prop {array[]} srsList An array of name-label objects for the allowed srs available. Use name:'native' to omit srsName param in wfs filter
+ * @prop {object[]} formats An array of name-label objects for the allowed formats available.
+ * @prop {object[]} srsList An array of name-label objects for the allowed srs available. Use name:'native' to omit srsName param in wfs filter
  * @prop {string} defaultSrs Deafult selected srs
  * @prop {string} closeGlyph The icon to use for close the dialog
  * @example
  * {
  *  "name": "WFSDownload",
  *  "cfg": {
- *     "formatFilter": {
- *	       "SHAPE-ZIP": "Shapefile",
- *	       "csv": "CSV"
- *     }
+ *    "formats": [
+ *            {"name": "csv", "label": "csv"},
+ *            {"name": "shape-zip", "label": "shape-zip"},
+ *            {"name": "excel", "label": "excel"},
+ *            {"name": "excel2007", "label": "excel2007"},
+ *            {"name": "dxf-zip", "label": "dxf-zip"}
+ *    ],
  *     "srsList": [
  *            {"name": "native", "label": "Native"},
  *            {"name": "EPSG:4326", "label": "WGS84"}
@@ -46,16 +49,16 @@ module.exports = {
             state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,
             state => state && state.wfsdownload && state.wfsdownload.downloadOptions,
             state => state && state.wfsdownload && state.wfsdownload.loading,
-            state => state && state.wfsdownload && state.wfsdownload.formats,
+            state => state && state.wfsdownload && state.wfsdownload.wfsFormats,
             state => state && state.wfsdownload && state.wfsdownload.formatsLoading,
             getSelectedLayer,
-            (url, filterObj, enabled, downloadOptions, loading, formats, formatsLoading, layer) => ({
+            (url, filterObj, enabled, downloadOptions, loading, wfsFormats, formatsLoading, layer) => ({
                 url,
                 filterObj,
                 enabled,
                 downloadOptions,
                 loading,
-                formats,
+                wfsFormats,
                 formatsLoading,
                 layer
             })

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -19,21 +19,18 @@ const DownloadDialog = require('../components/data/download/DownloadDialog');
  * @memberof plugins
  * @name WFSDownload
  * @class
- * @prop {object[]} formats An array of name-label objects for the allowed formats available.
- * @prop {object[]} srsList An array of name-label objects for the allowed srs available. Use name:'native' to omit srsName param in wfs filter
+ * @prop {object[]} formatFilter An object of "Name": "label" objects for the allowed format available. Now the list of available format is always fetched by server. This prop filter the result list. Use the example below
+ * @prop {array[]} srsList An array of name-label objects for the allowed srs available. Use name:'native' to omit srsName param in wfs filter
  * @prop {string} defaultSrs Deafult selected srs
  * @prop {string} closeGlyph The icon to use for close the dialog
  * @example
  * {
  *  "name": "WFSDownload",
  *  "cfg": {
- *    "formats": [
- *            {"name": "csv", "label": "csv"},
- *            {"name": "shape-zip", "label": "shape-zip"},
- *            {"name": "excel", "label": "excel"},
- *            {"name": "excel2007", "label": "excel2007"},
- *            {"name": "dxf-zip", "label": "dxf-zip"}
- *    ],
+ *     "formatFilter": {
+ *	       "SHAPE-ZIP": "Shapefile",
+ *	       "csv": "CSV"
+ *     }
  *     "srsList": [
  *            {"name": "native", "label": "Native"},
  *            {"name": "EPSG:4326", "label": "WGS84"}

--- a/web/client/reducers/__tests__/wfsdownload-test.js
+++ b/web/client/reducers/__tests__/wfsdownload-test.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {
-    onDownloadOptionChange, downloadFeatures, onDownloadFinished} = require('../../actions/wfsdownload');
+    onDownloadOptionChange, downloadFeatures, onDownloadFinished, onFormatOptionsFetch, updateFormats} = require('../../actions/wfsdownload');
 const wfsdownload = require('../wfsdownload');
 
 const expect = require('expect');
@@ -24,6 +24,15 @@ describe('Test the wfsdownload reducer', () => {
     it('onDownloadFinished', () => {
         const state = wfsdownload({loading: true}, onDownloadFinished());
         expect(state.loading).toBe(false);
+    });
+    it('onFormatOptionsFetch', () => {
+        const state = wfsdownload({formatsLoading: false, formats: [{name: "CSV", label: "CSV"}, {name: "SHAPE-FILE", label: "SHAPE-FILE"}]}, onFormatOptionsFetch());
+        expect(state.formatsLoading).toBe(true);
+        expect(state.formats).toEqual([]);
+    });
+    it('updateFormats', () => {
+        const state = wfsdownload({formatsLoading: true}, updateFormats());
+        expect(state.formatsLoading).toBe(false);
     });
 
 });

--- a/web/client/reducers/__tests__/wfsdownload-test.js
+++ b/web/client/reducers/__tests__/wfsdownload-test.js
@@ -26,9 +26,9 @@ describe('Test the wfsdownload reducer', () => {
         expect(state.loading).toBe(false);
     });
     it('onFormatOptionsFetch', () => {
-        const state = wfsdownload({formatsLoading: false, formats: [{name: "CSV", label: "CSV"}, {name: "SHAPE-FILE", label: "SHAPE-FILE"}]}, onFormatOptionsFetch());
+        const state = wfsdownload({formatsLoading: false, wfsFormats: [{name: "CSV", label: "CSV"}, {name: "SHAPE-FILE", label: "SHAPE-FILE"}]}, onFormatOptionsFetch());
         expect(state.formatsLoading).toBe(true);
-        expect(state.formats).toEqual([]);
+        expect(state.wfsFormats).toEqual([]);
     });
     it('updateFormats', () => {
         const state = wfsdownload({formatsLoading: true}, updateFormats());

--- a/web/client/reducers/wfsdownload.js
+++ b/web/client/reducers/wfsdownload.js
@@ -38,6 +38,7 @@ function wfsdownload( state = {downloadOptions: {singlePage: true}}, action) {
                 ...state,
                 layer: action.layer,
                 formats: [],
+                formatFilter: action.formatFilter,
                 formatsLoading: true
             };
         case DOWNLOAD_FINISHED: {

--- a/web/client/reducers/wfsdownload.js
+++ b/web/client/reducers/wfsdownload.js
@@ -37,8 +37,7 @@ function wfsdownload( state = {downloadOptions: {singlePage: true}}, action) {
             return {
                 ...state,
                 layer: action.layer,
-                formats: [],
-                formatFilter: action.formatFilter,
+                wfsFormats: [],
                 formatsLoading: true
             };
         case DOWNLOAD_FINISHED: {
@@ -50,7 +49,7 @@ function wfsdownload( state = {downloadOptions: {singlePage: true}}, action) {
         case FORMAT_OPTIONS_UPDATE: {
             return {
                 ...state,
-                formats: action.formats,
+                wfsFormats: action.wfsFormats,
                 formatsLoading: false
             };
         }

--- a/web/client/reducers/wfsdownload.js
+++ b/web/client/reducers/wfsdownload.js
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {DOWNLOAD_OPTIONS_CHANGE, DOWNLOAD_FEATURES, DOWNLOAD_FINISHED} = require('../actions/wfsdownload');
+const {DOWNLOAD_OPTIONS_CHANGE, DOWNLOAD_FEATURES, DOWNLOAD_FINISHED, FORMAT_OPTIONS_FETCH, FORMAT_OPTIONS_UPDATE} = require('../actions/wfsdownload');
 
 /**
  * reducer for wfsdownload
@@ -33,10 +33,24 @@ function wfsdownload( state = {downloadOptions: {singlePage: true}}, action) {
                     [action.key]: action.value
                 }
             };
+        case FORMAT_OPTIONS_FETCH:
+            return {
+                ...state,
+                layer: action.layer,
+                formats: [],
+                formatsLoading: true
+            };
         case DOWNLOAD_FINISHED: {
             return {
                 ...state,
                 loading: false
+            };
+        }
+        case FORMAT_OPTIONS_UPDATE: {
+            return {
+                ...state,
+                formats: action.formats,
+                formatsLoading: false
             };
         }
         default:


### PR DESCRIPTION
## Description
If for a WMS layer a corresponding WFS is available the user shall be able to download the WFS data of this layer from within the map/legend. The formats available are configured in the WFS definition (GetCapabilities).

## Issues
 - Fix #2448 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Feature


**What is the current behavior?** (You can also link to an open issue here)
The export data format from the feature grid is hard coded

**What is the new behavior?**
Now, the export data format from the feature grid is dinamically fetched by WFS getCapabilities
The formats options is still available. If configured, formats are not fetched by server
```
{
 "name": "WFSDownload",
 "cfg": {
   "formats": [
           {"name": "csv", "label": "csv"},
           {"name": "shape-zip", "label": "shape-zip"}
   ]
 }
}
```

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [] Yes
 - [X] No
