### PR TITLE
Do not use debug version OpenLayers

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -90,7 +90,7 @@
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.4/leaflet.draw.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.0.1/ol-debug.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.0.1/ol.js"></script>
         <!--<script src="https://www.mapquestapi.com/sdk/leaflet/v2.2/mq-map.js?key=__API_KEY_MAPQUEST__"></script>-->
         <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
         <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />


### PR DESCRIPTION
## Description
Reduce MapStore2 loading times by using the minified version of OpenLayers library instead of the debug version.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe:
Use the minified OpenLayers library as a dependency


**What is the current behavior?** (You can also link to an open issue here)
First paint is delayed by 2,3 seconds by the debug version on the library

**What is the new behavior?**
The loading time of the OpenLayers library is 60% faster

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
