### PR TITLE
Fix #2765: decreased default number of features loaded by FeatureGrid

### DIFF
--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -62,7 +62,7 @@ const emptyResultsState = {
     changes: [],
     pagination: {
         page: 0,
-        size: 10
+        size: 15
     },
     select: [],
     multiselect: false,

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -62,7 +62,7 @@ const emptyResultsState = {
     changes: [],
     pagination: {
         page: 0,
-        size: 20
+        size: 10
     },
     select: [],
     multiselect: false,


### PR DESCRIPTION


## Description
Default number of features loaded by FeatureGrid is decreased from 20 to 10  making feature loading more responsive. 

## Issues
 - Fix #2765 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix




**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

