### PR TITLE
Fixes #2455 Tooltip on layers and groups of TOC to display full title

### DIFF
--- a/web/client/components/TOC/DefaultGroup.jsx
+++ b/web/client/components/TOC/DefaultGroup.jsx
@@ -27,7 +27,8 @@ class DefaultGroup extends React.Component {
         visibilityCheckType: PropTypes.string,
         currentLocale: PropTypes.string,
         selectedNodes: PropTypes.array,
-        onSelect: PropTypes.func
+        onSelect: PropTypes.func,
+        titleTooltip: PropTypes.bool
     };
 
     static defaultProps = {
@@ -44,7 +45,8 @@ class DefaultGroup extends React.Component {
         level: 1,
         currentLocale: 'en-US',
         selectedNodes: [],
-        onSelect: () => {}
+        onSelect: () => {},
+        titleTooltip: false
     };
 
     renderVisibility = (error) => {
@@ -72,7 +74,7 @@ class DefaultGroup extends React.Component {
                 <div className="toc-default-group-head">
                     {grab}
                     {this.renderVisibility(error)}
-                    <GroupTitle node={this.props.node} currentLocale={this.props.currentLocale} onClick={this.props.onToggle} onSelect={this.props.onSelect}/>
+                    <GroupTitle tooltip={this.props.titleTooltip} node={this.props.node} currentLocale={this.props.currentLocale} onClick={this.props.onToggle} onSelect={this.props.onSelect}/>
                 </div>
                 <GroupChildren level={this.props.level + 1} onSort={this.props.onSort} position="collapsible">
                     {this.props.children}

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -36,7 +36,8 @@ class DefaultLayer extends React.Component {
         currentLocale: PropTypes.string,
         selectedNodes: PropTypes.array,
         filterText: PropTypes.string,
-        onUpdateNode: PropTypes.func
+        onUpdateNode: PropTypes.func,
+        titleTooltip: PropTypes.bool
     };
 
     static defaultProps = {
@@ -53,7 +54,8 @@ class DefaultLayer extends React.Component {
         currentLocale: 'en-US',
         selectedNodes: [],
         filterText: '',
-        onUpdateNode: () => {}
+        onUpdateNode: () => {},
+        titleTooltip: false
     };
 
     renderCollapsible = () => {
@@ -124,7 +126,7 @@ class DefaultLayer extends React.Component {
                 <div className="toc-default-layer-head">
                     {grab}
                     {this.renderVisibility()}
-                    <Title filterText={this.props.filterText} node={this.props.node} currentLocale={this.props.currentLocale} onClick={this.props.onSelect} onContextMenu={this.props.onContextMenu}/>
+                    <Title tooltip={this.props.titleTooltip} filterText={this.props.filterText} node={this.props.node} currentLocale={this.props.currentLocale} onClick={this.props.onSelect} onContextMenu={this.props.onContextMenu}/>
                     {this.props.node.loading ? <div className="toc-inline-loader"></div> : this.renderToolsLegend(isEmpty)}
                 </div>
                 {isEmpty ? null : this.renderCollapsible()}

--- a/web/client/components/TOC/fragments/GroupTitle.jsx
+++ b/web/client/components/TOC/fragments/GroupTitle.jsx
@@ -10,6 +10,8 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const StatusIcon = require('./StatusIcon');
 const {isObject} = require('lodash');
+const {Tooltip} = require('react-bootstrap');
+const OverlayTrigger = require('../../misc/OverlayTrigger');
 
 class GroupTitle extends React.Component {
     static propTypes = {
@@ -17,7 +19,8 @@ class GroupTitle extends React.Component {
         onClick: PropTypes.func,
         onSelect: PropTypes.func,
         style: PropTypes.object,
-        currentLocale: PropTypes.string
+        currentLocale: PropTypes.string,
+        tooltip: PropTypes.bool
     };
 
     static inheritedPropTypes = ['node'];
@@ -28,13 +31,21 @@ class GroupTitle extends React.Component {
         currentLocale: 'en-US',
         style: {
 
-        }
+        },
+        tooltip: false
     };
 
     render() {
         let expanded = this.props.node.expanded !== undefined ? this.props.node.expanded : true;
         const groupTitle = isObject(this.props.node.title) ? this.props.node.title[this.props.currentLocale] || this.props.node.title.default || this.props.node.name : this.props.node.title || this.props.node.name;
-        return (
+        return this.props.tooltip ? (
+            <OverlayTrigger placement="top" overlay={(<Tooltip id={"tooltip-layer-group"}>{groupTitle}</Tooltip>)}>
+                <div style={this.props.style}>
+                    <span className="toc-group-title" onClick={ this.props.onSelect ? (e) => this.props.onSelect(this.props.node.id, 'group', e.ctrlKey) : () => {}}>{groupTitle}</span><StatusIcon onClick={() => this.props.onClick(this.props.node.id, expanded)} expanded={expanded} node={this.props.node}/>
+                </div>
+            </OverlayTrigger>
+        ) :
+        (
             <div style={this.props.style}>
                 <span className="toc-group-title" onClick={ this.props.onSelect ? (e) => this.props.onSelect(this.props.node.id, 'group', e.ctrlKey) : () => {}}>{groupTitle}</span><StatusIcon onClick={() => this.props.onClick(this.props.node.id, expanded)} expanded={expanded} node={this.props.node}/>
             </div>

--- a/web/client/components/TOC/fragments/Title.jsx
+++ b/web/client/components/TOC/fragments/Title.jsx
@@ -9,6 +9,8 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 const {isObject} = require('lodash');
+const {Tooltip} = require('react-bootstrap');
+const OverlayTrigger = require('../../misc/OverlayTrigger');
 require("./css/toctitle.css");
 
 class Title extends React.Component {
@@ -17,14 +19,16 @@ class Title extends React.Component {
         onClick: PropTypes.func,
         onContextMenu: PropTypes.func,
         currentLocale: PropTypes.string,
-        filterText: PropTypes.string
+        filterText: PropTypes.string,
+        tooltip: PropTypes.bool
     };
 
     static defaultProps = {
         onClick: () => {},
         onContextMenu: () => {},
         currentLocale: 'en-US',
-        filterText: ''
+        filterText: '',
+        tooltip: false
     };
 
     getFilteredTitle = (title) => {
@@ -41,7 +45,19 @@ class Title extends React.Component {
     render() {
         const translation = isObject(this.props.node.title) ? this.props.node.title[this.props.currentLocale] || this.props.node.title.default : this.props.node.title;
         const title = translation || this.props.node.name;
-        return <div className="toc-title" onClick={this.props.onClick ? (e) => this.props.onClick(this.props.node.id, 'layer', e.ctrlKey) : () => {}} onContextMenu={(e) => {e.preventDefault(); this.props.onContextMenu(this.props.node); }}>{this.getFilteredTitle(title)}</div>;
+        return this.props.tooltip ? (
+            <OverlayTrigger placement="top" overlay={(<Tooltip id={"tooltip-layer-title"}>{title}</Tooltip>)}>
+                <div className="toc-title" onClick={this.props.onClick ? (e) => this.props.onClick(this.props.node.id, 'layer', e.ctrlKey) : () => {}} onContextMenu={(e) => {e.preventDefault(); this.props.onContextMenu(this.props.node); }}>
+                    {this.getFilteredTitle(title)}
+                </div>
+            </OverlayTrigger>
+
+        ) :
+        (
+            <div className="toc-title" onClick={this.props.onClick ? (e) => this.props.onClick(this.props.node.id, 'layer', e.ctrlKey) : () => {}} onContextMenu={(e) => {e.preventDefault(); this.props.onContextMenu(this.props.node); }}>
+                {this.getFilteredTitle(title)}
+            </div>
+        );
     }
 }
 

--- a/web/client/components/TOC/fragments/__tests__/GroupTitle-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/GroupTitle-test.jsx
@@ -11,6 +11,7 @@ const ReactDOM = require('react-dom');
 const GroupTitle = require('../GroupTitle');
 
 const expect = require('expect');
+const ReactTestUtils = require('react-dom/test-utils');
 
 describe('test GroupTitle module component', () => {
     beforeEach((done) => {
@@ -61,5 +62,33 @@ describe('test GroupTitle module component', () => {
         const title = domNode.getElementsByClassName('toc-group-title').item(0);
         expect(title).toExist();
         expect(title.innerHTML).toBe('');
+    });
+
+    it('tests GroupTitle with tooltip', () => {
+        const l = {
+            title: {
+                'default': 'Group',
+                'it-IT': 'Gruppo'
+            }
+        };
+        const comp = ReactDOM.render(<GroupTitle node={l} tooltip currentLocale="it-IT"/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        ReactTestUtils.Simulate.mouseOver(domNode);
+        expect(ReactDOM.findDOMNode(comp).getAttribute('aria-describedby')).toBe('tooltip-layer-group');
+    });
+
+    it('tests GroupTitle without tooltip', () => {
+        const l = {
+            title: {
+                'default': 'Group',
+                'it-IT': 'Gruppo'
+            }
+        };
+        const comp = ReactDOM.render(<GroupTitle node={l} currentLocale="it-IT"/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        ReactTestUtils.Simulate.mouseOver(domNode);
+        expect(ReactDOM.findDOMNode(comp).getAttribute('aria-describedby')).toBe(null);
     });
 });

--- a/web/client/components/TOC/fragments/__tests__/Title-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/Title-test.jsx
@@ -114,4 +114,42 @@ describe('test Title module component', () => {
         expect(domNode).toExist();
         expect(domNode.innerHTML).toBe(l.name);
     });
+
+    it('tests Title with tooltip', () => {
+        const l = {
+            name: 'layer00',
+            title: {
+                'default': 'Layer',
+                'it-IT': 'Livello'
+            },
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const comp = ReactDOM.render(<Title node={l} tooltip currentLocale="it-IT"/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        ReactTestUtils.Simulate.mouseOver(domNode);
+        expect(ReactDOM.findDOMNode(comp).getAttribute('aria-describedby')).toBe('tooltip-layer-title');
+    });
+
+    it('tests Title without tooltip', () => {
+        const l = {
+            name: 'layer00',
+            title: {
+                'default': 'Layer',
+                'it-IT': 'Livello'
+            },
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const comp = ReactDOM.render(<Title node={l} currentLocale="it-IT"/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        ReactTestUtils.Simulate.mouseOver(domNode);
+        expect(ReactDOM.findDOMNode(comp).getAttribute('aria-describedby')).toBe(null);
+    });
 });

--- a/web/client/components/TOC/fragments/css/toctitle.css
+++ b/web/client/components/TOC/fragments/css/toctitle.css
@@ -3,4 +3,5 @@
     max-width: 150px;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -144,6 +144,7 @@ class LayerTree extends React.Component {
         updateSettings: PropTypes.func,
         updateNode: PropTypes.func,
         removeNode: PropTypes.func,
+        activateTitleTooltip: PropTypes.bool,
         activateOpacityTool: PropTypes.bool,
         activateSortLayer: PropTypes.bool,
         activateFilterLayer: PropTypes.bool,
@@ -196,6 +197,7 @@ class LayerTree extends React.Component {
         onSelectNode: () => {},
         selectedNodes: [],
         activateOpacityTool: true,
+        activateTitleTooltip: true,
         activateSortLayer: true,
         activateFilterLayer: true,
         activateMapTitle: true,
@@ -249,6 +251,7 @@ class LayerTree extends React.Component {
             <DefaultGroup
                 onSort={!this.props.filterText && this.props.activateSortLayer ? this.props.onSort : null}
                 {...this.props.groupOptions}
+                titleTooltip={this.props.activateTitleTooltip}
                 propertiesChangeHandler={this.props.groupPropertiesChangeHandler}
                 onToggle={this.props.onToggleGroup}
                 style={this.props.groupStyle}
@@ -263,6 +266,7 @@ class LayerTree extends React.Component {
         return (
             <DefaultLayer
                 {...this.props.layerOptions}
+                titleTooltip={this.props.activateTitleTooltip}
                 onToggle={this.props.onToggleLayer}
                 activateOpacityTool={this.props.activateOpacityTool}
                 onContextMenu={this.props.onContextMenu}
@@ -393,6 +397,7 @@ class LayerTree extends React.Component {
  * @memberof plugins
  * @prop {boolean} cfg.activateFilterLayer: activate filter layers tool, default `true`
  * @prop {boolean} cfg.activateMapTitle: show map title, default `true`
+ * @prop {boolean} cfg.activateTitleTooltip: show tooltip with full title on layers and groups, default `true`
  * @prop {boolean} cfg.activateOpacityTool: show opacity slider in collapsible panel of layer, default `true`
  * @prop {boolean} cfg.activateToolsContainer: activate layers and group global toolbar, default `true`
  * @prop {boolean} cfg.activateLegendTool: show legend in collapsible panel, default `true`

--- a/web/client/themes/default/bootstrap-theme.less
+++ b/web/client/themes/default/bootstrap-theme.less
@@ -147,3 +147,7 @@ button.close {
 .dropdown-menu {
     padding: 0;
 }
+
+.tooltip-inner {
+    word-wrap: break-word;
+}

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -256,6 +256,8 @@
             height: @font-size-base * 1.4;
             margin: 0 5px;
             width: 140px;
+            text-overflow: ellipsis;
+            white-space: nowrap;
             cursor: pointer;
             &:hover {
                 font-weight: bold;


### PR DESCRIPTION
## Description
Added a tooltip on layers and groups in TOC.
![tooltip](https://user-images.githubusercontent.com/19175505/33621340-ac9220ca-d9ea-11e7-947c-de3b6e163e84.png)


## Issues
 - Fix #2455

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
No tooltips to diplay full title in TOC

**What is the new behavior?**
Tooltips will display full title on groups and layers in TOC

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
