### PR TITLE
Fixes #2291 If a map save fails, user is not warned

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -167,6 +167,7 @@
 
             "web/client/utils/index.jsdoc",
             "web/client/utils/CoordinatesUtils.js",
+            "web/client/utils/LocaleUtils.js",
             "web/client/utils/PluginsUtils.js",
             "web/client/utils/PrintUtils.js",
             "web/client/utils/ogc/Filter/FilterBuilder.js",

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -21,6 +21,8 @@
         "enable": "Aktiviere",
         "layers": "Ebenen",
         "warning": "Warnung",
+        "errorTitleDefault": "Fehler",
+        "errorDefault": "Ein Fehler ist aufgetreten",
         "version": {
             "label": "Version"
         },
@@ -209,6 +211,8 @@
             "errorFormat": "Unterstützte Formate: png/jpg",
             "errorSize": "Maximal zulässige Größe: 500kb",
             "error": "Das bereitgestellte Bild ist ungültig",
+            "savedMapTitle": "Gespeicherte Karte",
+            "savedMapMessage": "Karte wurde korrekt gespeichert",
             "thumbnailError": {
                 "error403": "Du hast keine Berechtigung um Thumbnails hochzuladen",
                 "error404": "Es gab einen Fehler während der Erstellung des Thumbnails",
@@ -216,9 +220,11 @@
                 "errorDefault": "Netzwerk Fehler"
             },
             "mapError": {
+                "errorTitle": "Aktuelle Karte kann nicht gespeichert werden",
                 "error403": "Du hast keine Berechtigung die Karte zu aktualisieren",
                 "error404": "Es gab einen Fehler während der Erstellung der Karte",
                 "error409": "Eine Karte mit diesem Namen existiert bereits",
+                "error500": "Interner Serverfehler. Überprüfen Sie, ob die Größe der Kartenkonfigurationsdatei den festgelegten Grenzwert überschreitet",
                 "errorDefault": "Netzwerk Fehler"
             },
             "permissions": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -21,6 +21,8 @@
         "enable": "Enable",
         "layers": "Layers",
         "warning": "Warning",
+        "errorTitleDefault": "Error",
+        "errorDefault": "An error occurred",
         "version": {
             "label": "Version"
         },
@@ -209,6 +211,8 @@
             "errorFormat": "Supported formats: png/jpg",
             "errorSize": "Max allowed size: 500kb",
             "error": "The provided image is invalid",
+            "savedMapTitle": "Saved Map",
+            "savedMapMessage": "Map has been saved correctly",
             "thumbnailError": {
                 "error403": "You are not allowed to update the thumbnail",
                 "error404": "An error occurred while creating the thumbnail",
@@ -216,9 +220,11 @@
                 "errorDefault": "Network error"
             },
             "mapError": {
+                "errorTitle": "Cannot save current map",
                 "error403": "You are not allowed to update the map",
                 "error404": "An error occurred while creating the map",
                 "error409": "A map with this name already exists",
+                "error500": "Internal Server Error. Verify if map configuration file size exceeds fixed limit",
                 "errorDefault": "Network error"
             },
             "permissions": {

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -21,6 +21,8 @@
         "enable": "Activar",
         "layers": "Capas",
         "warning": "Atención",
+        "errorTitleDefault": "Error",
+        "errorDefault": "Ocurrió un error",
         "version": {
             "label": "Versión"
         },
@@ -209,6 +211,8 @@
             "errorFormat": "Formatos soportados: png/jpg",
             "errorSize": "Tamaño máximo admitido: 500kb",
             "error": "La imagen proporcionada es inválida",
+            "savedMapTitle": "Mapa Guardado",
+            "savedMapMessage": "El mapa se ha guardado correctamente",
             "thumbnailError": {
                 "error403": "Error al modificar la viñeta",
                 "error404": "Error al crear la viñeta",
@@ -216,9 +220,11 @@
                 "errorDefault": "Error de red"
             },
             "mapError": {
+                "errorTitle": "No se puede guardar el mapa actual",
                 "error403": "Error al modificar el mapa",
                 "error404": "Error al crear el mapa",
                 "error409": "Nombre del mapa repetido",
+                "error500": "Error de servidor interno. Verificar si el tamaño del archivo de configuración del mapa excede el límite fijado",
                 "errorDefault": "Error de red"
             },
             "permissions": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -22,6 +22,8 @@
         "enable": "Activer",
         "layers": "Couches",
         "warning": "Attention",
+        "errorTitleDefault": "Erreur",
+        "errorDefault": "Une erreur est survenue",
         "version": {
             "label": "Version"
         },
@@ -210,6 +212,8 @@
             "errorFormat": "Formats supportés: png/jpg",
             "errorSize": "taille maximum autorisée: 500kb",
             "error": "L'image fournie est pas valide",
+            "savedMapTitle": "Carte Sauvegardée",
+            "savedMapMessage": "La carte a été enregistrée correctement",
             "thumbnailError": {
                 "error403": "Une erreur est survenue lors de la suppression de la vignette",
                 "error404": "Une erreur est survenue lors de la création de la vignette",
@@ -217,9 +221,11 @@
                 "errorDefault": "Une erreur est survenue sur le serveur"
             },
             "mapError": {
+                "errorTitle": "Impossible d'enregistrer la carte actuelle",
                 "error403": "Une erreur est survenue lors de la suppression de la carte",
                 "error404": "Une erreur est survenue lors de la création de la carte",
                 "error409": "Nom de la carte déjà choisie",
+                "error500": "Erreur Interne du Serveur. Vérifier si la taille du fichier de configuration de la carte dépasse la limite fixée",
                 "errorDefault": "Une erreur est survenue sur le serveur"
             },
             "permissions": {

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -21,6 +21,8 @@
         "enable": "Abilita",
         "layers": "Livelli",
         "warning": "Attenzione",
+        "errorTitleDefault": "Errore",
+        "errorDefault": "Si è verificato un errore",
         "version": {
             "label": "Versione"
         },
@@ -209,6 +211,8 @@
             "errorFormat": "Formati supportati: png/jpg",
             "errorSize": "Dimensione massima consentita: 500kb",
             "error": "L'immagine fornita non è valida",
+            "savedMapTitle": "Mappa Salvata",
+            "savedMapMessage": "La mappa è stata salvata correttamente",
             "thumbnailError": {
                 "error403": "Non disponi dei permessi per aggiornare la thumbnail",
                 "error404": "Non è stato possibile creare la thumbnail sul server",
@@ -216,9 +220,11 @@
                 "errorDefault": "Errore di rete"
             },
             "mapError": {
+                "errorTitle": "Non è stato possibile salvare la mappa",
                 "error403": "Non disponi dei permessi per aggiornare la mappa",
                 "error404": "Non è stato possibile creare la mappa sul server",
                 "error409": "Una mappa con questo nome esiste già",
+                "error500": "Errore interno del server. Verificare se la dimensione della configurazione di mappa supera il limite fissato",
                 "errorDefault": "Errore di rete"
             },
             "permissions": {

--- a/web/client/utils/LocaleUtils.js
+++ b/web/client/utils/LocaleUtils.js
@@ -51,6 +51,27 @@ const DATE_FORMATS = {
     "it-IT": "dd/MM/yyyy",
     "nl-NL": "dd/MM/yyyy"
 };
+
+const errorParser = {
+    geostore: {
+        mapsError: e => {
+            if (e.status === 403 || e.status === 404 || e.status === 409 || e.status === 500) {
+                return {
+                    title: 'map.mapError.errorTitle',
+                    message: 'map.mapError.error' + e.status
+                };
+            }
+            return {
+                title: 'map.mapError.errorTitle',
+                message: 'map.mapError.errorDefault'
+            };
+        }
+    }
+};
+/**
+ * Utilities for locales.
+ * @memberof utils
+ */
 const LocaleUtils = {
     ensureIntl(callback) {
         require.ensure(['intl', 'intl/locale-data/jsonp/en.js', 'intl/locale-data/jsonp/it.js', 'intl/locale-data/jsonp/fr.js', 'intl/locale-data/jsonp/de.js', 'intl/locale-data/jsonp/es.js', 'intl/locale-data/jsonp/nl.js'], (require) => {
@@ -107,6 +128,19 @@ const LocaleUtils = {
             message = message ? message[part] : null;
         });
         return message;
+    },
+    /**
+     * Return localized id of error messages
+     * @param e {object} error
+     * @param service {string} service that thrown the error
+     * @param section {string} section where the error happens
+     * @return {object} {title, message}
+     */
+    getErrorMessage: (e, service, section) => {
+        return service && section && errorParser[service] && errorParser[service][section] && errorParser[service][section](e) || {
+            title: 'errorTitleDefault',
+            message: 'errorDefault'
+        };
     }
 };
 

--- a/web/client/utils/__tests__/LocaleUtils-test.js
+++ b/web/client/utils/__tests__/LocaleUtils-test.js
@@ -34,4 +34,19 @@ describe('LocaleUtils', () => {
     it('getSupportedLocales', () => {
         expect(LocaleUtils.getSupportedLocales()).toExist();
     });
+
+    it('getErrorMessage', () => {
+        expect(LocaleUtils.getErrorMessage({status: 409}, 'geostore', 'mapsError')).toEqual({
+            title: 'map.mapError.errorTitle',
+            message: 'map.mapError.error409'
+        });
+        expect(LocaleUtils.getErrorMessage({status: 0}, 'geostore', 'mapsError')).toEqual({
+            title: 'map.mapError.errorTitle',
+            message: 'map.mapError.errorDefault'
+        });
+        expect(LocaleUtils.getErrorMessage()).toEqual({
+            title: 'errorTitleDefault',
+            message: 'errorDefault'
+        });
+    });
 });


### PR DESCRIPTION
## Description
Added feedback messages on save and save as.

![success save](https://user-images.githubusercontent.com/19175505/34764399-bdb33ca2-f5ee-11e7-947a-dc8e20d31f8e.png)

Recognized errors:  403 - 404 - 409 - 500
![error save](https://user-images.githubusercontent.com/19175505/34764401-bf799144-f5ee-11e7-9852-f9606523ea6f.png)


## Issues
 - Fix #2291

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issue #2291

**What is the new behavior?**
Notifications feedback will be shown after saving

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
