### PR TITLE
Fix #2903. Add support to hide spatial and cross layer filter

### DIFF
--- a/web/client/components/data/query/QueryBuilder.jsx
+++ b/web/client/components/data/query/QueryBuilder.jsx
@@ -63,7 +63,8 @@ class QueryBuilder extends React.Component {
         autocompleteEnabled: PropTypes.bool,
         emptyFilterWarning: PropTypes.bool,
         header: PropTypes.node,
-        zoom: PropTypes.number
+        zoom: PropTypes.number,
+        toolsOptions: PropTypes.object
     };
 
     static defaultProps = {
@@ -127,7 +128,8 @@ class QueryBuilder extends React.Component {
             onQuery: () => {},
             onReset: () => {},
             onChangeDrawingStatus: () => {}
-        }
+        },
+        toolsOptions: {}
     };
 
     render() {
@@ -174,7 +176,7 @@ class QueryBuilder extends React.Component {
                         addButtonIcon={this.props.addButtonIcon}
                         attributePanelExpanded={this.props.attributePanelExpanded}
                         actions={this.props.attributeFilterActions}/>
-                    <SpatialFilter
+                {this.props.toolsOptions.hideSpatialFilter ? null : <SpatialFilter
                         useMapProjection={this.props.useMapProjection}
                         spatialField={this.props.spatialField}
                         spatialOperations={this.props.spatialOperations}
@@ -182,15 +184,15 @@ class QueryBuilder extends React.Component {
                         spatialPanelExpanded={this.props.spatialPanelExpanded}
                         showDetailsPanel={this.props.showDetailsPanel}
                         actions={this.props.spatialFilterActions}
-                        zoom={this.props.zoom}/>
-                    <CrossLayerFilter
+                        zoom={this.props.zoom}/>}
+                {this.props.toolsOptions.hideCrossLayer ? null : <CrossLayerFilter
                         spatialOperations={this.props.spatialOperations}
                         crossLayerExpanded={this.props.crossLayerExpanded}
                         searchUrl={this.props.searchUrl}
                         featureTypeName={this.props.featureTypeName}
                         {...this.props.crossLayerFilterOptions}
                         {...this.props.crossLayerFilterActions}
-                        />
+                        />}
             </BorderLayout>
          : <div style={{margin: "0 auto", width: "60px"}}><Spinner spinnerName="three-bounce" overrideSpinnerClassName="spinner"/></div>;
     }

--- a/web/client/components/data/query/__tests__/QueryBuilder-test.jsx
+++ b/web/client/components/data/query/__tests__/QueryBuilder-test.jsx
@@ -141,6 +141,51 @@ describe('QueryBuilder', () => {
         const queryButton = document.getElementById('query-toolbar-query');
         expect(queryButton).toExist();
         expect(queryButton.getAttribute("disabled")).toBe('');
+        // check presence of attribute, spatial and cross layer filter
+        expect(document.querySelectorAll('.mapstore-switch-panel').length).toBe(3);
+    });
+    it('tool options', () => {
+        const groupLevels = 5;
+
+        const groupFields = [];
+
+        const filterFields = [{
+            rowId: 100,
+            groupId: 1,
+            attribute: "",
+            operator: null,
+            value: null,
+            exception: null
+        }];
+
+        const attributes = [{
+            id: "Attribute",
+            type: "list",
+            values: [
+                "attribute1",
+                "attribute2",
+                "attribute3",
+                "attribute4",
+                "attribute5"
+            ]
+        }];
+
+        const querybuilder = ReactDOM.render(
+            <QueryBuilder
+                toolsOptions={{
+                    hideCrossLayer: true,
+                    hideSpatialFilter: true
+                }}
+                filterFields={filterFields}
+                attributes={attributes}
+                groupFields={groupFields}
+                groupLevels={groupLevels}
+            />,
+            document.getElementById("container")
+        );
+        expect(querybuilder).toExist();
+        // only attribute filter should be shown
+        expect(document.querySelectorAll('.mapstore-switch-panel').length).toBe(1);
     });
 
     it('creates the QueryBuilder component in error state', () => {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -518,6 +518,10 @@
         }, {
           "name": "QueryPanel",
           "cfg": {
+            "toolsOptions": {
+              "hideCrossLayer": true,
+              "hideSpatialFilter": true
+            },
             "containerPosition": "columns"
           }
         }, "Dashboard", "Notifications"],

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -204,7 +204,8 @@ class QueryPanel extends React.Component {
         activateSettingsTool: PropTypes.bool,
         visibilityCheckType: PropTypes.string,
         settingsOptions: PropTypes.object,
-        layout: PropTypes.object
+        layout: PropTypes.object,
+        toolsOptions: PropTypes.object
     };
 
     static defaultProps = {
@@ -226,7 +227,8 @@ class QueryPanel extends React.Component {
         visibilityCheckType: "checkbox",
         settingsOptions: {},
         querypanelEnabled: false,
-        layout: {}
+        layout: {},
+        toolsOptions: {}
     };
 
     componentWillReceiveProps(newProps) {
@@ -275,6 +277,7 @@ class QueryPanel extends React.Component {
                 header={<QueryPanelHeader onToggleQuery={this.props.onToggleQuery} />}
                 spatialOperations={this.props.spatialOperations}
                 spatialMethodOptions={this.props.spatialMethodOptions}
+                toolsOptions={this.props.toolsOptions}
                 featureTypeErrorText={<Message msgId="layerProperties.featureTypeError"/>}/>
         </div>);
     };
@@ -301,15 +304,18 @@ class QueryPanel extends React.Component {
  *   - blacklist {string[]} a list of banned words excluded from the wfs search
  *   - maxFeatures {number} the maximum features fetched per request
  *   - predicate {string} the cql predicate
- *   - queriableAttributes {string[]} list of attributes to query on.
- *   - typeName {string} the workspace + layer name on geosever
+ *   - querableAttributes {string[]} list of attributes to query on.
+ *   - typeName {string} the workspace + layer name on geoserver
  *   - valueField {string} the attribute from features properties used as value/label in the autocomplete list
  *   - srsName {string} The projection of the requested features fetched via wfs
  *
  * @prop {object[]} cfg.spatialOperations: The list of geometric operations use to create the spatial filter.<br/>
+ * @prop {boolean} cfg.toolsOptions.hideCrossLayer force cross layer to hide
+ * @prop {boolean} cfg.toolsOptions.hideCrossLayer force cross layer filter panel to hide (when is not used or not usable)
+ * @prop {boolean} cfg.toolsOptions.hideSpatialFilter force spatial filter panel to hide (when is not used or not usable)
  *
  * @example
- * // This example configure a layer with polyogns geometry as spatial filter method
+ * // This example configure a layer with polygons geometry as spatial filter method
  * "spatialOperations": [
  *      {"id": "INTERSECTS", "name": "queryform.spatialfilter.operations.intersects"},
  *      {"id": "BBOX", "name": "queryform.spatialfilter.operations.bbox"},
@@ -339,7 +345,7 @@ class QueryPanel extends React.Component {
  *            "queriableAttributes": ["ATTRIBUTE_X"],
  *            "typeName": "workspace:typeName",
  *            "valueField": "ATTRIBUTE_Y",
- *            "srsName": "ESPG:3857"
+ *            "srsName": "EPSG:3857"
  *        },
  *        "customItemClassName": "customItemClassName"
  *    }


### PR DESCRIPTION
## Description
In some contexts like dashboard, the spatial filter and cross layer filters of querypanel are not used. It is better to hide them in that context. Moreover this pull request adds 
## Issues
 - Fix #2903

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)

- You see cross layer and spatial filter panels in dashboard but you can not use them

**What is the new behavior?**

 - You don't see the panels anymore. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No