### PR TITLE
Fixes #2137: WMS.parseLayerCapabilities does not consider nested layers

### DIFF
--- a/testConfig.js
+++ b/testConfig.js
@@ -3,6 +3,8 @@ module.exports = ({files, path, testFile, singleRun}) => ({
 
     browserNoActivityTimeout: 30000,
 
+    reportSlowerThan: 100,
+
     singleRun,
 
     frameworks: [ 'mocha' ],

--- a/web/client/actions/layerCapabilities.js
+++ b/web/client/actions/layerCapabilities.js
@@ -69,6 +69,8 @@ function getLayerCapabilities(layer, options) {
                     boundingBox: layerCapability.latLonBoundingBox,
                     availableStyles: layerCapability.style && (Array.isArray(layerCapability.style) ? layerCapability.style : [layerCapability.style])
                 }));
+            } else {
+                dispatch(updateNode(layer.id, "id", { capabilitiesLoading: null, capabilities: { error: "error getting capabilities", details: "no layer info" }, description: null }));
             }
             // return dispatch(updateNode(layer.id, "id", {capabilities: capabilities || {"error": "no describe Layer found"}}));
 

--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -169,18 +169,23 @@ const Api = {
     textSearch: function(url, startPosition, maxRecords, text) {
         return Api.getRecords(url, startPosition, maxRecords, text);
     },
-    parseLayerCapabilities: function(capabilities, layer) {
-        const layers = _.get(capabilities, "capability.layer.layer");
-        return _.head(layers.filter( ( capability ) => {
-            if (layer.name.split(":").length === 2 && capability.name && capability.name.split(":").length === 2 ) {
-                return layer.name === capability.name;
-            } else if (capability.name && capability.name.split(":").length === 2) {
-                return (layer.name === capability.name.split(":")[1]);
-            } else if (layer.name.split(":").length === 2) {
-                return layer.name.split(":")[1] === capability.name;
+    parseLayerCapabilities: function(capabilities, layer, lyrs) {
+        const layers = castArray(lyrs || _.get(capabilities, "capability.layer.layer"));
+        return layers.reduce((previous, capability) => {
+            if (previous) {
+                return previous;
             }
-            return layer.name === capability.name;
-        }));
+            if (!capability.name && capability.layer) {
+                return this.parseLayerCapabilities(capabilities, layer, castArray(capability.layer));
+            } else if (layer.name.split(":").length === 2 && capability.name && capability.name.split(":").length === 2) {
+                return layer.name === capability.name && capability;
+            } else if (capability.name && capability.name.split(":").length === 2) {
+                return (layer.name === capability.name.split(":")[1]) && capability;
+            } else if (layer.name.split(":").length === 2) {
+                return layer.name.split(":")[1] === capability.name && capability;
+            }
+            return layer.name === capability.name && capability;
+        }, null);
     },
     getBBox: function(record, bounds) {
         let layer = record;

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -143,4 +143,25 @@ describe('Test correctness of the WMS APIs', () => {
             }
         });
     });
+    it('parseLayerCapabilities nested', () => {
+        const capabilities = {
+            capability: {
+                layer: {
+                    layer: {
+                        layer: [
+                            {
+                                name: "mytest"
+                            },
+                            {
+                                name: "mytest2"
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+
+        const capability = API.parseLayerCapabilities(capabilities, {name: 'mytest'});
+        expect(capability).toExist();
+    });
 });


### PR DESCRIPTION
## Description
WMS.parseLayerCapabilities does not consider nested layers

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
WMS.parseLayerCapabilities does not consider nested layers

**What is the new behavior?**
WMS.parseLayerCapabilities considers nested layers


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
