### PR TITLE
Fix #2592 reorganized text widget into 1 page

### DIFF
--- a/web/client/components/widgets/builder/wizard/TextWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/TextWizard.jsx
@@ -6,9 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 const React = require('react');
-const ReactQuill = require('react-quill');
 const {wizardHanlders} = require('../../../misc/wizard/enhancers');
-const WidgetOptions = require('./common/WidgetOptions');
+const TextOptions = require('./text/TextOptions');
 const Wizard = wizardHanlders(require('../../../misc/wizard/WizardContainer'));
 
 
@@ -22,8 +21,7 @@ module.exports = ({
         setPage={setPage}
         onFinish={onFinish}
         hideButtons>
-        <ReactQuill value={editorData && editorData.text || ''} onChange={(val) => onChange("text", val)}/>
-        <WidgetOptions
+        <TextOptions
             key="widget-options"
             data={editorData}
             onChange={onChange}

--- a/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/text/TextOptions.jsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const { Col, Form, FormGroup, FormControl } = require('react-bootstrap');
+const localizedProps = require('../../../../misc/enhancers/localizedProps');
+const TitleInput = localizedProps("placeholder")(FormControl);
+
+const ReactQuill = require('react-quill');
+const Editor = localizedProps("placeholder")(ReactQuill);
+module.exports = ({ data = {}, onChange = () => { }}) => (
+    <div>
+        <Col key="form" xs={12}>
+            <Form>
+            <FormGroup controlId="title">
+                <Col sm={12}>
+                        <TitleInput style={{ marginBottom: 10 }} placeholder="widgets.builder.wizard.titlePlaceholder" value={data.title} type="text" onChange={e => onChange("title", e.target.value)} />
+                </Col>
+            </FormGroup>
+            </Form>
+        </Col>
+        <Editor placeholder="widgets.builder.wizard.textPlaceholder" value={data && data.text || ''} onChange={(val) => onChange("text", val)} />
+</div>
+);
+

--- a/web/client/components/widgets/builder/wizard/text/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/text/Toolbar.jsx
@@ -16,27 +16,14 @@ const getSaveTooltipId = (step, {id} = {}) => {
     }
     return "widgets.builder.wizard.addToTheMap";
 };
-const getNextTooltipId = () => {
-    return "widgets.builder.wizard.configureWidgetOptions";
-};
-const getBackTooltipId = () => "back"; // TODO I18N
-module.exports = ({step = 0, editorData = {}, onFinish = () => {}, setPage = () => {}} = {}) => (<Toolbar btnDefaultProps={{
+
+module.exports = ({step = 0, editorData = {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm"
     }}
     buttons={[{
-        onClick: () => setPage(Math.max(0, step - 1)),
-        visible: step > 0,
-        glyph: "arrow-left",
-        tooltipId: getBackTooltipId(step)
-    }, {
-        onClick: () => setPage(Math.min(step + 1, 2)),
-        visible: step === 0,
-        glyph: "arrow-right",
-        tooltipId: getNextTooltipId(step)
-    }, {
         onClick: () => onFinish(Math.min(step + 1, 1)),
-        visible: step === 1,
+        visible: step === 0,
         glyph: "floppy-disk",
         tooltipId: getSaveTooltipId(step, editorData)
     }]} />);

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -38,6 +38,15 @@ describe('Test the widgets reducer', () => {
     it('editWidget', () => {
         const state = widgets(undefined, editWidget({type: "bar"}));
         expect(state.builder.editor.type).toBe("bar");
+        expect(state.builder.settings.step).toBe(1);
+    });
+    it('editWidget initial by kind of widget', () => {
+        // default chart
+        expect(widgets(undefined, editWidget({ type: "bar" })).builder.settings.step).toBe(1);
+        // chart explicit
+        expect(widgets(undefined, editWidget({ widgetType: "chart" })).builder.settings.step).toBe(1);
+        // text explicit
+        expect(widgets(undefined, editWidget({ widgetType: "text" })).builder.settings.step).toBe(0);
     });
     it('onEditorChange', () => {
         const state = widgets(undefined, onEditorChange("type", "bar"));

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -62,7 +62,11 @@ function widgetsReducer(state = emptyState, action) {
                 ...action.widget,
                 // for backward compatibility for widgets without this
                 widgetType: action.widget && action.widget.widgetType || 'chart'
-            }, state);
+            }, set("builder.settings.step",
+                    (action.widget && action.widget.widgetType || 'chart') === 'chart'
+                    ? 1
+                    : 0
+                , state));
         }
         case EDITOR_CHANGE: {
             return set(`builder.editor.${action.key}`, action.value, state);

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1081,7 +1081,9 @@
                     "configureChartOptions": "Diagrammoptionen konfigurieren",
                     "configureWidgetOptions": "Widget-Optionen konfigurieren",
                     "updateWidget": "Aktualisieren Sie das Widget",
-                    "addToTheMap": "Hinzufügen des Widgets zur Karte"
+                    "addToTheMap": "Hinzufügen des Widgets zur Karte",
+                    "titlePlaceholder": "Gib den Titel ein...",
+                    "textPlaceholder": "Text eingeben..."
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Keine Widgets verfügbar",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1080,7 +1080,9 @@
                     "configureChartOptions": "Configure chart options",
                     "configureWidgetOptions": "Configure widget options",
                     "updateWidget": "Update the widget",
-                    "addToTheMap": "Add the widget to the map"
+                    "addToTheMap": "Add the widget to the map",
+                    "titlePlaceholder": "Insert title...",
+                    "textPlaceholder": "Insert text..."
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "No Widgets available",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1080,7 +1080,9 @@
                     "configureChartOptions": "Configurar opciones de gráfico",
                     "configureWidgetOptions": "Configurar las opciones del widget",
                     "updateWidget": "Actualiza el widget",
-                    "addToTheMap": "Agrega el widget al mapa"
+                    "addToTheMap": "Agrega el widget al mapa",
+                    "titlePlaceholder": "Ingrese el título...",
+                    "textPlaceholder": "Ingresar texto..."
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Sin widgets disponibles",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1084,7 +1084,7 @@
                     "configureChartOptions": "Configurer les options de graphique",
                     "configureWidgetOptions": "Configurer les options du widget",
                     "updateWidget": "Mettre à jour le widget",
-                    "addToTheMap": "Ajouter le widget à la carte"
+                    "addToTheMap": "Ajouter le widget à la carte",
                     "titlePlaceholder": "Entrez le titre...",
                     "textPlaceholder": "Entrez le texte..."
                 },

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1085,6 +1085,8 @@
                     "configureWidgetOptions": "Configurer les options du widget",
                     "updateWidget": "Mettre à jour le widget",
                     "addToTheMap": "Ajouter le widget à la carte"
+                    "titlePlaceholder": "Entrez le titre...",
+                    "textPlaceholder": "Entrez le texte..."
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Aucun widget disponible",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1081,7 +1081,9 @@
                     "configureChartOptions": "Configura le opzioni del grafico",
                     "configureWidgetOptions": "Configura le opzioni del widget",
                     "updateWidget": "Aggiorna il widget",
-                    "addToTheMap": "Aggiungi il widget alla mappa"
+                    "addToTheMap": "Aggiungi il widget alla mappa",
+                    "titlePlaceholder": "Inserisci il titolo...",
+                    "textPlaceholder": "Inserisci il testo..."
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Nessun widgets disponibile",


### PR DESCRIPTION
## Description
The 2nd page of the wizard for text widget contained title and description, but description was never used. Having a page with only 1 text input was ugly so I preferred to follow a little more the mockup using only one page to configure the text widget. 
The title is now in together with the WYSIWYG editor in the first and only page of wizard setup. 

![image](https://user-images.githubusercontent.com/1279510/36300264-d6f569a4-1300-11e8-9072-d52baaefda1f.png)

I also fixed the behaviour of re-edit a widget opening the page 1 (chart options) for charts and page 0 (the only one for text) for a better usability. 

## Issues
 - Fix #2592

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Text widget creation wizard had a description entry that was not used

**What is the new behavior?**
The description input is not present anymore. Every option of text widget configuration is in one page. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
