### PR TITLE
Fix #2859 Escape special XML chars for title and description

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -13,7 +13,10 @@ const ConfigUtils = require('../utils/ConfigUtils');
 const xml2js = require('xml2js');
 const xmlBuilder = new xml2js.Builder();
 const {registerErrorParser} = require('../utils/LocaleUtils');
-
+const generateMetadata = (name, description) =>
+    "<description><![CDATA[" + description + "]]></description>"
+    + "<metadata></metadata>"
+    + "<name><![CDATA[" + (name || "") + "]]></name>";
 let parseOptions = (opts) => opts;
 
 let parseAdminGroups = (groupsObj) => {
@@ -59,6 +62,7 @@ registerErrorParser('geostore', {...errorParser});
  * API for local config
  */
 const Api = {
+    generateMetadata,
     authProviderName: "geostore",
     addBaseUrl: function(options) {
         return assign(options || {}, {baseURL: ConfigUtils.getDefaults().geoStoreUrl});
@@ -170,8 +174,7 @@ const Api = {
     putResourceMetadata: function(resourceId, newName, newDescription, options) {
         return axios.put(
             "resources/resource/" + resourceId,
-            "<Resource><description>" + (newDescription || "") + "</description><metadata></metadata>" +
-            "<name>" + (newName || "") + "</name></Resource>",
+            "<Resource>" + generateMetadata(newName, newDescription) + "</Resource>",
             this.addBaseUrl(_.merge({
                 headers: {
                     'Content-Type': "application/xml"
@@ -239,8 +242,7 @@ const Api = {
         }
         return axios.post(
             "resources/",
-                "<Resource><description>" + description + "</description><metadata></metadata>" +
-                "<name>" + (name || "") + "</name><category><name>" + (category || "") + "</name></category>" +
+                "<Resource>" + generateMetadata(name, description) + "<category><name>" + (category || "") + "</name></category>" +
                 attributesSection +
                 "<store><data><![CDATA[" + (
                     data

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -100,8 +100,8 @@ describe('Test correctness of the GeoStore APIs', () => {
             message: 'map.mapError.errorDefault'
         });
     });
-    it('test security rules utils (writeSecurityRules)', () => {
-        const payload = API.writeSecurityRules(SAMPLE_RULES.SecurityRuleList);
-        expect(payload).toBe(SAMPLE_XML_RULES);
+    it('test generatemeatadata', () => {
+        const payload = API.generateMetadata("Special & chars", "&<>'\"");
+        expect(payload).toBe('<description><![CDATA[&<>\'"]]></description><metadata></metadata><name><![CDATA[Special & chars]]></name>');
     });
 });


### PR DESCRIPTION
## Description
Escape special XML chars for title and description using `<![CDATA[...]]>`

## Issues
 - Fix #2859

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Save or update maps and dashboards fails when you set in title or description one of the following chars:
```
< > &" '
```

**What is the new behavior?**
You can save the map using this chars for title and description without errors

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

