### PR TITLE
Fix #2558. Removed overwrite of OL event listener

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -103,24 +103,17 @@ class OpenlayersMap extends React.Component {
         });
 
         this.map = map;
-        const oldOn = this.map.on;
         this.map.disabledListeners = {};
-        this.map.on = (event, handler) => {
-            oldOn.call(this.map, event, (e) => {
-                if (!this.map.disabledListeners[event]) {
-                    handler(e);
-                }
-            });
-        };
         this.map.disableEventListener = (event) => {
             this.map.disabledListeners[event] = true;
         };
         this.map.enableEventListener = (event) => {
             delete this.map.disabledListeners[event];
         };
+        // TODO support disableEventListener
         map.on('moveend', this.updateMapInfoState);
         map.on('singleclick', (event) => {
-            if (this.props.onClick) {
+            if (this.props.onClick && !this.map.disabledListeners.singleclick) {
                 let pos = event.coordinate.slice();
                 let coords = ol.proj.toLonLat(pos, this.props.projection);
                 let tLng = CoordinatesUtils.normalizeLng(coords[0]);
@@ -153,6 +146,7 @@ class OpenlayersMap extends React.Component {
             }
         });
         const mouseMove = throttle(this.mouseMoveEvent, 100);
+        // TODO support disableEventListener
         map.on('pointermove', mouseMove);
 
         this.updateMapInfoState();

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -96,7 +96,7 @@ describe('OpenlayersMap', () => {
         expect(map.map.getView().getProjection().getCode()).toBe('EPSG:3857');
     });
 
-    it('click on feature', (done) => {
+    it('disable single click', (done) => {
         const testHandlers = {
             handler: () => {}
         };
@@ -105,6 +105,7 @@ describe('OpenlayersMap', () => {
             onClick={testHandlers.handler}/>);
         const map = ReactDOM.render(comp, document.getElementById("map"));
         expect(map).toExist();
+        map.map.disableEventListener('singleclick');
         setTimeout(() => {
             map.map.forEachFeatureAtPixel = (pixel, callback) => {
                 callback.call(null, {
@@ -128,7 +129,7 @@ describe('OpenlayersMap', () => {
                 pixel: map.map.getPixelFromCoordinate([10.3, 43.9]),
                 originalEvent: {}
             });
-            expect(spy.calls.length).toEqual(1);
+            expect(spy.calls.length).toEqual(0);
             done();
         }, 500);
     });
@@ -286,6 +287,24 @@ describe('OpenlayersMap', () => {
             expect(spy.calls[1].arguments[3].width).toExist();
             done();
         });
+    });
+    it('preserve listeners scope', (done) => {
+        const map = ReactDOM.render(
+            <OpenlayersMap
+                center={{y: 43.9, x: 10.3}}
+                zoom={11}
+            />
+        , document.getElementById("map"));
+
+        const olMap = map.map;
+        olMap.getView().setZoom(12);
+        const scopeObj = {test: "TEST"};
+        const handler = function() {
+            expect(this).toExist();
+            expect(this.test).toBe("TEST");
+            done();
+        };
+        olMap.on('moveend', handler, scopeObj);
     });
 
     it('check if the map changes when receive new props', () => {

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -95,7 +95,42 @@ describe('OpenlayersMap', () => {
         expect(map).toExist();
         expect(map.map.getView().getProjection().getCode()).toBe('EPSG:3857');
     });
-
+    it('click on feature', (done) => {
+        const testHandlers = {
+            handler: () => {}
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const comp = (<OpenlayersMap projection="EPSG:4326" center={{y: 43.9, x: 10.3}} zoom={11}
+            onClick={testHandlers.handler}/>);
+        const map = ReactDOM.render(comp, document.getElementById("map"));
+        expect(map).toExist();
+        setTimeout(() => {
+            map.map.forEachFeatureAtPixel = (pixel, callback) => {
+                callback.call(null, {
+                    feature: new ol.Feature({
+                        geometry: new ol.geom.Point([10.3, 43.9]),
+                        name: 'My Point'
+                    }),
+                    getGeometry: () => {
+                        return {
+                            getFirstCoordinate: () => [10.3, 43.9],
+                            getType: () => {
+                                return 'Point';
+                            }
+                        };
+                    }
+                });
+            };
+            map.map.dispatchEvent({
+                type: 'singleclick',
+                coordinate: [10.3, 43.9],
+                pixel: map.map.getPixelFromCoordinate([10.3, 43.9]),
+                originalEvent: {}
+            });
+            expect(spy.calls.length).toEqual(1);
+            done();
+        }, 500);
+    });
     it('disable single click', (done) => {
         const testHandlers = {
             handler: () => {}
@@ -287,24 +322,6 @@ describe('OpenlayersMap', () => {
             expect(spy.calls[1].arguments[3].width).toExist();
             done();
         });
-    });
-    it('preserve listeners scope', (done) => {
-        const map = ReactDOM.render(
-            <OpenlayersMap
-                center={{y: 43.9, x: 10.3}}
-                zoom={11}
-            />
-        , document.getElementById("map"));
-
-        const olMap = map.map;
-        olMap.getView().setZoom(12);
-        const scopeObj = {test: "TEST"};
-        const handler = function() {
-            expect(this).toExist();
-            expect(this.test).toBe("TEST");
-            done();
-        };
-        olMap.on('moveend', handler, scopeObj);
     });
 
     it('check if the map changes when receive new props', () => {

--- a/web/client/indexTemplate.html
+++ b/web/client/indexTemplate.html
@@ -92,7 +92,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.4/leaflet.draw.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.0.1/ol-debug.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.0.1/ol.js"></script>
     <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
     <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
     <script src="libs/cesium-navigation/cesium-navigation.js"></script>


### PR DESCRIPTION
## Description

`Map.jsx` overrides default event listeners but do not preserves function scopes.
This override is required only by the current implementation of DrawSupport that disables 'singleclick'
on map.
This pull request changes the semanthics of disableEventListeners to disable listeners of the map itself (not every click event) and for now I support only to disable 'singleclick'.
This way we can remove the override simplifying all the interaction and extending compatibility for every future update.

## Issues
 - Fix #2558

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
See #2558

**What is the new behavior?**
Now GeoLocator works as expected.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

**Other information**:
