### PR TITLE
Fix #2898 TOC moves down if Measure tool and print are opened

### DIFF
--- a/web/client/plugins/FloatingLegend.jsx
+++ b/web/client/plugins/FloatingLegend.jsx
@@ -40,13 +40,22 @@ class FloatingLegendComponent extends React.Component {
     static propTypes = {
         items: PropTypes.array,
         pluginName: PropTypes.string,
-        tooltipId: PropTypes.string
+        tooltipId: PropTypes.string,
+        className: PropTypes.string,
+        style: PropTypes.object
     };
 
     static defaultProps = {
         items: [],
         pluginName: 'drawer-menu',
-        tooltipId: 'floatinglegend.showTOC'
+        tooltipId: 'floatinglegend.showTOC',
+        className: 'ms-floatinglegend-container',
+        style: {
+            top: 0,
+            left: 0,
+            position: 'absolute',
+            height: '100%'
+        }
     };
 
     renderPanel() {
@@ -61,7 +70,9 @@ class FloatingLegendComponent extends React.Component {
 
     render() {
         return (
-            <div style={{position: 'absolute', height: '100%'}}>
+            <div
+                className={this.props.className}
+                style={{...this.props.style}}>
                 <FloatingLegend
                     {...this.props}
                     toggleButton={this.renderToggleButton()}/>

--- a/web/client/plugins/FloatingLegend.jsx
+++ b/web/client/plugins/FloatingLegend.jsx
@@ -72,7 +72,7 @@ class FloatingLegendComponent extends React.Component {
         return (
             <div
                 className={this.props.className}
-                style={{...this.props.style}}>
+                style={this.props.style}>
                 <FloatingLegend
                     {...this.props}
                     toggleButton={this.renderToggleButton()}/>


### PR DESCRIPTION
## Description
Added top and left style position to avoid relative translation of TOC button

## Issues
 - Fix #2898

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
 issue #2898

**What is the new behavior?**
TOC button doesn't move if print measure modals are open

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
