### PR TITLE
Fixes #2637: OpenLayers vector printing issues

### DIFF
--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -87,18 +87,20 @@ class MapPreview extends React.Component {
             })
         });
     };
-
-    renderLayerContent = (layer) => {
+    renderLayerContent = (layer, projection) => {
         if (layer.features && layer.type === "vector") {
             return layer.features.map( (feature) => {
                 return (
                     <Feature
+                        crs={projection}
                         key={feature.id}
                         type={feature.type}
                         geometry={feature.geometry}
                         msId={feature.id}
                         featuresCrs={ layer.featuresCrs || 'EPSG:4326' }
-                        style={ feature.style || layer.style || null }/>
+                        layerStyle={layer.style}
+                        style={ feature.style || layer.style || null }
+                        properties={feature.properties}/>
                 );
             });
         }
@@ -132,7 +134,7 @@ class MapPreview extends React.Component {
                 {this.props.layers.map((layer, index) =>
                     (<Layer key={layer.id || layer.name} position={index} type={layer.type}
                         options={assign({}, this.adjustResolution(layer), {srs: projection})}>
-                        {this.renderLayerContent(layer)}
+                        {this.renderLayerContent(layer, projection)}
                     </Layer>)
 
                 )}

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -326,8 +326,12 @@ const PrintUtils = {
             })
         }
     },
+    rgbaTorgb: (rgba = "") => {
+        return rgba.indexOf("rgba") !== -1 ? `rgb${rgba.slice(rgba.indexOf("("), rgba.lastIndexOf(","))})` : rgba;
+    },
     /**
      * Useful for print (Or generic Openlayers 2 conversion style)
+     * http://dev.openlayers.org/docs/files/OpenLayers/Feature/Vector-js.html#OpenLayers.Feature.Vector.OpenLayers.Feature.Vector.style
      */
     toOpenLayers2Style: function(layer, style) {
         if (!style) {
@@ -335,14 +339,14 @@ const PrintUtils = {
         }
         // commented the available options.
         return {
-            "fillColor": style.fillColor,
+            "fillColor": PrintUtils.rgbaTorgb(style.fillColor),
             "fillOpacity": style.fillOpacity,
              // "rotation": "30",
             "externalGraphic": style.iconUrl,
              // "graphicName": "circle",
              // "graphicOpacity": 0.4,
             "pointRadius": style.radius,
-            "strokeColor": style.color,
+            "strokeColor": PrintUtils.rgbaTorgb(style.fillColor),
             "strokeOpacity": style.opacity,
             "strokeWidth": style.weight
              // "strokeLinecap": "round",

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -190,4 +190,9 @@ describe('PrintUtils', () => {
         expect(printSpec.dpi).toBe(96);
         expect(printSpec.layers.length).toBe(1);
     });
+    it('from rgba to rgb', () => {
+        const rgb = PrintUtils.rgbaTorgb("rgba(255, 255, 255, 0.1)");
+        expect(rgb).toExist();
+        expect(rgb).toBe("rgb(255, 255, 255)");
+    });
 });


### PR DESCRIPTION
## Description
Fixed styling problem in print preview with ol map. Also fixed style for mapfish.

## Issues
 - Fix #2637
 - Fix geosolutions-it/austrocontrol-C125#30

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
With ol map, the print preview shows wrong styles for vector layer.
Mapfish crash due to unsupported style for vector layer

**What is the new behavior?**
Vector layer are correctly styled in print preview.
Mapfish doesn't crash.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
