### PR TITLE
Fix #2642. Removed entry from counter widget menu

### DIFF
--- a/web/client/components/widgets/widget/CounterWidget.jsx
+++ b/web/client/components/widgets/widget/CounterWidget.jsx
@@ -51,7 +51,6 @@ module.exports = ({
         topRightItems={showTable
             ? null : <ButtonToolbar>
             <DropdownButton pullRight bsStyle="default" className="widget-menu" title={<Glyphicon glyph="option-vertical" />} noCaret id="dropdown-no-caret">
-                <MenuItem onClick={() => toggleTableView()} eventKey="1"><Glyphicon glyph="features-grid"/>&nbsp;<Message msgId="widgets.widget.menu.showChartData" /></MenuItem>
                 <MenuItem onClick={() => onEdit()} eventKey="3"><Glyphicon glyph="pencil"/>&nbsp;<Message msgId="widgets.widget.menu.edit" /></MenuItem>
                 <MenuItem onClick={() => toggleDeleteConfirm(true)} eventKey="2"><Glyphicon glyph="trash"/>&nbsp;<Message msgId="widgets.widget.menu.delete" /></MenuItem>
             </DropdownButton>

--- a/web/client/components/widgets/widget/__tests__/CounterWidget-test.jsx
+++ b/web/client/components/widgets/widget/__tests__/CounterWidget-test.jsx
@@ -52,7 +52,7 @@ describe('CounterWidget component', () => {
     it('Test CounterWidget DropdownMenu', () => {
         ReactDOM.render(<CounterWidget />, document.getElementById("container"));
         const container = document.getElementById('container');
-        const el = container.querySelectorAll('.dropdown-menu dropdown-menu-right li');
-        expect(el).toEqual(2);
+        const el = container.querySelectorAll('.dropdown-menu li');
+        expect(el.length).toEqual(2);
     });
 });

--- a/web/client/components/widgets/widget/__tests__/CounterWidget-test.jsx
+++ b/web/client/components/widgets/widget/__tests__/CounterWidget-test.jsx
@@ -49,4 +49,10 @@ describe('CounterWidget component', () => {
         ReactTestUtils.Simulate.click(el); // <-- trigger event callback
         expect(spyonEdit).toHaveBeenCalled();
     });
+    it('Test CounterWidget DropdownMenu', () => {
+        ReactDOM.render(<CounterWidget onEdit={actions.onEdit} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelectorAll('.dropdown-menu dropdown-menu-right li');
+        expect(el).toEqual(2);
+    });
 });

--- a/web/client/components/widgets/widget/__tests__/CounterWidget-test.jsx
+++ b/web/client/components/widgets/widget/__tests__/CounterWidget-test.jsx
@@ -50,7 +50,7 @@ describe('CounterWidget component', () => {
         expect(spyonEdit).toHaveBeenCalled();
     });
     it('Test CounterWidget DropdownMenu', () => {
-        ReactDOM.render(<CounterWidget onEdit={actions.onEdit} />, document.getElementById("container"));
+        ReactDOM.render(<CounterWidget />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('.dropdown-menu dropdown-menu-right li');
         expect(el).toEqual(2);


### PR DESCRIPTION
## Description
Fix the dropdown menufor the counter widget

## Issues
 - Fix #2642 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
dropdown menu presents three elements

**What is the new behavior?**
now menu presents two elements


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
