### PR TITLE
Fix #2803 add popover overlay to the sync tool in feature grid

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -41,7 +41,9 @@ const {
     START_SYNC_WMS, startSyncWMS,
     storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER,
     fatureGridQueryResult, GRID_QUERY_RESULT,
-    moreFeatures, LOAD_MORE_FEATURES
+    moreFeatures, LOAD_MORE_FEATURES,
+    hideSyncPopover, HIDE_SYNC_POPOVER,
+    toggleShowAgain, TOGGLE_SHOW_AGAIN_FLAG
 } = require('../featuregrid');
 
 const idFeature = "2135";
@@ -95,6 +97,16 @@ describe('Test correctness of featurgrid actions', () => {
         const retval = clearChangeConfirmed();
         expect(retval).toExist();
         expect(retval.type).toBe(CLEAR_CHANGES_CONFIRMED);
+    });
+    it('Test hideSyncPopover action creator', () => {
+        const retval = hideSyncPopover();
+        expect(retval).toExist();
+        expect(retval.type).toBe(HIDE_SYNC_POPOVER);
+    });
+    it('Test toggleShowAgain action creator', () => {
+        const retval = toggleShowAgain();
+        expect(retval).toExist();
+        expect(retval.type).toBe(TOGGLE_SHOW_AGAIN_FLAG);
     });
     it('Test startDrawingFeature action creator', () => {
         const retval = startDrawingFeature();

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -45,6 +45,8 @@ const OPEN_ADVANCED_SEARCH = 'FEATUREGRID:ADVANCED_SEARCH';
 const ZOOM_ALL = 'FEATUREGRID:ZOOM_ALL';
 const INIT_PLUGIN = 'FEATUREGRID:INIT_PLUGIN';
 const SIZE_CHANGE = 'FEATUREGRID:SIZE_CHANGE';
+const TOGGLE_SHOW_AGAIN_FLAG = 'FEATUREGRID:TOGGLE_SHOW_AGAIN_FLAG';
+const HIDE_SYNC_POPOVER = 'FEATUREGRID:HIDE_SYNC_POPOVER';
 
 const MODES = {
     EDIT: "EDIT",
@@ -56,6 +58,16 @@ const STORE_ADVANCED_SEARCH_FILTER = 'STORE_ADVANCED_SEARCH_FILTER';
 const LOAD_MORE_FEATURES = "LOAD_MORE_FEATURES";
 const GRID_QUERY_RESULT = 'FEATUREGRID:QUERY_RESULT';
 
+function toggleShowAgain() {
+    return {
+        type: TOGGLE_SHOW_AGAIN_FLAG
+    };
+}
+function hideSyncPopover() {
+    return {
+        type: HIDE_SYNC_POPOVER
+    };
+}
 function fatureGridQueryResult(features, pages) {
     return {
         type: GRID_QUERY_RESULT,
@@ -381,6 +393,8 @@ module.exports = {
     toggleEditMode,
     toggleViewMode,
     initPlugin, INIT_PLUGIN,
+    hideSyncPopover, HIDE_SYNC_POPOVER,
+    toggleShowAgain, TOGGLE_SHOW_AGAIN_FLAG,
     START_SYNC_WMS, startSyncWMS,
     STOP_SYNC_WMS,
     storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER,

--- a/web/client/components/data/featuregrid/enhancers/withHint.js
+++ b/web/client/components/data/featuregrid/enhancers/withHint.js
@@ -4,7 +4,7 @@ const tooltip = require('../../../misc/enhancers/tooltip');
 const withPopover = require('./withPopover');
 module.exports = compose(
     branch(
-        (({renderPopover} = {}) => renderPopover),
+        (({renderPopover, popoverOptions} = {}) => renderPopover && !!popoverOptions),
         withPopover,
         tooltip
     )

--- a/web/client/components/data/featuregrid/enhancers/withHint.js
+++ b/web/client/components/data/featuregrid/enhancers/withHint.js
@@ -1,0 +1,11 @@
+
+const {compose, branch} = require('recompose');
+const tooltip = require('../../../misc/enhancers/tooltip');
+const withPopover = require('./withPopover');
+module.exports = compose(
+    branch(
+        (({renderPopover} = {}) => renderPopover),
+        withPopover,
+        tooltip
+    )
+);

--- a/web/client/components/data/featuregrid/enhancers/withPopover.js
+++ b/web/client/components/data/featuregrid/enhancers/withPopover.js
@@ -1,0 +1,28 @@
+const React = require('react');
+const Overlay = require('../../../misc/Overlay');
+const {Popover} = require('react-bootstrap');
+const ReactDOM = require('react-dom');
+
+/**
+ * An overlay popover is added to a Wrapped component
+ * @param {object} Wrapped must be a class component, do not use a functional
+ * component because it misses the refs property
+ * you can customize popover props, content and placement
+*/
+module.exports = (Wrapped) => class WithPopover extends React.Component {
+    render() {
+        let target = null;
+        const {popoverOptions, ...props} = this.props;
+        return (
+            <span className="mapstore-info-popover">
+                <Wrapped {...this.props} ref={button => { target = button; }} />
+                <Overlay placement={popoverOptions.placement} show target={() => ReactDOM.findDOMNode(target)}>
+                    <Popover
+                        {...popoverOptions.props}>
+                        {popoverOptions.content}
+                    </Popover>
+                </Overlay>
+            </span>
+        );
+    }
+};

--- a/web/client/components/data/featuregrid/enhancers/withTooltip.js
+++ b/web/client/components/data/featuregrid/enhancers/withTooltip.js
@@ -1,0 +1,8 @@
+const React = require('react');
+const OverlayTrigger = require('../../../misc/OverlayTrigger');
+const {Tooltip} = require('react-bootstrap');
+
+module.exports = (Wrapped) => ({tooltip, id, placement, ...props}) =>
+    (<OverlayTrigger placement={placement} overlay={<Tooltip id={`fe-${id}`}>{tooltip}</Tooltip>}>
+    <Wrapped {...props}/>
+    </OverlayTrigger>);

--- a/web/client/components/data/featuregrid/toolbars/TButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TButton.jsx
@@ -1,21 +1,21 @@
 const React = require('react');
-const {Button, Glyphicon, Tooltip} = require('react-bootstrap');
-const OverlayTrigger = require('../../../misc/OverlayTrigger');
+const {Button, Glyphicon} = require('react-bootstrap');
 const hideStyle = {
     width: 0,
     padding: 0,
     borderWidth: 0
 };
-const normalStyle = {
-};
-
+const normalStyle = {};
 const getStyle = (visible) => visible ? normalStyle : hideStyle;
-module.exports = ({disabled, id, tooltip="", visible, onClick, glyph, active, className = "square-button"}) =>
-    (<OverlayTrigger placement="top" overlay={<Tooltip id={`fe-${id}`}>{tooltip}</Tooltip>}>
-        <Button key={id} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
+
+module.exports = class SimpleTButton extends React.Component {
+    render() {
+        const {disabled, id, visible, onClick, glyph, active, className = "square-button", ...props} = this.props;
+        return (<Button {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
             style={getStyle(visible)}
             className={className}
             onClick={() => !disabled && onClick()}>
             <Glyphicon glyph={glyph}/>
-        </Button>
-    </OverlayTrigger>);
+        </Button>);
+    }
+};

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -1,8 +1,9 @@
 const React = require('react');
-const {ButtonGroup} = require('react-bootstrap');
+const {ButtonGroup, Glyphicon, Checkbox} = require('react-bootstrap');
 require("./toolbar.css");
 const Message = require('../../../I18N/Message');
-const TButton = require("./TButton");
+const withHint = require("../enhancers/withHint");
+const TButton = withHint(require("./TButton"));
 const getDrawFeatureTooltip = (isDrawing, isSimpleGeom) => {
     if (isDrawing) {
         return "featuregrid.toolbar.stopDrawGeom";
@@ -15,48 +16,52 @@ const getSaveMessageId = ({saving, saved}) => {
     }
     return "featuregrid.toolbar.saveChanges";
 };
-
-module.exports = ({events = {}, mode = "VIEW", showChartButton = true, selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, disableZoomAll = false} = {}) =>
-
-    (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
+module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: "32.2%"}, mode = "VIEW", showChartButton = true, selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, disableZoomAll = false} = {}) => {
+    return (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
-            tooltip={<Message msgId="featuregrid.toolbar.editMode"/>}
+            key="edit-mode"
+            tooltipId="featuregrid.toolbar.editMode"
             disabled={disableToolbar}
             visible={mode === "VIEW" && isEditingAllowed}
             onClick={events.switchEditMode}
             glyph="pencil"/>
         <TButton
             id="search"
-            tooltip={<Message msgId="featuregrid.toolbar.advancedFilter"/>}
+            key="search"
+            tooltipId="featuregrid.toolbar.advancedFilter"
             disabled={disableToolbar || !isSearchAllowed}
             visible={mode === "VIEW"}
             onClick={events.showQueryPanel}
             glyph="filter"/>
         <TButton
             id="zoom-all"
-            tooltip={<Message msgId="featuregrid.toolbar.zoomAll"/>}
+            key="zoom-all"
+            tooltipId="featuregrid.toolbar.zoomAll"
             disabled={disableToolbar || disableZoomAll}
             visible={mode === "VIEW"}
             onClick={events.zoomAll}
             glyph="zoom-to"/>
         <TButton
             id="back-view"
-            tooltip={<Message msgId="featuregrid.toolbar.quitEditMode"/>}
+            key="back-view"
+            tooltipId="featuregrid.toolbar.quitEditMode"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasChanges && !hasNewFeatures}
             onClick={events.switchViewMode}
             glyph="arrow-left"/>
         <TButton
             id="add-feature"
-            tooltip={<Message msgId="featuregrid.toolbar.addNewFeatures"/>}
+            key="add-feature"
+            tooltipId="featuregrid.toolbar.addNewFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasNewFeatures && !hasChanges && hasSupportedGeometry}
             onClick={events.createFeature}
             glyph="row-add"/>
         <TButton
             id="draw-feature"
-            tooltip={<Message msgId={getDrawFeatureTooltip(isDrawing, isSimpleGeom)}/>}
+            key="draw-feature"
+            tooltipId={getDrawFeatureTooltip(isDrawing, isSimpleGeom)}
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount === 1 && (!hasGeometry || hasGeometry && !isSimpleGeom) && hasSupportedGeometry}
             onClick={events.startDrawingFeature}
@@ -64,14 +69,16 @@ module.exports = ({events = {}, mode = "VIEW", showChartButton = true, selectedC
             glyph="pencil-add"/>
         <TButton
             id="remove-features"
-            tooltip={<Message msgId="featuregrid.toolbar.deleteSelectedFeatures"/>}
+            key="remove-features"
+            tooltipId="featuregrid.toolbar.deleteSelectedFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount > 0 && !hasChanges && !hasNewFeatures}
             onClick={events.deleteFeatures}
             glyph="trash-square"/>
         <TButton
             id="save-feature"
-            tooltip={<Message msgId={getSaveMessageId({saving, saved})}/>}
+            key="save-feature"
+            tooltipId={getSaveMessageId({saving, saved})}
             disabled={saving || saved || disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
             active={saved}
@@ -79,21 +86,24 @@ module.exports = ({events = {}, mode = "VIEW", showChartButton = true, selectedC
             glyph="floppy-disk"/>
         <TButton
             id="cancel-editing"
-            tooltip={<Message msgId="featuregrid.toolbar.cancelChanges"/>}
+            key="cancel-editing"
+            tooltipId="featuregrid.toolbar.cancelChanges"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
             onClick={events.clearFeatureEditing}
             glyph="remove-square"/>
         <TButton
             id="delete-geometry"
-            tooltip={<Message msgId="featuregrid.toolbar.deleteGeometry"/>}
+            key="delete-geometry"
+            tooltipId="featuregrid.toolbar.deleteGeometry"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasGeometry && selectedCount === 1 && hasSupportedGeometry}
             onClick={events.deleteGeometry}
             glyph="polygon-trash"/>
         <TButton
             id="download-grid"
-            tooltip={<Message msgId="featuregrid.toolbar.downloadGridData"/>}
+            key="download-grid"
+            tooltipId="featuregrid.toolbar.downloadGridData"
             disabled={disableToolbar || disableDownload}
             active={isDownloadOpen}
             visible={displayDownload && mode === "VIEW"}
@@ -101,25 +111,58 @@ module.exports = ({events = {}, mode = "VIEW", showChartButton = true, selectedC
             glyph="features-grid-download"/>
         <TButton
             id="grid-settings"
-            tooltip={<Message msgId="featuregrid.toolbar.hideShowColumns"/>}
+            key="grid-settings"
+            tooltipId="featuregrid.toolbar.hideShowColumns"
             disabled={disableToolbar}
             active={isColumnsOpen}
             visible={selectedCount <= 1 && mode === "VIEW"}
             onClick={events.settings}
             glyph="features-grid-set"/>
         <TButton
-            id="grid-map-filter"
-            tooltip={<Message msgId="featuregrid.toolbar.syncOnMap"/>}
-            disabled={disableToolbar}
-            active={isSyncActive}
-            visible={mode === "VIEW"}
-            onClick={events.sync}
-            glyph="map-filter"/>
-        <TButton
             id="grid-map-chart"
-            tooltip={<Message msgId="featuregrid.toolbar.createNewChart"/>}
+            key="grid-map-chart"
+            tooltipId="featuregrid.toolbar.createNewChart"
             disabled={disableToolbar}
             visible={mode === "VIEW" && showChartButton}
             onClick={events.chart}
             glyph="stats"/>
-    </ButtonGroup>);
+        <TButton
+            id="grid-map-filter"
+            key="grid-map-filter"
+            tooltipId="featuregrid.toolbar.syncOnMap"
+            disabled={disableToolbar}
+            active={isSyncActive}
+            visible={mode === "VIEW"}
+            onClick={events.sync}
+            glyph="map-filter"
+            renderPopover={syncPopover.showPopoverSync}
+            popoverOptions={{
+                placement: "top",
+                content: (<span>
+                    <p><Message msgId="featuregrid.toolbar.synchPopoverText"/></p>
+                    <p>
+                        <Checkbox {...{checked: syncPopover.showAgain, onClick: events.toggleShowAgain}}>
+                            <Message msgId="featuregrid.toolbar.notShowAgain"/>
+                        </Checkbox>
+                    </p>
+                </span>),
+                props: {
+                    id: "sync-popover",
+                    title: <div>
+                        <Message msgId="featuregrid.toolbar.synchPopoverTitle"/>
+                        <button onClick={() => {
+                            if (syncPopover.showAgain) {
+                                localStorage.setItem("showPopoverSync", false);
+                            }
+                            events.hideSyncPopover();
+                        }} className="close">
+                            <Glyphicon className="pull-right" glyph="1-close"/>
+                        </button>
+                    </div>,
+                    style: {
+                        bottom: syncPopover.dockSize
+                    }
+                }}
+        } />
+
+</ButtonGroup>); };

--- a/web/client/components/misc/enhancers/tooltip.jsx
+++ b/web/client/components/misc/enhancers/tooltip.jsx
@@ -30,7 +30,6 @@ const Message = require('../../I18N/Message');
  */
 module.exports = branch(
     ({tooltip, tooltipId} = {}) => tooltip || tooltipId,
-    // TODO return proper HOC
     (Wrapped) => ({tooltip, tooltipId, tooltipPosition = "top", tooltipTrigger, key, ...props} = {}) => (<OverlayTrigger
         trigger={tooltipTrigger}
         key={key}

--- a/web/client/components/widgets/widget/InfoPopover.jsx
+++ b/web/client/components/widgets/widget/InfoPopover.jsx
@@ -82,7 +82,7 @@ class InfoPopover extends React.Component {
                             </OverlayTrigger>)
                     : [
                         this.renderContent(),
-                        <Overlay show target={() => ReactDOM.findDOMNode(this.target)}>
+                        <Overlay placement={this.props.placement} show target={() => ReactDOM.findDOMNode(this.target)}>
                         {this.renderPopover()}
                         </Overlay>
                     ]}

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -73,7 +73,8 @@ const updateMapLayoutEpic = (action$, store) =>
                 mapInfoRequestsSelector(store.getState()).length > 0 && {right: mapLayout.right.md} || null
             ].filter(panel => panel)) || {right: 0};
 
-            const bottom = isFeatureGridOpen(store.getState()) && {bottom: getDockSize(store.getState()) * 100 + '%'} || {bottom: mapLayout.bottom.sm};
+            const dockSize = getDockSize(store.getState()) * 100;
+            const bottom = isFeatureGridOpen(store.getState()) && {bottom: dockSize + '%', dockSize} || {bottom: mapLayout.bottom.sm};
 
             const transform = isFeatureGridOpen(store.getState()) && {transform: 'translate(0, -' + mapLayout.bottom.sm + 'px)'} || {transform: 'none'};
             const height = {height: 'calc(100% - ' + mapLayout.bottom.sm + 'px)'};

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -15,7 +15,8 @@ const {paginationInfo, featureLoadingSelector, resultsSelector, isSyncWmsActive,
 const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector, hasGeometrySelector, isSimpleGeomSelector, hasNewFeaturesSelector, isSavingSelector, isSavedSelector, isDrawingSelector, canEditSelector, getAttributeFilter, hasSupportedGeometry, editingAllowedRolesSelector} = require('../../../selectors/featuregrid');
 const {userRoleSelector} = require('../../../selectors/security');
 const {isCesium} = require('../../../selectors/maptype');
-const {chartDisabledSelector} = require('../../../selectors/featuregrid');
+const {mapLayoutValuesSelector} = require('../../../selectors/mapLayout');
+const {chartDisabledSelector, showAgainSelector, showPopoverSyncSelector} = require('../../../selectors/featuregrid');
 const {deleteFeatures, toggleTool, clearChangeConfirmed, closeFeatureGridConfirmed, closeFeatureGrid} = require('../../../actions/featuregrid');
 const {toolbarEvents, pageEvents} = require('../index');
 const {getAttributeFields} = require('../../../utils/FeatureGridUtils');
@@ -35,6 +36,11 @@ const Toolbar = connect(
         hasChanges: hasChangesSelector,
         hasNewFeatures: hasNewFeaturesSelector,
         hasGeometry: hasGeometrySelector,
+        syncPopover: state => ({
+            showAgain: showAgainSelector(state),
+            showPopoverSync: showPopoverSyncSelector(state),
+            dockSize: mapLayoutValuesSelector(state, {dockSize: true}).dockSize + 3.2 + "%"
+        }),
         isDrawing: isDrawingSelector,
         showChartButton: state => !chartDisabledSelector(state) && widgetBuilderAvailable(state),
         isSimpleGeom: isSimpleGeomSelector,

--- a/web/client/plugins/featuregrid/toolbarEvents.js
+++ b/web/client/plugins/featuregrid/toolbarEvents.js
@@ -4,6 +4,8 @@ const {toggleTool,
     toggleViewMode,
     closeFeatureGridConfirm,
     saveChanges,
+    hideSyncPopover,
+    toggleShowAgain,
     createNewFeatures,
     startEditingFeature,
     startDrawingFeature,
@@ -32,5 +34,7 @@ module.exports = {
     showQueryPanel: () => openAdvancedSearch(),
     zoomAll: () => zoomAll(),
     sync: () => toggleSyncWms(),
+    hideSyncPopover: () => hideSyncPopover(),
+    toggleShowAgain: () => toggleShowAgain(),
     chart: () => createChart()
 };

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -46,7 +46,8 @@ const expect = require('expect');
 const featuregrid = require('../featuregrid');
 const {setFeatures, dockSizeFeatures, setLayer, toggleTool, customizeAttribute, selectFeatures, deselectFeatures, createNewFeatures, updateFilter,
     featureSaving, toggleSelection, clearSelection, MODES, toggleEditMode, toggleViewMode, saveSuccess, clearChanges, saveError, startDrawingFeature,
-    deleteGeometryFeature, geometryChanged, setSelectionOptions, changePage, featureModified, setPermission, disableToolbar, openFeatureGrid, closeFeatureGrid, initPlugin, sizeChange, storeAdvancedSearchFilter} = require('../../actions/featuregrid');
+    deleteGeometryFeature, geometryChanged, setSelectionOptions, changePage, featureModified, setPermission, disableToolbar, openFeatureGrid, closeFeatureGrid,
+    toggleShowAgain, hideSyncPopover, initPlugin, sizeChange, storeAdvancedSearchFilter} = require('../../actions/featuregrid');
 const {featureTypeLoaded, createQuery} = require('../../actions/wfsquery');
 
 const {changeDrawingStatus} = require('../../actions/draw');
@@ -64,6 +65,17 @@ describe('Test the featuregrid reducer', () => {
         expect(state.pagination).toExist();
         expect(state.select).toExist();
         expect(state.features).toExist();
+    });
+    it('hideSyncPopover', () => {
+        let state = featuregrid({}, hideSyncPopover());
+        expect(state.showPopoverSync).toBe(false);
+    });
+    it('toggleShowAgain toggling', () => {
+        let state = featuregrid({showAgain: false}, toggleShowAgain());
+        expect(state).toExist();
+        expect(state.showAgain).toBe(true);
+        let state2 = featuregrid({showAgain: true}, toggleShowAgain());
+        expect(state2.showAgain).toBe(false);
     });
     it('initPlugin', () => {
         const someValue = "someValue";

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -27,6 +27,8 @@ const {
     TOGGLE_MODE,
     MODES,
     GEOMETRY_CHANGED,
+    HIDE_SYNC_POPOVER,
+    TOGGLE_SHOW_AGAIN_FLAG,
     DELETE_GEOMETRY_FEATURE,
     START_DRAWING_FEATURE,
     SET_PERMISSION,
@@ -58,6 +60,8 @@ const emptyResultsState = {
     open: false,
     canEdit: false,
     focusOnEdit: true,
+    showAgain: true,
+    showPopoverSync: localStorage && localStorage.getItem("showPopoverSync") !== null ? localStorage.getItem("showPopoverSync") === "true" : true,
     mode: MODES.VIEW,
     changes: [],
     pagination: {
@@ -367,6 +371,12 @@ function featuregrid(state = emptyResultsState, action) {
     }
     case GRID_QUERY_RESULT: {
         return assign({}, state, {features: action.features || [], pages: action.pages || []});
+    }
+    case HIDE_SYNC_POPOVER: {
+        return assign({}, state, {showPopoverSync: false});
+    }
+    case TOGGLE_SHOW_AGAIN_FLAG: {
+        return assign({}, state, {showAgain: !state.showAgain});
     }
     default:
         return state;

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -27,6 +27,8 @@ const {
     isSavingSelector,
     isSavedSelector,
     canEditSelector,
+    showAgainSelector,
+    showPopoverSyncSelector,
     hasSupportedGeometry,
     getDockSize
 } = require('../featuregrid');
@@ -380,6 +382,24 @@ describe('Test featuregrid selectors', () => {
         const feature = selectedFeatureSelector(initialState);
         expect(feature).toExist();
         expect(feature.id).toBe(idFt1);
+    });
+    it('test showAgainSelector default ', () => {
+        const val = showAgainSelector(initialState);
+        expect(val).toExist();
+        expect(val).toBe(true);
+    });
+    it('test showAgainSelector default ', () => {
+        const val = showPopoverSyncSelector(initialState);
+        expect(val).toExist();
+        expect(val).toBe(true);
+    });
+    it('test showAgainSelector ', () => {
+        const val = showAgainSelector({featuregrid: {showAgain: false}});
+        expect(val).toBe(false);
+    });
+    it('test showPopoverSyncSelector ', () => {
+        const val = showPopoverSyncSelector({featuregrid: {showPopoverSync: false}});
+        expect(val).toBe(false);
     });
     it('test selectedFeaturesSelector ', () => {
         const features = selectedFeaturesSelector(initialState);

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -122,6 +122,8 @@ module.exports = {
     hasGeometrySelector: state => hasGeometrySelectedFeature(state),
     newFeaturesSelector,
     hasNewFeaturesSelector,
+    showAgainSelector: state => get(state, "featuregrid.showAgain", true),
+    showPopoverSyncSelector: state => get(state, "featuregrid.showPopoverSync", true),
     isSavingSelector: state => state && state.featuregrid && state.featuregrid.saving,
     editingAllowedRolesSelector: state => get(state, "featuregrid.editingAllowedRoles", ["ADMIN"]),
     isSavedSelector: state => state && state.featuregrid && state.featuregrid.saved,

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -153,3 +153,26 @@ textarea {
         top: 0;
     }
 }
+
+
+div#sync-popover.popover {
+     top: auto !important;
+     padding: 0;
+     h3 {
+         background-color: @ms2-color-primary;
+         color: @ms2-color-text-primary;
+     }
+     .mapstore-switch-btn{
+         margin-bottom: -5px;
+     }
+     .glyphicon-1-close:before {
+         font-size: @small-icon-size;
+     }
+     button.close{
+         font-size: inherit;
+     }
+     button.close:first-child:before {
+         font-size: 0px;
+     }
+
+}

--- a/web/client/themes/default/variables.less
+++ b/web/client/themes/default/variables.less
@@ -44,6 +44,7 @@
 @icon-resize-ratio: 1.6;
 
 @icon-size: 26px;
+@small-icon-size: 14px;
 @padding-left-square: floor(@icon-size/@icon-margin-ratio);
 @square-btn-size: @padding-left-square * 2 + @icon-size;
 

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1042,6 +1042,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Karte mit Filter synchronisieren ",
+                "synchPopoverText": "Verwenden Sie dieses Werkzeug, um die Karte mit dem ausgewählten Filter zu synchronisieren",
+                "notShowAgain": "  Zeigen Sie diese Nachricht nicht erneut an",
                 "editMode": "Bearbeitungsmodus",
                 "advancedFilter": "Erweiterte Suche",
                 "quitEditMode": "Beenden Sie den Bearbeitungsmodus",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1043,6 +1043,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Sync map with filter ",
+                "synchPopoverText": "Use this tool to synchronize the map with the selected filter",
+                "notShowAgain": "  Don't show this message again",
                 "editMode": "Edit mode",
                 "advancedFilter": "Advanced Search",
                 "quitEditMode": "Quit edit mode",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1042,6 +1042,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Sincronizar mapa con filtro ",
+                "synchPopoverText": "Use esta herramienta para sincronizar el mapa con el filtro seleccionado",
+                "notShowAgain": "  No mostrar este mensaje otra vez",
                 "editMode": "Modo de edición",
                 "advancedFilter": "Búsqueda avanzada",
                 "quitEditMode": "Salir del modo de edición",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1043,6 +1043,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Synchroniser la carte avec un filtre ",
+                "synchPopoverText": "Utilisez cet outil pour synchroniser la carte avec le filtre sélectionné",
+                "notShowAgain": "  Ne plus afficher ce message",
                 "editMode": "Mode édition",
                 "advancedFilter": "Recherche Avancée",
                 "quitEditMode": "Quitter le mode d'édition",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1043,6 +1043,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Sync map with filter ",
+                "synchPopoverText": "Use this tool to synchronize the map with the selected filter",
+                "notShowAgain": "  Don't show this message again",
                 "editMode": "Editiranje",
                 "advancedFilter": "Napredna pretraga",
                 "quitEditMode": "Napusti editiranje",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1042,6 +1042,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Sincronizza la mappa con il filtro ",
+                "synchPopoverText": "Usa questa icona per sincronizzare la mappa con il filtro selezionato",
+                "notShowAgain": "  Non mostrare più",
                 "editMode": "Entra in modalità editing",
                 "advancedFilter": "Ricerca avanzata",
                 "quitEditMode": "Esci dalla modalità editing",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -865,7 +865,23 @@
                 "featureClose":"Wilt u echt het rooster sluiten?",
                 "delete": "Valideren om de elementen te verwijderen?",
                 "missingGeometry": "Ontbrekende geometrie",
+                "filter": {
+                    "placeholders": {
+                        "default": "Search...",
+                        "string": "Type text to filter...",
+                        "number": "Type number or expression..."
+                    },
+                    "tooltips": {
+                        "editMode": "Quick search is not available in edit mode",
+                        "default": "Search...",
+                        "string": "Type text to filter...",
+                        "number": "Type a number or an expression. Examples: 10, > 2, < 10"
+                    }
+                },
                 "toolbar": {
+                    "synchPopoverTitle": "Sync map with filter ",
+                    "synchPopoverText": "Use this tool to synchronize the map with the selected filter",
+                    "notShowAgain": "  Don't show this message again",
                     "editMode": "Bewerkingsmodus",
                     "advancedFilter": "Geavanceerd zoeken",
                     "quitEditMode": "Verlaat de bewerkingsmodus",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -941,6 +941,9 @@
                 }
             },
             "toolbar": {
+                "synchPopoverTitle": "Sync map with filter ",
+                "synchPopoverText": "Use this tool to synchronize the map with the selected filter",
+                "notShowAgain": "  Don't show this message again",
                 "editMode": "Edit mode",
                 "advancedFilter": "Advanced Search",
                 "quitEditMode": "Quit edit mode",


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #2803


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Synch tool has no popover showing what this tool does.

**What is the new behavior?**
now it does
![image](https://user-images.githubusercontent.com/11991428/38943132-f0dba56c-4330-11e8-9e34-e48bb2241c16.png)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
