### PR TITLE
fix #2807 back interaction from widget to feature grid

### DIFF
--- a/web/client/epics/widgetsbuilder.js
+++ b/web/client/epics/widgetsbuilder.js
@@ -60,7 +60,7 @@ module.exports = {
             ...w,
             // override action's type
             type: undefined
-        }, {step: 0}))),
+        }, {step: 0}), onEditorChange("returnToFeatureGrid", true))),
     /**
      * Manages interaction with QueryPanel and widgetBuilder
      */

--- a/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
@@ -11,13 +11,13 @@ const { connect } = require('react-redux');
 const {setControlProperty} = require('../../../actions/controls');
 const {openFeatureGrid} = require('../../../actions/featuregrid');
 const { onEditorChange } = require('../../../actions/widgets');
-const {featureGridSelector} = require('../../../selectors/controls');
+const {returnToFeatureGridSelector} = require('../../../selectors/widgets');
 /**
  * Reset widgets
  */
 module.exports = compose(
     connect(() => ({
-        returnToFeatureGrid: state => featureGridSelector(state)}),
+        returnToFeatureGrid: state => returnToFeatureGridSelector(state)}),
     {
         backToWidgetList: () => onEditorChange('widgetType', undefined),
         backToFeatureGrid: () => setControlProperty("widgetBuilder", "enabled", false, false),

--- a/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
@@ -5,16 +5,37 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { compose, withProps } = require('recompose');
+const { compose, withProps, withHandlers} = require('recompose');
 const { connect } = require('react-redux');
 
+const {setControlProperty} = require('../../../actions/controls');
+const {openFeatureGrid} = require('../../../actions/featuregrid');
 const { onEditorChange } = require('../../../actions/widgets');
+const {featureGridSelector} = require('../../../selectors/controls');
 /**
  * Reset widgets
  */
 module.exports = compose(
-    connect(() => ({}), {
-        backFromWizard: () => onEditorChange('widgetType', undefined)
+    connect(() => ({
+        returnToFeatureGrid: state => featureGridSelector(state)}),
+    {
+        backToWidgetList: () => onEditorChange('widgetType', undefined),
+        backToFeatureGrid: () => setControlProperty("widgetBuilder", "enabled", false, false),
+        openFeatureGridTable: () => openFeatureGrid()
+    }),
+    withHandlers({
+        backFromWizard: ({
+            backToWidgetList = () => {},
+            backToFeatureGrid = () => {},
+            openFeatureGridTable = () => {},
+            returnToFeatureGrid
+        }) => () => {
+            if (returnToFeatureGrid) {
+                backToFeatureGrid();
+                openFeatureGridTable();
+            }
+            backToWidgetList();
+        }
     }),
     withProps(({ backFromWizard = () => {} }) => ({
         exitButton: {

--- a/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
@@ -20,21 +20,26 @@ module.exports = compose(
         returnToFeatureGrid: state => returnToFeatureGridSelector(state)}),
     {
         backToWidgetList: () => onEditorChange('widgetType', undefined),
-        backToFeatureGrid: () => setControlProperty("widgetBuilder", "enabled", false, false),
+        closeWidgetBuilder: () => setControlProperty("widgetBuilder", "enabled", false, false),
         openFeatureGridTable: () => openFeatureGrid()
     }),
+    /**
+     * it allows to return to the feature grid if the chart wizard has been opened from there.
+     * otherwise it goes back to the widget list
+    */
     withHandlers({
         backFromWizard: ({
             backToWidgetList = () => {},
-            backToFeatureGrid = () => {},
+            closeWidgetBuilder = () => {},
             openFeatureGridTable = () => {},
             returnToFeatureGrid
         }) => () => {
             if (returnToFeatureGrid) {
-                backToFeatureGrid();
+                closeWidgetBuilder();
                 openFeatureGridTable();
+            } else {
+                backToWidgetList();
             }
-            backToWidgetList();
         }
     }),
     withProps(({ backFromWizard = () => {} }) => ({

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -9,7 +9,11 @@
 const expect = require('expect');
 const {
     queryPanelSelector,
-    wfsDownloadAvailable
+    wfsDownloadAvailable,
+    wfsDownloadSelector,
+    widgetBuilderAvailable,
+    widgetBuilderSelector,
+    featureGridSelector
 } = require("../controls");
 
 const state = {
@@ -18,7 +22,15 @@ const state = {
             enabled: true
         },
         wfsdownload: {
-            available: true
+            available: true,
+            enabled: true
+        },
+        widgetBuilder: {
+            available: true,
+            enabled: true
+        },
+        featuregrid: {
+            enabled: true
         }
     }
 };
@@ -31,6 +43,26 @@ describe('Test controls selectors', () => {
     });
     it('test wfsDownloadAvailable', () => {
         const retVal = wfsDownloadAvailable(state);
+        expect(retVal).toExist();
+        expect(retVal).toBe(true);
+    });
+    it('test wfsDownloadSelector', () => {
+        const retVal = wfsDownloadSelector(state);
+        expect(retVal).toExist();
+        expect(retVal).toBe(true);
+    });
+    it('test widgetBuilderAvailable', () => {
+        const retVal = widgetBuilderAvailable(state);
+        expect(retVal).toExist();
+        expect(retVal).toBe(true);
+    });
+    it('test widgetBuilderSelector', () => {
+        const retVal = widgetBuilderSelector(state);
+        expect(retVal).toExist();
+        expect(retVal).toBe(true);
+    });
+    it('test featureGridSelector', () => {
+        const retVal = featureGridSelector(state);
         expect(retVal).toExist();
         expect(retVal).toBe(true);
     });

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -12,8 +12,7 @@ const {
     wfsDownloadAvailable,
     wfsDownloadSelector,
     widgetBuilderAvailable,
-    widgetBuilderSelector,
-    featureGridSelector
+    widgetBuilderSelector
 } = require("../controls");
 
 const state = {
@@ -61,10 +60,4 @@ describe('Test controls selectors', () => {
         expect(retVal).toExist();
         expect(retVal).toBe(true);
     });
-    it('test featureGridSelector', () => {
-        const retVal = featureGridSelector(state);
-        expect(retVal).toExist();
-        expect(retVal).toBe(true);
-    });
-
 });

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -18,7 +18,8 @@ const {
     getEditorSettings,
     getWidgetLayer,
     dependenciesSelector,
-    availableDependenciesSelector
+    availableDependenciesSelector,
+    returnToFeatureGridSelector
 } = require('../widgets');
 const {set} = require('../../utils/ImmutableUtils');
 describe('widgets selectors', () => {
@@ -64,6 +65,11 @@ describe('widgets selectors', () => {
         const state = set(`widgets.builder.settings`, { flag: true }, {});
         expect(getEditorSettings(state)).toExist();
         expect(getEditorSettings(state).flag).toBe(true);
+    });
+    it('returnToFeatureGridSelector', () => {
+        const state = set(`widgets.builder.editor`, { returnToFeatureGrid: true }, {});
+        expect(returnToFeatureGridSelector(state)).toExist();
+        expect(returnToFeatureGridSelector(state)).toBe(true);
     });
     it('getWidgetLayer', () => {
         const tocLayerState = {'layers': { selected: ["TEST1"], flat: [{id: "TEST1", name: "TEST1"}] }};

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -5,5 +5,6 @@ module.exports = {
     wfsDownloadAvailable: state => !!get(state, "controls.wfsdownload.available"),
     wfsDownloadSelector: state => !!get(state, "controls.wfsdownload.enabled"),
     widgetBuilderAvailable: state => get(state, "controls.widgetBuilder.available"),
-    widgetBuilderSelector: (state) => get(state, "controls.widgetBuilder.enabled")
+    widgetBuilderSelector: (state) => get(state, "controls.widgetBuilder.enabled"),
+    featureGridSelector: (state) => get(state, "controls.featuregrid.enabled")
 };

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -5,6 +5,5 @@ module.exports = {
     wfsDownloadAvailable: state => !!get(state, "controls.wfsdownload.available"),
     wfsDownloadSelector: state => !!get(state, "controls.wfsdownload.enabled"),
     widgetBuilderAvailable: state => get(state, "controls.widgetBuilder.available"),
-    widgetBuilderSelector: (state) => get(state, "controls.widgetBuilder.enabled"),
-    featureGridSelector: (state) => get(state, "controls.featuregrid.enabled")
+    widgetBuilderSelector: (state) => get(state, "controls.widgetBuilder.enabled")
 };

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -67,6 +67,7 @@ module.exports = {
     getDashboardWidgetsLayout: state => get(state, `widgets.containers[${DEFAULT_TARGET}].layouts`),
     getEditingWidget,
     getEditingWidgetLayer: state => get(getEditingWidget(state), "layer"),
+    returnToFeatureGridSelector: (state) => get(state, "widgets.builder.editor.returnToFeatureGrid", false),
     getEditingWidgetFilter: state => get(getEditingWidget(state), "filter"),
     getEditorSettings,
     getWidgetLayer,


### PR DESCRIPTION
## Description
Fixed back interaction if the char wizard is opened from the faature grid

## Issues
 - Fix #2807

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
actually the back button goes back to the selection type of the widget

**What is the new behavior?**
The back button in the toolbar goes back to the feature grid if it was opened

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
