### PR TITLE
fix #2825 interactions between featuregrid anche chart wizard

### DIFF
--- a/web/client/components/data/featuregrid/enhancers/withHint.js
+++ b/web/client/components/data/featuregrid/enhancers/withHint.js
@@ -1,8 +1,13 @@
 
-const {compose, branch} = require('recompose');
+const {compose, branch, withProps} = require('recompose');
 const tooltip = require('../../../misc/enhancers/tooltip');
 const withPopover = require('./withPopover');
+
+
 module.exports = compose(
+    withProps(({renderPopover, popoverOptions, ...props}) => {
+        return renderPopover ? {renderPopover, popoverOptions, ...props} : {...props};
+    }),
     branch(
         (({renderPopover, popoverOptions} = {}) => renderPopover && !!popoverOptions),
         withPopover,

--- a/web/client/components/data/featuregrid/enhancers/withPopover.js
+++ b/web/client/components/data/featuregrid/enhancers/withPopover.js
@@ -13,10 +13,10 @@ const ReactDOM = require('react-dom');
 module.exports = (Wrapped) => class WithPopover extends React.Component {
     render() {
         let target = null;
-        const {popoverOptions, ...props} = this.props;
+        const {popoverOptions, keyProp, ...props} = this.props;
         return (
             <span className="mapstore-info-popover">
-                <Wrapped {...(omit(props, ["renderPopover", "tooltipId"])) } ref={button => { target = button; }} />
+                <Wrapped {...(omit(props, ["renderPopover", "tooltipId"])) } key={keyProp} ref={button => { target = button; }} />
                 <Overlay placement={popoverOptions.placement} show target={() => ReactDOM.findDOMNode(target)}>
                     <Popover
                         {...popoverOptions.props}>

--- a/web/client/components/data/featuregrid/enhancers/withPopover.js
+++ b/web/client/components/data/featuregrid/enhancers/withPopover.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const Overlay = require('../../../misc/Overlay');
 const {Popover} = require('react-bootstrap');
+const {omit} = require('lodash');
 const ReactDOM = require('react-dom');
 
 /**
@@ -15,7 +16,7 @@ module.exports = (Wrapped) => class WithPopover extends React.Component {
         const {popoverOptions, ...props} = this.props;
         return (
             <span className="mapstore-info-popover">
-                <Wrapped {...this.props} ref={button => { target = button; }} />
+                <Wrapped {...(omit(props, ["renderPopover", "tooltipId"])) } ref={button => { target = button; }} />
                 <Overlay placement={popoverOptions.placement} show target={() => ReactDOM.findDOMNode(target)}>
                     <Popover
                         {...popoverOptions.props}>

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -20,7 +20,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
     return (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
-            keyProp="edit-mode"
             tooltipId="featuregrid.toolbar.editMode"
             disabled={disableToolbar}
             visible={mode === "VIEW" && isEditingAllowed}
@@ -28,7 +27,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="pencil"/>
         <TButton
             id="search"
-            keyProp="search"
             tooltipId="featuregrid.toolbar.advancedFilter"
             disabled={disableToolbar || !isSearchAllowed}
             visible={mode === "VIEW"}
@@ -36,7 +34,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="filter"/>
         <TButton
             id="zoom-all"
-            keyProp="zoom-all"
             tooltipId="featuregrid.toolbar.zoomAll"
             disabled={disableToolbar || disableZoomAll}
             visible={mode === "VIEW"}
@@ -44,7 +41,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="zoom-to"/>
         <TButton
             id="back-view"
-            keyProp="back-view"
             tooltipId="featuregrid.toolbar.quitEditMode"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasChanges && !hasNewFeatures}
@@ -52,7 +48,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="arrow-left"/>
         <TButton
             id="add-feature"
-            keyProp="add-feature"
             tooltipId="featuregrid.toolbar.addNewFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasNewFeatures && !hasChanges && hasSupportedGeometry}
@@ -60,7 +55,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="row-add"/>
         <TButton
             id="draw-feature"
-            keyProp="draw-feature"
             tooltipId={getDrawFeatureTooltip(isDrawing, isSimpleGeom)}
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount === 1 && (!hasGeometry || hasGeometry && !isSimpleGeom) && hasSupportedGeometry}
@@ -69,7 +63,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="pencil-add"/>
         <TButton
             id="remove-features"
-            keyProp="remove-features"
             tooltipId="featuregrid.toolbar.deleteSelectedFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount > 0 && !hasChanges && !hasNewFeatures}
@@ -77,7 +70,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="trash-square"/>
         <TButton
             id="save-feature"
-            keyProp="save-feature"
             tooltipId={getSaveMessageId({saving, saved})}
             disabled={saving || saved || disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
@@ -86,7 +78,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="floppy-disk"/>
         <TButton
             id="cancel-editing"
-            keyProp="cancel-editing"
             tooltipId="featuregrid.toolbar.cancelChanges"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
@@ -94,7 +85,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="remove-square"/>
         <TButton
             id="delete-geometry"
-            keyProp="delete-geometry"
             tooltipId="featuregrid.toolbar.deleteGeometry"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasGeometry && selectedCount === 1 && hasSupportedGeometry}
@@ -102,7 +92,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="polygon-trash"/>
         <TButton
             id="download-grid"
-            keyProp="download-grid"
             tooltipId="featuregrid.toolbar.downloadGridData"
             disabled={disableToolbar || disableDownload}
             active={isDownloadOpen}
@@ -111,7 +100,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="features-grid-download"/>
         <TButton
             id="grid-settings"
-            keyProp="grid-settings"
             tooltipId="featuregrid.toolbar.hideShowColumns"
             disabled={disableToolbar}
             active={isColumnsOpen}
@@ -120,7 +108,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="features-grid-set"/>
         <TButton
             id="grid-map-chart"
-            keyProp="grid-map-chart"
             tooltipId="featuregrid.toolbar.createNewChart"
             disabled={disableToolbar}
             visible={mode === "VIEW" && showChartButton}
@@ -128,7 +115,6 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="stats"/>
         <TButton
             id="grid-map-filter"
-            keyProp="grid-map-filter"
             tooltipId="featuregrid.toolbar.syncOnMap"
             disabled={disableToolbar}
             active={isSyncActive}

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -20,7 +20,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
     return (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
-            key="edit-mode"
+            keyProp="edit-mode"
             tooltipId="featuregrid.toolbar.editMode"
             disabled={disableToolbar}
             visible={mode === "VIEW" && isEditingAllowed}
@@ -28,7 +28,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="pencil"/>
         <TButton
             id="search"
-            key="search"
+            keyProp="search"
             tooltipId="featuregrid.toolbar.advancedFilter"
             disabled={disableToolbar || !isSearchAllowed}
             visible={mode === "VIEW"}
@@ -36,7 +36,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="filter"/>
         <TButton
             id="zoom-all"
-            key="zoom-all"
+            keyProp="zoom-all"
             tooltipId="featuregrid.toolbar.zoomAll"
             disabled={disableToolbar || disableZoomAll}
             visible={mode === "VIEW"}
@@ -44,7 +44,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="zoom-to"/>
         <TButton
             id="back-view"
-            key="back-view"
+            keyProp="back-view"
             tooltipId="featuregrid.toolbar.quitEditMode"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasChanges && !hasNewFeatures}
@@ -52,7 +52,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="arrow-left"/>
         <TButton
             id="add-feature"
-            key="add-feature"
+            keyProp="add-feature"
             tooltipId="featuregrid.toolbar.addNewFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasNewFeatures && !hasChanges && hasSupportedGeometry}
@@ -60,7 +60,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="row-add"/>
         <TButton
             id="draw-feature"
-            key="draw-feature"
+            keyProp="draw-feature"
             tooltipId={getDrawFeatureTooltip(isDrawing, isSimpleGeom)}
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount === 1 && (!hasGeometry || hasGeometry && !isSimpleGeom) && hasSupportedGeometry}
@@ -69,7 +69,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="pencil-add"/>
         <TButton
             id="remove-features"
-            key="remove-features"
+            keyProp="remove-features"
             tooltipId="featuregrid.toolbar.deleteSelectedFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount > 0 && !hasChanges && !hasNewFeatures}
@@ -77,7 +77,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="trash-square"/>
         <TButton
             id="save-feature"
-            key="save-feature"
+            keyProp="save-feature"
             tooltipId={getSaveMessageId({saving, saved})}
             disabled={saving || saved || disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
@@ -86,7 +86,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="floppy-disk"/>
         <TButton
             id="cancel-editing"
-            key="cancel-editing"
+            keyProp="cancel-editing"
             tooltipId="featuregrid.toolbar.cancelChanges"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
@@ -94,7 +94,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="remove-square"/>
         <TButton
             id="delete-geometry"
-            key="delete-geometry"
+            keyProp="delete-geometry"
             tooltipId="featuregrid.toolbar.deleteGeometry"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasGeometry && selectedCount === 1 && hasSupportedGeometry}
@@ -102,7 +102,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="polygon-trash"/>
         <TButton
             id="download-grid"
-            key="download-grid"
+            keyProp="download-grid"
             tooltipId="featuregrid.toolbar.downloadGridData"
             disabled={disableToolbar || disableDownload}
             active={isDownloadOpen}
@@ -111,7 +111,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="features-grid-download"/>
         <TButton
             id="grid-settings"
-            key="grid-settings"
+            keyProp="grid-settings"
             tooltipId="featuregrid.toolbar.hideShowColumns"
             disabled={disableToolbar}
             active={isColumnsOpen}
@@ -120,7 +120,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="features-grid-set"/>
         <TButton
             id="grid-map-chart"
-            key="grid-map-chart"
+            keyProp="grid-map-chart"
             tooltipId="featuregrid.toolbar.createNewChart"
             disabled={disableToolbar}
             visible={mode === "VIEW" && showChartButton}
@@ -128,7 +128,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="stats"/>
         <TButton
             id="grid-map-filter"
-            key="grid-map-filter"
+            keyProp="grid-map-filter"
             tooltipId="featuregrid.toolbar.syncOnMap"
             disabled={disableToolbar}
             active={isSyncActive}

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -20,6 +20,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
     return (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
+            keyProp="edit-mode"
             tooltipId="featuregrid.toolbar.editMode"
             disabled={disableToolbar}
             visible={mode === "VIEW" && isEditingAllowed}
@@ -27,6 +28,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="pencil"/>
         <TButton
             id="search"
+            keyProp="search"
             tooltipId="featuregrid.toolbar.advancedFilter"
             disabled={disableToolbar || !isSearchAllowed}
             visible={mode === "VIEW"}
@@ -34,6 +36,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="filter"/>
         <TButton
             id="zoom-all"
+            keyProp="zoom-all"
             tooltipId="featuregrid.toolbar.zoomAll"
             disabled={disableToolbar || disableZoomAll}
             visible={mode === "VIEW"}
@@ -41,6 +44,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="zoom-to"/>
         <TButton
             id="back-view"
+            keyProp="back-view"
             tooltipId="featuregrid.toolbar.quitEditMode"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasChanges && !hasNewFeatures}
@@ -48,6 +52,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="arrow-left"/>
         <TButton
             id="add-feature"
+            keyProp="add-feature"
             tooltipId="featuregrid.toolbar.addNewFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && !hasNewFeatures && !hasChanges && hasSupportedGeometry}
@@ -55,6 +60,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="row-add"/>
         <TButton
             id="draw-feature"
+            keyProp="draw-feature"
             tooltipId={getDrawFeatureTooltip(isDrawing, isSimpleGeom)}
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount === 1 && (!hasGeometry || hasGeometry && !isSimpleGeom) && hasSupportedGeometry}
@@ -63,6 +69,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="pencil-add"/>
         <TButton
             id="remove-features"
+            keyProp="remove-features"
             tooltipId="featuregrid.toolbar.deleteSelectedFeatures"
             disabled={disableToolbar}
             visible={mode === "EDIT" && selectedCount > 0 && !hasChanges && !hasNewFeatures}
@@ -70,6 +77,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="trash-square"/>
         <TButton
             id="save-feature"
+            keyProp="save-feature"
             tooltipId={getSaveMessageId({saving, saved})}
             disabled={saving || saved || disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
@@ -78,6 +86,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="floppy-disk"/>
         <TButton
             id="cancel-editing"
+            keyProp="cancel-editing"
             tooltipId="featuregrid.toolbar.cancelChanges"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasChanges || hasNewFeatures}
@@ -85,6 +94,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="remove-square"/>
         <TButton
             id="delete-geometry"
+            keyProp="delete-geometry"
             tooltipId="featuregrid.toolbar.deleteGeometry"
             disabled={disableToolbar}
             visible={mode === "EDIT" && hasGeometry && selectedCount === 1 && hasSupportedGeometry}
@@ -92,6 +102,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="polygon-trash"/>
         <TButton
             id="download-grid"
+            keyProp="download-grid"
             tooltipId="featuregrid.toolbar.downloadGridData"
             disabled={disableToolbar || disableDownload}
             active={isDownloadOpen}
@@ -100,6 +111,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="features-grid-download"/>
         <TButton
             id="grid-settings"
+            keyProp="grid-settings"
             tooltipId="featuregrid.toolbar.hideShowColumns"
             disabled={disableToolbar}
             active={isColumnsOpen}
@@ -108,6 +120,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="features-grid-set"/>
         <TButton
             id="grid-map-chart"
+            keyProp="grid-map-chart"
             tooltipId="featuregrid.toolbar.createNewChart"
             disabled={disableToolbar}
             visible={mode === "VIEW" && showChartButton}
@@ -115,6 +128,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             glyph="stats"/>
         <TButton
             id="grid-map-filter"
+            keyProp="grid-map-filter"
             tooltipId="featuregrid.toolbar.syncOnMap"
             disabled={disableToolbar}
             active={isSyncActive}

--- a/web/client/components/misc/enhancers/tooltip.jsx
+++ b/web/client/components/misc/enhancers/tooltip.jsx
@@ -30,8 +30,8 @@ const Message = require('../../I18N/Message');
  */
 module.exports = branch(
     ({tooltip, tooltipId} = {}) => tooltip || tooltipId,
-    (Wrapped) => ({tooltip, tooltipId, tooltipPosition = "top", tooltipTrigger, key, ...props} = {}) => (<OverlayTrigger
+    (Wrapped) => ({tooltip, tooltipId, tooltipPosition = "top", tooltipTrigger, keyProp, ...props} = {}) => (<OverlayTrigger
         trigger={tooltipTrigger}
-        key={key}
+        key={keyProp}
         placement={tooltipPosition}
-        overlay={<Tooltip id={"tooltip-" + {key}}>{tooltipId ? <Message msgId={tooltipId} /> : tooltip}</Tooltip>}><Wrapped {...props}/></OverlayTrigger>));
+        overlay={<Tooltip id={"tooltip-" + {keyProp}}>{tooltipId ? <Message msgId={tooltipId} /> : tooltip}</Tooltip>}><Wrapped {...props}/></OverlayTrigger>));

--- a/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withMapExitButton.js
@@ -16,8 +16,8 @@ const {returnToFeatureGridSelector} = require('../../../selectors/widgets');
  * Reset widgets
  */
 module.exports = compose(
-    connect(() => ({
-        returnToFeatureGrid: state => returnToFeatureGridSelector(state)}),
+    connect((state) => ({
+        returnToFeatureGrid: returnToFeatureGridSelector(state)}),
     {
         backToWidgetList: () => onEditorChange('widgetType', undefined),
         closeWidgetBuilder: () => setControlProperty("widgetBuilder", "enabled", false, false),
@@ -42,11 +42,11 @@ module.exports = compose(
             }
         }
     }),
-    withProps(({ backFromWizard = () => {} }) => ({
+    withProps(({ returnToFeatureGrid, backFromWizard = () => {} }) => ({
         exitButton: {
             onClick: backFromWizard,
             glyph: 'arrow-left',
-            tooltipId: "widgets.builder.wizard.backToWidgetTypeSelection"
+            tooltipId: returnToFeatureGrid ? "widgets.builder.wizard.backToFeatureGrid" : "widgets.builder.wizard.backToWidgetTypeSelection"
         }
     }))
 );

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1140,6 +1140,7 @@
                 "wizard": {
                     "backToTypeSelection": "Zurück zur Typenauswahl",
                     "backToWidgetTypeSelection": "Zurück zur Auswahl des Widget-Typs",
+                    "backToFeatureGrid": "Zurück zum Feature-Raster",
                     "backToLayerSelection": "Zurück zur Ebenenauswahl",
                     "backToMapSelection": "Zurück zur Kartenauswahl",
                     "backToChartOptions": "Zurück zu den Diagrammoptionen",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1141,6 +1141,7 @@
                 "wizard": {
                     "backToTypeSelection": "Back to type selection",
                     "backToWidgetTypeSelection": "Back to widget type selection",
+                    "backToFeatureGrid": "Back to the feature grid",
                     "backToLayerSelection": "Back to layer selection",
                     "backToMapSelection": "Back to map selection",
                     "backToChartOptions": "Back to chart options",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1140,6 +1140,7 @@
                 "wizard": {
                     "backToTypeSelection": "Volver a la selección de tipo",
                     "backToWidgetTypeSelection": "Volver a la selección del tipo de widget",
+                    "backToFeatureGrid": "Volver a la grilla de características",
                     "backToLayerSelection": "Volver a la selección de capas",
                     "backToMapSelection": "Volver a la selección del mapa",
                     "backToChartOptions": "Volver a las opciones de gráfico",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1141,6 +1141,7 @@
                 "wizard": {
                     "backToTypeSelection": "Retour à la sélection du type",
                     "backToWidgetTypeSelection": "Retour à la sélection du type de widget",
+                    "backToFeatureGrid": "Retour à la grille des fonctionnalités",
                     "backToLayerSelection": "Retour à la sélection du calque",
                     "backToMapSelection": "Retour à la sélection de la carte",
                     "backToChartOptions": "retour aux options de graphique",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1140,6 +1140,7 @@
                 "wizard": {
                     "backToTypeSelection": "Torna alla selezione del tipo",
                     "backToWidgetTypeSelection": "Torna alla selezione del tipo di widget",
+                    "backToFeatureGrid": "Torna alla tabella degli attributi",
                     "backToLayerSelection": "Torna alla selezione del livello",
                     "backToMapSelection": "Torna alla selezione della mappa",
                     "backToChartOptions": "Torna alle opzioni del grafico",


### PR DESCRIPTION
## Description
This PR will fix the back functionalities if the widget wizard is opened.

it will return to featuregrid only if it comes from there.

## Issues
 - Fix #2825 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
opening widget wizard - select chart, or table or counter - then back it opens the feature grid

**What is the new behavior?**
with the same path it returns to the widget list

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
One strange thing is that chrome dev tools is crashing, this is not happening on firefox.
if I close the chrome dev tools no crash (Aw, snap) appears.Tthis is not happening on an other pc.