### PR TITLE
MousePosition degrees template via plugin props

### DIFF
--- a/web/client/plugins/MousePosition.jsx
+++ b/web/client/plugins/MousePosition.jsx
@@ -64,11 +64,22 @@ const MousePositionButton = connect((state) => ({
 
 const MousePositionComponent = require('../components/mapcontrols/mouseposition/MousePosition');
 
-
 class MousePosition extends React.Component {
+
     render() {
+
+        const degreesTemplateComponent = ((degreesTemplateStr) => {
+            switch( degreesTemplateStr ) {
+              case "MousePositionLabelDD" : return require('../components/mapcontrols/mouseposition/MousePositionLabelDD');
+              case "MousePositionLabelDM" : return require('../components/mapcontrols/mouseposition/MousePositionLabelDM');
+              case "MousePositionLabelDMS" : return require('../components/mapcontrols/mouseposition/MousePositionLabelDMS');
+              case "MousePositionLabelDMSNW" : return require('../components/mapcontrols/mouseposition/MousePositionLabelDMSNW');
+              default: return require('../components/mapcontrols/mouseposition/MousePositionLabelDMS');
+            }
+        })(this.props.degreesTemplateStr);
+
         return (
-            <MousePositionComponent toggle={<MousePositionButton/>} {...this.props}/>
+            <MousePositionComponent toggle={<MousePositionButton/>} degreesTemplate={degreesTemplateComponent} {...this.props}/>
         );
     }
 }


### PR DESCRIPTION
## Description
Allow MousePosition degrees template to be selected via MousePosition plugin props

## Issues
 - None
 - Discussion: https://groups.google.com/forum/#!topic/mapstore-developers/buz2kpzo09I

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
The default for MousePosition plugin is to display coordinates in DMS format but I need DM.
It is not possible to configure the degreeTemplate from configuration but you can create your own MousPosition Plugin and pass your own template or one from the available ones.

**What is the new behavior?**
The MousePosition degreesTemplate can now be specified in localConfig.json:

    {
              "name": "MousePosition",
              "cfg": {
                "editCRS": true,
                "showLabels": true,
                "showToggle": true,
                "degreesTemplateStr": "MousePositionLabelDM",
                "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
                "additionalCRS": {}
    }

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Discussion: https://groups.google.com/forum/#!topic/mapstore-developers/buz2kpzo09I
