### PR TITLE
Closes #2391. Virtual Scrolling for FeatureGrid

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -39,7 +39,9 @@ const {
     initPlugin, INIT_PLUGIN,
     sizeChange, SIZE_CHANGE,
     START_SYNC_WMS, startSyncWMS,
-    storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER
+    storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER,
+    fatureGridQueryResult, GRID_QUERY_RESULT,
+    moreFeatures, LOAD_MORE_FEATURES
 } = require('../featuregrid');
 
 const idFeature = "2135";
@@ -257,5 +259,27 @@ describe('Test correctness of featurgrid actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(STORE_ADVANCED_SEARCH_FILTER);
         expect(retval.filterObj).toBe(filterObj);
+    });
+    it('Test storeAdvancedSearchFilter', () => {
+        const filterObj = {name: "A"};
+        const retval = storeAdvancedSearchFilter(filterObj);
+        expect(retval).toExist();
+        expect(retval.type).toBe(STORE_ADVANCED_SEARCH_FILTER);
+        expect(retval.filterObj).toBe(filterObj);
+    });
+    it('Test fatureGridQueryResult', () => {
+        const pages = [];
+        const retval = fatureGridQueryResult(features, pages);
+        expect(retval).toExist();
+        expect(retval.type).toBe(GRID_QUERY_RESULT);
+        expect(retval.features).toBe(features);
+        expect(retval.pages).toBe(pages);
+    });
+    it('Test moreFeatures', () => {
+        const pages = {startPage: 0, endPage: 2};
+        const retval = moreFeatures(pages);
+        expect(retval).toExist();
+        expect(retval.type).toBe(LOAD_MORE_FEATURES);
+        expect(retval.pages).toBe(pages);
     });
 });

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -53,6 +53,15 @@ const MODES = {
 const START_SYNC_WMS = 'FEATUREGRID:START_SYNC_WMS';
 const STOP_SYNC_WMS = 'FEATUREGRID:STOP_SYNC_WMS';
 const STORE_ADVANCED_SEARCH_FILTER = 'STORE_ADVANCED_SEARCH_FILTER';
+const LOAD_MORE_FEATURES = "LOAD_MORE_FEATURES";
+const GRID_QUERY_RESULT = 'FEATUREGRID:QUERY_RESULT';
+
+function fatureGridQueryResult(features, pages) {
+    return {
+        type: GRID_QUERY_RESULT,
+        features, pages
+    };
+}
 
 function storeAdvancedSearchFilter(filterObj) {
     return {
@@ -302,6 +311,12 @@ function sizeChange(size, dockProps) {
         dockProps
     };
 }
+const moreFeatures = (pages) => {
+    return {
+        type: LOAD_MORE_FEATURES,
+        pages
+    };
+};
 module.exports = {
     SELECT_FEATURES,
     DESELECT_FEATURES,
@@ -368,5 +383,7 @@ module.exports = {
     initPlugin, INIT_PLUGIN,
     START_SYNC_WMS, startSyncWMS,
     STOP_SYNC_WMS,
-    storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER
+    storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER,
+    moreFeatures, LOAD_MORE_FEATURES,
+    fatureGridQueryResult, GRID_QUERY_RESULT
 };

--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -27,7 +27,8 @@ class DownloadDialog extends React.Component {
         srsList: PropTypes.array,
         defaultSrs: PropTypes.string,
         layer: PropTypes.object,
-        formatsLoading: PropTypes.bool
+        formatsLoading: PropTypes.bool,
+        virtualScroll: PropTypes.bool
     };
 
     static defaultProps = {
@@ -45,7 +46,8 @@ class DownloadDialog extends React.Component {
         srsList: [
             {name: "native", label: "Native"},
             {name: "EPSG:4326", label: "WGS84"}
-        ]
+        ],
+        virtualScroll: false
     };
 
     componentDidMount() {
@@ -80,7 +82,8 @@ class DownloadDialog extends React.Component {
                     formats={this.props.formats}
                     srsList={this.props.srsList}
                     defaultSrs={this.props.defaultSrs}
-                    layer={this.props.layer}/>
+                    layer={this.props.layer}
+                    virtualScroll={this.props.virtualScroll}/>
                 </div>
             <div role="footer">
                 <Button

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -32,7 +32,8 @@ module.exports = class extends React.Component {
             onChange: PropTypes.func,
             defaultSrs: PropTypes.string,
             layer: PropTypes.object,
-            formatsLoading: PropTypes.bool
+            formatsLoading: PropTypes.bool,
+            virtualScroll: React.PropTypes.bool
     };
 
     static defaultProps = {
@@ -40,7 +41,8 @@ module.exports = class extends React.Component {
         formatsLoading: false,
         wfsFormats: [],
         formats: [],
-        srsList: []
+        srsList: [],
+        virtualScroll: false
     };
 
     getSelectedFormat = () => {
@@ -80,9 +82,9 @@ module.exports = class extends React.Component {
                 value={this.getSelectedSRS()}
                 onChange={(sel) => this.props.onChange("selectedSrs", sel.value)}
                 options={this.props.srsList.map(f => ({value: f.name, label: f.label || f.name}))} />
-            <Checkbox checked={this.props.downloadOptions.singlePage} onChange={() => this.props.onChange("singlePage", !this.props.downloadOptions.singlePage ) }>
+            {this.props.virtualScroll ? null : <Checkbox checked={this.props.downloadOptions.singlePage} onChange={() => this.props.onChange("singlePage", !this.props.downloadOptions.singlePage ) }>
                 <Message msgId="wfsdownload.downloadonlycurrentpage" />
-            </Checkbox>
+            </Checkbox>}
         </form>);
     }
 };

--- a/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
@@ -49,4 +49,10 @@ describe('Test for DownloadOptions component', () => {
         expect(events.onChange).toHaveBeenCalled();
 
     });
+    it('singlePage checkbox not to render in virtualScroll mode', () => {
+        ReactDOM.render(<DownloadOptions virtualScroll downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        const check = document.querySelector('input[type=checkbox]');
+        expect(check).toNotExist();
+
+    });
 });

--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -46,7 +46,9 @@ class FeatureGrid extends React.PureComponent {
         actionOpts: PropTypes.object,
         initPlugin: PropTypes.func,
         tools: PropTypes.array,
-        gridEvents: PropTypes.object
+        gridEvents: PropTypes.object,
+        virtualScroll: PropTypes.bool,
+        maxStoredPages: PropTypes.number
     };
     static childContextTypes = {
         isModified: PropTypes.func,
@@ -64,13 +66,15 @@ class FeatureGrid extends React.PureComponent {
         columnSettings: {},
         features: [],
         tools: [],
-        showDragHandle: false
+        showDragHandle: false,
+        virtualScroll: false,
+        maxStoredPages: 5
     };
     constructor(props) {
         super(props);
     }
     componentDidMount() {
-        this.props.initPlugin({editingAllowedRoles: this.props.editingAllowedRoles});
+        this.props.initPlugin({virtualScroll: this.props.virtualScroll, editingAllowedRoles: this.props.editingAllowedRoles, maxStoredPages: this.props.maxStoredPages});
     }
     getChildContext() {
         return {

--- a/web/client/components/data/featuregrid/Footer.jsx
+++ b/web/client/components/data/featuregrid/Footer.jsx
@@ -2,13 +2,8 @@ const React = require('react');
 const Message = require('../../I18N/Message');
 const {Button, Glyphicon, Grid, Row, Col} = require('react-bootstrap');
 const Spinner = require('react-spinkit');
-const toPage = ({startIndex = 0, maxFeatures = 1, totalFeatures = 0, resultSize} = {}) => ({
-    page: Math.ceil(startIndex / maxFeatures),
-    resultSize,
-    size: maxFeatures,
-    total: totalFeatures,
-    maxPages: Math.ceil(totalFeatures / maxFeatures) - 1
-});
+const {toPage} = require('../../../utils/FeatureGridUtils');
+
 module.exports = (props = {
     loading: false,
     onPageChange: () => {}
@@ -17,9 +12,9 @@ module.exports = (props = {
     return (<Grid className="bg-body data-grid-bottom-toolbar" fluid style={{width: "100%"}}>
         <Row className="featuregrid-toolbar-margin">
             <Col md={3}>
-                <span><Message msgId="featuregrid.resultInfo" msgParams={{start: page * size + 1, end: page * size + resultSize, total}} /></span>
+                <span><Message msgId={props.virtualScroll && "featuregrid.resultInfoVirtual" || "featuregrid.resultInfo"} msgParams={{start: page * size + 1, end: page * size + resultSize, total}} /></span>
             </Col>
-            <Col className="text-center" md={6}>
+            { !props.virtualScroll ? (<Col className="text-center" md={6}>
                 <Button
                     key="first-page"
                     onClick={() => props.onPageChange(0)}
@@ -43,7 +38,7 @@ module.exports = (props = {
                     className="no-border last-page"
                     disabled={page >= maxPages}
                 ><Glyphicon glyph="step-forward"/></Button>
-        </Col><Col md={3}>
+        </Col>) : null} <Col md={3}>
             {props.loading ? <span style={{"float": "right"}} ><Message msgId="loading" /><Spinner spinnerName="circle" style={{"float": "right"}}noFadeIn/></span> : null}
         </Col>
     </Row></Grid>);

--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -32,7 +32,7 @@ describe('Test for FeatureGrid component', () => {
         expect(document.getElementsByClassName('react-grid-Container').length).toBe(1);
     });
     it('render sample features', () => {
-        ReactDOM.render(<FeatureGrid describeFeatureType={describePois} features={museam.features}/>, document.getElementById("container"));
+        ReactDOM.render(<FeatureGrid describeFeatureType={describePois} virtualScroll={false} features={museam.features}/>, document.getElementById("container"));
         expect(document.getElementsByClassName('react-grid-HeaderCell').length).toBe(3);
         expect(document.getElementsByClassName('react-grid-Row').length).toBe(1);
     });
@@ -48,14 +48,14 @@ describe('Test for FeatureGrid component', () => {
             formatter: () => <div className="test-grid-tool" />
         };
         spyOn(tool.events, "onClick");
-        ReactDOM.render(<FeatureGrid describeFeatureType={describePois} features={museam.features} tools={[tool]}/>, document.getElementById("container"));
+        ReactDOM.render(<FeatureGrid virtualScroll={false} describeFeatureType={describePois} features={museam.features} tools={[tool]}/>, document.getElementById("container"));
         expect(document.getElementsByClassName('react-grid-HeaderCell').length).toBe(4);
         expect(document.getElementsByClassName('react-grid-Row').length).toBe(1);
         document.getElementsByClassName('test-grid-tool')[0].click();
         expect(tool.events.onClick).toHaveBeenCalled();
     });
     it('hide columns features', () => {
-        ReactDOM.render(<FeatureGrid describeFeatureType={describePois} features={museam.features} columnSettings={{NAME: {hide: true}}}/>, document.getElementById("container"));
+        ReactDOM.render(<FeatureGrid virtualScroll={false} describeFeatureType={describePois} features={museam.features} columnSettings={{NAME: {hide: true}}}/>, document.getElementById("container"));
         expect(document.getElementsByClassName('react-grid-HeaderCell').length).toBe(2);
     });
     it('sort event', () => {
@@ -63,7 +63,7 @@ describe('Test for FeatureGrid component', () => {
             onSort: () => {}
         };
         spyOn(events, "onSort");
-        ReactDOM.render(<FeatureGrid gridEvents={{onGridSort: events.onSort}} describeFeatureType={describePois} features={museam.features}/>, document.getElementById("container"));
+        ReactDOM.render(<FeatureGrid virtualScroll={false} gridEvents={{onGridSort: events.onSort}} describeFeatureType={describePois} features={museam.features}/>, document.getElementById("container"));
         document.getElementsByClassName('react-grid-HeaderCell-sortable')[0].click();
         expect(events.onSort).toHaveBeenCalled();
     });
@@ -75,7 +75,7 @@ describe('Test for FeatureGrid component', () => {
             onRowsToggled: () => {}
         };
         spyOn(events, "onRowsToggled");
-        ReactDOM.render(<FeatureGrid gridEvents={{onRowsToggled: events.onRowsToggled}} gridOpts= {{rowSelection: {
+        ReactDOM.render(<FeatureGrid virtualScroll={false} gridEvents={{onRowsToggled: events.onRowsToggled}} gridOpts= {{rowSelection: {
             showCheckbox: false,
             selectBy: {
                 keys: {
@@ -97,7 +97,7 @@ describe('Test for FeatureGrid component', () => {
         spyOn(events, "onRowsSelected");
         spyOn(events, "onRowsDeselected");
         spyOn(events, "onRowsToggled");
-        ReactDOM.render(<FeatureGrid
+        ReactDOM.render(<FeatureGrid virtualScroll={false}
             gridEvents={events}
             mode="EDIT"
             describeFeatureType={describePois}
@@ -107,6 +107,7 @@ describe('Test for FeatureGrid component', () => {
         TestUtils.Simulate.click(domNode);
         expect(events.onRowsSelected).toHaveBeenCalled();
         ReactDOM.render(<FeatureGrid
+            virtualScroll={false}
             gridEvents={events}
             mode="EDIT"
             describeFeatureType={describePois}

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -1,12 +1,47 @@
-const {featureTypeToGridColumns, getToolColumns, getRow, getGridEvents, applyAllChanges, createNewAndEditingFilter} = require('../../../../utils/FeatureGridUtils');
+const {featureTypeToGridColumns, getToolColumns, getRow, getRowVirtual, getGridEvents, applyAllChanges, createNewAndEditingFilter} = require('../../../../utils/FeatureGridUtils');
 const EditorRegistry = require('../../../../utils/featuregrid/EditorRegistry');
-const {compose, withPropsOnChange, withHandlers, defaultProps} = require('recompose');
+const {compose, withPropsOnChange, withHandlers, defaultProps, createEventHandler} = require('recompose');
 const {isNil} = require('lodash');
 const {getFilterRenderer} = require('../filterRenderers');
 const {getFormatter} = require('../formatters');
 const {manageFilterRendererState} = require('../enhancers/filterRenderers');
 
+const propsStreamFactory = require('../../../misc/enhancers/propsStreamFactory');
+
 const editors = require('../editors');
+const {getRowIdx} = require('../../../../utils/FeatureGridUtils');
+const loadMoreFeaturesStream = $props => {
+    return $props
+        .distinctUntilChanged(({features: oF, pages: oPages, isFocused: oFocused}, {features: nF, pages: nPages, isFocused: nFocused}) => oF === nF && oFocused === nFocused && oPages === nPages)
+        .switchMap(({size, pageEvents, isFocused, pages, pagination, vsOverScan = 10, scrollDebounce = 200, onGridScroll$}) => {
+            return onGridScroll$
+                .debounceTime(scrollDebounce)
+                .filter(() => !isFocused)
+                .map(({firstRowIdx, lastRowIdx}) => {
+                    const fr = firstRowIdx - vsOverScan < 0 ? 0 : firstRowIdx - vsOverScan;
+                    const lr = lastRowIdx + vsOverScan > pagination.totalFeatures - 1 ? pagination.totalFeatures - 1 : lastRowIdx + vsOverScan;
+                    const startPage = Math.floor(fr / size);
+                    const endPage = Math.floor(lr / size);
+                    let shouldLoad = false;
+                    for (let i = startPage; i <= endPage && !shouldLoad; i++) {
+                        if (getRowIdx(i * size, pages, size) === -1) {
+                            shouldLoad = true;
+                        }
+                    }
+                    return shouldLoad && {startPage, endPage};
+                })
+                .filter((l) => l)
+                .do((p) => pageEvents.moreFeatures(p));
+        });
+};
+
+const dataStreamFactory = $props => {
+    const {handler: onGridScroll, stream: onGridScroll$} = createEventHandler();
+    const $p = $props
+        .filter(({virtualScroll}) => virtualScroll).map(o => ({...o, onGridScroll$ }));
+    return loadMoreFeaturesStream($p).startWith({}).map( o => ({...o, onGridScroll}));
+};
+
 const featuresToGrid = compose(
     defaultProps({
         autocompleteEnabled: false,
@@ -20,7 +55,8 @@ const featuresToGrid = compose(
         select: [],
         changes: {},
         focusOnEdit: true,
-        editors
+        editors,
+        dataStreamFactory
     }),
     withPropsOnChange("showDragHandle", ({showDragHandle = false} = {}) => ({
         className: showDragHandle ? 'feature-grid-drag-handle-show' : 'feature-grid-drag-handle-hide'
@@ -30,7 +66,7 @@ const featuresToGrid = compose(
         props => ({displayFilters: props.enableColumnFilters})
     ),
     withPropsOnChange(
-        ["editingAllowedRoles"],
+        ["editingAllowedRoles", "virtualScroll"],
         props => ({
             editingAllowedRoles: props.editingAllowedRoles,
             initPlugin: props.initPlugin
@@ -68,18 +104,18 @@ const featuresToGrid = compose(
         })
     ),
     withPropsOnChange(
-        ["features", "newFeatures", "changes", "focusOnEdit"],
+        ["features", "newFeatures", "isFocused", "virualScroll"],
         props => ({
-            rowsCount: props.rows && props.rows.length || 0
+            rowsCount: ( props.isFocused || !props.virtualScroll) && props.rows && props.rows.length || (props.pagination && props.pagination.totalFeatures) || 0
         })
     ),
-    withHandlers({rowGetter: props => i => getRow(i, props.rows)}),
+    withHandlers({rowGetter: props => props.virtualScroll && (i => getRowVirtual(i, props.rows, props.pages, props.size)) || (i => getRow(i, props.rows))}),
     withPropsOnChange(
         ["describeFeatureType", "columnSettings", "tools", "actionOpts", "mode", "isFocused"],
         props => ({
             columns: getToolColumns(props.tools, props.rowGetter, props.describeFeatureType, props.actionOpts)
                 .concat(featureTypeToGridColumns(props.describeFeatureType, props.columnSettings, {
-                    editable: props.mode === "EDIT",
+                    editable: props.mode === "EDIT", // TODO REMEMBER TO REMOVE IT'S just to test editing
                     sortable: !props.isFocused
                 }, {
                     getEditor: (desc) => {
@@ -150,7 +186,8 @@ const featuresToGrid = compose(
                 ...gridOpts
             };
         }
-    )
+    ),
+    propsStreamFactory
 );
 module.exports = {
     featuresToGrid

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -13,7 +13,7 @@ const {getRowIdx} = require('../../../../utils/FeatureGridUtils');
 const loadMoreFeaturesStream = $props => {
     return $props
         .distinctUntilChanged(({features: oF, pages: oPages, isFocused: oFocused}, {features: nF, pages: nPages, isFocused: nFocused}) => oF === nF && oFocused === nFocused && oPages === nPages)
-        .switchMap(({size, pageEvents, isFocused, pages, pagination, vsOverScan = 10, scrollDebounce = 200, onGridScroll$}) => {
+        .switchMap(({size, pageEvents, isFocused, pages, pagination, vsOverScan = 20, scrollDebounce = 50, onGridScroll$}) => {
             return onGridScroll$
                 .debounceTime(scrollDebounce)
                 .filter(() => !isFocused)
@@ -56,7 +56,8 @@ const featuresToGrid = compose(
         changes: {},
         focusOnEdit: true,
         editors,
-        dataStreamFactory
+        dataStreamFactory,
+        virtualScroll: true
     }),
     withPropsOnChange("showDragHandle", ({showDragHandle = false} = {}) => ({
         className: showDragHandle ? 'feature-grid-drag-handle-show' : 'feature-grid-drag-handle-hide'
@@ -115,7 +116,7 @@ const featuresToGrid = compose(
         props => ({
             columns: getToolColumns(props.tools, props.rowGetter, props.describeFeatureType, props.actionOpts)
                 .concat(featureTypeToGridColumns(props.describeFeatureType, props.columnSettings, {
-                    editable: props.mode === "EDIT", // TODO REMEMBER TO REMOVE IT'S just to test editing
+                    editable: props.mode === "EDIT",
                     sortable: !props.isFocused
                 }, {
                     getEditor: (desc) => {

--- a/web/client/components/data/featuregrid/featuregrid.css
+++ b/web/client/components/data/featuregrid/featuregrid.css
@@ -6,3 +6,11 @@
 .feature-grid-drag-handle-hide .drag-handle {
     display: none;
 }
+.empty-row .react-grid-Cell {
+    background-color: "gray";
+    opacity: 0.5;
+}
+.empty-row:hover .react-grid-Cell {
+    background-color: "gray";
+    opacity: 0.5;
+}

--- a/web/client/components/data/featuregrid/featuregrid.css
+++ b/web/client/components/data/featuregrid/featuregrid.css
@@ -14,3 +14,6 @@
     background-color: "gray";
     opacity: 0.5;
 }
+.empty-row .react-grid-Cell__value .glyphicon-exclamation-mark{
+    opacity: 0;
+}

--- a/web/client/components/data/featuregrid/featuregrid.css
+++ b/web/client/components/data/featuregrid/featuregrid.css
@@ -14,6 +14,6 @@
     background-color: "gray";
     opacity: 0.5;
 }
-.empty-row .react-grid-Cell__value .glyphicon-exclamation-mark{
+.empty-row .react-grid-Cell__value .glyphicon-exclamation-mark {
     opacity: 0;
 }

--- a/web/client/components/data/featuregrid/renderers/RowRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/RowRenderer.jsx
@@ -5,14 +5,16 @@ const cellRenderer = require('./CellRenderer');
 
 class RowRenderer extends React.Component {
     static propTypes = {
-        columns: PropTypes.array
+        columns: PropTypes.array,
+        row: PropTypes.object
     };
     constructor(props) {
         super(props);
         this.setScrollLeft = (scrollBy) => this.refs.row.setScrollLeft(scrollBy);
     }
     render() {
-        return <Row cellRenderer={cellRenderer} ref="row" {...this.props} />;
+
+        return <Row extraClasses={this.props.row.id === "empty_row" && 'empty-row' || ''} cellRenderer={cellRenderer} ref="row" {...this.props} />;
     }
 
 }

--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -16,6 +16,7 @@ class DataGrid extends Grid {
     constructor(props) {
         super(props);
         this.handleSort = this._handleSort.bind(this);
+        this.getHeaderRows = this._getHeaderRows.bind(this);
     }
     componentDidMount() {
         this.setCanvasListner();
@@ -63,25 +64,10 @@ class DataGrid extends Grid {
             this.canvas.scrollTop = 0;
         }
     }
-    getHeaderRows = () => {
-        const _this4 = this;
-        let rows = [{ ref: function ref(node) {
-            _this4.row = node;
-            return node;
-        }, height: this.props.headerRowHeight || this.props.rowHeight, rowType: 'header' }];
-        if (this.state.canFilter === true) {
-            rows.push({
-                ref: function ref(node) {
-                    _this4.filterRow = node;
-                    return node;
-                },
-                filterable: true,
-                onFilterChange: this._onAddFilter,
-                height: this.props.headerFiltersHeight,
-                rowType: 'filter'
-            });
-        }
-        return rows;
+    _getHeaderRows() {
+        return super.getHeaderRows().map(r =>
+            r.rowType === 'filter' && {...r, onFilterChange: this._onAddFilter} || r
+            );
     }
     _onAddFilter = (filter) => {
         this.props.onAddFilter(filter);

--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -13,6 +13,10 @@ class DataGrid extends Grid {
     static propTypes = {
         displayFilters: PropTypes.bool
     }
+    constructor(props) {
+        super(props);
+        this.handleSort = this._handleSort.bind(this);
+    }
     componentDidMount() {
         this.setCanvasListner();
         if (this.props.displayFilters) {
@@ -51,6 +55,12 @@ class DataGrid extends Grid {
             if (!this.props.isFocused && this.canvas) {
                 this.scroll = this.canvas.scrollTop;
             }
+        }
+    }
+    _handleSort(columnKey, direction) {
+        super.handleSort(columnKey, direction);
+        if (this.canvas) {
+            this.canvas.scrollTop = 0;
         }
     }
     scrollListener = () => {

--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -63,6 +63,32 @@ class DataGrid extends Grid {
             this.canvas.scrollTop = 0;
         }
     }
+    getHeaderRows = () => {
+        const _this4 = this;
+        let rows = [{ ref: function ref(node) {
+            _this4.row = node;
+            return node;
+        }, height: this.props.headerRowHeight || this.props.rowHeight, rowType: 'header' }];
+        if (this.state.canFilter === true) {
+            rows.push({
+                ref: function ref(node) {
+                    _this4.filterRow = node;
+                    return node;
+                },
+                filterable: true,
+                onFilterChange: this._onAddFilter,
+                height: this.props.headerFiltersHeight,
+                rowType: 'filter'
+            });
+        }
+        return rows;
+    }
+    _onAddFilter = (filter) => {
+        this.props.onAddFilter(filter);
+        if (this.canvas) {
+            this.canvas.scrollTop = 0;
+        }
+    }
     scrollListener = () => {
         if (!this.props.isFocused) {
             this.scroll = this.canvas.scrollTop;

--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -7,24 +7,65 @@
  */
 const PropTypes = require('prop-types');
 const Grid = require('react-data-grid');
+const ReactDOM = require('react-dom');
 
 class DataGrid extends Grid {
     static propTypes = {
         displayFilters: PropTypes.bool
     }
     componentDidMount() {
+        this.setCanvasListner();
         if (this.props.displayFilters) {
             this.onToggleFilter();
         }
     }
     componentWillUnmount() {
+        if (this.canvas) {
+            this.canvas.removeEventListener('scroll', this.scrollListener);
+        }
         if (this.props.displayFilters) {
             this.onToggleFilter();
         }
     }
     componentDidUpdate(oldProps) {
-        if (oldProps.displayFilters !== this.props.displayFilters) {
+        const {virtualScroll, displayFilters} = this.props;
+        if (oldProps.displayFilters !== displayFilters) {
             this.onToggleFilter();
+        }
+        if (virtualScroll) {
+            // Check if canvas is always valid
+            if (this.canvas && this.canvas !== ReactDOM.findDOMNode(this).querySelector('.react-grid-Canvas')) {
+                this.canvas.removeEventListener('scroll', this.scrollListener);
+                this.setCanvasListner();
+            }
+            // Check if canvas exist
+            if (!this.canvas) {
+                this.setCanvasListner();
+            }
+            // When exiting feature editing we reset preious scroll
+            if (oldProps.isFocused && !this.props.isFocused ) {
+                this.canvas.scrollTop = this.scroll;
+            }else if (this.canvas && this.props.minHeight !== oldProps.minHeight) {
+                this.scrollListener(); // Emit scroll on  grid resize
+            }
+            if (!this.props.isFocused && this.canvas) {
+                this.scroll = this.canvas.scrollTop;
+            }
+        }
+    }
+    scrollListener = () => {
+        if (!this.props.isFocused) {
+            this.scroll = this.canvas.scrollTop;
+        }
+        const visibleRows = Math.ceil(this.canvas.clientHeight / this.props.rowHeight);
+        const firstRowIdx = Math.floor(this.canvas.scrollTop / this.props.rowHeight);
+        const lastRowIdx = firstRowIdx + visibleRows;
+        this.props.onGridScroll({firstRowIdx, lastRowIdx});
+    }
+    setCanvasListner = () => {
+        this.canvas = ReactDOM.findDOMNode(this).querySelector('.react-grid-Canvas');
+        if (this.canvas) {
+            this.canvas.addEventListener('scroll', this.scrollListener);
         }
     }
 }

--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -66,14 +66,16 @@ class DataGrid extends Grid {
     }
     _getHeaderRows() {
         return super.getHeaderRows().map(r =>
-            r.rowType === 'filter' && {...r, onFilterChange: this._onAddFilter} || r
+            r.rowType === 'filter' && {...r,
+                onFilterChange: (f) => {
+                    if (r.onFilterChange) {
+                        r.onFilterChange(f);
+                    }
+                    if (this.canvas) {
+                        this.canvas.scrollTop = 0;
+                    }
+                }} || r
             );
-    }
-    _onAddFilter = (filter) => {
-        this.props.onAddFilter(filter);
-        if (this.canvas) {
-            this.canvas.scrollTop = 0;
-        }
     }
     scrollListener = () => {
         if (!this.props.isFocused) {

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -25,7 +25,7 @@ const {geometryChanged} = require('../../actions/draw');
 const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery');
 
 
-const {setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrolLoadFeatures} = require('../featuregrid');
+const {setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrollLoadFeatures} = require('../featuregrid');
 
 
 const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -27,6 +27,7 @@ const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery')
 
 const {setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrolLoadFeatures} = require('../featuregrid');
 
+
 const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
 const {isEmpty, isNil} = require('lodash');
 const filterObj = {
@@ -1456,7 +1457,7 @@ describe('featuregrid Epics', () => {
             done();
         }, newState);
     });
-    it('test virtualScrolLoadFeatures to dispatch query action', (done) => {
+    it('test virtualScrollLoadFeatures to dispatch query action', (done) => {
         const stateFeaturegrid = {
             featuregrid: {
                 open: true,
@@ -1473,7 +1474,7 @@ describe('featuregrid Epics', () => {
         };
 
         const newState = assign({}, state, stateFeaturegrid);
-        testEpic(virtualScrolLoadFeatures, 1, [moreFeatures({startPage: 0, endPage: 2})], actions => {
+        testEpic(virtualScrollLoadFeatures, 1, [moreFeatures({startPage: 0, endPage: 2})], actions => {
 
             expect(actions.length).toBe(1);
             actions.map((action) => {
@@ -1489,7 +1490,7 @@ describe('featuregrid Epics', () => {
             done();
         }, newState);
     });
-    it('test virtualScrolLoadFeatures to emit GRID_QUERY_RESULT on query success', (done) => {
+    it('test virtualScrollLoadFeatures to emit GRID_QUERY_RESULT on query success', (done) => {
         const stateFeaturegrid = {
             featuregrid: {
                 open: true,
@@ -1506,7 +1507,7 @@ describe('featuregrid Epics', () => {
             }
         };
         const newState = assign({}, state, stateFeaturegrid);
-        testEpic(virtualScrolLoadFeatures, 2, [moreFeatures({startPage: 0, endPage: 2}), querySearchResponse({features: Array(30)}, " ", {pagination: {startIndex: 0, maxFeatures: 30}})], actions => {
+        testEpic(virtualScrollLoadFeatures, 2, [moreFeatures({startPage: 0, endPage: 2}), querySearchResponse({features: Array(30)}, " ", {pagination: {startIndex: 0, maxFeatures: 30}})], actions => {
             expect(actions.length).toBe(2);
             actions.map((action) => {
                 switch (action.type) {

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -11,20 +11,21 @@ const assign = require('object-assign');
 const Proj4js = require('proj4').default;
 const proj4 = Proj4js;
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
-const {toggleEditMode, toggleViewMode, openFeatureGrid, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch} = require('../../actions/featuregrid');
+const {toggleEditMode, toggleViewMode, openFeatureGrid, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch, moreFeatures, GRID_QUERY_RESULT} = require('../../actions/featuregrid');
 const {SET_HIGHLIGHT_FEATURES_PATH} = require('../../actions/highlight');
 const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 const {RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl} = require('../../actions/controls');
 const {ZOOM_TO_EXTENT} = require('../../actions/map');
 const {PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
-const {toggleSyncWms} = require('../../actions/wfsquery');
+const {toggleSyncWms, QUERY, querySearchResponse} = require('../../actions/wfsquery');
 const {CHANGE_LAYER_PROPERTIES} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
 
 const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery');
 
-const {setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch} = require('../featuregrid');
+
+const {setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrolLoadFeatures} = require('../featuregrid');
 
 const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
 const {isEmpty, isNil} = require('lodash');
@@ -92,58 +93,7 @@ const filterObj = {
     sortOptions: null,
     hits: false
   };
-const state = {
-    query: {
-        featureTypes: {
-            'editing:polygons': {
-                geometry: [{
-                    label: 'geometry',
-                    attribute: 'geometry',
-                    type: 'geometry',
-                    valueId: 'id',
-                    valueLabel: 'name',
-                    values: []
-                }],
-                original: {
-                    elementFormDefault: 'qualified',
-                    targetNamespace: 'http://geoserver.org/editing',
-                    targetPrefix: 'editing',
-                    featureTypes: [{
-                        typeName: 'polygons',
-                        properties: [{
-                                name: 'name',
-                                maxOccurs: 1,
-                                minOccurs: 0,
-                                nillable: true,
-                                type: 'xsd:string',
-                                localType: 'string'
-                            },
-                            {
-                                name: 'geometry',
-                                maxOccurs: 1,
-                                minOccurs: 0,
-                                nillable: true,
-                                type: 'gml:Polygon',
-                                localType: 'Polygon'
-                            }
-                        ]
-                    }]
-                },
-                attributes: [{
-                    label: 'name',
-                    attribute: 'name',
-                    type: 'string',
-                    valueId: 'id',
-                    valueLabel: 'name',
-                    values: []
-                }]
-            }
-        },
-        data: {},
-        result: {
-            type: 'FeatureCollection',
-            totalFeatures: 4,
-            features: [{
+const features = [{
                     type: 'Feature',
                     id: 'polygons.1',
                     geometry: {
@@ -254,7 +204,172 @@ const state = {
                         name: 'vvvv'
                     }
                 }
-            ],
+            ];
+const gmlFeatures = [{
+        type: 'Feature',
+        id: 'polygons.1',
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [-39,
+                        39
+                    ],
+                    [-39,
+                        38
+                    ],
+                    [-40,
+                        38
+                    ],
+                    [-39,
+                        39
+                    ]
+                ]
+            ]
+        },
+        geometry_name: 'geometry',
+        properties: {
+            name: 'test'
+        }
+    },
+    {
+        type: 'Feature',
+        id: 'polygons.2',
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [-48.77929687,
+                        37.54457732
+                    ],
+                    [-49.43847656,
+                        36.06686213
+                    ],
+                    [-46.31835937,
+                        35.53222623
+                    ],
+                    [-44.47265625,
+                        37.40507375
+                    ],
+                    [-48.77929687,
+                        37.54457732
+                    ]
+                ]
+            ]
+        },
+        geometry_name: 'geometry',
+        properties: {
+            name: 'poly2'
+        }
+    },
+    {
+        type: 'Feature',
+        id: 'polygons.6',
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [-50.16357422,
+                        28.90239723
+                    ],
+                    [-49.69116211,
+                        28.24632797
+                    ],
+                    [-48.2409668,
+                        28.56522549
+                    ],
+                    [-50.16357422,
+                        28.90239723
+                    ]
+                ]
+            ]
+        },
+        geometry_name: 'geometry',
+        properties: {
+            name: 'ads'
+        }
+    },
+    {
+        type: 'Feature',
+        id: 'polygons.7',
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [-64.46777344,
+                        33.90689555
+                    ],
+                    [-66.22558594,
+                        31.95216224
+                    ],
+                    [-63.32519531,
+                        30.97760909
+                    ],
+                    [-64.46777344,
+                        33.90689555
+                    ]
+                ]
+            ]
+        },
+        geometry_name: 'geometry',
+        properties: {
+            name: 'vvvv'
+        }
+    }
+];
+
+const state = {
+    query: {
+        featureTypes: {
+            'editing:polygons': {
+                geometry: [{
+                    label: 'geometry',
+                    attribute: 'geometry',
+                    type: 'geometry',
+                    valueId: 'id',
+                    valueLabel: 'name',
+                    values: []
+                }],
+                original: {
+                    elementFormDefault: 'qualified',
+                    targetNamespace: 'http://geoserver.org/editing',
+                    targetPrefix: 'editing',
+                    featureTypes: [{
+                        typeName: 'polygons',
+                        properties: [{
+                                name: 'name',
+                                maxOccurs: 1,
+                                minOccurs: 0,
+                                nillable: true,
+                                type: 'xsd:string',
+                                localType: 'string'
+                            },
+                            {
+                                name: 'geometry',
+                                maxOccurs: 1,
+                                minOccurs: 0,
+                                nillable: true,
+                                type: 'gml:Polygon',
+                                localType: 'Polygon'
+                            }
+                        ]
+                    }]
+                },
+                attributes: [{
+                    label: 'name',
+                    attribute: 'name',
+                    type: 'string',
+                    valueId: 'id',
+                    valueLabel: 'name',
+                    values: []
+                }]
+            }
+        },
+        data: {},
+        result: {
+            type: 'FeatureCollection',
+            totalFeatures: 4,
+            features,
             crs: {
                 type: 'name',
                 properties: {
@@ -351,118 +466,7 @@ const stateWithGmlGeometry = {
         result: {
             type: 'FeatureCollection',
             totalFeatures: 4,
-            features: [{
-                    type: 'Feature',
-                    id: 'polygons.1',
-                    geometry: {
-                        type: 'Polygon',
-                        coordinates: [
-                            [
-                                [-39,
-                                    39
-                                ],
-                                [-39,
-                                    38
-                                ],
-                                [-40,
-                                    38
-                                ],
-                                [-39,
-                                    39
-                                ]
-                            ]
-                        ]
-                    },
-                    geometry_name: 'geometry',
-                    properties: {
-                        name: 'test'
-                    }
-                },
-                {
-                    type: 'Feature',
-                    id: 'polygons.2',
-                    geometry: {
-                        type: 'Polygon',
-                        coordinates: [
-                            [
-                                [-48.77929687,
-                                    37.54457732
-                                ],
-                                [-49.43847656,
-                                    36.06686213
-                                ],
-                                [-46.31835937,
-                                    35.53222623
-                                ],
-                                [-44.47265625,
-                                    37.40507375
-                                ],
-                                [-48.77929687,
-                                    37.54457732
-                                ]
-                            ]
-                        ]
-                    },
-                    geometry_name: 'geometry',
-                    properties: {
-                        name: 'poly2'
-                    }
-                },
-                {
-                    type: 'Feature',
-                    id: 'polygons.6',
-                    geometry: {
-                        type: 'Polygon',
-                        coordinates: [
-                            [
-                                [-50.16357422,
-                                    28.90239723
-                                ],
-                                [-49.69116211,
-                                    28.24632797
-                                ],
-                                [-48.2409668,
-                                    28.56522549
-                                ],
-                                [-50.16357422,
-                                    28.90239723
-                                ]
-                            ]
-                        ]
-                    },
-                    geometry_name: 'geometry',
-                    properties: {
-                        name: 'ads'
-                    }
-                },
-                {
-                    type: 'Feature',
-                    id: 'polygons.7',
-                    geometry: {
-                        type: 'Polygon',
-                        coordinates: [
-                            [
-                                [-64.46777344,
-                                    33.90689555
-                                ],
-                                [-66.22558594,
-                                    31.95216224
-                                ],
-                                [-63.32519531,
-                                    30.97760909
-                                ],
-                                [-64.46777344,
-                                    33.90689555
-                                ]
-                            ]
-                        ]
-                    },
-                    geometry_name: 'geometry',
-                    properties: {
-                        name: 'vvvv'
-                    }
-                }
-            ],
+            gmlFeatures,
             crs: {
                 type: 'name',
                 properties: {
@@ -642,7 +646,8 @@ describe('featuregrid Epics', () => {
                 selectedLayer: "TEST_LAYER",
                 mode: 'EDIT',
                 select: [],
-                changes: []
+                changes: [],
+                features
             }
         };
 
@@ -949,7 +954,7 @@ describe('featuregrid Epics', () => {
                 }
             });
             done();
-        }, state);
+        }, {...state, featuregrid: {features}});
     });
 
     it('test resetControlsOnEnterInEditMode', (done) => {
@@ -1443,6 +1448,78 @@ describe('featuregrid Epics', () => {
                 switch (action.type) {
                     case CHANGE_DRAWING_STATUS:
                         expect(action.status).toBe('clean');
+                        break;
+                    default:
+                        expect(true).toBe(true);
+                }
+            });
+            done();
+        }, newState);
+    });
+    it('test virtualScrolLoadFeatures to dispatch query action', (done) => {
+        const stateFeaturegrid = {
+            featuregrid: {
+                open: true,
+                selectedLayer: "TEST__6",
+                mode: 'EDIT',
+                select: [{id: 'polygons.1', _new: 'polygons._new'}],
+                changes: [],
+                pages: [],
+                pagination: {
+                    size: 10
+                },
+                features: []
+            }
+        };
+
+        const newState = assign({}, state, stateFeaturegrid);
+        testEpic(virtualScrolLoadFeatures, 1, [moreFeatures({startPage: 0, endPage: 2})], actions => {
+
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case QUERY:
+                        expect(action.filterObj.pagination.startIndex).toBe(0);
+                        expect(action.filterObj.pagination.maxFeatures).toBe(30);
+                        break;
+                    default:
+                        expect(true).toBe(true);
+                }
+            });
+            done();
+        }, newState);
+    });
+    it('test virtualScrolLoadFeatures to emit GRID_QUERY_RESULT on query success', (done) => {
+        const stateFeaturegrid = {
+            featuregrid: {
+                open: true,
+                selectedLayer: "TEST__6",
+                mode: 'EDIT',
+                select: [{id: 'polygons.1', _new: 'polygons._new'}],
+                changes: [],
+                pages: [],
+                pagination: {
+                    size: 10
+
+                },
+                features: []
+            }
+        };
+        const newState = assign({}, state, stateFeaturegrid);
+        testEpic(virtualScrolLoadFeatures, 2, [moreFeatures({startPage: 0, endPage: 2}), querySearchResponse({features: Array(30)}, " ", {pagination: {startIndex: 0, maxFeatures: 30}})], actions => {
+            expect(actions.length).toBe(2);
+            actions.map((action) => {
+                switch (action.type) {
+                    case QUERY:
+                        expect(action.filterObj.pagination.startIndex).toBe(0);
+                        expect(action.filterObj.pagination.maxFeatures).toBe(30);
+                        break;
+                    case GRID_QUERY_RESULT:
+                        expect(action.features.length).toBe(30);
+                        expect(action.pages.length).toBe(3);
+                        expect(action.pages[0]).toBe(0);
+                        expect(action.pages[1]).toBe(10);
+                        expect(action.pages[2]).toBe(20);
                         break;
                     default:
                         expect(true).toBe(true);

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -6,14 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 const Rx = require('rxjs');
-const {get, head, isEmpty, find} = require('lodash');
+const {get, head, isEmpty, find, fill} = require('lodash');
 const { LOCATION_CHANGE } = require('react-router-redux');
 const Proj4js = require('proj4').default;
 const proj4 = Proj4js;
 const axios = require('../libs/ajax');
 const bbox = require('@turf/bbox');
 const {fidFilter} = require('../utils/ogc/Filter/filter');
-const {getDefaultFeatureProjection} = require('../utils/FeatureGridUtils');
+const {getDefaultFeatureProjection, getPagesToLoad} = require('../utils/FeatureGridUtils');
 const CoordinatesUtils = require('../utils/CoordinatesUtils');
 const LayersUtils = require('../utils/LayersUtils');
 const {isSimpleGeomType} = require('../utils/MapUtils');
@@ -22,7 +22,7 @@ const {changeDrawingStatus, GEOMETRY_CHANGED, drawSupportReset} = require('../ac
 const requestBuilder = require('../utils/ogc/WFST/RequestBuilder');
 const {findGeometryProperty} = require('../utils/ogc/WFS/base');
 const {setControlProperty} = require('../actions/controls');
-const {query, QUERY_CREATE, QUERY_RESULT, LAYER_SELECTED_FOR_SEARCH, FEATURE_TYPE_LOADED, UPDATE_QUERY, featureTypeSelected, createQuery, updateQuery, TOGGLE_SYNC_WMS} = require('../actions/wfsquery');
+const {query, QUERY_CREATE, QUERY_RESULT, LAYER_SELECTED_FOR_SEARCH, FEATURE_TYPE_LOADED, UPDATE_QUERY, featureTypeSelected, createQuery, updateQuery, TOGGLE_SYNC_WMS, QUERY_ERROR, FEATURE_LOADING} = require('../actions/wfsquery');
 const {reset, QUERY_FORM_SEARCH, loadFilter} = require('../actions/queryform');
 const {zoomToExtent} = require('../actions/map');
 
@@ -36,7 +36,7 @@ const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURE
     SELECT_FEATURES, DESELECT_FEATURES, START_DRAWING_FEATURE, CREATE_NEW_FEATURE,
     CLEAR_CHANGES_CONFIRMED, FEATURE_GRID_CLOSE_CONFIRMED,
     openFeatureGrid, closeFeatureGrid, OPEN_FEATURE_GRID, CLOSE_FEATURE_GRID, CLOSE_FEATURE_GRID_CONFIRM, OPEN_ADVANCED_SEARCH, ZOOM_ALL, UPDATE_FILTER, START_SYNC_WMS,
-    STOP_SYNC_WMS, startSyncWMS, storeAdvancedSearchFilter} = require('../actions/featuregrid');
+    STOP_SYNC_WMS, startSyncWMS, storeAdvancedSearchFilter, fatureGridQueryResult, LOAD_MORE_FEATURES} = require('../actions/featuregrid');
 
 const {TOGGLE_CONTROL, resetControls} = require('../actions/controls');
 const {setHighlightFeaturesPath} = require('../actions/highlight');
@@ -47,13 +47,13 @@ const {selectedFeaturesSelector, changesMapSelector, newFeaturesSelector, hasCha
 const {queryPanelSelector} = require('../selectors/controls');
 
 const {error, warning} = require('../actions/notifications');
-const {describeSelector, isDescribeLoaded, getFeatureById, wfsURL, wfsFilter, featureCollectionResultSelector, isSyncWmsActive} = require('../selectors/query');
+const {describeSelector, isDescribeLoaded, getFeatureById, wfsURL, wfsFilter, featureCollectionResultSelector, isSyncWmsActive, featureLoadingSelector} = require('../selectors/query');
 
 const {getLayerFromId} = require('../selectors/layers');
 
 const {interceptOGCError} = require('../utils/ObservableUtils');
 
-const {gridUpdateToQueryUpdate} = require('../utils/FeatureGridUtils');
+const {gridUpdateToQueryUpdate, getIdxFarhestEl, removePageFeatures, removePage} = require('../utils/FeatureGridUtils');
 
 const {queryFormUiStateSelector} = require('../selectors/queryform');
 /**
@@ -103,7 +103,7 @@ const setupDrawSupport = (state, original) => {
             ftId: feature.id
         };
         if (selectedFeaturesCount(state) === 1) {
-            if (feature.geometry === null) {
+            if (feature.geometry === null || feature.id === 'empty_row') {
                 return Rx.Observable.from([
                     drawSupportReset()
                 ]);
@@ -236,10 +236,13 @@ module.exports = {
             .concat(modeSelector(store.getState()) === MODES.VIEW ? Rx.Observable.of(toggleViewMode()) : Rx.Observable.empty())),
     /**
      * Create sorted queries on sort action
+     * With virtualSroll active reset to page 0 but the grid will reload
+     * to the current index
      * @memberof epics.featuregrid
      */
     featureGridSort: (action$, store) =>
-        action$.ofType(SORT_BY).switchMap( ({sortBy, sortOrder}) =>
+        action$.ofType(SORT_BY)
+        .switchMap( ({sortBy, sortOrder}) =>
             Rx.Observable.of( query(
                     wfsURL(store.getState()),
                     addPagination({
@@ -249,6 +252,11 @@ module.exports = {
                         getPagination(store.getState())
                     )
             ))
+            .merge(action$.ofType(QUERY_RESULT)
+                    .map((ra) => fatureGridQueryResult(get(ra, "result.features", []), [get(ra, "filterObj.pagination.startIndex")]))
+                    .takeUntil(action$.ofType(QUERY_ERROR))
+                    .take(1)
+                    )
         ),
     /**
      * Performs the query when the text filter is updated
@@ -266,7 +274,13 @@ module.exports = {
     featureGridChangePage: (action$, store) =>
         action$.ofType(CHANGE_PAGE)
             .merge(action$.ofType(UPDATE_QUERY).debounceTime(500).map(action => ({...action, page: 0})))
-            .switchMap(createLoadPageFlow(store)),
+            .switchMap((a) => createLoadPageFlow(store)(a)
+                .merge(action$.ofType(QUERY_RESULT)
+                    .map((ra) => fatureGridQueryResult(get(ra, "result.features", []), [get(ra, "filterObj.pagination.startIndex")]))
+                    .take(1)
+                    .takeUntil(action$.ofType(QUERY_ERROR))
+                )
+            ),
     /**
      * Reload the page on save success.
      * NOTE: The page is in the action.
@@ -281,13 +295,17 @@ module.exports = {
                     addPagination({
                             ...wfsFilter(store.getState())
                         },
-                        getPagination(store.getState(), {page, size})
+                        getPagination(store.getState(), {page: page, size})
                     )
                 ),
                 refreshLayerVersion(selectedLayerIdSelector(store.getState()))
-
-            ).merge(
-                action$.ofType(QUERY_RESULT).map(() => clearChanges())
+            )
+            .merge(action$.ofType(QUERY_RESULT)
+                .map((ra) => Rx.Observable.of(clearChanges(), fatureGridQueryResult(get(ra, "result.features", []), [get(ra, "filterObj.pagination.startIndex")]))
+                    )
+                .mergeAll()
+                .takeUntil(action$.ofType(QUERY_ERROR))
+                .take(2)
             )
         ),
     /**
@@ -554,8 +572,9 @@ module.exports = {
             );
         }),
     onFeatureGridZoomAll: (action$, store) =>
-        action$.ofType(ZOOM_ALL).switchMap(() =>
+        action$.ofType(ZOOM_ALL).filter(() => !get(store.getState(), "featuregird.virtualScroll", false)).switchMap(() =>
             Rx.Observable.of(zoomToExtent(bbox(featureCollectionResultSelector(store.getState())), "EPSG:4326"))
+
     ),
     /**
      * reset controls on edit mode switch
@@ -653,5 +672,63 @@ module.exports = {
                         }
                         return Rx.Observable.of(addFilterToWMSLayer(layerId, filter));
                     });
-            })
+            }),
+    virtualScrolLoadFeatures: (action$, {getState}) =>
+        action$.ofType(LOAD_MORE_FEATURES)
+        .filter(() => !featureLoadingSelector(getState()))
+        .switchMap( ac => {
+            const state = getState();
+            const {startPage, endPage} = ac.pages;
+            const {pages, pagination} = state.featuregrid;
+            const size = get(pagination, "size");
+            const nPs = getPagesToLoad(startPage, endPage, pages, size);
+            const needPages = (nPs[1] - nPs[0] + 1 );
+            return Rx.Observable.of( query(wfsURL(state),
+                    addPagination({
+                                ...(wfsFilter(state))
+                                },
+                                {startIndex: nPs[0] * size, maxFeatures: needPages * size }
+                            )
+                    )).filter(() => nPs.length > 0)
+                .merge( action$.ofType(QUERY_RESULT)
+                    .filter(() => nPs.length > 0)
+                    .map((ra) => {
+                        let {features = [], maxStoredPages} = (getState()).featuregrid;
+                        let fts = get(ra, "result.features", []);
+                        if (fts.length !== needPages * size) {
+                            fts = fts.concat(fill(Array(needPages * size - fts.length), false));
+                        }
+                        const startIdx = get(ra, "filterObj.pagination.startIndex");
+                        let oldPages = pages;
+                        // Cached page should be less than the max of maxStoredPages or the number of page needed to fill the visible are of the grid
+                        const nSpaces = oldPages.length + needPages - Math.max(maxStoredPages, (endPage - startPage + 1));
+                        if ( nSpaces > 0) {
+                            const firstRow = startPage * size;
+                            const lastRow = endPage * size;
+                            // Remove the farhest page from last loaded pages
+                            const averageIdx = firstRow + (lastRow - firstRow) / 2;
+                            for (let i = 0; i < nSpaces; i++) {
+                                const idxFarhestEl = getIdxFarhestEl(averageIdx, pages, firstRow, lastRow);
+                                const idxToRemove = idxFarhestEl * size;
+                                oldPages = removePage(idxFarhestEl, oldPages);
+                                features = removePageFeatures(features, idxToRemove, size);
+                            }
+                        }
+                        let pagesLoaded = [];
+                        for (let i = 0; i < needPages; i++) {
+                            pagesLoaded.push(startIdx + (size * i));
+                        }
+                        const newPages = oldPages.concat(pagesLoaded);
+                        const newFts = features.concat(fts);
+                        return fatureGridQueryResult( newFts, newPages);
+                    }).take(1).takeUntil(action$.ofType(QUERY_ERROR))
+                ).merge(action$.ofType(FEATURE_LOADING).filter(() => nPs.length > 0)
+                // When loading we store the load more features request, on loading end we emit the last
+                    .filter(a => !a.isLoading)
+                    .withLatestFrom(action$.ofType(LOAD_MORE_FEATURES))
+                    .map((p) => p[1])
+                    .take(1)
+                    .takeUntil(action$.ofType(QUERY_ERROR))
+                );
+        })
 };

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -673,7 +673,7 @@ module.exports = {
                         return Rx.Observable.of(addFilterToWMSLayer(layerId, filter));
                     });
             }),
-    virtualScrolLoadFeatures: (action$, {getState}) =>
+    virtualScrollLoadFeatures: (action$, {getState}) =>
         action$.ofType(LOAD_MORE_FEATURES)
         .filter(() => !featureLoadingSelector(getState()))
         .switchMap( ac => {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -53,7 +53,7 @@ const {getLayerFromId} = require('../selectors/layers');
 
 const {interceptOGCError} = require('../utils/ObservableUtils');
 
-const {gridUpdateToQueryUpdate, getIdxFarhestEl, removePageFeatures, removePage} = require('../utils/FeatureGridUtils');
+const {gridUpdateToQueryUpdate, getIdxFarthestEl, removePageFeatures, removePage} = require('../utils/FeatureGridUtils');
 
 const {queryFormUiStateSelector} = require('../selectors/queryform');
 /**
@@ -705,12 +705,12 @@ module.exports = {
                         if ( nSpaces > 0) {
                             const firstRow = startPage * size;
                             const lastRow = endPage * size;
-                            // Remove the farhest page from last loaded pages
+                            // Remove the farthest page from last loaded pages
                             const averageIdx = firstRow + (lastRow - firstRow) / 2;
                             for (let i = 0; i < nSpaces; i++) {
-                                const idxFarhestEl = getIdxFarhestEl(averageIdx, pages, firstRow, lastRow);
-                                const idxToRemove = idxFarhestEl * size;
-                                oldPages = removePage(idxFarhestEl, oldPages);
+                                const idxFarthestEl = getIdxFarthestEl(averageIdx, pages, firstRow, lastRow);
+                                const idxToRemove = idxFarthestEl * size;
+                                oldPages = removePage(idxFarthestEl, oldPages);
                                 features = removePageFeatures(features, idxToRemove, size);
                             }
                         }

--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -88,13 +88,14 @@ module.exports = {
                 });
             }),
     startFeatureExportDownload: (action$, store) =>
-        action$.ofType(DOWNLOAD_FEATURES).switchMap(action =>
-            getWFSFeature({
+        action$.ofType(DOWNLOAD_FEATURES).switchMap(action => {
+            const {virtualScroll= false} = (store.getState()).featuregrid;
+            return getWFSFeature({
                     url: action.url,
                     downloadOptions: action.downloadOptions,
                     filterObj: {
                         ...action.filterObj,
-                        pagination: get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null
+                        pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null
                     }
                 })
                 .do(({data, headers}) => {
@@ -111,7 +112,7 @@ module.exports = {
                             downloadOptions: action.downloadOptions,
                             filterObj: {
                                 ...action.filterObj,
-                                pagination: get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
+                                pagination: !virtualScroll && get(action, "downloadOptions.singlePage") ? action.filterObj && action.filterObj.pagination : null,
                                 sortOptions: getDefaultSortOptions(getFirstAttribute(store.getState()))
                             }
                         }).do(({data, headers}) => {
@@ -135,9 +136,8 @@ module.exports = {
                         position: "tr"
                     }),
                     onDownloadFinished())
-                )
-
-        ),
+                );
+        }),
     closeExportDownload: (action$, store) =>
         action$.ofType(TOGGLE_CONTROL)
         .filter((a) => a.control === "queryPanel" && !store.getState().controls.queryPanel.enabled && store.getState().controls.wfsdownload.enabled)

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -7,12 +7,12 @@
  */
 const React = require('react');
 const {connect} = require('react-redux');
-const {createSelector} = require('reselect');
+const {createSelector, createStructuredSelector} = require('reselect');
 const {bindActionCreators} = require('redux');
 const {get} = require('lodash');
 
 const Grid = require('../components/data/featuregrid/FeatureGrid');
-const {resultsSelector, describeSelector, wfsURLSelector, typeNameSelector} = require('../selectors/query');
+const {paginationInfo, describeSelector, wfsURLSelector, typeNameSelector} = require('../selectors/query');
 const {modeSelector, changesSelector, newFeaturesSelector, hasChangesSelector, selectedFeaturesSelector, getDockSize} = require('../selectors/featuregrid');
 const { toChangesMap} = require('../utils/FeatureGridUtils');
 const {getPanels, getHeader, getFooter, getDialogs, getEmptyRowsView, getFilterRenderers} = require('./featuregrid/panels/index');
@@ -149,10 +149,19 @@ const FeatureDock = (props = {
                 key={"feature-grid-container"}
                 columnSettings={props.attributes}
                 gridEvents={props.gridEvents}
+                pageEvents={props.pageEvents}
                 describeFeatureType={props.describe}
                 features={props.features}
                 minHeight={600}
-                tools={props.gridTools}/>
+                tools={props.gridTools}
+                pagination={props.pagination}
+                pages={props.pages}
+                virtualScroll={props.virtualScroll}
+                maxStoredPages={props.maxStoredPages}
+                vsOverScan={props.vsOverScan}
+                scrollDebounce={props.scrollDebounce}
+                size={props.size}
+                />
         </BorderLayout> }
 
         </ContainerDimensions>
@@ -164,7 +173,7 @@ const selector = createSelector(
     state => get(state, "queryform.autocompleteEnabled"),
     state => wfsURLSelector(state),
     state => typeNameSelector(state),
-    resultsSelector,
+    state => get(state, 'featuregrid.features') || EMPTY_ARR,
     describeSelector,
     state => get(state, "featuregrid.attributes"),
     state => get(state, "featuregrid.tools"),
@@ -175,7 +184,10 @@ const selector = createSelector(
     hasChangesSelector,
     state => get(state, 'featuregrid.focusOnEdit') || [],
     state => get(state, 'featuregrid.enableColumnFilters'),
-    (open, autocompleteEnabled, url, typeName, features = EMPTY_ARR, describe, attributes, tools, select, mode, changes, newFeatures = EMPTY_ARR, hasChanges, focusOnEdit, enableColumnFilters) => ({
+    createStructuredSelector(paginationInfo),
+    state => get(state, 'featuregrid.pages'),
+    state => get(state, 'featuregrid.pagination.size'),
+    (open, autocompleteEnabled, url, typeName, features = EMPTY_ARR, describe, attributes, tools, select, mode, changes, newFeatures = EMPTY_ARR, hasChanges, focusOnEdit, enableColumnFilters, pagination, pages, size) => ({
         open,
         autocompleteEnabled,
         url,
@@ -190,7 +202,10 @@ const selector = createSelector(
         mode,
         focusOnEdit,
         enableColumnFilters,
-        changes: toChangesMap(changes)
+        changes: toChangesMap(changes),
+        pagination,
+        pages,
+        size
     })
 );
 const EditorPlugin = connect(selector,

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -38,9 +38,16 @@ const Dock = connect(createSelector(
   * @class
   * @prop {object} cfg.customEditorsOptions Set of options used to connect the custom editors to the featuregrid
   * @prop {object} cfg.editingAllowedRoles array of user roles allowed to enter in edit mode
+  * @prop {boolean} cfg.virtualScroll defualt true. When false the grid uses paging mechanism otherwise virtual scroll is enabled
+  * @prop {number} cfg.maxStoredPages default 5. In virtual Scroll mode determines the size of the loaded pages cache
+  * @prop {number} cfg.vsOverScan default 20. Number of rows to load above/below the visible slice of the grid
+  * @prop {number} cfg.scrollDebounce default 50. In milliseconds the debounce interval between two scroll event
   * @classdesc
-  * FeatureEditor Plugin Provides functionalities to browse/edit data via WFS. It can be configured passing custom editors
-  * <br/>Rules are applied in order and the first rule that match the regex wins.
+  * FeatureEditor Plugin Provides functionalities to browse/edit data via WFS. The grid can be configured to use paging or
+  * <br/>virtual scroll mechanisms. By defualt virtual scroll is enabled. When on virtual scroll mode, the maxStoredPages param
+  * <br/>sets the size of loaded pages cache, while vsOverscan and scrollDebounce parmas determine the behavior of grid scrolling
+  * <br/>and of row loading.
+  * <br/>Furthermore it can be configured passing custom editors. Rules are applied in order and the first rule that match the regex wins
   * <br/>That means that for those conditions it is used the custom editor specified in the editor param.
   * <br/>All the conditions inside a rule must match to apply the editor.
   * <br/>If no rule is applied then it will be used the default editor based on the dataType of that column.

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -52,7 +52,8 @@ module.exports = {
             state => state && state.wfsdownload && state.wfsdownload.wfsFormats,
             state => state && state.wfsdownload && state.wfsdownload.formatsLoading,
             getSelectedLayer,
-            (url, filterObj, enabled, downloadOptions, loading, wfsFormats, formatsLoading, layer) => ({
+            state => state && state.featuregrid && state.featuregrid.virtualScroll,
+            (url, filterObj, enabled, downloadOptions, loading, wfsFormats, formatsLoading, layer, virtualScroll) => ({
                 url,
                 filterObj,
                 enabled,
@@ -60,7 +61,8 @@ module.exports = {
                 loading,
                 wfsFormats,
                 formatsLoading,
-                layer
+                layer,
+                virtualScroll
             })
     ), {
         onExport: downloadFeatures,

--- a/web/client/plugins/featuregrid/pageEvents.js
+++ b/web/client/plugins/featuregrid/pageEvents.js
@@ -1,5 +1,6 @@
-const {changePage} = require('../../actions/featuregrid');
+const {changePage, moreFeatures} = require('../../actions/featuregrid');
 
 module.exports = {
-    onPageChange: (page, size) => changePage(page, size)
+    onPageChange: (page, size) => changePage(page, size),
+    moreFeatures
 };

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -982,6 +982,7 @@
             "deselectall": "Auswahl aufheben",
             "backtosearch": "Zurück zur suche",
             "resultInfo": "{total, plural, =0 {Keine Artikel} =1 {{total} von {total}} other {{start}-{end} von {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {Keine Artikel} =1 {{total} von {total}} other {{total}}}",
             "pageInfo": "{totalPages, plural, =0 {keine Seite} =1 {Seite {totalPages} von {totalPages}} other {Seite {page} von {totalPages}}}",
             "pagination": {
                 "page": "Seite",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -981,6 +981,7 @@
             "deselectall": "Clear Selection",
             "backtosearch": "Back to search",
             "resultInfo": "{total, plural, =0 {No items} =1 {{total} Item of {total}} other {{start}-{end} of {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {No items} =1 {{total} Item of {total}} other {Items {total}}}",
             "pageInfo": "{totalPages, plural, =0 {No pages} =1 {Page {totalPages} of {totalPages}} other {Page {page} of {totalPages}}}",
             "pagination": {
                 "page": "Page",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -981,7 +981,7 @@
             "deselectall": "Clear Selection",
             "backtosearch": "Back to search",
             "resultInfo": "{total, plural, =0 {No items} =1 {{total} Item of {total}} other {{start}-{end} of {total}}}",
-            "resultInfoVirtual": "{total, plural, =0 {No items} =1 {{total} Item of {total}} other {Items {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {No items} =1 {{total} Item of {total}} other {{total} Items}}",
             "pageInfo": "{totalPages, plural, =0 {No pages} =1 {Page {totalPages} of {totalPages}} other {Page {page} of {totalPages}}}",
             "pagination": {
                 "page": "Page",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -982,6 +982,7 @@
             "deselectall": "Deseleccionar todos",
             "backtosearch": "Volver a la búsqueda",
             "resultInfo": "{total, plural, =0 {nada} =1 {{total} de {total}} other {{start}-{end} de {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {nada} =1 {{total} de {total}} other { {total}}}",
             "pageInfo": "{totalPages, plural, =0 {ningúna Página} =1 {Página {totalPages} de {totalPages}} other {Seite {page} de {totalPages}}}",
             "pagination": {
                 "page": "Página",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -984,6 +984,7 @@
             "deselectall": "Tout désélectionner",
             "backtosearch": "Retour à la recherche",
             "resultInfo": "{total, plural, =0 {aucun objet} =1 {{total} de {total}} other {{start}-{end} de {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {aucun objet} =1 {{total} de {total}} other {Object {total}}}",
             "pageInfo": "{totalPages, plural, =0 {No pages} =1 {Page {totalPages} de {totalPages}} other {Page {page} de {totalPages}}}",
             "pagination": {
                 "page": "Page",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -984,7 +984,7 @@
             "deselectall": "Tout désélectionner",
             "backtosearch": "Retour à la recherche",
             "resultInfo": "{total, plural, =0 {aucun objet} =1 {{total} de {total}} other {{start}-{end} de {total}}}",
-            "resultInfoVirtual": "{total, plural, =0 {aucun objet} =1 {{total} de {total}} other {Object {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {aucun objet} =1 {{total} de {total}} other {{total} Objets}}",
             "pageInfo": "{totalPages, plural, =0 {No pages} =1 {Page {totalPages} de {totalPages}} other {Page {page} de {totalPages}}}",
             "pagination": {
                 "page": "Page",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -982,7 +982,7 @@
             "deselectall": "Deseleziona tutti",
             "backtosearch": "Ritorna alla ricerca",
             "resultInfo": "{total, plural, =0 {Nessun elemento} =1 {{total} di {total}} other {{start}-{end} di {total}}}",
-            "resultInfoVirtual": "{total, plural, =0 {Nessun elemento} =1 {{total} di {total}} other {Elementi {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {Nessun elemento} =1 {{total} di {total}} other {{total} Elementi}}",
             "pageInfo": "{totalPages, plural, =0 {Nessuna pagina} =1 {Pagina {totalPages} di {totalPages}} other {Pagina {page} di {totalPages}}}",
             "pagination": {
                 "page": "Pagina",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -982,6 +982,7 @@
             "deselectall": "Deseleziona tutti",
             "backtosearch": "Ritorna alla ricerca",
             "resultInfo": "{total, plural, =0 {Nessun elemento} =1 {{total} di {total}} other {{start}-{end} di {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {Nessun elemento} =1 {{total} di {total}} other {Elementi {total}}}",
             "pageInfo": "{totalPages, plural, =0 {Nessuna pagina} =1 {Pagina {totalPages} di {totalPages}} other {Pagina {page} di {totalPages}}}",
             "pagination": {
                 "page": "Pagina",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -848,6 +848,7 @@
             "deselectall": "Deselecteer alles",
             "backtosearch": "Terug naar zoeken",
             "resultInfo": "{total, plural, =0 {geen enkel object} =1 {{total} van {total}} other {{start}-{end} van {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {geen enkel object} =1 {{total} van {total}} other {{total}}}",
             "pageInfo": "{totalPages, plural, =0 {No pages} =1 {Page {totalPages} van {totalPages}} other {Page {page} van {totalPages}}}",
             "pagination": {
                 "page": "Bladzijde",

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -177,9 +177,9 @@ module.exports = {
         }
         return [firstMissingPage, lastMissingPage].filter(p => p !== undefined);
     },
-    getIdxFarhestEl: (startIdx, pages = [], firstRow, lastRow) => {
+    getIdxFarthestEl: (startIdx, pages = [], firstRow, lastRow) => {
         return pages.map(val => firstRow <= val && val <= lastRow ? 0 : Math.abs(val - startIdx)).reduce((i, distance, idx, vals) => distance > vals[i] && idx || i, 0);
     },
-    removePage: (idxFarhestEl, pages) => pages.filter( (el, i) => i !== idxFarhestEl),
+    removePage: (idxFarthestEl, pages) => pages.filter( (el, i) => i !== idxFarthestEl),
     removePageFeatures: (features, idxToRemove, size) => features.filter((el, i) => i < idxToRemove || i >= idxToRemove + size)
 };

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -12,7 +12,27 @@ const {getFeatureTypeProperties, isGeometryType, isValid, isValidValueForPropert
 const getGeometryName = (describe) => get(findGeometryProperty(describe), "name");
 const getPropertyName = (name, describe) => name === "geometry" ? getGeometryName(describe) : name;
 
+const getBlockIdx = (indexes = [], size = 0, rowIdx) => findIndex(indexes, (startIdx) => startIdx <= rowIdx && rowIdx < startIdx + size);
+
+/** Features are stored in an array grupped by block of pages. The page could be loaded unorderd
+ * This function recover the correct rowIndex in features, given the array of indexes
+ * of loaded page and the page size.
+ * @param  {int}   rowIdx React-data-grid idex to search
+ * @param  {Array} idxes  Array of loaded pages start index
+ * @param  {size}  size   Page size
+ * @return {int}          The new correspondinx index in features array or -1 if not present
+ */
+const getRowIdx = (rowIdx, indexes, size) => {
+    const blockIdx = getBlockIdx(indexes, size, rowIdx);
+    return blockIdx === -1 ? blockIdx : blockIdx * size + rowIdx - indexes[blockIdx];
+};
+
+// const getRow = (i, rows) => rows[i];
+const EMPTY_ROW = {id: "empty_row", get: () => undefined};
+
+const getRowVirtual = (i, rows, pages = [], size) => rows[getRowIdx(i, pages, size)] || {...EMPTY_ROW};
 const getRow = (i, rows) => rows[i];
+
 /* eslint-disable */
 
 const toChangesMap = (changesArray) => changesArray.reduce((changes, c) => ({
@@ -56,6 +76,8 @@ const upsertFilterField = (filterFields = [], filter, newObject) => {
     return [...filterFields, newObject];
 };
 const getAttributeFields = (describe) => (getFeatureTypeProperties(describe) || []).filter( e => !isGeometryType(e));
+
+
 module.exports = {
     getAttributeFields,
     featureTypeToGridColumns: (
@@ -76,6 +98,7 @@ module.exports = {
                 filterRenderer: getFilterRenderer(desc, desc.name)
         })),
     getRow,
+    getRowVirtual,
     /**
      * Create a column from the configruation. Maps the events to call a function with the whole property
      * @param  {array} toolColumns Array of the tools configurations
@@ -130,5 +153,33 @@ module.exports = {
                 })
                 : (oldFilterObj.filterFields || []).filter(field => field.attribute !== (attribute))
         };
-    }
+    },
+    toPage: ({startIndex = 0, maxFeatures = 1, totalFeatures = 0, resultSize} = {}) => ({
+        page: Math.ceil(startIndex / maxFeatures),
+        resultSize,
+        size: maxFeatures,
+        total: totalFeatures,
+        maxPages: Math.ceil(totalFeatures / maxFeatures) - 1
+    }),
+    getRowIdx,
+    getPagesToLoad: (startPage, endPage, pages, size) => {
+        let firstMissingPage;
+        let lastMissingPage;
+        for (let i = startPage; i <= endPage && firstMissingPage === undefined; i++) {
+            if (getRowIdx(i * size, pages, size) === -1) {
+                firstMissingPage = i;
+            }
+        }
+        for (let i = endPage; i >= startPage && lastMissingPage === undefined; i--) {
+            if (getRowIdx(i * size, pages, size) === -1) {
+                lastMissingPage = i;
+            }
+        }
+        return [firstMissingPage, lastMissingPage].filter(p => p !== undefined);
+    },
+    getIdxFarhestEl: (startIdx, pages = [], firstRow, lastRow) => {
+        return pages.map(val => firstRow <= val && val <= lastRow ? 0 : Math.abs(val - startIdx)).reduce((i, distance, idx, vals) => distance > vals[i] && idx || i, 0);
+    },
+    removePage: (idxFarhestEl, pages) => pages.filter( (el, i) => i !== idxFarhestEl),
+    removePageFeatures: (features, idxToRemove, size) => features.filter((el, i) => i < idxToRemove || i >= idxToRemove + size)
 };


### PR DESCRIPTION
## Description
This pull add virtual scroll to feature grid
To configure virtualScroll  in localConfig add virtualScroll.
How MS2 loads and cache the feature depends this parameters.
maxStoredPages  default to 5, It's the page cache size (Note!! The cache size is the max between maxStoredPage and the number of pages needed to fill grid window)
vsOverScan default to 10. Given the first and last row of the grid windows, overscan is used as window's buffer
scrollDebounce default to 200 It's the time in milliseconds between scrolling events.
The features al always loaded per page, as in pagination, but all the pages needed to fill the grid window + overscan buffer are requested in a single query.
The pages are cached and if needed the farthest from the last loaded pages are removed.
## Issues
 - Fix #2391

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
The featuregrid is paginated

**What is the new behavior?**
The features are loaded when user scroll the grid

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
