### PR TITLE
Fix #2825. Improved messages in case of no attributes layer

### DIFF
--- a/web/client/components/widgets/builder/wizard/ChartWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/ChartWizard.jsx
@@ -9,8 +9,11 @@ const React = require('react');
 
 const { wizardHandlers } = require('../../../misc/wizard/enhancers');
 const loadingState = require('../../../misc/enhancers/loadingState')(({ loading, data }) => loading || !data, { width: 500, height: 200 });
-
-const ChartType = require('./chart/ChartType');
+const noAttribute = require('./common/noAttributesEmptyView');
+const hasNoAttributes = ({ featureTypeProperties = [] }) => featureTypeProperties.filter(({ type =""} = {}) => type.indexOf("gml:") !== 0).length === 0;
+const ChartType = noAttribute(
+    hasNoAttributes
+)(require('./chart/ChartType'));
 const wfsChartOptions = require('./common/wfsChartOptions');
 const ChartOptions = wfsChartOptions(require('./common/WPSWidgetOptions'));
 const WidgetOptions = require('./common/WidgetOptions');
@@ -91,6 +94,7 @@ module.exports = enhanceWizard(({ onChange = () => { }, onFinish = () => { }, se
                 } hideButtons>
         <ChartType
             key="type"
+            featureTypeProperties={featureTypeProperties}
             type={data.type}
             onSelect={i => {
                 onChange("type", i);

--- a/web/client/components/widgets/builder/wizard/CounterWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/CounterWizard.jsx
@@ -11,9 +11,10 @@ const { compose, lifecycle } = require('recompose');
 
 const {wizardHandlers} = require('../../../misc/wizard/enhancers');
 const loadingState = require('../../../misc/enhancers/loadingState')(({loading, data}) => loading || !data, {width: 500, height: 200});
-
 const wfsChartOptions = require('./common/wfsChartOptions');
-const CounterOptions = wfsChartOptions(require('./common/WPSWidgetOptions'));
+const noAttributes = require('./common/noAttributesEmptyView');
+
+const CounterOptions = wfsChartOptions(noAttributes(({options = []}) => options.length === 0)(require('./common/WPSWidgetOptions')));
 const WidgetOptions = require('./common/WidgetOptions');
 
 const wpsCounter = require('../../enhancers/wpsCounter');

--- a/web/client/components/widgets/builder/wizard/__tests__/CounterWizard-test.jsx
+++ b/web/client/components/widgets/builder/wizard/__tests__/CounterWizard-test.jsx
@@ -8,9 +8,11 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-
+const {get} = require('lodash');
 const expect = require('expect');
 const CounterWizard = require('../CounterWizard');
+
+const describeStates = require('json-loader!../../../../../test-resources/wfs/describe-states.json');
 describe('CounterWizard component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -21,8 +23,17 @@ describe('CounterWizard component', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
-    it('CounterWizard rendering with defaults', () => {
+    it('CounterWizard rendering empty-view', () => {
         ReactDOM.render(<CounterWizard />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.ms-wizard');
+        expect(el).toExist();
+        expect(container.querySelector('.chart-options-form')).toNotExist();
+        expect(container.querySelector('.empty-state-container')).toExist();
+
+    });
+    it('CounterWizard rendering with base attributes', () => {
+        ReactDOM.render(<CounterWizard featureTypeProperties={get(describeStates, "featureTypes[0].properties")}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('.ms-wizard');
         expect(el).toExist();

--- a/web/client/components/widgets/builder/wizard/common/noAttributesEmptyView.js
+++ b/web/client/components/widgets/builder/wizard/common/noAttributesEmptyView.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const emptyState = require('../../../../misc/enhancers/emptyState');
+const Message = require('../../../../I18N/Message');
+
+/**
+ * Enhances a component to show the empty view in case of no attributes.
+ * @param {function} the test to show the empty view
+ */
+const noAttributes = (func) => emptyState(
+    func,
+    {
+        title: <Message msgId="widgets.builder.errors.noAttributesTitle" />,
+        description: <Message msgId="widgets.builder.errors.noAttributesDescription" />,
+        glyph: 'warning-sign'
+    }
+);
+module.exports = noAttributes;

--- a/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
@@ -47,8 +47,15 @@ module.exports = ({openFilterEditor = () => {}, step = 0, stepButtons = [], edit
         glyph: "arrow-left",
         tooltipId: getBackTooltipId(step)
     }, ...stepButtons, {
-        visible: step === 0 && valid,
+        visible: step === 0,
         onClick: openFilterEditor,
+        /* if no valid attribute is present, filter must be disabled
+         * (Query panel don't work you can not proceed, so it doesn't make sense to
+         * create a filter if you can not create the widget)
+         * TODO: improve checking valid attributes presence instead
+         * of valid flag.
+         */
+        disabled: !valid,
         glyph: "filter",
         tooltipId: "widgets.builder.setupFilter"
     }, {

--- a/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/counter/Toolbar.jsx
@@ -47,7 +47,7 @@ module.exports = ({openFilterEditor = () => {}, step = 0, stepButtons = [], edit
         glyph: "arrow-left",
         tooltipId: getBackTooltipId(step)
     }, ...stepButtons, {
-        visible: step === 0,
+        visible: step === 0 && valid,
         onClick: openFilterEditor,
         glyph: "filter",
         tooltipId: "widgets.builder.setupFilter"

--- a/web/client/components/widgets/builder/wizard/counter/__tests__/Toolbar-test.jsx
+++ b/web/client/components/widgets/builder/wizard/counter/__tests__/Toolbar-test.jsx
@@ -35,9 +35,13 @@ describe('CounterWizard Toolbar component', () => {
         const buttons = container.querySelectorAll('button');
         expect(buttons.length).toBe(2);
         expect(buttons[0].querySelector('.glyphicon-filter')).toExist();
+        // filter should not enabled because valid means also that
+        // there are some attributes
+        expect(buttons[0].disabled).toBe(true);
         expect(buttons[1].querySelector('.glyphicon-arrow-right')).toExist();
         expect(buttons[1].disabled).toBe(true);
         ReactDOM.render(<Toolbar step={0} valid />, document.getElementById("container"));
+        expect(container.querySelectorAll('button')[1].disabled).toBe(false);
         expect(container.querySelectorAll('button')[1].disabled).toBeFalsy();
     });
     it('step 1', () => {

--- a/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/table/TableOptions.jsx
@@ -11,7 +11,7 @@ const { uniq, castArray, includes } = require('lodash');
 const { Row, Col, Form, Button } = require('react-bootstrap');
 const Message = require('../../../../I18N/Message');
 const StepHeader = require('../../../../misc/wizard/StepHeader');
-
+const noAttributes = require('../common/noAttributesEmptyView');
 const {withProps, withHandlers, compose} = require('recompose');
 const updatePropertyName = (arr, name, hide) => {
     const names = castArray(name);
@@ -20,18 +20,20 @@ const updatePropertyName = (arr, name, hide) => {
     }
     return uniq([...arr, ...names]);
 };
-const AttributeSelector = compose(withProps(
-    ({ attributes = [], options = {}} = {}) => ({ // TODO manage hide condition
-        attributes: attributes
-            .filter(a => !isGeometryType(a))
-            .map( a => ({
-                ...a,
-                label: a.name,
-                attribute: a.name,
-                hide: options.propertyName && (options.propertyName.indexOf( a.name ) < 0)
-            })
-        )
-    })),
+const AttributeSelector = compose(
+    withProps(
+        ({ attributes = [], options = {}} = {}) => ({ // TODO manage hide condition
+            attributes: attributes
+                .filter(a => !isGeometryType(a))
+                .map( a => ({
+                    ...a,
+                    label: a.name,
+                    attribute: a.name,
+                    hide: options.propertyName && (options.propertyName.indexOf( a.name ) < 0)
+                })
+            )
+        })),
+    noAttributes(({ attributes = []}) => attributes.length === 0),
     withHandlers({
         onChange: ({ onChange = () => {}, options = {}}) => (name, hide) => onChange("options.propertyName", updatePropertyName(options && options.propertyName || [], name, hide))
     })

--- a/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
@@ -23,7 +23,7 @@ const getBackTooltipId = step => {
     }
 };
 
-const getNextTooltipId = (step, valid) => valid ? "widgets.builder.wizard.configureWidgetOptions" : "widget.builder.wizard.errors.checkAtLeastOneAttribute";
+const getNextTooltipId = (step, valid) => valid ? "widgets.builder.wizard.configureWidgetOptions" : "widgets.builder.errors.checkAtLeastOneAttribute";
 
 const getSaveTooltipId = (step, {id} = {}) => {
     if (id) {
@@ -43,6 +43,7 @@ module.exports = ({ openFilterEditor = () => { }, step = 0, stepButtons = [], ed
     }, ...stepButtons, {
         visible: step >= 0,
         onClick: openFilterEditor,
+        disabled: !isValidStep1(editorData),
         glyph: "filter",
         tooltipId: "widgets.builder.setupFilter"
     }, {

--- a/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
+++ b/web/client/components/widgets/builder/wizard/table/Toolbar.jsx
@@ -43,6 +43,12 @@ module.exports = ({ openFilterEditor = () => { }, step = 0, stepButtons = [], ed
     }, ...stepButtons, {
         visible: step >= 0,
         onClick: openFilterEditor,
+         /* if no valid attribute is present, filter must be disabled
+         * (Query panel don't work you can not proceed, so it doesn't make sense to
+         * create a filter if you can not create the widget)
+         * TODO: improve checking valid attributes presence instead
+         * of valid flag.
+         */
         disabled: !isValidStep1(editorData),
         glyph: "filter",
         tooltipId: "widgets.builder.setupFilter"

--- a/web/client/components/widgets/builder/wizard/table/__tests__/TableOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/table/__tests__/TableOptions-test.jsx
@@ -31,6 +31,7 @@ describe('TableOptions component', () => {
         expect(el).toExist();
         const resetButton = document.querySelector('.btn');
         expect(resetButton).toNotExist();
+        expect(document.querySelector('.empty-state-container')).toExist();
     });
     it('Test TableOptions tools visibility', () => {
 

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -255,7 +255,6 @@
                 "name": "TOC",
                 "cfg": {
                     "activateQueryTool": true,
-                    "activateDownloadTool": true,
                     "activateAddLayerButton": true,
                     "spatialOperations": [
                         {"id": "INTERSECTS", "name": "queryform.spatialfilter.operations.intersects"},

--- a/web/client/plugins/widgetbuilder/TableBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TableBuilder.jsx
@@ -96,6 +96,7 @@ module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData
                     availableDependencies={availableDependencies}
                     onClose={onClose} />
                 {get(editorData, "options.propertyName.length") === 0 ? <InfoPopover
+                    trigger={false}
                     glyph="exclamation-mark"
                     bsStyle="warning"
                     text={<Message msgId="widgets.builder.errors.checkAtLeastOneAttribute" />} /> : null}

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1155,6 +1155,8 @@
                     "clearConnection": "Verbindung löschen"
                 },
                 "errors": {
+                    "noAttributesTitle": "Keine Attribute zum Anzeigen",
+                    "noAttributesDescription": "Für die ausgewählten Ebenen sind keine Attribute sichtbar. Bitte gehen Sie zurück und wählen Sie eine andere Ebene, um dieses Widget zu verwenden",
                     "noWidgetsAvailableTitle": "Das Widget für die ausgewählte Ebene kann nicht erstellt werden",
                     "noWidgetsAvailableDescription": "<p><strong>Bitte wählen Sie eine andere Ebene oder einen anderen Widgets-Typ</strong></p><p>Der Server bietet nicht die erforderlichen Dienste für die Ebene und den ausgewählten Widget-Typ</p><p> Mögliche Ursachen sind: <ul> <li> Der ausgewählte Layer ist ein Raster-Layer </li> <li> Der WFS-Service ist nicht verfügbar </li> <li> Der WPS-Prozess <code>gs:aggregate</code> ist nicht verfügbar </li> </ul> </p>",
                     "checkAtLeastOneAttribute": "Sie müssen mindestens eine Spalte auswählen"

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1156,6 +1156,8 @@
                     "clearConnection": "Clear connection"
                 },
                 "errors": {
+                    "noAttributesTitle": "No attributes to show",
+                    "noAttributesDescription": "The selected layers has no attributes to show. Please go back and select another layer to use this widget",
                     "noWidgetsAvailableTitle": "Can not create the widget for the selected layer",
                     "noWidgetsAvailableDescription": "<p><strong>Please try to select another layer or widget type</strong></p><p>The server doesn't provide the needed services for the layer and the widget type selected</p><p>Possible causes are: <ul><li>The selected layer is a raster layer</li><li>WFS service is not available</li><li>The WPS process <code>gs:aggregate</code> is not available</li></ul></p>",
                     "checkAtLeastOneAttribute": "You must select at least one column"

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1155,6 +1155,8 @@
                     "clearConnection": "Borrar conexión"
                 },
                 "errors": {
+                    "noAttributesTitle": "No hay atributos para mostrar",
+                    "noAttributesDescription": "Las capas seleccionadas no tienen atributos que mostrar. Vuelva atrás y seleccione otra capa para usar este widget",
                     "noWidgetsAvailableTitle": "No se puede crear el widget para la capa seleccionada",
                     "noWidgetsAvailableDescription": "<p> <strong> Intente seleccionar otra capa o tipo de widget </strong> </p> <p> El servidor no proporciona los servicios necesarios para la capa y el tipo de widget seleccionado </p> <p> Las posibles causas son: <ul> <li> La capa seleccionada es una capa ráster </li> <li> El servicio WFS no está disponible </li> <li> El proceso WPS <code>gs:aggregate</code> no está disponible </li> </ul> </p> ",
                     "checkAtLeastOneAttribute": "Debes seleccionar al menos una columna"

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1156,6 +1156,8 @@
                     "clearConnection": "Effacer la connexion"
                 },
                 "errors": {
+                    "noAttributesTitle": "Aucun attribut à afficher",
+                    "noAttributesDescription": "Les couches sélectionnées n'ont aucun attribut à afficher. Veuillez revenir en arrière et sélectionner une autre couche pour utiliser ce widget",
                     "noWidgetsAvailableTitle": "Impossible de créer le widget pour le calque sélectionné",
                     "noWidgetsAvailableDescription": "<p> <strong> Veuillez essayer de sélectionner un autre type de couche ou de widget </strong> </p> <p> Le serveur ne fournit pas les services requis pour la couche et le type de widget sélectionné </p> <p> Les causes possibles sont: <ul> <li> Le calque sélectionné est une couche raster </li> <li> Le service WFS n'est pas disponible </li> <li> Le processus WPS <code> gs:aggregate </code> n'est pas disponible </li> </ul> </p> ",
                     "checkAtLeastOneAttribute": "Vous devez sélectionner au moins une colonne"

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1155,6 +1155,8 @@
                     "clearConnection": "Disconnetti"
                 },
                 "errors": {
+                    "noAttributesTitle": "Nessun attributo disponibile",
+                    "noAttributesDescription": "Il layer selezionato non ha attributi da mostrare. Tornare indietro e selezionare un'altro livello per utilizzare questo widget",
                     "noWidgetsAvailableTitle": "Impossibile creare il widget per il livello selezionato",
                     "noWidgetsAvailableDescription": "<p><strong> Prova a selezionare un altro livello o tipo di widget </strong> </p><p>Il server non fornisce i servizi necessari per il livello e il tipo di widget selezionato </p> <p> Le possibili cause sono: <ul> <li> Il livello selezionato è un livello raster </li> <li> Il servizio WFS non è disponibile </li><li> Il processo WPS <code>gs:aggregate</code> non è disponibile </li> </ul></p>",
                     "checkAtLeastOneAttribute": "seleziona almeno un attributo"
@@ -1184,7 +1186,7 @@
                 },
                 "line": {
                     "title": "Grafico a Linea",
-                    "description": "Crea un grafico a linea da aggiungere alla mapp",
+                    "description": "Crea un grafico a linea da aggiungere alla mappa",
                     "caption": "linea"
                 },
                 "gauge": {


### PR DESCRIPTION
## Description
Added a more clear notification for layers that don't have valid attributes to show.
![image](https://user-images.githubusercontent.com/1279510/39037614-4d104fbc-4481-11e8-9266-9abb282e0e73.png)
Also fixed: 
 - italian I18N as in issue comment
 -  Removed download tool from TOC

## Issues
 - Fix #2825

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
