### PR TITLE
Fixed load of theme css

### DIFF
--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 /**
  * Copyright 2016, GeoSolutions Sas.
  * All rights reserved.
@@ -8,9 +7,8 @@ const PropTypes = require('prop-types');
  */
 const React = require('react');
 const {connect} = require('react-redux');
-
+const PropTypes = require('prop-types');
 const Debug = require('../development/Debug');
-
 const {Route} = require('react-router');
 const {ConnectedRouter} = require('react-router-redux');
 const createHistory = require('history/createHashHistory').default;
@@ -46,7 +44,9 @@ class StandardRouter extends React.Component {
             path: 'dist/themes'
         }
     };
-
+    state = {
+        renderChildren: false
+    }
     renderPages = () => {
         return this.props.pages.map((page, i) => {
             const pageConfig = page.pageConfig || {};
@@ -62,17 +62,24 @@ class StandardRouter extends React.Component {
         return (
 
             <div className={this.props.className}>
-                <Theme {...this.props.themeCfg} version={this.props.version}/>
-                <Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
-                    <ConnectedRouter history={history}>
-                        <div>
-                            {this.renderPages()}
-                        </div>
-                    </ConnectedRouter>
-                </Localized>
+                <Theme {...this.props.themeCfg} version={this.props.version} onLoad={this.loaded}>
+                    {this.state.renderChildren ? (<Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
+                        <ConnectedRouter history={history}>
+                            <div>
+                                {this.renderPages()}
+                            </div>
+                        </ConnectedRouter>
+                    </Localized>) : (<span><div className="_ms2_init_spinner _ms2_init_center"><div></div></div>
+                    <div className="_ms2_init_text _ms2_init_center">Loading</div></span>)}
+                </Theme>
                 <Debug/>
             </div>
         );
+    }
+    loaded = () => {
+        this.setState({
+            renderChildren: true
+        });
     }
 }
 

--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -45,7 +45,7 @@ class StandardRouter extends React.Component {
         }
     };
     state = {
-        renderChildren: false
+        themeLoaded: false
     }
     renderPages = () => {
         return this.props.pages.map((page, i) => {
@@ -62,8 +62,8 @@ class StandardRouter extends React.Component {
         return (
 
             <div className={this.props.className}>
-                <Theme {...this.props.themeCfg} version={this.props.version} onLoad={this.loaded}>
-                    {this.state.renderChildren ? (<Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
+                <Theme {...this.props.themeCfg} version={this.props.version} onLoad={this.themeLoaded}>
+                    {this.state.themeLoaded ? (<Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
                         <ConnectedRouter history={history}>
                             <div>
                                 {this.renderPages()}
@@ -76,9 +76,9 @@ class StandardRouter extends React.Component {
             </div>
         );
     }
-    loaded = () => {
+    themeLoaded = () => {
         this.setState({
-            renderChildren: true
+            themeLoaded: true
         });
     }
 }

--- a/web/client/components/theme/Theme.jsx
+++ b/web/client/components/theme/Theme.jsx
@@ -13,7 +13,7 @@ const reducePropsToState = (props) => {
     const innermostProps = props[props.length - 1];
     if (innermostProps && innermostProps.version) {
         return {
-            version: escape(innermostProps.version) !== "%24%7Bmapstore2.version%7D%0D%0A" ? "?" + innermostProps.version : '',
+            version: innermostProps.version.indexOf('${mapstore2.version}') !== -1 ? "?" + innermostProps.version : '',
             theme: innermostProps.theme || 'default',
             themeElement: innermostProps.themeElement || 'theme_stylesheet',
             prefix: innermostProps.prefix || ConfigUtils.getConfigProp('themePrefix') || 'ms2',
@@ -57,10 +57,6 @@ class Theme extends React.Component {
     };
     static defaultProps = {
         theme: 'default'
-    };
-
-    state = {
-        renderChildren: false
     };
 
     render() {


### PR DESCRIPTION
## Description
The application is rendered when the theme is fully loaded.

## Issues
 - Fix #2460


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
it loads the app while the theme isn't loaded yet displaying for a moment the css related to bootstrap.

**What is the new behavior?**
it waits default.css to be fully loaded

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
