### PR TITLE
Fixes #2598 Background layers with errors have visibility true after saving

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -354,7 +354,7 @@ const LayersUtils = {
             url: layer.url,
             bbox: layer.bbox,
             nativeCrs: layer.nativeCrs,
-            visibility: layer.loadingError === 'Error' ? true : layer.visibility,
+            visibility: layer.visibility,
             singleTile: layer.singleTile || false,
             allowedSRS: layer.allowedSRS,
             matrixIds: layer.matrixIds,


### PR DESCRIPTION
## Description
This happens because of a control on save introduced for layer with errors.
This is not needed anymore because layers with error now are always visible.


## Issues
 - Fix #2598

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issue #2598

**What is the new behavior?**
only selected background has visible true

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
