### PR TITLE
fix #2803 synch popover defaults

### DIFF
--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -60,7 +60,7 @@ const emptyResultsState = {
     open: false,
     canEdit: false,
     focusOnEdit: true,
-    showAgain: true,
+    showAgain: false,
     showPopoverSync: localStorage && localStorage.getItem("showPopoverSync") !== null ? localStorage.getItem("showPopoverSync") === "true" : true,
     mode: MODES.VIEW,
     changes: [],
@@ -141,6 +141,7 @@ function featuregrid(state = emptyResultsState, action) {
     switch (action.type) {
     case INIT_PLUGIN: {
         return assign({}, state, {
+            showPopoverSync: localStorage && localStorage.getItem("showPopoverSync") !== null ? localStorage.getItem("showPopoverSync") === "true" : true,
             editingAllowedRoles: action.options.editingAllowedRoles || state.editingAllowedRoles || ["ADMIN"],
             virtualScroll: !!action.options.virtualScroll,
             maxStoredPages: action.options.maxStoredPages || 5

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -385,10 +385,9 @@ describe('Test featuregrid selectors', () => {
     });
     it('test showAgainSelector default ', () => {
         const val = showAgainSelector(initialState);
-        expect(val).toExist();
-        expect(val).toBe(true);
+        expect(val).toBe(false);
     });
-    it('test showAgainSelector default ', () => {
+    it('test showPopoverSyncSelector default ', () => {
         const val = showPopoverSyncSelector(initialState);
         expect(val).toExist();
         expect(val).toBe(true);

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -122,7 +122,7 @@ module.exports = {
     hasGeometrySelector: state => hasGeometrySelectedFeature(state),
     newFeaturesSelector,
     hasNewFeaturesSelector,
-    showAgainSelector: state => get(state, "featuregrid.showAgain", true),
+    showAgainSelector: state => get(state, "featuregrid.showAgain", false),
     showPopoverSyncSelector: state => get(state, "featuregrid.showPopoverSync", true),
     isSavingSelector: state => state && state.featuregrid && state.featuregrid.saving,
     editingAllowedRolesSelector: state => get(state, "featuregrid.editingAllowedRoles", ["ADMIN"]),


### PR DESCRIPTION
## Description
synch tool popover must change two things:
- by default the checkbox "don't sho this again" to be non checked.
- reopen every time the feature grid opens

## Issues
 - Fix #2803

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
- the popover appears only a time per session
- by default the checkbox is checked

**What is the new behavior?**
- every time the feature grid opens, the popover is shown
- by default is non checked

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
