### PR TITLE
fix #2602

### DIFF
--- a/web/client/components/misc/__tests__/Dialog-test.jsx
+++ b/web/client/components/misc/__tests__/Dialog-test.jsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Dialog = require('../Dialog');
+
+describe("Dialog component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done ) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('Dialog loading process for local vector', () => {
+        ReactDOM.render(<Dialog id={"mapstore-shapefile-upload"} />, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const loader = container.querySelector('.sk-circle-wrapper .sk-fade-in');
+        expect(loader).toExist();
+    });
+});

--- a/web/client/components/misc/style/dialog.css
+++ b/web/client/components/misc/style/dialog.css
@@ -1,3 +1,23 @@
 .modal-dialog-container{
     box-shadow: 0 0 5px 1px rgba(94,94,94,1);
 }
+@keyframes sk-fade-in {
+    0%{
+        opacity: 1;
+    }
+}
+@-webkit-keyframes sk-fade-in {
+    0%{
+        opacity: 1;
+    }
+}
+@-moz-keyframes sk-fade-in {
+    0%{
+        opacity: 1;
+    }
+}
+@-ms-keyframes sk-fade-in {
+    0%{
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
## Description
Correct the opacity of the loader of the dialog box to display it on loading

## Issues
 - Fix #2602 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
While uploading local vector loader doesn't appear

**What is the new behavior?**
Loader appear inside the dialog box while uploading local vector

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

