### PR TITLE
Add back buttons to dashboard and map widgets

### DIFF
--- a/web/client/components/widgets/builder/wizard/ChartWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/ChartWizard.jsx
@@ -82,7 +82,13 @@ module.exports = enhanceWizard(({ onChange = () => { }, onFinish = () => { }, se
         step={step}
         setPage={setPage}
         onFinish={onFinish}
-        isStepValid={n => n === 1 ? isChartOptionsValid(data.options) : true} hideButtons>
+        isStepValid={n =>
+                n === 0
+                    ? data.chartType
+                    : n === 1
+                        ? isChartOptionsValid(data.options)
+                        : true
+                } hideButtons>
         <ChartType
             key="type"
             type={data.type}

--- a/web/client/components/widgets/builder/wizard/chart/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/Toolbar.jsx
@@ -59,7 +59,7 @@ module.exports = ({
         tooltipId: "widgets.builder.setupFilter"
     }, {
         onClick: () => setPage(Math.min(step + 1, 2)),
-        visible: !!(step === 0 && (!editorData.type || editorData.type.indexOf("WI") !== 0)) || step === 1,
+        visible: !!( step === 1 ),
         disabled: step === 1 && !valid,
         glyph: "arrow-right",
         tooltipId: getNextTooltipId(step)

--- a/web/client/components/widgets/builder/wizard/chart/__tests__/Toolbar-test.jsx
+++ b/web/client/components/widgets/builder/wizard/chart/__tests__/Toolbar-test.jsx
@@ -33,12 +33,7 @@ describe('CounterWizard Toolbar component', () => {
         const el = container.querySelector('.btn-group');
         expect(el).toExist();
         const buttons = container.querySelectorAll('button');
-        expect(buttons.length).toBe(2);
-        expect(buttons[0].querySelector('.glyphicon-filter')).toExist();
-        expect(buttons[1].querySelector('.glyphicon-arrow-right')).toExist();
-        expect(buttons[1].disabled).toBe(true);
-        ReactDOM.render(<Toolbar step={0} valid />, document.getElementById("container"));
-        expect(container.querySelectorAll('button')[1].disabled).toBeFalsy();
+        expect(buttons.length).toBe(0);
     });
     it('step 1', () => {
         ReactDOM.render(<Toolbar step={1} valid />, document.getElementById("container"));
@@ -46,22 +41,28 @@ describe('CounterWizard Toolbar component', () => {
         const el = container.querySelector('.btn-group');
         expect(el).toExist();
         const buttons = container.querySelectorAll('button');
-        expect(buttons.length).toBe(2);
+        expect(buttons.length).toBe(3);
         expect(buttons[0].querySelector('.glyphicon-arrow-left')).toExist();
-        expect(buttons[1].querySelector('.glyphicon-floppy-disk')).toExist();
+        expect(buttons[1].querySelector('.glyphicon-filter')).toExist();
     });
-    it('step buttons', () => {
-        ReactDOM.render(<Toolbar stepButtons={[{text: "text", glyph: 'test', id: "test-button"}]} step={0} valid={false} />, document.getElementById("container"));
+    it('step 2', () => {
+        ReactDOM.render(<Toolbar step={1} valid />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('.btn-group');
         expect(el).toExist();
         const buttons = container.querySelectorAll('button');
         expect(buttons.length).toBe(3);
-        expect(buttons[0].querySelector('.glyphicon-test')).toExist();
+        expect(buttons[0].querySelector('.glyphicon-arrow-left')).toExist();
         expect(buttons[1].querySelector('.glyphicon-filter')).toExist();
         expect(buttons[2].querySelector('.glyphicon-arrow-right')).toExist();
-        expect(buttons[2].disabled).toBe(true);
-        ReactDOM.render(<Toolbar step={0} valid />, document.getElementById("container"));
-        expect(container.querySelectorAll('button')[1].disabled).toBeFalsy();
+    });
+    it('step buttons', () => {
+        ReactDOM.render(<Toolbar stepButtons={[{ text: "text", glyph: 'test', id: "test-button" }]} step={0} valid={false} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.btn-group');
+        expect(el).toExist();
+        const buttons = container.querySelectorAll('button');
+        expect(buttons.length).toBe(1);
+        expect(buttons[0].querySelector('.glyphicon-test')).toExist();
     });
 });

--- a/web/client/components/widgets/builder/wizard/common/layerselector/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/common/layerselector/Toolbar.jsx
@@ -10,15 +10,15 @@ const React = require('react');
 
 const Toolbar = require('../../../../../misc/toolbar/Toolbar');
 
-module.exports = ({canProceed, selected, onProceed = () => {}} = {}) => (<Toolbar btnDefaultProps={{
+module.exports = ({ canProceed, selected, stepButtons = [], onProceed = () => {}} = {}) => (<Toolbar btnDefaultProps={{
         className: "square-button-md",
         bsStyle: "primary",
         bsSize: "sm"
     }}
-    buttons={[{
-        onClick: onProceed,
-        disabled: !canProceed,
-        tooltipId: "widgets.builder.wizard.useTheSelectedLayer",
-        visible: selected,
-        glyph: "arrow-right"
+    buttons={[...stepButtons, {
+            onClick: onProceed,
+            disabled: !canProceed,
+            tooltipId: "widgets.builder.wizard.useTheSelectedLayer",
+            visible: selected,
+            glyph: "arrow-right"
     }]} />);

--- a/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
@@ -53,7 +53,7 @@ module.exports = compose(
             })
             )
     )
-)(({ onClose = () => { }, setSelected = () => { }, onMapChoice = () => { }, selected } = {}) =>
+)(({ onClose = () => { }, setSelected = () => { }, onMapChoice = () => { }, stepButtons = [], selected } = {}) =>
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
@@ -62,7 +62,7 @@ module.exports = compose(
                     bsStyle: "primary",
                     bsSize: "sm"
                 }}
-                buttons={[{
+                buttons={[...stepButtons, {
                 tooltipId: "widgets.builder.wizard.useThisMap",
                 onClick: () => onMapChoice(selected),
                 visible: true,

--- a/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/map/Toolbar.jsx
@@ -22,16 +22,16 @@ module.exports = ({ step = 0, buttons, tocButtons = [], stepButtons = [], editor
     bsSize: "sm"
 }}
     buttons={buttons || [...(step === 0 ? tocButtons : []), {
+        onClick: () => setPage(Math.max(step - 1, 0)),
+        visible: step === 1,
+        glyph: "arrow-left",
+        tooltipId: "widgets.builder.wizard.configureMapOptions"
+    }, ...stepButtons, {
         onClick: () => toggleLayerSelector(true),
         visible: step === 0,
         glyph: "plus",
         tooltipId: "widgets.builder.wizard.addLayer"
     }, {
-        onClick: () => setPage(Math.max(step - 1, 0)),
-        visible: step === 1,
-        glyph: "arrow-left",
-        tooltipId: "widgets.builder.wizard.configureMapOptions"
-        }, ...stepButtons, {
         onClick: () => setPage(Math.min(step + 1, 2)),
         visible: step === 0,
         glyph: "arrow-right",

--- a/web/client/components/widgets/builder/wizard/text/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/text/Toolbar.jsx
@@ -17,11 +17,11 @@ const getSaveTooltipId = (step, {id} = {}) => {
     return "widgets.builder.wizard.addToTheMap";
 };
 
-module.exports = ({step = 0, editorData = {}, onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
+module.exports = ({ step = 0, editorData = {}, stepButtons = [], onFinish = () => {}} = {}) => (<Toolbar btnDefaultProps={{
         bsStyle: "primary",
         bsSize: "sm"
     }}
-    buttons={[{
+    buttons={[...stepButtons, {
         onClick: () => onFinish(Math.min(step + 1, 1)),
         visible: step === 0,
         glyph: "floppy-disk",

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -17,12 +17,14 @@ const {dashboardSelector} = require('./widgetbuilder/commons');
 const { createWidget, toggleConnection } = require('../actions/widgets');
 const { triggerShowConnections } = require('../actions/dashboard');
 const { showConnectionsSelector } = require('../selectors/dashboard');
+const withDashboardExitButton = require('./widgetbuilder/enhancers/withDashboardExitButton');
 const Builder =
     compose(
         connect(dashboardSelector, { toggleConnection, triggerShowConnections}),
         withProps(({ availableDependencies = []}) => ({
             availableDependencies: availableDependencies.filter(d => d !== "map")
         })),
+        withDashboardExitButton
     )(require('./widgetbuilder/WidgetTypeBuilder'));
 
 const Toolbar = compose(

--- a/web/client/plugins/WidgetsBuilder.jsx
+++ b/web/client/plugins/WidgetsBuilder.jsx
@@ -13,6 +13,7 @@ const Dock = require('react-dock').default;
 
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
+const { compose } = require('recompose');
 
 const {setControlProperty} = require('../actions/controls');
 
@@ -20,12 +21,16 @@ const {mapLayoutValuesSelector} = require('../selectors/maplayout');
 const {widgetBuilderSelector} = require('../selectors/controls');
 const { dependenciesSelector, availableDependenciesSelector} = require('../selectors/widgets');
 const { toggleConnection } = require('../actions/widgets');
-const Builder = connect(
-    createSelector(
-        dependenciesSelector,
-        availableDependenciesSelector,
-        (dependencies, availableDependenciesProps) => ({ dependencies, ...availableDependenciesProps}))
-    , { toggleConnection })(require('./widgetbuilder/WidgetTypeBuilder'));
+const withMapExitButton = require('./widgetbuilder/enhancers/withMapExitButton');
+const Builder = compose(
+    connect(
+        createSelector(
+            dependenciesSelector,
+            availableDependenciesSelector,
+            (dependencies, availableDependenciesProps) => ({ dependencies, ...availableDependenciesProps }))
+    , { toggleConnection }),
+    withMapExitButton
+)(require('./widgetbuilder/WidgetTypeBuilder'));
 
 class SideBarComponent extends React.Component {
      static propTypes = {

--- a/web/client/plugins/widgetbuilder/ChartBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/ChartBuilder.jsx
@@ -19,6 +19,7 @@ const builderConfiguration = require('../../components/widgets/enhancers/builder
 const chartLayerSelector = require('./enhancers/chartLayerSelector');
 const viewportBuilderConnect = require('./enhancers/connection/viewportBuilderConnect');
 const viewportBuilderConnectMask = require('./enhancers/connection/viewportBuilderConnectMask');
+const withExitButton = require('./enhancers/withExitButton');
 const withConnectButton = require('./enhancers/connection/withConnectButton');
 const {
     wizardStateToProps,
@@ -53,6 +54,7 @@ const Toolbar = compose(
         wizardStateToProps
     ),
     viewportBuilderConnect,
+    withExitButton(),
     withConnectButton(({step}) => step === 1)
 
 )(require('../../components/widgets/builder/wizard/chart/Toolbar'));
@@ -71,11 +73,12 @@ const chooseLayerEnhancer = compose(
 
 );
 
-module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData, toggleConnection, availableDependencies = [], dependencies, ...props} = {}) =>
+module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, editorData, toggleConnection, availableDependencies = [], dependencies, ...props} = {}) =>
 
     (<BorderLayout
         header={<BuilderHeader onClose={onClose}>
             <Toolbar
+                exitButton={exitButton}
                 editorData={editorData}
                 toggleConnection={toggleConnection}
                 availableDependencies={availableDependencies}

--- a/web/client/plugins/widgetbuilder/CounterBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/CounterBuilder.jsx
@@ -20,6 +20,7 @@ const chartLayerSelector = require('./enhancers/chartLayerSelector');
 const viewportBuilderConnect = require('./enhancers/connection/viewportBuilderConnect');
 const viewportBuilderConnectMask = require('./enhancers/connection/viewportBuilderConnectMask');
 
+const withExitButton = require('./enhancers/withExitButton');
 const withConnectButton = require('./enhancers/connection/withConnectButton');
 
 const {
@@ -56,6 +57,7 @@ const Toolbar = compose(
         wizardStateToProps
     ),
     viewportBuilderConnect,
+    withExitButton(),
     withConnectButton(({ step }) => step === 0)
 )(require('../../components/widgets/builder/wizard/counter/Toolbar'));
 
@@ -72,10 +74,11 @@ const chooseLayerEnhancer = compose(
     )
 );
 
-module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData, toggleConnection, availableDependencies=[], dependencies, ...props } = {}) =>
+module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, editorData, toggleConnection, availableDependencies=[], dependencies, ...props } = {}) =>
 
     (<BorderLayout
         header={<BuilderHeader onClose={onClose}><Toolbar
+            exitButton={exitButton}
             editorData={editorData}
             toggleConnection={toggleConnection}
             availableDependencies={availableDependencies}

--- a/web/client/plugins/widgetbuilder/LayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/LayerSelector.jsx
@@ -27,11 +27,11 @@ const Catalog = compose(
  * Builder page that allows layer's selection
  * @prop {function} [layerValidationStream]
  */
-module.exports = ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = () => { }, selected, error, canProceed, layer, catalog, catalogServices} = {}) =>
+module.exports = ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = () => { }, stepButtons, selected, error, canProceed, layer, catalog, catalogServices} = {}) =>
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
-        <Toolbar canProceed={canProceed} onProceed={() => onLayerChoice(layer)} />
+        <Toolbar stepButtons={stepButtons} canProceed={canProceed} onProceed={() => onLayerChoice(layer)} />
         {selected && !canProceed && error ? <InfoPopover
             trigger={false}
             glyph="warning-sign"

--- a/web/client/plugins/widgetbuilder/MapBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/MapBuilder.jsx
@@ -27,7 +27,9 @@ const Toolbar = mapToolbar(require('../../components/widgets/builder/wizard/map/
  * Prompts Map Selection or Layer selector (to add layers)
  */
 const chooseMapEnhancer = compose(
-    connect(wizardSelector),
+    connect(wizardSelector, {
+        onResetChange: onEditorChange
+    }),
     // map selector
     branch(
         ({ editorData = {} } = {}) => !editorData.map,
@@ -46,10 +48,20 @@ const chooseMapEnhancer = compose(
                         toggleLayerSelector(false);
                     }
                 }),
-                layerSelector
+                layerSelector,
             )(require('./MapLayerSelector'))
         )
-    )
+    ),
+    // add button to back to map selection
+    withProps(({ onResetChange = () => { } }) => ({
+        exitButton: {
+            glyph: 'arrow-left',
+            onClick: () => {
+                // options will not be valid anymore in case of layer change
+                onResetChange("map", undefined);
+            }
+        }
+    }))
 );
 const Builder = connect(
     wizardSelector,
@@ -74,13 +86,14 @@ module.exports = mapBuilder(({
         enabled, onClose = () => {},
         toggleLayerSelector = () => {},
         editorData = {},
-        editNode, setEditNode, closeNodeEditor, selectedGroups=[], selectedLayers=[], selectedNodes, onNodeSelect = () => {},
+        editNode, setEditNode, closeNodeEditor, selectedGroups=[], exitButton, selectedLayers=[], selectedNodes, onNodeSelect = () => {},
     availableDependencies = [], toggleConnection = () => {}
     } = {}) =>
     (<BorderLayout
         className = "map-selector"
         header={(<BuilderHeader onClose={onClose}>
             <Toolbar
+            exitButton={exitButton}
             editorData={editorData}
             availableDependencies={availableDependencies}
             toggleConnection={toggleConnection}

--- a/web/client/plugins/widgetbuilder/MapSelector.jsx
+++ b/web/client/plugins/widgetbuilder/MapSelector.jsx
@@ -5,14 +5,28 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const { compose, withProps } = require('recompose');
 const {connect} = require('react-redux');
 const { onEditorChange } = require('../../actions/widgets');
 const { normalizeMap } = require('../../utils/LayersUtils');
 
-module.exports = connect(
-    () => ({}), {
-        onMapSelected: ({ map }) => onEditorChange("map", normalizeMap(map))
+module.exports = compose(
+    connect(
+        () => ({}), {
+            onMapSelected: ({ map }) => onEditorChange("map", normalizeMap(map)),
+            onResetChange: onEditorChange
 
-    }
-
+        }),
+        // add button to back to widget type selection
+        withProps(({ onResetChange = () => { } }) => ({
+            stepButtons: [{
+                glyph: 'arrow-left',
+                tooltipId: 'widgets.builder.wizard.backToWidgetTypeSelection',
+                onClick: () => {
+                    // options will not be valid anymore in case of layer change
+                    onResetChange("map", undefined);
+                    onResetChange("widgetType", undefined);
+                }
+            }]
+        }))
 )(require('../../components/widgets/builder/wizard/map/MapSelector'));

--- a/web/client/plugins/widgetbuilder/TableBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TableBuilder.jsx
@@ -21,6 +21,7 @@ const builderConfiguration = require('../../components/widgets/enhancers/builder
 const chartLayerSelector = require('./enhancers/chartLayerSelector');
 const viewportBuilderConnect = require('./enhancers/connection/viewportBuilderConnect');
 const viewportBuilderConnectMask = require('./enhancers/connection/viewportBuilderConnectMask');
+const withExitButton = require('./enhancers/withExitButton');
 const withConnectButton = require('./enhancers/connection/withConnectButton');
 const {
     wizardStateToProps,
@@ -66,6 +67,7 @@ const Toolbar = compose(
         wizardStateToProps
     ),
     viewportBuilderConnect,
+    withExitButton(),
     withConnectButton(({ step }) => step === 0)
 )(require('../../components/widgets/builder/wizard/table/Toolbar'));
 
@@ -82,13 +84,14 @@ const chooseLayerEnhancer = compose(
     )
 );
 
-module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData = {}, toggleConnection, availableDependencies = [], dependencies, ...props } = {}) =>
+module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData = {}, exitButton, toggleConnection, availableDependencies = [], dependencies, ...props } = {}) =>
 
     (<BorderLayout
         header={
             <BuilderHeader onClose={onClose}>
                 <Toolbar
                     editorData={editorData}
+                    exitButton={exitButton}
                     toggleConnection={toggleConnection}
                     availableDependencies={availableDependencies}
                     onClose={onClose} />

--- a/web/client/plugins/widgetbuilder/TextBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TextBuilder.jsx
@@ -7,16 +7,29 @@
  */
 const React = require('react');
 const {connect} = require('react-redux');
+const { compose, withProps } = require('recompose');
 const {onEditorChange, insertWidget, setPage} = require('../../actions/widgets');
 const {wizardSelector, wizardStateToProps} = require('./commons');
 const BorderLayout = require('../../components/layout/BorderLayout');
+const withExitButton = require('./enhancers/withExitButton');
 const BuilderHeader = require('./BuilderHeader');
 
-const Toolbar = connect(wizardSelector, {
-        setPage,
-        insertWidget
-    },
-    wizardStateToProps
+const Toolbar = compose(
+    connect(wizardSelector, {
+            setPage,
+            insertWidget,
+            onResetChange: onEditorChange
+        },
+        wizardStateToProps,
+    ),
+    withProps(({ onResetChange = () => { } }) => ({
+        exitButton: {
+            glyph: 'arrow-left',
+            tooltipId: "widgets.builder.wizard.backToWidgetTypeSelection",
+            onClick: () => onResetChange('widgetType', undefined)
+        }
+    })),
+    withExitButton(),
 )(require('../../components/widgets/builder/wizard/text/Toolbar'));
 
 const Builder = connect(
@@ -26,7 +39,7 @@ const Builder = connect(
     },
     wizardStateToProps
 )(require('../../components/widgets/builder/wizard/TextWizard'));
-module.exports = ({enabled, onClose = () => {}} = {}) =>
+module.exports = ({ enabled, onClose = () => {}} = {}) =>
     (<BorderLayout
         header={<BuilderHeader onClose={onClose}><Toolbar /></BuilderHeader>}
         >

--- a/web/client/plugins/widgetbuilder/enhancers/chartLayerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/chartLayerSelector.js
@@ -6,17 +6,30 @@
  * LICENSE file in the root directory of this source tree.
  */
 const { connect } = require('react-redux');
-const { compose, defaultProps, setDisplayName } = require('recompose');
+const { compose, defaultProps, withProps, setDisplayName } = require('recompose');
 const layerSelector = require('./layerSelector');
 const { onEditorChange } = require('../../../actions/widgets');
 const canGenerateCharts = require('../../../observables/widgets/canGenerateCharts');
 module.exports = compose(
     setDisplayName('ChartLayerSelector'),
     connect(() => ({}), {
-        onLayerChoice: (l) => onEditorChange("layer", l)
+        onLayerChoice: (l) => onEditorChange("layer", l),
+        onResetChange: onEditorChange
     }),
     defaultProps({
         layerValidationStream: stream$ => stream$.switchMap(layer => canGenerateCharts(layer))
     }),
+    // add button to back to widget type selection
+    withProps(({ onResetChange = () => { } }) => ({
+        stepButtons: [{
+            glyph: 'arrow-left',
+            tooltipId: "widgets.builder.wizard.backToWidgetTypeSelection",
+            onClick: () => {
+                // options will not be valid anymore in case of layer change
+                onResetChange("options", undefined);
+                onResetChange("widgetType", undefined);
+            }
+        }]
+    })),
     layerSelector
 );

--- a/web/client/plugins/widgetbuilder/enhancers/connection/withConnectButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/withConnectButton.js
@@ -20,7 +20,7 @@ module.exports = (showCondition = () => true) => compose(
         connected,
         ...props
     }) => ({
-        stepButtons: [{
+            stepButtons: [...stepButtons, {
             onClick: () => toggleConnection(availableDependencies),
             disabled: disableMultiDependencySupport,
             visible: !!showCondition(props) && !!canConnect && availableDependencies.length > 0,
@@ -31,7 +31,7 @@ module.exports = (showCondition = () => true) => compose(
                 : availableDependencies.length === 1
                     ? "widgets.builder.wizard.connectToTheMap"
                     : "widgets.builder.wizard.connectToAMap"
-        }, ...stepButtons
+        }
         ]
     }))
 );

--- a/web/client/plugins/widgetbuilder/enhancers/mapToolbar.js
+++ b/web/client/plugins/widgetbuilder/enhancers/mapToolbar.js
@@ -14,6 +14,7 @@ const { wizardSelector, wizardStateToProps } = require('../commons');
 
 const mapBuilderConnect = require('./connection/mapBuilderConnect');
 const withConnectButton = require('./connection/withConnectButton');
+const withExitButton = require('./withExitButton');
 module.exports = compose(
     connect(wizardSelector, {
         setPage,
@@ -54,6 +55,9 @@ module.exports = compose(
         }))
     ),
     mapBuilderConnect,
+    withExitButton(undefined, {
+        tooltipId: "widgets.builder.wizard.backToMapSelection"
+    }),
     withConnectButton(({step}) => step === 0)
 
 );

--- a/web/client/plugins/widgetbuilder/enhancers/withDashboardExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withDashboardExitButton.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { compose, withProps } = require('recompose');
+const { connect } = require('react-redux');
+
+const { onEditorChange } = require('../../../actions/widgets');
+/**
+ * Reset widgets
+ */
+module.exports = compose(
+    connect(() => ({}), {
+        backFromWizard: () => onEditorChange('layer', undefined)
+    }),
+    withProps(({ backFromWizard = () => {} }) => ({
+        exitButton: {
+            onClick: backFromWizard,
+            glyph: 'arrow-left',
+            tooltipId: "widgets.builder.wizard.backToLayerSelection"
+        }
+    }))
+);

--- a/web/client/plugins/widgetbuilder/enhancers/withExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withExitButton.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {withProps} = require('recompose');
+module.exports = (visible = ({step}) => step === 0, overrides = {}) => withProps(({ stepButtons = [], exitButton, ...props}) => ({
+    stepButtons: [{
+        ...exitButton,
+        visible: visible({stepButtons, exitButton, ...props}),
+        ...overrides
+    }, ...stepButtons]
+}));

--- a/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { compose, withProps } = require('recompose');
+const { connect } = require('react-redux');
+
+const { onEditorChange } = require('../../../actions/widgets');
+/**
+ * Reset widgets
+ */
+module.exports = compose(
+    connect(() => ({}), {
+        backFromWizard: () => onEditorChange('widgetType', undefined)
+    }),
+    withProps(({ backFromWizard = () => {} }) => ({
+        exitButton: {
+            onClick: backFromWizard,
+            glyph: 'arrow-left',
+            tooltipId: "widgets.builder.wizard.backToWidgetTypeSelection"
+        }
+    }))
+);

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1113,6 +1113,9 @@
                 },
                 "wizard": {
                     "backToTypeSelection": "Zurück zur Typenauswahl",
+                    "backToWidgetTypeSelection": "Zurück zur Auswahl des Widget-Typs",
+                    "backToLayerSelection": "Zurück zur Ebenenauswahl",
+                    "backToMapSelection": "Zurück zur Kartenauswahl",
                     "backToChartOptions": "Zurück zu den Diagrammoptionen",
                     "configureChartOptions": "Diagrammoptionen konfigurieren",
                     "configureWidgetOptions": "Widget-Optionen konfigurieren",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1114,6 +1114,9 @@
                 },
                 "wizard": {
                     "backToTypeSelection": "Back to type selection",
+                    "backToWidgetTypeSelection": "Back to widget type selection",
+                    "backToLayerSelection": "Back to layer selection",
+                    "backToMapSelection": "Back to map selection",
                     "backToChartOptions": "Back to chart options",
                     "configureChartOptions": "Configure chart options",
                     "configureWidgetOptions": "Configure widget options",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1113,6 +1113,9 @@
                 },
                 "wizard": {
                     "backToTypeSelection": "Volver a la selección de tipo",
+                    "backToWidgetTypeSelection": "Volver a la selección del tipo de widget",
+                    "backToLayerSelection": "Volver a la selección de capas",
+                    "backToMapSelection": "Volver a la selección del mapa",
                     "backToChartOptions": "Volver a las opciones de gráfico",
                     "configureChartOptions": "Configurar opciones de gráfico",
                     "configureWidgetOptions": "Configurar las opciones del widget",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1114,6 +1114,9 @@
                 },
                 "wizard": {
                     "backToTypeSelection": "Retour à la sélection du type",
+                    "backToWidgetTypeSelection": "Retour à la sélection du type de widget",
+                    "backToLayerSelection": "Retour à la sélection du calque",
+                    "backToMapSelection": "Retour à la sélection de la carte",
                     "backToChartOptions": "retour aux options de graphique",
                     "configureChartOptions": "Configurer les options de graphique",
                     "configureWidgetOptions": "Configurer les options du widget",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1113,6 +1113,9 @@
                 },
                 "wizard": {
                     "backToTypeSelection": "Torna alla selezione del tipo",
+                    "backToWidgetTypeSelection": "Torna alla selezione del tipo di widget",
+                    "backToLayerSelection": "Torna alla selezione del livello",
+                    "backToMapSelection": "Torna alla selezione della mappa",
                     "backToChartOptions": "Torna alle opzioni del grafico",
                     "configureChartOptions": "Configura le opzioni del grafico",
                     "configureWidgetOptions": "Configura le opzioni del widget",


### PR DESCRIPTION
## Description
This PR add back buttons to every widget builder both in dashboard and map. Fixed also an issue that allowed to proceed with chart wizard when widget type was not selected.
## Issues
 - Connected to #2790

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature
 
**What is the current behavior?** (You can also link to an open issue here)
If you want to change base data (widget type, layer, map) you had to restart the widget creation process. 

**What is the new behavior?**
You can go back to widget, layer and map selection during the workflow

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
