### PR TITLE
Fix #2491. Avoid wrong coordinate changes with openlayers map click

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -128,10 +128,11 @@ class OpenlayersMap extends React.Component {
                 map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
                     if (layer && layer.get('handleClickOnLayer')) {
                         layerInfo = layer.get('msId');
+                        const geom = feature.getGeometry();
+                        // TODO getFirstCoordinate makes sense only for points, maybe centroid is more appropriate
+                        const getCoord = geom.getType() === "GeometryCollection" ? geom.getGeometries()[0].getFirstCoordinate() : geom.getFirstCoordinate();
+                        coords = ol.proj.toLonLat(getCoord, this.props.projection);
                     }
-                    const geom = feature.getGeometry();
-                    const getCoord = geom.getType() === "GeometryCollection" ? geom.getGeometries()[0].getFirstCoordinate() : geom.getFirstCoordinate();
-                    coords = ol.proj.toLonLat(getCoord, this.props.projection);
                     tLng = CoordinatesUtils.normalizeLng(coords[0]);
                 });
                 this.props.onClick({


### PR DESCRIPTION
## Description
The openlayers map simulate feature click inside his singleclick event. The problem was that the point was moved everytime a vector layer is clicked, not only when the layer had `handleClickOnLayer` set to true.
For the future (and all the maps) I think we should avoid this and pass in the click event the feature clicked, instead of changing the clicked point. This is easier now because the mouse click event is now managed separately from the feature info. 
## Issues
 - Fix #2491

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 

 - [x] Bugfix
 


**What is the current behavior?** 
See #2491 

**What is the new behavior?**
The marker is in the correct point. 
The behavior is the original when `handleClickOnLayer` is true. 
![image](https://user-images.githubusercontent.com/1279510/34051439-e56a0260-e1be-11e7-860f-a51e315df061.png)


**Does this PR introduce a breaking change?**

 - [x] No


