### PR TITLE
Fix #2503. Removed hardcoded URL. use CORS

### DIFF
--- a/web/client/examples/featuregrid/localConfig.json
+++ b/web/client/examples/featuregrid/localConfig.json
@@ -63,6 +63,9 @@
         ]
     },
     "printUrl": "https://demo.geo-solutions.it/geoserver/pdf/info.json",
-    "proxyUrl": "/mapstore/proxy/?url=",
+    "proxyUrl": {
+        "url": "/proxy/?url=",
+        "useCORS": ["http://demo.geo-solutions.it:80/geoserver", "http://demo.geo-solutions.it/geoserver", "https://demo.geo-solutions.it:443/geoserver", "https://demo.geo-solutions.it/geoserver"]
+    },
     "translationsPath": "../../translations"
 }

--- a/web/client/examples/featuregrid/stores/store.js
+++ b/web/client/examples/featuregrid/stores/store.js
@@ -45,8 +45,7 @@ module.exports = (plugins) => {
                 .switchMap((layer) => Rx.Observable.of(
                     clearChanges(),
                     browseData({
-                        ...getLayerFromId(store.getState(), layer.id),
-                        url: 'http://demo.geo-solutions.it:80/geoserver/wfs'
+                        ...getLayerFromId(store.getState(), layer.id)
                     })
         ))
     }, plugins);


### PR DESCRIPTION
## Description
This fixes featuregrid example by removing hardcoded URL, that doesn't seems to be needed anymore. To avoid proxy issues, the example is configured to use CORS.

## Issues
 - Fix #2503

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) <-- No tests for examples
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Feature grid example doesn't work

**What is the new behavior?**
Featuregrid example works

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

**Other information**:
This doesn't fix stable version of mapstore2 example. To fix it we allow http (not secured) request on demo or fix release and rebuild