### PR TITLE
Fix #2696 map rotation style for openlayers

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -98,6 +98,14 @@
         "mobile": [{
                 "name": "Map",
                 "cfg": {
+                    "mapOptions": {
+                      "openlayers": {
+                        "interactions": {
+                          "pinchRotate": false,
+                          "altShiftDragRotate": false
+                        }
+                      }
+                    },
                     "tools": ["locate"]
                 }
             }, "Version", "DrawerMenu",
@@ -195,6 +203,10 @@
             "cfg": {
               "mapOptions": {
                 "openlayers": {
+                  "interactions": {
+                    "pinchRotate": false,
+                    "altShiftDragRotate": false
+                  },
                   "attribution": {
                     "container": "#mapstore-map-footer-container"
                   }
@@ -349,8 +361,12 @@
                 "name": "Map",
                 "cfg": {
                     "tools": ["locate"],
-                  "mapOptions": {
+                    "mapOptions": {
                     "openlayers": {
+                      "interactions": {
+                        "pinchRotate": false,
+                        "altShiftDragRotate": false
+                      },
                       "attribution": {
                         "container": "#mapstore-map-footer-container"
                       }

--- a/web/client/themes/default/less/ol.less
+++ b/web/client/themes/default/less/ol.less
@@ -132,7 +132,10 @@ div.ol-scale-line-inner {
             font-size: 36px;
         }
     }
-    .ol-rotate-reset:hover {
+    .ol-rotate-reset:hover, .ol-rotate-reset:focus {
         background-color: darken(@ms2-color-primary, 5%);
     }
+}
+.ol-rotate:hover {
+    background: none;
 }


### PR DESCRIPTION
## Description
Now the style of the map rotation tool is aligned with the theme using theme variables.

## Issues
 - Fix #2696

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
The map rotation tool style was the original one coming from ol.
![image](https://user-images.githubusercontent.com/11991428/38666679-c8b5600a-3e3f-11e8-849f-3c9d59fea3be.png)

**What is the new behavior?**
now it is aligned with the theme one
![image](https://user-images.githubusercontent.com/11991428/38666652-b72c489e-3e3f-11e8-9031-9887cc7ddec1.png)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
