### PR TITLE
Added versioning for css (branch c028)

### DIFF
--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -22,7 +22,8 @@ const Localized = require('../I18N/Localized');
 const assign = require('object-assign');
 
 const Theme = connect((state) => ({
-    theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id
+    theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id,
+    version: state.version && state.version.current
 }), {}, (stateProps, dispatchProps, ownProps) => {
     return assign({}, stateProps, dispatchProps, ownProps);
 })(require('../theme/Theme'));

--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -22,8 +22,7 @@ const Localized = require('../I18N/Localized');
 const assign = require('object-assign');
 
 const Theme = connect((state) => ({
-    theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id,
-    version: state.version && state.version.current
+    theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id
 }), {}, (stateProps, dispatchProps, ownProps) => {
     return assign({}, stateProps, dispatchProps, ownProps);
 })(require('../theme/Theme'));
@@ -34,7 +33,8 @@ class StandardRouter extends React.Component {
         locale: PropTypes.object,
         pages: PropTypes.array,
         className: PropTypes.string,
-        themeCfg: PropTypes.object
+        themeCfg: PropTypes.object,
+        version: PropTypes.string
     };
 
     static defaultProps = {
@@ -62,7 +62,7 @@ class StandardRouter extends React.Component {
         return (
 
             <div className={this.props.className}>
-                <Theme {...this.props.themeCfg}/>
+                <Theme {...this.props.themeCfg} version={this.props.version}/>
                 <Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
                     <ConnectedRouter history={history}>
                         <div>

--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -12,8 +12,9 @@ const ConfigUtils = require('../../utils/ConfigUtils');
 
 const reducePropsToState = (props) => {
     const innermostProps = props[props.length - 1];
-    if (innermostProps) {
+    if (innermostProps && innermostProps.version) {
         return {
+            version: innermostProps.version || '',
             theme: innermostProps.theme || 'default',
             themeElement: innermostProps.themeElement || 'theme_stylesheet',
             prefix: innermostProps.prefix || ConfigUtils.getConfigProp('themePrefix') || 'ms2',
@@ -35,7 +36,7 @@ const handleStateChangeOnClient = (themeCfg) => {
             document.head.insertBefore(link, document.head.firstChild);
         }
         const basePath = link.href && link.href.substring(0, link.href.lastIndexOf("/")) || themeCfg.path;
-        link.setAttribute('href', basePath + "/" + themeCfg.theme + ".css");
+        link.setAttribute('href', basePath + "/" + themeCfg.theme + ".css?" + themeCfg.version);
 
         const prefixContainer = themeCfg.prefixContainer;
         const prefix = themeCfg.prefix;
@@ -49,7 +50,8 @@ const handleStateChangeOnClient = (themeCfg) => {
 
 class Theme extends React.Component {
     static propTypes = {
-        theme: PropTypes.string.isRequired
+        theme: PropTypes.string.isRequired,
+        version: PropTypes.string
     };
 
     static defaultProps = {

--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -18,7 +18,7 @@ const reducePropsToState = (props) => {
     */
     if (innermostProps && innermostProps.version) {
         return {
-            version: !innermostProps.version && innermostProps.version !== "${mapstore2.version}\n" ? "?" + innermostProps.version : '',
+            version: innermostProps.version !== "${mapstore2.version}\n" ? "?" + innermostProps.version : '',
             theme: innermostProps.theme || 'default',
             themeElement: innermostProps.themeElement || 'theme_stylesheet',
             prefix: innermostProps.prefix || ConfigUtils.getConfigProp('themePrefix') || 'ms2',

--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -14,7 +14,7 @@ const reducePropsToState = (props) => {
     const innermostProps = props[props.length - 1];
     if (innermostProps && innermostProps.version) {
         return {
-            version: innermostProps.version || '',
+            version: !innermostProps.version && innermostProps.version !== "${mapstore2.version}\n" ? "?" + innermostProps.version : '',
             theme: innermostProps.theme || 'default',
             themeElement: innermostProps.themeElement || 'theme_stylesheet',
             prefix: innermostProps.prefix || ConfigUtils.getConfigProp('themePrefix') || 'ms2',
@@ -36,7 +36,7 @@ const handleStateChangeOnClient = (themeCfg) => {
             document.head.insertBefore(link, document.head.firstChild);
         }
         const basePath = link.href && link.href.substring(0, link.href.lastIndexOf("/")) || themeCfg.path;
-        link.setAttribute('href', basePath + "/" + themeCfg.theme + ".css?" + themeCfg.version);
+        link.setAttribute('href', basePath + "/" + themeCfg.theme + ".css" + themeCfg.version);
 
         const prefixContainer = themeCfg.prefixContainer;
         const prefix = themeCfg.prefix;

--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -12,6 +12,10 @@ const ConfigUtils = require('../../utils/ConfigUtils');
 
 const reducePropsToState = (props) => {
     const innermostProps = props[props.length - 1];
+    /**
+     * version is taken from the build.hs which inject something like SNAPSHOT-lastSHACommit
+     * if not available it will include default.css as usual
+    */
     if (innermostProps && innermostProps.version) {
         return {
             version: !innermostProps.version && innermostProps.version !== "${mapstore2.version}\n" ? "?" + innermostProps.version : '',

--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -1,21 +1,17 @@
-const PropTypes = require('prop-types');
-/**
+/*
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const PropTypes = require('prop-types');
 const React = require('react');
 const withSideEffect = require('react-side-effect');
 const ConfigUtils = require('../../utils/ConfigUtils');
 
 const reducePropsToState = (props) => {
     const innermostProps = props[props.length - 1];
-    /**
-     * version is taken from the build.hs which inject something like SNAPSHOT-lastSHACommit
-     * if not available it will include default.css as usual
-    */
     if (innermostProps && innermostProps.version) {
         return {
             version: innermostProps.version !== "${mapstore2.version}\n" ? "?" + innermostProps.version : '',


### PR DESCRIPTION
## Description
Added versioning for the generated default.css

## Issues
 - Fix #2460

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
it loads default.css

**What is the new behavior?**
it loads default.css?VERSION where VERSION is injected with the build process

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

**Other information**:
**NOTE**: this change is only for the project c028:

it is necessary for the project to include version.txt in the root, update pom and to change a bit the build.sh file as done for the C-028 project. 

build.sh changes
```
export GITREV=`git log -1 --format="%H"`
export VERSION="SNAPSHOT-$GITREV"

npm install
npm run compile
npm run lint
mvn clean install -Dmapstore2.version=$VERSION

```
