### PR TITLE
Fix #2610 clipped long descriptions of catalog cards

### DIFF
--- a/web/client/components/catalog/RecordItem.css
+++ b/web/client/components/catalog/RecordItem.css
@@ -27,6 +27,11 @@
     overflow: hidden;
 }
 
+.record-item-description {
+    width: 350px;
+    white-space: nowrap;
+}
+
 .record-item .preview{
     float: left;
     width: 150px;

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -143,7 +143,7 @@ class RecordItem extends React.Component {
                 <div>
                     <h4 className="truncateText">{record && this.getTitle(record.title)}</h4>
                     <h4 className="truncateText"><small>{record && record.identifier}</small></h4>
-                    <p className="truncateText record-item-description">{this.renderDescription(record)}</p>
+                    <p className="truncateText record-item-description" style={{display: 'block'}}>{this.renderDescription(record)}</p>
                 </div>
                   {this.renderButtons(record)}
             </Panel>


### PR DESCRIPTION
## Description
Clipped long descriptions of catalog cards with text-overflow ellipsis.

## Issues
 - Fix #2610


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix









**Does this PR introduce a breaking change?** (check one with "x", remove the other)


 - [x] No


