### PR TITLE
Fixes #2514: ignore feature attribute in default identify json rowviewer

### DIFF
--- a/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
@@ -10,7 +10,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const {isString} = require('lodash');
 
-const alwaysExcluded = ["exclude", "titleStyle", "listStyle", "componentStyle", "title"];
+const alwaysExcluded = ["exclude", "titleStyle", "listStyle", "componentStyle", "title", "feature"];
 
 class PropertiesViewer extends React.Component {
     static displayName = 'PropertiesViewer';

--- a/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
@@ -67,4 +67,14 @@ describe('PropertiesViewer', () => {
         }, true)).toBe(true);
     });
 
+    it('test feature isexcluded', () => {
+        const cmp = ReactDOM.render(<PropertiesViewer feature={"myfeature"} title="testTitle" />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        expect(cmpDom.innerText.indexOf('myfeature')).toBe(-1);
+    });
+
 });


### PR DESCRIPTION
## Description
Ignore feature attribute in default identify json rowviewer

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Internal feature attribute is shown in identify result

**What is the new behavior?**
Internal feature attribute is not shown in identify result

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
