### PR TITLE
Fixes #2248 Leaflet doesn't detect tiles errors

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -314,4 +314,83 @@ describe('LeafletMap', () => {
         attributions = document.body.getElementsByClassName('leaflet-control-attribution');
         expect(attributions.length).toBe(0);
     });
+
+    it('add layer observable', () => {
+
+        let map = ReactDOM.render(
+            <LeafletMap center={{y: 43.9, x: 10.3}} zoom={11}/>,
+            document.getElementById("container"));
+
+        expect(map).toExist();
+        let event = {
+            layer: {
+                layerId: 2,
+                on: () => {},
+                _ms2LoadingTileCount: 1
+            }
+        };
+
+        map.addLayerObservable(event, false);
+        expect(event.layer.layerLoadingStream$).toNotExist();
+        expect(event.layer.layerErrorStream$).toNotExist();
+        expect(event.layer.layerLoadStream$).toNotExist();
+
+    });
+
+    it('add layer observable no tile error', () => {
+
+        const actions = {
+            onLayerError: () => {}
+        };
+
+        const spyLayerError = expect.spyOn(actions, 'onLayerError');
+
+        let map = ReactDOM.render(
+            <LeafletMap center={{y: 43.9, x: 10.3}} zoom={11} onLayerError={actions.onLayerError}/>,
+            document.getElementById("container"));
+
+        expect(map).toExist();
+        let event = {
+            layer: {
+                layerId: 2,
+                on: () => {},
+                _ms2LoadingTileCount: 1
+            }
+        };
+
+        map.addLayerObservable(event, true);
+
+        event.layer.layerLoadingStream$.next();
+        event.layer.layerLoadStream$.next();
+        expect(spyLayerError).toNotHaveBeenCalled();
+    });
+
+    it('add layer observable with tile error', () => {
+
+        const actions = {
+            onLayerError: () => {}
+        };
+
+        const spyLayerError = expect.spyOn(actions, 'onLayerError');
+
+        let map = ReactDOM.render(
+            <LeafletMap center={{y: 43.9, x: 10.3}} zoom={11} onLayerError={actions.onLayerError}/>,
+            document.getElementById("container"));
+
+        expect(map).toExist();
+        let event = {
+            layer: {
+                layerId: 2,
+                on: () => {},
+                _ms2LoadingTileCount: 1
+            }
+        };
+
+        map.addLayerObservable(event, true);
+
+        event.layer.layerLoadingStream$.next();
+        event.layer.layerErrorStream$.next({ target: { layerId: 2 }});
+        event.layer.layerLoadStream$.next();
+        expect(spyLayerError).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Description
Updated observables management on leaflet layers.

After we had Annotation Plugin to MapStore2 the lifecycle of leaflet layers has changed.
Now they add only one time  the `load`, `loading` and `tileerror ` events and the load observables because of the new flag [ms2Added ](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/components/map/leaflet/Map.jsx#L150L165).
When a layer has been removed it triggers the `layerremove` event that it complete the stream of the observable of the layers so if we will add again the layer, the observable are not created again (e.g. toggle visibility of the layer cause this behaviours)

## Issues
 - Fix #2248

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Issue #2248

**What is the new behavior?**
Correct detection of tiles errors on leaflet

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
