### PR TITLE
Quick fix for the build of css

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -2,8 +2,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 var path = require("path");
 const glob = require('glob');
 const extractThemesPlugin = new ExtractTextPlugin({
-    filename: '[name].css',
-    disable: process.env.NODE_ENV !== "production"
+    filename: '[name].css'
 });
 
 


### PR DESCRIPTION
## Description
Build of css from less was broken by a webpack wrong config

## Issues
 - Build of css from less was broken by a webpack wrong config

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Build of css from less was broken by a webpack wrong config

**What is the new behavior?**
Build of css works again
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
