### PR TITLE
Fix #2722 add a regex for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ before_install:
 branches:
   only:
     - master
+    - /[cC]\d{2,3}\w*/
     - /^\d{4}\.\d{2}.\d{2}$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
 branches:
   only:
     - master
-    - /^[cC]\d{2,3}\w*/
+    - /^[cC]\d{3}[\w-]*/
     - /^\d{4}\.\d{2}.\d{2}$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
 branches:
   only:
     - master
-    - /[cC]\d{2,3}\w*/
+    - /^[cC]\d{2,3}\w*/
     - /^\d{4}\.\d{2}.\d{2}$/


### PR DESCRIPTION
## Description
Updated travis build configuration

## Issues
 - Fix #2722


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
now it does not start the build on project branches such as c125_annotations

**What is the new behavior?**
now it starts travis build on branches that matches the regex

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
