### PR TITLE
Fixes #2608: custom mapOptions are not saved with maps

### DIFF
--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -333,7 +333,8 @@ function saveMapConfiguration(currentMap, currentLayers, currentGroups, textSear
         maxExtent: currentMap.maxExtent,
         projection: currentMap.projection,
         units: currentMap.units,
-        zoom: currentMap.zoom
+        zoom: currentMap.zoom,
+        mapOptions: currentMap.mapOptions || {}
     };
 
     const layers = currentLayers.map((layer) => {

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -339,6 +339,269 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url"
                 }],
+                mapOptions: {},
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                text_serch_config: '',
+                units: 'm',
+                zoom: 10
+            },
+            version: 2
+        });
+    });
+
+    it('save map configuration with map options', () => {
+        const flat = [
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer001",
+                loading: true,
+                name: "layer001",
+                params: {},
+                search: {},
+                singleTile: false,
+                thumbURL: "THUMB_URL",
+                title: "layer001",
+                type: "wms",
+                url: "",
+                visibility: true,
+                catalogURL: "url"
+            },
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer002",
+                loading: true,
+                name: "layer002",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer002",
+                type: "wms",
+                url: "",
+                visibility: true,
+                catalogURL: "url"
+            },
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer003",
+                loading: true,
+                name: "layer003",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer003",
+                type: "wms",
+                url: "",
+                visibility: true,
+                catalogURL: "url"
+            }
+        ];
+
+        const groups = [
+            { expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002'] },
+            {
+                expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                nodes: [{ expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003'] }
+                ]
+            }
+        ];
+
+        const mapConfig = {
+            center: { x: 0, y: 0, crs: 'EPSG:4326' },
+            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+            projection: 'EPSG:900913',
+            units: 'm',
+            zoom: 10,
+            mapOptions: {
+                view: {
+                    resolutions: [
+                        84666.66666666688,
+                        42333.33333333344,
+                        21166.66666666672,
+                        10583.33333333336,
+                        5291.66666666668,
+                        2645.83333333334,
+                        1322.91666666667,
+                        661.458333333335000,
+                        529.166666666668000,
+                        396.875000000001000,
+                        264.583333333334000,
+                        132.291666666667000,
+                        66.145833333333500,
+                        39.687500000000100,
+                        26.458333333333400,
+                        13.229166666666700,
+                        6.614583333333350,
+                        3.968750000000010,
+                        2.645833333333340,
+                        1.322916666666670,
+                        0.661458333333335
+                    ]
+                }
+            }
+        };
+
+        const saved = saveMapConfiguration(mapConfig, flat, groups, '', {});
+        expect(saved).toEqual({
+            map: {
+                center: { crs: 'EPSG:4326', x: 0, y: 0 },
+                groups: [{
+                    id: 'Default',
+                    expanded: true
+                }, {
+                    id: 'custom',
+                    expanded: false
+                }, {
+                    id: 'custom.nested001',
+                    expanded: true
+                    }],
+                layers: [{
+                    allowedSRS: {},
+                    thumbURL: "THUMB_URL",
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    description: undefined,
+                    dimensions: [],
+                    nativeCrs: undefined,
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer001",
+                    matrixIds: undefined,
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer001",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: undefined,
+                    tiled: undefined,
+                    title: "layer001",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url"
+                },
+                {
+                    allowedSRS: {},
+                    thumbURL: undefined,
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    description: undefined,
+                    dimensions: [],
+                    nativeCrs: undefined,
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer002",
+                    matrixIds: undefined,
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer002",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: undefined,
+                    tiled: undefined,
+                    title: "layer002",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url"
+                },
+                {
+                    allowedSRS: {},
+                    thumbURL: undefined,
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    description: undefined,
+                    dimensions: [],
+                    nativeCrs: undefined,
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer003",
+                    matrixIds: undefined,
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer003",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: undefined,
+                    tiled: undefined,
+                    title: "layer003",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url"
+                }],
+                mapOptions: {
+                    view: {
+                        resolutions: [
+                            84666.66666666688,
+                            42333.33333333344,
+                            21166.66666666672,
+                            10583.33333333336,
+                            5291.66666666668,
+                            2645.83333333334,
+                            1322.91666666667,
+                            661.458333333335000,
+                            529.166666666668000,
+                            396.875000000001000,
+                            264.583333333334000,
+                            132.291666666667000,
+                            66.145833333333500,
+                            39.687500000000100,
+                            26.458333333333400,
+                            13.229166666666700,
+                            6.614583333333350,
+                            3.968750000000010,
+                            2.645833333333340,
+                            1.322916666666670,
+                            0.661458333333335
+                        ]
+                    }
+                },
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
                 text_serch_config: '',
@@ -566,6 +829,7 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url"
                 }],
+                mapOptions: {},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
                 text_serch_config: '',


### PR DESCRIPTION
## Description
custom mapOptions should be saved with maps

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
custom mapOptions are not saved with maps

**What is the new behavior?**
custom mapOptions are saved with maps

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
