### PR TITLE
fix #2864 properties row viewer

### DIFF
--- a/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
@@ -48,7 +48,7 @@ class PropertiesViewer extends React.Component {
             .filter(this.toExlude)
             .map((key) => {
                 return (
-                    <p key={key} style={this.props.listStyle}><b>{key}</b> {this.renderProperty(this.props[key])}</p>
+                    <p key={key} style={this.props.listStyle}><b>{key}</b> <span dangerouslySetInnerHTML={{__html: this.renderProperty(this.props[key])}}/></p>
                 );
             });
     };

--- a/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 /**
  * Copyright 2015, GeoSolutions Sas.
  * All rights reserved.
@@ -8,7 +7,9 @@ const PropTypes = require('prop-types');
  */
 
 const React = require('react');
+const PropTypes = require('prop-types');
 const {isString} = require('lodash');
+const {containsHTML} = require('../../../../../utils/StringUtils');
 
 const alwaysExcluded = ["exclude", "titleStyle", "listStyle", "componentStyle", "title", "feature"];
 
@@ -43,13 +44,13 @@ class PropertiesViewer extends React.Component {
         }
     };
 
+
     getBodyItems = () => {
         return Object.keys(this.props)
             .filter(this.toExlude)
             .map((key) => {
-                return (
-                    <p key={key} style={this.props.listStyle}><b>{key}</b> <span dangerouslySetInnerHTML={{__html: this.renderProperty(this.props[key])}}/></p>
-                );
+                const val = this.renderProperty(this.props[key]);
+                return <p key={key} style={this.props.listStyle}><b>{key}</b> {containsHTML(val) ? <span dangerouslySetInnerHTML={{__html: val}}/> : val}</p>;
             });
     };
 

--- a/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
@@ -77,4 +77,22 @@ describe('PropertiesViewer', () => {
         expect(cmpDom.innerText.indexOf('myfeature')).toBe(-1);
     });
 
+
+    it('test rendering an html property', () => {
+        const testProps = {
+            withHtml: "<div> some text </div>"
+        };
+        const cmp = ReactDOM.render(<PropertiesViewer {...testProps}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+        expect(cmpDom.childNodes.length).toBe(1);
+
+        const body = cmpDom.childNodes.item(0);
+        const pChild = body.childNodes.item(0);
+        const spanChild = pChild.childNodes.item(4);
+        expect(spanChild).toExist();
+        expect(spanChild.childNodes.item(0).outerHTML).toBe(testProps.withHtml);
+    });
 });

--- a/web/client/utils/StringUtils.js
+++ b/web/client/utils/StringUtils.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Utility functions for String manipulations.
+ * @memberof utils
+ */
+const StringUtils = {
+    /**
+     * Tests if a string contains html tags
+     * @param {string} str string to parse with regex
+     * @return {bool} the result of the test
+    */
+    containsHTML: (str) => {
+        // regex used http://www.pagecolumn.com/tool/all_about_html_tags.htm
+        const htmlRegex = new RegExp("<(.|\\n)*?>", 'g');
+        return htmlRegex.test(str);
+    }
+
+};
+
+module.exports = StringUtils;

--- a/web/client/utils/__tests__/StringUtils-test.js
+++ b/web/client/utils/__tests__/StringUtils-test.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const {containsHTML} = require('../StringUtils');
+
+describe('StringUtils test', () => {
+    it('test contains html', () => {
+        const withHtml = "<div> some val </div>";
+        const withoutHtml = "some val";
+
+        expect(containsHTML(withHtml)).toBe(true);
+        expect(containsHTML(withoutHtml)).toBe(false);
+    });
+
+});


### PR DESCRIPTION
## Description
now if a properties contains html tag they are correctly rendered in get feature info viewer

## Issues
 - Fix #2864


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
see issue 

**What is the new behavior?**
properties with html tag are correctly rendered.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
