### PR TITLE
Fixes #2499: wrong center reprojection on map init

### DIFF
--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -144,24 +144,10 @@ var ConfigUtils = {
     },
 
     getCenter: function(center, projection) {
-        var retval;
-        if ((center.x || center.x === 0) && (center.y || center.y === 0) && center.crs) {
-            if (center.crs !== "EPSG:4326") {
-                let xy = Proj4js.toPoint([center.x, center.y]);
-                const epsgMap = new Proj4js.Proj(center.crs);
-                Proj4js.transform(epsgMap, epsg4326, xy);
-                retval = {y: xy.y, x: xy.x, crs: "EPSG:4326"};
-            } else {
-                retval = center;
-            }
-            return retval;
-        }
-        let xy = Proj4js.toPoint(center);
-        if (projection) {
-            const epsgMap = new Proj4js.Proj(projection);
-            Proj4js.transform(epsgMap, epsg4326, xy);
-        }
-        return {y: xy.y, x: xy.x, crs: "EPSG:4326"};
+        const point = isArray(center) ? {x: center[0], y: center[1]} : center;
+        const crs = center.crs || projection || 'EPSG:4326';
+        const transformed = crs !== 'EPSG:4326' ? Proj4js.transform(new Proj4js.Proj(crs), epsg4326, point) : point;
+        return assign({}, transformed, {crs: "EPSG:4326"});
     },
     normalizeConfig: function(config) {
         const {layers, groups, plugins, ...other} = config;

--- a/web/client/utils/__tests__/ConfigUtils-test.js
+++ b/web/client/utils/__tests__/ConfigUtils-test.js
@@ -200,6 +200,16 @@ describe('ConfigUtils', () => {
         expect(center.y).toExist();
         expect(center.x).toExist();
         expect(center.crs).toBe('EPSG:4326');
+        expect(Math.round(center.x)).toBe(13);
+        expect(Math.round(center.y)).toBe(39);
+
+        center = ConfigUtils.getCenter([1459732, 4786738], 'EPSG:900913');
+        expect(center).toExist();
+        expect(center.y).toExist();
+        expect(center.x).toExist();
+        expect(center.crs).toBe('EPSG:4326');
+        expect(Math.round(center.x)).toBe(13);
+        expect(Math.round(center.y)).toBe(39);
     });
 
     it('getConfigurationOptions', () => {


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Reprojection of center assumes point is transformed in place, this is wrong in latest proj4js

**What is the new behavior?**
Reprojection of center takes the new point returned from proj4js transform function

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
