### PR TITLE
Fix #2497. Add showExpandTitle option to the TOC

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -37,7 +37,8 @@ class DefaultLayer extends React.Component {
         selectedNodes: PropTypes.array,
         filterText: PropTypes.string,
         onUpdateNode: PropTypes.func,
-        titleTooltip: PropTypes.bool
+        titleTooltip: PropTypes.bool,
+        showExpandTitle: PropTypes.bool
     };
 
     static defaultProps = {
@@ -55,7 +56,8 @@ class DefaultLayer extends React.Component {
         selectedNodes: [],
         filterText: '',
         onUpdateNode: () => {},
-        titleTooltip: false
+        titleTooltip: false,
+        showExpandTitle: false
     };
 
     renderCollapsible = () => {
@@ -63,8 +65,10 @@ class DefaultLayer extends React.Component {
         return (
             <div key="legend" position="collapsible" className="collapsible-toc">
                 <Grid fluid>
+                    {this.props.showExpandTitle ? <Row><Col xs={12} className="toc-full-title">{this.getTitle(this.props.node)}</Col></Row> : null}
                     {this.props.activateOpacityTool ?
                     <Row>
+
                         <Col xs={12} className="mapstore-slider with-tooltip">
                             <Slider start={[layerOpacity]}
                                 disabled={!this.props.node.visibility}
@@ -146,7 +150,10 @@ class DefaultLayer extends React.Component {
 
         return !this.props.filterText ? this.renderNode(grab, hide, selected, error, warning, other) : filteredNode;
     }
-
+    getTitle = (layer) => {
+        const translation = isObject(layer.title) ? layer.title[this.props.currentLocale] || layer.title.default : layer.title;
+        return translation || layer.name;
+    }
     filterLayers = (layer) => {
         const translation = isObject(layer.title) ? layer.title[this.props.currentLocale] || layer.title.default : layer.title;
         const title = translation || layer.name;

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -38,7 +38,7 @@ class DefaultLayer extends React.Component {
         filterText: PropTypes.string,
         onUpdateNode: PropTypes.func,
         titleTooltip: PropTypes.bool,
-        showExpandTitle: PropTypes.bool
+        showFullTitleOnExpand: PropTypes.bool
     };
 
     static defaultProps = {
@@ -57,7 +57,7 @@ class DefaultLayer extends React.Component {
         filterText: '',
         onUpdateNode: () => {},
         titleTooltip: false,
-        showExpandTitle: false
+        showFullTitleOnExpand: false
     };
 
     renderCollapsible = () => {
@@ -65,7 +65,7 @@ class DefaultLayer extends React.Component {
         return (
             <div key="legend" position="collapsible" className="collapsible-toc">
                 <Grid fluid>
-                    {this.props.showExpandTitle ? <Row><Col xs={12} className="toc-full-title">{this.getTitle(this.props.node)}</Col></Row> : null}
+                    {this.props.showFullTitleOnExpand ? <Row><Col xs={12} className="toc-full-title">{this.getTitle(this.props.node)}</Col></Row> : null}
                     {this.props.activateOpacityTool ?
                     <Row>
 

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -231,7 +231,7 @@ describe('test DefaultLayer module component', () => {
             opacity: 0.5
         };
 
-        let comp = ReactDOM.render(<Layer showExpandTitle visibilityCheckType="checkbox" node={l} />,
+        let comp = ReactDOM.render(<Layer showFullTitleOnExpand visibilityCheckType="checkbox" node={l} />,
             document.getElementById("container"));
         expect(comp).toExist();
         let domNode = ReactDOM.findDOMNode(comp);

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -178,7 +178,7 @@ describe('test DefaultLayer module component', () => {
         expect(tool.getAttribute('disabled')).toBe('true');
     });
 
-    it('tests disable lagend and opaicty tools', () => {
+    it('tests disable legend and opacity tools', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -199,7 +199,7 @@ describe('test DefaultLayer module component', () => {
         expect(button.length).toBe(0);
     });
 
-    it('tests disable opaicty tools', () => {
+    it('tests disable opacity tools', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -220,6 +220,31 @@ describe('test DefaultLayer module component', () => {
         expect(button.length).toBe(1);
         const slider = domNode.getElementsByClassName("mapstore-slider");
         expect(slider.length).toBe(0);
+    });
+    it('show full title', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            storeIndex: 9,
+            type: 'wms',
+            opacity: 0.5
+        };
+
+        let comp = ReactDOM.render(<Layer showExpandTitle visibilityCheckType="checkbox" node={l} />,
+            document.getElementById("container"));
+        expect(comp).toExist();
+        let domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        let title = domNode.getElementsByClassName("toc-full-title");
+        expect(title.length).toBe(1);
+        comp = ReactDOM.render(<Layer visibilityCheckType="checkbox" node={l} />,
+            document.getElementById("container"));
+        domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        title = domNode.getElementsByClassName("toc-full-title");
+        expect(title.length).toBe(0);
+
     });
 
 });

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -411,6 +411,7 @@ class LayerTree extends React.Component {
  * @prop {boolean} cfg.activateSortLayer: activate drag and drob to sort layers, default `true`
  * @prop {boolean} cfg.activateAddLayerButton: activate a button to open the catalog, default `false`
  * @prop {object} cfg.layerOptions: options to pass to the layer.
+ * @prop {boolean} cfg.showExpandTitle shows full length title in the legend. default `false`.
  * Some of the layerOptions are: `legendContainerStyle`, `legendStyle`. These 2 allow to customize the legend:
  * For instance you can pass some stying props to the legend.
  * this example is to make the legend scrollable horizontally

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -145,7 +145,7 @@ class LayerTree extends React.Component {
         updateNode: PropTypes.func,
         removeNode: PropTypes.func,
         activateTitleTooltip: PropTypes.bool,
-        showExpandTitle: PropTypes.bool,
+        showFullTitleOnExpand: PropTypes.bool,
         activateOpacityTool: PropTypes.bool,
         activateSortLayer: PropTypes.bool,
         activateFilterLayer: PropTypes.bool,
@@ -199,7 +199,7 @@ class LayerTree extends React.Component {
         selectedNodes: [],
         activateOpacityTool: true,
         activateTitleTooltip: true,
-        showExpandTitle: false,
+        showFullTitleOnExpand: false,
         activateSortLayer: true,
         activateFilterLayer: true,
         activateMapTitle: true,
@@ -269,7 +269,7 @@ class LayerTree extends React.Component {
             <DefaultLayer
                 {...this.props.layerOptions}
                 titleTooltip={this.props.activateTitleTooltip}
-                showExpandTitle={this.props.showExpandTitle}
+                showFullTitleOnExpand={this.props.showFullTitleOnExpand}
                 onToggle={this.props.onToggleLayer}
                 activateOpacityTool={this.props.activateOpacityTool}
                 onContextMenu={this.props.onContextMenu}
@@ -411,7 +411,7 @@ class LayerTree extends React.Component {
  * @prop {boolean} cfg.activateSortLayer: activate drag and drob to sort layers, default `true`
  * @prop {boolean} cfg.activateAddLayerButton: activate a button to open the catalog, default `false`
  * @prop {object} cfg.layerOptions: options to pass to the layer.
- * @prop {boolean} cfg.showExpandTitle shows full length title in the legend. default `false`.
+ * @prop {boolean} cfg.showFullTitleOnExpand shows full length title in the legend. default `false`.
  * Some of the layerOptions are: `legendContainerStyle`, `legendStyle`. These 2 allow to customize the legend:
  * For instance you can pass some stying props to the legend.
  * this example is to make the legend scrollable horizontally

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -145,6 +145,7 @@ class LayerTree extends React.Component {
         updateNode: PropTypes.func,
         removeNode: PropTypes.func,
         activateTitleTooltip: PropTypes.bool,
+        showExpandTitle: PropTypes.bool,
         activateOpacityTool: PropTypes.bool,
         activateSortLayer: PropTypes.bool,
         activateFilterLayer: PropTypes.bool,
@@ -198,6 +199,7 @@ class LayerTree extends React.Component {
         selectedNodes: [],
         activateOpacityTool: true,
         activateTitleTooltip: true,
+        showExpandTitle: false,
         activateSortLayer: true,
         activateFilterLayer: true,
         activateMapTitle: true,
@@ -267,6 +269,7 @@ class LayerTree extends React.Component {
             <DefaultLayer
                 {...this.props.layerOptions}
                 titleTooltip={this.props.activateTitleTooltip}
+                showExpandTitle={this.props.showExpandTitle}
                 onToggle={this.props.onToggleLayer}
                 activateOpacityTool={this.props.activateOpacityTool}
                 onContextMenu={this.props.onContextMenu}


### PR DESCRIPTION
## Description
Add the option to show full title in expand panel

## Issues
 - Fix #2497.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Title can be shown only in the tooltip

**What is the new behavior?**
Admin can configure the application to show the full title in TOC's layer's exandible panel

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
