### PR TITLE
fix#2602 loader spinner on import local file

### DIFF
--- a/web/client/components/shapefile/SelectShape.jsx
+++ b/web/client/components/shapefile/SelectShape.jsx
@@ -40,7 +40,7 @@ class SelectShape extends React.Component {
 
     render() {
         return (
-            this.props.loading ? <div className="btn btn-info" style={{"float": "center"}}> <Spinner spinnerName="circle" overrideSpinnerClassName="spinner"/></div> :
+            this.props.loading ? <div className="btn btn-info" style={{"float": "center"}}> <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/></div> :
             <Dropzone rejectClassName="alert-danger" className="alert alert-info" onDrop={this.checkfile}>
               <div className="dropzone-content" style={{textAlign: "center"}}>{this.props.text}</div>
             </Dropzone>

--- a/web/client/components/shapefile/__tests__/SelectShape-test.jsx
+++ b/web/client/components/shapefile/__tests__/SelectShape-test.jsx
@@ -142,4 +142,12 @@ describe("Test the select shapefile component", () => {
         }];
         TestUtils.Simulate.drop(content, { dataTransfer: { files } });
     });
+
+    it('upload local vector, show loader', () => {
+        const cmp = ReactDOM.render(<SelectShape loading />, document.getElementById("container"));
+        expect(cmp).toExist();
+        const spinner = document.querySelector('.spinner');
+        /* check class sk-fade-in not present to ensure loader is not fade and correctly shown */
+        expect(spinner.className.indexOf('sk-fade-in')).toBe(-1);
+    });
 });


### PR DESCRIPTION
## Description
Show the loader while uploading local vector file

## Issues
 - Fix #2602 loading spinner on import local file

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
While uploading local vector loader doesn't appear

**What is the new behavior?**
Loader appear inside the dialog box while uploading local vector

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

