### PR TITLE
Fix #2794 Force update of map widget position on save

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/PreviewMap.jsx
+++ b/web/client/components/widgets/builder/wizard/map/PreviewMap.jsx
@@ -6,14 +6,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
-const { compose, withHandlers} = require('recompose');
-
-module.exports = compose(
-    withHandlers({
-        onMapViewChanges: ({onChange = () => {}}) => map => {
-            onChange('map', map);
-            onChange('mapStateSource', map.mapStateSource);
-        }
-    })
-)(require('../../../widget/MapView'));
+const {previewMap} = require('./enhancers/previewMap');
+module.exports = previewMap(require('../../../widget/MapView'));

--- a/web/client/components/widgets/builder/wizard/map/PreviewMap.jsx
+++ b/web/client/components/widgets/builder/wizard/map/PreviewMap.jsx
@@ -6,5 +6,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {previewMap} = require('./enhancers/previewMap');
+const previewMap = require('./enhancers/previewMap');
 module.exports = previewMap(require('../../../widget/MapView'));

--- a/web/client/components/widgets/builder/wizard/map/PreviewMap.jsx
+++ b/web/client/components/widgets/builder/wizard/map/PreviewMap.jsx
@@ -11,6 +11,9 @@ const { compose, withHandlers} = require('recompose');
 
 module.exports = compose(
     withHandlers({
-        onMapViewChanges: ({onChange = () => {}}) => map => onChange('map', map)
+        onMapViewChanges: ({onChange = () => {}}) => map => {
+            onChange('map', map);
+            onChange('mapStateSource', map.mapStateSource);
+        }
     })
 )(require('../../../widget/MapView'));

--- a/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/previewMap-test.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/previewMap-test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {createSink} = require('recompose');
+const expect = require('expect');
+const previewMap = require('../previewMap');
+
+describe('previewMap enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('previewMap enhancer callbacks', (done) => {
+        const actions = {
+            callback: () => { }
+        };
+        const spyCallback = expect.spyOn(actions, 'callback');
+        const Sink = previewMap(createSink( props => {
+            props.onMapViewChanges({mapStateSource: "TEST"});
+            expect(spyCallback).toHaveBeenCalled();
+            expect(spyCallback.calls.length).toBe(2);
+            expect(spyCallback.calls[0].arguments[0]).toBe("map");
+            expect(spyCallback.calls[1].arguments[0]).toBe("mapStateSource");
+            expect(spyCallback.calls[1].arguments[1]).toBe("TEST");
+            done();
+
+        }));
+        ReactDOM.render(<Sink onChange={actions.callback}/>, document.getElementById("container"));
+    });
+
+});

--- a/web/client/components/widgets/builder/wizard/map/enhancers/previewMap.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/previewMap.js
@@ -1,0 +1,10 @@
+const { compose, withHandlers } = require('recompose');
+
+module.exports = compose(
+    withHandlers({
+        onMapViewChanges: ({ onChange = () => { } }) => map => {
+            onChange('map', map);
+            onChange('mapStateSource', map.mapStateSource);
+        }
+    })
+);


### PR DESCRIPTION
## Description
This fixes map widget position update problems from preview
## Issues
 - Fix #2794

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
When you edit an existing map widget moving the center of the preview, the position is not updated on save.

**What is the new behavior?**
The position is now correctly updated

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

