### PR TITLE
Minor fixes to localized strings

### DIFF
--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -254,7 +254,7 @@
                 "errorWhenDeleting": "Beim Löschen ist ein Fehler aufgetreten",
                 "errorSizeExceeded": "Bitte verkleinern Sie die Größe der Details oder die Qualität der Bilder"
             },
-            "search": "Suche nach Karten..."
+            "search": "Suche..."
         },
         "resources": {
             "deleteConfirmTitle": "Bist du sicher",
@@ -1157,6 +1157,7 @@
             "title": "Titel",
             "description": "Beschreibung",
             "errors": {
+                "notext": "Kein Text verfügbar",
                 "nodata": "Keine Daten für den ausgewählten Layer / Filter verfügbar",
                 "nodatainviewport": "Keine Daten im aktuellen Ansichtsfenster",
                 "timeoutExpired": "Der Service hat zu lange gedauert. Vielleicht ist die Abfrage zu komplex oder der Server ist beschäftigt",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -255,7 +255,7 @@
                 "errorWhenDeleting": "An error occurred during deleting process",
                 "errorSizeExceeded": "Please, reduce the size of the details or the quality of the images"
             },
-			"search": "search for maps..."
+			"search": "search..."
 		},
         "resources": {
             "deleteConfirmTitle": "Are you sure",
@@ -1158,6 +1158,7 @@
             "title": "Title",
             "description": "Description",
             "errors": {
+                "notext": "No text available",
                 "nodata": "No data available for the selected layer/filter",
                 "nodatainviewport": "No data in the current viewport",
                 "timeoutExpired": "The service took too much time to respond. Maybe the query is too complex or the server is busy",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -254,7 +254,7 @@
                 "errorWhenDeleting": "Se produjo un error durante el proceso de eliminación",
                 "errorSizeExceeded": "Por favor, reduzca el tamaño de los detalles o la calidad de las imágenes"
             },
-            "search": "buscador de mapas ..."
+            "search": "buscar..."
         },
         "resources": {
             "deleteConfirmTitle": "¿Estás seguro?",
@@ -1157,6 +1157,7 @@
             "title": "Título",
             "description": "Descripción",
             "errors": {
+                "notext": "Sin texto disponible",
                 "nodata": "No hay datos disponibles para la capa / filtro seleccionado",
                 "nodatainviewport": "Sin datos en la ventana gráfica actual",
                 "timeoutExpired": "El servicio tomó demasiado tiempo para responder. Tal vez la consulta es demasiado compleja o el servidor está ocupado",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -255,7 +255,7 @@
                 "errorWhenDeleting": "Une erreur s'est produite lors du processus de suppression",
                 "errorSizeExceeded": "S'il vous plaît, réduisez la taille des détails ou la qualité des images"
             },
-            "search": "rechercher des cartes ..."
+            "search": "rechercher ..."
         },
         "resources": {
             "deleteConfirmTitle": "Etes-vous sûr",
@@ -1158,6 +1158,7 @@
             "title": "Titre",
             "description": "Description",
             "errors": {
+                "notext": "Aucun texte disponible",
                 "nodata": "Aucune donnée disponible pour la couche / filtre sélectionné",
                 "nodatainviewport": "Aucune donnée dans la fenêtre courante",
                 "timeoutExpired": "Le service a pris trop de temps pour répondre. Peut-être que la requête est trop complexe ou que le serveur est occupé",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -254,7 +254,7 @@
                 "errorWhenDeleting": "C'è stato un errore durante la cancellazione",
                 "errorSizeExceeded": "Riduci il contenuto o la qualità delle immagini"
             },
-			"search": "Cerca mappe..."
+			"search": "Cerca..."
 		},
         "resources": {
             "deleteConfirmTitle": "Sei sicuro",
@@ -1157,6 +1157,7 @@
             "title": "Titolo",
             "description": "Descrizione",
             "errors": {
+                "notext": "Nessun testo disponibile",
                 "nodata": "Nessun dato disponibile per il livello/filtro selezionati",
                 "nodatainviewport": "Nessun dato per la vista selezionata",
                 "timeoutExpired": "Il servizio ha impiegato troppo tempo a rispondere. La query potrebbe essere troppo complicata o il server troppo occupato",


### PR DESCRIPTION
## Description
 - Add error message for text not present
 - Changed "search for maps..." into "search..." because now you sarch also featured and dashboards

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: localized strings


**What is the current behavior?** (You can also link to an open issue here)
 - no text widget tool tip was not localized
 - "Search for maps " searches for maps and dashboard

**What is the new behavior?**
 - text widgets with no text now have a localized tool tip
 - search label is consistent

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
