### PR TITLE
Fix #2451. Disable translate when editing is disabled

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -422,11 +422,12 @@ class DrawSupport extends React.Component {
         }
         if (newProps.options.editEnabled) {
             this.addModifyInteraction();
+            // removed for polygon because of the issue https://github.com/geosolutions-it/MapStore2/issues/2378
+            if (getSimpleGeomType(newProps.drawMethod) !== "Polygon") {
+                this.addTranslateInteraction();
+            }
         }
-        // removed for polygon because of the issue https://github.com/geosolutions-it/MapStore2/issues/2378
-        if (getSimpleGeomType(newProps.drawMethod) !== "Polygon") {
-            this.addTranslateInteraction();
-        }
+
         if (newProps.options.drawEnabled) {
             this.handleDrawAndEdit(newProps.drawMethod, newProps.options.startingPoint, newProps.options.maxPoints);
         }

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -189,6 +189,94 @@ describe('Test DrawSupport', () => {
         });
         expect(spyChangeStatus.calls.length).toBe(1);
     });
+    it('translate disabled when not editing', () => {
+        const fakeMap = {
+            addLayer: () => {},
+            removeLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[
+                  [13, 43],
+                  [15, 43],
+                  [15, 44],
+                  [13, 44]
+                ]]
+            },
+            properties: {
+                'name': "some name"
+            }
+        };
+
+
+        const support = ReactDOM.render(
+            <DrawSupport features={[]} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        ReactDOM.render(
+            <DrawSupport features={[feature]} map={fakeMap} drawStatus="drawOrEdit" drawMethod="Some" options={{
+                    drawEnabled: false, editEnabled: false}}
+                />, document.getElementById("container"));
+        expect(support.translateInteraction).toNotExist();
+    });
+    it('translate disabled when Polygon', () => {
+        const fakeMap = {
+            addLayer: () => {},
+            removeLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[
+                  [13, 43],
+                  [15, 43],
+                  [15, 44],
+                  [13, 44]
+                ]]
+            },
+            properties: {
+                'name': "some name"
+            }
+        };
+
+
+        const support = ReactDOM.render(
+            <DrawSupport features={[]} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        ReactDOM.render(
+            <DrawSupport features={[feature]} map={fakeMap} drawStatus="drawOrEdit" drawMethod="Polygon" options={{
+                    drawEnabled: false, editEnabled: true}}
+                />, document.getElementById("container"));
+        expect(support.translateInteraction).toNotExist();
+    });
 
     it('end drawing', () => {
         const fakeMap = {


### PR DESCRIPTION
## Description
This changes disable translate when editing is disabled. This caused the translate issue on query builder. 

## Issues
 - Fix #2451
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix



**What is the current behavior?** (You can also link to an open issue here)
When reload the spatial filter it was draggable

**What is the new behavior?**
The spatial filter is not draggable anymore.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No


**Other information**:
Looking at drawSupport is not clear what is the meaning of all commands and how they have to be used. Could someone explain it better in documentation?