### PR TITLE
Connect to #2662 Geodashboard single connection support

### DIFF
--- a/web/client/actions/widgets.js
+++ b/web/client/actions/widgets.js
@@ -17,6 +17,11 @@ const UPDATE_PROPERTY = "WIDGETS:UPDATE_PROPERTY";
 const CHANGE_LAYOUT = "WIDGETS:CHANGE_LAYOUT";
 const DELETE = "WIDGETS:DELETE";
 const CLEAR_WIDGETS = "WIDGETS:CLEAR_WIDGETS";
+const ADD_DEPENDENCY = "WIDGETS:ADD_DEPENDENCY";
+const REMOVE_DEPENDENCY = "WIDGETS:REMOVE_DEPENDENCY";
+const LOAD_DEPENDENCIES = "WIDGETS:LOAD_DEPENDENCIES";
+const RESET_DEPENDENCIES = "WIDGETS:RESET_DEPENDENCIES";
+
 const OPEN_FILTER_EDITOR = "WIDGETS:OPEN_FILTER_EDITOR";
 const EXPORT_CSV = "WIDGETS:EXPORT_CSV";
 const EXPORT_IMAGE = "WIDGETS:EXPORT_IMAGE";
@@ -146,6 +151,25 @@ const changeEditorSetting = (key, value) => ({
     key,
     value
 });
+
+const addDependency = (key, value) => ({
+    type: ADD_DEPENDENCY,
+    key,
+    value
+});
+
+const removeDependency = (key) => ({
+    type: REMOVE_DEPENDENCY,
+    key
+});
+
+const resetDependencies = () => ({
+    type: RESET_DEPENDENCIES
+});
+const loadDependencies = (dependencies) => ({
+    type: LOAD_DEPENDENCIES,
+    dependencies
+});
 /**
  * Change the page setting of the editor
  * @param  {number} step the page number
@@ -180,6 +204,10 @@ module.exports = {
     EDIT_NEW,
     EDITOR_CHANGE,
     EDITOR_SETTING_CHANGE,
+    ADD_DEPENDENCY,
+    REMOVE_DEPENDENCY,
+    LOAD_DEPENDENCIES,
+    RESET_DEPENDENCIES,
     DEFAULT_TARGET,
     OPEN_FILTER_EDITOR,
     EXPORT_CSV,
@@ -198,5 +226,9 @@ module.exports = {
     editNewWidget,
     onEditorChange,
     changeEditorSetting,
+    addDependency,
+    removeDependency,
+    loadDependencies,
+    resetDependencies,
     setPage
 };

--- a/web/client/components/widgets/builder/wizard/ChartWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/ChartWizard.jsx
@@ -1,14 +1,14 @@
- /**
-  * Copyright 2017, GeoSolutions Sas.
-  * All rights reserved.
-  *
-  * This source code is licensed under the BSD-style license found in the
-  * LICENSE file in the root directory of this source tree.
-  */
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 const React = require('react');
 
-const {wizardHandlers} = require('../../../misc/wizard/enhancers');
-const loadingState = require('../../../misc/enhancers/loadingState')(({loading, data}) => loading || !data, {width: 500, height: 200});
+const { wizardHandlers } = require('../../../misc/wizard/enhancers');
+const loadingState = require('../../../misc/enhancers/loadingState')(({ loading, data }) => loading || !data, { width: 500, height: 200 });
 
 const ChartType = require('./chart/ChartType');
 const wfsChartOptions = require('./common/wfsChartOptions');
@@ -16,11 +16,13 @@ const ChartOptions = wfsChartOptions(require('./common/WPSWidgetOptions'));
 const WidgetOptions = require('./common/WidgetOptions');
 const sampleData = require('../../enhancers/sampleChartData');
 const wpsChart = require('../../enhancers/wpsChart');
+const dependenciesToWidget = require('../../enhancers/dependenciesToWidget');
 const dependenciesToFilter = require('../../enhancers/dependenciesToFilter');
 const emptyChartState = require('../../enhancers/emptyChartState');
 const errorChartState = require('../../enhancers/errorChartState');
-const {compose, lifecycle} = require('recompose');
+const { compose, lifecycle } = require('recompose');
 const enhancePreview = compose(
+    dependenciesToWidget,
     dependenciesToFilter,
     wpsChart,
     loadingState,
@@ -41,13 +43,14 @@ const isChartOptionsValid = (options = {}) => options.aggregateFunction && optio
 const Wizard = wizardHandlers(require('../../../misc/wizard/WizardContainer'));
 
 
-const renderPreview = ({data = {}, layer, dependencies={}, setValid = () => {}}) => isChartOptionsValid(data.options)
+const renderPreview = ({ data = {}, layer, dependencies = {}, setValid = () => { } }) => isChartOptionsValid(data.options)
     ? (<PreviewChart
         key="preview-chart"
         onLoad={() => setValid(true)}
         onLoadError={() => setValid(false)}
         isAnimationActive={false}
         dependencies={dependencies}
+        dependenciesMap={data.dependenciesMap}
         {...sampleProps}
         type={data.type}
         legend={data.legend}
@@ -57,7 +60,7 @@ const renderPreview = ({data = {}, layer, dependencies={}, setValid = () => {}})
         mapSync={data.mapSync}
         autoColorOptions={data.autoColorOptions}
         options={data.options}
-        />)
+    />)
     : (<SampleChart
         key="sample-chart"
         isAnimationActive={false}
@@ -67,24 +70,25 @@ const renderPreview = ({data = {}, layer, dependencies={}, setValid = () => {}})
         legend={data.legend} />);
 
 const enhanceWizard = compose(lifecycle({
-    componentWillReceiveProps: ({data = {}, valid, setValid = () => {}} = {}) => {
+    componentWillReceiveProps: ({ data = {}, valid, setValid = () => { } } = {}) => {
         if (valid && !isChartOptionsValid(data.options)) {
             setValid(false);
         }
-    }})
+    }
+})
 );
-module.exports = enhanceWizard(({onChange = () => {}, onFinish = () => {}, setPage= () => {}, setValid = () => {}, data = {}, layer ={}, step=0, types, featureTypeProperties, dependencies}) =>
+module.exports = enhanceWizard(({ onChange = () => { }, onFinish = () => { }, setPage = () => { }, setValid = () => { }, data = {}, layer = {}, step = 0, types, featureTypeProperties, dependencies }) =>
     (<Wizard
         step={step}
         setPage={setPage}
         onFinish={onFinish}
-        isStepValid={ n => n === 1 ? isChartOptionsValid(data.options) : true} hideButtons>
+        isStepValid={n => n === 1 ? isChartOptionsValid(data.options) : true} hideButtons>
         <ChartType
             key="type"
             type={data.type}
-            onSelect={ i => {
+            onSelect={i => {
                 onChange("type", i);
-            }}/>
+            }} />
         <ChartOptions
             dependencies={dependencies}
             key="chart-options"
@@ -93,13 +97,13 @@ module.exports = enhanceWizard(({onChange = () => {}, onFinish = () => {}, setPa
             data={data}
             onChange={onChange}
             layer={data.layer || layer}
-            sampleChart={renderPreview({data, layer: data.layer || layer, dependencies, setValid: v => setValid(v && isChartOptionsValid(data.options))})}
+            sampleChart={renderPreview({ data, layer: data.layer || layer, dependencies, setValid: v => setValid(v && isChartOptionsValid(data.options)) })}
         />
         <WidgetOptions
             key="widget-options"
             data={data}
             onChange={onChange}
             layer={data.layer || layer}
-            sampleChart={renderPreview({data, layer: data.layer || layer, dependencies, setValid: v => setValid(v && isChartOptionsValid(data.options))})}
+            sampleChart={renderPreview({ data, layer: data.layer || layer, dependencies, setValid: v => setValid(v && isChartOptionsValid(data.options)) })}
         />
-</Wizard>));
+    </Wizard>));

--- a/web/client/components/widgets/builder/wizard/CounterWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/CounterWizard.jsx
@@ -18,6 +18,7 @@ const WidgetOptions = require('./common/WidgetOptions');
 
 const wpsCounter = require('../../enhancers/wpsCounter');
 const dependenciesToFilter = require('../../enhancers/dependenciesToFilter');
+const dependenciesToWidget = require('../../enhancers/dependenciesToWidget');
 const emptyChartState = require('../../enhancers/emptyChartState');
 const errorChartState = require('../../enhancers/errorChartState');
 
@@ -32,8 +33,8 @@ const triggerSetValid = compose(
         }
     }));
 
-const enhanchePreview = compose(
-
+const enhancePreview = compose(
+    dependenciesToWidget,
     dependenciesToFilter,
     wpsCounter,
     triggerSetValid,
@@ -51,7 +52,7 @@ const Wizard = wizardHandlers(require('../../../misc/wizard/WizardContainer'));
 
 
 const Counter = require('../../widget/CounterView');
-const Preview = enhanchePreview(Counter);
+const Preview = enhancePreview(Counter);
 const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid = () => { } }) =>
     !isCounterOptionsValid(data.options)
         ? <Counter
@@ -62,6 +63,7 @@ const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid =
         : <Preview
             {...sampleProps}
             valid={valid}
+            dependenciesMap={data.dependenciesMap}
             dependencies={dependencies}
             setValid={setValid}
             type={data.type}

--- a/web/client/components/widgets/builder/wizard/chart/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/Toolbar.jsx
@@ -39,7 +39,11 @@ const getSaveTooltipId = (step, {id} = {}) => {
     }
     return "widgets.builder.wizard.addToTheMap";
 };
-module.exports = ({openFilterEditor = () => {}, step = 0, editorData = {}, valid, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
+module.exports = ({
+    step = 0, editorData = {}, valid, setPage = () => {}, onFinish = () => {},
+    stepButtons = [],
+    openFilterEditor = () => {}
+    } = {}) => (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm"
     }}
@@ -48,7 +52,7 @@ module.exports = ({openFilterEditor = () => {}, step = 0, editorData = {}, valid
         visible: step > 0,
         glyph: "arrow-left",
         tooltipId: getBackTooltipId(step)
-    }, {
+    }, ...stepButtons, {
         visible: step > 0,
         onClick: openFilterEditor,
         glyph: "filter",

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -57,7 +57,6 @@ module.exports = ({
             showColorRampSelector: true,
             showLegend: true
         },
-        dependencies,
         aggregationOptions = [],
         sampleChart}) => (<Row>
         <StepHeader title={<Message msgId={`widgets.chartOptionsTitle`} />} />

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -133,21 +133,6 @@ module.exports = ({
                   onChange={v => {onChange("autoColorOptions", {...v.options, name: v.name}); }}/>
           </Col>
         </FormGroup> : null}
-        {dependencies && dependencies.viewport
-            ? (<FormGroup controlId="mapSync" className="mapstore-block-width">
-            <Col componentClass={ControlLabel} sm={6}>
-              <Message msgId={`widgets.mapSync`} />
-            </Col>
-          <Col sm={6}>
-              <SwitchButton
-                  checked={data.mapSync}
-                  onChange={(val) => {
-                      onChange("mapSync", val);
-                  }}
-                  />
-          </Col>
-        </FormGroup>)
-            : null}
         {formOptions.showLegend ? <FormGroup controlId="displayLegend">
             <Col componentClass={ControlLabel} sm={6}>
                 <Message msgId={getLabelMessageId("displayLegend", data)} />

--- a/web/client/components/widgets/builder/wizard/common/__tests__/WPSWidgetOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/WPSWidgetOptions-test.jsx
@@ -55,12 +55,8 @@ describe('WPSWidgetOptions component', () => {
 
 
         ReactTestUtils.Simulate.change(inputs[3]);
-        expect(spyonChange.calls[3].arguments[0]).toBe("mapSync");
+        expect(spyonChange.calls[3].arguments[0]).toBe("legend");
         expect(spyonChange.calls[3].arguments[1]).toBe(true);
-
-        ReactTestUtils.Simulate.change(inputs[4]);
-        expect(spyonChange.calls[4].arguments[0]).toBe("legend");
-        expect(spyonChange.calls[4].arguments[1]).toBe(true);
     });
     it('Test WPSWidgetOptions onChange for counter context', () => {
         const actions = {
@@ -91,9 +87,5 @@ describe('WPSWidgetOptions component', () => {
         ReactTestUtils.Simulate.change(inputs[2], { target: { value: 'test' } });
         expect(spyonChange.calls[2].arguments[0]).toBe("options.seriesOptions.[0].uom");
         expect(spyonChange.calls[2].arguments[1]).toBe("test");
-
-        ReactTestUtils.Simulate.change(inputs[3]);
-        expect(spyonChange.calls[3].arguments[0]).toBe("mapSync");
-        expect(spyonChange.calls[3].arguments[1]).toBe(true);
     });
 });

--- a/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
@@ -37,7 +37,7 @@ const getSaveTooltipId = (step, {id} = {}) => {
     }
     return "widgets.builder.wizard.addToTheMap";
 };
-module.exports = ({openFilterEditor = () => {}, step = 0, editorData = {}, valid, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
+module.exports = ({openFilterEditor = () => {}, step = 0, stepButtons = [], editorData = {}, valid, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm"
     }}
@@ -46,7 +46,7 @@ module.exports = ({openFilterEditor = () => {}, step = 0, editorData = {}, valid
         visible: step > 0,
         glyph: "arrow-left",
         tooltipId: getBackTooltipId(step)
-    }, {
+    }, ...stepButtons, {
         visible: step === 0,
         onClick: openFilterEditor,
         glyph: "filter",

--- a/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
@@ -17,11 +17,20 @@ const getSaveTooltipId = (step, {id} = {}) => {
     return "widgets.builder.wizard.addToTheMap";
 };
 
-module.exports = ({ step = 0, buttons, tocButtons = [], editorData = {}, setPage = () => {}, onFinish = () => { }, toggleLayerSelector = () => { } } = {}) => (<Toolbar btnDefaultProps={{
+module.exports = ({
+        step = 0, buttons, tocButtons = [], editorData = {},
+        setPage = () => {}, onFinish = () => {},
+        toggleLayerSelector = () => {} } = {},
+        availableMaps = [], toggleConnection = () => { }, connected) => (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm"
     }}
     buttons={buttons || [ ...(step === 0 ? tocButtons : []), {
+        onClick: () => toggleConnection(),
+        visible: step === 0 && availableMaps.length > 0,
+        glyph: connected ? "unplug" : "plug",
+        tooltipId: "widgets.builder.wizard.connect"
+    }, {
         onClick: () => toggleLayerSelector(true),
         visible: step === 0,
         glyph: "plus",

--- a/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
@@ -10,27 +10,18 @@ const React = require('react');
 
 const Toolbar = require('../../../../misc/toolbar/Toolbar');
 
-const getSaveTooltipId = (step, {id} = {}) => {
+const getSaveTooltipId = (step, { id } = {}) => {
     if (id) {
         return "widgets.builder.wizard.updateWidget";
     }
     return "widgets.builder.wizard.addToTheMap";
 };
 
-module.exports = ({
-        step = 0, buttons, tocButtons = [], editorData = {},
-        setPage = () => {}, onFinish = () => {},
-        toggleLayerSelector = () => {} } = {},
-        availableMaps = [], toggleConnection = () => { }, connected) => (<Toolbar btnDefaultProps={{
-        bsStyle: "primary",
-        bsSize: "sm"
-    }}
-    buttons={buttons || [ ...(step === 0 ? tocButtons : []), {
-        onClick: () => toggleConnection(),
-        visible: step === 0 && availableMaps.length > 0,
-        glyph: connected ? "unplug" : "plug",
-        tooltipId: "widgets.builder.wizard.connect"
-    }, {
+module.exports = ({ step = 0, buttons, tocButtons = [], editorData = {}, setPage = () => { }, onFinish = () => { }, toggleLayerSelector = () => { } } = {}) => (<Toolbar btnDefaultProps={{
+    bsStyle: "primary",
+    bsSize: "sm"
+}}
+    buttons={buttons || [...(step === 0 ? tocButtons : []), {
         onClick: () => toggleLayerSelector(true),
         visible: step === 0,
         glyph: "plus",

--- a/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
@@ -52,21 +52,6 @@ module.exports = ({ data = { options: {} }, onChange = () => { }, dependencies, 
                 options={data.options}
                 onChange={onChange}
                 attributes={featureTypeProperties}/>
-            {dependencies && dependencies.viewport
-                ? (<FormGroup style={{ marginTop: "20px" }}controlId="mapSync" className="mapstore-block-width">
-                    <Col componentClass={ControlLabel} sm={6}>
-                        <Message msgId={`widgets.mapSync`} />
-                    </Col>
-                    <Col sm={6}>
-                        <SwitchButton
-                            checked={data.mapSync}
-                            onChange={(val) => {
-                                onChange("mapSync", val);
-                            }}
-                        />
-                    </Col>
-                </FormGroup>)
-                : null}
             {data.options && data.options.columnSettings
                 ? <Button style={{"float": "right"}} onClick={() => onChange("options.columnSettings", undefined)}><Message msgId="widgets.builder.wizard.resetColumnsSizes" /></Button>
                 : null

--- a/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
@@ -8,10 +8,9 @@
 const React = require('react');
 const { isGeometryType } = require('../../../../../utils/ogc/WFS/base');
 const { uniq, castArray, includes } = require('lodash');
-const { Row, Col, Form, FormGroup, ControlLabel, Button } = require('react-bootstrap');
+const { Row, Col, Form, Button } = require('react-bootstrap');
 const Message = require('../../../../I18N/Message');
 const StepHeader = require('../../../../misc/wizard/StepHeader');
-const SwitchButton = require('../../../../misc/switch/SwitchButton');
 
 const {withProps, withHandlers, compose} = require('recompose');
 const updatePropertyName = (arr, name, hide) => {
@@ -39,7 +38,7 @@ const AttributeSelector = compose(withProps(
 )(require('../../../../data/featuregrid/AttributeTable'));
 
 
-module.exports = ({ data = { options: {} }, onChange = () => { }, dependencies, featureTypeProperties, sampleChart}) => (<Row>
+module.exports = ({ data = { options: {} }, onChange = () => { }, featureTypeProperties, sampleChart}) => (<Row>
     <StepHeader title={<Message msgId={`widgets.builder.wizard.configureTableOptions`} />} />
           <Col xs={12}>
               <div >

--- a/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
@@ -31,7 +31,7 @@ const getSaveTooltipId = (step, {id} = {}) => {
     }
     return "widgets.builder.wizard.addToTheMap";
 };
-module.exports = ({openFilterEditor = () => {}, step = 0, editorData = {}, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
+module.exports = ({ openFilterEditor = () => { }, step = 0, stepButtons = [], editorData = {}, setPage = () => {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm"
     }}
@@ -40,7 +40,7 @@ module.exports = ({openFilterEditor = () => {}, step = 0, editorData = {}, setPa
         visible: step > 0,
         glyph: "arrow-left",
         tooltipId: getBackTooltipId(step)
-    }, {
+    }, ...stepButtons, {
         visible: step >= 0,
         onClick: openFilterEditor,
         glyph: "filter",

--- a/web/client/components/widgets/builder/wizard/table/__tests__/TableOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/table/__tests__/TableOptions-test.jsx
@@ -38,8 +38,6 @@ describe('TableOptions component', () => {
             data={{ options: { columnSettings: { test: {} } } }}
             featureTypeProperties={get(describeStates, "featureTypes[0].properties")}
             dependencies={{ viewport: {} }} />, document.getElementById("container"));
-        const switchEl = document.querySelector('.mapstore-switch-btn');
-        expect(switchEl).toExist();
         const resetButton = document.querySelector('.btn');
         expect(resetButton).toExist();
 
@@ -55,14 +53,11 @@ describe('TableOptions component', () => {
             onChange={actions.onChange}
             dependencies={{ viewport: {} }} />, document.getElementById("container"));
         const inputs = document.querySelectorAll('input');
-        expect(inputs.length).toBe(16); // 15 + 1 mapSync because dependencies is present
-        ReactTestUtils.Simulate.change(inputs[15]);
-        expect(spyonChange.calls[0].arguments[0]).toBe("mapSync");
-        expect(spyonChange.calls[0].arguments[1]).toBe(true);
+        expect(inputs.length).toBe(15);
         const resetButton = document.querySelector('.btn');
         expect(resetButton).toExist();
         ReactTestUtils.Simulate.click(resetButton);
-        expect(spyonChange.calls[1].arguments[0]).toBe("options.columnSettings");
-        expect(spyonChange.calls[1].arguments[1]).toBe(undefined);
+        expect(spyonChange.calls[0].arguments[0]).toBe("options.columnSettings");
+        expect(spyonChange.calls[0].arguments[1]).toBe(undefined);
     });
 });

--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToWidget-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToWidget-test.jsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {createSink} = require('recompose');
+const expect = require('expect');
+const dependenciesToWidget = require('../dependenciesToWidget');
+
+describe('dependenciesToWidget enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('dependency transformation', (done) => {
+        const Sink = dependenciesToWidget(createSink( props => {
+            expect(props).toExist();
+            expect(props.dependencies.x).toBe("a");
+            done();
+        }));
+        ReactDOM.render(<Sink dependenciesMap={{x: "b"}} dependencies={{b: "a"}}/>, document.getElementById("container"));
+    });
+});

--- a/web/client/components/widgets/enhancers/dependenciesToFilter.js
+++ b/web/client/components/widgets/enhancers/dependenciesToFilter.js
@@ -9,6 +9,9 @@ const {compose, withPropsOnChange} = require('recompose');
 const CoordinatesUtils = require('../../../utils/CoordinatesUtils');
 const FilterUtils = require('../../../utils/FilterUtils');
 const filterBuilder = require('../../../utils/ogc/Filter/FilterBuilder');
+/**
+ * Merges filter object and dependencies map into an ogc filter
+ */
 module.exports = compose(
    withPropsOnChange(
        ({mapSync, geomProp, dependencies = {}} = {}, nextProps = {}, filter) =>

--- a/web/client/components/widgets/enhancers/dependenciesToWidget.js
+++ b/web/client/components/widgets/enhancers/dependenciesToWidget.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {withProps} = require('recompose');
+/**
+ * re-map widget dependencies to a new object, based on a mapping object
+ *
+ * @param {object} widget dependencyMap. a map of key1: key2, where key1 is the key to return and key2 is the key of the value to return in the deps object
+ * @param {object} deps the original dependencies object
+ */
+const buildDependencies = (map, deps) => map
+    ? Object.keys(map).reduce((ret, k) => ({
+        ...ret,
+        [k]: deps[map[k]]
+    }), {})
+    : deps;
+/**
+ * re-map widget `dependencies` based on `dependenciesMap` property (if `dependenciesMap` is present).
+ * @example
+ * const dependenciesMap={x: "a"};
+ * const dependencies={a: "b"};
+ * return <EnhancedCmp dependenciesMap={dependenciesMap} dependencies={dependencies} />
+ * // the enhancer will pass to the component dependencies={x: "b"}
+ */
+module.exports = withProps(
+    ({ dependencies, dependenciesMap }) => ({
+        dependencies: dependenciesMap
+            ? buildDependencies(dependenciesMap, dependencies)
+            : dependencies
+    })
+);

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -53,7 +53,7 @@ module.exports = pure(({
             {...actions}
             {...w}
             dependencies={dependencies}
-                updateProperty={(...args) => updateWidgetProperty(w.id, ...args)}
+            updateProperty={(...args) => updateWidgetProperty(w.id, ...args)}
             onDelete={() => deleteWidget(w)}
             onEdit={() => editWidget(w)} /></div>))
     }

--- a/web/client/components/widgets/widget/DefaultWidget.jsx
+++ b/web/client/components/widgets/widget/DefaultWidget.jsx
@@ -7,16 +7,31 @@
  */
 const React = require('react');
 const enhanceChartWidget = require('../enhancers/chartWidget');
-const enhanceTextWidget = require('../enhancers/deleteWidget');
+const deleteWidget = require('../enhancers/deleteWidget');
 const enhanceTableWidget = require('../enhancers/tableWidget');
 const wpsChart = require('../enhancers/wpsChart');
+const {compose} = require('recompose');
 const dependenciesToFilter = require('../enhancers/dependenciesToFilter');
-const ChartWidget = dependenciesToFilter(wpsChart(enhanceChartWidget(require('./ChartWidget'))));
-const TextWidget = enhanceTextWidget(require('./TextWidget'));
-const MapWidget = enhanceTextWidget(require('./MapWidget'));
-const TableWidget = dependenciesToFilter(enhanceTableWidget(require('./TableWidget')));
+const dependenciesToWidget = require('../enhancers/dependenciesToWidget');
+const ChartWidget = compose(
+    dependenciesToWidget,
+    dependenciesToFilter,
+    wpsChart,
+    enhanceChartWidget
+)(require('./ChartWidget'));
+const TextWidget = deleteWidget(require('./TextWidget'));
+const MapWidget = deleteWidget(require('./MapWidget'));
+const TableWidget = compose(
+    dependenciesToWidget,
+    dependenciesToFilter,
+    enhanceTableWidget
+)(require('./TableWidget'));
 const enhanceCounter = require('../enhancers/counterWidget');
-const CounterWidget = dependenciesToFilter(enhanceCounter(require("./CounterWidget")));
+const CounterWidget = compose(
+    dependenciesToWidget,
+    dependenciesToFilter,
+    enhanceCounter
+)(require("./CounterWidget"));
 module.exports = ({
     dependencies,
     exportCSV = () => {},

--- a/web/client/epics/__tests__/dashboard-test.js
+++ b/web/client/epics/__tests__/dashboard-test.js
@@ -147,7 +147,7 @@ describe('openDashboardWidgetEditor epic', () => {
                     case EDIT_NEW:
                         expect(action.widget).toExist();
                         // verify default mapSync
-                        expect(action.widget.mapSync).toBe(true);
+                        expect(action.widget.mapSync).toBe(false);
                         break;
                     default:
                         done(new Error("Action not recognized"));

--- a/web/client/epics/dashboard.js
+++ b/web/client/epics/dashboard.js
@@ -54,7 +54,7 @@ module.exports = {
         .filter( () => isDashboardAvailable(getState()))
         .switchMap((w) => Rx.Observable.of(editNewWidget({
             legend: false,
-            mapSync: true,
+            mapSync: false,
             ...w,
             // override action's type
             type: undefined

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 const {compose, withProps} = require('recompose');
 const {createSelector} = require('reselect');
 const {mapIdSelector} = require('../selectors/map');
-const { getDashboardWidgets, dashBoardDependenciesSelector, getDashboardWidgetsLayout} = require('../selectors/widgets');
+const { getDashboardWidgets, dependenciesSelector, getDashboardWidgetsLayout} = require('../selectors/widgets');
 const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage} = require('../actions/widgets');
 const ContainerDimensions = require('react-container-dimensions').default;
 
@@ -22,7 +22,7 @@ const WidgetsView = compose(
             mapIdSelector,
             getDashboardWidgets,
             getDashboardWidgetsLayout,
-            dashBoardDependenciesSelector,
+            dependenciesSelector,
             (id, widgets, layouts, dependencies) => ({
                 id,
                 widgets,

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -7,7 +7,7 @@
  */
 
 const React = require('react');
-
+const {withProps, compose} = require('recompose');
 const {createSelector} = require('reselect');
 const {connect} = require('react-redux');
 const PropTypes = require('prop-types');
@@ -15,7 +15,13 @@ const PropTypes = require('prop-types');
 const {isDashboardEditing} = require('../selectors/dashboard');
 const {dashboardSelector} = require('./widgetbuilder/commons');
 
-const Builder = connect(dashboardSelector)(require('./widgetbuilder/WidgetTypeBuilder'));
+const Builder =
+    compose(
+        connect(dashboardSelector),
+        withProps(({ availableDependencies = []}) => ({
+            availableDependencies: availableDependencies.filter(d => d !== "map")
+        }))
+    )(require('./widgetbuilder/WidgetTypeBuilder'));
 const Toolbar = require('../components/misc/toolbar/Toolbar');
 const {createWidget} = require('../actions/widgets');
 

--- a/web/client/plugins/WidgetsBuilder.jsx
+++ b/web/client/plugins/WidgetsBuilder.jsx
@@ -18,8 +18,12 @@ const {setControlProperty} = require('../actions/controls');
 
 const {mapLayoutValuesSelector} = require('../selectors/maplayout');
 const {widgetBuilderSelector} = require('../selectors/controls');
-const {dependenciesSelector} = require('../selectors/widgets');
-const Builder = connect(createSelector(dependenciesSelector, dependencies => ({dependencies})))(require('./widgetbuilder/WidgetTypeBuilder'));
+const { dependenciesSelector, availableDependenciesSelector} = require('../selectors/widgets');
+const Builder = connect(
+    createSelector(
+        dependenciesSelector,
+        availableDependenciesSelector,
+        (dependencies, availableDependenciesProps) => ({ dependencies, ...availableDependenciesProps})))(require('./widgetbuilder/WidgetTypeBuilder'));
 
 class SideBarComponent extends React.Component {
      static propTypes = {

--- a/web/client/plugins/widgetbuilder/ChartBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/ChartBuilder.jsx
@@ -9,7 +9,7 @@
 const React = require('react');
 const {connect} = require('react-redux');
 
-const {compose, renameProps, branch, renderComponent} = require('recompose');
+const { compose, renameProps, branch, renderComponent} = require('recompose');
 
 const BorderLayout = require('../../components/layout/BorderLayout');
 
@@ -17,6 +17,7 @@ const {insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSett
 
 const builderConfiguration = require('../../components/widgets/enhancers/builderConfiguration');
 const chartLayerSelector = require('./enhancers/chartLayerSelector');
+const withViewportConnectButtons = require('./enhancers/connection/withViewportConnectButtons');
 const {
     wizardStateToProps,
     wizardSelector
@@ -40,12 +41,17 @@ const Builder = connect(
 )(require('../../components/widgets/builder/wizard/ChartWizard')));
 
 const BuilderHeader = require('./BuilderHeader');
-const Toolbar = connect(wizardSelector, {
-        openFilterEditor,
-        setPage,
-        insertWidget
-    },
-    wizardStateToProps
+const Toolbar = compose(
+    connect(wizardSelector, {
+            openFilterEditor,
+            setPage,
+            onChange: onEditorChange,
+            insertWidget
+        },
+        wizardStateToProps
+    ),
+    withViewportConnectButtons(({step}) => step === 1)
+
 )(require('../../components/widgets/builder/wizard/chart/Toolbar'));
 
 /*
@@ -60,10 +66,10 @@ const chooseLayerEnhancer = compose(
     )
 );
 
-module.exports = chooseLayerEnhancer(({enabled, onClose = () => {}, dependencies, ...props} = {}) =>
+module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, availableDependencies = {}, dependencies, ...props} = {}) =>
 
     (<BorderLayout
-        header={<BuilderHeader onClose={onClose}><Toolbar onClose={onClose}/></BuilderHeader>}
+        header={<BuilderHeader onClose={onClose}><Toolbar availableDependencies={availableDependencies} onClose={onClose}/></BuilderHeader>}
         >
         {enabled ? <Builder dependencies={dependencies} {...props}/> : null}
     </BorderLayout>));

--- a/web/client/plugins/widgetbuilder/CounterBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/CounterBuilder.jsx
@@ -17,6 +17,7 @@ const { insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSet
 
 const builderConfiguration = require('../../components/widgets/enhancers/builderConfiguration');
 const chartLayerSelector = require('./enhancers/chartLayerSelector');
+const withViewportConnectButtons = require('./enhancers/connection/withViewportConnectButtons');
 
 const {
     wizardStateToProps,
@@ -41,19 +42,24 @@ const Builder = connect(
 )(require('../../components/widgets/builder/wizard/CounterWizard')));
 
 const BuilderHeader = require('./BuilderHeader');
-const Toolbar = connect(wizardSelector, {
-    openFilterEditor,
-    setPage,
-    insertWidget
-},
-    wizardStateToProps
+const Toolbar = compose(
+    connect(
+        wizardSelector, {
+            openFilterEditor,
+            setPage,
+            onChange: onEditorChange,
+            insertWidget
+        },
+        wizardStateToProps
+    ),
+    withViewportConnectButtons(({ step }) => step === 0)
 )(require('../../components/widgets/builder/wizard/counter/Toolbar'));
 
 /*
- * in case you don't have a layer selected (e.g. dashboard) the chartbuilder
+ * in case you don't have a layer selected (e.g. dashboard) the chart builder
  * prompts a catalog view to allow layer selection
  */
-const chooseLayerEhahncer = compose(
+const chooseLayerEnhancer = compose(
     connect(wizardSelector),
     branch(
         ({ layer } = {}) => !layer,
@@ -61,10 +67,10 @@ const chooseLayerEhahncer = compose(
     )
 );
 
-module.exports = chooseLayerEhahncer(({ enabled, onClose = () => { }, dependencies, ...props } = {}) =>
+module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, availableDependencies={}, dependencies, ...props } = {}) =>
 
     (<BorderLayout
-        header={<BuilderHeader onClose={onClose}><Toolbar onClose={onClose} /></BuilderHeader>}
+        header={<BuilderHeader onClose={onClose}><Toolbar availableDependencies={availableDependencies} onClose={onClose} /></BuilderHeader>}
     >
         {enabled ? <Builder formOptions={{
             showColorRamp: false,

--- a/web/client/plugins/widgetbuilder/MapBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/MapBuilder.jsx
@@ -8,7 +8,7 @@
 const React = require('react');
 const {connect} = require('react-redux');
 const {onEditorChange} = require('../../actions/widgets');
-const { wizardSelector, wizardStateToProps, multiMapConnectionSelector} = require('./commons');
+const { wizardSelector, wizardStateToProps, availableDependenciesSelector} = require('./commons');
 const layerSelector = require('./enhancers/layerSelector');
 const manageLayers = require('./enhancers/manageLayers');
 const mapToolbar = require('./enhancers/mapToolbar');
@@ -64,7 +64,7 @@ const mapBuilder = compose(
     })),
     handleNodeSelection,
     handleNodeEditing,
-    connect(multiMapConnectionSelector)
+    connect(availableDependenciesSelector)
 );
 
 
@@ -72,13 +72,13 @@ module.exports = mapBuilder(({
     enabled, onClose = () => {},
     toggleLayerSelector = () => {},
     editNode, setEditNode, closeNodeEditor, selectedGroups=[], selectedLayers=[], selectedNodes, onNodeSelect = () => {} } = {},
-    availableMaps = []
+    availableDependencies = []
     ) =>
     (<BorderLayout
         className = "map-selector"
         header={(<BuilderHeader onClose={onClose}>
             <Toolbar
-            availableMaps={availableMaps}
+            availableDependencies={availableDependencies}
             selectedNodes={selectedNodes}
             selectedLayers={selectedLayers}
             selectedGroups={selectedGroups}

--- a/web/client/plugins/widgetbuilder/MapBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/MapBuilder.jsx
@@ -8,7 +8,7 @@
 const React = require('react');
 const {connect} = require('react-redux');
 const {onEditorChange} = require('../../actions/widgets');
-const {wizardSelector, wizardStateToProps} = require('./commons');
+const { wizardSelector, wizardStateToProps, multiMapConnectionSelector} = require('./commons');
 const layerSelector = require('./enhancers/layerSelector');
 const manageLayers = require('./enhancers/manageLayers');
 const mapToolbar = require('./enhancers/mapToolbar');
@@ -54,7 +54,7 @@ const Builder = connect(
     {
         onChange: onEditorChange
     },
-    wizardStateToProps
+    wizardStateToProps,
 )(require('../../components/widgets/builder/wizard/MapWizard'));
 
 const mapBuilder = compose(
@@ -63,15 +63,22 @@ const mapBuilder = compose(
         map: editorData.map
     })),
     handleNodeSelection,
-    handleNodeEditing
+    handleNodeEditing,
+    connect(multiMapConnectionSelector)
 );
 
 
-module.exports = mapBuilder(({ enabled, onClose = () => { }, toggleLayerSelector = () => { }, editNode, setEditNode, closeNodeEditor, selectedGroups=[], selectedLayers=[], selectedNodes, onNodeSelect = () => { } } = {}) =>
+module.exports = mapBuilder(({
+    enabled, onClose = () => {},
+    toggleLayerSelector = () => {},
+    editNode, setEditNode, closeNodeEditor, selectedGroups=[], selectedLayers=[], selectedNodes, onNodeSelect = () => {} } = {},
+    availableMaps = []
+    ) =>
     (<BorderLayout
         className = "map-selector"
         header={(<BuilderHeader onClose={onClose}>
             <Toolbar
+            availableMaps={availableMaps}
             selectedNodes={selectedNodes}
             selectedLayers={selectedLayers}
             selectedGroups={selectedGroups}

--- a/web/client/plugins/widgetbuilder/TableBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TableBuilder.jsx
@@ -1,5 +1,3 @@
-import { mapPropsStream } from 'recompose';
-
 /*
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
@@ -12,7 +10,7 @@ const React = require('react');
 const { connect } = require('react-redux');
 const {get} = require('lodash');
 const { isGeometryType } = require('../../utils/ogc/WFS/base');
-const { compose, renameProps, branch, renderComponent } = require('recompose');
+const { compose, renameProps, branch, renderComponent, mapPropsStream } = require('recompose');
 const InfoPopover = require('../../components/widgets/widget/InfoPopover');
 const Message = require('../../components/I18N/Message');
 const BorderLayout = require('../../components/layout/BorderLayout');
@@ -21,6 +19,7 @@ const { insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSet
 
 const builderConfiguration = require('../../components/widgets/enhancers/builderConfiguration');
 const chartLayerSelector = require('./enhancers/chartLayerSelector');
+const withViewportConnectButtons = require('./enhancers/connection/withViewportConnectButtons');
 const {
     wizardStateToProps,
     wizardSelector
@@ -55,12 +54,16 @@ const Builder = connect(
 )(require('../../components/widgets/builder/wizard/TableWizard')));
 
 const BuilderHeader = require('./BuilderHeader');
-const Toolbar = connect(wizardSelector, {
-    openFilterEditor,
-    setPage,
-    insertWidget
-},
-    wizardStateToProps
+const Toolbar = compose(
+    connect(wizardSelector, {
+        openFilterEditor,
+        setPage,
+        onChange: onEditorChange,
+        insertWidget
+    },
+        wizardStateToProps
+    ),
+    withViewportConnectButtons(({ step }) => step === 0)
 )(require('../../components/widgets/builder/wizard/table/Toolbar'));
 
 /*
@@ -75,12 +78,12 @@ const chooseLayerEnhancer = compose(
     )
 );
 
-module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData = {}, dependencies, ...props } = {}) =>
+module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData = {}, availableDependencies = {}, dependencies, ...props } = {}) =>
 
     (<BorderLayout
         header={
             <BuilderHeader onClose={onClose}>
-                <Toolbar onClose={onClose} />
+                <Toolbar availableDependencies={availableDependencies} onClose={onClose} />
                 {get(editorData, "options.propertyName.length") === 0 ? <InfoPopover
                     glyph="exclamation-mark"
                     bsStyle="warning"

--- a/web/client/plugins/widgetbuilder/commons.js
+++ b/web/client/plugins/widgetbuilder/commons.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {createSelector} = require('reselect');
-const { getEditingWidget, getEditorSettings, getWidgetLayer, dashBoardDependenciesSelector, getMapWidgets} = require('../../selectors/widgets');
+const { getEditingWidget, dependenciesSelector, getEditorSettings, getWidgetLayer, availableDependenciesSelector} = require('../../selectors/widgets');
+
 const wizardStateToProps = ( stateProps = {}, dispatchProps = {}, ownProps = {}) => ({
          ...ownProps,
          ...stateProps,
@@ -31,18 +32,17 @@ const wizardSelector = createSelector(
  );
 const dashboardSelector = createSelector(
     getEditingWidget,
-    dashBoardDependenciesSelector, // TODO dependencies
-    ({layer}) => ({layer}));
-const multiMapConnectionSelector = createSelector(
-    getEditingWidget,
-    getMapWidgets,
-    (w = {}, ws) => ({
-        availableMaps: ws.filter((ww = {}) => ww.id !== w.id)
-    })
-);
+    dependenciesSelector,
+    availableDependenciesSelector, // TODO dependencies
+    ({ layer }, dependencies, dependencyConnectProps) => ({
+        layer,
+        dependencies,
+        ...dependencyConnectProps
+    }));
+
 module.exports = {
     getWidgetLayer,
-    multiMapConnectionSelector,
+    availableDependenciesSelector,
     dashboardSelector,
     wizardStateToProps,
     wizardSelector

--- a/web/client/plugins/widgetbuilder/commons.js
+++ b/web/client/plugins/widgetbuilder/commons.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {createSelector} = require('reselect');
-const {getEditingWidget, getEditorSettings, getWidgetLayer, dashBoardDependenciesSelector} = require('../../selectors/widgets');
+const { getEditingWidget, getEditorSettings, getWidgetLayer, dashBoardDependenciesSelector, getMapWidgets} = require('../../selectors/widgets');
 const wizardStateToProps = ( stateProps = {}, dispatchProps = {}, ownProps = {}) => ({
          ...ownProps,
          ...stateProps,
@@ -33,9 +33,16 @@ const dashboardSelector = createSelector(
     getEditingWidget,
     dashBoardDependenciesSelector, // TODO dependencies
     ({layer}) => ({layer}));
-
+const multiMapConnectionSelector = createSelector(
+    getEditingWidget,
+    getMapWidgets,
+    (w = {}, ws) => ({
+        availableMaps: ws.filter((ww = {}) => ww.id !== w.id)
+    })
+);
 module.exports = {
     getWidgetLayer,
+    multiMapConnectionSelector,
     dashboardSelector,
     wizardStateToProps,
     wizardSelector

--- a/web/client/plugins/widgetbuilder/enhancers/chartLayerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/chartLayerSelector.js
@@ -12,7 +12,7 @@ const { onEditorChange } = require('../../../actions/widgets');
 const canGenerateCharts = require('../../../observables/widgets/canGenerateCharts');
 module.exports = compose(
     setDisplayName('ChartLayerSelector'),
-    connect(() => { }, {
+    connect(() => ({}), {
         onLayerChoice: (l) => onEditorChange("layer", l)
     }),
     defaultProps({

--- a/web/client/plugins/widgetbuilder/enhancers/connection/viewportConnect.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/viewportConnect.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {withHandlers, withProps, compose} = require('recompose');
+const {omit} = require('lodash');
 
 /**
  * Provides proper handlers and variables to connect a widget to a map viewport in the toolbar or other builders
@@ -27,8 +28,16 @@ module.exports = compose(
              * update dependenciesMap to `undefined` if id === map because in this case there is no need to remap
              * because dependencies from main map is named as viewport
              */
-            const newValue = !editorData.mapSync && id !== 'map' ? `${id}.viewport` : undefined;
-            onChange('dependenciesMap', { ...editorData.dependenciesMap, viewport: newValue});
+            const viewport =
+                !editorData.mapSync
+                    ? id === 'map'
+                        ? 'viewport'
+                        : `${id}.viewport`
+
+                    : undefined;
+            const {dependenciesMap = {}} = editorData;
+            onChange('dependenciesMap', viewport ? { ...dependenciesMap, viewport } : omit(dependenciesMap, 'viewport') );
+
 
         }
     }),

--- a/web/client/plugins/widgetbuilder/enhancers/connection/viewportConnect.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/viewportConnect.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {withHandlers, withProps, compose} = require('recompose');
+
+/**
+ * Provides proper handlers and variables to connect a widget to a map viewport in the toolbar or other builders
+ * requires:
+ *  - editorData object
+ *  - onChange: function to change widget properties
+ *  - toggleDependencySelector function in case of multiple maps
+ *
+ */
+module.exports = compose(
+    withProps(({ editorData = {} }) => ({
+        canConnect: editorData.geomProp,
+        connected: editorData.mapSync
+    })),
+    withHandlers({
+        toggleConnection: ({ onChange = () => { }, editorData = {} }) => (widget, id) => {
+            onChange('mapSync', !editorData.mapSync);
+            /*
+             * update dependenciesMap to `undefined` if id === map because in this case there is no need to remap
+             * because dependencies from main map is named as viewport
+             */
+            const newValue = !editorData.mapSync && id !== 'map' ? `${id}.viewport` : undefined;
+            onChange('dependenciesMap', { ...editorData.dependenciesMap, viewport: newValue});
+
+        }
+    }),
+    withHandlers({
+        toggleConnection: ({ toggleConnection = () => { }, toggleDependencySelector = () => { }, widget, editorData = {}}) =>
+            (available = []) => available.length === 1 || editorData.mapSync
+                ? toggleConnection(widget, available[0])
+                : toggleDependencySelector()
+    })
+);

--- a/web/client/plugins/widgetbuilder/enhancers/connection/withViewportConnectButtons.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/withViewportConnectButtons.js
@@ -23,10 +23,15 @@ module.exports = (showCondition = () => true) => compose(
         }) => ({
             stepButtons: [{
                     onClick: () => toggleConnection(availableDependencies),
+                    disabled: availableDependencies.length > 1, // TODO: remove when support multi map
                     visible: showCondition(props) && canConnect && availableDependencies.length > 0,
                     bsStyle: connected ? "success" : "primary",
                     glyph: connected ? "plug" : "unplug",
-                    tooltipId: "widgets.builder.wizard.connect"
+                tooltipId: connected
+                    ? "widgets.builder.wizard.clearConnection"
+                    : availableDependencies.length === 1
+                        ? "widgets.builder.wizard.connectToTheMap"
+                        : "connection to multiple maps not supported yet" // TODO: "widgets.builder.wizard.connectToAMap"
                 }, ...stepButtons
             ]
         }))

--- a/web/client/plugins/widgetbuilder/enhancers/connection/withViewportConnectButtons.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/withViewportConnectButtons.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {withProps, compose} = require('recompose');
+const viewportConnect = require('./viewportConnect');
+/**
+ * Returns an enhancer that add `stepButtons` for viewport connection to a wizard toolbar
+ * @param {function} showCondition parses props to allow visualization of the buttons (if other connect condition are satisfied)
+ */
+module.exports = (showCondition = () => true) => compose(
+    viewportConnect,
+    withProps(({
+            stepButtons = [],
+            toggleConnection = () => { },
+            availableDependencies = [],
+            canConnect,
+            connected,
+            ...props
+        }) => ({
+            stepButtons: [{
+                    onClick: () => toggleConnection(availableDependencies),
+                    visible: showCondition(props) && canConnect && availableDependencies.length > 0,
+                    bsStyle: connected ? "success" : "primary",
+                    glyph: connected ? "plug" : "unplug",
+                    tooltipId: "widgets.builder.wizard.connect"
+                }, ...stepButtons
+            ]
+        }))
+);

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -14,6 +14,10 @@ const {
     deleteWidget,
     changeLayout,
     clearWidgets,
+    addDependency,
+    removeDependency,
+    resetDependencies,
+    loadDependencies,
     DEFAULT_TARGET
 } = require('../../actions/widgets');
 const {configureMap} = require('../../actions/config');
@@ -93,6 +97,29 @@ describe('Test the widgets reducer', () => {
         const newState = widgets(state, clearWidgets());
         expect(newState.containers[DEFAULT_TARGET].widgets.length).toBe(0);
     });
-
-
+    it('widgets addDependency', () => {
+        const action = addDependency("key", "value");
+        const state = widgets({ dependencies: {} }, action);
+        expect(state).toExist();
+        expect(state.dependencies.key).toBe("value");
+    });
+    it('widgets removeDependency', () => {
+        const action = removeDependency("key");
+        const state = widgets({dependencies: {key: "value"}}, action);
+        expect(state).toExist();
+        expect(state.dependencies.key).toBeFalsy();
+    });
+    it('widgets loadDependencies', () => {
+        const action = loadDependencies({key: "value"});
+        const state = widgets( undefined, action);
+        expect(state).toExist();
+        expect(state.dependencies.key).toBe("value");
+    });
+    it('widgets resetDependencies', () => {
+        const action = resetDependencies();
+        const state = widgets( {dependencies: {key: "value"}}, action);
+        expect(state).toExist();
+        expect(state.dependencies.key).toBeFalsy();
+        expect(state.dependencies.viewport).toBe("map.bbox");
+    });
 });

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -18,7 +18,8 @@ const {arrayUpsert, arrayDelete} = require('../utils/ImmutableUtils');
 
 const emptyState = {
     dependencies: {
-        viewport: "map.bbox"
+        viewport: "map.bbox",
+        center: "map.center"
     },
     containers: {
         floating: {

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { EDIT_NEW, INSERT, EDIT, UPDATE_PROPERTY, DELETE, EDITOR_CHANGE, EDITOR_SETTING_CHANGE, CHANGE_LAYOUT, CLEAR_WIDGETS, DEFAULT_TARGET} = require('../actions/widgets');
+const { EDIT_NEW, INSERT, EDIT, UPDATE_PROPERTY, DELETE, EDITOR_CHANGE, EDITOR_SETTING_CHANGE, CHANGE_LAYOUT, CLEAR_WIDGETS, DEFAULT_TARGET,
+ADD_DEPENDENCY, REMOVE_DEPENDENCY, LOAD_DEPENDENCIES, RESET_DEPENDENCIES} = require('../actions/widgets');
 const {
     MAP_CONFIG_LOADED
 } = require('../actions/config');
@@ -109,6 +110,19 @@ function widgetsReducer(state = emptyState, action) {
         case CLEAR_WIDGETS: {
             return set(`containers[${DEFAULT_TARGET}]`, emptyState.containers[DEFAULT_TARGET], state);
         }
+        case ADD_DEPENDENCY: {
+            const {key, value} = action;
+            return set(`dependencies[${key}]`, value, state);
+        }
+        case REMOVE_DEPENDENCY: {
+            const {key} = action;
+            return set(`dependencies[${key}]`, null, state);
+        }
+        case LOAD_DEPENDENCIES:
+            const {dependencies} = action;
+            return set(`dependencies`, dependencies, state);
+        case RESET_DEPENDENCIES:
+            return set('dependencies', emptyState.dependencies, state);
         default:
             return state;
     }

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -76,11 +76,40 @@ describe('widgets selectors', () => {
     it('dependenciesSelector', () => {
         const state = {
             widgets: {
+                containers: {
+                    [DEFAULT_TARGET]: {
+                        widgets: [{
+                            id: "WIDGET_ID",
+                            map: {
+                                center: {
+                                    x: -4.866943359375001,
+                                    y: 43.96119063892024,
+                                    crs: 'EPSG:4326'
+                                },
+                                bbox: {
+                                    bounds: {
+                                        minx: -1346514.6902716649,
+                                        miny: 5126784.36114334,
+                                        maxx: 262943.37730100635,
+                                        maxy: 5792092.255337515
+                                    }
+                                }
+                            }
+                        }]
+                    }
+                },
                 dependencies: {
                     a: "mydep.a",
                     b: "mydep.b",
-                    c: "map.abc"
-                }
+                    // special map path
+                    c: "map.abc",
+                    // special widgets path
+                    d: "widgets[\"WIDGET_ID\"].center",
+                    e: "widgets[WIDGET_ID].center",
+                    f: "widgets[NO_ID].center",
+                    g: "widgets[otherStateSlice]"
+                },
+             otherStateSlice: "otherStateValue"
              },
              mydep: {
                  a: "A",
@@ -96,6 +125,10 @@ describe('widgets selectors', () => {
         expect(dependencies.a).toBe("A");
         expect(dependencies.b).toBe("B");
         expect(dependencies.c).toBe("ABC");
+        expect(dependencies.d).toBe(state.widgets.containers[DEFAULT_TARGET].widgets[0].center);
+        expect(dependencies.e).toBe(state.widgets.containers[DEFAULT_TARGET].widgets[0].center);
+        expect(dependencies.f).toBeFalsy();
+        expect(dependencies.g).toBe(state.widgets.otherStateSlice);
     });
 
 });

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -17,7 +17,8 @@ const {
     getEditingWidgetFilter,
     getEditorSettings,
     getWidgetLayer,
-    dependenciesSelector
+    dependenciesSelector,
+    availableDependenciesSelector
 } = require('../widgets');
 const {set} = require('../../utils/ImmutableUtils');
 describe('widgets selectors', () => {
@@ -73,6 +74,27 @@ describe('widgets selectors', () => {
         const widgetLayer = set(`widgets.builder.editor`, { layer: { name: "TEST2" } }, dashboardNoLayer);
         expect(getWidgetLayer(widgetLayer).name).toBe("TEST2");
     });
+    it('getMapWidgets', () => {
+        const state = {
+            widgets: {
+                containers: {
+                    [DEFAULT_TARGET]: {
+                        widgets: [{
+                            id: "WIDGET",
+                            widgetType: "map"
+                        }, {
+
+                        }, {
+                            widgetType: "table"
+                        }]
+                    }
+                }
+            }
+        };
+        expect(availableDependenciesSelector(state)).toExist();
+        expect(availableDependenciesSelector(state).availableDependencies[0]).toBe('widgets[WIDGET].map');
+        expect(availableDependenciesSelector(state).availableDependencies[1]).toBe('map');
+    });
     it('dependenciesSelector', () => {
         const state = {
             widgets: {
@@ -104,10 +126,10 @@ describe('widgets selectors', () => {
                     // special map path
                     c: "map.abc",
                     // special widgets path
-                    d: "widgets[\"WIDGET_ID\"].center",
-                    e: "widgets[WIDGET_ID].center",
-                    f: "widgets[NO_ID].center",
-                    g: "widgets[otherStateSlice]"
+                    d: "widgets[\"WIDGET_ID\"].map.center",
+                    e: "widgets[WIDGET_ID].map.center",
+                    f: "widgets[NO_ID].map.center",
+                    g: "widgets.otherStateSlice"
                 },
              otherStateSlice: "otherStateValue"
              },
@@ -125,8 +147,8 @@ describe('widgets selectors', () => {
         expect(dependencies.a).toBe("A");
         expect(dependencies.b).toBe("B");
         expect(dependencies.c).toBe("ABC");
-        expect(dependencies.d).toBe(state.widgets.containers[DEFAULT_TARGET].widgets[0].center);
-        expect(dependencies.e).toBe(state.widgets.containers[DEFAULT_TARGET].widgets[0].center);
+        expect(dependencies.d).toBe(state.widgets.containers[DEFAULT_TARGET].widgets[0].map.center);
+        expect(dependencies.e).toBe(state.widgets.containers[DEFAULT_TARGET].widgets[0].map.center);
         expect(dependencies.f).toBeFalsy();
         expect(dependencies.g).toBe(state.widgets.otherStateSlice);
     });

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -38,6 +38,7 @@ module.exports = {
     getEditingWidgetFilter: state => get(getEditingWidget(state), "filter"),
     getEditorSettings,
     getWidgetLayer,
+    getMapWidgets: state => (get(state, `widgets.containers[${DEFAULT_TARGET}].widgets`) || []).filter(({type} = {}) => type === "map"),
     dashBoardDependenciesSelector: () => ({}), // TODO dashboard dependencies
     /**
      * transforms dependencies in the form `{ k1: "path1", k1, "path2" }` into

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1126,7 +1126,10 @@
                     "useThisMap": "Benutze diese Karte",
                     "configureMapOptions": "Kartenoptionen konfigurieren",
                     "addLayer": "Fügt der Karte eine Ebene hinzu",
-                    "useTheSelectedLayer": "Verwende die ausgewählte Ebene"
+                    "useTheSelectedLayer": "Verwende die ausgewählte Ebene",
+                    "connectToAMap": "Mit einer Karte verbinden",
+                    "connectToTheMap": "Verbinden mit der Karte",
+                    "clearConnection": "Verbindung löschen"
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Keine Widgets verfügbar",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1127,7 +1127,10 @@
                     "useThisMap": "Use this map",
                     "configureMapOptions": "Configure map options",
                     "addLayer": "Add a layer to the map",
-                    "useTheSelectedLayer": "Use the selected layer"
+                    "useTheSelectedLayer": "Use the selected layer",
+                    "connectToAMap": "Connect to a map",
+                    "connectToTheMap": "Connect to the map",
+                    "clearConnection": "Clear connection"
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "No Widgets available",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1126,7 +1126,10 @@
                     "useThisMap": "Usar este mapa",
                     "configureMapOptions": "Configurar opciones de mapa",
                     "addLayer": "Agregar una capa al mapa",
-                    "useTheSelectedLayer": "Usar la capa seleccionada"
+                    "useTheSelectedLayer": "Usar la capa seleccionada",
+                    "connectToAMap": "Conectar a un mapa",
+                    "connectToTheMap": "Conectarse al mapa",
+                    "clearConnection": "Borrar conexión"
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Sin widgets disponibles",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1127,7 +1127,10 @@
                     "useThisMap": "Utiliser cette carte",
                     "configureMapOptions": "Configurer les options de la carte",
                     "addLayer": "Ajouter une couche à la carte",
-                    "useTheSelectedLayer": "Utiliser le calque sélectionné"
+                    "useTheSelectedLayer": "Utiliser le calque sélectionné",
+                    "connectToAMap": "Se connecter à une carte",
+                    "connectToTheMap": "Se connecter à la carte",
+                    "clearConnection": "Effacer la connexion"
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Aucun widget disponible",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1126,7 +1126,10 @@
                     "useThisMap": "Usa questa mappa",
                     "configureMapOptions": "Configura opzioni mappa",
                     "addLayer": "Aggiungi un livello alla mappa",
-                    "useTheSelectedLayer": "Usa il livello selezionato"
+                    "useTheSelectedLayer": "Usa il livello selezionato",
+                    "connectToAMap": "Connetti a una mappa",
+                    "connectToTheMap": "Connetti alla mappa",
+                    "clearConnection": "Disconnetti"
                 },
                 "errors": {
                     "noWidgetsAvailableTitle": "Nessun widgets disponibile",


### PR DESCRIPTION
## Description
This pull request adds the possibility to connect the widgets to a map on the dashboard or the main map in the map view .

## Issues
 - Connect to #2662

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** 
You can not connect widgets to maps in the geodashboard

**What is the new behavior?**
If you have a single map, you can connect it to the dashboard. Now the connection to map is aligned to the mockup using the button 
![image](https://user-images.githubusercontent.com/1279510/38036324-c3bc7362-32a6-11e8-90a4-17b6db8bcf1d.png)
![image](https://user-images.githubusercontent.com/1279510/38036373-d8230b0e-32a6-11e8-9f6e-acd8bd4a1f25.png)


**Does this PR introduce a breaking change?** 

 - [x] No
