### PR TITLE
Fix #2576. Avoid confirm window callback if not managed

### DIFF
--- a/web/client/components/maps/modals/MetadataModal.jsx
+++ b/web/client/components/maps/modals/MetadataModal.jsx
@@ -90,7 +90,6 @@ class MetadataModal extends React.Component {
             onBackDetails: () => {},
             onUndoDetails: () => {},
             onToggleGroupProperties: () => {},
-            onToggleUnsavedChangesModal: () => {},
             onToggleDetailsSheet: () => {},
             onUpdateDetails: () => {},
             onDeleteDetails: () => {},
@@ -165,7 +164,7 @@ class MetadataModal extends React.Component {
 
     onCloseMapPropertiesModal = () => {
         // TODO write only a single function used also in onClose property
-        if ( this.props.map.unsavedChanges) {
+        if (this.props.map.unsavedChanges && this.props.detailsSheetActions.onToggleUnsavedChangesModal) {
             this.props.detailsSheetActions.onToggleUnsavedChangesModal();
         } else {
             this.props.onDisplayMetadataEdit(false);
@@ -257,7 +256,9 @@ class MetadataModal extends React.Component {
                     buttons={[{
                         text: <Message msgId="no"/>,
                         onClick: () => {
-                            this.props.detailsSheetActions.onToggleUnsavedChangesModal();
+                            if (this.props.detailsSheetActions.onToggleUnsavedChangesModal) {
+                                this.props.detailsSheetActions.onToggleUnsavedChangesModal();
+                            }
                             this.props.onDisplayMetadataEdit(true);
                         }
                     }, {

--- a/web/client/components/maps/modals/__tests__/MetaDataModal-test.jsx
+++ b/web/client/components/maps/modals/__tests__/MetaDataModal-test.jsx
@@ -8,6 +8,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var MetadataModal = require('../MetadataModal.jsx');
+const ReactTestUtils = require('react-dom/test-utils');
 var expect = require('expect');
 
 describe('This test for MetadataModal', () => {
@@ -55,6 +56,42 @@ describe('This test for MetadataModal', () => {
         const modalDivList = document.getElementsByClassName("modal-content");
         const closeBtnList = modalDivList.item(0).getElementsByTagName('button');
         expect(closeBtnList.length).toBe(2);
+    });
+    /*
+     * This checks if you can close the modal even if the function (confirm) is not defined.
+     * see https://github.com/geosolutions-it/MapStore2/issues/2576
+     */
+    it('Test MetadataModal onToggleUnsavedChangesModal only if present', () => {
+        let thumbnail = "myThumnbnailUrl";
+        let errors = ["FORMAT"];
+        let map = {
+            unsavedChanges: true,
+            thumbnail: thumbnail,
+            id: 123,
+            canWrite: true,
+            errors: errors
+        };
+        const actions = {
+            onToggleUnsavedChangesModal: () => {},
+            onDisplayMetadataEdit: () => {}
+        };
+        const spyonToggleUnsavedChangesModal = expect.spyOn(actions, 'onToggleUnsavedChangesModal');
+        const spyonDisplayMetadataEdit = expect.spyOn(actions, 'onDisplayMetadataEdit');
+        const cmp = ReactDOM.render(<MetadataModal
+            show useModal map={map} id="MetadataModal"
+            detailsSheetActions={{onToggleUnsavedChangesModal: actions.onToggleUnsavedChangesModal}} onDisplayMetadataEdit={actions.spyonDisplayMetadataEdit} />, document.getElementById("container"));
+        expect(cmp).toExist();
+        let el = document.querySelector('#ms-resizable-modal .btn-group button');
+        expect(el).toExist();
+        ReactTestUtils.Simulate.click(el); // <-- trigger event callback
+        expect(spyonToggleUnsavedChangesModal).toHaveBeenCalled();
+        expect(spyonDisplayMetadataEdit).toNotHaveBeenCalled();
+        ReactDOM.render(<MetadataModal
+            show useModal map={map} id="MetadataModal"
+            onDisplayMetadataEdit={actions.onDisplayMetadataEdit} />, document.getElementById("container"));
+        el = document.querySelector('#ms-resizable-modal .btn-group button');
+        ReactTestUtils.Simulate.click(el);
+        expect(spyonDisplayMetadataEdit).toHaveBeenCalled();
     });
 
     it('creates the component with a format error', () => {


### PR DESCRIPTION
## Description
If the confirm window is not managed, you should close the Metadata modal anyway.

## Issues
 - Fix #2576

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
 - You couldn't close the save as dialog after an error on saving.

**What is the new behavior?**
- You can close the window

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
IMHO Confirm dialog flag should be managed internally for the future