### PR TITLE
fix #2861 layer metadata layout

### DIFF
--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -6,7 +6,7 @@
     margin: 0;
     top: 0;
     left: 0;
-    
+
     .ms-header {
         .row {
             &:first-child {
@@ -159,7 +159,7 @@
                 margin: (@square-btn-size - 34) / 2;
             }
         }
-    }    
+    }
 }
 
 @media (min-width: 505px) and (max-width: 768px) {
@@ -295,6 +295,20 @@
         .modal-dialog {
             transition: 0.3s ease-in;
             transform: translateY(-25%);
+        }
+    }
+}
+
+
+.toolbar-panel.portal-dialog {
+    .modal-body {
+        table {
+            tr {
+                td:nth-child(2) {
+                    word-break: break-word;
+                }
+            }
+
         }
     }
 }


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #2861 on c125_annotations branch


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
text overflow on layer metadata on certain layers which longwords with no space within.

**What is the new behavior?**
this long word is broke into pieces. no overflow happens

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
