### PR TITLE
Fix #2725 Tooltips doesn't show up when fullscreen is enabled

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -8,7 +8,8 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const {ButtonGroup, Button, Glyphicon, Tooltip, OverlayTrigger} = require('react-bootstrap');
+const {ButtonGroup, Button, Glyphicon, Tooltip} = require('react-bootstrap');
+const OverlayTrigger = require('../misc/OverlayTrigger');
 const ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 const {head} = require('lodash');
 const ConfirmModal = require('../maps/modals/ConfirmModal');

--- a/web/client/components/TOC/fragments/StatusIcon.jsx
+++ b/web/client/components/TOC/fragments/StatusIcon.jsx
@@ -8,8 +8,9 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const {Glyphicon, OverlayTrigger, Tooltip} = require('react-bootstrap');
+const {Glyphicon, Tooltip} = require('react-bootstrap');
 const Message = require('../../I18N/Message');
+const OverlayTrigger = require('../../misc/OverlayTrigger');
 
 class StatusIcon extends React.Component {
     static propTypes = {

--- a/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/AttributeFilter.jsx
@@ -9,7 +9,8 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const LocaleUtils = require('../../../../utils/LocaleUtils');
-const {OverlayTrigger, Tooltip} = require('react-bootstrap');
+const {Tooltip} = require('react-bootstrap');
+const OverlayTrigger = require('../../../misc/OverlayTrigger');
 
 class AttributeFilter extends React.PureComponent {
     static propTypes = {

--- a/web/client/components/data/featuregrid/toolbars/TButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TButton.jsx
@@ -1,5 +1,6 @@
 const React = require('react');
-const {Button, Glyphicon, Tooltip, OverlayTrigger} = require('react-bootstrap');
+const {Button, Glyphicon, Tooltip} = require('react-bootstrap');
+const OverlayTrigger = require('../../../misc/OverlayTrigger');
 const hideStyle = {
     width: 0,
     padding: 0,

--- a/web/client/components/misc/enhancers/tooltip.jsx
+++ b/web/client/components/misc/enhancers/tooltip.jsx
@@ -7,7 +7,8 @@
   */
 const React = require('react');
 const {branch} = require('recompose');
-const { Tooltip, OverlayTrigger} = require('react-bootstrap');
+const { Tooltip } = require('react-bootstrap');
+const OverlayTrigger = require('../OverlayTrigger');
 const Message = require('../../I18N/Message');
 
 /**

--- a/web/client/components/widgets/widget/InfoPopover.jsx
+++ b/web/client/components/widgets/widget/InfoPopover.jsx
@@ -10,9 +10,10 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const {
     Popover,
-    OverlayTrigger,
     Glyphicon
 } = require('react-bootstrap');
+
+const OverlayTrigger = require('../../misc/OverlayTrigger');
 
 class InfoPopover extends React.Component {
 

--- a/web/client/plugins/featuregrid/gridTools.jsx
+++ b/web/client/plugins/featuregrid/gridTools.jsx
@@ -2,7 +2,9 @@ const React = require('react');
 const bbox = require('@turf/bbox');
 const {zoomToExtent} = require('../../actions/map');
 const Message = require('../../components/I18N/Message');
-const {Glyphicon, OverlayTrigger, Tooltip} = require('react-bootstrap');
+const {Glyphicon, Tooltip} = require('react-bootstrap');
+const OverlayTrigger = require('../../components/misc/OverlayTrigger');
+
 module.exports = [{
         name: '',
         key: "geometry",


### PR DESCRIPTION
## Description
Replaced OverlayTrigger of react bootstrap with the custom one from misc folder to display tooltips on fullscreen.

## Issues
 - Fix #2725

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Tooltips doesn't show up on fullscreen

**What is the new behavior?**
Tooltips shows up on fullscreen

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
