### PR TITLE
Temp Fix for #2736. Disable Tutorial for IE

### DIFF
--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -122,6 +122,7 @@ const Tutorial = connect(tutorialPluginSelector, (dispatch) => {
 
 module.exports = {
     TutorialPlugin: assign(Tutorial, {
+        disablePluginIf: "{state('browser') && (state('browser').ie || state('browser').ie11)}",
         BurgerMenu: {
             name: 'tutorial',
             position: 1000,


### PR DESCRIPTION
## Description
This disabled tutorial for IE users
## Issues
 - Fix #2736

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: generic configuration of plugins


**What is the current behavior?** (You can also link to an open issue here)
see #2736

**What is the new behavior?**
The tutorial is not present for IE users

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

