### PR TITLE
Fixes #2524: CSW catalog not recognizing WMS 1.3.0 layers

### DIFF
--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -53,12 +53,12 @@ const converters = {
                     const URI = isArray(dc.URI) ? dc.URI : (dc.URI && [dc.URI] || []);
                     let thumb = head([].filter.call(URI, (uri) => {return uri.name === "thumbnail"; }) );
                     thumbURL = thumb ? thumb.value : null;
-                    wms = head([].filter.call(URI, (uri) => { return uri.protocol === "OGC:WMS-1.1.1-http-get-map"; }));
+                    wms = head([].filter.call(URI, (uri) => { return uri.protocol && uri.protocol.match(/^OGC:WMS-(.*)-http-get-map/g); }));
                 }
                 // look in references objects
                 if (!wms && dc && dc.references && dc.references.length) {
                     let refs = Array.isArray(dc.references) ? dc.references : [dc.references];
-                    wms = head([].filter.call( refs, (ref) => { return ref.scheme === "OGC:WMS-1.1.1-http-get-map" || ref.scheme === "OGC:WMS"; }));
+                    wms = head([].filter.call(refs, (ref) => { return ref.scheme && (ref.scheme.match(/^OGC:WMS-(.*)-http-get-map/g) || ref.scheme === "OGC:WMS"); }));
                     if (wms) {
                         let urlObj = urlUtil.parse(wms.value, true);
                         let layerName = urlObj.query && urlObj.query.layers;

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -178,6 +178,24 @@ describe('Test the CatalogUtils', () => {
         expect(records.length).toBe(1);
     });
 
+    it('csw with DC URI and WMS 1.3.0', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    URI: [{
+                        name: "thumbnail",
+                        value: "http://thumb"
+                    }, {
+                        name: "wms",
+                        protocol: "OGC:WMS-1.3.0-http-get-map",
+                        value: "http://geoserver"
+                    }]
+                }
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+    });
+
     it('csw with DC references', () => {
         const records = CatalogUtils.getCatalogRecords('csw', {
             records: [{


### PR DESCRIPTION
## Description
CSW catalog should recognize WMS 1.3.0 layers

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
CSW catalog not recognizing WMS 1.3.0 layers

**What is the new behavior?**
CSW catalog recognizes WMS 1.3.0 layers


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
