### PR TITLE
Fix #2892. Remove authkey from dashboard layers

### DIFF
--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -208,12 +208,13 @@ describe('Tests ajax library', () => {
         expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
         // authkey authentication with user
         expect.spyOn(SecurityUtils, 'getSecurityInfo').andReturn(securityInfoB);
-        axios.get('http://www.some-site.com/geoserver?parameter1=value1&parameter2=value2').then(() => {
+        axios.get('http://www.some-site.com/geoserver?parameter1=value1&parameter2=value2&authkey=TEST_AUTHKEY').then(() => {
             done();
         }).catch((exception) => {
             expect(exception.config).toExist();
             expect(exception.config.url).toExist();
             expect(exception.config.url.indexOf('authkey')).toBeGreaterThan(-1);
+            expect(exception.config.url.indexOf("TEST_AUTHKEY")).toBeLessThan(0);
             done();
         });
     });

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -20,6 +20,8 @@ const urlUtil = require('url');
 function addParameterToAxiosConfig(axiosConfig, parameterName, parameterValue) {
     // FIXME: the parameters can also be a URLSearchParams
     axiosConfig.params = assign({}, axiosConfig.params, {[parameterName]: parameterValue});
+    // remove from URL auth parameters if any, to avoid possible duplication
+    axiosConfig.url = axiosConfig.url ? ConfigUtils.getUrlWithoutParameters(axiosConfig.url, [parameterName]) : axiosConfig.url;
 }
 
 /**

--- a/web/client/observables/wms.js
+++ b/web/client/observables/wms.js
@@ -9,6 +9,7 @@ const {Observable} = require('rxjs');
 const axios = require('../libs/ajax');
 const WMS = require('../api/WMS');
 const LayersUtils = require('../utils/LayersUtils');
+const SecurityUtils = require('../utils/SecurityUtils');
 const urlUtil = require('url');
 const {interceptOGCError} = require('../utils/ObservableUtils');
 const toDescribeLayerURL = ({name, search = {}, url} = {}) => {
@@ -39,9 +40,10 @@ module.exports = {
         .map( ({data = {}}) => data && data.layerDescriptions[0])
         .map(({owsURL} = {}) => ({
             ...l,
+            params: {}, // TODO: if needed, clean them up
             search: owsURL ? {
                 type: "wfs",
-                url: owsURL // TODO maybe we should we clean URL from authkey params
+                url: SecurityUtils.cleanAuthParamsFromURL(owsURL)
             } : undefined
         }))
 };

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -17,7 +17,7 @@ const {head, isNil} = require('lodash');
 const SecurityUtils = {
 
     /**
-     * Stores the logged user secuirty information.
+     * Stores the logged user security information.
      */
     setStore: function(store) {
         this.store = store;
@@ -65,7 +65,7 @@ const SecurityUtils = {
 
     /**
      * Return the user attributes as an array. If the user is undefined or
-     * doens't have any attributes an empty array is returned.
+     * doesn't have any attributes an empty array is returned.
      */
     getUserAttributes: function(providedUser) {
         const user = providedUser ? providedUser : this.getUser();
@@ -79,7 +79,7 @@ const SecurityUtils = {
     },
 
     /**
-     * Search in the user attributes an attribute that matchs the provided
+     * Search in the user attributes an attribute that matches the provided
      * attribute name. The search will not be case sensitive. Undefined is
      * returned if the attribute could not be found.
      */
@@ -95,7 +95,7 @@ const SecurityUtils = {
     },
 
     /**
-     * Search in the user attributes an attribute that matchs the provided
+     * Search in the user attributes an attribute that matches the provided
      * attribute name. The search will not be case sensitive. Undefined is
      * returned if the attribute could not be found otherwise the attribute
      * value is returned.
@@ -122,8 +122,8 @@ const SecurityUtils = {
 
     /**
      * Returns the authentication method that should be used for the provided URL.
-     * We go through the authentication rules and find the first one that matchs
-     * the provided URL, if no rule matchs the provided URL undefined is returned.
+     * We go through the authentication rules and find the first one that matches
+     * the provided URL, if no rule matches the provided URL undefined is returned.
      */
     getAuthenticationMethod: function(url) {
         const foundRule = head(this.getAuthenticationRules().filter(
@@ -133,8 +133,8 @@ const SecurityUtils = {
 
     /**
      * Returns the authentication rule that should be used for the provided URL.
-     * We go through the authentication rules and find the first one that matchs
-     * the provided URL, if no rule matchs the provided URL undefined is returned.
+     * We go through the authentication rules and find the first one that matches
+     * the provided URL, if no rule matches the provided URL undefined is returned.
      */
     getAuthenticationRule: function(url) {
         return head(this.getAuthenticationRules().filter(
@@ -157,7 +157,7 @@ const SecurityUtils = {
 
     /**
      * This method will add query parameter based authentications to an object
-     * containing query paramaters.
+     * containing query parameters.
      */
     addAuthenticationParameter: function(url, parameters, securityToken) {
         if (!url || !this.isAuthenticationActivated()) {
@@ -172,7 +172,7 @@ const SecurityUtils = {
             const authParam = this.getAuthKeyParameter(url);
             return assign(parameters || {}, {[authParam]: token});
         default:
-                // we cannot handle the required authentication method
+            // we cannot handle the required authentication method
             return parameters;
         }
     },
@@ -180,7 +180,9 @@ const SecurityUtils = {
         const foundRule = head(this.getAuthenticationRules().filter(
             rule => rule && rule.urlPattern && url.match(new RegExp(rule.urlPattern, "i"))));
         return foundRule && foundRule.authkeyParamName ? foundRule.authkeyParamName : 'authkey';
-    }
+    },
+    cleanAuthParamsFromURL: (url) => ConfigUtils.filterUrlParams(url, [SecurityUtils.getAuthKeyParameter(url)].filter(p => p))
+
 };
 
 module.exports = SecurityUtils;

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -200,4 +200,11 @@ describe('Test security utils methods', () => {
         expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
         expect(SecurityUtils.addAuthenticationParameter("a test url", null)).toEqual({'authkey': 'goodtoken'});
     });
+    it('cleanAuthParamsFromURL', () => {
+        // mocking the authentication rules
+        expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
+        expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
+        expect.spyOn(SecurityUtils, 'getSecurityInfo').andReturn(securityInfoC);
+        expect(SecurityUtils.cleanAuthParamsFromURL('http://www.some-site.com/geoserver?parameter1=value1&parameter2=value2&authkey=SOME_AUTH_KEY').indexOf('authkey')).toBe(-1);
+    });
 });


### PR DESCRIPTION
## Description
Removes configured authkey from URLs of the catalog when a rule is configured to manage that parameter. This avoid to save authkeys inside the dashboard resources. 

## Issues
 - Fix #2892

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
 - URLs provided by GeoServer contain authkey (When authkey is used) and they are saved in widgets context. 

**What is the new behavior?**
 - The authkey parameters are removed, if managed by mapstore, from the URL and configuration of layers used in dashboard. So widgets will be saved on dashboards without authkey. 
 - Any duplicated authkey will be removed in any case from the url, if already managed my mapstore.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
