### PR TITLE
Fixes #1506 OpenLayers and Leaflet vector different default styles 

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "rxjs": "5.1.1",
     "screenfull": "3.1.0",
     "shpjs": "3.4.2",
+    "tinycolor2": "1.4.1",
     "turf-bbox": "3.0.10",
     "turf-buffer": "3.0.10",
     "turf-intersect": "3.0.10",

--- a/web/client/actions/__tests__/search-test.js
+++ b/web/client/actions/__tests__/search-test.js
@@ -15,13 +15,15 @@ var {
     TEXT_SEARCH_ITEM_SELECTED,
     TEXT_SEARCH_NESTED_SERVICES_SELECTED,
     TEXT_SEARCH_CANCEL_ITEM,
+    UPDATE_RESULTS_STYLE,
     searchResultLoaded,
     searchTextLoading,
     searchResultError,
     textSearch,
     selectSearchItem,
     selectNestedService,
-    cancelSelectedItem
+    cancelSelectedItem,
+    updateResultsStyle
 } = require('../search');
 
 describe('Test correctness of the search actions', () => {
@@ -56,11 +58,12 @@ describe('Test correctness of the search actions', () => {
         expect(retval2.append).toBe(true);
     });
     it('serch item selected', () => {
-        const retval = selectSearchItem("A", "B");
+        const retval = selectSearchItem("A", "B", {color: '#ff0000'});
         expect(retval).toExist();
         expect(retval.type).toBe(TEXT_SEARCH_ITEM_SELECTED);
         expect(retval.item).toEqual("A");
         expect(retval.mapConfig).toBe("B");
+        expect(retval.resultsStyle).toEqual({color: '#ff0000'});
     });
     it('serch item cancelled', () => {
         const retval = cancelSelectedItem("ITEM");
@@ -77,6 +80,11 @@ describe('Test correctness of the search actions', () => {
         expect(retval.items).toEqual(items);
         expect(retval.services).toEqual(services);
     });
-
-
+    it('update results style', () => {
+        const style = {color: '#ff0000'};
+        const retval = updateResultsStyle(style);
+        expect(retval).toExist();
+        expect(retval.type).toBe(UPDATE_RESULTS_STYLE);
+        expect(retval.style).toEqual({color: '#ff0000'});
+    });
 });

--- a/web/client/actions/search.js
+++ b/web/client/actions/search.js
@@ -18,6 +18,8 @@ const TEXT_SEARCH_ERROR = 'TEXT_SEARCH_ERROR';
 const TEXT_SEARCH_CANCEL_ITEM = 'TEXT_SEARCH_CANCEL_ITEM';
 const TEXT_SEARCH_ITEM_SELECTED = 'TEXT_SEARCH_ITEM_SELECTED';
 const TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE = 'TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE';
+const UPDATE_RESULTS_STYLE = 'UPDATE_RESULTS_STYLE';
+
 /**
  * updates the results of the search result loaded
  * @memberof actions.search
@@ -120,12 +122,14 @@ function textSearch(searchText, {services = null} = {}) {
  * @memberof actions.search
  * @param {object} item the selected item
  * @param {object} mapConfig the current map configuration (with size, projection...)
+ * @param {object} resultsStyle style to apply to results geometries
  */
-function selectSearchItem(item, mapConfig) {
+function selectSearchItem(item, mapConfig, resultsStyle) {
     return {
         type: TEXT_SEARCH_ITEM_SELECTED,
         item,
-        mapConfig
+        mapConfig,
+        resultsStyle
     };
 
 }
@@ -172,6 +176,18 @@ function setHighlightedFeature(feature) {
 }
 
 /**
+ * Change default style of results geometries
+ * @memberof actions.search
+ * @param {object} style style of results geometries
+ */
+function updateResultsStyle(style) {
+    return {
+        type: UPDATE_RESULTS_STYLE,
+        style
+    };
+}
+
+/**
  * Actions for search
  * @name actions.search
  */
@@ -189,6 +205,7 @@ module.exports = {
     TEXT_SEARCH_NESTED_SERVICES_SELECTED,
     TEXT_SEARCH_CANCEL_ITEM,
     TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE,
+    UPDATE_RESULTS_STYLE,
     searchTextLoading,
     searchResultError,
     searchResultLoaded,
@@ -200,5 +217,6 @@ module.exports = {
     selectNestedService,
     selectSearchItem,
     cancelSelectedItem,
-    setHighlightedFeature
+    setHighlightedFeature,
+    updateResultsStyle
 };

--- a/web/client/components/map/leaflet/Feature.jsx
+++ b/web/client/components/map/leaflet/Feature.jsx
@@ -53,6 +53,8 @@ const geometryToLayer = function(geojson, options) {
     if (!coords && !geometry) {
         return null;
     }
+
+    const style = options.style && options.style[geometry.type] || options.style;
     let layer;
     switch (geometry.type) {
     case 'Point':
@@ -71,13 +73,13 @@ const geometryToLayer = function(geojson, options) {
 
     case 'LineString':
         latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, coordsToLatLng);
-        layer = new L.Polyline(latlngs, options.style && options.style.LineString || options.style);
+        layer = new L.Polyline(latlngs, style);
         layer.msId = geojson.id;
         return layer;
     case 'MultiLineString':
         latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, coordsToLatLng);
         for (i = 0, len = latlngs.length; i < len; i++) {
-            layer = new L.Polyline(latlngs[i], options.style && options.style.MultiLineString || options.style);
+            layer = new L.Polyline(latlngs[i], style);
             layer.msId = geojson.id;
             if (layer) {
                 layers.push(layer);
@@ -86,13 +88,13 @@ const geometryToLayer = function(geojson, options) {
         return new L.FeatureGroup(layers);
     case 'Polygon':
         latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, coordsToLatLng);
-        layer = new L.Polygon(latlngs, options.style && options.style.Polygon || options.style);
+        layer = new L.Polygon(latlngs, style);
         layer.msId = geojson.id;
         return layer;
     case 'MultiPolygon':
         latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, coordsToLatLng);
         for (i = 0, len = latlngs.length; i < len; i++) {
-            layer = new L.Polygon(latlngs[i], options.style && options.style.MultiPolygon || options.style);
+            layer = new L.Polygon(latlngs[i], style);
             layer.msId = geojson.id;
             if (layer) {
                 layers.push(layer);

--- a/web/client/components/map/leaflet/Feature.jsx
+++ b/web/client/components/map/leaflet/Feature.jsx
@@ -71,13 +71,13 @@ const geometryToLayer = function(geojson, options) {
 
     case 'LineString':
         latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, coordsToLatLng);
-        layer = new L.Polyline(latlngs, options.style);
+        layer = new L.Polyline(latlngs, options.style && options.style.LineString || options.style);
         layer.msId = geojson.id;
         return layer;
     case 'MultiLineString':
         latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, coordsToLatLng);
         for (i = 0, len = latlngs.length; i < len; i++) {
-            layer = new L.Polyline(latlngs[i], options.style);
+            layer = new L.Polyline(latlngs[i], options.style && options.style.MultiLineString || options.style);
             layer.msId = geojson.id;
             if (layer) {
                 layers.push(layer);
@@ -86,13 +86,13 @@ const geometryToLayer = function(geojson, options) {
         return new L.FeatureGroup(layers);
     case 'Polygon':
         latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, coordsToLatLng);
-        layer = new L.Polygon(latlngs, options.style);
+        layer = new L.Polygon(latlngs, options.style && options.style.Polygon || options.style);
         layer.msId = geojson.id;
         return layer;
     case 'MultiPolygon':
         latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, coordsToLatLng);
         for (i = 0, len = latlngs.length; i < len; i++) {
-            layer = new L.Polygon(latlngs[i], options.style);
+            layer = new L.Polygon(latlngs[i], options.style && options.style.MultiPolygon || options.style);
             layer.msId = geojson.id;
             if (layer) {
                 layers.push(layer);

--- a/web/client/components/map/leaflet/__tests__/Feature-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Feature-test.jsx
@@ -1,0 +1,265 @@
+/**
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Feature = require('../Feature');
+const expect = require('expect');
+
+const container = {
+    addLayer: () => {},
+    removeLayer: () => {}
+};
+
+describe('leaflet Feature component', () => {
+
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('test LineString style', () => {
+        const geometry = {
+            type: 'LineString',
+            coordinates: [
+                [100.0, 0.0], [101.0, 1.0]
+            ]
+        };
+        const type = 'Feature';
+        let lineString = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(lineString._layer).toExist();
+        expect({...lineString._layer.options}).toEqual({});
+
+        const style = {
+            color: '#3388ff',
+            weight: 4
+        };
+
+        lineString = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={style}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(lineString._layer).toExist();
+        expect({...lineString._layer.options}).toEqual(style);
+
+        const styleWithFeatureType = {
+            color: '#3388ff',
+            weight: 4,
+            LineString: {
+                color: '#ffaa33',
+                weight: 10
+            }
+        };
+
+        lineString = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={styleWithFeatureType}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(lineString._layer).toExist();
+        expect({...lineString._layer.options}).toEqual(styleWithFeatureType.LineString);
+    });
+
+
+    it('test MultiLineString style', () => {
+        const geometry = {
+            type: 'MultiLineString',
+            coordinates: [
+                [ [100.0, 0.0], [101.0, 1.0] ],
+                [ [102.0, 2.0], [103.0, 3.0] ]
+            ]
+        };
+        const type = 'Feature';
+        let multiLineString = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(multiLineString._layer).toExist();
+
+        let layersKeys = Object.keys(multiLineString._layer._layers);
+        let firstLayer = multiLineString._layer._layers[layersKeys[0]];
+        expect({...firstLayer.options}).toEqual({});
+
+        const style = {
+            color: '#3388ff',
+            weight: 4
+        };
+
+        multiLineString = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={style}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(multiLineString._layer).toExist();
+
+        layersKeys = Object.keys(multiLineString._layer._layers);
+        firstLayer = multiLineString._layer._layers[layersKeys[0]];
+        expect({...firstLayer.options}).toEqual(style);
+
+        const styleWithFeatureType = {
+            color: '#3388ff',
+            weight: 4,
+            MultiLineString: {
+                color: '#ffaa33',
+                weight: 10
+            }
+        };
+
+        multiLineString = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={styleWithFeatureType}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(multiLineString._layer).toExist();
+
+        layersKeys = Object.keys(multiLineString._layer._layers);
+        firstLayer = multiLineString._layer._layers[layersKeys[0]];
+        expect({...firstLayer.options}).toEqual(styleWithFeatureType.MultiLineString);
+    });
+
+    it('test Polygon style', () => {
+        const geometry = {
+            type: 'Polygon',
+            coordinates: [
+                [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
+            ]
+        };
+
+        const type = 'Feature';
+        let polygon = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(polygon._layer).toExist();
+        expect({...polygon._layer.options}).toEqual({});
+
+        const style = {
+            color: '#3388ff',
+            weight: 4,
+            dashArray: '',
+            fillColor: 'rgba(51, 136, 255, 0.2)'
+        };
+
+        polygon = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={style}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(polygon._layer).toExist();
+        expect({...polygon._layer.options}).toEqual(style);
+
+        const styleWithFeatureType = {
+            color: '#3388ff',
+            weight: 4,
+            dashArray: '',
+            fillColor: 'rgba(51, 136, 255, 0.2)',
+            Polygon: {
+                color: '#ffaa33',
+                weight: 10,
+                dashArray: '10 5',
+                fillColor: '#333333'
+            }
+        };
+
+        polygon = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={styleWithFeatureType}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(polygon._layer).toExist();
+        expect({...polygon._layer.options}).toEqual(styleWithFeatureType.Polygon);
+    });
+
+    it('test MultiPolygon style', () => {
+        const geometry = {
+            type: 'MultiPolygon',
+            coordinates: [
+                [
+                    [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0] ]
+                ],
+                [
+                    [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
+                    [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
+                ]
+            ]
+        };
+
+        const type = 'Feature';
+        let multiPolygon = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(multiPolygon._layer).toExist();
+
+        let layersKeys = Object.keys(multiPolygon._layer._layers);
+        let firstLayer = multiPolygon._layer._layers[layersKeys[0]];
+        expect({...firstLayer.options}).toEqual({});
+
+        const style = {
+            color: '#3388ff',
+            weight: 4,
+            dashArray: '',
+            fillColor: 'rgba(51, 136, 255, 0.2)'
+        };
+
+        multiPolygon = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={style}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        expect(multiPolygon._layer).toExist();
+
+        layersKeys = Object.keys(multiPolygon._layer._layers);
+        firstLayer = multiPolygon._layer._layers[layersKeys[0]];
+        expect({...firstLayer.options}).toEqual(style);
+
+        const styleWithFeatureType = {
+            color: '#3388ff',
+            weight: 4,
+            dashArray: '',
+            fillColor: 'rgba(51, 136, 255, 0.2)',
+            MultiPolygon: {
+                color: '#ffaa33',
+                weight: 10,
+                dashArray: '10 5',
+                fillColor: '#333333'
+            }
+        };
+
+        multiPolygon = ReactDOM.render(<Feature
+            type={type}
+            container={container}
+            style={styleWithFeatureType}
+            geometry={geometry}/>, document.getElementById("container"));
+
+        layersKeys = Object.keys(multiPolygon._layer._layers);
+        firstLayer = multiPolygon._layer._layers[layersKeys[0]];
+        expect({...firstLayer.options}).toEqual(styleWithFeatureType.MultiPolygon);
+    });
+});

--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -3,6 +3,7 @@ var markerShadow = require('./img/marker-shadow.png');
 var ol = require('openlayers');
 
 const assign = require('object-assign');
+const {trim, isString} = require('lodash');
 
 const image = new ol.style.Circle({
   radius: 5,
@@ -12,61 +13,71 @@ const image = new ol.style.Circle({
 
 const Icons = require('../../../utils/openlayers/Icons');
 
+
+const strokeStyle = (options, defaultsStyle = {color: 'blue', width: 3, lineDash: [4]}) => ({
+    stroke: new ol.style.Stroke(
+        options.style ?
+        options.style.stroke || {
+            color: options.style.color || defaultsStyle.color,
+            lineDash: isString(options.style.dashArray) && trim(options.style.dashArray).split(' ') || defaultsStyle.lineDash,
+            width: options.style.weight || defaultsStyle.width,
+            lineCap: options.style.lineCap || 'round',
+            lineJoin: options.style.lineJoin || 'round',
+            lineDashOffset: options.style.dashOffset || 0
+        }
+        :
+        {...defaultsStyle}
+    )
+});
+
+const fillStyle = (options, defaultsStyle = {color: 'rgba(0, 0, 255, 0.1)'}) => ({
+    fill: new ol.style.Fill(
+        options.style ?
+        options.style.fill || {
+            color: options.style.fillColor || defaultsStyle.color
+        }
+        :
+        {...defaultsStyle}
+    )
+});
+
 const defaultStyles = {
-  'Point': () => [new ol.style.Style({
-      image: image
-  })],
-  'LineString': () => [new ol.style.Style({
-    stroke: new ol.style.Stroke({
-      color: 'green',
-      width: 1
-    })
-  })],
-  'MultiLineString': () => [new ol.style.Style({
-    stroke: new ol.style.Stroke({
-      color: 'green',
-      width: 1
-    })
-  })],
-  'MultiPoint': () => [new ol.style.Style({
-    image: image
-  })],
-  'MultiPolygon': () => [new ol.style.Style({
-    stroke: new ol.style.Stroke({
-        color: 'blue',
-        lineDash: [4],
-        width: 3
-    }),
-    fill: new ol.style.Fill({
-      color: 'rgba(0, 0, 255, 0.1)'
-    })
-  })],
-  'Polygon': () => [new ol.style.Style({
-    stroke: new ol.style.Stroke({
-      color: 'blue',
-      lineDash: [4],
-      width: 3
-    }),
-    fill: new ol.style.Fill({
-      color: 'rgba(0, 0, 255, 0.1)'
-    })
-  })],
-  'GeometryCollection': () => [new ol.style.Style({
-    stroke: new ol.style.Stroke({
-      color: 'magenta',
-      width: 2
-    }),
-    fill: new ol.style.Fill({
-      color: 'magenta'
-    }),
-    image: new ol.style.Circle({
-      radius: 10,
-      fill: null,
+    'Point': () => [new ol.style.Style({
+        image: image
+    })],
+    'LineString': options => [new ol.style.Style(assign({},
+        strokeStyle(options, {color: 'green', width: 1})
+    ))],
+    'MultiLineString': options => [new ol.style.Style(assign({},
+        strokeStyle(options, {color: 'green', width: 1})
+    ))],
+    'MultiPoint': () => [new ol.style.Style({
+        image: image
+    })],
+    'MultiPolygon': options => [new ol.style.Style(assign({},
+        strokeStyle(options),
+        fillStyle(options)
+    ))],
+    'Polygon': options => [new ol.style.Style(assign({},
+        strokeStyle(options),
+        fillStyle(options)
+    ))],
+    'GeometryCollection': () => [new ol.style.Style({
       stroke: new ol.style.Stroke({
+        color: 'magenta',
+        width: 2
+      }),
+      fill: new ol.style.Fill({
         color: 'magenta'
+      }),
+      image: new ol.style.Circle({
+        radius: 10,
+        fill: null,
+        stroke: new ol.style.Stroke({
+          color: 'magenta'
+        })
       })
-    })
-  })],
+    })],
   'Circle': () => [new ol.style.Style({
     stroke: new ol.style.Stroke({
       color: 'red',
@@ -100,8 +111,9 @@ const defaultStyles = {
     })]
 };
 
-var styleFunction = function(feature, options) {
-    return defaultStyles[feature.getGeometry().getType()](options);
+const styleFunction = function(feature, options) {
+    const type = feature.getGeometry().getType();
+    return defaultStyles[type](options && options.style && options.style[type] && {style: {...options.style[type]}} || options || {});
 };
 
 function getMarkerStyle(options) {
@@ -147,7 +159,7 @@ function getStyle(options) {
                     case "MultiPoint":
                         return markerStyle;
                     default:
-                        return styleFunction(feature);
+                        return styleFunction(feature, options);
                 }
             };
         } else {

--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -5,6 +5,8 @@ var ol = require('openlayers');
 const assign = require('object-assign');
 const {trim, isString} = require('lodash');
 
+const {colorToRgbaStr} = require('../../../utils/ColorUtils');
+
 const image = new ol.style.Circle({
   radius: 5,
   fill: null,
@@ -34,7 +36,7 @@ const fillStyle = (options, defaultsStyle = {color: 'rgba(0, 0, 255, 0.1)'}) => 
     fill: new ol.style.Fill(
         options.style ?
         options.style.fill || {
-            color: options.style.fillColor || defaultsStyle.color
+            color: colorToRgbaStr(options.style.fillColor, options.style.fillOpacity) || defaultsStyle.color
         }
         :
         {...defaultsStyle}

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -188,7 +188,8 @@ describe('Test VectorStyle', () => {
                 color: '#3388ff',
                 weight: 4,
                 dashArray: '',
-                fillColor: 'rgba(51, 136, 255, 0.2)'
+                fillColor: 'rgb(51, 136, 255)',
+                fillOpacity: 0.2
             }
         };
 
@@ -206,7 +207,8 @@ describe('Test VectorStyle', () => {
                 color: '#3388ff',
                 weight: 4,
                 dashArray: '',
-                fillColor: 'rgba(51, 136, 255, 0.2)',
+                fillColor: '#3388ff',
+                fillOpacity: 0.2,
                 Polygon: {
                     color: '#ffaa33',
                     weight: 10,
@@ -220,7 +222,7 @@ describe('Test VectorStyle', () => {
         olFill = olStyle[0].getFill();
         olStroke = olStyle[0].getStroke();
 
-        expect(olFill.getColor()).toBe('#333333');
+        expect(olFill.getColor()).toBe('rgb(51, 51, 51)');
         expect(olStroke.getColor()).toBe('#ffaa33');
         expect(olStroke.getWidth()).toBe(10);
         expect(olStroke.getLineDash()).toEqual(['10', '5']);
@@ -255,7 +257,8 @@ describe('Test VectorStyle', () => {
                 color: '#3388ff',
                 weight: 4,
                 dashArray: '',
-                fillColor: 'rgba(51, 136, 255, 0.2)'
+                fillColor: '#3388ff',
+                fillOpacity: 0.2
             }
         };
 
@@ -273,7 +276,8 @@ describe('Test VectorStyle', () => {
                 color: '#3388ff',
                 weight: 4,
                 dashArray: '',
-                fillColor: 'rgba(51, 136, 255, 0.2)',
+                fillColor: '#3388ff',
+                fillOpacity: 0.2,
                 MultiPolygon: {
                     color: '#ffaa33',
                     weight: 10,
@@ -287,7 +291,7 @@ describe('Test VectorStyle', () => {
         olFill = olStyle[0].getFill();
         olStroke = olStyle[0].getStroke();
 
-        expect(olFill.getColor()).toBe('#333333');
+        expect(olFill.getColor()).toBe('rgb(51, 51, 51)');
         expect(olStroke.getColor()).toBe('#ffaa33');
         expect(olStroke.getWidth()).toBe(10);
         expect(olStroke.getLineDash()).toEqual(['10', '5']);

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -71,4 +71,227 @@ describe('Test VectorStyle', () => {
         expect(style).toExist();
         expect(style.getImage()).toExist();
     });
+
+
+    it('test styleFunction with LineString', () => {
+
+        const lineString = new ol.Feature({
+            geometry: new ol.geom.LineString([
+                [100.0, 0.0], [101.0, 1.0]
+            ])
+        });
+
+        let olStyle = VectorStyle.styleFunction(lineString);
+        let olStroke = olStyle[0].getStroke();
+
+        expect(olStroke.getColor()).toBe('green');
+        expect(olStroke.getWidth()).toBe(1);
+
+        const options = {
+            style: {
+                color: '#3388ff',
+                weight: 4
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(lineString, options);
+        olStroke = olStyle[0].getStroke();
+
+        expect(olStroke.getColor()).toBe('#3388ff');
+        expect(olStroke.getWidth()).toBe(4);
+
+        const optionsWithFeatureType = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                LineString: {
+                    color: '#ffaa33',
+                    weight: 10
+                }
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(lineString, optionsWithFeatureType);
+        olStroke = olStyle[0].getStroke();
+
+        expect(olStroke.getColor()).toBe('#ffaa33');
+        expect(olStroke.getWidth()).toBe(10);
+
+    });
+
+    it('test styleFunction with MultiLineString', () => {
+
+        const multiLineString = new ol.Feature({
+            geometry: new ol.geom.MultiLineString([
+                [ [100.0, 0.0], [101.0, 1.0] ],
+                [ [102.0, 2.0], [103.0, 3.0] ]
+            ])
+        });
+
+        let olStyle = VectorStyle.styleFunction(multiLineString);
+        let olStroke = olStyle[0].getStroke();
+
+        expect(olStroke.getColor()).toBe('green');
+        expect(olStroke.getWidth()).toBe(1);
+
+        const options = {
+            style: {
+                color: '#3388ff',
+                weight: 4
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(multiLineString, options);
+        olStroke = olStyle[0].getStroke();
+
+        expect(olStroke.getColor()).toBe('#3388ff');
+        expect(olStroke.getWidth()).toBe(4);
+
+        const optionsWithFeatureType = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                MultiLineString: {
+                    color: '#ffaa33',
+                    weight: 10
+                }
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(multiLineString, optionsWithFeatureType);
+        olStroke = olStyle[0].getStroke();
+
+        expect(olStroke.getColor()).toBe('#ffaa33');
+        expect(olStroke.getWidth()).toBe(10);
+
+    });
+
+    it('test styleFunction with Polygon', () => {
+
+        const polygon = new ol.Feature({
+            geometry: new ol.geom.Polygon([
+                [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
+            ])
+        });
+
+        let olStyle = VectorStyle.styleFunction(polygon);
+        let olFill = olStyle[0].getFill();
+        let olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgba(0, 0, 255, 0.1)');
+        expect(olStroke.getColor()).toBe('blue');
+        expect(olStroke.getWidth()).toBe(3);
+        expect(olStroke.getLineDash()).toEqual([4]);
+
+        const options = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                dashArray: '',
+                fillColor: 'rgba(51, 136, 255, 0.2)'
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(polygon, options);
+        olFill = olStyle[0].getFill();
+        olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgba(51, 136, 255, 0.2)');
+        expect(olStroke.getColor()).toBe('#3388ff');
+        expect(olStroke.getWidth()).toBe(4);
+        expect(olStroke.getLineDash()).toEqual(['']);
+
+        const optionsWithFeatureType = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                dashArray: '',
+                fillColor: 'rgba(51, 136, 255, 0.2)',
+                Polygon: {
+                    color: '#ffaa33',
+                    weight: 10,
+                    dashArray: '10 5',
+                    fillColor: '#333333'
+                }
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(polygon, optionsWithFeatureType);
+        olFill = olStyle[0].getFill();
+        olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('#333333');
+        expect(olStroke.getColor()).toBe('#ffaa33');
+        expect(olStroke.getWidth()).toBe(10);
+        expect(olStroke.getLineDash()).toEqual(['10', '5']);
+
+    });
+
+    it('test styleFunction with MultiPolygon', () => {
+
+        const multiPolygon = new ol.Feature({
+            geometry: new ol.geom.MultiPolygon([
+                [
+                    [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0] ]
+                ],
+                [
+                    [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
+                    [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
+                ]
+            ])
+        });
+
+        let olStyle = VectorStyle.styleFunction(multiPolygon);
+        let olFill = olStyle[0].getFill();
+        let olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgba(0, 0, 255, 0.1)');
+        expect(olStroke.getColor()).toBe('blue');
+        expect(olStroke.getWidth()).toBe(3);
+        expect(olStroke.getLineDash()).toEqual([4]);
+
+        const options = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                dashArray: '',
+                fillColor: 'rgba(51, 136, 255, 0.2)'
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(multiPolygon, options);
+        olFill = olStyle[0].getFill();
+        olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgba(51, 136, 255, 0.2)');
+        expect(olStroke.getColor()).toBe('#3388ff');
+        expect(olStroke.getWidth()).toBe(4);
+        expect(olStroke.getLineDash()).toEqual(['']);
+
+        const optionsWithFeatureType = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                dashArray: '',
+                fillColor: 'rgba(51, 136, 255, 0.2)',
+                MultiPolygon: {
+                    color: '#ffaa33',
+                    weight: 10,
+                    dashArray: '10 5',
+                    fillColor: '#333333'
+                }
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(multiPolygon, optionsWithFeatureType);
+        olFill = olStyle[0].getFill();
+        olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('#333333');
+        expect(olStroke.getColor()).toBe('#ffaa33');
+        expect(olStroke.getWidth()).toBe(10);
+        expect(olStroke.getLineDash()).toEqual(['10', '5']);
+
+    });
+
 });

--- a/web/client/components/mapcontrols/search/SearchResultList.jsx
+++ b/web/client/components/mapcontrols/search/SearchResultList.jsx
@@ -24,7 +24,8 @@ class SearchResultList extends React.Component {
         onItemClick: PropTypes.func,
         addMarker: PropTypes.func,
         afterItemClick: PropTypes.func,
-        notFoundMessage: PropTypes.oneOfType([PropTypes.object, PropTypes.string])
+        notFoundMessage: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+        resultsStyle: PropTypes.object
     };
 
     static defaultProps = {
@@ -37,11 +38,12 @@ class SearchResultList extends React.Component {
         },
         onItemClick: () => {},
         addMarker: () => {},
-        afterItemClick: () => {}
+        afterItemClick: () => {},
+        resultsStyle: {}
     };
 
     onItemClick = (item) => {
-        this.props.onItemClick(item, this.props.mapConfig);
+        this.props.onItemClick(item, this.props.mapConfig, this.props.resultsStyle);
     };
 
     renderResults = () => {

--- a/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
@@ -135,7 +135,9 @@ describe("test the SearchResultList", () => {
             boundingbox: [1, 2, 3, 4]
         }];
         const spy = expect.spyOn(testHandlers, 'clickHandler');
-        var tb = ReactDOM.render(<SearchResultList results={items} mapConfig={{size: 100, projection: "EPSG:4326"}}
+        const mapConfig = {size: 100, projection: "EPSG:4326"};
+        const resultsStyle = {color: '#ff0000'};
+        var tb = ReactDOM.render(<SearchResultList results={items} mapConfig={mapConfig} resultsStyle={resultsStyle}
             onItemClick={testHandlers.clickHandler}
             afterItemClick={testHandlers.afterItemClick}/>, document.getElementById("container"));
         let elem = TestUtils.scryRenderedComponentsWithType(tb, SearchResult);
@@ -144,6 +146,7 @@ describe("test the SearchResultList", () => {
         let elem1 = TestUtils.findRenderedDOMComponentWithClass(elem[0], "search-result");
         ReactDOM.findDOMNode(elem1).click();
         expect(spy.calls.length).toEqual(1);
+        expect(spy).toHaveBeenCalledWith(items[0], mapConfig, resultsStyle);
     });
 
 

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -11,7 +11,7 @@ var expect = require('expect');
 
 const configureMockStore = require('redux-mock-store').default;
 const { createEpicMiddleware, combineEpics } = require('redux-observable');
-const { textSearch, selectSearchItem, TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_TEXT_CHANGE } = require('../../actions/search');
+const { textSearch, selectSearchItem, TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_TEXT_CHANGE, UPDATE_RESULTS_STYLE } = require('../../actions/search');
 const {CHANGE_MAP_VIEW} = require('../../actions/map');
 const {searchEpic, searchItemSelected } = require('../search');
 const rootEpic = combineEpics(searchEpic, searchItemSelected);
@@ -106,10 +106,11 @@ describe('search Epics', () => {
         store.dispatch( action );
 
         let actions = store.getActions();
-        expect(actions.length).toBe(4);
+        expect(actions.length).toBe(5);
         expect(actions[1].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
-        expect(actions[2].type).toBe(CHANGE_MAP_VIEW);
-        expect(actions[3].type).toBe(TEXT_SEARCH_ADD_MARKER);
+        expect(actions[2].type).toBe(UPDATE_RESULTS_STYLE);
+        expect(actions[3].type).toBe(CHANGE_MAP_VIEW);
+        expect(actions[4].type).toBe(TEXT_SEARCH_ADD_MARKER);
     });
 
     it('searchItemSelected epic with nested services', () => {
@@ -124,8 +125,8 @@ describe('search Epics', () => {
         store.dispatch( action );
 
         let actions = store.getActions();
-        expect(actions.length).toBe(6);
-        let expectedActions = [CHANGE_MAP_VIEW, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_TEXT_CHANGE ];
+        expect(actions.length).toBe(7);
+        let expectedActions = [CHANGE_MAP_VIEW, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_RESULTS_PURGE, UPDATE_RESULTS_STYLE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_TEXT_CHANGE ];
         let actionsType = actions.map(a => a.type);
 
         expectedActions.forEach((a) => {

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -27,6 +27,7 @@ const {changeMapView} = require('../actions/map');
 const toBbox = require('turf-bbox');
 const {generateTemplateString} = require('../utils/TemplateUtils');
 const assign = require('object-assign');
+const {updateResultsStyle} = require('../actions/search');
 
 const {get} = require('lodash');
 
@@ -107,6 +108,7 @@ const searchItemSelected = action$ =>
                 // center by the max. extent defined in the map's config
                 let newCenter = mapUtils.getCenterForExtent(bbox, "EPSG:4326");
                 let actions = [
+                    updateResultsStyle(action.resultsStyle || null),
                     changeMapView(newCenter, newZoom, {
                         bounds: {
                             minx: bbox[0],

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -172,12 +172,6 @@ class extends React.Component {
             services: [{type: "nominatim"}]
         },
         resultsStyle: {
-            iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
-            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-            iconSize: [25, 41],
-            iconAnchor: [12, 41],
-            popupAnchor: [1, -34],
-            shadowSize: [41, 41],
             color: '#3388ff',
             weight: 4,
             dashArray: '',

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -69,7 +69,7 @@ const ToggleButton = require('./searchbar/ToggleButton');
  *      "withToggle": ["max-width: 768px", "min-width: 768px"],
  *      "resultsStyle": {
  *          "iconUrl": "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
- *          "shadowUrl": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png",
+ *          "shadowUrl": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-shadow.png",
  *          "iconSize": [25, 41],
  *          "iconAnchor": [12, 41],
  *          "popupAnchor": [1, -34],
@@ -77,8 +77,8 @@ const ToggleButton = require('./searchbar/ToggleButton');
  *          "color": "#ff0000",
  *          "weight": 4,
  *          "dashArray": "",
- *          "fillColor": "rgba(255, 0, 255, 0.2)",
- *          "fillOpacity": 1.0,
+ *          "fillColor": "#3388ff",
+ *          "fillOpacity": 0.2,
  *          "LineString": {
  *              // custom style for LineString, it overrides deafult/general style (optional)
  *          },
@@ -175,8 +175,8 @@ class extends React.Component {
             color: '#3388ff',
             weight: 4,
             dashArray: '',
-            fillColor: 'rgba(51, 136, 255, 0.2)',
-            fillOpacity: 1.0
+            fillColor: '#3388ff',
+            fillOpacity: 0.2
         },
         fitResultsToMapSize: true,
         withToggle: false,

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -132,6 +132,7 @@ class extends React.Component {
     static propTypes = {
         fitResultsToMapSize: PropTypes.bool,
         searchOptions: PropTypes.object,
+        resultsStyle: PropTypes.object,
         selectedItems: PropTypes.array,
         selectedServices: PropTypes.array,
         userServices: PropTypes.array,
@@ -143,6 +144,19 @@ class extends React.Component {
     static defaultProps = {
         searchOptions: {
             services: [{type: "nominatim"}]
+        },
+        resultsStyle: {
+            iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            iconSize: [25, 41],
+            iconAnchor: [12, 41],
+            popupAnchor: [1, -34],
+            shadowSize: [41, 41],
+            color: '#3388ff',
+            weight: 4,
+            dashArray: '',
+            fillColor: 'rgba(51, 136, 255, 0.2)',
+            fillOpacity: 1.0
         },
         fitResultsToMapSize: true,
         withToggle: false,
@@ -201,7 +215,7 @@ class extends React.Component {
                     helpText={<Message msgId="helptexts.searchBar"/>}>
                     {this.getSearchAndToggleButton()}
                 </HelpWrapper>
-                <SearchResultList fitToMapSize={this.props.fitResultsToMapSize} searchOptions={this.props.searchOptions} key="nominatimresults"/>
+                <SearchResultList fitToMapSize={this.props.fitResultsToMapSize} searchOptions={this.props.searchOptions} resultsStyle={this.props.resultsStyle} key="nominatimresults"/>
             </span>)
         ;
     }

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -66,13 +66,39 @@ const ToggleButton = require('./searchbar/ToggleButton');
  * {
  *  "name": "Search",
  *  "cfg": {
- *    "withToggle": ["max-width: 768px", "min-width: 768px"]
+ *      "withToggle": ["max-width: 768px", "min-width: 768px"],
+ *      "resultsStyle": {
+ *          "iconUrl": "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+ *          "shadowUrl": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png",
+ *          "iconSize": [25, 41],
+ *          "iconAnchor": [12, 41],
+ *          "popupAnchor": [1, -34],
+ *          "shadowSize": [41, 41],
+ *          "color": "#ff0000",
+ *          "weight": 4,
+ *          "dashArray": "",
+ *          "fillColor": "rgba(255, 0, 255, 0.2)",
+ *          "fillOpacity": 1.0,
+ *          "LineString": {
+ *              // custom style for LineString, it overrides deafult/general style (optional)
+ *          },
+ *          "MultiLineString": {
+ *              // custom style for MultiLineString, it overrides deafult/general style (optional)
+ *          },
+ *          "Polygon": {
+ *              // custom style for Polygon, it overrides deafult/general style (optional)
+ *          },
+ *          "MultiPolygon": {
+ *              // custom style for MultiPolygon, it overrides deafult/general style (optional)
+ *          }
+ *      }
+ *    }
  *  }
  * }
  * @class Search
  * @memberof plugins
  * @prop {object} cfg.searchOptions initial search options
-
+ * @prop {object} cfg.resultsStyle custom style for search results
  * @prop {bool} cfg.fitResultsToMapSize true by default, fits the result list to the mapSize (can be disabled, for custom uses)
  * @prop {searchService[]} cfg.searchOptions.services a list of services to perform search.
  * a **nominatim** search service look like this:

--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -7,7 +7,7 @@
  */
 var expect = require('expect');
 var search = require('../search');
-const {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_CANCEL_ITEM} = require('../../actions/search');
+const {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_CANCEL_ITEM, UPDATE_RESULTS_STYLE} = require('../../actions/search');
 
 describe('Test the search reducer', () => {
     it('search results loading', () => {
@@ -110,5 +110,13 @@ describe('Test the search reducer', () => {
         });
         expect(state.searchText).toBe("text2");
         expect(state.selectedItems.length).toBe(1);
+    });
+    it('update results style', () => {
+        const style = {color: '#ff0000'};
+        const state = search({}, {
+            type: UPDATE_RESULTS_STYLE,
+            style
+        });
+        expect(state.style).toEqual(style);
     });
 });

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -7,7 +7,7 @@
  */
 
 var {TEXT_SEARCH_RESULTS_LOADED, TEXT_SEARCH_RESULTS_PURGE, TEXT_SEARCH_RESET, TEXT_SEARCH_ADD_MARKER, TEXT_SEARCH_TEXT_CHANGE, TEXT_SEARCH_LOADING, TEXT_SEARCH_ERROR,
-    TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_CANCEL_ITEM, TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE} = require('../actions/search');
+    TEXT_SEARCH_NESTED_SERVICES_SELECTED, TEXT_SEARCH_CANCEL_ITEM, TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE, UPDATE_RESULTS_STYLE} = require('../actions/search');
 var {RESET_CONTROLS} = require('../actions/controls');
 
 const assign = require('object-assign');
@@ -107,6 +107,8 @@ function search(state = null, action) {
             selectedItems: state.selectedItems && state.selectedItems.filter(item => item !== action.item),
             searchText: state.searchText === "" && action.item && action.item.text ? action.item.text.substring(0, action.item.text.length) : state.searchText
         });
+    case UPDATE_RESULTS_STYLE:
+        return assign({}, state, {style: action.style});
     default:
         return state;
     }

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -120,6 +120,15 @@ describe('Test layers selectors', () => {
             color: '#ff0000'
         };
 
+        const deafaultIconStyle = {
+            iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            iconSize: [25, 41],
+            iconAnchor: [12, 41],
+            popupAnchor: [1, -34],
+            shadowSize: [41, 41]
+        };
+
         const props = layerSelectorWithMarkers({config: {layers: [{type: "osm"}]}, search: {
             markerPosition: {
                 type: "Feature",
@@ -132,7 +141,7 @@ describe('Test layers selectors', () => {
         }});
         expect(props.length).toBe(2);
         expect(props[1].type).toBe("vector");
-        expect(props[1].style).toEqual(style);
+        expect(props[1].style).toEqual({...deafaultIconStyle, ...style});
     });
 
     it('test groupsSelector from layers flat one group', () => {

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -93,6 +93,48 @@ describe('Test layers selectors', () => {
         expect(props[1].type).toBe("vector");
     });
 
+    it('test layerSelectorWithMarkers with default style', () => {
+        const props = layerSelectorWithMarkers({config: {layers: [{type: "osm"}]}, search: {
+            markerPosition: {
+                type: "Feature",
+                geometry: {
+                    type: "Point",
+                    coordinates: [0, 0]
+                }
+            }
+        }});
+        expect(props.length).toBe(2);
+        expect(props[1].type).toBe("vector");
+        expect(props[1].style).toEqual({
+            iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            iconSize: [25, 41],
+            iconAnchor: [12, 41],
+            popupAnchor: [1, -34],
+            shadowSize: [41, 41]
+        });
+    });
+
+    it('test layerSelectorWithMarkers with custom style', () => {
+        const style = {
+            color: '#ff0000'
+        };
+
+        const props = layerSelectorWithMarkers({config: {layers: [{type: "osm"}]}, search: {
+            markerPosition: {
+                type: "Feature",
+                geometry: {
+                    type: "Point",
+                    coordinates: [0, 0]
+                }
+            },
+            style
+        }});
+        expect(props.length).toBe(2);
+        expect(props[1].type).toBe("vector");
+        expect(props[1].style).toEqual(style);
+    });
+
     it('test groupsSelector from layers flat one group', () => {
         const props = groupsSelector({layers: {
             flat: [{type: "osm", id: "layer1", group: "group1"}, {type: "wms", id: "layer2", group: "group1"}],

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -107,7 +107,7 @@ describe('Test layers selectors', () => {
         expect(props[1].type).toBe("vector");
         expect(props[1].style).toEqual({
             iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
-            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-shadow.png',
             iconSize: [25, 41],
             iconAnchor: [12, 41],
             popupAnchor: [1, -34],
@@ -120,9 +120,9 @@ describe('Test layers selectors', () => {
             color: '#ff0000'
         };
 
-        const deafaultIconStyle = {
+        const defaultIconStyle = {
             iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
-            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+            shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-shadow.png',
             iconSize: [25, 41],
             iconAnchor: [12, 41],
             popupAnchor: [1, -34],
@@ -141,7 +141,7 @@ describe('Test layers selectors', () => {
         }});
         expect(props.length).toBe(2);
         expect(props[1].type).toBe("vector");
-        expect(props[1].style).toEqual({...deafaultIconStyle, ...style});
+        expect(props[1].style).toEqual({...defaultIconStyle, ...style});
     });
 
     it('test groupsSelector from layers flat one group', () => {

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -10,7 +10,7 @@ const {createSelector} = require('reselect');
 
 const MapInfoUtils = require('../utils/MapInfoUtils');
 const LayersUtils = require('../utils/LayersUtils');
-const {head, isEmpty, find} = require('lodash');
+const {head, isEmpty, find, isObject} = require('lodash');
 
 const layersSelector = state => state.layers && state.layers.flat || state.layers || state.config && state.config.layers || [];
 const currentBackgroundLayerSelector = state => head(layersSelector(state).filter(l => l && l.visibility && l.group === "background"));
@@ -33,7 +33,7 @@ const layerSelectorWithMarkers = createSelector(
             newLayers.push(MapInfoUtils.getMarkerLayer("GeoCoder", geocoder.markerPosition, "marker",
                 {
                     overrideOLStyle: true,
-                    style: {
+                    style: isObject(geocoder.style) && !isEmpty(geocoder.style) && geocoder.style || {
                         iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
                         shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
                         iconSize: [25, 41],

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -22,6 +22,15 @@ const geoColderSelector = state => state.search && state.search;
 // TODO currently loading flag causes a re-creation of the selector on any pan
 // to avoid this separate loading from the layer object
 
+const deafaultIconStyle = {
+    iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
+    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+    shadowSize: [41, 41]
+};
+
 const layerSelectorWithMarkers = createSelector(
     [layersSelector, markerSelector, geoColderSelector],
     (layers = [], markerPosition, geocoder) => {
@@ -33,14 +42,7 @@ const layerSelectorWithMarkers = createSelector(
             newLayers.push(MapInfoUtils.getMarkerLayer("GeoCoder", geocoder.markerPosition, "marker",
                 {
                     overrideOLStyle: true,
-                    style: isObject(geocoder.style) && !isEmpty(geocoder.style) && geocoder.style || {
-                        iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
-                        shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-                        iconSize: [25, 41],
-                        iconAnchor: [12, 41],
-                        popupAnchor: [1, -34],
-                        shadowSize: [41, 41]
-                    }
+                    style: isObject(geocoder.style) && !isEmpty(geocoder.style) && {...deafaultIconStyle, ...geocoder.style} || deafaultIconStyle
                 }, geocoder.markerLabel
             ));
         }

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -22,9 +22,9 @@ const geoColderSelector = state => state.search && state.search;
 // TODO currently loading flag causes a re-creation of the selector on any pan
 // to avoid this separate loading from the layer object
 
-const deafaultIconStyle = {
+const defaultIconStyle = {
     iconUrl: "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/images/marker-shadow.png',
     iconSize: [25, 41],
     iconAnchor: [12, 41],
     popupAnchor: [1, -34],
@@ -42,7 +42,7 @@ const layerSelectorWithMarkers = createSelector(
             newLayers.push(MapInfoUtils.getMarkerLayer("GeoCoder", geocoder.markerPosition, "marker",
                 {
                     overrideOLStyle: true,
-                    style: isObject(geocoder.style) && !isEmpty(geocoder.style) && {...deafaultIconStyle, ...geocoder.style} || deafaultIconStyle
+                    style: isObject(geocoder.style) && !isEmpty(geocoder.style) && {...defaultIconStyle, ...geocoder.style} || defaultIconStyle
                 }, geocoder.markerLabel
             ));
         }

--- a/web/client/utils/ColorUtils.js
+++ b/web/client/utils/ColorUtils.js
@@ -5,7 +5,8 @@
   * This source code is licensed under the BSD-style license found in the
   * LICENSE file in the root directory of this source tree.
   */
-
+const tinycolor = require("tinycolor2");
+const {toNumber} = require("lodash");
 /**
  * Porting of various MapStore(1) utilities for random/color scale generations
  * @name ColorUtils
@@ -155,6 +156,17 @@ const ColorUtils = {
             let rgb = ColorUtils.hexToRgb(hex);
             return ColorUtils.rgbToHsv(rgb);
         }
+    },
+    /**
+    * convert any valid css color to rgba str
+    * @param {string} color any valid css color
+    * @param {number} opacity 0 - 1 alpha value
+    * @param {string} defaultColor any valid css color
+    * @return {string} rgba string or undefined if color and defaultColor are undefined
+    */
+    colorToRgbaStr: (color, alpha, defaultColor) => {
+        const c = tinycolor(color);
+        return color && c.setAlpha(toNumber(alpha !== undefined ? alpha : c.getAlpha())).toRgbString() || defaultColor;
     }
 };
 module.exports = ColorUtils;

--- a/web/client/utils/__tests__/ColorUtils-test.js
+++ b/web/client/utils/__tests__/ColorUtils-test.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const ColorUtils = require('../ColorUtils');
+
+describe('Test the ColorUtils', () => {
+    it('colorToRgbaStr name color', () => {
+        const rgbaColor = ColorUtils.colorToRgbaStr("red");
+        expect(rgbaColor).toBe("rgb(255, 0, 0)");
+    });
+    it('colorToRgbaStr hex color', () => {
+        const rgbaColor = ColorUtils.colorToRgbaStr("#FF0000", 0.5);
+        expect(rgbaColor).toBe("rgba(255, 0, 0, 0.5)");
+    });
+    it('colorToRgbaStr rgba color with overrided alpha', () => {
+        const rgbaColor = ColorUtils.colorToRgbaStr("rgba(255, 255, 255, 0.8)", 0.5);
+        expect(rgbaColor).toBe("rgba(255, 255, 255, 0.5)");
+    });
+    it('colorToRgbaStr rgba color', () => {
+        const rgbaColor = ColorUtils.colorToRgbaStr("rgba(255, 255, 255, 0.8)");
+        expect(rgbaColor).toBe("rgba(255, 255, 255, 0.8)");
+    });
+    it('colorToRgbaStr undefined color', () => {
+        const rgbaColor = ColorUtils.colorToRgbaStr();
+        expect(rgbaColor).toBe(undefined);
+    });
+
+});


### PR DESCRIPTION
## Description
This PR introduces the posiibilities to customize styles for geometries of searched feature (geocoder).
Added a default style to align OL with Leaflet.

custom configuration:
```
{
    "name": "Search",
    "cfg": {
        "resultsStyle": {
            "iconUrl": "https://cdn.rawgit.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png",
            "shadowUrl": "https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png",
            "iconSize": [
                25,
                41
            ],
            "iconAnchor": [
                12,
                41
            ],
            "popupAnchor": [
                1,
                -34
            ],
            "shadowSize": [
                41,
                41
            ],
            "color": "#ff0000",
            "weight": 4,
            "dashArray": "",
            "fillColor": "rgba(255, 0, 255, 0.2)",
            "fillOpacity": 1.0,
            "LineString": {
                // custom style for LineString, it overrides deafult/general style (optional)
            },
            "MultiLineString": {
                // custom style for MultiLineString, it overrides deafult/general style (optional)
            },
            "Polygon": {
                // custom style for Polygon, it overrides deafult/general style (optional)
            },
            "MultiPolygon": {
                // custom style for MultiPolygon, it overrides deafult/general style (optional)
            }
        }
    }
}
```

## Issues
 - Fix #1506

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
It's not possible to customize the style of resulted geometries from search (geocoder).
Deafult styles of OL and Leaflet are different.

**What is the new behavior?**
It's possible to customize the style of resulted geometries from search (geocoder).
Added a default style to align OL with Leaflet.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
