### PR TITLE
Fixes issue #1993 After the first save, a map cannot be re-saved 

### DIFF
--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -222,7 +222,9 @@ const storeDetailsInfoEpic = (action$, store) =>
     action$.ofType(MAP_INFO_LOADED)
     .switchMap(() => {
         const mapId = mapIdSelector(store.getState());
-        return Rx.Observable.fromPromise(
+        return !mapId ?
+            Rx.Observable.empty() :
+            Rx.Observable.fromPromise(
             GeoStoreApi.getResourceAttribute(mapId, "details")
             .then(res => res.data).catch(() => {
                 return null;

--- a/web/client/plugins/Save.jsx
+++ b/web/client/plugins/Save.jsx
@@ -34,7 +34,8 @@ const selector = createSelector(mapSelector, mapOptionsToSaveSelector, layersSel
     mapId: map && map.mapId,
     layers,
     textSearchConfig,
-    groups
+    groups,
+    newMapId: map && map.newMapId + ''
 }));
 
 class Save extends React.Component {
@@ -49,7 +50,8 @@ class Save extends React.Component {
         layers: PropTypes.array,
         groups: PropTypes.array,
         params: PropTypes.object,
-        textSearchConfig: PropTypes.object
+        textSearchConfig: PropTypes.object,
+        newMapId: PropTypes.string
     };
 
     static defaultProps = {
@@ -87,10 +89,10 @@ class Save extends React.Component {
     }
 
     goForTheUpdate = () => {
-        if (this.props.mapId) {
+        if (this.props.mapId || this.props.newMapId) {
             if (this.props.map && this.props.layers) {
                 const resultingmap = MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions);
-                this.props.onMapSave(this.props.mapId, resultingmap);
+                this.props.onMapSave(this.props.mapId || this.props.newMapId, resultingmap);
                 this.props.onClose();
             }
         }
@@ -113,9 +115,9 @@ module.exports = {
                 // display the BurgerMenu button only if the map can be edited
                 selector: (state) => {
                     let map = state.map && state.map.present || state.map || state.config && state.config.map || null;
-                    if (map && map.mapId && state && state.security && state.security.user) {
+                    if (map && (map.mapId || map.newMapId) && state && state.security && state.security.user) {
                         if (state.maps && state.maps.results) {
-                            let mapId = map.mapId;
+                            let mapId = map.mapId || map.newMapId + '';
                             let currentMap = state.maps.results.filter(item=> item && '' + item.id === mapId);
                             if (currentMap && currentMap.length > 0 && currentMap[0].canEdit) {
                                 return { };

--- a/web/client/plugins/Save.jsx
+++ b/web/client/plugins/Save.jsx
@@ -34,8 +34,7 @@ const selector = createSelector(mapSelector, mapOptionsToSaveSelector, layersSel
     mapId: map && map.mapId,
     layers,
     textSearchConfig,
-    groups,
-    newMapId: map && map.newMapId + ''
+    groups
 }));
 
 class Save extends React.Component {
@@ -50,8 +49,7 @@ class Save extends React.Component {
         layers: PropTypes.array,
         groups: PropTypes.array,
         params: PropTypes.object,
-        textSearchConfig: PropTypes.object,
-        newMapId: PropTypes.string
+        textSearchConfig: PropTypes.object
     };
 
     static defaultProps = {
@@ -89,10 +87,10 @@ class Save extends React.Component {
     }
 
     goForTheUpdate = () => {
-        if (this.props.mapId || this.props.newMapId) {
+        if (this.props.mapId) {
             if (this.props.map && this.props.layers) {
                 const resultingmap = MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions);
-                this.props.onMapSave(this.props.mapId || this.props.newMapId, resultingmap);
+                this.props.onMapSave(this.props.mapId, resultingmap);
                 this.props.onClose();
             }
         }
@@ -115,9 +113,9 @@ module.exports = {
                 // display the BurgerMenu button only if the map can be edited
                 selector: (state) => {
                     let map = state.map && state.map.present || state.map || state.config && state.config.map || null;
-                    if (map && (map.mapId || map.newMapId) && state && state.security && state.security.user) {
+                    if (map && map.mapId && state && state.security && state.security.user) {
                         if (state.maps && state.maps.results) {
-                            let mapId = map.mapId || map.newMapId + '';
+                            let mapId = map.mapId;
                             let currentMap = state.maps.results.filter(item=> item && '' + item.id === mapId);
                             if (currentMap && currentMap.length > 0 && currentMap[0].canEdit) {
                                 return { };

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -28,7 +28,6 @@ const MapUtils = require('../utils/MapUtils');
 const saveAsStateSelector = createStructuredSelector({
     show: state => state.controls && state.controls.saveAs && state.controls.saveAs.enabled,
     mapType: state => mapTypeSelector(state),
-    newMapId: state => state.currentMap && state.currentMap.newMapId,
     user: state => state.security && state.security.user,
     currentMap: state => state.currentMap,
     metadata: state => state.maps.metadata,
@@ -54,7 +53,6 @@ class SaveAs extends React.Component {
     static propTypes = {
         additionalOptions: PropTypes.object,
         show: PropTypes.bool,
-        newMapId: PropTypes.number,
         map: PropTypes.object,
         user: PropTypes.object,
         mapType: PropTypes.string,
@@ -103,11 +101,10 @@ class SaveAs extends React.Component {
         this.onMissingInfo(nextProps);
     }
 
-    onMissingInfo = (props) => {
-        let map = props.map;
-        if (map && props.currentMap.mapId && !this.props.newMapId
-        || map && props.currentMap.mapId && props.currentMap.mapId !== this.props.newMapId) {
-            this.context.router.history.push("/viewer/" + props.mapType + "/" + props.currentMap.mapId);
+    onMissingInfo = (nextProps) => {
+        const map = nextProps.map;
+        if (map && nextProps.currentMap.mapId && this.props.currentMap.mapId !== nextProps.currentMap.mapId) {
+            this.context.router.history.push("/viewer/" + nextProps.mapType + "/" + nextProps.currentMap.mapId);
             this.props.resetCurrentMap();
         }
     };

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -105,7 +105,8 @@ class SaveAs extends React.Component {
 
     onMissingInfo = (props) => {
         let map = props.map;
-        if (map && props.currentMap.mapId && !this.props.newMapId) {
+        if (map && props.currentMap.mapId && !this.props.newMapId
+        || map && props.currentMap.mapId && props.currentMap.mapId !== this.props.newMapId) {
             this.context.router.history.push("/viewer/" + props.mapType + "/" + props.currentMap.mapId);
             this.props.resetCurrentMap();
         }

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -8,7 +8,7 @@
 var expect = require('expect');
 
 var mapConfig = require('../config');
-const {DETAILS_LOADED} = require('../../actions/maps');
+const {DETAILS_LOADED, MAP_CREATED} = require('../../actions/maps');
 
 
 describe('Test the mapConfig reducer', () => {
@@ -86,5 +86,30 @@ describe('Test the mapConfig reducer', () => {
         expect(state.map).toExist();
         expect(state.map.info).toExist();
         expect(state.map.info.details).toBe(detailsUri);
+    });
+    it('map created', () => {
+        expect(mapConfig({
+            map: {
+                present: {
+                    mapId: 1
+                }
+            }
+        }, {type: MAP_CREATED, resourceId: 2})).toEqual({
+            map: {
+                mapId: undefined,
+                newMapId: 2
+            }
+        });
+        expect(mapConfig({
+            map: {
+                present: {}
+            }
+        }, {type: MAP_CREATED, resourceId: 2})).toEqual({
+            map: {
+                mapId: undefined,
+                newMapId: 2
+            }
+        });
+        expect(mapConfig({}, {type: MAP_CREATED, resourceId: 2})).toEqual({});
     });
 });

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -87,6 +87,7 @@ describe('Test the mapConfig reducer', () => {
         expect(state.map.info).toExist();
         expect(state.map.info.details).toBe(detailsUri);
     });
+
     it('map created', () => {
         expect(mapConfig({
             map: {
@@ -96,8 +97,8 @@ describe('Test the mapConfig reducer', () => {
             }
         }, {type: MAP_CREATED, resourceId: 2})).toEqual({
             map: {
-                mapId: undefined,
-                newMapId: 2
+                mapId: 2,
+                version: 2
             }
         });
         expect(mapConfig({
@@ -106,8 +107,8 @@ describe('Test the mapConfig reducer', () => {
             }
         }, {type: MAP_CREATED, resourceId: 2})).toEqual({
             map: {
-                mapId: undefined,
-                newMapId: 2
+                mapId: 2,
+                version: 2
             }
         });
         expect(mapConfig({}, {type: MAP_CREATED, resourceId: 2})).toEqual({});

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -74,8 +74,8 @@ function mapConfig(state = null, action) {
     case MAP_CREATED: {
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         if (map) {
-            // set mapId to undefined to override the current map on save
-            map = assign({}, map, {mapId: undefined, newMapId: action.resourceId});
+            // version needed to avoid automapupdate to start
+            map = assign({}, map, {mapId: action.resourceId, version: 2});
             return assign({}, state, {map: map});
         }
     }

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -73,8 +73,9 @@ function mapConfig(state = null, action) {
         return state;
     case MAP_CREATED: {
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
-        if (map && !map.mapId) {
-            map = assign({}, map, {newMapId: action.resourceId});
+        if (map) {
+            // set mapId to undefined to override the current map on save
+            map = assign({}, map, {mapId: undefined, newMapId: action.resourceId});
             return assign({}, state, {map: map});
         }
     }

--- a/web/client/reducers/currentMap.js
+++ b/web/client/reducers/currentMap.js
@@ -124,7 +124,7 @@ function currentMap(state = {}, action) {
         return assign({}, state, {updating: false});
     }
     case MAP_CREATED: {
-        return assign({}, state, {mapId: action.resourceId, newMapId: action.resourceId});
+        return assign({}, state, {mapId: action.resourceId});
     }
     case PERMISSIONS_LIST_LOADING: {
         return assign({}, state, {permissionLoading: true});


### PR DESCRIPTION
## Description
This PR enable "Save" in burger menu for new maps

## Issues
 - Fix #1993

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Save Plugin is not visible on new map so the user need to back to homepage and open the map again to save the new configuration

**What is the new behavior?**
Save plugin is enabled for new map after the first save

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
