### PR TITLE
 Exclude google background #2786 from widgets 

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
@@ -12,7 +12,7 @@ require('rxjs');
 const GeoStoreDAO = require('../../../../../api/GeoStoreDAO');
 const axios = require('../../../../../libs/ajax');
 const ConfigUtils = require('../../../../../utils/ConfigUtils');
-
+const { excludeGoogleBackground } = require('../../../../../utils/LayersUtils');
 const BorderLayout = require('../../../../layout/BorderLayout');
 
 const Toolbar = require('../../../../misc/toolbar/Toolbar');
@@ -35,12 +35,12 @@ module.exports = compose(
                 let mapState = (!config.version && typeof map.id !== 'string') ? ConfigUtils.convertFromLegacy(config) : ConfigUtils.normalizeConfig(config.map);
                 return {
                     ...(mapState && mapState.map || {}),
-                    layers: mapState.layers.map(l => {
+                    layers: excludeGoogleBackground(mapState.layers.map(l => {
                         if (l.group === "background" && (l.type === "ol" || l.type === "OpenLayers.Layer")) {
                             l.type = "empty";
                         }
                         return l;
-                    })
+                    }))
                 };
             }))
             .then(res => onMapSelected({

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -8,7 +8,7 @@
 
 const assign = require('object-assign');
 const toBbox = require('turf-bbox');
-const {isString, isObject, isArray, head, isEmpty} = require('lodash');
+const { isString, isObject, isArray, head, isEmpty, findIndex} = require('lodash');
 const REG_GEOSERVER_RULE = /\/[\w- ]*geoserver[\w- ]*\//;
 const findGeoServerName = ({url, regex = REG_GEOSERVER_RULE}) => {
     return regex.test(url) && url.match(regex)[0] || null;
@@ -468,6 +468,36 @@ const LayersUtils = {
             SecurityUtils.addAuthenticationParameter(url, authenticationParam, options.securityToken);
         });
         return authenticationParam;
+    },
+    /**
+     * Removes google backgrounds and select an alternative one as visible
+     * returns a new list of layers modified accordingly
+     */
+    excludeGoogleBackground: ll => {
+        const hasVisibleGoogleBackground = ll.filter(({ type, group, visibility } = {}) => group === 'background' && type === 'google' && visibility).length > 0;
+        const layers = ll.filter(({ type } = {}) => type !== 'google');
+        const backgrounds = layers.filter(({ group } = {}) => group === 'background');
+
+        // check if the selection of a new background is required
+        if (hasVisibleGoogleBackground && backgrounds.filter(({ visibility } = {}) => visibility).length === 0) {
+            // select the first available
+            if (backgrounds.length > 0) {
+                const candidate = findIndex(layers, {group: 'background'});
+                return layers.map((l, i) => i === candidate ? {...l, visibility: true} : l);
+            }
+            // add osm if any other background is missing
+            return [{
+                "type": "osm",
+                "title": "Open Street Map",
+                "name": "mapnik",
+                "source": "osm",
+                "group": "background",
+                "visibility": true
+            }, ...layers];
+
+
+        }
+        return layers;
     }
 };
 

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -12,6 +12,7 @@ const typeV1 = "empty";
 const emptyBackground = {
     type: typeV1
 };
+
 const bingLayerWithApikey = {
     type: 'bing',
     apiKey: "SOME_APIKEY_VALUE"
@@ -418,6 +419,43 @@ describe('LayersUtils', () => {
     it('getURLs', () => {
         expect(LayersUtils.getURLs(['http://url/?delete=param'])).toEqual(['http://url/']);
         expect(LayersUtils.getURLs(['http://url/?delete=param'], '?custom=param')).toEqual(['http://url/?custom=param']);
+    });
+    it('excludeGoogleBackground', () => {
+        const GOOGLE_BG = {
+            type: 'google',
+            group: 'background',
+            visibility: true
+        };
+
+        const LAYERS_1 = [GOOGLE_BG, wmsLayer];
+        const LAYERS_2 = [GOOGLE_BG, bingLayerWithApikey, wmsLayer];
+        const LAYERS_3 = [GOOGLE_BG, {group: 'background', ...bingLayerWithApikey}, wmsLayer];
+        const LAYERS_4 = [{visibility: false, ...GOOGLE_BG}, { group: 'background', visibility: true, ...bingLayerWithApikey }, wmsLayer];
+
+        // check adds a osm as default background
+        const RES_1 = LayersUtils.excludeGoogleBackground(LAYERS_1);
+        expect(RES_1.length).toBe(2);
+        expect(RES_1[0].type).toBe('osm');
+        expect(RES_1[0].visibility).toBe(true);
+
+        // check adds anyway osm as default background
+        const RES_2 = LayersUtils.excludeGoogleBackground(LAYERS_2);
+        expect(RES_2.length).toBe(3);
+        expect(RES_2[0].type).toBe('osm');
+        expect(RES_2[0].visibility).toBe(true);
+
+        // check select as visible the first background available
+        const RES_3 = LayersUtils.excludeGoogleBackground(LAYERS_3);
+        expect(RES_3.length).toBe(2);
+        expect(RES_3[0].type).toBe('bing');
+        expect(RES_3[0].visibility).toBe(true);
+
+        // check select as visible the first background available
+        const RES_4 = LayersUtils.excludeGoogleBackground(LAYERS_4);
+        expect(RES_4.length).toBe(2);
+        expect(RES_4[0].type).toBe('bing');
+        expect(RES_4[0].visibility).toBe(true);
+
     });
 
 });


### PR DESCRIPTION
## Description
This PR avoid issues is a workaround for #2786 removing google layers from widgets.
See conversation in the issue. 

## Issues
 - #2786

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
Google layers have problems if incuded in widgets

**What is the new behavior?**
Google layers in widgets are not allowed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
