### PR TITLE
Fix #2862. Add geofence icon to the manager menu

### DIFF
--- a/web/client/plugins/manager/ManagerMenu.jsx
+++ b/web/client/plugins/manager/ManagerMenu.jsx
@@ -56,7 +56,7 @@ class ManagerMenu extends React.Component {
         },
         {
             "msgId": "rulesmanager.menutitle",
-            "glyph": "lock",
+            "glyph": "admin-geofence",
             "path": "/rules-manager"
         }],
         role: "",


### PR DESCRIPTION
## Description
Add geofence icon to the manager menu
![image](https://user-images.githubusercontent.com/1279510/40011722-e95b8262-57a8-11e8-8e30-f9b3097af006.png)

## Issues
 - Fix #2862

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Icon for rule manager is a simple lock

**What is the new behavior?**
Use icon from #2873
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
