### PR TITLE
Fix #2790 improved wizard messages

### DIFF
--- a/web/client/components/catalog/CatalogForm.jsx
+++ b/web/client/components/catalog/CatalogForm.jsx
@@ -7,10 +7,11 @@
  */
 const React = require('react');
 const { Col, FormGroup, FormControl, Grid, Row } = require('react-bootstrap');
+const Message = require('../I18N/Message');
 const CatalogServiceSelector = require('./CatalogServiceSelector');
 const localizeProps = require('../misc/enhancers/localizedProps');
 const SearchInput = localizeProps("placeholder")(FormControl);
-module.exports = ({ onSearchTextChange = () => { }, searchText, title, catalog, services, isValidServiceSelected, showCatalogSelector}) =>
+module.exports = ({ onSearchTextChange = () => { }, searchText, title = <Message msgId={"catalog.title"} />, catalog, services, isValidServiceSelected, showCatalogSelector}) =>
 ( <Grid className="catalog-form" fluid><Row><Col xs={12}>
     <h4 className="text-center">{title}</h4>
     {showCatalogSelector

--- a/web/client/components/catalog/CompactCatalog.jsx
+++ b/web/client/components/catalog/CompactCatalog.jsx
@@ -87,10 +87,10 @@ module.exports = compose(
                     .ignoreElements() // don't want to emit props
         )))
 
-)(({ setSearchText = () => { }, selected, onRecordSelected, loading, searchText, items = [], total, catalog, services, showCatalogSelector}) => {
+)(({ setSearchText = () => { }, selected, onRecordSelected, loading, searchText, items = [], total, catalog, services, title, showCatalogSelector}) => {
     return (<BorderLayout
                 className="compat-catalog"
-        header={<CatalogForm services={services ? services : [catalog]} showCatalogSelector={showCatalogSelector} title={<Message msgId={"catalog.title"} />} searchText={searchText} onSearchTextChange={setSearchText}/>}
+        header={<CatalogForm services={services ? services : [catalog]} showCatalogSelector={showCatalogSelector} title={title} searchText={searchText} onSearchTextChange={setSearchText}/>}
                 footer={<div className="catalog-footer">
                     <span>{loading ? <LoadingSpinner /> : null}</span>
                     {!isNil(total) ? <span className="res-info"><Message msgId="catalog.pageInfoInfinite" msgParams={{loaded: items.length, total}}/></span> : null}

--- a/web/client/components/misc/enhancers/localizeStringMap.js
+++ b/web/client/components/misc/enhancers/localizeStringMap.js
@@ -30,7 +30,7 @@ const accumulate = (props, locale) => (acc = {}, propName) => ({
  * @param  {string|[string]} propNames Name of the prop(s) to replace. can be an array or a single prop
  * @return {HOC}         An HOC that replaces the prop string with localized string.
  * @example
- * const Input = localizeProps('title')(TitleBar);
+ * const Input = localizeStringMap('title')(TitleBar);
  * // render
  * //...
  * <Input placeholder={{title}} />

--- a/web/client/components/misc/enhancers/localizeStringMap.js
+++ b/web/client/components/misc/enhancers/localizeStringMap.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+const PropTypes = require('prop-types');
+const { castArray, isObject } = require('lodash');
+const {getContext, mapProps, compose} = require('recompose');
+
+const getLocalizedProp = (locale, prop) => isObject(prop) ? prop[locale] || prop.default : prop;
+
+const accumulate = (props, locale) => (acc = {}, propName) => ({
+            ...acc,
+    [propName]: props[propName] && getLocalizedProp(locale, props[propName])
+});
+/**
+ * Converts the props indicated as arguments into localized strings checking if they are map of localized strings, like this:
+ * ```
+ * {
+ *  "default": "TEST",
+ *  "en-US": "TEST en-US"
+ * }
+ * ```
+ * @name localizeStringMap
+ * @memberof components.misc.enhancers
+ * @param  {string|[string]} propNames Name of the prop(s) to replace. can be an array or a single prop
+ * @return {HOC}         An HOC that replaces the prop string with localized string.
+ * @example
+ * const Input = localizeProps('title')(TitleBar);
+ * // render
+ * //...
+ * <Input placeholder={{title}} />
+ */
+module.exports = (propNames) => compose(
+    getContext({
+        locale: PropTypes.string
+    }),
+    mapProps(({locale, ...props}) => ({
+        ...props,
+        ...(castArray(propNames).reduce(accumulate(props, locale), {}))
+    })
+));

--- a/web/client/components/misc/enhancers/localizedProps.js
+++ b/web/client/components/misc/enhancers/localizedProps.js
@@ -31,7 +31,7 @@ const accumulate = (props, messages) => (acc = {}, propName) => ({
  * const Input = localizeProps('placeholder')(BootstrapInput);
  * // render
  * //...
- * <Input placholder="path.to.placeholder.message" />
+ * <Input placeholder="path.to.placeholder.message" />
  */
 module.exports = (propNames) => compose(
     getContext({

--- a/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
+++ b/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
@@ -20,6 +20,7 @@ const getAllowedAggregationOptions = (propertyName, featureTypeProperties = []) 
           {value: "Count", label: "COUNT"},
           {value: "Sum", label: "SUM"},
           {value: "Average", label: "AVG"},
+          {value: "StdDev", label: "STDDEV"},
           {value: "Min", label: "MIN"},
           {value: "Max", label: "MAX"}
       ];

--- a/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
@@ -13,8 +13,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 const React = require('react');
+const {compose, withProps} = require('recompose');
 const StepHeader = require('../../../../misc/wizard/StepHeader');
 const emptyState = require('../../../../misc/enhancers/emptyState');
+const localizeStringMap = require('../../../../misc/enhancers/localizeStringMap');
 const Message = require('../../../../I18N/Message');
 const TOC = emptyState(
     ({ map = {} } = {}) => !map.layers || (map.layers || []).filter(l => l.group !== 'background').length === 0,
@@ -26,24 +28,33 @@ const TOC = emptyState(
      )(require('./TOC'));
 const nodeEditor = require('./enhancers/nodeEditor');
 const Editor = nodeEditor(require('./NodeEditor'));
+const EditorTitle = compose(
+    nodeEditor,
+    withProps(({selectedNode: layer}) => ({
+        title: layer && layer.title
+    })),
+    localizeStringMap('title')
+)(StepHeader);
+
 
 module.exports = ({ preview, map = {}, onChange = () => { }, selectedNodes = [], onNodeSelect = () => { }, editNode, closeNodeEditor = () => { } }) => (<div>
-    <StepHeader title={<Message msgId={`widgets.builder.wizard.preview`} />} />
-    <div key="sample" >
+    <StepHeader title={<Message msgId={`widgets.builder.wizard.configureMapOptions`} />} />
+    <div key="sample" style={{marginTop: 10}}>
+        <StepHeader title={<Message msgId={`widgets.builder.wizard.preview`} />} />
         <div style={{ width: "100%", height: "200px"}}>
             {preview}
         </div>
     </div>
     {editNode
-        ? [<StepHeader title={<Message msgId={`Layers`} />} />,
+        ? [<EditorTitle map={map} editNode={editNode} />,
         <Editor
             closeNodeEditor={closeNodeEditor}
             editNode={editNode}
             map={map}
-            onChange={onChange} />]
-        : <TOC
+            onChange={onChange} />
+            ] : [<StepHeader title={<Message msgId={`Layers`} />} />, <TOC
             selectedNodes={selectedNodes}
             onSelect={onNodeSelect}
             onChange={onChange}
-            map={map} />}
+            map={map} />]}
 </div>);

--- a/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
@@ -52,7 +52,7 @@ module.exports = ({ preview, map = {}, onChange = () => { }, selectedNodes = [],
             editNode={editNode}
             map={map}
             onChange={onChange} />
-            ] : [<StepHeader title={<Message msgId={`Layers`} />} />, <TOC
+            ] : [<StepHeader title={<Message msgId={`layers`} />} />, <TOC
             selectedNodes={selectedNodes}
             onSelect={onNodeSelect}
             onChange={onChange}

--- a/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
@@ -20,6 +20,7 @@ const BuilderHeader = require('../../BuilderHeader');
 
 const { compose, withState, mapPropsStream, withHandlers } = require('recompose');
 const mcEnhancer = require('../../../../maps/enhancers/mapCatalogWithEmptyMap');
+const Message = require('../../../../I18N/Message');
 const MapCatalog = mcEnhancer(require('../../../../maps/MapCatalog'));
 /**
  * Builder page that allows layer's selection
@@ -74,5 +75,5 @@ module.exports = compose(
             }]} />
         </BuilderHeader>}
     >
-        <MapCatalog selected={selected} onSelected={r => setSelected(r)} />
+        <MapCatalog title={<Message msgId="widgets.builder.wizard.selectAMap" />} selected={selected} onSelected={r => setSelected(r)} />
     </BorderLayout>));

--- a/web/client/plugins/widgetbuilder/Catalog.jsx
+++ b/web/client/plugins/widgetbuilder/Catalog.jsx
@@ -5,5 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-module.exports = require('../../components/catalog/CompactCatalog');
+const React = require('react');
+const Message = require('../../components/I18N/Message');
+const {defaultProps} = require('recompose');
+module.exports =
+    defaultProps({
+        title: <Message msgId="widgets.builder.wizard.selectALayer" />
+    })(require('../../components/catalog/CompactCatalog'));

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1128,6 +1128,8 @@
                     "backToLayerSelection": "Zurück zur Ebenenauswahl",
                     "backToMapSelection": "Zurück zur Kartenauswahl",
                     "backToChartOptions": "Zurück zu den Diagrammoptionen",
+                    "selectALayer": "Wähle eine Ebene",
+                    "selectAMap": "Wählen Sie eine Karte",
                     "configureChartOptions": "Diagrammoptionen konfigurieren",
                     "configureWidgetOptions": "Widget-Optionen konfigurieren",
                     "backToTableOptions": "Zurück zu den Tabellenoptionen",
@@ -1186,8 +1188,8 @@
                     "caption": "gauge"
                 }
             },
-            "chartOptionsTitle": "Kartendaten",
-            "widgetOptionsTitle": "Widget Info",
+            "chartOptionsTitle": "Daten konfigurieren",
+            "widgetOptionsTitle": "Widget-Informationen konfigurieren",
             "groupByAttributes": {
                 "line": "X-Attribut",
                 "pie": "Gruppiere nach",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1129,6 +1129,8 @@
                     "backToLayerSelection": "Back to layer selection",
                     "backToMapSelection": "Back to map selection",
                     "backToChartOptions": "Back to chart options",
+                    "selectALayer": "Select a layer",
+                    "selectAMap": "Select a map",
                     "configureChartOptions": "Configure chart options",
                     "configureWidgetOptions": "Configure widget options",
                     "backToTableOptions": "Back to table options",
@@ -1187,8 +1189,8 @@
                     "caption": "gauge"
                 }
             },
-            "chartOptionsTitle": "Data",
-            "widgetOptionsTitle": "Widget Info",
+            "chartOptionsTitle": "Configure data",
+            "widgetOptionsTitle": "Configure Widget Info",
             "groupByAttributes": {
                 "line": "X Attribute",
                 "pie": "Group By",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1128,9 +1128,11 @@
                     "backToLayerSelection": "Volver a la selección de capas",
                     "backToMapSelection": "Volver a la selección del mapa",
                     "backToChartOptions": "Volver a las opciones de gráfico",
+                    "selectALayer": "Seleccionar una capa",
+                    "selectAMap": "Seleccionar un mapa",
                     "configureChartOptions": "Configurar opciones de gráfico",
                     "configureWidgetOptions": "Configurar las opciones del widget",
-                     "backToTableOptions": "Volver a las opciones de mesa",
+                    "backToTableOptions": "Volver a las opciones de mesa",
                     "configureTableOptions": "Configurar opciones de tabla",
                     "resetColumnsSizes": "Restablecer todos los cambios en los tamaños de columna",
                     "updateWidget": "Actualiza el widget",
@@ -1186,8 +1188,8 @@
                     "caption": "indicatores"
                 }
             },
-            "chartOptionsTitle": "Datos",
-            "widgetOptionsTitle": "Información de widget",
+            "chartOptionsTitle": "Configurar Datos",
+            "widgetOptionsTitle": "Configurar Información de widget",
             "groupByAttributes": {
                 "line": "Atributo X",
                 "pie": "Agrupar por",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1129,6 +1129,8 @@
                     "backToLayerSelection": "Retour à la sélection du calque",
                     "backToMapSelection": "Retour à la sélection de la carte",
                     "backToChartOptions": "retour aux options de graphique",
+                    "selectALayer": "Sélectionner une couche",
+                    "selectAMap": "Sélectionnez une carte",
                     "configureChartOptions": "Configurer les options de graphique",
                     "configureWidgetOptions": "Configurer les options du widget",
                     "backToTableOptions": "Retour à l'option de table",
@@ -1187,8 +1189,8 @@
                     "caption": "jauge"
                 }
             },
-            "chartOptionsTitle": "Données",
-            "widgetOptionsTitle": "Info sur le widget",
+            "chartOptionsTitle": "Configurer les données",
+            "widgetOptionsTitle": "Configurer les informations du widget",
             "groupByAttributes": {
                 "line": "Attributs X",
                 "pie": "Grouper par",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1128,6 +1128,8 @@
                     "backToLayerSelection": "Torna alla selezione del livello",
                     "backToMapSelection": "Torna alla selezione della mappa",
                     "backToChartOptions": "Torna alle opzioni del grafico",
+                    "selectALayer": "Seleziona un livello",
+                    "selectAMap": "Seleziona una mappa",
                     "configureChartOptions": "Configura le opzioni del grafico",
                     "configureWidgetOptions": "Configura le opzioni del widget",
                      "backToTableOptions": "Torna alle opzioni della tabella",
@@ -1186,8 +1188,8 @@
                     "caption": "cruscotto"
                 }
             },
-            "chartOptionsTitle": "Dati",
-            "widgetOptionsTitle": "Informazioni",
+            "chartOptionsTitle": "Configura dati",
+            "widgetOptionsTitle": "Configura informazioni widget",
             "groupByAttributes": {
                 "line": "Attributo X",
                 "pie": "Raggruppa per",


### PR DESCRIPTION
## Description
Improve widget builder messages. Also localized missing strings and improved usability. 
## Issues
 - Fix #2790


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
introduced `localizeStringMap` that localized props like layer or group titles as properties.
```
const obj1 = {
"default": "String",
"en-US": "String localized in en-US"
...
}
const str = "TEST"
const CMP = localizeStringMap('testProp')(MyCmp);
<CMP testProp={obj1 || str} /> // the nested component will receive testProp="TEST" if the passed object is  str. Passing obj1 the nested component will receive  testProp="String localized in en-US" is current locale is testProp="en-US" or default other wise.
```