### PR TITLE
Fix #2858 change label for annotations text style

### DIFF
--- a/web/client/components/style/TextStyler.jsx
+++ b/web/client/components/style/TextStyler.jsx
@@ -42,7 +42,7 @@ class TextStyler extends React.Component {
         styleType: "Text",
         uomValues: [{value: "px"}, {value: "em"}],
         fontWeightValues: [{value: "normal"}, {value: "bold"}],
-        alignValues: [{value: "start"}, {value: "center"}, {value: "end"}],
+        alignValues: [{value: "start", label: "left"}, {value: "center", label: "center"}, {value: "end", label: "right"}],
         fontStyleValues: [{value: "normal"}, {value: "italic"}],
         fontFamilyValues: [{value: "Arial"}, {value: "FontAwesome"}, {value: "Courier"}],
         shapeStyle: {},
@@ -164,7 +164,7 @@ class TextStyler extends React.Component {
                         <Col xs={6} style={{position: 'static'}}>
                             <Combobox
                                 value={style.textAlign || "center"}
-                                textField="value"
+                                textField="label"
                                 valueField="value"
                                 messages={messages}
                                 data={this.props.alignValues}


### PR DESCRIPTION
## Description
This pr change the labels for text align in text styler for annotations.
the behaviour and positions is the same as before

notice that there is an issue on ol which LTR and RTL are not supported from "start" and "end" keywords. see [this](https://github.com/openlayers/openlayers/issues/7367)

## Issues
 - Fix #2858

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
now you can select start or end from text align field in text styler

**What is the new behavior?**
labels are changed
start --> left
end --> right

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
