### PR TITLE
Fixes #2476 Print plugin causes an error when opened on Leaflet

### DIFF
--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -326,10 +326,10 @@ class LeafletMap extends React.Component {
         var center = this.map.getCenter();
         this.props.onMapViewChanges({x: center.lng, y: center.lat, crs: "EPSG:4326"}, this.map.getZoom(), {
             bounds: {
-                minx: bbox[0],
-                miny: bbox[1],
-                maxx: bbox[2],
-                maxy: bbox[3]
+                minx: parseFloat(bbox[0]),
+                miny: parseFloat(bbox[1]),
+                maxx: parseFloat(bbox[2]),
+                maxy: parseFloat(bbox[3])
             },
             crs: 'EPSG:4326',
             rotation: 0
@@ -375,10 +375,10 @@ class LeafletMap extends React.Component {
             let bbox = new L.LatLngBounds(southWest, northEast).toBBoxString().split(',');
             return {
                 bounds: {
-                    minx: bbox[0],
-                    miny: bbox[1],
-                    maxx: bbox[2],
-                    maxy: bbox[3]
+                    minx: parseFloat(bbox[0]),
+                    miny: parseFloat(bbox[1]),
+                    maxx: parseFloat(bbox[2]),
+                    maxy: parseFloat(bbox[3])
                 },
                 crs: 'EPSG:4326',
                 rotation: 0

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -11,6 +11,7 @@ var LeafletMap = require('../Map.jsx');
 var LeafLetLayer = require('../Layer.jsx');
 var expect = require('expect');
 var mapUtils = require('../../../../utils/MapUtils');
+const {isNumber} = require('lodash');
 require('leaflet-draw');
 
 require('../../../../utils/leaflet/Layers');
@@ -223,10 +224,17 @@ describe('LeafletMap', () => {
         expect(bbox).toExist();
         expect(mapBbox).toExist();
         expect(bbox.bounds).toExist();
-        expect(bbox.bounds.minx).toBe(mapBbox[0]);
-        expect(bbox.bounds.miny).toBe(mapBbox[1]);
-        expect(bbox.bounds.maxx).toBe(mapBbox[2]);
-        expect(bbox.bounds.maxy).toBe(mapBbox[3]);
+
+        expect(isNumber(bbox.bounds.minx)).toBe(true);
+        expect(isNumber(bbox.bounds.miny)).toBe(true);
+        expect(isNumber(bbox.bounds.maxx)).toBe(true);
+        expect(isNumber(bbox.bounds.maxy)).toBe(true);
+
+        expect(Math.round(bbox.bounds.minx)).toBe(Math.round(parseFloat(mapBbox[0])));
+        expect(Math.round(bbox.bounds.miny)).toBe(Math.round(parseFloat(mapBbox[1])));
+        expect(Math.round(bbox.bounds.maxx)).toBe(Math.round(parseFloat(mapBbox[2])));
+        expect(Math.round(bbox.bounds.maxy)).toBe(Math.round(parseFloat(mapBbox[3])));
+
         expect(bbox.crs).toExist();
         // in the case of leaflet the bounding box CRS should always be "EPSG:4326" and the roation 0
         expect(bbox.crs).toBe("EPSG:4326");


### PR DESCRIPTION
## Description
Bounds of leaflet map will be float instead of string with this changes.

## Issues
 - Fix #2476

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Could not open the print plugin on leaflet map and app crashes

**What is the new behavior?**
Print plugin can be open and works as expected

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
