### PR TITLE
Fixes #2252: switching from tiled to single tiled in leaflet wms some…

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -562,4 +562,36 @@ describe('Leaflet layer', () => {
         expect(lcount).toBe(1);
 
     });
+
+    it('switches a wms layer to singleTile for leaflet map', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            "maxZoom": 23,
+            "singleTile": false
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <LeafLetLayer type="wms"
+                 options={options} map={map}/>, document.getElementById("container"));
+        var lcount = 0;
+
+        expect(layer).toExist();
+
+        const newOptions = assign({}, options, {
+            singleTile: true
+        });
+        layer = ReactDOM.render(
+            <LeafLetLayer type="wms"
+                 options={newOptions} map={map}/>, document.getElementById("container"));
+        expect(layer).toExist();
+        // count layers
+        map.eachLayer(function() {lcount++; });
+        expect(lcount).toBe(1);
+        expect(layer.layer.options.maxZoom).toBe(23);
+    });
 });

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -143,33 +143,25 @@ Layers.registerType('wms', {
         return L.tileLayer.multipleUrlWMS(urls, queryParameters);
     },
     update: function(layer, newOptions, oldOptions) {
+        if (oldOptions.singleTile !== newOptions.singleTile) {
+            let newLayer;
+            const urls = getWMSURLs(isArray(newOptions.url) ? newOptions.url : [newOptions.url]);
+            const queryParameters = wmsToLeafletOptions(newOptions) || {};
+            urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters));
+            if (newOptions.singleTile) {
+                // return the nonTiledLayer
+                newLayer = L.nonTiledLayer.wmsCustom(urls[0], queryParameters);
+            } else {
+                newLayer = L.tileLayer.multipleUrlWMS(urls, queryParameters);
+            }
+            return newLayer;
+        }
         // find the options that make a parameter change
         let oldqueryParameters = WMSUtils.filterWMSParamOptions(wmsToLeafletOptions(oldOptions));
         let newQueryParameters = WMSUtils.filterWMSParamOptions(wmsToLeafletOptions(newOptions));
         let newParameters = Object.keys(newQueryParameters).filter((key) => {return newQueryParameters[key] !== oldqueryParameters[key]; });
         let removeParams = Object.keys(oldqueryParameters).filter((key) => { return oldqueryParameters[key] !== newQueryParameters[key]; });
         let newParams = {};
-        let newLayer;
-        if (oldOptions.singleTile !== newOptions.singleTile) {
-            const urls = getWMSURLs(isArray(newOptions.url) ? newOptions.url : [newOptions.url]);
-            urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, newQueryParameters));
-            if (newOptions.singleTile) {
-                // return the nonTiledLayer
-                newLayer = L.nonTiledLayer.wmsCustom(urls[0], newQueryParameters);
-            } else {
-                newLayer = L.tileLayer.multipleUrlWMS(urls, newQueryParameters);
-            }
-            if ( newParameters.length > 0 ) {
-                newParams = newParameters.reduce( (accumulator, currentValue) => {
-                    return objectAssign({}, accumulator, {[currentValue]: newQueryParameters[currentValue] });
-                }, newParams);
-                // set new options as parameters, merged with params
-                newLayer.setParams(objectAssign(newParams, newParams.params, newOptions.params));
-            } else if (!isEqual(newOptions.params, oldOptions.params)) {
-                newLayer.setParams(newOptions.params);
-            }
-            return newLayer;
-        }
         if (removeParams.length > 0) {
             layer.removeParams(removeParams, newParameters.length > 0);
         }


### PR DESCRIPTION
… parameters are lost

## Description
Switching WMS layers from single tile to tiled and viceversa, some parameters are lost

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Switching WMS layers from single tile to tiled and viceversa, some parameters are lost

**What is the new behavior?**
Switching WMS layers from single tile to tiled and viceversa, some parameters are not lost anymore (e.g. maxZoom)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
