### PR TITLE
DrawSupport:Replace does not add drawinteraction by default

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -152,7 +152,7 @@ class DrawSupport extends React.Component {
 
     replaceFeatures = (newProps) => {
         if (!this.drawLayer) {
-            this.addLayer(newProps, true);
+            this.addLayer(newProps, newProps.options && newProps.options.drawEnabled || false);
         } else {
             this.drawSource.clear();
             this.addFeatures(newProps);

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -593,6 +593,80 @@ describe('Test DrawSupport', () => {
         expect(spyAddFeature.calls.length).toBe(1);
     });
 
+    it('replace features no draw interaction', () => {
+        const fakeMap = {
+            addLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[13, 43], [14, 44]]
+            },
+            properties: {
+                'name': "some name"
+            }
+        };
+
+        const support = ReactDOM.render(
+            <DrawSupport features={[]} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        const spyAddInteraction = expect.spyOn(support, "addInteractions");
+        ReactDOM.render(
+            <DrawSupport features={[feature]} map={fakeMap} drawStatus="replace" drawMethod="MultiLineString" options={{drawEnabled: false}}
+                />, document.getElementById("container"));
+        expect(spyAddInteraction.calls.length).toBe(0);
+    });
+
+    it('replace features with draw interaction', () => {
+        const fakeMap = {
+            addLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[13, 43], [14, 44]]
+            },
+            properties: {
+                'name': "some name"
+            }
+        };
+
+        const support = ReactDOM.render(
+            <DrawSupport features={[]} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        const spyAddInteraction = expect.spyOn(support, "addInteractions");
+        ReactDOM.render(
+            <DrawSupport features={[feature]} map={fakeMap} drawStatus="replace" drawMethod="MultiLineString" options={{drawEnabled: true}}
+                />, document.getElementById("container"));
+        expect(spyAddInteraction.calls.length).toBe(1);
+    });
+
     it('replace features circle', () => {
         const fakeMap = {
             addLayer: () => {},


### PR DESCRIPTION
## Description
Hi,
 
This PR change a little bit the drawsupport replace function as proposed here https://groups.google.com/forum/#!topic/mapstore-developers/s3A77gAHleU

It add the possibility to choose to add interactions whit the drawEnabled option. By default, it's false.

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Refactoring (no functional changes, no api changes)

**What is the current behavior?** (You can also link to an open issue here)
DrawSupport : When the draw layer is not defined and replace function is called. The draw layer is initialized with draw interactions by default : call to add layer with True hardcoded

**What is the new behavior?**
DrawSupport : When the draw layer is not defined and replace function is called. The draw layer is NOT initialized with draw interactions by default : call to add layer use  options.drawEnabled parameter. By default the value is False/

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x ] Yes


This PR may introduce breaking change. As described before the current behavior is to add by default the interactions when using replace. And this PR set the default to false. If it is not possible or correct to use "False" by default , i can change this PR to have the same default behaviour

**Other information**:

If tests case are needed, please let me know
