### PR TITLE
Fix #2573. Empty filter notification with cross layer filter

### DIFF
--- a/web/client/components/data/query/QueryToolbar.jsx
+++ b/web/client/components/data/query/QueryToolbar.jsx
@@ -86,7 +86,10 @@ class QueryToolbar extends React.Component {
             !fieldsWithValues && !this.props.spatialField.geometry;
 
 
-        const showTooltip = this.props.emptyFilterWarning && this.props.filterFields.filter((field) => field.value).length === 0 && !this.props.spatialField.geometry;
+        const showTooltip = this.props.emptyFilterWarning
+            && this.props.filterFields.filter((field) => field.value).length === 0
+            && !this.props.spatialField.geometry
+            && !(this.props.crossLayerFilter && this.props.crossLayerFilter.attribute && this.props.crossLayerFilter.operation);
 
         const buttons = [{
             tooltipId: "queryform.reset",
@@ -97,6 +100,7 @@ class QueryToolbar extends React.Component {
         }, {
             tooltipId: showTooltip ? "queryform.emptyfilter" : this.props.queryBtnMsgId,
             disabled: queryDisabled,
+            className: showTooltip ? "showWarning" : undefined,
             glyph: this.props.queryBtnGlyph,
             id: "query-toolbar-query",
             onClick: this.search

--- a/web/client/components/data/query/QueryToolbar.jsx
+++ b/web/client/components/data/query/QueryToolbar.jsx
@@ -100,8 +100,8 @@ class QueryToolbar extends React.Component {
         }, {
             tooltipId: showTooltip ? "queryform.emptyfilter" : this.props.queryBtnMsgId,
             disabled: queryDisabled,
-            className: showTooltip ? "showWarning" : undefined,
             glyph: this.props.queryBtnGlyph,
+            className: showTooltip ? "square-button-md showWarning" : "square-button-md",
             id: "query-toolbar-query",
             onClick: this.search
         }];

--- a/web/client/components/data/query/__tests__/QueryToolbar-test.jsx
+++ b/web/client/components/data/query/__tests__/QueryToolbar-test.jsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const expect = require('expect');
+const QueryToolbar = require('../QueryToolbar');
+describe('QueryToolbar component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('QueryToolbar rendering with defaults', () => {
+        ReactDOM.render(<QueryToolbar />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.query-toolbar');
+        expect(el).toExist();
+    });
+    it('QueryToolbar check empty filter warning', () => {
+        ReactDOM.render(<QueryToolbar emptyFilterWarning allowEmptyFilter spatialField={{}} crossLayerFilter={{attribute: "ATTR", operation: undefined}}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('#query-toolbar-query.showWarning');
+        expect(el).toExist();
+        ReactDOM.render(<QueryToolbar emptyFilterWarning allowEmptyFilter spatialField={{}} crossLayerFilter={{attribute: "ATTR", operation: "INTERSECT"}}/>, document.getElementById("container"));
+        expect(container.querySelector('#query-toolbar-query.showWarning')).toNotExist();
+        expect(container.querySelector('#query-toolbar-query')).toExist();
+        ReactDOM.render(<QueryToolbar emptyFilterWarning allowEmptyFilter spatialField={{geometry: {}}} crossLayerFilter={{attribute: "ATTR", operation: undefined}}/>, document.getElementById("container"));
+        expect(container.querySelector('#query-toolbar-query.showWarning')).toNotExist();
+
+    });
+});


### PR DESCRIPTION
## Description
Empty filter notification was shown even if a cross layer filter was defined. This changes hide that notification when a cross layer filter is present. Add also tests for QueryToolbar component.
## Issues
 - Fix #2573

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
 - Tooltip was shown even if a cross layer filter was defined

**What is the new behavior?**
- Tooltip is not shown anymore

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

