### PR TITLE
Fixed #2583. Fixed typo in doc

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -38,10 +38,10 @@ const Dock = connect(createSelector(
   * @class
   * @prop {object} cfg.customEditorsOptions Set of options used to connect the custom editors to the featuregrid
   * @prop {object} cfg.editingAllowedRoles array of user roles allowed to enter in edit mode
-  * @prop {boolean} cfg.virtualScroll defualt true. When false the grid uses paging mechanism otherwise virtual scroll is enabled
+  * @prop {boolean} cfg.virtualScroll default true. Activates virtualScroll. When false the grid uses normal pagination
   * @prop {number} cfg.maxStoredPages default 5. In virtual Scroll mode determines the size of the loaded pages cache
   * @prop {number} cfg.vsOverScan default 20. Number of rows to load above/below the visible slice of the grid
-  * @prop {number} cfg.scrollDebounce default 50. In milliseconds the debounce interval between two scroll event
+  * @prop {number} cfg.scrollDebounce default 50. milliseconds of debounce interval between two scroll event
   * @classdesc
   * FeatureEditor Plugin Provides functionalities to browse/edit data via WFS. The grid can be configured to use paging or
   * <br/>virtual scroll mechanisms. By defualt virtual scroll is enabled. When on virtual scroll mode, the maxStoredPages param


### PR DESCRIPTION
## Description
Fixed typo in FeatureEditor Documentation. 

## Issues
 - Fix #2583
 
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe: doc


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
