### PR TITLE
Issue #2469. Fixed zoom to polygon geometry (KML/KMZ GXP)

### DIFF
--- a/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
+++ b/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
@@ -247,8 +247,8 @@ class ShapeFileUploadAndStyle extends React.Component {
                 ];
             }
             if (this.state.zoomOnShapefiles) {
-                this.props.updateShapeBBox(bbox.length && bbox || this.props.bbox);
-                this.props.onZoomSelected(bbox.length && bbox || this.props.bbox, "EPSG:4326");
+                this.props.updateShapeBBox(bbox && bbox.length ? bbox : this.props.bbox);
+                this.props.onZoomSelected(bbox && bbox.length ? bbox : this.props.bbox, "EPSG:4326");
             }
             this.props.onShapeSuccess(this.props.layers[0].name + LocaleUtils.getMessageById(this.context.messages, "shapefile.success"));
             this.props.onLayerAdded(this.props.selected);

--- a/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
+++ b/web/client/components/shapefile/ShapefileUploadAndStyle.jsx
@@ -237,28 +237,18 @@ class ShapeFileUploadAndStyle extends React.Component {
         }
         Promise.resolve(this.props.addShapeLayer( styledLayer )).then(() => {
             this.props.shapeLoading(false);
-
-            // calculates the bbox that contains all shapefiles added
-            const bbox = this.props.layers[0].features.reduce((bboxtotal, feature) => {
-                if (feature.geometry.bbox && feature.geometry.bbox[0] && feature.geometry.bbox[1] && feature.geometry.bbox[2] && feature.geometry.bbox[3] ) {
-                    return [
-                        Math.min(bboxtotal[0], feature.geometry.bbox[0]),
-                        Math.min(bboxtotal[1], feature.geometry.bbox[1]),
-                        Math.max(bboxtotal[2], feature.geometry.bbox[2]),
-                        Math.max(bboxtotal[3], feature.geometry.bbox[3])
-                    ] || bboxtotal;
-                } else if (feature.geometry && feature.geometry.type === "Point" && feature.geometry.coordinates && feature.geometry.coordinates.length >= 2) {
-                    return [Math.min(bboxtotal[0], feature.geometry.coordinates[0]),
-                        Math.min(bboxtotal[1], feature.geometry.coordinates[1]),
-                        Math.max(bboxtotal[2], feature.geometry.coordinates[0]),
-                        Math.max(bboxtotal[3], feature.geometry.coordinates[1])
-                    ];
-                }
-                return bboxtotal;
-            }, this.props.bbox);
+            let bbox = [];
+            if (this.props.layers[0].bbox && this.props.bbox) {
+                bbox = [
+                    Math.min(this.props.bbox[0], this.props.layers[0].bbox.bounds.minx),
+                    Math.min(this.props.bbox[1], this.props.layers[0].bbox.bounds.miny),
+                    Math.max(this.props.bbox[2], this.props.layers[0].bbox.bounds.maxx),
+                    Math.max(this.props.bbox[3], this.props.layers[0].bbox.bounds.maxy)
+                ];
+            }
             if (this.state.zoomOnShapefiles) {
-                this.props.updateShapeBBox(bbox);
-                this.props.onZoomSelected(bbox, "EPSG:4326");
+                this.props.updateShapeBBox(bbox.length && bbox || this.props.bbox);
+                this.props.onZoomSelected(bbox.length && bbox || this.props.bbox, "EPSG:4326");
             }
             this.props.onShapeSuccess(this.props.layers[0].name + LocaleUtils.getMessageById(this.context.messages, "shapefile.success"));
             this.props.onLayerAdded(this.props.selected);

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -7,6 +7,7 @@
  */
 
 const assign = require('object-assign');
+const toBbox = require('turf-bbox');
 const {isString, isObject, isArray, head, isEmpty} = require('lodash');
 const REG_GEOSERVER_RULE = /\/[\w- ]*geoserver[\w- ]*\//;
 const findGeoServerName = ({url, regex = REG_GEOSERVER_RULE}) => {
@@ -294,6 +295,7 @@ const LayersUtils = {
         return mapState;
     },
     geoJSONToLayer: (geoJSON, id) => {
+        const bbox = toBbox(geoJSON);
         return {
             type: 'vector',
             visibility: true,
@@ -301,6 +303,15 @@ const LayersUtils = {
             id,
             name: geoJSON.fileName,
             hideLoading: true,
+            bbox: {
+                bounds: {
+                    minx: bbox[0],
+                    miny: bbox[1],
+                    maxx: bbox[2],
+                    maxy: bbox[3]
+                },
+                crs: "EPSG:4326"
+            },
             features: geoJSON.features.map((feature, idx) => {
                 if (!feature.id) {
                     feature.id = idx;


### PR DESCRIPTION
## Description
On import KML/KMZ GXP the zoomTo works for point only

## Issues
 - Fix #2469 


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
When you Add a KML/KMZ GXP with geometry type polygon The map doesn't  zoom to layer

**What is the new behavior?**
The map zooms to polygon layer

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [X] No

