### PR TITLE
Fixed sidegrid css  for different screen resolutions

### DIFF
--- a/web/client/themes/default/less/sidegrid.less
+++ b/web/client/themes/default/less/sidegrid.less
@@ -135,7 +135,7 @@
 }
 
 .mapstore-side-card .mapstore-side-card-info {
-    width: 75%;
+    width: 72%;
     height: 104px;
     padding: 8px;
 }


### PR DESCRIPTION
## Description
The current sidegrid style has 75% for description, that is at limit on current usage. The compact catalog on some screens round 1px more and so you can't see the description anymore.
**NOTE**: This is a temp fix because sidegrid has also this issue: 
 
![image](https://user-images.githubusercontent.com/1279510/36305860-ae8600d6-1315-11e8-8293-4419809cf2b4.png)
but @allyoucanmap should fix this soon. 

## Issues
 - Fix #2593

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) - no tests for css
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
 - On some screens you couldn't see the catalog descriptions

**What is the new behavior?**
 - The descriptions are now visible on any screen

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
