### PR TITLE
fix #2696 map rotation disables correctly

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -270,12 +270,14 @@ class MapPlugin extends React.Component {
 
     render() {
         if (this.props.map) {
+            const {mapOptions = {}} = this.props.map;
+
             return (
                 <plugins.Map id="map"
                     {...this.props.options}
-                    mapOptions={this.getMapOptions()}
                     projectionDefs={this.props.projectionDefs}
                     {...this.props.map}
+                    mapOptions={assign({}, mapOptions, this.getMapOptions())}
                     zoomControl={this.props.zoomControl}>
                     {this.renderLayers()}
                     {this.renderSupportTools()}


### PR DESCRIPTION
## Description
The configuration that would disable the map rotation for openlayers were not considered due to a bug that this PR is going to fix.

## Issues
 - Fix #2696

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
load this [map](https://dev.mapstore2.geo-solutions.it/mapstore/#/viewer/openlayers/356)
try to rotate (alt shift) or from mobile with pinch rotation

**What is the new behavior?**
with any map you can't rotate

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
