### PR TITLE
Fix #2888 switch to correct 2d mapType

### DIFF
--- a/web/client/epics/__tests__/globeswitcher-test.js
+++ b/web/client/epics/__tests__/globeswitcher-test.js
@@ -9,22 +9,23 @@
 var expect = require('expect');
 
 const {toggle3d, UPDATE_LAST_2D_MAPTYPE} = require('../../actions/globeswitcher');
+const { localConfigLoaded } = require('../../actions/localConfig');
+
 const assign = require('object-assign');
 
-const {updateRouteOn3dSwitch} = require('../globeswitcher');
+
+const { updateRouteOn3dSwitch, updateLast2dMapTypeOnChangeEvents} = require('../globeswitcher');
+
 const {testEpic} = require('./epicTestUtils');
 describe('globeswitcher Epics', () => {
-    it('updates maptype', (done) => {
-        testEpic(updateRouteOn3dSwitch, 2, assign({hash: "/viewer/leaflet/2"}, toggle3d(true, "leaflet")), actions => {
-            expect(actions.length).toBe(2);
+    it('updates maptype toggling to 3D', (done) => {
+        testEpic(updateRouteOn3dSwitch, 1, assign({hash: "/viewer/leaflet/2"}, toggle3d(true, "leaflet")), actions => {
+            expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
                 case "@@router/CALL_HISTORY_METHOD":
                     expect(action.payload.method).toBe('push');
                     expect(action.payload.args.length).toBe(1);
-                    break;
-                case UPDATE_LAST_2D_MAPTYPE:
-                    expect(action.mapType).toBe("leaflet");
                     break;
                 default:
                     expect(true).toBe(false);
@@ -35,18 +36,14 @@ describe('globeswitcher Epics', () => {
         });
 
     });
-
-    it('updates maptype on newmap', (done) => {
-        testEpic(updateRouteOn3dSwitch, 2, assign({hash: "/viewer/leaflet/new"}, toggle3d(true, "leaflet")), actions => {
-            expect(actions.length).toBe(2);
+    it('updates maptype toggling from 3D', (done) => {
+        testEpic(updateRouteOn3dSwitch, 1, assign({ hash: "/viewer/cesium/2" }, toggle3d(true, "leaflet")), actions => {
+            expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
                     case "@@router/CALL_HISTORY_METHOD":
                         expect(action.payload.method).toBe('push');
                         expect(action.payload.args.length).toBe(1);
-                        break;
-                    case UPDATE_LAST_2D_MAPTYPE:
-                        expect(action.mapType).toBe("leaflet");
                         break;
                     default:
                         expect(true).toBe(false);
@@ -57,4 +54,62 @@ describe('globeswitcher Epics', () => {
         });
 
     });
+
+    it('updates maptype on newmap', (done) => {
+        testEpic(updateRouteOn3dSwitch, 1, assign({hash: "/viewer/leaflet/new"}, toggle3d(true, "leaflet")), actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case "@@router/CALL_HISTORY_METHOD":
+                        expect(action.payload.method).toBe('push');
+                        expect(action.payload.args.length).toBe(1);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+
+                }
+            });
+            done();
+        });
+
+    });
+    it('updateLast2dMapTypeOnChangeEvents', (done) => {
+        testEpic(updateLast2dMapTypeOnChangeEvents, 1, [localConfigLoaded(), assign({ hash: "/viewer/leaflet/new" }, toggle3d(true))], actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case UPDATE_LAST_2D_MAPTYPE:
+                        expect(action.mapType).toBe('leaflet');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+
+                }
+            });
+            done();
+        });
+
+    });
+    it('updateLast2dMapTypeOnChangeEvents with custom mapType', (done) => {
+        testEpic(updateLast2dMapTypeOnChangeEvents, 1, [localConfigLoaded(), assign({ hash: "/viewer/leaflet/new" }, toggle3d(true))], actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case UPDATE_LAST_2D_MAPTYPE:
+                        expect(action.mapType).toBe('openlayers');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+
+                }
+            });
+            done();
+        }, {
+            maptype: {
+                mapType: 'openlayers'
+            }
+        });
+
+    });
+
 });

--- a/web/client/epics/globeswitcher.js
+++ b/web/client/epics/globeswitcher.js
@@ -6,6 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {TOGGLE_3D, updateLast2dMapType} = require('../actions/globeswitcher');
+const {MAP_TYPE_CHANGED} = require('../actions/maptype');
+const { mapTypeSelector } = require('../selectors/maptype');
+const {LOCAL_CONFIG_LOADED} = require('../actions/localConfig');
 
 const Rx = require('rxjs');
 const {get} = require('lodash');
@@ -29,18 +32,23 @@ const replaceMapType = (path, newMapType) => {
  */
 const updateRouteOn3dSwitch = (action$, store) =>
     action$.ofType(TOGGLE_3D)
-        .switchMap( action => {
-            const newPath = replaceMapType(action.hash || location.hash, action.enable ? "cesium" : get(store.getState(), "globeswitcher.last2dMapType") || "leaflet");
+        .switchMap( (action) => {
+            const newPath = replaceMapType(action.hash || location.hash, action.enable ? "cesium" : get(store.getState(), "globeswitcher.last2dMapType") || 'leaflet');
             if (newPath) {
-                return Rx.Observable.from([push(newPath), updateLast2dMapType(action.originalMapType)]);
+                return Rx.Observable.from([push(newPath)]);
             }
-            Rx.Observable.of(updateLast2dMapType(action.mapType));
+            Rx.Observable.empty();
         });
+const updateLast2dMapTypeOnChangeEvents = (action$, store) => action$
+    .ofType(LOCAL_CONFIG_LOADED).map(() => mapTypeSelector(store.getState()))
+    .merge(action$.ofType(MAP_TYPE_CHANGED, TOGGLE_3D).pluck('mapType').filter((mapType) => mapType && mapType !== "cesium"))
+    .switchMap(type => Rx.Observable.of(updateLast2dMapType(type)));
 /**
  * Epics for 3d switcher functionality
  * @name epics.globeswitcher
  * @type {Object}
  */
 module.exports = {
-    updateRouteOn3dSwitch
+    updateRouteOn3dSwitch,
+    updateLast2dMapTypeOnChangeEvents
 };

--- a/web/client/themes/default/less/dashboard.less
+++ b/web/client/themes/default/less/dashboard.less
@@ -1,5 +1,8 @@
 #dashboard-view-container{
     position: absolute;
+    #home-button {
+        float: right;
+    }
     #mapstore-navbar-container {
         margin-bottom: 0;
         z-index: 100;


### PR DESCRIPTION
## Description
This Fix #2888 my inspecting and setting correct 2d maptype. It checks the mapType in the state on localConfig loaded event to guess default 2D map type, even when not set yet by other location changes.
## Issues
 - Fix #2888

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
When open 3D map directly then switch from 3D to 2D mode, the maptype is set to leaflet instead of openlayers for desktop environment.

**What is the new behavior?**
The default 2d type is updated on localConfig loaded

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
+ minor fix to dashboard style of home button