### PR TITLE
Closes #2203. GetFeatureInfo active by default

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -18,6 +18,7 @@ var {
     SHOW_REVERSE_GEOCODE,
     HIDE_REVERSE_GEOCODE,
     GET_VECTOR_INFO,
+    TOGGLE_MAPINFO_STATE,
     getFeatureInfo,
     changeMapInfoState,
     newMapInfoRequest,
@@ -25,7 +26,8 @@ var {
     changeMapInfoFormat,
     showMapinfoRevGeocode,
     hideMapinfoRevGeocode,
-    getVectorInfo
+    getVectorInfo,
+    toggleMapInfoState
 } = require('../mapInfo');
 
 describe('Test correctness of the map actions', () => {
@@ -190,5 +192,10 @@ describe('Test correctness of the map actions', () => {
         const e = hideMapinfoRevGeocode();
         expect(e).toExist();
         expect(e.type).toBe(HIDE_REVERSE_GEOCODE);
+    });
+
+    it('toggle map info state', () => {
+        const retval = toggleMapInfoState();
+        expect(retval.type).toBe(TOGGLE_MAPINFO_STATE);
     });
 });

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -26,6 +26,7 @@ const GET_VECTOR_INFO = 'GET_VECTOR_INFO';
 const NO_QUERYABLE_LAYERS = 'NO_QUERYABLE_LAYERS';
 const CLEAR_WARNING = 'CLEAR_WARNING';
 const FEATURE_INFO_CLICK = 'FEATURE_INFO_CLICK';
+const TOGGLE_MAPINFO_STATE = 'TOGGLE_MAPINFO_STATE';
 
 /**
  * Private
@@ -189,6 +190,12 @@ function hideMapinfoRevGeocode() {
     };
 }
 
+function toggleMapInfoState() {
+    return {
+        type: TOGGLE_MAPINFO_STATE
+    };
+}
+
 module.exports = {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
@@ -205,6 +212,7 @@ module.exports = {
     NO_QUERYABLE_LAYERS,
     CLEAR_WARNING,
     FEATURE_INFO_CLICK,
+    TOGGLE_MAPINFO_STATE,
     getFeatureInfo,
     changeMapInfoState,
     newMapInfoRequest,
@@ -219,5 +227,6 @@ module.exports = {
     noQueryableLayers,
     clearWarning,
     errorFeatureInfo,
-    loadFeatureInfo
+    loadFeatureInfo,
+    toggleMapInfoState
 };

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -25,6 +25,7 @@ const HIDE_REVERSE_GEOCODE = 'HIDE_REVERSE_GEOCODE';
 const GET_VECTOR_INFO = 'GET_VECTOR_INFO';
 const NO_QUERYABLE_LAYERS = 'NO_QUERYABLE_LAYERS';
 const CLEAR_WARNING = 'CLEAR_WARNING';
+const FEATURE_INFO_CLICK = 'FEATURE_INFO_CLICK';
 
 /**
  * Private
@@ -203,6 +204,7 @@ module.exports = {
     GET_VECTOR_INFO,
     NO_QUERYABLE_LAYERS,
     CLEAR_WARNING,
+    FEATURE_INFO_CLICK,
     getFeatureInfo,
     changeMapInfoState,
     newMapInfoRequest,

--- a/web/client/actions/measurement.js
+++ b/web/client/actions/measurement.js
@@ -7,7 +7,6 @@
  */
 const CHANGE_MEASUREMENT_TOOL = 'CHANGE_MEASUREMENT_TOOL';
 const CHANGE_MEASUREMENT_STATE = 'CHANGE_MEASUREMENT_STATE';
-const {setControlProperty} = require('./controls');
 
 // TODO: the measurement control should use the "controls" state
 function toggleMeasurement(measurement) {
@@ -19,7 +18,6 @@ function toggleMeasurement(measurement) {
 
 function changeMeasurement(measurement) {
     return (dispatch) => {
-        dispatch(setControlProperty('info', 'enabled', false, false));
         dispatch(toggleMeasurement(measurement));
     };
 }

--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -126,7 +126,11 @@ class Identify extends React.Component {
     state = {
         fullClass: ''
     };
-
+    componentDidMount() {
+        if (this.props.enabled) {
+            this.props.changeMousePointer('pointer');
+        }
+    }
     componentWillReceiveProps(newProps) {
         if (this.needsRefresh(newProps)) {
             if (!newProps.point.modifiers || newProps.point.modifiers.ctrl !== true || !newProps.allowMultiselection) {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -463,10 +463,15 @@ class DrawSupport extends React.Component {
 
     removeDrawInteraction = () => {
         if (this.drawInteraction) {
-            this.props.map.enableEventListener('singleclick');
             this.props.map.removeInteraction(this.drawInteraction);
             this.drawInteraction = null;
             this.sketchFeature = null;
+            /** Map Singleclick event is dealyed by 250 ms see here
+              * https://openlayers.org/en/latest/apidoc/ol.MapBrowserEvent.html#event:singleclick
+              * This timeout prevents ol map to throw mapClick event that has alredy been managed
+              * by the draw interaction.
+             */
+            setTimeout(() => this.props.map.enableEventListener('singleclick'), 500);
             setTimeout(() => this.setDoubleClickZoomEnabled(true), 250);
         }
     };

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -7,13 +7,26 @@
 */
 const Rx = require('rxjs');
 
-const {LOAD_FEATURE_INFO, GET_VECTOR_INFO} = require('../actions/mapInfo');
+const {LOAD_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLICK} = require('../actions/mapInfo');
 const {closeFeatureGrid} = require('../actions/featuregrid');
+const {CHANGE_MOUSE_POINTER, CLICK_ON_MAP} = require('../actions/map');
+const {MAP_CONFIG_LOADED} = require('../actions/config');
+const {stopGetFeatureInfoSelector} = require('../selectors/mapinfo');
 
 module.exports = {
     closeFeatureGridFromIdentifyEpic: (action$) =>
         action$.ofType(LOAD_FEATURE_INFO, GET_VECTOR_INFO)
         .switchMap(() => {
             return Rx.Observable.of(closeFeatureGrid());
+        }),
+    changeMapPointer: (action$, store) =>
+        action$.ofType(CHANGE_MOUSE_POINTER)
+        .filter(() => !(store.getState()).map)
+        .switchMap((a) => action$.ofType(MAP_CONFIG_LOADED).mapTo(a)),
+    onMapClick: (action$, store) =>
+        action$.ofType(CLICK_ON_MAP).filter(() => {
+            const {disableAlwaysOn = false} = (store.getState()).mapInfo;
+            return disableAlwaysOn || !stopGetFeatureInfoSelector(store.getState() || {});
         })
+        .map(({point, layer}) => ({type: FEATURE_INFO_CLICK, point, layer}))
 };

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -203,8 +203,7 @@
                 },
                 "override": {
                   "Toolbar": {
-                    "position": 11,
-                    "alwaysVisible": true
+                    "position": 11
                   }
                 }
             },

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -7,6 +7,8 @@
  */
 const React = require('react');
 
+const {Glyphicon} = require('react-bootstrap');
+
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 
@@ -14,7 +16,7 @@ const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
 const {on} = require('../actions/controls');
 
-const {getFeatureInfo, getVectorInfo, purgeMapInfoResults, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning} = require('../actions/mapInfo');
+const {getFeatureInfo, getVectorInfo, purgeMapInfoResults, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState} = require('../actions/mapInfo');
 const {closeAnnotations} = require('../actions/annotations');
 const {changeMousePointer} = require('../actions/map');
 const {changeMapInfoFormat} = require('../actions/mapInfo');
@@ -53,10 +55,12 @@ const conditionalToggle = on.bind(null, purgeMapInfoResults(), (state) =>
  * Identify plugin. This plugin allows to perform getfeature info.
  * It can be configured to have a mobile or a desktop flavor.
  * It's enabled by default. The bubbling of an on_click_map action to GFI is stopped
- * if Annotations orFeatureGrid plugins are editing, draw or measurement supports are
- * active ore the identify plugin is disabled.
- * To restore old behaviour, in mapInfo state, set enabled to false and disabledAlwaysOn to true and
- * manage the plugin using changeMapInfoState action or toggleControl action with 'info' as control name.
+ * if Annotations or FeatureGrid plugins are editing, draw or measurement supports are
+ * active, the query panel is active or the identify plugin is disabled.
+ * To restore old behaviour, in mapInfo state, set disabledAlwaysOn to true and
+ * manage the plugin using toggleControl action with 'info' as control name.
+ * It's possible also possible disable the plugin by changeMapInfoState or toggleMapInfoState actions
+ *
  * @class Identify
  * @memberof plugins
  * @static
@@ -117,6 +121,18 @@ const FeatureInfoFormatSelector = connect((state) => ({
 
 module.exports = {
     IdentifyPlugin: assign(IdentifyPlugin, {
+        Toolbar: {
+            name: 'info',
+            position: 6,
+            tooltip: "info.tooltip",
+            icon: <Glyphicon glyph="map-marker"/>,
+            help: <Message msgId="helptexts.infoButton"/>,
+            action: toggleMapInfoState,
+            selector: (state) => ({
+                bsStyle: state.mapInfo && state.mapInfo.enabled ? "success" : "primary",
+                active: !!(state.mapInfo && state.mapInfo.enabled)
+            })
+        },
         Settings: {
             tool: <FeatureInfoFormatSelector
                 key="featureinfoformat"

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -22,8 +22,6 @@ const {currentLocaleSelector} = require('../selectors/locale');
 
 const Message = require('./locale/Message');
 
-const {Glyphicon} = require('react-bootstrap');
-
 const assign = require('object-assign');
 
 require('./identify/identify.css');
@@ -54,6 +52,11 @@ const conditionalToggle = on.bind(null, purgeMapInfoResults(), (state) =>
 /**
  * Identify plugin. This plugin allows to perform getfeature info.
  * It can be configured to have a mobile or a desktop flavor.
+ * It's enabled by default. The bubbling of an on_click_map action to GFI is stopped
+ * if Annotations orFeatureGrid plugins are editing, draw or measurement supports are
+ * active ore the identify plugin is disabled.
+ * To restore old behaviour, in mapInfo state, set enabled to false and disabledAlwaysOn to true and
+ * manage the plugin using changeMapInfoState action or toggleControl action with 'info' as control name.
  * @class Identify
  * @memberof plugins
  * @static
@@ -114,15 +117,6 @@ const FeatureInfoFormatSelector = connect((state) => ({
 
 module.exports = {
     IdentifyPlugin: assign(IdentifyPlugin, {
-        disablePluginIf: "{state('featuregridmode') === 'EDIT'}",
-        Toolbar: {
-            name: 'info',
-            position: 6,
-            tooltip: "info.tooltip",
-            icon: <Glyphicon glyph="map-marker"/>,
-            help: <Message msgId="helptexts.infoButton"/>,
-            toggle: true
-        },
         Settings: {
             tool: <FeatureInfoFormatSelector
                 key="featureinfoformat"

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -246,4 +246,10 @@ describe('Test the mapInfo reducer', () => {
         expect(state.showMarker).toBe(false);
     });
 
+    it('should toggle mapinfo state', () => {
+        let state = mapInfo({enabled: true}, {type: 'TOGGLE_MAPINFO_STATE'});
+        expect(state).toExist();
+        expect(state.enabled).toBe(false);
+    });
+
 });

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -194,11 +194,11 @@ describe('Test the mapInfo reducer', () => {
     });
 
     it('set a new point on map which has been clicked', () => {
-        let state = mapInfo({}, {type: 'CLICK_ON_MAP', point: "p"});
+        let state = mapInfo({}, {type: 'FEATURE_INFO_CLICK', point: "p"});
         expect(state.clickPoint).toExist();
         expect(state.clickPoint).toBe('p');
 
-        state = mapInfo({clickPoint: 'oldP'}, {type: 'CLICK_ON_MAP', point: "p"});
+        state = mapInfo({clickPoint: 'oldP'}, {type: 'FEATURE_INFO_CLICK', point: "p"});
         expect(state.clickPoint).toExist();
         expect(state.clickPoint).toBe('p');
     });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -21,7 +21,8 @@ const {
     GET_VECTOR_INFO,
     NO_QUERYABLE_LAYERS,
     CLEAR_WARNING,
-    FEATURE_INFO_CLICK
+    FEATURE_INFO_CLICK,
+    TOGGLE_MAPINFO_STATE
 } = require('../actions/mapInfo');
 
 const {RESET_CONTROLS} = require('../actions/controls');
@@ -58,6 +59,10 @@ function mapInfo(state = initState, action) {
     case CHANGE_MAPINFO_STATE:
         return assign({}, state, {
             enabled: action.enabled
+        });
+    case TOGGLE_MAPINFO_STATE:
+        return assign({}, state, {
+            enabled: !state.enabled
         });
     case NEW_MAPINFO_REQUEST: {
         const {reqId, request} = action;

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {CLICK_ON_MAP} = require('../actions/map');
-
 const {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
@@ -22,7 +20,8 @@ const {
     HIDE_REVERSE_GEOCODE,
     GET_VECTOR_INFO,
     NO_QUERYABLE_LAYERS,
-    CLEAR_WARNING
+    CLEAR_WARNING,
+    FEATURE_INFO_CLICK
 } = require('../actions/mapInfo');
 
 const {RESET_CONTROLS} = require('../actions/controls');
@@ -44,8 +43,9 @@ function receiveResponse(state, action, type) {
     }
     return state;
 }
+const initState = {enabled: true};
 
-function mapInfo(state = {}, action) {
+function mapInfo(state = initState, action) {
     switch (action.type) {
     case NO_QUERYABLE_LAYERS:
         return assign({}, state, {
@@ -80,7 +80,7 @@ function mapInfo(state = {}, action) {
     case ERROR_FEATURE_INFO: {
         return receiveResponse(state, action, 'error');
     }
-    case CLICK_ON_MAP: {
+    case FEATURE_INFO_CLICK: {
         return assign({}, state, {
             clickPoint: action.point,
             clickLayer: action.layer || null

--- a/web/client/selectors/__tests__/mapinfo-test.js
+++ b/web/client/selectors/__tests__/mapinfo-test.js
@@ -8,7 +8,7 @@
 
 
 const expect = require('expect');
-const {mapInfoRequestsSelector, generalInfoFormatSelector} = require('../mapinfo');
+const {mapInfoRequestsSelector, generalInfoFormatSelector, stopGetFeatureInfoSelector} = require('../mapinfo');
 
 describe('Test mapinfo selectors', () => {
     it('test generalInfoFormatSelector default value', () => {
@@ -37,4 +37,65 @@ describe('Test mapinfo selectors', () => {
         });
         expect(props).toEqual(['request']);
     });
+    it('test stopGetFeatureInfoSelector', () => {
+        const props = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            }
+        });
+        expect(props).toEqual(false);
+    });
+    it('test stopGetFeatureInfoSelector when identify is disabled', () => {
+        const props = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: false
+            }
+        });
+        expect(props).toEqual(true);
+    });
+    it('test stopGetFeatureInfoSelector with draw active', () => {
+        const props = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            },
+            draw: {
+                drawStatus: 'start'
+            }
+        });
+        expect(props).toEqual(true);
+    });
+    it('test stopGetFeatureInfoSelector with measurement active', () => {
+        const props = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            },
+            measurement: {
+                areaMeasureEnabled: true
+            }
+        });
+        expect(props).toEqual(true);
+    });
+    it('test stopGetFeatureInfoSelector with annotations editing', () => {
+        const props = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            },
+            annotations: {
+                editing: {}
+            }
+        });
+        expect(props).toEqual(true);
+    });
+    it('test stopGetFeatureInfoSelector with grid editing', () => {
+        const props = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            },
+            featuregrid: {
+                mode: "EDIT"
+            }
+        });
+        expect(props).toEqual(true);
+    });
+
 });

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -9,7 +9,7 @@
 const {get} = require('lodash');
 
 const {createSelector} = require('reselect');
-
+const {modeSelector} = require('./featuregrid');
 /**
  * selects mapinfo state
  * @name mapinfo
@@ -39,7 +39,7 @@ const drawSupportActiveSelector = (state) => {
     const drawStatus = get(state, "draw.drawStatus", false);
     return drawStatus && drawStatus !== 'clean' && drawStatus !== 'stop';
 };
-const gridEditingSelector = (state) => get(state, "featuregrid.mode") === 'EDIT';
+const gridEditingSelector = createSelector(modeSelector, (mode) => mode === 'EDIT');
 const annotationsEditingSelector = (state) => get(state, "annotations.editing");
 const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false);
 

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -10,6 +10,8 @@ const {get} = require('lodash');
 
 const {createSelector} = require('reselect');
 const {modeSelector} = require('./featuregrid');
+const {queryPanelSelector} = require('./controls');
+
 /**
  * selects mapinfo state
  * @name mapinfo
@@ -50,8 +52,8 @@ const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false)
  * @return {boolean} true if the get feature info has to stop the request
  */
 
-const stopGetFeatureInfoSelector = createSelector(mapInfoDisabledSelector, measureActiveSelector, drawSupportActiveSelector, gridEditingSelector, annotationsEditingSelector,
-    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isGridEditing, isAnnotationsEditing) => isMapInfoDisabled || !!isMeasureActive || isDrawSupportActive || isGridEditing || !!isAnnotationsEditing);
+const stopGetFeatureInfoSelector = createSelector(mapInfoDisabledSelector, measureActiveSelector, drawSupportActiveSelector, gridEditingSelector, annotationsEditingSelector, queryPanelSelector,
+    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isGridEditing, isAnnotationsEditing, isQueryPanelActive) => isMapInfoDisabled || !!isMeasureActive || isDrawSupportActive || isGridEditing || !!isAnnotationsEditing || !!isQueryPanelActive);
 
 module.exports = {
     generalInfoFormatSelector,

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -8,6 +8,8 @@
 
 const {get} = require('lodash');
 
+const {createSelector} = require('reselect');
+
 /**
  * selects mapinfo state
  * @name mapinfo
@@ -32,7 +34,27 @@ const mapInfoRequestsSelector = state => get(state, "mapInfo.requests") || [];
  */
 const generalInfoFormatSelector = (state) => get(state, "mapInfo.infoFormat", "text/plain");
 
+const measureActiveSelector = (state) => get(state, "measurement.lineMeasureEnabled") || get(state, "measurement.areaMeasureEnabled") || get(state, "measurement.bearingMeasureEnabled");
+const drawSupportActiveSelector = (state) => {
+    const drawStatus = get(state, "draw.drawStatus", false);
+    return drawStatus && drawStatus !== 'clean' && drawStatus !== 'stop';
+};
+const gridEditingSelector = (state) => get(state, "featuregrid.mode") === 'EDIT';
+const annotationsEditingSelector = (state) => get(state, "annotations.editing");
+const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false);
+
+/**
+ * selects stopGetFeatureInfo from state
+ * @memberof selectors.mapinfo
+ * @param  {object} state the state
+ * @return {boolean} true if the get feature info has to stop the request
+ */
+
+const stopGetFeatureInfoSelector = createSelector(mapInfoDisabledSelector, measureActiveSelector, drawSupportActiveSelector, gridEditingSelector, annotationsEditingSelector,
+    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isGridEditing, isAnnotationsEditing) => isMapInfoDisabled || !!isMeasureActive || isDrawSupportActive || isGridEditing || !!isAnnotationsEditing);
+
 module.exports = {
     generalInfoFormatSelector,
-    mapInfoRequestsSelector
+    mapInfoRequestsSelector,
+    stopGetFeatureInfoSelector
 };


### PR DESCRIPTION
## Description
The GFI tool has become active by default. The user just needs to click on map to get the feature info. The GFI is stopped if Annotation or Grid plugins are editing, draw or measure support are active.
## Issues
 - Fix #2203 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
The GFI is enabled from the btn in toolbar. It's disabled by some other tolls but not reenabled.

**What is the new behavior?**
The GFI is enabled by default, and disabled/enabled under some circumstance.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

**Other information**:
It is possible to control the GFI, by setting the state variables: enabled and disableAlwaysOn. #2462 
Remove "alwaysVisible": true from override tool configuration in identify config (localconfig.json)