### PR TITLE
Fix #2561. Add DETAILS to default categories

### DIFF
--- a/project/custom/templates/web/src/main/resources/sample_categories.xml
+++ b/project/custom/templates/web/src/main/resources/sample_categories.xml
@@ -6,4 +6,7 @@
     <Category>
         <name>THUMBNAIL</name>
     </Category>
+    <Category>
+        <name>DETAILS</name>
+    </Category>
 </CategoryList>

--- a/project/standard/templates/web/src/main/resources/sample_categories.xml
+++ b/project/standard/templates/web/src/main/resources/sample_categories.xml
@@ -6,4 +6,7 @@
     <Category>
         <name>THUMBNAIL</name>
     </Category>
+    <Category>
+        <name>DETAILS</name>
+    </Category>
 </CategoryList>

--- a/web/src/main/resources/sample_categories.xml
+++ b/web/src/main/resources/sample_categories.xml
@@ -6,4 +6,7 @@
     <Category>
         <name>THUMBNAIL</name>
     </Category>
+    <Category>
+        <name>DETAILS</name>
+    </Category>
 </CategoryList>


### PR DESCRIPTION
## Description
Add DETAILS to default categories

## Issues
 - Fix #2561

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)


 - [x] Other... Please describe: initial configuration


**What is the current behavior?** (You can also link to an open issue here)
Brand new MapStore doesn't have DETAILS category, so you can't save detail cards

**What is the new behavior?**
The DETAILS category is created on startup

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

