### PR TITLE
Fix #2556 Removed duplication of OL geoms due to double initialization

### DIFF
--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -31,21 +31,6 @@ class Feature extends React.Component {
 
     componentDidMount() {
         this.addFeatures(this.props);
-        const format = new ol.format.GeoJSON();
-        const geometry = this.props.geometry.type === "GeometryCollection" ? this.props.geometry && this.props.geometry.geometries : this.props.geometry && this.props.geometry.coordinates;
-
-        if (this.props.container && geometry) {
-            this._feature = format.readFeatures({
-                type: this.props.type,
-                properties: this.props.properties,
-                geometry: this.props.geometry,
-                id: this.props.msId});
-            this._feature.forEach((f) => f.getGeometry().transform(this.props.featuresCrs, this.props.crs || 'EPSG:3857'));
-            if (this.props.style && (this.props.style !== this.props.layerStyle)) {
-                this._feature.forEach((f) => { f.setStyle(getStyle({style: this.props.style})); });
-            }
-            this.props.container.getSource().addFeatures(this._feature);
-        }
     }
 
     shouldComponentUpdate(nextProps) {

--- a/web/client/components/map/openlayers/__tests__/Feature-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Feature-test.jsx
@@ -181,11 +181,12 @@ describe('Test Feature', () => {
                  container={container}
                  featuresCrs={"EPSG:4326"}
                  crs={"EPSG:4326"}
+                 style={{}}
                  />, document.getElementById("container"));
 
         style = layer._feature[0].getStyle();
-        expect(style).toNotExist();
-
+        expect(style).toExist();
+        // change geometry
         layer = ReactDOM.render(
             <Feature type="vector"
                  options={options}
@@ -198,9 +199,108 @@ describe('Test Feature', () => {
                  crs={"EPSG:4326"}
                  style={{}}
                  />, document.getElementById("container"));
+        const count = container.getSource().getFeatures().length;
+        expect(count).toBe(1);
+    });
+    it('updating a feature with no msId', () => {
+        var options = {
+            crs: 'EPSG:4326',
+            features: {
+                type: 'FeatureCollection',
+                crs: {
+                    'type': 'name',
+                    'properties': {
+                        'name': 'EPSG:4326'
+                    }
+                },
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Polygon',
+                            coordinates: [[
+                              [13, 43],
+                              [15, 43],
+                              [15, 44],
+                              [13, 44]
+                            ]]
+                        },
+                        properties: {
+                            'name': "some name"
+                        }
+                    }
+                ]
+            }
+        };
+        const source = new ol.source.Vector({
+            features: []
+        });
+        let container = new ol.layer.Vector({
+            source: source,
+            visible: true,
+            zIndex: 1
+        });
+        const geometry = options.features.features[0].geometry;
+        const type = options.features.features[0].type;
+        const properties = options.features.features[0].properties;
+
+        // create layers
+        let layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(container.getSource().getFeatures().length === 1 );
+
+        let style = layer._feature[0].getStyle();
+        expect(style).toNotExist();
+
+        options.features.features[0].properties.name = 'other name';
+        const newGeometry = {
+            ...geometry,
+            coordinates: [ [0, 0],
+            [0, 1],
+            [1, 1],
+            [1, 1]]
+        };
+        layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={newGeometry}
+                 type={type}
+                 properties={properties}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 />, document.getElementById("container"));
+
+        style = layer._feature[0].getStyle();
+        expect(style).toNotExist();
+
+        layer = ReactDOM.render(
+            <Feature type="vector"
+                 options={options}
+                 geometry={geometry}
+                 type={type}
+                 properties={properties}
+                 container={container}
+                 featuresCrs={"EPSG:4326"}
+                 crs={"EPSG:4326"}
+                 style={{}}
+                 />, document.getElementById("container"));
 
         style = layer._feature[0].getStyle();
         expect(style).toExist();
+        const count = container.getSource().getFeatures().length;
+        expect(count).toBe(1);
     });
 
     it('adding a feature with geom type GeometryCollections to a vector layer', () => {


### PR DESCRIPTION
## Description
Removed duplicated initialization that was adding an orphan feature in the OL layer. The duplicated feature will not be correctly removed on update because it is compared with this._feature that is changed (this problem is related only to Features without id (e.g. Geocoding markers, annotations...). Features with an id like featuregrid, editor and so on should not be affected.  
## Issues
 - Fix #2556

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
- See #2556

**What is the new behavior?**
 - No duplicated initialization. Any update to annotation or change of point will be correctly applied. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
