### PR TITLE
Fix #2565. Save thumbURL property if present

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -334,6 +334,7 @@ const LayersUtils = {
             id: layer.id,
             features: layer.features,
             format: layer.format,
+            thumbURL: layer.thumbURL,
             group: layer.group,
             search: layer.search,
             source: layer.source,

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -154,6 +154,7 @@ describe('Test the MapUtils', () => {
                 params: {},
                 search: {},
                 singleTile: false,
+                thumbURL: "THUMB_URL",
                 title: "layer001",
                 type: "wms",
                 url: "",
@@ -225,6 +226,7 @@ describe('Test the MapUtils', () => {
                 }],
                 layers: [{
                     allowedSRS: {},
+                    thumbURL: "THUMB_URL",
                     availableStyles: undefined,
                     bbox: {},
                     capabilitiesURL: undefined,
@@ -262,6 +264,7 @@ describe('Test the MapUtils', () => {
                 },
                 {
                     allowedSRS: {},
+                    thumbURL: undefined,
                     availableStyles: undefined,
                     bbox: {},
                     capabilitiesURL: undefined,
@@ -299,6 +302,7 @@ describe('Test the MapUtils', () => {
                 },
                 {
                     allowedSRS: {},
+                    thumbURL: undefined,
                     availableStyles: undefined,
                     bbox: {},
                     capabilitiesURL: undefined,
@@ -449,6 +453,7 @@ describe('Test the MapUtils', () => {
                 }],
                 layers: [{
                     allowedSRS: {},
+                    thumbURL: undefined,
                     availableStyles: undefined,
                     bbox: {},
                     capabilitiesURL: undefined,
@@ -486,6 +491,7 @@ describe('Test the MapUtils', () => {
                 },
                 {
                     allowedSRS: {},
+                    thumbURL: undefined,
                     availableStyles: undefined,
                     bbox: {},
                     capabilitiesURL: undefined,
@@ -523,6 +529,7 @@ describe('Test the MapUtils', () => {
                 },
                 {
                     allowedSRS: {},
+                    thumbURL: undefined,
                     availableStyles: undefined,
                     bbox: {},
                     capabilitiesURL: undefined,


### PR DESCRIPTION
## Description
This changes save thumbURL in Map.
## Issues
 - Fix #2565


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 

 - [x] Bugfix

**What is the current behavior?** 
 - You can see custom (e.g. WMS) background thumbnails in the new map context (because it's loaded by `new.json`), but when you try to save, next time you're not able to see thumbnail anymore

**What is the new behavior?**
 - Now the thumbnail is saved with other properties. 


**Does this PR introduce a breaking change?**

 - [x] No

