### PR TITLE
#2827 Minor fixes

### DIFF
--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -60,6 +60,7 @@ const TOGGLE_DETAILS_EDITABILITY = 'DETAILS:TOGGLE_DETAILS_EDITABILITY';
 const DETAILS_LOADED = 'DETAILS:DETAILS_LOADED';
 const DETAILS_SAVING = 'DETAILS:DETAILS_SAVING';
 const NO_DETAILS_AVAILABLE = "NO_DETAILS_AVAILABLE";
+const FEATURED_MAPS_SET_ENABLED = "FEATURED_MAPS:SET_ENABLED";
 
 
 /**
@@ -893,6 +894,15 @@ function doNothing() {
     };
 }
 
+/**
+ * enable/disabled the "featured maps" functionality
+ * @memberof actions.maps
+ * @param {boolean} enabled the `enabled` flag
+ */
+const setFeaturedMapsEnabled = (enabled) => ({
+    type: FEATURED_MAPS_SET_ENABLED,
+    enabled
+});
 
 /**
  * Actions for maps
@@ -941,6 +951,7 @@ module.exports = {
     detailsLoaded, DETAILS_LOADED,
     detailsSaving, DETAILS_SAVING,
     toggleDetailsEditability, TOGGLE_DETAILS_EDITABILITY,
+    setFeaturedMapsEnabled, FEATURED_MAPS_SET_ENABLED,
     metadataChanged,
     loadMaps,
     mapsLoading,

--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -25,7 +25,8 @@ class MapCard extends React.Component {
         onEdit: PropTypes.func,
         onMapDelete: PropTypes.func,
         onUpdateAttribute: PropTypes.func,
-        backgroundOpacity: PropTypes.number
+        backgroundOpacityStart: PropTypes.number,
+        backgroundOpacityEnd: PropTypes.number
     };
 
     static contextTypes = {
@@ -46,7 +47,8 @@ class MapCard extends React.Component {
         onMapDelete: ()=> {},
         onEdit: () => {},
         onUpdateAttribute: () => {},
-        backgroundOpacity: 0.3
+        backgroundOpacityStart: 0.7,
+        backgroundOpacityEnd: 0.3
     };
 
     onEdit = (map, openModalProperties) => {
@@ -70,7 +72,7 @@ class MapCard extends React.Component {
     getCardStyle = () => {
         if (this.props.map.thumbnail) {
             return assign({}, this.props.style, {
-                background: 'linear-gradient(rgba(0, 0, 0, ' + this.props.backgroundOpacity + '), rgba(0, 0, 0, ' + this.props.backgroundOpacity + ') ), url(' + (this.props.map.thumbnail === null || this.props.map.thumbnail === "NODATA" ? thumbUrl : decodeURIComponent(this.props.map.thumbnail)) + ')'
+                background: 'linear-gradient(rgba(0, 0, 0, ' + this.props.backgroundOpacityStart + '), rgba(0, 0, 0, ' + this.props.backgroundOpacityEnd + ') ), url(' + (this.props.map.thumbnail === null || this.props.map.thumbnail === "NODATA" ? thumbUrl : decodeURIComponent(this.props.map.thumbnail)) + ')'
             });
         }
         return this.props.style;

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -13,7 +13,8 @@ const {defaultProps, compose, mapPropsStream} = require('recompose');
 const {createSelector} = require('reselect');
 const {connect} = require('react-redux');
 const {isEqual} = require('lodash');
-const {setControlProperty} = require('../actions/controls');
+const { setFeaturedMapsEnabled} = require('../actions/maps');
+
 const Message = require("../components/I18N/Message");
 const maptypeEpics = require('../epics/maptype');
 const mapsEpics = require('../epics/maps');
@@ -106,7 +107,7 @@ const updateFeaturedMapsStream = mapPropsStream(props$ =>
 
 const FeaturedMapsPlugin = compose(
     connect(featuredMapsPluginSelector, {
-        onStart: setControlProperty.bind(null, 'featuredmaps', 'enabled', true)
+        onStart: () => setFeaturedMapsEnabled( true )
     }),
     defaultProps({
         mapType: 'leaflet',

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -16,13 +16,13 @@ const maptypeEpics = require('../epics/maptype');
 const mapsEpics = require('../epics/maps');
 const {mapTypeSelector} = require('../selectors/maptype');
 const {userRoleSelector} = require('../selectors/security');
+const { isFeaturedMapsEnabled } = require('../selectors/featuredmaps');
 const {createSelector} = require('reselect');
 
 const MapsGrid = require('./maps/MapsGrid');
 const MetadataModal = require('./maps/MetadataModal');
 
 const {loadMaps} = require('../actions/maps');
-const {get} = require('lodash');
 
 const PaginationToolbar = connect((state) => {
     if (!state.maps ) {
@@ -105,7 +105,7 @@ const mapsPluginSelector = createSelector([
     mapTypeSelector,
     state => state.maps && state.maps.searchText,
     state => state.maps && state.maps.results ? state.maps.results : [],
-    state => get(state, 'controls.featuredmaps.enabled') ? true : false,
+    isFeaturedMapsEnabled,
     userRoleSelector
 ], (mapType, searchText, maps, featuredEnabled, role) => ({
     mapType,

--- a/web/client/reducers/__tests__/featuredmaps-test.js
+++ b/web/client/reducers/__tests__/featuredmaps-test.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 const expect = require('expect');
-const {attributeUpdated, mapDeleted, mapMetadataUpdated, permissionsUpdated, mapsLoading} = require('../../actions/maps');
+const {attributeUpdated, mapDeleted, mapMetadataUpdated, permissionsUpdated, mapsLoading, setFeaturedMapsEnabled} = require('../../actions/maps');
+const { isFeaturedMapsEnabled } = require('../../selectors/featuredmaps');
 const featuredmaps = require('../featuredmaps');
 
 describe('Test the featuredmaps reducer', () => {
@@ -60,6 +61,12 @@ describe('Test the featuredmaps reducer', () => {
         const searchText = 'text';
         const state = featuredmaps({}, mapsLoading(searchText, {}));
         expect(state.searchText).toEqual(searchText);
+    });
+    it('featuredmaps enabled', () => {
+        const fm = featuredmaps({}, setFeaturedMapsEnabled(true) );
+        expect(isFeaturedMapsEnabled({
+            featuredmaps: fm
+        })).toBe(true);
     });
 
 });

--- a/web/client/reducers/featuredmaps.js
+++ b/web/client/reducers/featuredmaps.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {ATTRIBUTE_UPDATED, MAP_DELETED, MAP_METADATA_UPDATED, PERMISSIONS_UPDATED, MAPS_LIST_LOADING} = require('../actions/maps');
+const { ATTRIBUTE_UPDATED, MAP_DELETED, MAP_METADATA_UPDATED, PERMISSIONS_UPDATED, MAPS_LIST_LOADING, FEATURED_MAPS_SET_ENABLED} = require('../actions/maps');
+
 const {set} = require('../utils/ImmutableUtils');
 
 function dashboard(state = {}, action) {
@@ -40,6 +41,9 @@ function dashboard(state = {}, action) {
             return {...state,
                 searchText: action.searchText
             };
+        }
+        case FEATURED_MAPS_SET_ENABLED: {
+            return set("enabled", action.enabled, state);
         }
         default:
             return state;

--- a/web/client/selectors/featuredmaps.js
+++ b/web/client/selectors/featuredmaps.js
@@ -12,7 +12,7 @@
  * @memberof selectors
  * @static
  */
-
+const { get } = require('lodash');
 module.exports = {
     /**
      * selects latestResource from featuredmaps, it's the latest resource updated
@@ -28,6 +28,14 @@ module.exports = {
      * @param  {object}  state applications state
      * @return {string}  current searched text
      */
-    searchTextSelector: state => state && state.featuredmaps && state.featuredmaps.searchText || ''
+    searchTextSelector: state => state && state.featuredmaps && state.featuredmaps.searchText || '',
+    /**
+     * selects flag for featuredmaps enabled
+     * @memberof selectors.featuredmaps
+     * @param  {object}  state applications state
+     * @return {boolean}  current searched text
+     */
+    isFeaturedMapsEnabled: state => get(state, "featuredmaps.enabled")
+
 };
 

--- a/web/client/themes/default/less/maps-properties.less
+++ b/web/client/themes/default/less/maps-properties.less
@@ -301,7 +301,7 @@
                 .shadow-far;
                 cursor: pointer;
                 z-index: 10;
-                opacity: 0.7;
+                opacity: 0.8;
             }
             .shadow-soft;
             .gridcard-title {

--- a/web/client/themes/default/less/square-button.less
+++ b/web/client/themes/default/less/square-button.less
@@ -24,6 +24,9 @@
 
 .square-button-md {
     // !important due to vertical btn-group eg. dashboard
+    &.input-group-addon {
+        display: flex;
+    }
     &, .btn-group-vertical & {
         height: @square-btn-medium-size;
         width: @square-btn-medium-size;

--- a/web/client/themes/default/less/square-button.less
+++ b/web/client/themes/default/less/square-button.less
@@ -1,8 +1,8 @@
 .square-button {
     // !important due to vertical btn-group eg. dashboard
-    height: @square-btn-size !important;
-    width: @square-btn-size !important;
-    outline: 0 !important;
+    height: @square-btn-size;
+    width: @square-btn-size;
+    outline: 0;
     .glyphicon {
         margin: auto;
         font-size: @icon-size;
@@ -24,10 +24,13 @@
 
 .square-button-md {
     // !important due to vertical btn-group eg. dashboard
-    height: @square-btn-medium-size !important;
-    width: @square-btn-medium-size !important;
-    padding: 0;
-    outline: 0 !important;
+    &, .btn-group-vertical & {
+        height: @square-btn-medium-size;
+        width: @square-btn-medium-size;
+        padding: 0;
+        outline: 0;
+    }
+
     .glyphicon {
         margin: auto;
         font-size: @icon-size-md;
@@ -44,10 +47,12 @@
 }
 
 .square-button-sm {
-    height: @square-btn-small-size !important;
-    width: @square-btn-small-size !important;
-    padding: 0;
-    outline: 0 !important;
+     &, .btn-group-vertical & {
+        height: @square-btn-small-size;
+        width: @square-btn-small-size ;
+        padding: 0;
+        outline: 0 ;
+     }
     .glyphicon {
         margin: auto;
         font-size: @icon-size-sm;


### PR DESCRIPTION
## Description
 - Improved readability of cards (white thumbnails made the cards almost unreadable)
 - Moved enabled flag in the featuredmaps reducer (this avoid featuredmaps to disappear when "RESET_CONTROLS" is called

## Issues
- Connected to #2827 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
 - When reset controls is called (this may happen at anytime) the featuredgrid stars disappear. 
 - cards title and description are not readable if a thumbnail is black and white (e.g. white page screenshot with some text)

**What is the new behavior?**
 - The cards title and description are readable also with black/white thumbnails

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

