### PR TITLE
Fixes #2220 Full screen covers portal modals 

### DIFF
--- a/web/client/components/misc/WithContainer.jsx
+++ b/web/client/components/misc/WithContainer.jsx
@@ -13,6 +13,6 @@ const ConfigUtils = require('../../utils/ConfigUtils');
 
 module.exports = (Component) => {
     return (props) => {
-        return <Component {...props} container={document.querySelector('.' + (ConfigUtils.getConfigProp('themePrefix') || 'ms2')) || document.body}/>;
+        return <Component {...props} container={document.querySelector('.' + (ConfigUtils.getConfigProp('themePrefix') || 'ms2') + " > div") || document.body}/>;
     };
 };

--- a/web/client/components/misc/__tests__/WithContainer-test.jsx
+++ b/web/client/components/misc/__tests__/WithContainer-test.jsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const withContainer = require('../WithContainer');
+const Portal = withContainer(require('react-overlays').Portal);
+const expect = require('expect');
+const ConfigUtils = require('../../../utils/ConfigUtils');
+
+describe('WithContainer Overlay', () => {
+    beforeEach((done) => {
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('test with no class', () => {
+        document.body.innerHTML = '<div id="main-conatiner"><div id="container"><div><div id="old-container"></div></div>';
+        const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
+        const el = ReactDOM.findDOMNode(cmp);
+        expect(el).toExist();
+        expect(document.body.children[1].children[0].getAttribute('class')).toBe('portal-child');
+        expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
+    });
+
+    it('test with default ms2 class', () => {
+        document.body.innerHTML = '<div id="main-conatiner" class="ms2"><div id="container"><div><div id="old-container"></div></div>';
+        const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
+        const el = ReactDOM.findDOMNode(cmp);
+        expect(el).toExist();
+        expect(document.getElementById('container').querySelector('.portal-child')).toExist();
+        expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
+    });
+
+    it('test with default custom class', () => {
+        ConfigUtils.setConfigProp('themePrefix', 'custom');
+        document.body.innerHTML = '<div id="main-conatiner" class="custom"><div id="container"><div><div id="old-container"></div></div>';
+        const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
+        const el = ReactDOM.findDOMNode(cmp);
+        expect(el).toExist();
+        expect(document.getElementById('container').querySelector('.portal-child')).toExist();
+        expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
+    });
+
+});

--- a/web/client/components/misc/__tests__/WithContainer-test.jsx
+++ b/web/client/components/misc/__tests__/WithContainer-test.jsx
@@ -15,48 +15,6 @@ const ConfigUtils = require('../../../utils/ConfigUtils');
 
 describe('WithContainer Overlay', () => {
     beforeEach((done) => {
-        document.body.innerHTML = '<div id="main-conatiner"><div id="container"><div><div id="old-container"></div></div>';
-        setTimeout(done);
-    });
-
-    afterEach((done) => {
-        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
-        document.body.innerHTML = '';
-        setTimeout(done);
-    });
-
-    it('test with no class', () => {
-        const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
-        const el = ReactDOM.findDOMNode(cmp);
-        expect(el).toExist();
-        expect(document.body.children[1].children[0].getAttribute('class')).toBe('portal-child');
-        expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
-    });
-});
-
-describe('WithContainer Overlay', () => {
-    beforeEach((done) => {
-        document.body.innerHTML = '<div id="main-conatiner" class="ms2"><div id="container"><div><div id="old-container"></div></div>';
-        setTimeout(done);
-    });
-
-    afterEach((done) => {
-        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
-        document.body.innerHTML = '';
-        setTimeout(done);
-    });
-
-    it('test with default ms2 class', () => {
-        const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
-        const el = ReactDOM.findDOMNode(cmp);
-        expect(el).toExist();
-        expect(document.getElementById('container').querySelector('.portal-child')).toExist();
-        expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
-    });
-});
-
-describe('WithContainer Overlay', () => {
-    beforeEach((done) => {
         document.body.innerHTML = '<div id="main-conatiner" class="custom"><div id="container"><div><div id="old-container"></div></div>';
         setTimeout(done);
     });

--- a/web/client/components/misc/__tests__/WithContainer-test.jsx
+++ b/web/client/components/misc/__tests__/WithContainer-test.jsx
@@ -15,6 +15,7 @@ const ConfigUtils = require('../../../utils/ConfigUtils');
 
 describe('WithContainer Overlay', () => {
     beforeEach((done) => {
+        document.body.innerHTML = '<div id="main-conatiner"><div id="container"><div><div id="old-container"></div></div>';
         setTimeout(done);
     });
 
@@ -25,31 +26,53 @@ describe('WithContainer Overlay', () => {
     });
 
     it('test with no class', () => {
-        document.body.innerHTML = '<div id="main-conatiner"><div id="container"><div><div id="old-container"></div></div>';
         const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
         const el = ReactDOM.findDOMNode(cmp);
         expect(el).toExist();
         expect(document.body.children[1].children[0].getAttribute('class')).toBe('portal-child');
         expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
     });
+});
+
+describe('WithContainer Overlay', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="main-conatiner" class="ms2"><div id="container"><div><div id="old-container"></div></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
 
     it('test with default ms2 class', () => {
-        document.body.innerHTML = '<div id="main-conatiner" class="ms2"><div id="container"><div><div id="old-container"></div></div>';
         const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
         const el = ReactDOM.findDOMNode(cmp);
         expect(el).toExist();
         expect(document.getElementById('container').querySelector('.portal-child')).toExist();
         expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
+    });
+});
+
+describe('WithContainer Overlay', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="main-conatiner" class="custom"><div id="container"><div><div id="old-container"></div></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
     });
 
     it('test with default custom class', () => {
         ConfigUtils.setConfigProp('themePrefix', 'custom');
-        document.body.innerHTML = '<div id="main-conatiner" class="custom"><div id="container"><div><div id="old-container"></div></div>';
         const cmp = ReactDOM.render(<div id="old-portal-container"><Portal><div className="portal-child"/></Portal></div>, document.getElementById("old-container"));
         const el = ReactDOM.findDOMNode(cmp);
         expect(el).toExist();
         expect(document.getElementById('container').querySelector('.portal-child')).toExist();
         expect(document.getElementById('old-portal-container').querySelector('.portal-child')).toBe(null);
     });
-
 });


### PR DESCRIPTION
## Description
modal currently tested:
- print modal
- print modal preview
- upload vector file
- import vector file
- measure
- settings
- configure search service
- save
- save as
- share
- annotation (exit from editing without save)
- about
- more info in identify
- layer settings
- remove layer
- group settings
- user info
- change password

## Issues
 - Fix #2220

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Modals aren't displayed when fullscreen has been activated

**What is the new behavior?**
Modals are displayed when fullscreen has been activated

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
