### PR TITLE
Fix #2812 parseInitialState function 

### DIFF
--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -121,11 +121,10 @@ class StandardApp extends React.Component {
         });
     };
     /**
-     * A function used to parse the initialState in the localConfig.json
-     * If an array of simple values is parsed then just return their values, otherwise return the recursive func
-     * @param {object} state the piece of state to be parsed
-     * @param {object} context contains the mode to be used
-     * @return {object} the object parsed.
+     * It returns an object of the same structure of the initialState but replacing strings like "{someExpression}" with the result of the expression between brackets.
+     * @param {object} state the object to parse
+     * @param {object} context context for expression
+     * @return {object} the modified object
     */
     parseInitialState = (state, context) => {
         return Object.keys(state || {}).reduce((previous, key) => {

--- a/web/client/components/app/__tests__/StandardApp-test.jsx
+++ b/web/client/components/app/__tests__/StandardApp-test.jsx
@@ -147,6 +147,7 @@ describe('StandardApp', () => {
             initialState: {
                 defaultState: {
                     test: "test",
+                    withArrayEmpty: [],
                     withArray: [valueArr1],
                     withArrayObj: [valueArr2, {
                         innerObjTest: innerObjTestValue
@@ -159,6 +160,7 @@ describe('StandardApp', () => {
         expect(app).toExist();
         const parsedInitialState = app.parseInitialState(storeOpts.initialState, {});
         expect(parsedInitialState.defaultState.withArray.length).toBe(1);
+        expect(parsedInitialState.defaultState.withArrayEmpty.length).toBe(0);
         expect(parsedInitialState.defaultState.withArray[0]).toBe(valueArr1);
         expect(parsedInitialState.defaultState.withArrayObj.length).toBe(2);
         expect(parsedInitialState.defaultState.withArrayObj[0]).toBe(valueArr2);

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -35,7 +35,7 @@ const getRow = (i, rows) => rows[i];
 
 /* eslint-disable */
 
-const toChangesMap = (changesArray) => isArray(changesArray) ? changesArray.reduce((changes, c) => ({
+const toChangesMap = (changesArray = []) => isArray(changesArray) ? changesArray.reduce((changes, c) => ({
     ...changes,
     [c.id]: {
         ...changes[c.id],


### PR DESCRIPTION
## Description
Now it is possible to add ["string value"] inside initalState configuration
it is parsed correctly.

## Issues
 - Fix #2812

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see issue #2812

**What is the new behavior?**
Now it is possible for example to copy the default state of reducer from featureGrid to the initialState inside configuration with no error raising in the console.
it loads correctly the map if we do that.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
