### PR TITLE
Fixes #2223 Should be disable CreateNewMap plugin on mobile?

### DIFF
--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -56,7 +56,7 @@ class CreateNewMap extends React.Component {
 module.exports = {
     CreateNewMapPlugin: connect((state) => ({
         mapType: mapTypeSelector(state),
-        isLoggedIn: state && state.security && state.security.user && state.security.user.enabled && true || false,
+        isLoggedIn: state && state.security && state.security.user && state.security.user.enabled && !(state.browser && state.browser.mobile) && true || false,
         user: state && state.security && state.security.user
     }))(CreateNewMap)
 };


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #2223
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
Create new map button is visible on mobile device when logged in as admin or user with write permission, but Catalog, Save and Save plugin aren't available

**What is the new behavior?**
Create new map button is not visible on mobile device when logged in as admin or user with write permission

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
