### PR TITLE
Improved suggestion when the user can not create a widget

### DIFF
--- a/web/client/components/misc/Overlay.jsx
+++ b/web/client/components/misc/Overlay.jsx
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const withContainer = require('./WithContainer');
+
+module.exports = withContainer(require('react-bootstrap').Overlay);

--- a/web/client/components/widgets/widget/InfoPopover.jsx
+++ b/web/client/components/widgets/widget/InfoPopover.jsx
@@ -7,12 +7,14 @@
  */
 
 const React = require('react');
+const ReactDOM = require('react-dom');
 const PropTypes = require('prop-types');
 const {
     Popover,
     Glyphicon
 } = require('react-bootstrap');
 
+const Overlay = require('../../misc/Overlay');
 const OverlayTrigger = require('../../misc/OverlayTrigger');
 
 class InfoPopover extends React.Component {
@@ -25,7 +27,9 @@ class InfoPopover extends React.Component {
         bsStyle: PropTypes.string,
         placement: PropTypes.string,
         left: PropTypes.number,
-        top: PropTypes.number
+        top: PropTypes.number,
+        trigger: PropTypes.array,
+        target: PropTypes.any
     };
 
     static defaultProps = {
@@ -36,7 +40,8 @@ class InfoPopover extends React.Component {
         left: 200,
         top: 50,
         glyph: "question-sign",
-        bsStyle: 'info'
+        bsStyle: 'info',
+        trigger: ['hover', 'focus']
     };
 
     renderPopover() {
@@ -51,13 +56,27 @@ class InfoPopover extends React.Component {
             </Popover>
         );
     }
-
+    renderContent() {
+        return (<Glyphicon
+            ref={button => {
+                this.target = button;
+            }}
+            className={`text-${this.props.bsStyle}`}
+            glyph={this.props.glyph} />);
+    }
     render() {
         return (
             <span className="mapstore-info-popover">
-                <OverlayTrigger trigger={['hover', 'focus']} placement={this.props.placement} overlay={this.renderPopover()}>
-                    <Glyphicon className={`text-${this.props.bsStyle}`} glyph="question-sign"/>
-                </OverlayTrigger>
+                {this.props.trigger
+                        ? (<OverlayTrigger trigger={this.props.trigger} placement={this.props.placement} overlay={this.renderPopover()}>
+                                {this.renderContent()}
+                            </OverlayTrigger>)
+                    : [
+                        this.renderContent(),
+                        <Overlay show target={() => ReactDOM.findDOMNode(this.target)}>
+                        {this.renderPopover()}
+                        </Overlay>
+                    ]}
             </span>
         );
     }

--- a/web/client/components/widgets/widget/InfoPopover.jsx
+++ b/web/client/components/widgets/widget/InfoPopover.jsx
@@ -16,7 +16,16 @@ const {
 
 const Overlay = require('../../misc/Overlay');
 const OverlayTrigger = require('../../misc/OverlayTrigger');
-
+/**
+ * InfoPopover. A component that renders a icon with a Popover.
+ * @prop {string} title the title of popover
+ * @prop {string} text the text of popover
+ * @prop {string} glyph glyph id for the icon
+ * @prop {number} left left prop of popover
+ * @prop {number} right right prop of popover
+ * @prop {string} placement position of popover
+ * @prop {boolean|String[]} trigger ['hover', 'focus'] by default. false always show the popover. Array with hover, focus and/or click string to specify events that trigger popover to show.
+ */
 class InfoPopover extends React.Component {
 
     static propTypes = {
@@ -28,8 +37,7 @@ class InfoPopover extends React.Component {
         placement: PropTypes.string,
         left: PropTypes.number,
         top: PropTypes.number,
-        trigger: PropTypes.array,
-        target: PropTypes.any
+        trigger: PropTypes.oneOf([PropTypes.array, PropTypes.bool])
     };
 
     static defaultProps = {
@@ -65,10 +73,11 @@ class InfoPopover extends React.Component {
             glyph={this.props.glyph} />);
     }
     render() {
+        const trigger = this.props.trigger === true ? ['hover', 'focus'] : this.props.trigger;
         return (
             <span className="mapstore-info-popover">
                 {this.props.trigger
-                        ? (<OverlayTrigger trigger={this.props.trigger} placement={this.props.placement} overlay={this.renderPopover()}>
+                        ? (<OverlayTrigger trigger={trigger} placement={this.props.placement} overlay={this.renderPopover()}>
                                 {this.renderContent()}
                             </OverlayTrigger>)
                     : [

--- a/web/client/plugins/widgetbuilder/LayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/LayerSelector.jsx
@@ -15,7 +15,7 @@ const Toolbar = require('../../components/widgets/builder/wizard/common/layersel
 const BuilderHeader = require('./BuilderHeader');
 const InfoPopover = require('../../components/widgets/widget/InfoPopover');
 const {Message, HTML} = require('../../components/I18N/I18N');
-const { compose, branch} = require('recompose');
+const { compose, branch } = require('recompose');
 
 const Catalog = compose(
     branch(
@@ -27,13 +27,14 @@ const Catalog = compose(
  * Builder page that allows layer's selection
  * @prop {function} [layerValidationStream]
  */
-module.exports = ({onClose = () => {}, setSelected = () => {}, onLayerChoice = () => {}, selected, canProceed, layer, catalog, catalogServices} = {}) =>
+module.exports = ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = () => { }, selected, error, canProceed, layer, catalog, catalogServices} = {}) =>
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
         <Toolbar canProceed={canProceed} onProceed={() => onLayerChoice(layer)} />
-        { selected && !canProceed ? <InfoPopover
-            glyph="exclamation-mark"
+        {selected && !canProceed && error ? <InfoPopover
+            trigger={false}
+            glyph="warning-sign"
             bsStyle="warning"
             title={<Message msgId="widgets.builder.errors.noWidgetsAvailableTitle" />}
             text={<HTML msgId="widgets.builder.errors.noWidgetsAvailableDescription"/>} /> : null}

--- a/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
@@ -30,7 +30,8 @@ module.exports = compose(
                         .mapTo({ canProceed: true })
                         .catch((error) => Rx.Observable.of({ error, canProceed: false }))
             ).startWith({})
-            .combineLatest(props$, ({ canProceed } = {}, props) => ({
+            .combineLatest(props$, ({ canProceed, error } = {}, props) => ({
+                error,
                 canProceed,
                 ...props
             })

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1134,9 +1134,9 @@
                     "clearConnection": "Verbindung löschen"
                 },
                 "errors": {
-                    "noWidgetsAvailableTitle": "Keine Widgets verfügbar",
-                    "noWidgetsAvailableDescription": "<p> Sie können keine Widgets für die ausgewählte Ebene erstellen. Dies liegt wahrscheinlich daran, dass der Layer nicht für die verfügbaren Widgets geeignet ist oder der Server nicht alle benötigten Services oder Informationen zum Generieren eines Widgets bereitstellt. Mögliche Ursachen sind: <ul><li> Die ausgewählte Ebene ist eine Rasterebene </li><li> WFS-Dienst ist nicht verfügbar </li><li> gs: Aggregatprozess ist nicht verfügbar </li> </ul>) <p>",
-                     "checkAtLeastOneAttribute": "Sie müssen mindestens eine Spalte auswählen"
+                    "noWidgetsAvailableTitle": "Das Widget für die ausgewählte Ebene kann nicht erstellt werden",
+                    "noWidgetsAvailableDescription": "<p><strong>Bitte wählen Sie eine andere Ebene oder einen anderen Widgets-Typ</strong></p><p>Der Server bietet nicht die erforderlichen Dienste für die Ebene und den ausgewählten Widget-Typ</p><p> Mögliche Ursachen sind: <ul> <li> Der ausgewählte Layer ist ein Raster-Layer </li> <li> Der WFS-Service ist nicht verfügbar </li> <li> Der WPS-Prozess <code>gs:aggregate</code> ist nicht verfügbar </li> </ul> </p>",
+                    "checkAtLeastOneAttribute": "Sie müssen mindestens eine Spalte auswählen"
                 },
                 "setupFilter": "Konfigurieren Sie einen Filter für die Widgetdaten"
             },

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1135,8 +1135,8 @@
                     "clearConnection": "Clear connection"
                 },
                 "errors": {
-                    "noWidgetsAvailableTitle": "No Widgets available",
-                    "noWidgetsAvailableDescription": "<p>You can't create any widgets for the selected layer. This is probably because the layer is not suitable for the available widgets or the server doesn't expose all the needed services or information to generate widget. Possible causes are: <ul><li>The selected layer is a raster layer</li><li>WFS service is not available</li><li><code>gs:aggregate process</code> is not available</li></ul><p>",
+                    "noWidgetsAvailableTitle": "Das Widget für die ausgewählte Ebene kann nicht erstellt werden",
+                    "noWidgetsAvailableDescription": "<p><strong>Please try to select another layer or widget type</strong></p><p>The server doesn't provide the needed services for the layer and the widget type selected</p><p>Possible causes are: <ul><li>The selected layer is a raster layer</li><li>WFS service is not available</li><li>The WPS process <code>gs:aggregate</code> is not available</li></ul></p>",
                     "checkAtLeastOneAttribute": "You must select at least one column"
                 },
                 "setupFilter": "Configure a filter for the widget data"

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1135,7 +1135,7 @@
                     "clearConnection": "Clear connection"
                 },
                 "errors": {
-                    "noWidgetsAvailableTitle": "Das Widget für die ausgewählte Ebene kann nicht erstellt werden",
+                    "noWidgetsAvailableTitle": "Can not create the widget for the selected layer",
                     "noWidgetsAvailableDescription": "<p><strong>Please try to select another layer or widget type</strong></p><p>The server doesn't provide the needed services for the layer and the widget type selected</p><p>Possible causes are: <ul><li>The selected layer is a raster layer</li><li>WFS service is not available</li><li>The WPS process <code>gs:aggregate</code> is not available</li></ul></p>",
                     "checkAtLeastOneAttribute": "You must select at least one column"
                 },

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1134,8 +1134,8 @@
                     "clearConnection": "Borrar conexión"
                 },
                 "errors": {
-                    "noWidgetsAvailableTitle": "Sin widgets disponibles",
-                    "noWidgetsAvailableDescription": "<p> No puede crear ningún widgets para la capa seleccionada. Esto es probablemente porque la capa no es adecuada para los widgets disponibles o el servidor no expone todos los servicios o información necesarios para generar el widget. Las posibles causas son: <ul> <li> La capa seleccionada es una capa ráster </li> <li> El servicio WFS no está disponible </li> <li> gs: el proceso agregado no está disponible </li> </ul >) <p>",
+                    "noWidgetsAvailableTitle": "No se puede crear el widget para la capa seleccionada",
+                    "noWidgetsAvailableDescription": "<p> <strong> Intente seleccionar otra capa o tipo de widget </strong> </p> <p> El servidor no proporciona los servicios necesarios para la capa y el tipo de widget seleccionado </p> <p> Las posibles causas son: <ul> <li> La capa seleccionada es una capa ráster </li> <li> El servicio WFS no está disponible </li> <li> El proceso WPS <code>gs:aggregate</code> no está disponible </li> </ul> </p> ",
                     "checkAtLeastOneAttribute": "Debes seleccionar al menos una columna"
                 },
                 "setupFilter": "Configurar un filtro para los datos del widget"

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1135,8 +1135,8 @@
                     "clearConnection": "Effacer la connexion"
                 },
                 "errors": {
-                    "noWidgetsAvailableTitle": "Aucun widget disponible",
-                    "noWidgetsAvailableDescription": "<p> Vous ne pouvez pas créer de widget pour le calque sélectionné. C'est probablement parce que la couche ne convient pas aux widgets ou que le serveur n'expose pas tous les services ou informations nécessaires pour générer un widget. Les causes possibles sont: <ul> <li> Le calque sélectionné est une couche raster </li><li> Le service WFS n'est pas disponible</li><li>gs:aggregate process n'est pas disponible </li> </ul>) <p>",
+                    "noWidgetsAvailableTitle": "Impossible de créer le widget pour le calque sélectionné",
+                    "noWidgetsAvailableDescription": "<p> <strong> Veuillez essayer de sélectionner un autre type de couche ou de widget </strong> </p> <p> Le serveur ne fournit pas les services requis pour la couche et le type de widget sélectionné </p> <p> Les causes possibles sont: <ul> <li> Le calque sélectionné est une couche raster </li> <li> Le service WFS n'est pas disponible </li> <li> Le processus WPS <code> gs:aggregate </code> n'est pas disponible </li> </ul> </p> ",
                     "checkAtLeastOneAttribute": "Vous devez sélectionner au moins une colonne"
                 },
                 "setupFilter": "Configurer un filtre pour les données du widget"

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1134,8 +1134,8 @@
                     "clearConnection": "Disconnetti"
                 },
                 "errors": {
-                    "noWidgetsAvailableTitle": "Nessun widgets disponibile",
-                    "noWidgetsAvailableDescription": "<p>Non si possono creare widget per il livello selezionato. Questo perchè il livello non è adatto a nessuno degli widget disponibili o perché il server non espone sufficienti servizi per gernerali. Possibili cause: <ul><li>Hai selezionato un livello raster</li><li>Il servizio WFS non è disponibile per il livello in oggetto</li><li>Il processo gs:aggregate non è disponibile sul server</li></ul> )<p>",
+                    "noWidgetsAvailableTitle": "Impossibile creare il widget per il livello selezionato",
+                    "noWidgetsAvailableDescription": "<p><strong> Prova a selezionare un altro livello o tipo di widget </strong> </p><p>Il server non fornisce i servizi necessari per il livello e il tipo di widget selezionato </p> <p> Le possibili cause sono: <ul> <li> Il livello selezionato è un livello raster </li> <li> Il servizio WFS non è disponibile </li><li> Il processo WPS <code>gs:aggregate</code> non è disponibile </li> </ul></p>",
                     "checkAtLeastOneAttribute": "seleziona almeno un attributo"
                 },
                 "setupFilter": "Configura un filtro per il livello selezionato"


### PR DESCRIPTION
## Description
Now the popup is opened automatically when the selected layer can not be used:
![image](https://user-images.githubusercontent.com/1279510/38362814-7d0093b8-38d2-11e8-916a-f0d7414e5fcb.png)


## Issues
 - Connected to #2790

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
The popup is not too much visible, the message not enough clear

**What is the new behavior?**
Now the popup shown automatically when the selected layer can not be used. The message is more clear.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
