### PR TITLE
Fixes #2021: Limit list of srs saved in layers from catalog to the ones supported by the current mapstore2 instance

### DIFF
--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -216,7 +216,7 @@ const converters = {
     }
 };
 const buildSRSMap = (srs) => {
-    return srs.reduce((previous, current) => {
+    return srs.filter(s => CoordinatesUtils.isSRSAllowed(s)).reduce((previous, current) => {
         return assign(previous, {[current]: true});
     }, {});
 };

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -675,6 +675,9 @@ const CoordinatesUtils = {
             parseFloat(b.$.maxy)
         ], SRS, 'EPSG:4326')));
         return isArray(bbox) && {minx: bbox[0], miny: bbox[1], maxx: bbox[2], maxy: bbox[3]} || null;
+    },
+    isSRSAllowed: (srs) => {
+        return !!Proj4js.defs(srs);
     }
 };
 

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -41,6 +41,19 @@ describe('Test the CatalogUtils', () => {
         expect(records[0].dimensions[0].values.length).toBe(2);
     });
 
+    it('wms limited srs', () => {
+        const records = CatalogUtils.getCatalogRecords('wms', {
+            records: [{
+                SRS: ['EPSG:4326', 'EPSG:3857', 'EPSG:5041']
+            }]
+        }, { url: 'http://sample' });
+        expect(records.length).toBe(1);
+        const layer = CatalogUtils.recordToLayer(records[0]);
+        expect(layer.allowedSRS['EPSG:4326']).toBe(true);
+        expect(layer.allowedSRS['EPSG:3857']).toBe(true);
+        expect(layer.allowedSRS['EPSG:5041']).toNotExist();
+    });
+
     it('wmts', () => {
         const records = CatalogUtils.getCatalogRecords('wmts', {
             records: [{}]


### PR DESCRIPTION
## Description
Limit list of srs saved in layers from catalog to the on es supported by the current mapstore2 instance

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
The complete list of SRS codes supported by a WMS service is saved with any layer coming from that service.

**What is the new behavior?**
The list of SRS codes supported by a WMS service is filtered by the list of proj4 available codes (usually only EPSG:4326,  EPSG:3857 and a bunch of other ones).

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
