### PR TITLE
Fixed #2568 Support for custom info formats and viewers

### DIFF
--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -60,14 +60,12 @@ const MapInfoUtils = {
     /**
      * @return {string} the info format value from layer, otherwise the info format in settings
      */
-    getDefaultInfoFormatValueFromLayer(layer, props) {
-        if (layer.featureInfo
+    getDefaultInfoFormatValueFromLayer: (layer, props) =>
+        layer.featureInfo
             && layer.featureInfo.format
-            && MapInfoUtils.getAvailableInfoFormat()[layer.featureInfo.format]) {
-            return MapInfoUtils.getAvailableInfoFormat()[layer.featureInfo.format];
-        }
-        return props.format || 'application/json';
-    },
+            && INFO_FORMATS[layer.featureInfo.format]
+            || props.format
+            || 'application/json',
     getLayerFeatureInfoViewer(layer) {
         if (layer.featureInfo
             && layer.featureInfo.viewer) {

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -17,7 +17,8 @@ var {
     getValidator,
     getViewer,
     setViewer,
-    getLabelFromValue
+    getLabelFromValue,
+    getDefaultInfoFormatValueFromLayer
 } = require('../MapInfoUtils');
 
 const CoordinatesUtils = require('../CoordinatesUtils');
@@ -342,4 +343,10 @@ describe('MapInfoUtils', () => {
         let label = getLabelFromValue("text_or_something_else");
         expect(label).toBe("TEXT");
     });
+});
+it('getDefaultInfoFormatValueFromLayer', () => {
+    const jsonFormat = getDefaultInfoFormatValueFromLayer({featureInfo: {format: "JSON"}}, {});
+    expect(jsonFormat).toBe('application/json');
+    const htmlFormat = getDefaultInfoFormatValueFromLayer({}, {format: "text/html"});
+    expect(htmlFormat).toBe('text/html');
 });


### PR DESCRIPTION
## Description
MapStore2 supports custom viewers and for GetFeatureInfo. They may require some specific format. Anyway the format validity is checked on the wrong list. The format may be json, gml or others for custom viewers. 
## Issues
 - Fix #2568

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Custom viewers (specific projects) didn't work if they had JSON as format. 

**What is the new behavior?**
Now custom viewers work

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
