### PR TITLE
Fix #2493. Escape single quotes in CQL_FILTER generation

### DIFF
--- a/web/client/components/misc/AutocompleteWFSCombobox.jsx
+++ b/web/client/components/misc/AutocompleteWFSCombobox.jsx
@@ -12,6 +12,9 @@ const PagedComboboxWithFeatures = require('./combobox/PagedComboboxWithFeatures'
 const {generateTemplateString} = require('../../utils/TemplateUtils');
 const {setObservableConfig, mapPropsStreamWithConfig, compose, withStateHandlers, withPropsOnChange, withHandlers} = require('recompose');
 const rxjsConfig = require('recompose/rxjsObservableConfig').default;
+
+const {escapeCQLStrings} = require('../../utils/FilterUtils');
+
 setObservableConfig(rxjsConfig);
 const mapPropsStream = mapPropsStreamWithConfig(rxjsConfig);
 
@@ -128,7 +131,7 @@ const addStateHandlers = compose(
                                     queryCollection: {
                                         typeName: options.crossLayer.typeName,
                                         geometryName: options.crossLayer.geometryName,
-                                        cqlFilter: generateTemplateString(options.crossLayer.cqlTemplate || "")(feature)
+                                        cqlFilter: generateTemplateString(options.crossLayer.cqlTemplate || "", escapeCQLStrings)(feature)
                                     }
                                 }
                             : undefined

--- a/web/client/utils/TemplateUtils.js
+++ b/web/client/utils/TemplateUtils.js
@@ -17,23 +17,27 @@ module.exports = {
     generateTemplateString: (function() {
         var cache = {};
 
-        function generateTemplate(template) {
+        function generateTemplate(template, escapeFn) {
 
             var fn = cache[template];
-
-            if (!fn) {
+            // if escapeFn is defined, no cache is used
+            if (!fn || escapeFn) {
                 fn = (map) => {
 
                     let sanitized = template
                     .replace(/\$\{([\s]*[^;\s\{]+[\s]*)\}/g, (_, match) => {
-                        return match.trim().split(".").reduce((a, b) => {
+                        const escapeFunction = escapeFn || (a => a);
+                        return escapeFunction(match.trim().split(".").reduce((a, b) => {
                             return a && a[b];
-                        }, map);
+                        }, map));
                     });
 
                     return isString(sanitized) && sanitized || '';
                 };
-                cache[template] = fn;
+                if (!escapeFn) {
+                    cache[template] = fn;
+                }
+
 
             }
             return fn;

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -835,6 +835,18 @@ describe('FilterUtils', () => {
         expect(FilterUtils.cqlBooleanField("attribute_1", "=", undefined)).toBe("");
         expect(FilterUtils.cqlBooleanField("attribute_1", "=", null)).toBe("");
     });
+    it('Check if cqlStringField(attribute, operator, value)', () => {
+        // testing operator =
+        expect(FilterUtils.cqlStringField("attribute_1", "=", "Alabama")).toBe("\"attribute_1\"='Alabama'");
+        // test escape single quotes
+        expect(FilterUtils.cqlStringField("attribute_1", "=", "PRE'")).toBe("\"attribute_1\"='PRE'''");
+        // test isNull
+        expect(FilterUtils.cqlStringField("attribute_1", "isNull", "")).toBe("isNull(\"attribute_1\")=true");
+        // test ilike
+        expect(FilterUtils.cqlStringField("attribute_1", "ilike", "A")).toBe("strToLowerCase(\"attribute_1\") LIKE '%a%'");
+        // test LIKE
+        expect(FilterUtils.cqlStringField("attribute_1", "like", "A")).toBe("\"attribute_1\" LIKE '%A%'");
+    });
     it('Check if ogcBooleanField(attribute, operator, value, nsplaceholder)', () => {
         // testing operators
         expect(FilterUtils.ogcBooleanField("attribute_1", "=", true, "ogc"))

--- a/web/client/utils/__tests__/TemplateUtils-test.js
+++ b/web/client/utils/__tests__/TemplateUtils-test.js
@@ -39,4 +39,10 @@ describe('TemplateUtils', () => {
         expect(templateResult3).toBe("this is a second TEST");
 
     });
+    it('test escape function', () => {
+        let templateFunction = TemplateUtils.generateTemplateString("this is a ${test}", a => a + "2");
+        expect(templateFunction).toExist();
+        let templateResult = templateFunction({test: "TEST"});
+        expect(templateResult).toBe("this is a TEST2");
+    });
 });


### PR DESCRIPTION
## Description
This fixes CQL Generation for single quotes. 
The fixes are applied to : 
 - cqlFilter geneation in FilterUtils
 - adding an optional escapeFn to TemplateUtils, in order to allow escaping of cqlFilter in the wfsGeocoder

## Issues
 - Fix #2493

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
See #2493. In addition wfsGeoCoder filters failed if the filter configured contained a single quote. 
E.g. 
` "cqlTemplate":  "ATTR_NAME = '${properties.ATTR}'"` and `properties.ATTR = "I'm an issue"`.

**What is the new behavior?**
No errors in sync map for both wfsGeoCoder (featuregrid) or syncMap 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No


