### PR TITLE
fix #2711 remove arc layer when toggling length measure tool (leaflet)

### DIFF
--- a/web/client/components/map/leaflet/MeasurementSupport.jsx
+++ b/web/client/components/map/leaflet/MeasurementSupport.jsx
@@ -432,6 +432,7 @@ class MeasurementSupport extends React.Component {
             this.drawControl.disable();
             this.drawControl = null;
             this.removeLastLayer();
+            this.removeArcLayer();
             this.props.map.off('draw:created', this.onDrawCreated, this);
             this.props.map.off('draw:drawstart', this.onDrawStart, this);
             this.props.map.off('draw:drawvertex', this.onDrawVertex, this);


### PR DESCRIPTION
## Description
Length measure tool for leaflet when toggled off does not clean geometry on the map

## Issues
 - Fix #2711


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
actually a measure feature is not cleared when you toggle off the 

**What is the new behavior?**
now if you have drawn a length measure and you toggle off the length tool or toggle on other tools

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
