### PR TITLE
Fix #2452 with WFSGeoCoder

### DIFF
--- a/web/client/actions/__tests__/queryform-test.js
+++ b/web/client/actions/__tests__/queryform-test.js
@@ -42,6 +42,7 @@ const {
     CHANGE_SPATIAL_ATTRIBUTE,
     TOGGLE_AUTOCOMPLETE_MENU,
     SET_AUTOCOMPLETE_MODE,
+    CHANGE_SPATIAL_FILTER_VALUE,
     setAutocompleteMode,
     toggleMenu,
     changeDwithinValue,
@@ -76,7 +77,8 @@ const {
     simpleFilterFieldUpdate,
     addSimpleFilterField,
     removeSimpleFilterField,
-    removeAllSimpleFilterFields
+    removeAllSimpleFilterFields,
+    changeSpatialFilterValue
 } = require('../queryform');
 
 describe('Test correctness of the queryform actions', () => {
@@ -405,5 +407,28 @@ describe('Test correctness of the queryform actions', () => {
 
         expect(retval).toExist();
         expect(retval.type).toBe(REMOVE_ALL_SIMPLE_FILTER_FIELDS);
+    });
+    it('removeAllSimpleFilterFields', () => {
+        const arg = {
+            collectGeometries: {},
+            options: {},
+            feature: { geometry: {
+                type: "Point",
+                coordinates: [1, 1]
+            }},
+            srsName: {},
+            style: {}
+        };
+        let retval = changeSpatialFilterValue(arg);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(CHANGE_SPATIAL_FILTER_VALUE);
+        expect(retval.geometry).toBe(arg.feature.geometry);
+        expect(retval.collectGeometries).toBe(arg.collectGeometries);
+        expect(retval.options).toBe(arg.options);
+        expect(retval.feature).toBe(arg.feature);
+        expect(retval.srsName).toBe(arg.srsName);
+        expect(retval.style).toBe(arg.style);
+
     });
 });

--- a/web/client/actions/queryform.js
+++ b/web/client/actions/queryform.js
@@ -195,9 +195,10 @@ function changeSpatialAttribute(attribute) {
     };
 }
 
-function changeSpatialFilterValue({feature, srsName, collectGeometries, style, options} = {}) {
+function changeSpatialFilterValue({feature, srsName, collectGeometries, style, options, value} = {}) {
     return {
         type: CHANGE_SPATIAL_FILTER_VALUE,
+        value,
         collectGeometries,
         options,
         geometry: feature && feature.geometry,

--- a/web/client/actions/queryform.js
+++ b/web/client/actions/queryform.js
@@ -195,10 +195,11 @@ function changeSpatialAttribute(attribute) {
     };
 }
 
-function changeSpatialFilterValue({feature, srsName, collectGeometries, style} = {}) {
+function changeSpatialFilterValue({feature, srsName, collectGeometries, style, options} = {}) {
     return {
         type: CHANGE_SPATIAL_FILTER_VALUE,
         collectGeometries,
+        options,
         geometry: feature && feature.geometry,
         feature,
         srsName,

--- a/web/client/actions/queryform.js
+++ b/web/client/actions/queryform.js
@@ -23,6 +23,7 @@ const SELECT_VIEWPORT_SPATIAL_METHOD = 'SELECT_VIEWPORT_SPATIAL_METHOD';
 const UPDATE_GEOMETRY = 'UPDATE_GEOMETRY';
 const SELECT_SPATIAL_OPERATION = 'SELECT_SPATIAL_OPERATION';
 const CHANGE_SPATIAL_ATTRIBUTE = 'CHANGE_SPATIAL_ATTRIBUTE';
+const CHANGE_SPATIAL_FILTER_VALUE = 'CHANGE_SPATIAL_FILTER_VALUE';
 const REMOVE_SPATIAL_SELECT = 'REMOVE_SPATIAL_SELECT';
 const SHOW_SPATIAL_DETAILS = 'SHOW_SPATIAL_DETAILS';
 const QUERY_FORM_SEARCH = 'QUERY_FORM_SEARCH';
@@ -194,6 +195,16 @@ function changeSpatialAttribute(attribute) {
     };
 }
 
+function changeSpatialFilterValue({feature, srsName, collectGeometries, style} = {}) {
+    return {
+        type: CHANGE_SPATIAL_FILTER_VALUE,
+        collectGeometries,
+        geometry: feature && feature.geometry,
+        feature,
+        srsName,
+        style
+    };
+}
 function removeSpatialSelection() {
     return {
         type: REMOVE_SPATIAL_SELECT
@@ -418,6 +429,7 @@ module.exports = {
     SELECT_SPATIAL_METHOD,
     SELECT_SPATIAL_OPERATION,
     CHANGE_SPATIAL_ATTRIBUTE,
+    CHANGE_SPATIAL_FILTER_VALUE,
     REMOVE_SPATIAL_SELECT,
     SHOW_SPATIAL_DETAILS,
     SET_CROSS_LAYER_PARAMETER,
@@ -473,6 +485,7 @@ module.exports = {
     selectSpatialMethod,
     selectSpatialOperation,
     changeSpatialAttribute,
+    changeSpatialFilterValue,
     removeSpatialSelection,
     showSpatialSelectionDetails,
     setCrossLayerFilterParameter,

--- a/web/client/components/data/featuregrid/dialog/ConfirmClear.jsx
+++ b/web/client/components/data/featuregrid/dialog/ConfirmClear.jsx
@@ -6,6 +6,7 @@ module.exports = ({
     saving = false,
     onConfirm = () => {}
 } = {}) => (<Confirm
+    draggable={false}
     show
     onClose={onClose}
     onConfirm={onConfirm}

--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -180,6 +180,7 @@ class SpatialFilter extends React.Component {
                     </Col>
                     <Col xs={6}>
                             <AutocompleteWFSCombobox
+                                value={this.props.spatialField}
                                 key={this.props.spatialField.method}
                                 options={selectedMethod}
                                 autocompleteStreamFactory={createWFSFetchStream}

--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -50,6 +50,7 @@ class SpatialFilter extends React.Component {
             onExpandSpatialFilterPanel: () => {},
             onSelectSpatialMethod: () => {},
             onSelectSpatialOperation: () => {},
+            onChangeSpatialFilterValue: () => {},
             onChangeDrawingStatus: () => {},
             onRemoveSpatialSelection: () => {},
             onShowSpatialSelectionDetails: () => {},
@@ -175,16 +176,21 @@ class SpatialFilter extends React.Component {
             <div className="container-fluid">
                 <Row className="filter-field-row filter-field-fixed-row">
                     <Col xs={6}>
-                        <span>{this.props.spatialField.method}</span>
+                        <span>{selectedMethod && selectedMethod.name || selectedMethod.id}</span>
                     </Col>
                     <Col xs={6}>
                             <AutocompleteWFSCombobox
+                                key={this.props.spatialField.method}
+                                options={selectedMethod}
                                 autocompleteStreamFactory={createWFSFetchStream}
                                 valueField={selectedMethod && selectedMethod.filterProps && selectedMethod.filterProps.valueField}
                                 textField={selectedMethod && selectedMethod.filterProps && selectedMethod.filterProps.valueField}
                                 url={selectedMethod && selectedMethod.url}
                                 filter="contains"
-                                onChangeDrawingStatus={this.props.actions.onChangeDrawingStatus}
+                                onChangeSpatialFilterValue={this.props.actions.onChangeSpatialFilterValue}
+                                onChangeDrawingStatus={(...props) => {
+                                    this.props.actions.onChangeDrawingStatus(...props);
+                                }}
                                 filterProps={selectedMethod && selectedMethod.filterProps}
                             />
                     </Col>

--- a/web/client/components/map/leaflet/DrawSupport.jsx
+++ b/web/client/components/map/leaflet/DrawSupport.jsx
@@ -11,7 +11,7 @@ const {head} = require('lodash');
 const L = require('leaflet');
 require('leaflet-draw');
 const {isSimpleGeomType, getSimpleGeomType} = require('../../../utils/MapUtils');
-const {fromLeafletFeatureToQueryform, boundsToOLExtent} = require('../../../utils/DrawSupportUtils');
+const {boundsToOLExtent} = require('../../../utils/DrawSupportUtils');
 const assign = require('object-assign');
 
 const CoordinatesUtils = require('../../../utils/CoordinatesUtils');

--- a/web/client/components/map/leaflet/DrawSupport.jsx
+++ b/web/client/components/map/leaflet/DrawSupport.jsx
@@ -346,10 +346,6 @@ class DrawSupport extends React.Component {
         if (newProps.options.drawEnabled) {
             this.addDrawInteraction(props);
         }
-        if (newProps.options.updateSpatialField) {
-            const feature = fromLeafletFeatureToQueryform(this.drawLayer);
-            this.props.onEndDrawing(feature, this.props.drawOwner);
-        }
     };
 
     addEditInteraction = (newProps) => {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -141,6 +141,7 @@ class DrawSupport extends React.Component {
             });
             this.drawSource.addFeature(feature);
         });
+        this.updateFeatureStyles(features);
         if (features.length === 0 && (options.editEnabled || options.drawEnabled)) {
             const feature = new ol.Feature({
                 geometry: this.createOLGeometry({type: drawMethod, coordinates: null})
@@ -428,13 +429,6 @@ class DrawSupport extends React.Component {
         }
         if (newProps.options.drawEnabled) {
             this.handleDrawAndEdit(newProps.drawMethod, newProps.options.startingPoint, newProps.options.maxPoints);
-        }
-        if (newProps.options.updateSpatialField) {
-            this.sketchFeature = this.drawSource.getFeatures()[0];
-            this.sketchFeature.set('id', uuid.v1());
-            const feature = this.fromOLFeature(this.sketchFeature);
-
-            this.props.onEndDrawing(feature, this.props.drawOwner);
         }
     };
 

--- a/web/client/components/misc/AutocompleteWFSCombobox.jsx
+++ b/web/client/components/misc/AutocompleteWFSCombobox.jsx
@@ -59,12 +59,10 @@ const addStateHandlers = compose(
         maxFeatures: 5,
         value: props.value,
         onChangeDrawingStatus: props.onChangeDrawingStatus,
-        itemComponent: props.itemComponent,
-        attribute: props.column && props.column.key
+        itemComponent: props.itemComponent
     }), {
-        select: (state) => (selected) => {
+        select: () => (selected) => {
             return ({
-                ...state,
                 selected
             });
         },
@@ -73,7 +71,6 @@ const addStateHandlers = compose(
                 state.onChangeDrawingStatus('clean', null, "queryform", [], {});
             }
             return ({
-                ...state,
                 delayDebounce: 500,
                 selected: false,
                 changingPage: false,
@@ -86,7 +83,6 @@ const addStateHandlers = compose(
         focus: (state) => (options) => {
             if (options && options.length === 0 && state.value === "") {
                 return ({
-                    ...state,
                     delayDebounce: 0,
                     currentPage: 1,
                     performFetch: true,
@@ -96,59 +92,45 @@ const addStateHandlers = compose(
             }
             return (state);
         },
-        toggle: (state) => (v, feature, page) => {
+        toggle: (state) => () => {
             return ({
-            ...state,
-            open: state.changingPage ? true : !state.open,
-            value: state.currentPage === page && !v && !feature ? "" : state.value
+            open: state.changingPage ? true : !state.open
         }); },
         loadNextPage: (state) => () => ({
-            ...state,
             currentPage: state.currentPage + 1,
             performFetch: true,
             changingPage: true,
-            delayDebounce: 0,
-            value: state.value
+            delayDebounce: 0
         }),
         loadPrevPage: (state) => () => ({
-            ...state,
             currentPage: state.currentPage - 1,
             performFetch: true,
             changingPage: true,
-            delayDebounce: 0,
-            value: state.value
+            delayDebounce: 0
         })
     }),
     withHandlers({
         select: ({options, onChangeSpatialFilterValue = () => {}, select = () => {}} = {}) => (value, feature, srsName, style) => {
             if (feature) {
-                if (options && options.crossLayer) {
-                    const cqlFilter = generateTemplateString(options.crossLayer.cqlTemplate || "")(feature);
-                    const collectGeometries = {
-                        queryCollection: {
-                            typeName: options.crossLayer.typeName,
-                            geometryName: options.crossLayer.geometryName,
-                            cqlFilter: cqlFilter
-                        }
-                    };
-                    onChangeSpatialFilterValue({
-                        geometry: feature.geometry,
-                        feature,
-                        srsName,
-                        style,
-                        options: options,
-                        collectGeometries
-                    });
-                } else {
-                    onChangeSpatialFilterValue({
-                        geometry: feature.geometry,
-                        feature,
-                        srsName,
-                        style,
-                        options: options
-                    });
-                }
-
+                onChangeSpatialFilterValue({
+                    geometry: feature.geometry,
+                    value,
+                    feature,
+                    srsName,
+                    style,
+                    options,
+                    collectGeometries:
+                        options && options.crossLayer
+                            ?
+                                {
+                                    queryCollection: {
+                                        typeName: options.crossLayer.typeName,
+                                        geometryName: options.crossLayer.geometryName,
+                                        cqlFilter: generateTemplateString(options.crossLayer.cqlTemplate || "")(feature)
+                                    }
+                                }
+                            : undefined
+                });
             }
             select(true);
         }

--- a/web/client/components/misc/ConfirmDialog.jsx
+++ b/web/client/components/misc/ConfirmDialog.jsx
@@ -20,6 +20,7 @@ class UserDialog extends React.Component {
     static propTypes = {
         // props
         show: PropTypes.bool,
+        draggable: PropTypes.bool,
         onClose: PropTypes.func,
         onConfirm: PropTypes.func,
         onSave: PropTypes.func,
@@ -49,7 +50,7 @@ class UserDialog extends React.Component {
     };
 
     render() {
-        return (<Dialog onClickOut={this.props.onClose} id="confirm-dialog" modal={this.props.modal} style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
+        return (<Dialog draggable={this.props.draggable} onClickOut={this.props.onClose} id="confirm-dialog" modal={this.props.modal} style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
             <span role="header">
                 <span className="user-panel-title">{this.props.title}</span>
                 <button onClick={this.props.onClose} className="login-panel-close close">

--- a/web/client/epics/queryform.js
+++ b/web/client/epics/queryform.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {Observable} = require('rxjs');
+const bbox = require('@turf/bbox');
+
+const {changeDrawingStatus} = require('../actions/draw');
+const {zoomToExtent} = require('../actions/map');
+const {CHANGE_SPATIAL_FILTER_VALUE} = require('../actions/queryform');
+
+module.exports = {
+    updateSpatialFilterValue: action$ =>
+        action$.ofType(CHANGE_SPATIAL_FILTER_VALUE)
+        .switchMap( ({feature, srsName, style, options}) => Observable.of(
+            // draw the filter on map
+            changeDrawingStatus('drawOrEdit', feature.geometry.type, "queryform", [feature],
+                {
+                    editEnabled: false,
+                    stopAfterDrawing: true,
+                    featureProjection: srsName
+                }, style)
+            // set proper filter based on options
+        ).concat((feature && options && options.autoZoom)
+            ? [zoomToExtent(bbox(feature), srsName)]
+            : []))
+};

--- a/web/client/observables/autocomplete.js
+++ b/web/client/observables/autocomplete.js
@@ -60,12 +60,13 @@ const createPagedUniqueAutompleteStream = (props$) => props$
         return Rx.Observable.of({fetchedData: {values: [], size: 0}, busy: false});
     }).startWith({});
 
-const createWFSFetchStream = (props$) => props$
-    .throttle(props => Rx.Observable.timer(props.delayDebounce || 0))
-    .merge(props$.debounce(props => Rx.Observable.timer(props.delayDebounce || 0)))
+const createWFSFetchStream = (props$) =>
+    Rx.Observable.merge(
+        props$.distinctUntilChanged(({value} = {}, {value: nextValue} = {}) => value === nextValue ).debounce(props => Rx.Observable.timer(props.delayDebounce || 0)),
+        props$.distinctUntilChanged( ({filterProps, currentPage} = {}, {filterProps: nextFilterProps, currentPage: nextCurrentPage} ) => filterProps === nextFilterProps && currentPage === nextCurrentPage)
+    )
     .switchMap((p) => {
         if (p.performFetch) {
-
             let parsed = url.parse(p.url, true);
             let newPathname = "";
             if (endsWith(parsed.pathname, "wfs") || endsWith(parsed.pathname, "wms") || endsWith(parsed.pathname, "ows") || endsWith(parsed.pathname, "wps")) {

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -326,6 +326,11 @@ class QueryPanel extends React.Component {
  *        "name": "methodName",
  *        "type": "wfsGeocoder",
  *        "url": "urlToGeoserver",
+ *        "crossLayer": { // if this is present, allows to optimize the filter using crossLayerFilter functinalities instead of geometry. The server must support them
+ *           "cqlTemplate": "ATTRIBUTE_Y = '${properties.ATTRIBUTE_Y}'", // a template to generate the filter from the feature properties
+ *           "geometryName": "GEOMETRY",
+ *           "typeName": "workspace:typeName"
+ *        },
  *        "filterProps": {
  *            "blacklist": [],
  *            "maxFeatures": 5,

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -53,6 +53,7 @@ const {
     selectViewportSpatialMethod,
     selectSpatialOperation,
     removeSpatialSelection,
+    changeSpatialFilterValue,
     showSpatialSelectionDetails,
     setCrossLayerFilterParameter,
     addCrossLayerFilterField,
@@ -128,6 +129,7 @@ const SmartQueryForm = connect((state) => {
             onExpandAttributeFilterPanel: expandAttributeFilterPanel
         }, dispatch),
         spatialFilterActions: bindActionCreators({
+            onChangeSpatialFilterValue: changeSpatialFilterValue,
             onExpandSpatialFilterPanel: expandSpatialFilterPanel,
             onSelectSpatialMethod: selectSpatialMethod,
             onSelectViewportSpatialMethod: selectViewportSpatialMethod,
@@ -331,7 +333,7 @@ class QueryPanel extends React.Component {
  *            "queriableAttributes": ["ATTRIBUTE_X"],
  *            "typeName": "workspace:typeName",
  *            "valueField": "ATTRIBUTE_Y",
-+ *            "srsName": "ESPG:3857"
+ *            "srsName": "ESPG:3857"
  *        },
  *        "customItemClassName": "customItemClassName"
  *    }
@@ -359,5 +361,5 @@ module.exports = {
         queryform: require('../reducers/queryform'),
         query: require('../reducers/query')
     },
-    epics: {featureTypeSelectedEpic, wfsQueryEpic, viewportSelectedEpic, redrawSpatialFilterEpic, ...autocompleteEpics}
+    epics: {featureTypeSelectedEpic, wfsQueryEpic, viewportSelectedEpic, redrawSpatialFilterEpic, ...autocompleteEpics, ...require('../epics/queryform')}
 };

--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -11,9 +11,11 @@ const queryform = require('../queryform');
 const {featureCollection} = require('../../test-resources/featureCollectionZone.js');
 const {
     UPDATE_FILTER_FIELD_OPTIONS, SET_AUTOCOMPLETE_MODE, TOGGLE_AUTOCOMPLETE_MENU,
+    CHANGE_SPATIAL_FILTER_VALUE,
     loadFilter,
     expandCrossLayerFilterPanel, setCrossLayerFilterParameter, resetCrossLayerFilter,
-    addCrossLayerFilterField, updateCrossLayerFilterField, removeCrossLayerFilterField
+    addCrossLayerFilterField, updateCrossLayerFilterField, removeCrossLayerFilterField,
+    changeSpatialFilterValue
 } = require('../../actions/queryform');
 const {END_DRAWING, CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 
@@ -493,6 +495,26 @@ describe('Test the queryform reducer', () => {
         let state = queryform(initialState, testAction);
         expect(state).toExist();
         expect(state.spatialField.attribute).toEqual(attribute);
+    });
+
+    it('test CHANGE_SPATIAL_FILTER_VALUE', () => {
+        const initialState = { spatialField: {geometry: {}} };
+        const args = {
+            collectGeometries: {},
+            value: "SELECTED_VALUE",
+            feature: {
+                geometry: {
+                    type: "Point",
+                    coordinates: [1, 1]
+                }
+            }
+        };
+        const action = changeSpatialFilterValue(args);
+        const newState = queryform(initialState, action);
+        expect(newState.spatialField).toExist();
+        expect(newState.spatialField.geometry).toBe(args.feature.geometry);
+        expect(newState.spatialField.collectGeometries).toBe(args.collectGeometries);
+        expect(newState.spatialField.value).toBe(args.value);
     });
 
     it('test CHANGE_DRAWING_STATUS', () => {

--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -11,7 +11,6 @@ const queryform = require('../queryform');
 const {featureCollection} = require('../../test-resources/featureCollectionZone.js');
 const {
     UPDATE_FILTER_FIELD_OPTIONS, SET_AUTOCOMPLETE_MODE, TOGGLE_AUTOCOMPLETE_MENU,
-    CHANGE_SPATIAL_FILTER_VALUE,
     loadFilter,
     expandCrossLayerFilterPanel, setCrossLayerFilterParameter, resetCrossLayerFilter,
     addCrossLayerFilterField, updateCrossLayerFilterField, removeCrossLayerFilterField,

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -288,6 +288,7 @@ function queryform(state = initialState, action) {
         }
         case CHANGE_SPATIAL_FILTER_VALUE: {
             return assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {
+                value: action.value,
                 collectGeometries: action.collectGeometries,
                 geometry: action.geometry
             })});

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -22,6 +22,7 @@ const {
     SELECT_SPATIAL_METHOD,
     SELECT_SPATIAL_OPERATION,
     CHANGE_SPATIAL_ATTRIBUTE,
+    CHANGE_SPATIAL_FILTER_VALUE,
     REMOVE_SPATIAL_SELECT,
     SHOW_SPATIAL_DETAILS,
     QUERY_FORM_RESET,
@@ -285,10 +286,19 @@ function queryform(state = initialState, action) {
 
             return state;
         }
+        case CHANGE_SPATIAL_FILTER_VALUE: {
+            return assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {
+                collectGeometries: action.collectGeometries,
+                geometry: action.geometry
+            })});
+        }
         case END_DRAWING: {
             let newState;
             if (action.owner === "queryform") {
-                newState = assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {geometry: action.geometry})});
+                newState = assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {
+                    collectGeometries: action.collectGeometries,
+                    geometry: action.geometry
+                })});
             } else {
                 newState = state;
             }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -552,7 +552,7 @@
                 "filterType": "Tipo di filtro",
                 "geometric_operation": "Operazione Geometrica",
                 "combo_placeholder": "Seleziona...",
-                "spatial_filter_header": "Regioni di interesse",
+                "spatial_filter_header": "Regione di interesse",
                 "draw_start_label": "Disegna sulla mappa l'area di interesse",
                 "dwithin_label": "metri",
                 "details": {

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -647,6 +647,64 @@ describe('FilterUtils', () => {
         let filter = FilterUtils.toOGCFilter("ft_name_test", filterObj);
         expect(filter).toEqual(expected);
     });
+    it('Check SpatialFilterField OGC collectGeometries', () => {
+        let filterObj = {
+            spatialField: {
+                "operation": "INTERSECTS",
+                "attribute": "geometry",
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "TEST",
+                        cqlFilter: "INCLUDE",
+                        geometryName: "GEOMETRY"
+                    }
+                },
+                "geometry": {
+                    "type": "Point",
+                    "projection": "EPSG:4326",
+                    "coordinates": [1, 1]
+                }
+            }
+        };
+        const expectedGeom = "<ogc:Intersects>"
+         + '<ogc:PropertyName>geometry</ogc:PropertyName>'
+         + '<ogc:Function name="collectGeometries">'
+         + '<ogc:Function name="queryCollection">'
+         + '<ogc:Literal>TEST</ogc:Literal>'
+         + '<ogc:Literal>GEOMETRY</ogc:Literal>'
+         + '<ogc:Literal>INCLUDE</ogc:Literal>'
+         + '</ogc:Function></ogc:Function>'
+         + "</ogc:Intersects>";
+        let expected =
+            '<wfs:GetFeature service="WFS" version="2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"><wfs:Query typeNames="ft_name_test" srsName="EPSG:4326"><fes:Filter>'
+            + expectedGeom
+            + '</fes:Filter></wfs:Query></wfs:GetFeature>';
+        let filter = FilterUtils.toOGCFilter("ft_name_test", filterObj);
+        expect(filter).toEqual(expected);
+    });
+    it('Check SpatialFilterField CQL collectGeometries', () => {
+        let filterObj = {
+            spatialField: {
+                "operation": "INTERSECTS",
+                "attribute": "geometry",
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "TEST",
+                        cqlFilter: "INCLUDE",
+                        geometryName: "GEOMETRY"
+                    }
+                },
+                "geometry": {
+                    "type": "Point",
+                    "projection": "EPSG:4326",
+                    "coordinates": [1, 1]
+                }
+            }
+        };
+
+        let filter = FilterUtils.toCQLFilter(filterObj);
+        expect(filter).toEqual('(INTERSECTS(geometry, collectGeometries(queryCollection(\'TEST\', \'GEOMETRY\',\'INCLUDE\'))))');
+    });
     it('Check SpatialFilterField cql', () => {
         let filterObj = {
             simpleFilterFields: [{


### PR DESCRIPTION
## Description
This enhances the wfsGeoCoder in querypanel's spatial field to use cross layer filtering. 
If this option is configured, the querybuilder will show the geometry as usual, but the effective filter will be generated using "cross layer filtering" instead of the geometry. 
This improve both performances and reduces the size of the filter, that can be used also as cql_filter in URL without exceeding max URL length. 

## Issues
 - Fix #2452 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
Sync map do not work if the geometry is too complex

**What is the new behavior?**
When properly configured, the sync map works also with complex geometries. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
A limitation of this solution is that this improvement can not be applied you're working with different servers. 