### PR TITLE
Fix translate interactions on openlayers and other issues on 2709

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -543,7 +543,7 @@ class DrawSupport extends React.Component {
             this.translateInteraction.on('translateend', this.updateFeatureExtent);
             this.props.map.addInteraction(this.translateInteraction);
 
-
+            this.addTranslateListener();
             if (this.modifyInteraction) {
                 this.props.map.removeInteraction(this.modifyInteraction);
             }
@@ -851,7 +851,7 @@ class DrawSupport extends React.Component {
 
             this.props.onGeometryChanged(features, this.props.drawOwner, this.props.drawOwner, false, this.props.drawMethod === "Text", this.props.drawMethod === "Circle");
         });
-        this.addTranlateListener();
+        this.addTranslateListener();
         this.props.map.addInteraction(this.translateInteraction);
     }
 
@@ -962,7 +962,7 @@ class DrawSupport extends React.Component {
         });
     }
 
-    addTranlateListener = () => {
+    addTranslateListener = () => {
         document.addEventListener("keydown", (event) => {
             if (event.altKey && event.code === "AltLeft") {
                 this.translateInteraction.setActive(true);

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -715,7 +715,7 @@ describe('Test DrawSupport', () => {
             <DrawSupport features={[feature]} map={fakeMap} drawStatus="drawOrEdit" drawMethod="Polygon" options={{
                     drawEnabled: false, editEnabled: true}}
                 />, document.getElementById("container"));
-        expect(support.translateInteraction).toNotExist();
+        expect(support.translateInteraction).toExist();
     });
 
     it('end drawing', () => {
@@ -1439,7 +1439,7 @@ describe('Test DrawSupport', () => {
                 }}
                 />, document.getElementById("container"));
         expect(spyAddLayer.calls.length).toBe(1);
-        expect(spyAddInteraction.calls.length).toBe(2);
+        expect(spyAddInteraction.calls.length).toBe(3);
     });
 
     it('draw or edit, endevent', () => {

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -195,7 +195,7 @@ class AnnotationsEditor extends React.Component {
                         <Toolbar
                             btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary'}}
                             buttons={[ {
-                                glyph: 'back',
+                                glyph: 'arrow-left',
                                 tooltipId: "annotations.back",
                                 visible: this.props.showBack,
                                 onClick: () => {this.props.onCancel(); this.props.onCleanHighlight(); }
@@ -236,7 +236,7 @@ class AnnotationsEditor extends React.Component {
                     <Toolbar
                         btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary'}}
                         buttons={[ {
-                            glyph: 'back',
+                            glyph: 'arrow-left',
                             tooltipId: "annotations.back",
                             visible: true,
                             onClick: () => {

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -305,6 +305,7 @@ function annotations(state = { validationErrors: {} }, action) {
                     styling: false,
                     drawing: false,
                     filter: null,
+                    editedFields: {},
                     originalStyle: null
                 });
             }

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -271,10 +271,11 @@
                     display: flex;
                     flex-direction: column;
 
-                    #ms-ann-description-editor {
+                    .mapstore-annotations-info-viewer-description {
                         flex: 1;
                         display: flex;
                         .quill  {
+                            overflow: -webkit-paged-y;
                             flex: 1;
                             display: flex;
                             flex-direction: column;
@@ -287,6 +288,11 @@
                 }
             }
         }
+    }
+}
+.mapstore-annotations-info-viewer-item.mapstore-annotations-info-viewer-description {
+    .quill {
+        overflow: -webkit-paged-y;
     }
 }
 

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -271,11 +271,10 @@
                     display: flex;
                     flex-direction: column;
 
-                    .mapstore-annotations-info-viewer-description {
+                    #ms-ann-description-editor {
                         flex: 1;
                         display: flex;
                         .quill  {
-                            overflow: -webkit-paged-y;
                             flex: 1;
                             display: flex;
                             flex-direction: column;


### PR DESCRIPTION
## Description
- When in editing you can translate the features if you press  the left ALT button on the keyboard (left one).
- style on editor are fixed
- now shows correctly the title after deleting it and closing the annotations panel

by default translate interaction is disabled

## Issues
 - Fix [#33](https://github.com/geosolutions-it/austrocontrol-C125/issues/33)
- Fixed also the comments on [2709](https://github.com/geosolutions-it/MapStore2/issues/2709)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Now you cannot translate features only pressing ALT button

**What is the new behavior?**
Now you can translate features only pressing ALT button

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
