### PR TITLE
Fix Reproject Geometries drawsupport OL

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -771,7 +771,7 @@ class DrawSupport extends React.Component {
 
             const geojsonFormat = new ol.format.GeoJSON();
             let features = e.features.getArray().map((f) => {
-                return reprojectGeoJson(geojsonFormat.writeFeatureObject(f.clone()), this.props.map.getView().getProjection().getCode(), this.props.options.featureProjection);
+                return reprojectGeoJson(geojsonFormat.writeFeatureObject(f.clone()), this.props.map.getView().getProjection().getCode(), "EPSG:4326");
             });
 
             this.props.onGeometryChanged(features, this.props.drawOwner, false, "editing"); // TODO FIX THIS
@@ -790,7 +790,7 @@ class DrawSupport extends React.Component {
 
             const geojsonFormat = new ol.format.GeoJSON();
             let features = e.features.getArray().map((f) => {
-                return reprojectGeoJson(geojsonFormat.writeFeatureObject(f.clone()), this.props.map.getView().getProjection().getCode(), this.props.options.featureProjection);
+                return reprojectGeoJson(geojsonFormat.writeFeatureObject(f.clone()), this.props.map.getView().getProjection().getCode(), "EPSG:4326");
             });
 
             this.props.onGeometryChanged(features, this.props.drawOwner, this.props.drawOwner, false, this.props.drawMethod === "Text");

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -345,14 +345,14 @@ class DrawSupport extends React.Component {
             // this.drawLayer.getSource().getFeatures()[0].set("textValues", previousTexts.concat(["dsfgsdgsgs"]));
 
             const geojsonFormat = new ol.format.GeoJSON();
-            let newFeature = reprojectGeoJson(geojsonFormat.writeFeatureObject(this.sketchFeature.clone()), this.props.map.getView().getProjection().getCode(), this.props.options.featureProjection);
+            let newFeature = reprojectGeoJson(geojsonFormat.writeFeatureObject(this.sketchFeature.clone()), this.props.map.getView().getProjection().getCode(), "EPSG:4326");
             if (newFeature.geometry.type === "Polygon") {
                 newFeature.geometry.coordinates[0].push(newFeature.geometry.coordinates[0][0]);
             }
 
             this.props.onGeometryChanged([newFeature], this.props.drawOwner, this.props.options && this.props.options.stopAfterDrawing ? "enterEditMode" : "", drawMethod === "Text");
             this.props.onEndDrawing(feature, this.props.drawOwner);
-            feature = reprojectGeoJson(feature, this.props.map.getView().getProjection().getCode(), this.props.options.featureProjection);
+            feature = reprojectGeoJson(feature, this.props.map.getView().getProjection().getCode(), "EPSG:4326");
             let properties = this.props.features[0].properties;
             if (drawMethod === "Text") {
                 properties = assign({}, this.props.features[0].properties, {
@@ -367,7 +367,7 @@ class DrawSupport extends React.Component {
                 this.props.onChangeDrawingStatus('stop', this.props.drawMethod, this.props.drawOwner, newFeatures);
             } else {
                 this.props.onChangeDrawingStatus('replace', this.props.drawMethod, this.props.drawOwner,
-                    newFeatures.map((f) => reprojectGeoJson(f, this.props.options.featureProjection, this.props.map.getView().getProjection().getCode())),
+                    newFeatures.map((f) => reprojectGeoJson(f, "EPSG:4326", this.props.map.getView().getProjection().getCode())),
                     assign({}, this.props.options, { featureProjection: this.props.map.getView().getProjection().getCode()}));
             }
             if (this.selectInteraction) {

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -199,7 +199,7 @@ function annotations(state = { validationErrors: {} }, action) {
             });
         case UPDATE_ANNOTATION_GEOMETRY: {
             let stylerType;
-            let availableStyler = getAvailableStyler(convertGeoJSONToInternalModel(action.geometry, typeof action.textChanged !== "string" ? state.editing.properties.textValues || ["v"] : [] ));
+            let availableStyler = getAvailableStyler(convertGeoJSONToInternalModel(action.geometry, typeof action.textChanged === "boolean" && action.textChanged ? state.editing.properties.textValues || ["v"] : [] ));
             if (action.geometry.type === "GeometryCollection") {
                 stylerType = availableStyler.indexOf(state.stylerType) !== -1 ? state.stylerType : head(availableStyler);
             } else {


### PR DESCRIPTION
## Description
when drawing the second marker in the state were pushed a geometry in 3857 and not in 4326

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
drawing more points and exiting drawing state make disappear the geometry due to wrong crs used

**What is the new behavior?**
no longer disappears

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


for the future we should use the crs section of the geojson and not the option featureProjection