### PR TITLE
Fix #2662. Add widget connections and colors

### DIFF
--- a/web/client/actions/dashboard.js
+++ b/web/client/actions/dashboard.js
@@ -1,8 +1,11 @@
 const SET_EDITOR_AVAILABLE = "DASHBOARD:SET_AVAILABLE";
 const SET_EDITING = "DASHBOARD:SET_EDITING";
+const SHOW_CONNECTIONS = "DASHBOARD:SHOW_CONNECTIONS";
 module.exports = {
     SET_EDITING,
     setEditing: (editing) => ({type: SET_EDITING, editing }),
     SET_EDITOR_AVAILABLE,
-    setEditorAvailable: available => ({type: SET_EDITOR_AVAILABLE, available})
+    setEditorAvailable: available => ({type: SET_EDITOR_AVAILABLE, available}),
+    SHOW_CONNECTIONS,
+    triggerShowConnections: show => ({ type: SHOW_CONNECTIONS, show})
 };

--- a/web/client/components/dashboard/Dashboard.jsx
+++ b/web/client/components/dashboard/Dashboard.jsx
@@ -18,11 +18,11 @@ module.exports =
             ({widgets = []} = {}) => widgets.length === 0,
             () => ({
                 glyph: "dashboard",
-                title: <Message msgId="dashboard.emptyTitle" /> // TODO i18n
+                title: <Message msgId="dashboard.emptyTitle" />
             })
         ),
         defaultProps({
-            isWidgetSelectable: ({}) => true // TODO: filter widgets
+            isWidgetSelectable: ({}) => true
         }),
         withSelection
     )(require('../widgets/view/WidgetsView'));

--- a/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
@@ -20,7 +20,7 @@ const nodeEditor = require('./enhancers/nodeEditor');
 const Editor = nodeEditor(require('./NodeEditor'));
 
 module.exports = ({ preview, map = {}, onChange = () => { }, selectedNodes = [], onNodeSelect = () => { }, editNode, closeNodeEditor = () => { } }) => (<div>
-    <StepHeader title={<Message msgId={`Preview`} />} />
+    <StepHeader title={<Message msgId={`widgets.builder.wizard.preview`} />} />
     <div key="sample" >
         <div style={{ width: "100%", height: "200px"}}>
             {preview}

--- a/web/client/components/widgets/enhancers/withGroupColor.jsx
+++ b/web/client/components/widgets/enhancers/withGroupColor.jsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {withProps} = require('recompose');
+const {get, head} = require('lodash');
+const getGroupColor = groups => get(head(groups, ({ color }) => color), 'color');
+/**
+ * get the first color found in widget groups array.
+ */
+module.exports = withProps(({ groups, showGroupColor, headerStyle = {borderTop: "3px solid rgba(0,0,0,0)", transition: "border-color .5s ease-out"} }) => ({
+    headerStyle: showGroupColor && groups && getGroupColor(groups)
+        ? { ...headerStyle, borderTop: `3px solid ${getGroupColor(groups)}` }
+        : headerStyle
+}));

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -8,14 +8,16 @@
 const React = require('react');
 
 const { pure } = require('recompose');
-
+const { find } = require('lodash');
 /*
 react-grid-layout-resize-prevent-collision is a fork of react-grid-layout deployed on npmjs.org to fix https://github.com/STRML/react-grid-layout/issues/655
 You can install and use react-grid-layout again when the issue is fixed
 */
 const { Responsive, WidthProvider: widthProvider } = require('react-grid-layout-resize-prevent-collision');
 const ResponsiveReactGridLayout = widthProvider(Responsive);
-const DefaultWidget = require('../widget/DefaultWidget');
+const withGroupColor = require('../enhancers/withGroupColor');
+const DefaultWidget = withGroupColor(require('../widget/DefaultWidget'));
+const getWidgetGroups = (groups = [], w) => groups.filter(g => find(g.widgets, id => id === w.id));
 require('react-grid-layout-resize-prevent-collision/css/styles.css');
 
 module.exports = pure(({
@@ -28,6 +30,8 @@ module.exports = pure(({
     widgets = [],
     layouts,
     dependencies,
+    showGroupColor,
+    groups = [],
     getWidgetClass = () => { },
     onWidgetClick = () => { },
     updateWidgetProperty = () => { },
@@ -54,6 +58,8 @@ module.exports = pure(({
                 data-grid={w.dataGrid}
                 {...actions}
                 {...w}
+                groups={getWidgetGroups(groups, w)}
+                showGroupColor={showGroupColor}
                 dependencies={dependencies}
                 updateProperty={(...args) => updateWidgetProperty(w.id, ...args)}
                 onDelete={() => deleteWidget(w)}

--- a/web/client/components/widgets/widget/ChartWidget.jsx
+++ b/web/client/components/widgets/widget/ChartWidget.jsx
@@ -31,6 +31,7 @@ module.exports = ({
     id,
     title,
     description,
+    headerStyle,
     data = [],
     series = [],
     loading,
@@ -45,6 +46,7 @@ module.exports = ({
     ...props}) =>
     (<WidgetContainer
         id={`widget-chart-${id}`}
+        headerStyle={headerStyle}
         title={title}
         topLeftItems={renderHeaderLeftTopItem({loading, title, description, showTable, toggleTableView})}
         confirmDelete={confirmDelete}

--- a/web/client/components/widgets/widget/CounterWidget.jsx
+++ b/web/client/components/widgets/widget/CounterWidget.jsx
@@ -36,6 +36,7 @@ module.exports = ({
     width,
     height,
     confirmDelete= false,
+    headerStyle,
     toggleTableView= () => {},
     toggleDeleteConfirm= () => {},
     onEdit= () => {},
@@ -48,6 +49,7 @@ module.exports = ({
         confirmDelete={confirmDelete}
         onDelete={onDelete}
         toggleDeleteConfirm = {toggleDeleteConfirm}
+        headerStyle={headerStyle}
         topRightItems={showTable
             ? null : <ButtonToolbar>
             <DropdownButton pullRight bsStyle="default" className="widget-menu" title={<Glyphicon glyph="option-vertical" />} noCaret id="dropdown-no-caret">

--- a/web/client/components/widgets/widget/MapWidget.jsx
+++ b/web/client/components/widgets/widget/MapWidget.jsx
@@ -35,9 +35,10 @@ module.exports = ({
     map,
     mapStateSource,
     confirmDelete = false,
-    onDelete = () => {}
+    onDelete = () => {},
+    headerStyle
 } = {}) =>
-    (<WidgetContainer id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm}
+    (<WidgetContainer id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm} headerStyle={headerStyle}
         topLeftItems={renderHeaderLeftTopItem({ loading, title, description })}
         topRightItems={<ButtonToolbar>
             <DropdownButton pullRight bsStyle="default" className="widget-menu" title={<Glyphicon glyph="option-vertical" />} noCaret id="dropdown-no-caret">

--- a/web/client/components/widgets/widget/TableWidget.jsx
+++ b/web/client/components/widgets/widget/TableWidget.jsx
@@ -34,6 +34,7 @@ module.exports = ({
     description,
     loading,
     confirmDelete = false,
+    headerStyle,
     toggleTableView = () => { },
     toggleDeleteConfirm = () => { },
     onEdit = () => { },
@@ -54,6 +55,7 @@ module.exports = ({
     (<WidgetContainer
         id={`widget-chart-${id}`}
         title={title}
+        headerStyle={headerStyle}
         topLeftItems={renderHeaderLeftTopItem({ loading, title, description, toggleTableView })}
         confirmDelete={confirmDelete}
         onDelete={onDelete}

--- a/web/client/components/widgets/widget/TextWidget.jsx
+++ b/web/client/components/widgets/widget/TextWidget.jsx
@@ -21,10 +21,11 @@ module.exports = ({
     onEdit = () => {},
     toggleDeleteConfirm = () => {},
     id, title, text,
+    headerStyle,
     confirmDelete= false,
     onDelete=() => {}
 } = {}) =>
-(<WidgetContainer id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm}
+    (<WidgetContainer id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm} headerStyle={headerStyle}
     topRightItems={<ButtonToolbar>
         <DropdownButton pullRight bsStyle="default" className="widget-menu" title={<Glyphicon glyph="option-vertical" />} noCaret id="dropdown-no-caret">
             <MenuItem onClick={() => onEdit()} eventKey="3"><Glyphicon glyph="pencil"/>&nbsp;<Message msgId="widgets.widget.menu.edit" /></MenuItem>

--- a/web/client/components/widgets/widget/WidgetContainer.jsx
+++ b/web/client/components/widgets/widget/WidgetContainer.jsx
@@ -19,10 +19,11 @@ module.exports = ({
     onDelete=() => {},
     topLeftItems,
     topRightItems,
+    headerStyle = {},
     children
     }) =>
     (<div className="mapstore-widget-card" id={id}>
-        <BorderLayout header={(<div className={`mapstore-widget-info ${handle ? handle : ""}`}>
+        <BorderLayout header={(<div style={headerStyle} className={`mapstore-widget-info ${handle ? handle : ""}`}>
                     <div className="mapstore-widget-header">
                         {topLeftItems}
                         <span className="widget-title">{title}</span>

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -12,8 +12,9 @@ const {connect} = require('react-redux');
 const { compose, withProps, withHandlers } = require('recompose');
 const {createSelector} = require('reselect');
 const {mapIdSelector} = require('../selectors/map');
-const { getDashboardWidgets, dependenciesSelector, getDashboardWidgetsLayout, isWidgetSelectionActive, getEditingWidget} = require('../selectors/widgets');
+const { getDashboardWidgets, dependenciesSelector, getDashboardWidgetsLayout, isWidgetSelectionActive, getEditingWidget, getWidgetsDependenciesGroups} = require('../selectors/widgets');
 const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage, selectWidget} = require('../actions/widgets');
+const {showConnectionsSelector} = require('../selectors/dashboard');
 const ContainerDimensions = require('react-container-dimensions').default;
 
 const PropTypes = require('prop-types');
@@ -26,13 +27,17 @@ const WidgetsView = compose(
             dependenciesSelector,
             isWidgetSelectionActive,
             (state) => get(getEditingWidget(state), "id"),
-            (id, widgets, layouts, dependencies, selectionActive, editingWidgetId) => ({
+            getWidgetsDependenciesGroups,
+            showConnectionsSelector,
+            (id, widgets, layouts, dependencies, selectionActive, editingWidgetId, groups, showGroupColor) => ({
                 id,
                 widgets,
                 layouts,
                 dependencies,
                 selectionActive,
-                editingWidgetId
+                editingWidgetId,
+                groups,
+                showGroupColor
             })
         ), {
             editWidget,

--- a/web/client/plugins/widgetbuilder/commons.js
+++ b/web/client/plugins/widgetbuilder/commons.js
@@ -7,6 +7,7 @@
  */
 const {createSelector} = require('reselect');
 const { getEditingWidget, dependenciesSelector, getEditorSettings, getWidgetLayer, availableDependenciesSelector} = require('../../selectors/widgets');
+const { showConnectionsSelector } = require('../../selectors/dashboard');
 
 const wizardStateToProps = ( stateProps = {}, dispatchProps = {}, ownProps = {}) => ({
          ...ownProps,
@@ -32,10 +33,12 @@ const wizardSelector = createSelector(
  );
 const dashboardSelector = createSelector(
     getEditingWidget,
+    showConnectionsSelector,
     dependenciesSelector,
     availableDependenciesSelector,
-    ({ layer }, dependencies, dependencyConnectProps) => ({
+    ({ layer }, showConnections, dependencies, dependencyConnectProps) => ({
         layer,
+        showConnections,
         dependencies,
         ...dependencyConnectProps
     }));

--- a/web/client/plugins/widgetbuilder/enhancers/connection/withConnectButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/withConnectButton.js
@@ -30,7 +30,7 @@ module.exports = (showCondition = () => true) => compose(
                 ? "widgets.builder.wizard.clearConnection"
                 : availableDependencies.length === 1
                     ? "widgets.builder.wizard.connectToTheMap"
-                    : "widgets.builder.wizard.connectToAMap" // TODO: "widgets.builder.wizard.connectToAMap"
+                    : "widgets.builder.wizard.connectToAMap"
         }, ...stepButtons
         ]
     }))

--- a/web/client/reducers/__tests__/dashboard-test.js
+++ b/web/client/reducers/__tests__/dashboard-test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const { setEditorAvailable, setEditing, triggerShowConnections } = require('../../actions/dashboard');
+const { insertWidget, updateWidget, deleteWidget } = require('../../actions/widgets');
+const dashboard = require('../dashboard');
+describe('Test the dashboard reducer', () => {
+    it('setEditorAvailable action', () => {
+        const state = dashboard({}, setEditorAvailable( true ));
+        expect(state.editor.available).toBe(true);
+    });
+    it('setEditing', () => {
+        const state = dashboard({}, setEditing(true));
+        expect(state.editing).toBe(true);
+    });
+    it('disable editing on insert/update/delete', () => {
+        expect(dashboard({ editing: true }, insertWidget({})).editing).toBeFalsy();
+        expect(dashboard({ editing: true }, updateWidget({})).editing).toBeFalsy();
+        expect(dashboard({ editing: true }, deleteWidget({})).editing).toBeFalsy();
+    });
+    it('triggerShowConnections', () => {
+        const state = dashboard({}, triggerShowConnections(true));
+        expect(state.showConnections).toBe(true);
+    });
+
+});

--- a/web/client/reducers/dashboard.js
+++ b/web/client/reducers/dashboard.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {SET_EDITING, SET_EDITOR_AVAILABLE} = require('../actions/dashboard');
+const { SET_EDITING, SET_EDITOR_AVAILABLE, SHOW_CONNECTIONS} = require('../actions/dashboard');
 const {INSERT, UPDATE, DELETE} = require('../actions/widgets');
 const {set} = require('../utils/ImmutableUtils');
 function dashboard(state = {}, action) {
@@ -21,6 +21,8 @@ function dashboard(state = {}, action) {
         case INSERT:
         case DELETE:
             return set("editing", action.editing, state);
+        case SHOW_CONNECTIONS:
+            return set("showConnections", action.show, state);
         default:
             return state;
     }

--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -9,7 +9,9 @@ const expect = require('expect');
 
 const {
     isDashboardAvailable,
-    isDashboardEditing} = require('../dashboard');
+    isDashboardEditing,
+    showConnectionsSelector
+} = require('../dashboard');
 describe('dashboard selectors', () => {
     it('test isDashboardAvailable selector', () => {
         const state = {dashboard: {editor: {available: true}}};
@@ -18,5 +20,12 @@ describe('dashboard selectors', () => {
     it('test isDashboardEditing selector', () => {
         const state = { dashboard: { editing: true } };
         expect(isDashboardEditing(state)).toBe(true);
+    });
+    it('test showConnectionsSelector', () => {
+        expect(showConnectionsSelector({
+            dashboard: {
+                showConnections: true
+            }
+        })).toBe(true);
     });
 });

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -152,5 +152,4 @@ describe('widgets selectors', () => {
         expect(dependencies.f).toBeFalsy();
         expect(dependencies.g).toBe(state.widgets.otherStateSlice);
     });
-
 });

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -1,8 +1,9 @@
 const isDashboardAvailable = state => state && state.dashboard && state.dashboard.editor && state.dashboard.editor.available;
 const isDashboardEditing = state => state && state.dashboard && state.dashboard.editing;
+const showConnectionsSelector = state => state && state.dashboard && state.dashboard.showConnections;
 
 module.exports = {
     isDashboardAvailable,
-    isDashboardEditing
-
+    isDashboardEditing,
+    showConnectionsSelector
 };

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -1,7 +1,8 @@
-const { get, find, castArray, isEqualWith} = require('lodash');
+const { get, castArray, isEqualWith} = require('lodash');
 const {mapSelector} = require('./map');
 const {getSelectedLayer} = require('./layers');
 const {DEFAULT_TARGET, DEPENDENCY_SELECTOR_KEY, WIDGETS_REGEX} = require('../actions/widgets');
+const { getWidgetsGroups, getWidgetDependency} = require('../utils/WidgetsUtils');
 
 const {isDashboardAvailable, isDashboardEditing} = require('./dashboard');
 const {defaultMemoize, createSelector, createSelectorCreator} = require('reselect');
@@ -27,15 +28,7 @@ const getWidgetLayer = createSelector(
     state => isDashboardAvailable(state) && isDashboardEditing(state),
     ({layer} = {}, selectedLayer, dashboardEditing) => layer || !dashboardEditing && selectedLayer
 );
-const getWidgetDependency = (k, widgets) => {
-    const [match, id, rest] = WIDGETS_REGEX.exec(k);
-    if (match) {
-        const widget = find(widgets, { id });
-        return rest
-            ? get(widget, rest)
-            : widget;
-    }
-};
+
 const getFloatingWidgets = state => get(state, `widgets.containers[${DEFAULT_TARGET}].widgets`);
 
 const getMapWidgets = state => (getFloatingWidgets(state) || []).filter(({ widgetType } = {}) => widgetType === "map");
@@ -60,6 +53,11 @@ const getDependencySelectorConfig = state => get(getEditorSettings(state), `${DE
  * @param {object} state the state
  */
 const isWidgetSelectionActive = state => get(getDependencySelectorConfig(state), 'active');
+
+const getWidgetsDependenciesGroups = createSelector(
+    getFloatingWidgets,
+    widgets => getWidgetsGroups(widgets)
+);
 
 module.exports = {
     getFloatingWidgets,
@@ -98,5 +96,6 @@ module.exports = {
         }), {})
     ),
     isWidgetSelectionActive,
-    getDependencySelectorConfig
+    getDependencySelectorConfig,
+    getWidgetsDependenciesGroups
 };

--- a/web/client/test-resources/widgets/complex_graph.json
+++ b/web/client/test-resources/widgets/complex_graph.json
@@ -1,0 +1,546 @@
+{
+  "widgets": [
+    {
+      "id": "bd02b5b0-37e5-11e8-8356-a9f1e7707f6f",
+      "layer": false,
+      "url": false,
+      "legend": false,
+      "mapSync": false,
+      "widgetType": "map",
+      "map": {
+        "map": {
+          "center": {
+            "x": -0.18782921925813859,
+            "y": 44.08755782761387,
+            "crs": "EPSG:4326"
+          },
+          "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+          ],
+          "projection": "EPSG:900913",
+          "units": "m",
+          "zoom": 6,
+          "mapOptions": {}
+        },
+        "layers": [
+          {
+            "id": "mapnik__0",
+            "group": "background",
+            "source": "osm",
+            "name": "mapnik",
+            "title": "Open Street Map",
+            "type": "osm",
+            "visibility": true,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "HYBRID__1",
+            "group": "background",
+            "source": "google",
+            "name": "HYBRID",
+            "title": "Google HYBRID",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "osm__2",
+            "group": "background",
+            "source": "mapquest",
+            "name": "osm",
+            "title": "MapQuest OSM",
+            "type": "mapquest",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "apiKey": "__API_KEY_MAPQUEST__"
+          },
+          {
+            "id": "Night2012__3",
+            "group": "background",
+            "source": "nasagibs",
+            "name": "Night2012",
+            "provider": "NASAGIBS.ViirsEarthAtNight2012",
+            "title": "NASAGIBS Night 2012",
+            "type": "tileprovider",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "OpenTopoMap__4",
+            "group": "background",
+            "source": "OpenTopoMap",
+            "name": "OpenTopoMap",
+            "provider": "OpenTopoMap",
+            "title": "OpenTopoMap",
+            "type": "tileprovider",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "undefined__5",
+            "group": "background",
+            "source": "ol",
+            "title": "Empty Background",
+            "type": "empty",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          }
+        ],
+        "groups": [
+          {
+            "id": "Default",
+            "expanded": true
+          },
+          {
+            "id": "Local shape",
+            "expanded": true
+          }
+        ],
+        "center": {
+          "x": -10.546875,
+          "y": 42.553080288955805,
+          "crs": "EPSG:4326"
+        },
+        "bbox": {
+          "bounds": {
+            "minx": -9001224.450862356,
+            "miny": -78271.51696402114,
+            "maxx": 6653078.941941742,
+            "maxy": 10566654.790142763
+          },
+          "crs": "EPSG:3857",
+          "rotation": 0
+        },
+        "zoom": 1,
+        "size": {
+          "width": 200,
+          "height": 136
+        },
+        "projection": "EPSG:3857",
+        "mapStateSource": "bd02b5b0-37e5-11e8-8356-a9f1e7707f6f"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "c66b2830-37e5-11e8-8356-a9f1e7707f6f",
+      "layer": {
+        "type": "wms",
+        "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+        "visibility": true,
+        "dimensions": [],
+        "name": "topp:states",
+        "title": "USA Population",
+        "description": "This is some census data on the states.",
+        "bbox": {
+          "crs": "EPSG:4326",
+          "bounds": {
+            "minx": -124.73142200000001,
+            "miny": 24.955967,
+            "maxx": -66.969849,
+            "maxy": 49.371735
+          }
+        },
+        "links": [],
+        "params": {
+          "layers": "topp:states"
+        },
+        "allowedSRS": {},
+        "search": {
+          "type": "wfs",
+          "url": "https://demo.geo-solutions.it:443/geoserver/wfs?"
+        }
+      },
+      "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+      "legend": false,
+      "mapSync": true,
+      "type": "bar",
+      "widgetType": "chart",
+      "geomProp": "the_geom",
+      "dependenciesMap": {
+        "viewport": "widgets[bd02b5b0-37e5-11e8-8356-a9f1e7707f6f].map.viewport"
+      },
+      "options": {
+        "groupByAttributes": "STATE_NAME",
+        "aggregationAttribute": "STATE_NAME",
+        "aggregateFunction": "Count"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "cbc25830-37e5-11e8-8356-a9f1e7707f6f",
+      "layer": false,
+      "url": false,
+      "legend": false,
+      "mapSync": true,
+      "widgetType": "map",
+      "map": {
+        "map": {
+          "center": {
+            "x": -0.18782921925813859,
+            "y": 44.08755782761387,
+            "crs": "EPSG:4326"
+          },
+          "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+          ],
+          "projection": "EPSG:900913",
+          "units": "m",
+          "zoom": 6,
+          "mapOptions": {}
+        },
+        "layers": [
+          {
+            "id": "mapnik__0",
+            "group": "background",
+            "source": "osm",
+            "name": "mapnik",
+            "title": "Open Street Map",
+            "type": "osm",
+            "visibility": true,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "HYBRID__1",
+            "group": "background",
+            "source": "google",
+            "name": "HYBRID",
+            "title": "Google HYBRID",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "osm__2",
+            "group": "background",
+            "source": "mapquest",
+            "name": "osm",
+            "title": "MapQuest OSM",
+            "type": "mapquest",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "apiKey": "__API_KEY_MAPQUEST__"
+          },
+          {
+            "id": "Night2012__3",
+            "group": "background",
+            "source": "nasagibs",
+            "name": "Night2012",
+            "provider": "NASAGIBS.ViirsEarthAtNight2012",
+            "title": "NASAGIBS Night 2012",
+            "type": "tileprovider",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "OpenTopoMap__4",
+            "group": "background",
+            "source": "OpenTopoMap",
+            "name": "OpenTopoMap",
+            "provider": "OpenTopoMap",
+            "title": "OpenTopoMap",
+            "type": "tileprovider",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "undefined__5",
+            "group": "background",
+            "source": "ol",
+            "title": "Empty Background",
+            "type": "empty",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          }
+        ],
+        "groups": [
+          {
+            "id": "Default",
+            "expanded": true
+          },
+          {
+            "id": "Local shape",
+            "expanded": true
+          }
+        ],
+        "center": {
+          "x": -10.546875,
+          "y": 42.55308028895579,
+          "crs": "EPSG:4326"
+        },
+        "bbox": {
+          "bounds": {
+            "minx": -9001224.450862356,
+            "miny": -78271.516964023,
+            "maxx": 6653078.941941742,
+            "maxy": 10566654.790142763
+          },
+          "crs": "EPSG:3857",
+          "rotation": 0
+        },
+        "zoom": 1,
+        "size": {
+          "width": 200,
+          "height": 136
+        },
+        "projection": "EPSG:3857",
+        "mapStateSource": "cbc25830-37e5-11e8-8356-a9f1e7707f6f"
+      },
+      "dependenciesMap": {
+        "center": "widgets[bd02b5b0-37e5-11e8-8356-a9f1e7707f6f].map.center",
+        "zoom": "widgets[bd02b5b0-37e5-11e8-8356-a9f1e7707f6f].map.zoom"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "dad8a630-37e5-11e8-8356-a9f1e7707f6f",
+      "layer": false,
+      "url": false,
+      "legend": false,
+      "mapSync": false,
+      "widgetType": "map",
+      "map": {
+        "map": {
+          "center": {
+            "x": -96.416015625,
+            "y": 38.75408327579141,
+            "crs": "EPSG:4326"
+          },
+          "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+          ],
+          "projection": "EPSG:900913",
+          "units": "m",
+          "zoom": 4
+        },
+        "layers": [
+          {
+            "group": "background",
+            "source": "osm",
+            "name": "mapnik",
+            "title": "Open Street Map",
+            "type": "osm",
+            "visibility": true,
+            "singleTile": false,
+            "dimensions": [],
+            "id": "mapnik__0"
+          },
+          {
+            "group": "background",
+            "source": "google",
+            "name": "HYBRID",
+            "title": "Google HYBRID",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "id": "HYBRID__1"
+          },
+          {
+            "group": "background",
+            "source": "mapquest",
+            "name": "osm",
+            "title": "MapQuest OSM",
+            "type": "mapquest",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "apiKey": "__API_KEY_MAPQUEST__",
+            "id": "osm__2"
+          },
+          {
+            "group": "background",
+            "source": "nasagibs",
+            "name": "Night2012",
+            "provider": "NASAGIBS.ViirsEarthAtNight2012",
+            "title": "NASAGIBS Night 2012",
+            "type": "tileprovider",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "id": "Night2012__3"
+          },
+          {
+            "group": "background",
+            "source": "OpenTopoMap",
+            "name": "OpenTopoMap",
+            "provider": "OpenTopoMap",
+            "title": "OpenTopoMap",
+            "type": "tileprovider",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "id": "OpenTopoMap__4"
+          },
+          {
+            "search": {
+              "url": "https://demo.geo-solutions.it:443/geoserver/wfs?",
+              "type": "wfs"
+            },
+            "name": "topp:states",
+            "title": "USA Population",
+            "type": "wms",
+            "url": "https://demo.geo-solutions.it/geoserver/wms",
+            "bbox": {
+              "crs": "EPSG:4326",
+              "bounds": {
+                "minx": "-124.731422",
+                "miny": "24.955967",
+                "maxx": "-66.969849",
+                "maxy": "49.371735"
+              }
+            },
+            "visibility": true,
+            "singleTile": false,
+            "dimensions": [],
+            "params": {},
+            "id": "topp:states__5"
+          }
+        ],
+        "groups": {
+          "id": "Default",
+          "expanded": true
+        },
+        "center": {
+          "x": -101.953125,
+          "y": 33.72433966174758,
+          "crs": "EPSG:4326"
+        },
+        "bbox": {
+          "bounds": {
+            "minx": -19176521.656185016,
+            "miny": -1330615.7883883514,
+            "maxx": -3522218.2633809205,
+            "maxy": 9314310.518718434
+          },
+          "crs": "EPSG:3857",
+          "rotation": 0
+        },
+        "zoom": 1,
+        "size": {
+          "width": 200,
+          "height": 136
+        },
+        "projection": "EPSG:3857",
+        "mapStateSource": "dad8a630-37e5-11e8-8356-a9f1e7707f6f"
+      },
+      "dependenciesMap": {
+        "center": "widgets[bd02b5b0-37e5-11e8-8356-a9f1e7707f6f].map.center",
+        "zoom": "widgets[bd02b5b0-37e5-11e8-8356-a9f1e7707f6f].map.zoom"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "e6db99b0-37e5-11e8-8356-a9f1e7707f6f",
+      "layer": {
+        "type": "wms",
+        "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+        "visibility": true,
+        "dimensions": [],
+        "name": "topp:states",
+        "title": "USA Population",
+        "description": "This is some census data on the states.",
+        "bbox": {
+          "crs": "EPSG:4326",
+          "bounds": {
+            "minx": -124.73142200000001,
+            "miny": 24.955967,
+            "maxx": -66.969849,
+            "maxy": 49.371735
+          }
+        },
+        "links": [],
+        "params": {
+          "layers": "topp:states"
+        },
+        "allowedSRS": {},
+        "search": {
+          "type": "wfs",
+          "url": "https://demo.geo-solutions.it:443/geoserver/wfs?"
+        }
+      },
+      "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+      "legend": false,
+      "mapSync": true,
+      "widgetType": "counter",
+      "geomProp": "the_geom",
+      "dependenciesMap": {
+        "viewport": "widgets[dad8a630-37e5-11e8-8356-a9f1e7707f6f].map.viewport"
+      },
+      "options": {
+        "aggregationAttribute": "STATE_FIPS",
+        "aggregateFunction": "Count"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    }
+  ]
+}

--- a/web/client/test-resources/widgets/widgets1.json
+++ b/web/client/test-resources/widgets/widgets1.json
@@ -1,0 +1,590 @@
+{
+  "widgets": [
+    {
+      "id": "e448d550-37ef-11e8-a12b-f182297314df",
+      "layer": false,
+      "url": false,
+      "legend": false,
+      "mapSync": false,
+      "widgetType": "map",
+      "map": {
+        "map": {
+          "center": {
+            "x": 13.7109375,
+            "y": 45.40616374516014,
+            "crs": "EPSG:4326"
+          },
+          "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+          ],
+          "projection": "EPSG:900913",
+          "zoom": 6,
+          "mapOptions": {}
+        },
+        "layers": [
+          {
+            "id": "Aerial__0",
+            "group": "background",
+            "source": "bing",
+            "name": "Aerial",
+            "title": "Bing Aerial",
+            "type": "bing",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "apiKey": "AhuXBu7ipR1gNbBfXhtUAyCZ6rkC5PkWpxs2MnMRZ1ZupxQfivjLCch22ozKSCAn"
+          },
+          {
+            "id": "mapnik__1",
+            "group": "background",
+            "source": "osm",
+            "name": "mapnik",
+            "title": "Open Street Map",
+            "type": "osm",
+            "visibility": true,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "osm__2",
+            "group": "background",
+            "source": "mapquest",
+            "name": "osm",
+            "title": "MapQuest OpenStreetMap",
+            "type": "mapquest",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "apiKey": "__API_KEY_MAPQUEST__"
+          },
+          {
+            "id": "ROADMAP__3",
+            "group": "background",
+            "source": "google",
+            "name": "ROADMAP",
+            "opacity": 1,
+            "title": "Google Roadmap",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "TERRAIN__4",
+            "group": "background",
+            "source": "google",
+            "name": "TERRAIN",
+            "opacity": 1,
+            "title": "Google Terrain",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "HYBRID__5",
+            "group": "background",
+            "source": "google",
+            "name": "HYBRID",
+            "opacity": 1,
+            "title": "Google Hybrid",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "geosolutions:regioni__7",
+            "search": {
+              "url": "https://demo.geo-solutions.it:443/geoserver/wfs",
+              "type": "wfs"
+            },
+            "name": "geosolutions:regioni",
+            "description": "Regioni Italiane",
+            "title": "Regioni Italiane",
+            "type": "wms",
+            "url": "https://demo.geo-solutions.it/geoserver/wms",
+            "bbox": {
+              "crs": "EPSG:4326",
+              "bounds": {
+                "minx": "5.8584576618073285",
+                "miny": "33.95924422826462",
+                "maxx": "20.294159056849427",
+                "maxy": "48.394945623306725"
+              }
+            },
+            "visibility": true,
+            "singleTile": false,
+            "allowedSRS": {
+              "CRS:84": true
+            },
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "catalogURL": null,
+            "params": {}
+          },
+          {
+            "id": "unesco:Unesco_point__6",
+            "search": {
+              "url": "https://demo.geo-solutions.it:443/geoserver/wfs?",
+              "type": "wfs"
+            },
+            "name": "unesco:Unesco_point",
+            "title": "Unesco Items",
+            "type": "wms",
+            "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+            "bbox": {
+              "crs": "EPSG:4326",
+              "bounds": {
+                "minx": 7.466999156080053,
+                "miny": 36.67491984727179,
+                "maxx": 18.033902263137904,
+                "maxy": 46.656160442453356
+              }
+            },
+            "visibility": true,
+            "singleTile": false,
+            "allowedSRS": {},
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "params": {
+              "layers": "unesco:Unesco_point"
+            }
+          }
+        ],
+        "groups": [
+          {
+            "id": "Default",
+            "expanded": true
+          }
+        ],
+        "center": {
+          "x": 14.062500000000007,
+          "y": 41.31082388091819,
+          "crs": "EPSG:4326"
+        },
+        "bbox": {
+          "bounds": {
+            "minx": -391357.58482010174,
+            "miny": 3727680.995411477,
+            "maxx": 3522218.2633809224,
+            "maxy": 6388912.572188173
+          },
+          "crs": "EPSG:3857",
+          "rotation": 0
+        },
+        "zoom": 3,
+        "size": {
+          "width": 200,
+          "height": 136
+        },
+        "projection": "EPSG:3857",
+        "mapStateSource": "e448d550-37ef-11e8-a12b-f182297314df"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "ec974c50-37ef-11e8-a12b-f182297314df",
+      "layer": {
+        "type": "wms",
+        "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+        "visibility": true,
+        "dimensions": [],
+        "name": "unesco:Unesco_point",
+        "title": "Unesco Items",
+        "description": "",
+        "bbox": {
+          "crs": "EPSG:4326",
+          "bounds": {
+            "minx": 7.466999156080053,
+            "miny": 36.67491984727179,
+            "maxx": 18.033902263137904,
+            "maxy": 46.656160442453356
+          }
+        },
+        "links": [],
+        "params": {
+          "layers": "unesco:Unesco_point"
+        },
+        "allowedSRS": {},
+        "search": {
+          "type": "wfs",
+          "url": "https://demo.geo-solutions.it:443/geoserver/wfs?"
+        }
+      },
+      "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+      "legend": false,
+      "mapSync": true,
+      "widgetType": "counter",
+      "geomProp": "the_geom",
+      "dependenciesMap": {
+        "viewport": "widgets[e448d550-37ef-11e8-a12b-f182297314df].map.viewport"
+      },
+      "options": {
+        "aggregationAttribute": "cod_unesco",
+        "aggregateFunction": "Count"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "132746e0-37f0-11e8-a12b-f182297314df",
+      "layer": false,
+      "url": false,
+      "legend": false,
+      "mapSync": false,
+      "widgetType": "map",
+      "map": {
+        "map": {
+          "center": {
+            "x": 13.7109375,
+            "y": 45.40616374516014,
+            "crs": "EPSG:4326"
+          },
+          "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+          ],
+          "projection": "EPSG:900913",
+          "zoom": 6,
+          "mapOptions": {}
+        },
+        "layers": [
+          {
+            "id": "Aerial__0",
+            "group": "background",
+            "source": "bing",
+            "name": "Aerial",
+            "title": "Bing Aerial",
+            "type": "bing",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "apiKey": "AhuXBu7ipR1gNbBfXhtUAyCZ6rkC5PkWpxs2MnMRZ1ZupxQfivjLCch22ozKSCAn"
+          },
+          {
+            "id": "mapnik__1",
+            "group": "background",
+            "source": "osm",
+            "name": "mapnik",
+            "title": "Open Street Map",
+            "type": "osm",
+            "visibility": true,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "osm__2",
+            "group": "background",
+            "source": "mapquest",
+            "name": "osm",
+            "title": "MapQuest OpenStreetMap",
+            "type": "mapquest",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false,
+            "apiKey": "__API_KEY_MAPQUEST__"
+          },
+          {
+            "id": "ROADMAP__3",
+            "group": "background",
+            "source": "google",
+            "name": "ROADMAP",
+            "opacity": 1,
+            "title": "Google Roadmap",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "TERRAIN__4",
+            "group": "background",
+            "source": "google",
+            "name": "TERRAIN",
+            "opacity": 1,
+            "title": "Google Terrain",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "id": "HYBRID__5",
+            "group": "background",
+            "source": "google",
+            "name": "HYBRID",
+            "opacity": 1,
+            "title": "Google Hybrid",
+            "type": "google",
+            "visibility": false,
+            "singleTile": false,
+            "dimensions": [],
+            "hideLoading": false,
+            "handleClickOnLayer": false
+          },
+          {
+            "type": "wms",
+            "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+            "visibility": true,
+            "dimensions": [],
+            "name": "topp:states",
+            "title": "USA Population",
+            "description": "This is some census data on the states.",
+            "bbox": {
+              "crs": "EPSG:4326",
+              "bounds": {
+                "minx": -124.73142200000001,
+                "miny": 24.955967,
+                "maxx": -66.969849,
+                "maxy": 49.371735
+              }
+            },
+            "links": [],
+            "params": {
+              "layers": "topp:states"
+            },
+            "allowedSRS": {},
+            "search": {
+              "type": "wfs",
+              "url": "https://demo.geo-solutions.it:443/geoserver/wfs?"
+            },
+            "id": "topp:states__kv71kamysw"
+          }
+        ],
+        "groups": [
+          {
+            "id": "Default",
+            "expanded": true
+          }
+        ],
+        "center": {
+          "x": -95.44921875000004,
+          "y": 37.57941251343838,
+          "crs": "EPSG:4326"
+        },
+        "bbox": {
+          "bounds": {
+            "minx": -12582146.351966297,
+            "miny": 3189564.3162838332,
+            "maxx": -8668570.503765272,
+            "maxy": 5850795.89306053
+          },
+          "crs": "EPSG:3857",
+          "rotation": 0
+        },
+        "zoom": 3,
+        "size": {
+          "width": 200,
+          "height": 136
+        },
+        "projection": "EPSG:3857",
+        "mapStateSource": "132746e0-37f0-11e8-a12b-f182297314df"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    },
+    {
+      "id": "1ac5f5e0-37f0-11e8-a12b-f182297314df",
+      "layer": {
+        "type": "wms",
+        "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+        "visibility": true,
+        "dimensions": [],
+        "name": "topp:states",
+        "title": "USA Population",
+        "description": "This is some census data on the states.",
+        "bbox": {
+          "crs": "EPSG:4326",
+          "bounds": {
+            "minx": -124.73142200000001,
+            "miny": 24.955967,
+            "maxx": -66.969849,
+            "maxy": 49.371735
+          }
+        },
+        "links": [],
+        "params": {
+          "layers": "topp:states"
+        },
+        "allowedSRS": {},
+        "search": {
+          "type": "wfs",
+          "url": "https://demo.geo-solutions.it:443/geoserver/wfs?"
+        }
+      },
+      "url": "https://demo.geo-solutions.it:443/geoserver/wms",
+      "legend": false,
+      "mapSync": true,
+      "widgetType": "counter",
+      "geomProp": "the_geom",
+      "options": {
+        "aggregationAttribute": "STATE_NAME",
+        "aggregateFunction": "Count"
+      },
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      },
+      "dependenciesMap": {
+        "viewport": "widgets[132746e0-37f0-11e8-a12b-f182297314df].map.viewport"
+      }
+    },
+    {
+      "id": "2c1c48d0-37f0-11e8-a12b-f182297314df",
+      "layer": false,
+      "url": false,
+      "legend": false,
+      "mapSync": false,
+      "widgetType": "text",
+      "title": "test",
+      "text": "<p>test</p>",
+      "dataGrid": {
+        "y": 0,
+        "x": 0,
+        "w": 1,
+        "h": 1
+      }
+    }
+  ],
+  "layouts": {
+    "lg": [
+      {
+        "w": 1,
+        "h": 1,
+        "x": 1,
+        "y": 0,
+        "i": "e448d550-37ef-11e8-a12b-f182297314df",
+        "moved": false,
+        "static": false
+      },
+      {
+        "w": 1,
+        "h": 1,
+        "x": 0,
+        "y": 0,
+        "i": "ec974c50-37ef-11e8-a12b-f182297314df",
+        "moved": false,
+        "static": false
+      },
+      {
+        "w": 1,
+        "h": 1,
+        "x": 1,
+        "y": 1,
+        "i": "132746e0-37f0-11e8-a12b-f182297314df",
+        "moved": false,
+        "static": false
+      },
+      {
+        "w": 1,
+        "h": 1,
+        "x": 0,
+        "y": 1,
+        "i": "1ac5f5e0-37f0-11e8-a12b-f182297314df",
+        "moved": false,
+        "static": false
+      },
+      {
+        "w": 1,
+        "h": 2,
+        "x": 2,
+        "y": 0,
+        "i": "2c1c48d0-37f0-11e8-a12b-f182297314df",
+        "moved": false,
+        "static": false
+      }
+    ]
+  },
+  "layout": [
+    {
+      "w": 1,
+      "h": 1,
+      "x": 1,
+      "y": 0,
+      "i": "e448d550-37ef-11e8-a12b-f182297314df",
+      "moved": false,
+      "static": false
+    },
+    {
+      "w": 1,
+      "h": 1,
+      "x": 0,
+      "y": 0,
+      "i": "ec974c50-37ef-11e8-a12b-f182297314df",
+      "moved": false,
+      "static": false
+    },
+    {
+      "w": 1,
+      "h": 1,
+      "x": 1,
+      "y": 1,
+      "i": "132746e0-37f0-11e8-a12b-f182297314df",
+      "moved": false,
+      "static": false
+    },
+    {
+      "w": 1,
+      "h": 1,
+      "x": 0,
+      "y": 1,
+      "i": "1ac5f5e0-37f0-11e8-a12b-f182297314df",
+      "moved": false,
+      "static": false
+    },
+    {
+      "w": 1,
+      "h": 2,
+      "x": 2,
+      "y": 0,
+      "i": "2c1c48d0-37f0-11e8-a12b-f182297314df",
+      "moved": false,
+      "static": false
+    }
+  ]
+  }

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1125,6 +1125,7 @@
                     "textPlaceholder": "Text eingeben...",
                     "useThisMap": "Benutze diese Karte",
                     "configureMapOptions": "Kartenoptionen konfigurieren",
+                    "preview": "Vorschau",
                     "addLayer": "Fügt der Karte eine Ebene hinzu",
                     "useTheSelectedLayer": "Verwende die ausgewählte Ebene",
                     "connectToAMap": "Mit einer Karte verbinden",
@@ -1224,7 +1225,9 @@
         },
         "dashboard": {
             "editor": {
-                "addACardToTheDashboard": "Agregar un widget al tablero"
+                "addACardToTheDashboard": "Agregar un widget al tablero",
+                "showConnections": "Verbindungen anzeigen",
+                "hideConnections": "Verbindungen ausblenden"
             },
             "emptyTitle": "Das Armaturenbrett ist leer"
         },

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1225,7 +1225,7 @@
         },
         "dashboard": {
             "editor": {
-                "addACardToTheDashboard": "Agregar un widget al tablero",
+                "addACardToTheDashboard": "Ein Widget zum Dashboard hinzufügen",
                 "showConnections": "Verbindungen anzeigen",
                 "hideConnections": "Verbindungen ausblenden"
             },

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1126,6 +1126,7 @@
                     "textPlaceholder": "Insert text...",
                     "useThisMap": "Use this map",
                     "configureMapOptions": "Configure map options",
+                    "preview": "Preview",
                     "addLayer": "Add a layer to the map",
                     "useTheSelectedLayer": "Use the selected layer",
                     "connectToAMap": "Connect to a map",
@@ -1225,7 +1226,9 @@
         },
         "dashboard": {
             "editor": {
-                "addACardToTheDashboard": "Add a widget to the dashboard"
+                "addACardToTheDashboard": "Add a widget to the dashboard",
+                "showConnections": "Show connections",
+                "hideConnections": "HideConnections"
             },
             "emptyTitle": "The dashboard is empty"
         },

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1125,6 +1125,7 @@
                     "textPlaceholder": "Ingresar texto...",
                     "useThisMap": "Usar este mapa",
                     "configureMapOptions": "Configurar opciones de mapa",
+                    "preview": "Vista previa",
                     "addLayer": "Agregar una capa al mapa",
                     "useTheSelectedLayer": "Usar la capa seleccionada",
                     "connectToAMap": "Conectar a un mapa",
@@ -1224,7 +1225,9 @@
         },
         "dashboard": {
             "editor": {
-                "addACardToTheDashboard": "Agregar un widget al tablero"
+                "addACardToTheDashboard": "Agregar un widget al tablero",
+                "showConnections": "Mostrar conexiones",
+                "hideConnections": "Ocultar conexiones"
             },
             "emptyTitle": "El tablero está vacío"
         },

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1126,6 +1126,7 @@
                     "textPlaceholder": "Entrez le texte...",
                     "useThisMap": "Utiliser cette carte",
                     "configureMapOptions": "Configurer les options de la carte",
+                    "preview": "Aperçu",
                     "addLayer": "Ajouter une couche à la carte",
                     "useTheSelectedLayer": "Utiliser le calque sélectionné",
                     "connectToAMap": "Se connecter à une carte",
@@ -1224,7 +1225,9 @@
         },
         "dashboard": {
              "editor": {
-                "addACardToTheDashboard": "Ajouter un widget au tableau de bord"
+                "addACardToTheDashboard": "Ajouter un widget au tableau de bord",
+                "showConnections": "Afficher les connexions",
+                "hideConnections": "Masquer les connexions"
             },
             "emptyTitle": "Le tableau de bord est vide"
         },

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1125,6 +1125,7 @@
                     "textPlaceholder": "Inserisci il testo...",
                     "useThisMap": "Usa questa mappa",
                     "configureMapOptions": "Configura opzioni mappa",
+                    "preview": "Anteprima",
                     "addLayer": "Aggiungi un livello alla mappa",
                     "useTheSelectedLayer": "Usa il livello selezionato",
                     "connectToAMap": "Connetti a una mappa",
@@ -1224,7 +1225,9 @@
         },
         "dashboard": {
              "editor": {
-                "addACardToTheDashboard": "Aggiungi un widget alla dashboard"
+                "addACardToTheDashboard": "Aggiungi un widget alla dashboard",
+                "showConnections": "Mostra connessioni",
+                "hideConnections": "Nascondi connessioni"
             },
             "emptyTitle": "La dashboard è vuota"
         },

--- a/web/client/utils/GraphUtils.js
+++ b/web/client/utils/GraphUtils.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+/* Breadth First Search function
+     * id is the source vertex
+     * allPairs is the input array, which contains length 2 arrays
+     * visited is a dictionary for keeping track of whether a node is visited
+     */
+const bfs = (id, allPairs, visited) => {
+    const q = [];
+    const curr = [];
+    let i;
+    let v = id;
+    let pair;
+    q.push(v);
+    while (q.length > 0) {
+        v = q.shift();
+        if (!visited[v]) {
+            visited[v] = true;
+            curr.push(v);
+            // go through the input array to find vertices that are
+            // directly adjacent to the current vertex, and put them
+            // onto the queue
+            for (i = 0; i < allPairs.length; i += 1) {
+                pair = allPairs[i];
+                if (pair[0] === v && !visited[pair[1]]) {
+                    q.push(pair[1]);
+                } else if (pair[1] === v && !visited[pair[0]]) {
+                    q.push(pair[0]);
+                }
+            }
+        }
+    }
+    // return everything in the current "group"
+    return curr;
+};
+const findGroups = (pairs) => {
+    let visited = {};
+    let groups = [];
+    for (let i = 0, length = pairs.length; i < length; i += 1) {
+        let currentPair = pairs[i];
+        let u = currentPair[0];
+        let v = currentPair[1];
+        let src = null;
+        if (!visited[u]) {
+            src = u;
+        } else if (!visited[v]) {
+            src = v;
+        }
+        if (src) {
+            // there is an unvisited vertex in this pair.
+            // perform a breadth first search, and push the resulting
+            // group onto the list of all groups
+            groups.push(bfs(src, pairs, visited));
+        }
+    }
+    return groups;
+};
+
+/**
+ * Utility functions for graphs
+ * @name GraphUtils
+ * @memberof utils
+ */
+module.exports = {
+    bfs,
+    findGroups
+};

--- a/web/client/utils/WidgetsUtils.js
+++ b/web/client/utils/WidgetsUtils.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { get, find } = require('lodash');
+const {WIDGETS_REGEX} = require('../actions/widgets');
+const { findGroups } = require('./GraphUtils');
+const { sameToneRangeColors } = require('./ColorUtils');
+
+const getDependentWidget = (k, widgets) => {
+    const [match, id] = WIDGETS_REGEX.exec(k);
+    if (match) {
+        const widget = find(widgets, { id });
+        return widget;
+    }
+};
+
+const getWidgetDependency = (k, widgets) => {
+    const regRes = WIDGETS_REGEX.exec(k);
+    const rest = regRes && regRes[2];
+    const widget = getDependentWidget(k, widgets);
+    return rest
+        ? get(widget, rest)
+        : widget;
+};
+const getConnectionList = (widgets = []) => {
+    return widgets.reduce(
+    (acc, curr) => {
+        // note: check mapSync because dependency map is not actually cleaned
+        const depMap = (get(curr, "mapSync") && get(curr, "dependenciesMap")) || {};
+        const dependencies = Object.keys(depMap).map(k => getDependentWidget(depMap[k], widgets)) || [];
+        return [
+            ...acc,
+            ...(dependencies.map(d => [curr.id, d.id]))
+        ];
+    }, []);
+};
+
+module.exports = {
+    getWidgetDependency,
+    getConnectionList,
+    getWidgetsGroups: (widgets = []) => {
+        const groups = findGroups(getConnectionList(widgets));
+        const colorsOpts = { base: 190, range: 340, options: { base: 10, range: 360, s: 0.67, v: 0.67 } };
+        const colors = sameToneRangeColors(colorsOpts.base, colorsOpts.range, groups.length + 1, colorsOpts.options);
+        return groups.map((members, i) => ({
+            color: colors[i],
+            widgets: members
+        }));
+    }
+};

--- a/web/client/utils/__tests__/WidgetsUtils-test.js
+++ b/web/client/utils/__tests__/WidgetsUtils-test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const { getConnectionList, getWidgetsGroups } = require('../WidgetsUtils');
+
+const {widgets} = require('json-loader!../../test-resources/widgets/widgets1.json');
+const { widgets: complexGraphWidgets } = require('json-loader!../../test-resources/widgets/complex_graph.json');
+describe('Test WidgetsUtils', () => {
+    it('test getConnectionList', () => {
+        const pairs = getConnectionList(widgets);
+        expect(pairs).toExist();
+        expect(pairs.length).toBe(2);
+        pairs.map(p => {
+            expect(p.length).toBe(2);
+            if (p[0] === "ec974c50-37ef-11e8-a12b-f182297314df" ) {
+                expect(p[1]).toBe("e448d550-37ef-11e8-a12b-f182297314df");
+            }
+            if (p[0] === "1ac5f5e0-37f0-11e8-a12b-f182297314df") {
+                expect(p[1]).toBe("132746e0-37f0-11e8-a12b-f182297314df");
+            }
+        });
+        const complexGraphPairs = getConnectionList(complexGraphWidgets);
+        // verify that connections without mapSync=true are not taken into account
+        expect(complexGraphPairs.length).toBe(4);
+    });
+    it('test getWidgetsGroups', () => {
+        const groups = getWidgetsGroups(widgets);
+        expect(groups[0].widgets[0]).toBe("ec974c50-37ef-11e8-a12b-f182297314df");
+        expect(groups[0].widgets[1]).toBe("e448d550-37ef-11e8-a12b-f182297314df");
+        expect(groups[0].color !== groups[1].color).toBe(true);
+        expect(groups[1].widgets[0]).toBe("1ac5f5e0-37f0-11e8-a12b-f182297314df");
+        expect(groups[1].widgets[1]).toBe("132746e0-37f0-11e8-a12b-f182297314df");
+        expect(groups.length).toBe(2);
+        expect(groups[0].color !== groups[1].color).toBe(true);
+        groups.map(g => expect(g.widgets.length).toBe(2));
+        const complexChartGroups = getWidgetsGroups(complexGraphWidgets);
+        // verify that connections without mapSync=true are not taken into account
+        expect(complexChartGroups.length).toBe(2);
+        expect(complexChartGroups[0].widgets.length).toBe(3);
+        expect(complexChartGroups[1].widgets.length).toBe(2);
+    });
+});


### PR DESCRIPTION
## Description
Add connections colors to dashboard, finalizing dashboard connection support. 
![image](https://user-images.githubusercontent.com/1279510/38314221-018dcbee-3826-11e8-96ad-d714ce05fbe0.png)

## Issues
 - Fix #2662

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
 - [x] Feature

**What is the current behavior?**
Connection where not visible

**What is the new behavior?**
Connections can be shown triggering "show/hide Connection" button in dashboard editor. You can a strip above the connected widgets, the same color means they are connected. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

