### PR TITLE
Fix #2893 Improve CSW management of OGC:WMS reference and bounding box, Fix #2883 Red screen error on catalog

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -85,7 +85,6 @@ var Api = {
         return new Promise((resolve) => {
             require.ensure(['../utils/ogc/CSW', '../utils/ogc/Filter'], () => {
                 const {CSW, marshaller, unmarshaller} = require('../utils/ogc/CSW');
-
                 let body = marshaller.marshalString({
                     name: "csw:GetRecords",
                     value: CSW.getRecords(startPosition, maxRecords, filter)
@@ -128,7 +127,7 @@ var Api = {
                                                 let uc = el.value.upperCorner;
                                                 bbox = [lc[1], lc[0], uc[1], uc[0]];
                                                 // TODO parse the extent's crs
-                                                let crsCode = el.value && el.value.crs && el.value.crs.split(":::")[1];
+                                                let crsCode = el.value && el.value.crs && _.last(el.value.crs.split(":"));
                                                 if (crsCode === "WGS 1984") {
                                                     crs = "EPSG:4326";
                                                 } else if (crsCode) {

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -128,7 +128,7 @@ var Api = {
                                                 bbox = [lc[1], lc[0], uc[1], uc[0]];
                                                 // TODO parse the extent's crs
                                                 let crsCode = el.value && el.value.crs && _.last(el.value.crs.split(":"));
-                                                if (crsCode === "WGS 1984") {
+                                                if (crsCode === "WGS 1984" || crsCode === "WGS84") {
                                                     crs = "EPSG:4326";
                                                 } else if (crsCode) {
                                                     // TODO check is valid EPSG code

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -70,7 +70,7 @@ describe('TOC Toolbar', () => {
                     maxy: 9,
                     minx: -10,
                     miny: -9
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             },
             search: {
                 url: 'l001url'
@@ -92,7 +92,7 @@ describe('TOC Toolbar', () => {
             maxy: 9,
             minx: -10,
             miny: -9
-        }, 'EPSG');
+        }, 'EPSG:4326');
 
         TestUtils.Simulate.click(btn[1]);
         expect(spySettings).toHaveBeenCalledWith('l001', 'layers', {opacity: 1 });
@@ -130,7 +130,7 @@ describe('TOC Toolbar', () => {
                     maxy: 9,
                     minx: -10,
                     miny: -9
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             }
         }];
 
@@ -149,7 +149,7 @@ describe('TOC Toolbar', () => {
             maxy: 9,
             minx: -10,
             miny: -9
-        }, 'EPSG');
+        }, 'EPSG:4326');
 
         TestUtils.Simulate.click(btn[1]);
         expect(spySettings).toHaveBeenCalledWith('l001', 'layers', {opacity: 1 });
@@ -173,7 +173,7 @@ describe('TOC Toolbar', () => {
                     maxy: 9,
                     minx: -10,
                     miny: -9
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             }
         }];
 
@@ -207,7 +207,7 @@ describe('TOC Toolbar', () => {
                     maxy: 9,
                     minx: -10,
                     miny: -9
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             },
             search: {
                 url: 'l001url'
@@ -248,7 +248,7 @@ describe('TOC Toolbar', () => {
                     maxy: 9,
                     minx: -10,
                     miny: -9
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             },
             search: {
                 url: 'l001url'
@@ -263,7 +263,7 @@ describe('TOC Toolbar', () => {
                     maxy: 29,
                     minx: 28,
                     miny: 27
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             },
             search: {
                 url: 'l002url'
@@ -292,7 +292,7 @@ describe('TOC Toolbar', () => {
             maxy: 29,
             minx: -10,
             miny: -9
-        }, 'EPSG');
+        }, 'EPSG:4326');
 
         TestUtils.Simulate.click(btn[1]);
         expect(spySettings).toHaveBeenCalledWith('g001', 'groups', {});
@@ -313,7 +313,7 @@ describe('TOC Toolbar', () => {
                     maxy: 9,
                     minx: -10,
                     miny: -9
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             },
             search: {
                 url: 'l001url'
@@ -328,7 +328,7 @@ describe('TOC Toolbar', () => {
                     maxy: 29,
                     minx: 28,
                     miny: 27
-                }, crs: 'EPSG'
+                }, crs: 'EPSG:4326'
             },
             search: {
                 url: 'l002url'
@@ -375,6 +375,31 @@ describe('TOC Toolbar', () => {
         TestUtils.Simulate.click(btn[0]);
         const removeModal = document.getElementsByClassName('modal-dialog').item(0);
         expect(removeModal).toExist();
+    });
+
+    it('layer single selection (epsg not supported)', () => {
+
+        const selectedLayers = [{
+            id: 'l001',
+            title: 'layer001',
+            name: 'layer001name',
+            bbox: {
+                bounds: {
+                    maxx: 10,
+                    maxy: 9,
+                    minx: -10,
+                    miny: -9
+                }, crs: 'EPSG:3003'
+            }
+        }];
+
+        const cmp = ReactDOM.render(<Toolbar selectedLayers={selectedLayers} onToolsActions={onToolsActions}/>, document.getElementById("container"));
+
+        const el = ReactDOM.findDOMNode(cmp);
+        expect(el).toExist();
+        const btn = el.getElementsByClassName('btn');
+        expect(btn.length).toBe(3);
+        expect(btn[0].style.cursor).toBe('default');
     });
 
 });

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -206,7 +206,7 @@ class Catalog extends React.Component {
                     records={this.props.records}
                     authkeyParamNames={this.props.authkeyParamNames}
                     catalogURL={this.isValidServiceSelected() && this.props.services[this.props.selectedService].url || ""}
-                    catalogType={this.props.services[this.props.selectedService].type}
+                    catalogType={this.props.services[this.props.selectedService] && this.props.services[this.props.selectedService].type}
                     onLayerAdd={this.props.onLayerAdd}
                     onZoomToExtent={this.props.onZoomToExtent}
                     zoomToLayer={this.props.zoomToLayer}

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -137,6 +137,7 @@ class RecordItem extends React.Component {
 
     render() {
         let record = this.props.record;
+        const {wms, wmts} = extractOGCServicesReferences(record);
         return (
             <Panel className="record-item" style={{padding: 0}}>
                 {this.renderThumb(record && record.thumbnail, record)}
@@ -144,6 +145,7 @@ class RecordItem extends React.Component {
                     <h4 className="truncateText">{record && this.getTitle(record.title)}</h4>
                     <h4 className="truncateText"><small>{record && record.identifier}</small></h4>
                     <p className="truncateText record-item-description">{this.truncateDescription(this.renderDescription(record), 70)}</p>
+                    {!wms && !wmts && <small className="text-danger"><Message msgId="catalog.missingReference"/></small>}
                 </div>
                   {this.renderButtons(record)}
             </Panel>

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -387,4 +387,31 @@ describe('This test for RecordItem', () => {
         expect(titleAndIdentifier.length).toBe(2);
         expect(titleAndIdentifier.item(0).innerText).toBe('');
     });
+
+    it('record without references', () => {
+        const recordWithoutRef = {
+            identifier: "test-identifier",
+            title: "sample title",
+            tags: ["subject1", "subject2"],
+            description: "sample abstract",
+            thumbnail: "img.jpg",
+            boundingBox: {
+                extent: [10.686,
+                    44.931,
+                    46.693,
+                    12.54],
+                crs: "EPSG:4326"
+            },
+            references: []
+        };
+
+        const item = ReactDOM.render(<ReactItem record={recordWithoutRef}/>, document.getElementById("container"));
+        expect(item).toExist();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toExist();
+        const dangerText = itemDom.getElementsByClassName('text-danger');
+        expect(dangerText.length).toBe(1);
+    });
+
 });

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -136,7 +136,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             onClick={events.sync}
             glyph="map-filter"
             renderPopover={syncPopover.showPopoverSync}
-            popoverOptions={{
+            popoverOptions={!disableToolbar && {
                 placement: "top",
                 content: (<span>
                     <p><Message msgId="featuregrid.toolbar.synchPopoverText"/></p>

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -24,6 +24,8 @@ const {changeDrawingStatus} = require('../actions/draw');
 const {INIT_QUERY_PANEL} = require('../actions/wfsquery');
 const {getJSONFeatureWA} = require('../observables/wfs');
 const {describeFeatureTypeToAttributes} = require('../utils/FeatureTypeUtils');
+const notifications = require('../actions/notifications');
+
 const extractInfo = (data) => {
     return {
         geometry: data.featureTypes[0].properties
@@ -79,7 +81,15 @@ const featureTypeSelectedEpic = (action$, store) =>
                     try {
                         JSON.parse(response.data);
                     } catch (e) {
-                        return Rx.Observable.from([featureTypeError(action.typeName, 'Error from WFS: ' + e.message)]);
+                        return Rx.Observable.from([
+                            featureTypeError(action.typeName, 'Error from WFS: ' + e.message),
+                            notifications.error({
+                                title: 'warning',
+                                message: 'layerProperties.featureTypeErrorInvalidJSON',
+                                autoDismiss: 3,
+                                position: 'tc'
+                            })
+                        ]);
                     }
                     return Rx.Observable.from([featureTypeError(action.typeName, 'Error: feature types are empty')]);
                 })

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -66,7 +66,7 @@ class CreateNewMap extends React.Component {
 const {areDashboardsAvailable} = require('../selectors/dashboards');
 module.exports = {
     CreateNewMapPlugin: connect((state) => ({
-        dashboardsAvailable: areDashboardsAvailable,
+        dashboardsAvailable: areDashboardsAvailable(state),
         mapType: mapTypeSelector(state),
         isLoggedIn: state && state.security && state.security.user && state.security.user.enabled && !(state.browser && state.browser.mobile) && true || false,
         user: state && state.security && state.security.user

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -16,11 +16,12 @@ const {getTitleSelector, modeSelector, selectedFeaturesCount, hasChangesSelector
 const {userRoleSelector} = require('../../../selectors/security');
 const {isCesium} = require('../../../selectors/maptype');
 const {mapLayoutValuesSelector} = require('../../../selectors/maplayout');
-const {chartDisabledSelector, showAgainSelector, showPopoverSyncSelector} = require('../../../selectors/featuregrid');
+const {chartDisabledSelector, showAgainSelector, showPopoverSyncSelector, selectedLayerNameSelector} = require('../../../selectors/featuregrid');
 const {deleteFeatures, toggleTool, clearChangeConfirmed, closeFeatureGridConfirmed, closeFeatureGrid} = require('../../../actions/featuregrid');
 const {toolbarEvents, pageEvents} = require('../index');
 const {getAttributeFields} = require('../../../utils/FeatureGridUtils');
 const {getFilterRenderer} = require('../../../components/data/featuregrid/filterRenderers');
+const {isDescribeLoaded} = require('../../../selectors/query');
 
 const filterEditingAllowedUser = (role, editingAllowedRoles = ["ADMIN"]) => {
     return editingAllowedRoles.indexOf(role) !== -1;
@@ -45,7 +46,7 @@ const Toolbar = connect(
         showChartButton: state => !chartDisabledSelector(state) && widgetBuilderAvailable(state),
         isSimpleGeom: isSimpleGeomSelector,
         selectedCount: selectedFeaturesCount,
-        disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar,
+        disableToolbar: state => state && state.featuregrid && state.featuregrid.disableToolbar || !isDescribeLoaded(state, selectedLayerNameSelector(state)),
         displayDownload: wfsDownloadAvailable,
         disableDownload: state => (resultsSelector(state) || []).length === 0,
         isDownloadOpen: state => state && state.controls && state.controls.wfsdownload && state.controls.wfsdownload.enabled,

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -30,7 +30,8 @@ const {
     showAgainSelector,
     showPopoverSyncSelector,
     hasSupportedGeometry,
-    getDockSize
+    getDockSize,
+    selectedLayerNameSelector
 } = require('../featuregrid');
 
 const idFt1 = "idFt1";
@@ -472,4 +473,23 @@ describe('Test featuregrid selectors', () => {
         expect(getDockSize({ featuregrid: {dockSize: 0.5} })).toBe(0.5);
         expect(getDockSize({})).toBe(undefined);
     });
+
+    it('test selectedLayerNameSelector', () => {
+        const state = {...initialState, layers: {
+            flat: [{
+                id: "TEST_LAYER",
+                title: "Test Layer",
+                name: 'editing:polygons'
+            }]
+        }, featuregrid: {
+          open: true,
+          selectedLayer: "TEST_LAYER",
+          mode: modeEdit,
+          select: [feature1, feature2],
+          changes: [{id: feature2.id, updated: {geometry: null}}]
+        }};
+        expect(selectedLayerNameSelector(state)).toBe('editing:polygons');
+        expect(selectedLayerNameSelector({})).toBe('');
+    });
+
 });

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -141,5 +141,16 @@ module.exports = {
      * @return {boolean}       true if the geometry is supported, false otherwise
      */
     hasSupportedGeometry,
-    getDockSize: state => state.featuregrid && state.featuregrid.dockSize
+    getDockSize: state => state.featuregrid && state.featuregrid.dockSize,
+    /**
+     * get selected layer name
+     * @function
+     * @memberof selectors.featuregrid
+     * @param  {object}  state applications state
+     * @return {string}       name of selected layer
+     */
+    selectedLayerNameSelector: state => {
+        const layer = getLayerById(state, selectedLayerIdSelector(state));
+        return layer && layer.name || '';
+    }
 };

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -60,7 +60,7 @@
             "deleteLayerMessage": "Möchtest du wirklich diese Ebene löschen?",
             "confirmDelete": "Bist du sicher?",
             "featureTypeError": "Layerattribute können nicht geladen werden",
-            "featureTypeErrorInvalidJSON": "Layerattribute können nicht geladen werden. Die Antwort ist kein gültiges JSON-Objekt", 
+            "featureTypeErrorInvalidJSON": "Layerattribute können nicht geladen werden. Antwort ist nicht gültig", 
             "elevation": "Höhe",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -60,6 +60,7 @@
             "deleteLayerMessage": "Möchtest du wirklich diese Ebene löschen?",
             "confirmDelete": "Bist du sicher?",
             "featureTypeError": "Layerattribute können nicht geladen werden",
+            "featureTypeErrorInvalidJSON": "Layerattribute können nicht geladen werden. Die Antwort ist kein gültiges JSON-Objekt", 
             "elevation": "Höhe",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
@@ -383,6 +384,7 @@
             "refreshConfirm": "Aktualisieren",
             "refreshMessage": "Laden Sie die WMS-Layer-Konfiguration von dem Server(s)",
             "refreshError": "Fehler beim Aktualisieren von Ebenen: ",
+            "epsgNotSupported": "CRS {epsg} wird für das Zoomen auf Layer nicht unterstützt",
             "refreshOptions": {
                 "bbox": "BBOX aktualisieren",
                 "search": "Suchoptionen aktualisieren",
@@ -906,6 +908,7 @@
             "type": "Typ",
             "serviceTitle": "Titel",
             "serviceTitlePlaceholder": "Geben Sie einen Titel ein",
+            "missingReference": "Fehlende OGC-Referenzmetadaten",
             "notification": {
                 "warningAddCatalogService": "Geben Sie eine gültige URL und einen Titel ein",
                 "addCatalogService": "Service wurde korrekt hinzugefügt",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -60,6 +60,7 @@
             "deleteLayerMessage": "Do you really want to delete this Layer?",
             "confirmDelete": "Are you sure?",
             "featureTypeError": "Cannot load layer attributes",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object", 
             "elevation": "Elevation",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
@@ -384,6 +385,7 @@
             "refreshConfirm": "Update",
             "refreshMessage": "Reload WMS layers configuration from the server(s)",
             "refreshError": "Error updating layers: ",
+            "epsgNotSupported": "CRS {epsg} not supported for zoom to layer",
             "refreshOptions": {
                 "bbox": "Update BBOX",
                 "search": "Update search options",
@@ -907,6 +909,7 @@
             "type": "Type",
             "serviceTitle": "Title",
             "serviceTitlePlaceholder": "type a title",
+            "missingReference": "Missing OGC reference metadata",
             "notification": {
                 "warningAddCatalogService": "Insert a valid url and title",
                 "addCatalogService": "Service added correctly",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -60,7 +60,7 @@
             "deleteLayerMessage": "Do you really want to delete this Layer?",
             "confirmDelete": "Are you sure?",
             "featureTypeError": "Cannot load layer attributes",
-            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object", 
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid", 
             "elevation": "Elevation",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -60,6 +60,7 @@
             "deleteLayerMessage": "Está totalmente seguro de querer borrar este mapa?",
             "confirmDelete": "Está seguro?",
             "featureTypeError": "Imposible cargar los atributos del mapa",
+            "featureTypeErrorInvalidJSON": "Imposible cargar los atributos del mapa. La respuesta no es un objeto JSON válido", 
             "elevation": "Elevación",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
@@ -383,6 +384,7 @@
             "refreshConfirm": "Refrescar",
             "refreshMessage": "Recargue la configuración de las capas WMS a partir del/delos servidor(es)",
             "refreshError": "Error refrescando los mapas: ",
+            "epsgNotSupported": "CRS {epsg} no es compatible con el zoom a la capa",
             "refreshOptions": {
                 "bbox": "Refrecar BBOX",
                 "search": "Refrescar las optiones de búsqueda",
@@ -906,6 +908,7 @@
             "type": "Tipo",
             "serviceTitle": "Título",
             "serviceTitlePlaceholder": "escribe un título",
+            "missingReference": "Metadatos de referencia OGC faltantes",
             "notification": {
                 "warningAddCatalogService": "Insertar una url y un título válidos",
                 "addCatalogService": "Servicio añadido correctamente",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -60,7 +60,7 @@
             "deleteLayerMessage": "Está totalmente seguro de querer borrar este mapa?",
             "confirmDelete": "Está seguro?",
             "featureTypeError": "Imposible cargar los atributos del mapa",
-            "featureTypeErrorInvalidJSON": "Imposible cargar los atributos del mapa. La respuesta no es un objeto JSON válido", 
+            "featureTypeErrorInvalidJSON": "Imposible cargar los atributos del mapa. La respuesta no es válida", 
             "elevation": "Elevación",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -61,6 +61,7 @@
             "deleteLayerMessage": "Voulez-vous vraiment supprimer cette couche?",
             "confirmDelete": "Êtes-vous sûr?",
             "featureTypeError": "Impossible de charger les attributs de calque",
+            "featureTypeErrorInvalidJSON": "Impossible de charger les attributs de calque. La réponse n'est pas un objet JSON valide",
             "elevation": "élévation",
             "titleTranslations": "Traductions du titre",
             "groupProperties": "Propriétés du groupe",
@@ -384,6 +385,7 @@
             "refreshConfirm": "Mettre à jour",
             "refreshMessage": "Rechargez la configuration des couches WMS à partir du(s) serveur(s)",
             "refreshError": "Erreur lors de la mise à jour des couches: ",
+            "epsgNotSupported": "CRS {epsg} non pris en charge pour le zoom sur la couche",
             "refreshOptions": {
                 "bbox": "Mettre à jour BBOX",
                 "search": "Mettre à jour les options de recherche",
@@ -907,6 +909,7 @@
             "type": "Type",
             "serviceTitle": "Titre",
             "serviceTitlePlaceholder": "tapez un titre",
+            "missingReference": "Missing OGC reference metadata",
             "notification": {
                 "warningAddCatalogService": "Insérer une URL et un titre valides",
                 "addCatalogService": "Service ajouté correctement",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -61,7 +61,7 @@
             "deleteLayerMessage": "Voulez-vous vraiment supprimer cette couche?",
             "confirmDelete": "Êtes-vous sûr?",
             "featureTypeError": "Impossible de charger les attributs de calque",
-            "featureTypeErrorInvalidJSON": "Impossible de charger les attributs de calque. La réponse n'est pas un objet JSON valide",
+            "featureTypeErrorInvalidJSON": "Impossible de charger les attributs de calque. La réponse n'est pas valide",
             "elevation": "élévation",
             "titleTranslations": "Traductions du titre",
             "groupProperties": "Propriétés du groupe",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -60,6 +60,7 @@
             "deleteLayerMessage": "Želite li zaista izbrisati ovaj sloj?",
             "confirmDelete": "Jeste li sigurni?",
             "featureTypeError": "Nije moguće učitavanje atributa sloja",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object",
             "elevation": "Nadmorska visina",
             "titleTranslations": "Prijevodi naslova",
             "groupProperties": "Svojstva grupe",
@@ -355,6 +356,7 @@
             "refreshConfirm": "Ažuriraj",
             "refreshMessage": "Ponovno učitaj konfiguraciju WMS slojeva sa servera",
             "refreshError": "Greška prilikom ažuriranja slojeva: ",
+            "epsgNotSupported": "CRS {epsg} not supported for zoom to layer",
             "refreshOptions": {
                 "bbox": "Ažuriraj granični okvir",
                 "search": "Ažuriraj postavke pretraživanja",
@@ -878,6 +880,7 @@
             "type": "Tip",
             "serviceTitle": "Naslov",
             "serviceTitlePlaceholder": "unesi naslov",
+            "missingReference": "Missing OGC reference metadata",
             "notification": {
                 "warningAddCatalogService": "Unesi ispravni url i naslov",
                 "addCatalogService": "Servis je dodan ispravno",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -60,7 +60,7 @@
             "deleteLayerMessage": "Želite li zaista izbrisati ovaj sloj?",
             "confirmDelete": "Jeste li sigurni?",
             "featureTypeError": "Nije moguće učitavanje atributa sloja",
-            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid",
             "elevation": "Nadmorska visina",
             "titleTranslations": "Prijevodi naslova",
             "groupProperties": "Svojstva grupe",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -60,6 +60,7 @@
             "deleteLayerMessage": "Sei sicuro di voler eliminare questo livello?",
             "confirmDelete": "Sei sicuro?",
             "featureTypeError": "Impossibile caricare gli attributi del layer",
+            "featureTypeErrorInvalidJSON": "Impossibile caricare gli attributi del layer. La risposta non è un oggetto JSON valido",
             "elevation": "Elevazione",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",
@@ -383,6 +384,7 @@
             "refreshConfirm": "Aggiorna",
             "refreshMessage": "Ricarica la configurazione dei layer WMS dai rispettivi server",
             "refreshError": "Errore di aggiornamento sui layer: ",
+            "epsgNotSupported": "CRS {epsg} non supportato per zoom al layer",
             "refreshOptions": {
                 "bbox": "Aggiorna area di zoom",
                 "search": "Aggiorna opzioni di ricerca",
@@ -906,6 +908,7 @@
             "type": "Tipo",
             "serviceTitle": "Titolo",
             "serviceTitlePlaceholder": "inserisci un titolo",
+            "missingReference": "Metadati di riferimento OGC mancanti",
             "notification": {
                 "warningAddCatalogService": "Inserisci un url e titolo validi.",
                 "addCatalogService": "Servizio aggiunto corretamente.",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -60,7 +60,7 @@
             "deleteLayerMessage": "Sei sicuro di voler eliminare questo livello?",
             "confirmDelete": "Sei sicuro?",
             "featureTypeError": "Impossibile caricare gli attributi del layer",
-            "featureTypeErrorInvalidJSON": "Impossibile caricare gli attributi del layer. La risposta non è un oggetto JSON valido",
+            "featureTypeErrorInvalidJSON": "Impossibile caricare gli attributi del layer. La risposta non è valida",
             "elevation": "Elevazione",
             "titleTranslations": "Title translations",
             "groupProperties": "Group properties",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -54,7 +54,7 @@
             "deleteLayerMessage": "Weet u zeker dat u deze laag wilt verwijderen?",
             "confirmDelete": "Bent u zeker?",
             "featureTypeError": "De atributen van de laag kunnen niet geladen worden",
-            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid",
             "elevation": "hoogte",
             "titleTranslations": "Title translations",
             "groupProperties": "Groep properties",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -54,6 +54,7 @@
             "deleteLayerMessage": "Weet u zeker dat u deze laag wilt verwijderen?",
             "confirmDelete": "Bent u zeker?",
             "featureTypeError": "De atributen van de laag kunnen niet geladen worden",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object",
             "elevation": "hoogte",
             "titleTranslations": "Title translations",
             "groupProperties": "Groep properties",
@@ -267,6 +268,7 @@
             "refreshConfirm": "Bijwerken",
             "refreshMessage": "Laad de configuratie van de WMS-lagen opnieuw vanaf de server(s)",
             "refreshError": "Fout bij het bijwerken van de lagen: ",
+            "epsgNotSupported": "CRS {epsg} not supported for zoom to layer",
             "refreshOptions": {
                 "bbox": "BBOX bijwerken",
                 "search": "De zoekopties bijwerken",
@@ -723,7 +725,8 @@
             "search": "Zoek",
             "reset": "Verwijder",
             "options": "Opties",
-            "srs_not_allowed": "Deze service ondersteunt het geografische coördinatensysteem van de kaart niet"
+            "srs_not_allowed": "Deze service ondersteunt het geografische coördinatensysteem van de kaart niet",
+            "missingReference": "Missing OGC reference metadata"
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -52,7 +52,7 @@
             "deleteLayerMessage": "你真的想删除这个层？",
             "confirmDelete": "你确定?",
             "featureTypeError": "无法加载图层属性",
-            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid",
             "elevation": "海拔",
             "titleTranslations": "标题 translations",
             "groupProperties": "组属性",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -52,6 +52,7 @@
             "deleteLayerMessage": "你真的想删除这个层？",
             "confirmDelete": "你确定?",
             "featureTypeError": "无法加载图层属性",
+            "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not a valid JSON object",
             "elevation": "海拔",
             "titleTranslations": "标题 translations",
             "groupProperties": "组属性",
@@ -283,6 +284,7 @@
             "refreshConfirm": "更新",
             "refreshMessage": "从服务器重新加载WMS图层配置",
             "refreshError": "更新图层时出错： ",
+            "epsgNotSupported": "CRS {epsg} not supported for zoom to layer",
             "refreshOptions": {
                 "bbox": "更新BBOX",
                 "search": "更新搜索选项",
@@ -777,6 +779,7 @@
             "type": "Type",
             "serviceTitle": "Title",
             "serviceTitlePlaceholder": "type a title",
+            "missingReference": "Missing OGC reference metadata",
             "notification": {
                 "warningAddCatalogService": "Insert a valid url and title",
                 "addCatalogService": "Service added correctly",

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -54,7 +54,7 @@ const converters = {
                     const URI = isArray(dc.URI) ? dc.URI : (dc.URI && [dc.URI] || []);
                     let thumb = head([].filter.call(URI, (uri) => {return uri.name === "thumbnail"; }) );
                     thumbURL = thumb ? thumb.value : null;
-                    wms = head([].filter.call(URI, (uri) => { return uri.protocol && uri.protocol.match(/^OGC:WMS-(.*)-http-get-map/g); }));
+                    wms = head([].filter.call(URI, (uri) => { return uri.protocol && (uri.protocol.match(/^OGC:WMS-(.*)-http-get-map/g) || uri.protocol.match(/^OGC:WMS/g)); }));
                 }
                 // look in references objects
                 if (!wms && dc && dc.references && dc.references.length) {

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -227,4 +227,36 @@ describe('Test the CatalogUtils', () => {
         }, {});
         expect(records.length).toBe(1);
     });
+
+    it('csw with DC references with only OGC:WMS in URI, GeoNetwork', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    URI: [
+                        {
+                            TYPE_NAME: 'DC_1_1.URI',
+                            protocol: 'OGC:WMS',
+                            name: 'wms-name',
+                            description: 'wms-desc',
+                            value: 'wms-url'
+                        },
+                        {
+                            TYPE_NAME: 'DC_1_1.URI',
+                            protocol: 'WWW:LINK-1.0-http--related',
+                            name: 'link-name',
+                            description: 'link-desc',
+                            value: 'link-url'
+                        },
+                        {
+                            TYPE_NAME: 'DC_1_1.URI',
+                            protocol: 'image/png',
+                            name: 'thumbnail',
+                            value: 'path-to-thumbnail'
+                        }
+                    ]
+                }
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+    });
 });


### PR DESCRIPTION
## Description

Added OGC:WMS to CSW reference while parsing records

Messages:
In some cases catalog doesn't provide reference to get layer
so following message will be displayed
![2018-05-14 15_18_37-mapstore 2 homepage](https://user-images.githubusercontent.com/19175505/39999797-543b3d30-578a-11e8-87f8-9e5b2d087513.png)

if epsg of layer is not supported from MapStore2
zoom to layer will show this message

![2018-05-14 15_19_09-mapstore 2 homepage](https://user-images.githubusercontent.com/19175505/39999798-54f13022-578a-11e8-9787-f282feb69c04.png)

in case of bad response on wfs describe layer it will show following message and feature grid toolbar will be desabled

![2018-05-14 15_20_01-mapstore 2 homepage](https://user-images.githubusercontent.com/19175505/39999800-5622138a-578a-11e8-9759-8a9b7498204c.png)


## Issues
 - Fix #2893 
 - Fix #2883

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
some catalog aren't correctly loaded because send an OGC:WMS reference not supported from MapStore2

**What is the new behavior?**
Improved CSW management of reference/error messages

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
