### PR TITLE
Fixes #2130: CRS not normalized in openlayers WMS requests

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -342,7 +342,7 @@ class OpenlayersMap extends React.Component {
 
     createView = (center, zoom, projection, options) => {
         const viewOptions = assign({}, {
-            projection: projection,
+            projection: CoordinatesUtils.normalizeSRS(projection),
             center: [center.x, center.y],
             zoom: zoom
         }, options || {});

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -87,6 +87,15 @@ describe('OpenlayersMap', () => {
         }, 500);
     });
 
+    it('normalized CRS', () => {
+        const comp = (<OpenlayersMap projection="EPSG:900913" center={{y: 43.9, x: 10.3}} zoom={11}
+            />);
+
+        const map = ReactDOM.render(comp, document.getElementById("map"));
+        expect(map).toExist();
+        expect(map.map.getView().getProjection().getCode()).toBe('EPSG:3857');
+    });
+
     it('click on feature', (done) => {
         const testHandlers = {
             handler: () => {}


### PR DESCRIPTION
## Description
OpenLayers is appending a wrong CRS attribute to WMS requests if projection is EPSG:900913. The result is SRS=EPSG:3857&CRS=EPSG:900913

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
OpenLayers is appending a wrong CRS attribute to WMS requests if projection is EPSG:900913. The result is SRS=EPSG:3857&CRS=EPSG:900913

**What is the new behavior?**
SRS=EPSG:3857&CRS=EPSG:3857

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
