### PR TITLE
Fix #2534 IE11 load problem (RELEASE 2017.06.00)

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -157,7 +157,8 @@ class DefaultLayer extends React.Component {
     filterLayers = (layer) => {
         const translation = isObject(layer.title) ? layer.title[this.props.currentLocale] || layer.title.default : layer.title;
         const title = translation || layer.name;
-        return title.toLowerCase().includes(this.props.filterText.toLowerCase());
+        const testRegex = new RegExp(this.props.filterText.toLowerCase());
+        return testRegex.test(title.toLowerCase());
     }
 }
 

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -157,8 +157,7 @@ class DefaultLayer extends React.Component {
     filterLayers = (layer) => {
         const translation = isObject(layer.title) ? layer.title[this.props.currentLocale] || layer.title.default : layer.title;
         const title = translation || layer.name;
-        const testRegex = new RegExp(this.props.filterText.toLowerCase());
-        return testRegex.test(title.toLowerCase());
+        return title.toLowerCase().indexOf(this.props.filterText.toLowerCase()) !== -1;
     }
 }
 

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -61,8 +61,7 @@ const addFilteredAttributesGroups = (nodes, filters) => {
 const filterLayersByTitle = (layer, filterText, currentLocale) => {
     const translation = isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title;
     const title = translation || layer.name;
-    const testRegex = new RegExp(filterText.toLowerCase());
-    return testRegex.test(title.toLowerCase());
+    return title.toLowerCase().indexOf(filterText.toLowerCase()) !== -1;
 };
 
 const tocSelector = createSelector(

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -61,7 +61,8 @@ const addFilteredAttributesGroups = (nodes, filters) => {
 const filterLayersByTitle = (layer, filterText, currentLocale) => {
     const translation = isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title;
     const title = translation || layer.name;
-    return title.toLowerCase().includes(filterText.toLowerCase());
+    const testRegex = new RegExp(filterText.toLowerCase());
+    return testRegex.test(title.toLowerCase());
 };
 
 const tocSelector = createSelector(


### PR DESCRIPTION
## Description
We used a method not supported for IE11

## Issues
 - Fix #2534

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#2534 

**What is the new behavior?**
maps loads correctly, and toc filters layes name correctly

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
