### PR TITLE
Showing spatial filter selection area when FeatureGrid is open

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -40,6 +40,7 @@ const {
     sizeChange, SIZE_CHANGE,
     START_SYNC_WMS, startSyncWMS,
     storeAdvancedSearchFilter, STORE_ADVANCED_SEARCH_FILTER,
+    setShowCurrentFilter, SET_SHOW_CURRENT_FILTER,
     fatureGridQueryResult, GRID_QUERY_RESULT,
     moreFeatures, LOAD_MORE_FEATURES,
     hideSyncPopover, HIDE_SYNC_POPOVER,
@@ -293,5 +294,13 @@ describe('Test correctness of featurgrid actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(LOAD_MORE_FEATURES);
         expect(retval.pages).toBe(pages);
+    });
+
+    it('Test setShowCurrentFilter', () => {
+        const showFilteredObject = true;
+        const retval = setShowCurrentFilter(showFilteredObject);
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_SHOW_CURRENT_FILTER);
+        expect(retval.showFilteredObject).toBe(showFilteredObject);
     });
 });

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 
+const SET_SHOW_CURRENT_FILTER = 'SET_SHOW_CURRENT_FILTER';
 const SELECT_FEATURES = 'FEATUREGRID:SELECT_FEATURES';
 const DESELECT_FEATURES = 'FEATUREGRID:DESELECT_FEATURES';
 const CLEAR_SELECTION = 'FEATUREGRID:CLEAR_SELECTION';
@@ -104,6 +105,12 @@ function selectFeatures(features, append) {
         type: SELECT_FEATURES,
         features,
         append
+    };
+}
+function setShowCurrentFilter(showFilteredObject) {
+    return {
+        type: SET_SHOW_CURRENT_FILTER,
+        showFilteredObject
     };
 }
 function geometryChanged(features) {
@@ -364,6 +371,7 @@ module.exports = {
     OPEN_FEATURE_GRID, openFeatureGrid,
     CLOSE_FEATURE_GRID_CONFIRM, closeFeatureGridConfirm,
     FEATURE_GRID_CLOSE_CONFIRMED, closeFeatureGridConfirmed,
+    SET_SHOW_CURRENT_FILTER, setShowCurrentFilter,
     DISABLE_TOOLBAR, disableToolbar,
     OPEN_ADVANCED_SEARCH, openAdvancedSearch,
     ZOOM_ALL, zoomAll,

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -244,7 +244,13 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home", "FeatureEditor",
+            }, "Home",
+            {
+                "name": "FeatureEditor",
+                "cfg": {
+                    "showFilteredObject": true
+                }
+            },
             "WFSDownload",
             {
               "name": "QueryPanel",

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -244,7 +244,7 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home","FeatureEditor",
+            }, "Home", "FeatureEditor",
             "WFSDownload",
             {
               "name": "QueryPanel",

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -244,13 +244,7 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home",
-            {
-                "name": "FeatureEditor",
-                "cfg": {
-                    "showFilteredObject": true
-                }
-            },
+            }, "Home","FeatureEditor",
             "WFSDownload",
             {
               "name": "QueryPanel",

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -11,7 +11,12 @@ const {createSelector, createStructuredSelector} = require('reselect');
 const {bindActionCreators} = require('redux');
 const {get} = require('lodash');
 
-const Grid = require('../components/data/featuregrid/FeatureGrid');
+const {lifecycle} = require('recompose');
+const Grid = lifecycle({
+    componentDidMount() {
+        this.props.onMount(this.props.showFilteredObject);
+    }
+})(require('../components/data/featuregrid/FeatureGrid'));
 const {paginationInfo, describeSelector, wfsURLSelector, typeNameSelector} = require('../selectors/query');
 const {modeSelector, changesSelector, newFeaturesSelector, hasChangesSelector, selectedFeaturesSelector, getDockSize} = require('../selectors/featuregrid');
 const { toChangesMap} = require('../utils/FeatureGridUtils');
@@ -20,7 +25,7 @@ const BorderLayout = require('../components/layout/BorderLayout');
 const EMPTY_ARR = [];
 const EMPTY_OBJ = {};
 const {gridTools, gridEvents, pageEvents, toolbarEvents} = require('./featuregrid/index');
-const {initPlugin, sizeChange} = require('../actions/featuregrid');
+const {initPlugin, sizeChange, setShowCurrentFilter} = require('../actions/featuregrid');
 const ContainerDimensions = require('react-container-dimensions').default;
 const {mapLayoutValuesSelector} = require('../selectors/maplayout');
 const Dock = connect(createSelector(
@@ -139,6 +144,8 @@ const FeatureDock = (props = {
             footer={getFooter(props)}>
             {getDialogs(props.tools)}
             <Grid
+                onMount={props.onMount}
+                showFilteredObject={props.showFilteredObject}
                 editingAllowedRoles={props.editingAllowedRoles}
                 initPlugin={props.initPlugin}
                 customEditorsOptions={props.customEditorsOptions}
@@ -217,6 +224,7 @@ const selector = createSelector(
 );
 const EditorPlugin = connect(selector,
     (dispatch) => ({
+        onMount: bindActionCreators(setShowCurrentFilter, dispatch),
         gridEvents: bindActionCreators(gridEvents, dispatch),
         pageEvents: bindActionCreators(pageEvents, dispatch),
         initPlugin: bindActionCreators((options) => initPlugin(options), dispatch),

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -47,6 +47,7 @@ const Dock = connect(createSelector(
   * @prop {number} cfg.maxStoredPages default 5. In virtual Scroll mode determines the size of the loaded pages cache
   * @prop {number} cfg.vsOverScan default 20. Number of rows to load above/below the visible slice of the grid
   * @prop {number} cfg.scrollDebounce default 50. milliseconds of debounce interval between two scroll event
+  * @prop {boolean} cfg.showFilteredObject default false. Displays spatial filter selection area when true
   * @classdesc
   * FeatureEditor Plugin Provides functionalities to browse/edit data via WFS. The grid can be configured to use paging or
   * <br/>virtual scroll mechanisms. By defualt virtual scroll is enabled. When on virtual scroll mode, the maxStoredPages param

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -346,7 +346,7 @@ const filteredFeatures = createSelector(
                 }
             ]
         };
-        return reprojectGeoJson(geometry, geometryCrs, 'EPSG:4326').features;
+        return geometryCoordinates.length > 0 && geometryType ? reprojectGeoJson(geometry, geometryCrs, 'EPSG:4326').features : [];
     }
 
 );

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -317,54 +317,16 @@ class MapPlugin extends React.Component {
 const {mapSelector, projectionDefsSelector} = require('../selectors/map');
 const { mapTypeSelector } = require('../selectors/maptype');
 const {layerSelectorWithMarkers} = require('../selectors/layers');
-const {selectedFeatures, filteredspatialObjectCoord, filteredspatialObjectType, filteredSpatialObjectCrs, filteredSpatialObjectId} = require('../selectors/highlight');
+const {highlighedFeatures} = require('../selectors/highlight');
 const {securityTokenSelector} = require('../selectors/security');
-const {reprojectGeoJson} = require('../utils/CoordinatesUtils');
 
-const filteredFeatures = createSelector(
-    [
-        filteredspatialObjectCoord,
-        filteredspatialObjectType,
-        filteredSpatialObjectId,
-        filteredSpatialObjectCrs
-    ],
-    ( geometryCoordinates, geometryType, geometryId, geometryCrs) => {
-        let geometry = {
-            type: "FeatureCollection",
-            features: [
-                {
-                    type: "Feature",
-                    geometry: {
-                        type: geometryType,
-                        coordinates: geometryCoordinates
-                    },
-                    style: {
-                        fillColor: 'rgba(255, 255, 255, 0.2)',
-                        color: '#ffcc33'
-                    },
-                    id: geometryId
-                }
-            ]
-        };
-        return geometryCoordinates.length > 0 && geometryType ? reprojectGeoJson(geometry, geometryCrs, 'EPSG:4326').features : [];
-    }
-
-);
-
-const getFeatures = createSelector(
-    [
-        filteredFeatures,
-        selectedFeatures
-    ],
-    (featuresFiltered, featuresSelected) => [ ...featuresSelected, ...featuresFiltered]
-);
 const selector = createSelector(
     [
         projectionDefsSelector,
         mapSelector,
         mapTypeSelector,
         layerSelectorWithMarkers,
-        getFeatures,
+        highlighedFeatures,
         (state) => state.mapInitialConfig && state.mapInitialConfig.loadingError && state.mapInitialConfig.loadingError.data,
         securityTokenSelector,
         (state) => state.mousePosition && state.mousePosition.enabled

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -55,275 +55,275 @@ const {changeDrawingStatus} = require('../../actions/draw');
 const museam = require('json-loader!../../test-resources/wfs/museam.json');
 describe('Test the featuregrid reducer', () => {
 
-    // it('returns original state on unrecognized action', () => {
-    //     let state = featuregrid(1, {type: 'UNKNOWN'});
-    //     expect(state).toBe(1);
-    // });
-    // it('default state', () => {
-    //     let state = featuregrid(undefined, {type: 'UNKNOWN'});
-    //     expect(state).toExist();
-    //     expect(state.pagination).toExist();
-    //     expect(state.select).toExist();
-    //     expect(state.features).toExist();
-    // });
-    // it('hideSyncPopover', () => {
-    //     let state = featuregrid({}, hideSyncPopover());
-    //     expect(state.showPopoverSync).toBe(false);
-    // });
-    // it('toggleShowAgain toggling', () => {
-    //     let state = featuregrid({showAgain: false}, toggleShowAgain());
-    //     expect(state).toExist();
-    //     expect(state.showAgain).toBe(true);
-    //     let state2 = featuregrid({showAgain: true}, toggleShowAgain());
-    //     expect(state2.showAgain).toBe(false);
-    // });
-    // it('initPlugin', () => {
-    //     const someValue = "someValue";
-    //     const editingAllowedRoles = [someValue];
-    //     let state = featuregrid({}, initPlugin({editingAllowedRoles}));
-    //     expect(state).toExist();
-    //     expect(state.editingAllowedRoles.length).toBe(1);
-    //     expect(state.editingAllowedRoles[0]).toBe(someValue);
-    // });
-    // it('openFeatureGrid', () => {
-    //     let state = featuregrid(undefined, openFeatureGrid());
-    //     expect(state).toExist();
-    //     expect(state.open).toBe(true);
-    // });
-    // it('closeFeatureGrid', () => {
-    //     let state = featuregrid(undefined, closeFeatureGrid());
-    //     expect(state).toExist();
-    //     expect(state.open).toBe(false);
-    //     expect(state.mode).toBe(MODES.VIEW);
-    // });
+    it('returns original state on unrecognized action', () => {
+        let state = featuregrid(1, {type: 'UNKNOWN'});
+        expect(state).toBe(1);
+    });
+    it('default state', () => {
+        let state = featuregrid(undefined, {type: 'UNKNOWN'});
+        expect(state).toExist();
+        expect(state.pagination).toExist();
+        expect(state.select).toExist();
+        expect(state.features).toExist();
+    });
+    it('hideSyncPopover', () => {
+        let state = featuregrid({}, hideSyncPopover());
+        expect(state.showPopoverSync).toBe(false);
+    });
+    it('toggleShowAgain toggling', () => {
+        let state = featuregrid({showAgain: false}, toggleShowAgain());
+        expect(state).toExist();
+        expect(state.showAgain).toBe(true);
+        let state2 = featuregrid({showAgain: true}, toggleShowAgain());
+        expect(state2.showAgain).toBe(false);
+    });
+    it('initPlugin', () => {
+        const someValue = "someValue";
+        const editingAllowedRoles = [someValue];
+        let state = featuregrid({}, initPlugin({editingAllowedRoles}));
+        expect(state).toExist();
+        expect(state.editingAllowedRoles.length).toBe(1);
+        expect(state.editingAllowedRoles[0]).toBe(someValue);
+    });
+    it('openFeatureGrid', () => {
+        let state = featuregrid(undefined, openFeatureGrid());
+        expect(state).toExist();
+        expect(state.open).toBe(true);
+    });
+    it('closeFeatureGrid', () => {
+        let state = featuregrid(undefined, closeFeatureGrid());
+        expect(state).toExist();
+        expect(state.open).toBe(false);
+        expect(state.mode).toBe(MODES.VIEW);
+    });
 
-    // it('selectFeature', () => {
-    //     // TODO FIX this test or the reducer
-    //     // single select
-    //     let state = featuregrid( undefined, selectFeatures([1, 2]));
-    //     expect(state.select).toExist();
-    //     expect(state.select.length).toBe(1);
-    //     expect(state.select[0]).toBe(1);
-    //     state = featuregrid( state, selectFeatures([1, 2]));
-    //     expect(state.select).toExist();
-    //     expect(state.select.length).toBe(1);
-    //     expect(state.select[0]).toBe(1);
-    //     // check multiselect true, append false
-    //     state = featuregrid(undefined, {type: 'UNKNOWN'});
-    //     state = featuregrid({...state, multiselect: true}, selectFeatures([1, 2], false));
-    //     expect(state.select).toExist();
-    //     expect(state.select.length).toBe(1);
-    //     expect(state.select[0]).toBe(1);
+    it('selectFeature', () => {
+        // TODO FIX this test or the reducer
+        // single select
+        let state = featuregrid( undefined, selectFeatures([1, 2]));
+        expect(state.select).toExist();
+        expect(state.select.length).toBe(1);
+        expect(state.select[0]).toBe(1);
+        state = featuregrid( state, selectFeatures([1, 2]));
+        expect(state.select).toExist();
+        expect(state.select.length).toBe(1);
+        expect(state.select[0]).toBe(1);
+        // check multiselect true, append false
+        state = featuregrid(undefined, {type: 'UNKNOWN'});
+        state = featuregrid({...state, multiselect: true}, selectFeatures([1, 2], false));
+        expect(state.select).toExist();
+        expect(state.select.length).toBe(1);
+        expect(state.select[0]).toBe(1);
 
-    //     // check multiselect true, append true
-    //     state = featuregrid( state, selectFeatures([3], true));
-    //     expect(state.select).toExist();
-    //     expect(state.select.length).toBe(2);
-    //     expect(state.select[1]).toBe(3);
-    // });
+        // check multiselect true, append true
+        state = featuregrid( state, selectFeatures([3], true));
+        expect(state.select).toExist();
+        expect(state.select.length).toBe(2);
+        expect(state.select[1]).toBe(3);
+    });
 
-    // it('clearSelection', () => {
-    //     let state = featuregrid({select: [1, 2]}, clearSelection());
-    //     expect(state.select).toExist();
-    //     expect(state.select.length).toBe(0);
-    // });
-    // it('featureModified', () => {
-    //     const features = [feature1, feature2];
-    //     let updated = [{
-    //         geometry: null,
-    //         id: idFt2
-    //     }, {
-    //         name: "newName",
-    //         id: idFt1
-    //     }];
-    //     let state = featuregrid({select: [1, 2]}, featureModified(features, updated));
-    //     expect(state.changes.length).toBe(2);
-    //     expect(state.select).toExist();
-    // });
-    // it('deselectFeature', () => {
-    //     let state = featuregrid( {select: [1, 2], changes: []}, deselectFeatures([1]));
-    //     expect(state.select).toExist();
-    //     expect(state.select[0]).toBe(2);
-    // });
+    it('clearSelection', () => {
+        let state = featuregrid({select: [1, 2]}, clearSelection());
+        expect(state.select).toExist();
+        expect(state.select.length).toBe(0);
+    });
+    it('featureModified', () => {
+        const features = [feature1, feature2];
+        let updated = [{
+            geometry: null,
+            id: idFt2
+        }, {
+            name: "newName",
+            id: idFt1
+        }];
+        let state = featuregrid({select: [1, 2]}, featureModified(features, updated));
+        expect(state.changes.length).toBe(2);
+        expect(state.select).toExist();
+    });
+    it('deselectFeature', () => {
+        let state = featuregrid( {select: [1, 2], changes: []}, deselectFeatures([1]));
+        expect(state.select).toExist();
+        expect(state.select[0]).toBe(2);
+    });
 
-    // it('toggleSelection', () => {
-    //     let state = featuregrid( {select: [1, 2], multiselect: true, changes: []}, toggleSelection([1]));
-    //     expect(state.select).toExist();
-    //     expect(state.select[0]).toBe(2);
-    //     expect(state.select.length).toBe(1);
-    //     state = featuregrid( state, toggleSelection([2]));
-    //     expect(state.select.length).toBe(0);
-    //     state = featuregrid( state, toggleSelection([6]));
-    //     expect(state.select.length).toBe(1);
-    //     expect(state.select[0]).toBe(6);
-    //     state = featuregrid( state, toggleSelection([6]));
-    //     expect(state.select.length).toBe(0);
-    // });
+    it('toggleSelection', () => {
+        let state = featuregrid( {select: [1, 2], multiselect: true, changes: []}, toggleSelection([1]));
+        expect(state.select).toExist();
+        expect(state.select[0]).toBe(2);
+        expect(state.select.length).toBe(1);
+        state = featuregrid( state, toggleSelection([2]));
+        expect(state.select.length).toBe(0);
+        state = featuregrid( state, toggleSelection([6]));
+        expect(state.select.length).toBe(1);
+        expect(state.select[0]).toBe(6);
+        state = featuregrid( state, toggleSelection([6]));
+        expect(state.select.length).toBe(0);
+    });
 
-    // it('setFeatures', () => {
-    //     let state = featuregrid( {}, setFeatures(museam.features));
-    //     expect(state.features).toExist();
-    //     expect(state.features.length).toBe(1);
-    // });
-    // it('dockSizeFeatures', () => {
-    //     let state = featuregrid( {}, dockSizeFeatures(200));
-    //     expect(state.dockSize).toBe(200);
-    // });
-    // it('toggleEditMode edit', () => {
-    //     let state = featuregrid( {}, toggleEditMode());
-    //     expect(state.multiselect).toBeTruthy();
-    //     expect(state.mode).toBe(MODES.EDIT);
-    //     expect(state.tools.settings).toBeFalsy();
-    // });
-    // it('toggleViewMode view', () => {
-    //     let state = featuregrid( {}, toggleViewMode());
-    //     expect(state.multiselect).toBeFalsy();
-    //     expect(state.mode).toBe(MODES.VIEW);
-    // });
-    // it('featureSaving', () => {
-    //     let state = featuregrid( {}, featureSaving());
-    //     expect(state.saving).toBeTruthy();
-    //     expect(state.loading).toBeTruthy();
-    // });
-    // it('saveSuccess', () => {
-    //     let state = featuregrid( {}, saveSuccess());
-    //     expect(state.deleteConfirm).toBeFalsy();
-    //     expect(state.saved).toBeTruthy();
-    //     expect(state.saving).toBeFalsy();
-    //     expect(state.loading).toBeFalsy();
-    // });
-    // it('clearChanges', () => {
-    //     let state = featuregrid( {select: [feature1, feature2]}, clearChanges());
-    //     expect(state.deleteConfirm).toBeFalsy();
-    //     expect(state.saved).toBeFalsy();
-    //     expect(state.newFeatures.length).toBe(0);
-    //     expect(state.changes.length).toBe(0);
-    // });
-    // it('createNewFeatures', () => {
-    //     let state = featuregrid( {}, createNewFeatures([1]));
-    //     expect(state.deleteConfirm).toBeFalsy();
-    //     expect(state.saved).toBeFalsy();
-    //     expect(state.newFeatures.length).toBe(1);
-    // });
-    // it('saveError', () => {
-    //     let state = featuregrid( {}, saveError());
-    //     expect(state.deleteConfirm).toBeFalsy();
-    //     expect(state.saving).toBeFalsy();
-    //     expect(state.loading).toBeFalsy();
-    // });
-    // it('setLayer', () => {
-    //     let state = featuregrid( {}, setLayer("TEST_ID"));
-    //     expect(state.selectedLayer).toBe("TEST_ID");
-    // });
-    // it('toggleTool', () => {
-    //     let state = featuregrid( {}, toggleTool("toolA"));
-    //     expect(state.tools).toExist();
-    //     expect(state.tools.toolA).toBe(true);
-    //     state = featuregrid( state, toggleTool("toolA"));
-    //     expect(state.tools.toolA).toBe(false);
-    //     state = featuregrid( state, toggleTool("toolA", "value"));
-    //     expect(state.tools.toolA).toBe("value");
-    // });
-    // it('customizeAttribute', () => {
-    //     let state = featuregrid( {}, customizeAttribute("attrA", "test", true));
-    //     expect(state.attributes).toExist();
-    //     expect(state.attributes.attrA).toExist();
-    //     expect(state.attributes.attrA.test).toBe(true);
-    //     // auto toggle
-    //     state = featuregrid( state, customizeAttribute("attrA", "test"));
-    //     expect(state.attributes.attrA.test).toBe(false);
-    //     state = featuregrid( state, customizeAttribute("attrA", "test", "value"));
-    //     expect(state.attributes.attrA.test).toBe("value");
-    // });
-    // it('startDrawingFeature', () => {
-    //     let state = featuregrid( {drawing: true}, startDrawingFeature());
-    //     expect(state.drawing).toBe(false);
-    // });
-    // it('setSelectionOptions({multiselect= false} = {})', () => {
-    //     let state = featuregrid( {}, setSelectionOptions({}));
-    //     expect(state.multiselect).toBe(false);
-    // });
-    // it('changePage', () => {
-    //     let state = featuregrid( {}, changePage(1, 4));
-    //     expect(state.pagination.size).toBe(4);
-    //     expect(state.pagination.page).toBe(1);
-    // });
-    // it('setPermission', () => {
-    //     let state = featuregrid( {}, setPermission({canEdit: true}));
-    //     expect(state.canEdit).toBe(true);
-    // });
+    it('setFeatures', () => {
+        let state = featuregrid( {}, setFeatures(museam.features));
+        expect(state.features).toExist();
+        expect(state.features.length).toBe(1);
+    });
+    it('dockSizeFeatures', () => {
+        let state = featuregrid( {}, dockSizeFeatures(200));
+        expect(state.dockSize).toBe(200);
+    });
+    it('toggleEditMode edit', () => {
+        let state = featuregrid( {}, toggleEditMode());
+        expect(state.multiselect).toBeTruthy();
+        expect(state.mode).toBe(MODES.EDIT);
+        expect(state.tools.settings).toBeFalsy();
+    });
+    it('toggleViewMode view', () => {
+        let state = featuregrid( {}, toggleViewMode());
+        expect(state.multiselect).toBeFalsy();
+        expect(state.mode).toBe(MODES.VIEW);
+    });
+    it('featureSaving', () => {
+        let state = featuregrid( {}, featureSaving());
+        expect(state.saving).toBeTruthy();
+        expect(state.loading).toBeTruthy();
+    });
+    it('saveSuccess', () => {
+        let state = featuregrid( {}, saveSuccess());
+        expect(state.deleteConfirm).toBeFalsy();
+        expect(state.saved).toBeTruthy();
+        expect(state.saving).toBeFalsy();
+        expect(state.loading).toBeFalsy();
+    });
+    it('clearChanges', () => {
+        let state = featuregrid( {select: [feature1, feature2]}, clearChanges());
+        expect(state.deleteConfirm).toBeFalsy();
+        expect(state.saved).toBeFalsy();
+        expect(state.newFeatures.length).toBe(0);
+        expect(state.changes.length).toBe(0);
+    });
+    it('createNewFeatures', () => {
+        let state = featuregrid( {}, createNewFeatures([1]));
+        expect(state.deleteConfirm).toBeFalsy();
+        expect(state.saved).toBeFalsy();
+        expect(state.newFeatures.length).toBe(1);
+    });
+    it('saveError', () => {
+        let state = featuregrid( {}, saveError());
+        expect(state.deleteConfirm).toBeFalsy();
+        expect(state.saving).toBeFalsy();
+        expect(state.loading).toBeFalsy();
+    });
+    it('setLayer', () => {
+        let state = featuregrid( {}, setLayer("TEST_ID"));
+        expect(state.selectedLayer).toBe("TEST_ID");
+    });
+    it('toggleTool', () => {
+        let state = featuregrid( {}, toggleTool("toolA"));
+        expect(state.tools).toExist();
+        expect(state.tools.toolA).toBe(true);
+        state = featuregrid( state, toggleTool("toolA"));
+        expect(state.tools.toolA).toBe(false);
+        state = featuregrid( state, toggleTool("toolA", "value"));
+        expect(state.tools.toolA).toBe("value");
+    });
+    it('customizeAttribute', () => {
+        let state = featuregrid( {}, customizeAttribute("attrA", "test", true));
+        expect(state.attributes).toExist();
+        expect(state.attributes.attrA).toExist();
+        expect(state.attributes.attrA.test).toBe(true);
+        // auto toggle
+        state = featuregrid( state, customizeAttribute("attrA", "test"));
+        expect(state.attributes.attrA.test).toBe(false);
+        state = featuregrid( state, customizeAttribute("attrA", "test", "value"));
+        expect(state.attributes.attrA.test).toBe("value");
+    });
+    it('startDrawingFeature', () => {
+        let state = featuregrid( {drawing: true}, startDrawingFeature());
+        expect(state.drawing).toBe(false);
+    });
+    it('setSelectionOptions({multiselect= false} = {})', () => {
+        let state = featuregrid( {}, setSelectionOptions({}));
+        expect(state.multiselect).toBe(false);
+    });
+    it('changePage', () => {
+        let state = featuregrid( {}, changePage(1, 4));
+        expect(state.pagination.size).toBe(4);
+        expect(state.pagination.page).toBe(1);
+    });
+    it('setPermission', () => {
+        let state = featuregrid( {}, setPermission({canEdit: true}));
+        expect(state.canEdit).toBe(true);
+    });
 
-    // it('CHANGE_DRAWING_STATUS', () => {
-    //     let state = featuregrid( {}, changeDrawingStatus("clean"));
-    //     expect(state.drawing).toBe(false);
-    //     state = featuregrid( {drawing: true, pagination: {size: 3}}, changeDrawingStatus("stop"));
-    //     expect(state.drawing).toBe(true);
-    //     expect(state.pagination.size).toBe(3);
-    // });
-    // it('DELETE_GEOMETRY_FEATURE', () => {
-    //     let state = featuregrid( {newFeatures: []}, deleteGeometryFeature([feature1]));
-    //     expect(state.changes.length).toBe(1);
-    //     expect(state.newFeatures.length).toBe(0);
-    //     state = featuregrid( {newFeatures: [newfeature3], changes: []}, deleteGeometryFeature([newfeature3]));
-    //     expect(state.changes.length).toBe(0);
-    //     expect(state.newFeatures.length).toBe(1);
-    // });
-    // it('GEOMETRY_CHANGED', () => {
-    //     let state = featuregrid( {newFeatures: []}, geometryChanged([feature1]));
-    //     expect(state.changes.length).toBe(1);
-    //     expect(state.newFeatures.length).toBe(0);
-    //     state = featuregrid( state, geometryChanged([feature1]));
-    //     expect(state.changes.length).toBe(2);
+    it('CHANGE_DRAWING_STATUS', () => {
+        let state = featuregrid( {}, changeDrawingStatus("clean"));
+        expect(state.drawing).toBe(false);
+        state = featuregrid( {drawing: true, pagination: {size: 3}}, changeDrawingStatus("stop"));
+        expect(state.drawing).toBe(true);
+        expect(state.pagination.size).toBe(3);
+    });
+    it('DELETE_GEOMETRY_FEATURE', () => {
+        let state = featuregrid( {newFeatures: []}, deleteGeometryFeature([feature1]));
+        expect(state.changes.length).toBe(1);
+        expect(state.newFeatures.length).toBe(0);
+        state = featuregrid( {newFeatures: [newfeature3], changes: []}, deleteGeometryFeature([newfeature3]));
+        expect(state.changes.length).toBe(0);
+        expect(state.newFeatures.length).toBe(1);
+    });
+    it('GEOMETRY_CHANGED', () => {
+        let state = featuregrid( {newFeatures: []}, geometryChanged([feature1]));
+        expect(state.changes.length).toBe(1);
+        expect(state.newFeatures.length).toBe(0);
+        state = featuregrid( state, geometryChanged([feature1]));
+        expect(state.changes.length).toBe(2);
 
-    // });
-    // it('DISABLE_TOOLBAR', () => {
-    //     let state = featuregrid({}, {type: "UNKNOWN"});
-    //     expect(state.disableToolbar).toBeFalsy();
-    //     state = featuregrid({}, disableToolbar(true));
-    //     expect(state.disableToolbar).toBe(true);
+    });
+    it('DISABLE_TOOLBAR', () => {
+        let state = featuregrid({}, {type: "UNKNOWN"});
+        expect(state.disableToolbar).toBeFalsy();
+        state = featuregrid({}, disableToolbar(true));
+        expect(state.disableToolbar).toBe(true);
 
-    //     state = featuregrid({}, disableToolbar(false));
-    //     expect(state.disableToolbar).toBe(false);
+        state = featuregrid({}, disableToolbar(false));
+        expect(state.disableToolbar).toBe(false);
 
-    // });
-    // it('UPDATE_FILTER', () => {
-    //     const update = {attribute: "ATTRIBUTE", opeartor: "OPERATOR", value: "VAL", rawValue: "RAWVAL"};
-    //     let state = featuregrid({}, updateFilter(update));
-    //     expect(state.filters).toExist();
-    //     expect(state.filters[update.attribute]).toExist();
-    //     expect(state.filters[update.attribute].value).toBe(update.value);
-    //     state = featuregrid({}, createQuery("url", {}));
-    //     expect(state.filters).toExist();
-    //     expect(state.filters[update.attribute]).toNotExist();
+    });
+    it('UPDATE_FILTER', () => {
+        const update = {attribute: "ATTRIBUTE", opeartor: "OPERATOR", value: "VAL", rawValue: "RAWVAL"};
+        let state = featuregrid({}, updateFilter(update));
+        expect(state.filters).toExist();
+        expect(state.filters[update.attribute]).toExist();
+        expect(state.filters[update.attribute].value).toBe(update.value);
+        state = featuregrid({}, createQuery("url", {}));
+        expect(state.filters).toExist();
+        expect(state.filters[update.attribute]).toNotExist();
 
-    // });
-    // it('featureTypeLoaded', () => {
-    //     let state = featuregrid( {}, featureTypeLoaded("typeName", {
-    //         original: {featureTypes: [
-    //         {
-    //             properties: [
-    //                 {},
-    //                 {localType: "Point"}
-    //             ]
-    //         }]}}));
-    //     expect(state.localType).toBe("Point");
+    });
+    it('featureTypeLoaded', () => {
+        let state = featuregrid( {}, featureTypeLoaded("typeName", {
+            original: {featureTypes: [
+            {
+                properties: [
+                    {},
+                    {localType: "Point"}
+                ]
+            }]}}));
+        expect(state.localType).toBe("Point");
 
-    // });
-    // it('SIZE_CHANGE', () => {
-    //     let state = featuregrid({}, sizeChange(0.5, {maxDockSize: 0.7, minDockSize: 0.1}));
-    //     expect(state.dockSize).toBe(0.5);
-    //     state = featuregrid({}, sizeChange(0.8, {maxDockSize: 0.7, minDockSize: 0.1}));
-    //     expect(state.dockSize).toBe(0.7);
-    //     state = featuregrid({}, sizeChange(0.05, {maxDockSize: 0.7, minDockSize: 0.1}));
-    //     expect(state.dockSize).toBe(0.1);
-    //     state = featuregrid({}, sizeChange(0.5));
-    //     expect(state.dockSize).toBe(0.5);
-    // });
-    // it("storeAdvancedSearchFilter", () => {
-    //     const filterObj = {test: 'test'};
-    //     let state = featuregrid({selectedLayer: "test_layer"}, storeAdvancedSearchFilter(filterObj));
-    //     expect(state.advancedFilters.test_layer).toBe(filterObj);
-    // });
+    });
+    it('SIZE_CHANGE', () => {
+        let state = featuregrid({}, sizeChange(0.5, {maxDockSize: 0.7, minDockSize: 0.1}));
+        expect(state.dockSize).toBe(0.5);
+        state = featuregrid({}, sizeChange(0.8, {maxDockSize: 0.7, minDockSize: 0.1}));
+        expect(state.dockSize).toBe(0.7);
+        state = featuregrid({}, sizeChange(0.05, {maxDockSize: 0.7, minDockSize: 0.1}));
+        expect(state.dockSize).toBe(0.1);
+        state = featuregrid({}, sizeChange(0.5));
+        expect(state.dockSize).toBe(0.5);
+    });
+    it("storeAdvancedSearchFilter", () => {
+        const filterObj = {test: 'test'};
+        let state = featuregrid({selectedLayer: "test_layer"}, storeAdvancedSearchFilter(filterObj));
+        expect(state.advancedFilters.test_layer).toBe(filterObj);
+    });
     it('SET_SHOW_CURRENT_FILTER', () => {
         let state = featuregrid({}, setShowCurrentFilter(true));
         expect(state.showFilteredObject).toBe(true);

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -47,7 +47,7 @@ const featuregrid = require('../featuregrid');
 const {setFeatures, dockSizeFeatures, setLayer, toggleTool, customizeAttribute, selectFeatures, deselectFeatures, createNewFeatures, updateFilter,
     featureSaving, toggleSelection, clearSelection, MODES, toggleEditMode, toggleViewMode, saveSuccess, clearChanges, saveError, startDrawingFeature,
     deleteGeometryFeature, geometryChanged, setSelectionOptions, changePage, featureModified, setPermission, disableToolbar, openFeatureGrid, closeFeatureGrid,
-    toggleShowAgain, hideSyncPopover, initPlugin, sizeChange, storeAdvancedSearchFilter} = require('../../actions/featuregrid');
+    toggleShowAgain, hideSyncPopover, initPlugin, sizeChange, storeAdvancedSearchFilter, setShowCurrentFilter} = require('../../actions/featuregrid');
 const {featureTypeLoaded, createQuery} = require('../../actions/wfsquery');
 
 const {changeDrawingStatus} = require('../../actions/draw');
@@ -55,273 +55,277 @@ const {changeDrawingStatus} = require('../../actions/draw');
 const museam = require('json-loader!../../test-resources/wfs/museam.json');
 describe('Test the featuregrid reducer', () => {
 
-    it('returns original state on unrecognized action', () => {
-        let state = featuregrid(1, {type: 'UNKNOWN'});
-        expect(state).toBe(1);
-    });
-    it('default state', () => {
-        let state = featuregrid(undefined, {type: 'UNKNOWN'});
-        expect(state).toExist();
-        expect(state.pagination).toExist();
-        expect(state.select).toExist();
-        expect(state.features).toExist();
-    });
-    it('hideSyncPopover', () => {
-        let state = featuregrid({}, hideSyncPopover());
-        expect(state.showPopoverSync).toBe(false);
-    });
-    it('toggleShowAgain toggling', () => {
-        let state = featuregrid({showAgain: false}, toggleShowAgain());
-        expect(state).toExist();
-        expect(state.showAgain).toBe(true);
-        let state2 = featuregrid({showAgain: true}, toggleShowAgain());
-        expect(state2.showAgain).toBe(false);
-    });
-    it('initPlugin', () => {
-        const someValue = "someValue";
-        const editingAllowedRoles = [someValue];
-        let state = featuregrid({}, initPlugin({editingAllowedRoles}));
-        expect(state).toExist();
-        expect(state.editingAllowedRoles.length).toBe(1);
-        expect(state.editingAllowedRoles[0]).toBe(someValue);
-    });
-    it('openFeatureGrid', () => {
-        let state = featuregrid(undefined, openFeatureGrid());
-        expect(state).toExist();
-        expect(state.open).toBe(true);
-    });
-    it('closeFeatureGrid', () => {
-        let state = featuregrid(undefined, closeFeatureGrid());
-        expect(state).toExist();
-        expect(state.open).toBe(false);
-        expect(state.mode).toBe(MODES.VIEW);
-    });
+    // it('returns original state on unrecognized action', () => {
+    //     let state = featuregrid(1, {type: 'UNKNOWN'});
+    //     expect(state).toBe(1);
+    // });
+    // it('default state', () => {
+    //     let state = featuregrid(undefined, {type: 'UNKNOWN'});
+    //     expect(state).toExist();
+    //     expect(state.pagination).toExist();
+    //     expect(state.select).toExist();
+    //     expect(state.features).toExist();
+    // });
+    // it('hideSyncPopover', () => {
+    //     let state = featuregrid({}, hideSyncPopover());
+    //     expect(state.showPopoverSync).toBe(false);
+    // });
+    // it('toggleShowAgain toggling', () => {
+    //     let state = featuregrid({showAgain: false}, toggleShowAgain());
+    //     expect(state).toExist();
+    //     expect(state.showAgain).toBe(true);
+    //     let state2 = featuregrid({showAgain: true}, toggleShowAgain());
+    //     expect(state2.showAgain).toBe(false);
+    // });
+    // it('initPlugin', () => {
+    //     const someValue = "someValue";
+    //     const editingAllowedRoles = [someValue];
+    //     let state = featuregrid({}, initPlugin({editingAllowedRoles}));
+    //     expect(state).toExist();
+    //     expect(state.editingAllowedRoles.length).toBe(1);
+    //     expect(state.editingAllowedRoles[0]).toBe(someValue);
+    // });
+    // it('openFeatureGrid', () => {
+    //     let state = featuregrid(undefined, openFeatureGrid());
+    //     expect(state).toExist();
+    //     expect(state.open).toBe(true);
+    // });
+    // it('closeFeatureGrid', () => {
+    //     let state = featuregrid(undefined, closeFeatureGrid());
+    //     expect(state).toExist();
+    //     expect(state.open).toBe(false);
+    //     expect(state.mode).toBe(MODES.VIEW);
+    // });
 
-    it('selectFeature', () => {
-        // TODO FIX this test or the reducer
-        // single select
-        let state = featuregrid( undefined, selectFeatures([1, 2]));
-        expect(state.select).toExist();
-        expect(state.select.length).toBe(1);
-        expect(state.select[0]).toBe(1);
-        state = featuregrid( state, selectFeatures([1, 2]));
-        expect(state.select).toExist();
-        expect(state.select.length).toBe(1);
-        expect(state.select[0]).toBe(1);
-        // check multiselect true, append false
-        state = featuregrid(undefined, {type: 'UNKNOWN'});
-        state = featuregrid({...state, multiselect: true}, selectFeatures([1, 2], false));
-        expect(state.select).toExist();
-        expect(state.select.length).toBe(1);
-        expect(state.select[0]).toBe(1);
+    // it('selectFeature', () => {
+    //     // TODO FIX this test or the reducer
+    //     // single select
+    //     let state = featuregrid( undefined, selectFeatures([1, 2]));
+    //     expect(state.select).toExist();
+    //     expect(state.select.length).toBe(1);
+    //     expect(state.select[0]).toBe(1);
+    //     state = featuregrid( state, selectFeatures([1, 2]));
+    //     expect(state.select).toExist();
+    //     expect(state.select.length).toBe(1);
+    //     expect(state.select[0]).toBe(1);
+    //     // check multiselect true, append false
+    //     state = featuregrid(undefined, {type: 'UNKNOWN'});
+    //     state = featuregrid({...state, multiselect: true}, selectFeatures([1, 2], false));
+    //     expect(state.select).toExist();
+    //     expect(state.select.length).toBe(1);
+    //     expect(state.select[0]).toBe(1);
 
-        // check multiselect true, append true
-        state = featuregrid( state, selectFeatures([3], true));
-        expect(state.select).toExist();
-        expect(state.select.length).toBe(2);
-        expect(state.select[1]).toBe(3);
-    });
+    //     // check multiselect true, append true
+    //     state = featuregrid( state, selectFeatures([3], true));
+    //     expect(state.select).toExist();
+    //     expect(state.select.length).toBe(2);
+    //     expect(state.select[1]).toBe(3);
+    // });
 
-    it('clearSelection', () => {
-        let state = featuregrid({select: [1, 2]}, clearSelection());
-        expect(state.select).toExist();
-        expect(state.select.length).toBe(0);
-    });
-    it('featureModified', () => {
-        const features = [feature1, feature2];
-        let updated = [{
-            geometry: null,
-            id: idFt2
-        }, {
-            name: "newName",
-            id: idFt1
-        }];
-        let state = featuregrid({select: [1, 2]}, featureModified(features, updated));
-        expect(state.changes.length).toBe(2);
-        expect(state.select).toExist();
-    });
-    it('deselectFeature', () => {
-        let state = featuregrid( {select: [1, 2], changes: []}, deselectFeatures([1]));
-        expect(state.select).toExist();
-        expect(state.select[0]).toBe(2);
-    });
+    // it('clearSelection', () => {
+    //     let state = featuregrid({select: [1, 2]}, clearSelection());
+    //     expect(state.select).toExist();
+    //     expect(state.select.length).toBe(0);
+    // });
+    // it('featureModified', () => {
+    //     const features = [feature1, feature2];
+    //     let updated = [{
+    //         geometry: null,
+    //         id: idFt2
+    //     }, {
+    //         name: "newName",
+    //         id: idFt1
+    //     }];
+    //     let state = featuregrid({select: [1, 2]}, featureModified(features, updated));
+    //     expect(state.changes.length).toBe(2);
+    //     expect(state.select).toExist();
+    // });
+    // it('deselectFeature', () => {
+    //     let state = featuregrid( {select: [1, 2], changes: []}, deselectFeatures([1]));
+    //     expect(state.select).toExist();
+    //     expect(state.select[0]).toBe(2);
+    // });
 
-    it('toggleSelection', () => {
-        let state = featuregrid( {select: [1, 2], multiselect: true, changes: []}, toggleSelection([1]));
-        expect(state.select).toExist();
-        expect(state.select[0]).toBe(2);
-        expect(state.select.length).toBe(1);
-        state = featuregrid( state, toggleSelection([2]));
-        expect(state.select.length).toBe(0);
-        state = featuregrid( state, toggleSelection([6]));
-        expect(state.select.length).toBe(1);
-        expect(state.select[0]).toBe(6);
-        state = featuregrid( state, toggleSelection([6]));
-        expect(state.select.length).toBe(0);
-    });
+    // it('toggleSelection', () => {
+    //     let state = featuregrid( {select: [1, 2], multiselect: true, changes: []}, toggleSelection([1]));
+    //     expect(state.select).toExist();
+    //     expect(state.select[0]).toBe(2);
+    //     expect(state.select.length).toBe(1);
+    //     state = featuregrid( state, toggleSelection([2]));
+    //     expect(state.select.length).toBe(0);
+    //     state = featuregrid( state, toggleSelection([6]));
+    //     expect(state.select.length).toBe(1);
+    //     expect(state.select[0]).toBe(6);
+    //     state = featuregrid( state, toggleSelection([6]));
+    //     expect(state.select.length).toBe(0);
+    // });
 
-    it('setFeatures', () => {
-        let state = featuregrid( {}, setFeatures(museam.features));
-        expect(state.features).toExist();
-        expect(state.features.length).toBe(1);
-    });
-    it('dockSizeFeatures', () => {
-        let state = featuregrid( {}, dockSizeFeatures(200));
-        expect(state.dockSize).toBe(200);
-    });
-    it('toggleEditMode edit', () => {
-        let state = featuregrid( {}, toggleEditMode());
-        expect(state.multiselect).toBeTruthy();
-        expect(state.mode).toBe(MODES.EDIT);
-        expect(state.tools.settings).toBeFalsy();
-    });
-    it('toggleViewMode view', () => {
-        let state = featuregrid( {}, toggleViewMode());
-        expect(state.multiselect).toBeFalsy();
-        expect(state.mode).toBe(MODES.VIEW);
-    });
-    it('featureSaving', () => {
-        let state = featuregrid( {}, featureSaving());
-        expect(state.saving).toBeTruthy();
-        expect(state.loading).toBeTruthy();
-    });
-    it('saveSuccess', () => {
-        let state = featuregrid( {}, saveSuccess());
-        expect(state.deleteConfirm).toBeFalsy();
-        expect(state.saved).toBeTruthy();
-        expect(state.saving).toBeFalsy();
-        expect(state.loading).toBeFalsy();
-    });
-    it('clearChanges', () => {
-        let state = featuregrid( {select: [feature1, feature2]}, clearChanges());
-        expect(state.deleteConfirm).toBeFalsy();
-        expect(state.saved).toBeFalsy();
-        expect(state.newFeatures.length).toBe(0);
-        expect(state.changes.length).toBe(0);
-    });
-    it('createNewFeatures', () => {
-        let state = featuregrid( {}, createNewFeatures([1]));
-        expect(state.deleteConfirm).toBeFalsy();
-        expect(state.saved).toBeFalsy();
-        expect(state.newFeatures.length).toBe(1);
-    });
-    it('saveError', () => {
-        let state = featuregrid( {}, saveError());
-        expect(state.deleteConfirm).toBeFalsy();
-        expect(state.saving).toBeFalsy();
-        expect(state.loading).toBeFalsy();
-    });
-    it('setLayer', () => {
-        let state = featuregrid( {}, setLayer("TEST_ID"));
-        expect(state.selectedLayer).toBe("TEST_ID");
-    });
-    it('toggleTool', () => {
-        let state = featuregrid( {}, toggleTool("toolA"));
-        expect(state.tools).toExist();
-        expect(state.tools.toolA).toBe(true);
-        state = featuregrid( state, toggleTool("toolA"));
-        expect(state.tools.toolA).toBe(false);
-        state = featuregrid( state, toggleTool("toolA", "value"));
-        expect(state.tools.toolA).toBe("value");
-    });
-    it('customizeAttribute', () => {
-        let state = featuregrid( {}, customizeAttribute("attrA", "test", true));
-        expect(state.attributes).toExist();
-        expect(state.attributes.attrA).toExist();
-        expect(state.attributes.attrA.test).toBe(true);
-        // auto toggle
-        state = featuregrid( state, customizeAttribute("attrA", "test"));
-        expect(state.attributes.attrA.test).toBe(false);
-        state = featuregrid( state, customizeAttribute("attrA", "test", "value"));
-        expect(state.attributes.attrA.test).toBe("value");
-    });
-    it('startDrawingFeature', () => {
-        let state = featuregrid( {drawing: true}, startDrawingFeature());
-        expect(state.drawing).toBe(false);
-    });
-    it('setSelectionOptions({multiselect= false} = {})', () => {
-        let state = featuregrid( {}, setSelectionOptions({}));
-        expect(state.multiselect).toBe(false);
-    });
-    it('changePage', () => {
-        let state = featuregrid( {}, changePage(1, 4));
-        expect(state.pagination.size).toBe(4);
-        expect(state.pagination.page).toBe(1);
-    });
-    it('setPermission', () => {
-        let state = featuregrid( {}, setPermission({canEdit: true}));
-        expect(state.canEdit).toBe(true);
-    });
+    // it('setFeatures', () => {
+    //     let state = featuregrid( {}, setFeatures(museam.features));
+    //     expect(state.features).toExist();
+    //     expect(state.features.length).toBe(1);
+    // });
+    // it('dockSizeFeatures', () => {
+    //     let state = featuregrid( {}, dockSizeFeatures(200));
+    //     expect(state.dockSize).toBe(200);
+    // });
+    // it('toggleEditMode edit', () => {
+    //     let state = featuregrid( {}, toggleEditMode());
+    //     expect(state.multiselect).toBeTruthy();
+    //     expect(state.mode).toBe(MODES.EDIT);
+    //     expect(state.tools.settings).toBeFalsy();
+    // });
+    // it('toggleViewMode view', () => {
+    //     let state = featuregrid( {}, toggleViewMode());
+    //     expect(state.multiselect).toBeFalsy();
+    //     expect(state.mode).toBe(MODES.VIEW);
+    // });
+    // it('featureSaving', () => {
+    //     let state = featuregrid( {}, featureSaving());
+    //     expect(state.saving).toBeTruthy();
+    //     expect(state.loading).toBeTruthy();
+    // });
+    // it('saveSuccess', () => {
+    //     let state = featuregrid( {}, saveSuccess());
+    //     expect(state.deleteConfirm).toBeFalsy();
+    //     expect(state.saved).toBeTruthy();
+    //     expect(state.saving).toBeFalsy();
+    //     expect(state.loading).toBeFalsy();
+    // });
+    // it('clearChanges', () => {
+    //     let state = featuregrid( {select: [feature1, feature2]}, clearChanges());
+    //     expect(state.deleteConfirm).toBeFalsy();
+    //     expect(state.saved).toBeFalsy();
+    //     expect(state.newFeatures.length).toBe(0);
+    //     expect(state.changes.length).toBe(0);
+    // });
+    // it('createNewFeatures', () => {
+    //     let state = featuregrid( {}, createNewFeatures([1]));
+    //     expect(state.deleteConfirm).toBeFalsy();
+    //     expect(state.saved).toBeFalsy();
+    //     expect(state.newFeatures.length).toBe(1);
+    // });
+    // it('saveError', () => {
+    //     let state = featuregrid( {}, saveError());
+    //     expect(state.deleteConfirm).toBeFalsy();
+    //     expect(state.saving).toBeFalsy();
+    //     expect(state.loading).toBeFalsy();
+    // });
+    // it('setLayer', () => {
+    //     let state = featuregrid( {}, setLayer("TEST_ID"));
+    //     expect(state.selectedLayer).toBe("TEST_ID");
+    // });
+    // it('toggleTool', () => {
+    //     let state = featuregrid( {}, toggleTool("toolA"));
+    //     expect(state.tools).toExist();
+    //     expect(state.tools.toolA).toBe(true);
+    //     state = featuregrid( state, toggleTool("toolA"));
+    //     expect(state.tools.toolA).toBe(false);
+    //     state = featuregrid( state, toggleTool("toolA", "value"));
+    //     expect(state.tools.toolA).toBe("value");
+    // });
+    // it('customizeAttribute', () => {
+    //     let state = featuregrid( {}, customizeAttribute("attrA", "test", true));
+    //     expect(state.attributes).toExist();
+    //     expect(state.attributes.attrA).toExist();
+    //     expect(state.attributes.attrA.test).toBe(true);
+    //     // auto toggle
+    //     state = featuregrid( state, customizeAttribute("attrA", "test"));
+    //     expect(state.attributes.attrA.test).toBe(false);
+    //     state = featuregrid( state, customizeAttribute("attrA", "test", "value"));
+    //     expect(state.attributes.attrA.test).toBe("value");
+    // });
+    // it('startDrawingFeature', () => {
+    //     let state = featuregrid( {drawing: true}, startDrawingFeature());
+    //     expect(state.drawing).toBe(false);
+    // });
+    // it('setSelectionOptions({multiselect= false} = {})', () => {
+    //     let state = featuregrid( {}, setSelectionOptions({}));
+    //     expect(state.multiselect).toBe(false);
+    // });
+    // it('changePage', () => {
+    //     let state = featuregrid( {}, changePage(1, 4));
+    //     expect(state.pagination.size).toBe(4);
+    //     expect(state.pagination.page).toBe(1);
+    // });
+    // it('setPermission', () => {
+    //     let state = featuregrid( {}, setPermission({canEdit: true}));
+    //     expect(state.canEdit).toBe(true);
+    // });
 
-    it('CHANGE_DRAWING_STATUS', () => {
-        let state = featuregrid( {}, changeDrawingStatus("clean"));
-        expect(state.drawing).toBe(false);
-        state = featuregrid( {drawing: true, pagination: {size: 3}}, changeDrawingStatus("stop"));
-        expect(state.drawing).toBe(true);
-        expect(state.pagination.size).toBe(3);
-    });
-    it('DELETE_GEOMETRY_FEATURE', () => {
-        let state = featuregrid( {newFeatures: []}, deleteGeometryFeature([feature1]));
-        expect(state.changes.length).toBe(1);
-        expect(state.newFeatures.length).toBe(0);
-        state = featuregrid( {newFeatures: [newfeature3], changes: []}, deleteGeometryFeature([newfeature3]));
-        expect(state.changes.length).toBe(0);
-        expect(state.newFeatures.length).toBe(1);
-    });
-    it('GEOMETRY_CHANGED', () => {
-        let state = featuregrid( {newFeatures: []}, geometryChanged([feature1]));
-        expect(state.changes.length).toBe(1);
-        expect(state.newFeatures.length).toBe(0);
-        state = featuregrid( state, geometryChanged([feature1]));
-        expect(state.changes.length).toBe(2);
+    // it('CHANGE_DRAWING_STATUS', () => {
+    //     let state = featuregrid( {}, changeDrawingStatus("clean"));
+    //     expect(state.drawing).toBe(false);
+    //     state = featuregrid( {drawing: true, pagination: {size: 3}}, changeDrawingStatus("stop"));
+    //     expect(state.drawing).toBe(true);
+    //     expect(state.pagination.size).toBe(3);
+    // });
+    // it('DELETE_GEOMETRY_FEATURE', () => {
+    //     let state = featuregrid( {newFeatures: []}, deleteGeometryFeature([feature1]));
+    //     expect(state.changes.length).toBe(1);
+    //     expect(state.newFeatures.length).toBe(0);
+    //     state = featuregrid( {newFeatures: [newfeature3], changes: []}, deleteGeometryFeature([newfeature3]));
+    //     expect(state.changes.length).toBe(0);
+    //     expect(state.newFeatures.length).toBe(1);
+    // });
+    // it('GEOMETRY_CHANGED', () => {
+    //     let state = featuregrid( {newFeatures: []}, geometryChanged([feature1]));
+    //     expect(state.changes.length).toBe(1);
+    //     expect(state.newFeatures.length).toBe(0);
+    //     state = featuregrid( state, geometryChanged([feature1]));
+    //     expect(state.changes.length).toBe(2);
 
-    });
-    it('DISABLE_TOOLBAR', () => {
-        let state = featuregrid({}, {type: "UNKNOWN"});
-        expect(state.disableToolbar).toBeFalsy();
-        state = featuregrid({}, disableToolbar(true));
-        expect(state.disableToolbar).toBe(true);
+    // });
+    // it('DISABLE_TOOLBAR', () => {
+    //     let state = featuregrid({}, {type: "UNKNOWN"});
+    //     expect(state.disableToolbar).toBeFalsy();
+    //     state = featuregrid({}, disableToolbar(true));
+    //     expect(state.disableToolbar).toBe(true);
 
-        state = featuregrid({}, disableToolbar(false));
-        expect(state.disableToolbar).toBe(false);
+    //     state = featuregrid({}, disableToolbar(false));
+    //     expect(state.disableToolbar).toBe(false);
 
-    });
-    it('UPDATE_FILTER', () => {
-        const update = {attribute: "ATTRIBUTE", opeartor: "OPERATOR", value: "VAL", rawValue: "RAWVAL"};
-        let state = featuregrid({}, updateFilter(update));
-        expect(state.filters).toExist();
-        expect(state.filters[update.attribute]).toExist();
-        expect(state.filters[update.attribute].value).toBe(update.value);
-        state = featuregrid({}, createQuery("url", {}));
-        expect(state.filters).toExist();
-        expect(state.filters[update.attribute]).toNotExist();
+    // });
+    // it('UPDATE_FILTER', () => {
+    //     const update = {attribute: "ATTRIBUTE", opeartor: "OPERATOR", value: "VAL", rawValue: "RAWVAL"};
+    //     let state = featuregrid({}, updateFilter(update));
+    //     expect(state.filters).toExist();
+    //     expect(state.filters[update.attribute]).toExist();
+    //     expect(state.filters[update.attribute].value).toBe(update.value);
+    //     state = featuregrid({}, createQuery("url", {}));
+    //     expect(state.filters).toExist();
+    //     expect(state.filters[update.attribute]).toNotExist();
 
-    });
-    it('featureTypeLoaded', () => {
-        let state = featuregrid( {}, featureTypeLoaded("typeName", {
-            original: {featureTypes: [
-            {
-                properties: [
-                    {},
-                    {localType: "Point"}
-                ]
-            }]}}));
-        expect(state.localType).toBe("Point");
+    // });
+    // it('featureTypeLoaded', () => {
+    //     let state = featuregrid( {}, featureTypeLoaded("typeName", {
+    //         original: {featureTypes: [
+    //         {
+    //             properties: [
+    //                 {},
+    //                 {localType: "Point"}
+    //             ]
+    //         }]}}));
+    //     expect(state.localType).toBe("Point");
 
-    });
-    it('SIZE_CHANGE', () => {
-        let state = featuregrid({}, sizeChange(0.5, {maxDockSize: 0.7, minDockSize: 0.1}));
-        expect(state.dockSize).toBe(0.5);
-        state = featuregrid({}, sizeChange(0.8, {maxDockSize: 0.7, minDockSize: 0.1}));
-        expect(state.dockSize).toBe(0.7);
-        state = featuregrid({}, sizeChange(0.05, {maxDockSize: 0.7, minDockSize: 0.1}));
-        expect(state.dockSize).toBe(0.1);
-        state = featuregrid({}, sizeChange(0.5));
-        expect(state.dockSize).toBe(0.5);
-    });
-    it("storeAdvancedSearchFilter", () => {
-        const filterObj = {test: 'test'};
-        let state = featuregrid({selectedLayer: "test_layer"}, storeAdvancedSearchFilter(filterObj));
-        expect(state.advancedFilters.test_layer).toBe(filterObj);
+    // });
+    // it('SIZE_CHANGE', () => {
+    //     let state = featuregrid({}, sizeChange(0.5, {maxDockSize: 0.7, minDockSize: 0.1}));
+    //     expect(state.dockSize).toBe(0.5);
+    //     state = featuregrid({}, sizeChange(0.8, {maxDockSize: 0.7, minDockSize: 0.1}));
+    //     expect(state.dockSize).toBe(0.7);
+    //     state = featuregrid({}, sizeChange(0.05, {maxDockSize: 0.7, minDockSize: 0.1}));
+    //     expect(state.dockSize).toBe(0.1);
+    //     state = featuregrid({}, sizeChange(0.5));
+    //     expect(state.dockSize).toBe(0.5);
+    // });
+    // it("storeAdvancedSearchFilter", () => {
+    //     const filterObj = {test: 'test'};
+    //     let state = featuregrid({selectedLayer: "test_layer"}, storeAdvancedSearchFilter(filterObj));
+    //     expect(state.advancedFilters.test_layer).toBe(filterObj);
+    // });
+    it('SET_SHOW_CURRENT_FILTER', () => {
+        let state = featuregrid({}, setShowCurrentFilter(true));
+        expect(state.showFilteredObject).toBe(true);
     });
 });

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -40,7 +40,8 @@ const {
     SIZE_CHANGE,
     STORE_ADVANCED_SEARCH_FILTER,
     GRID_QUERY_RESULT,
-    LOAD_MORE_FEATURES
+    LOAD_MORE_FEATURES,
+    SET_SHOW_CURRENT_FILTER
 } = require('../actions/featuregrid');
 const{
     FEATURE_TYPE_LOADED,
@@ -57,6 +58,7 @@ const emptyResultsState = {
     filters: {},
     editingAllowedRoles: ["ADMIN"],
     enableColumnFilters: true,
+    showFilteredObject: true,
     open: false,
     canEdit: false,
     focusOnEdit: true,
@@ -178,6 +180,9 @@ function featuregrid(state = emptyResultsState, action) {
             });
     case SET_SELECTION_OPTIONS: {
         return assign({}, state, {multiselect: action.multiselect});
+    }
+    case SET_SHOW_CURRENT_FILTER: {
+        return assign({}, state, { showFilteredObject: action.showFilteredObject});
     }
     case CLEAR_SELECTION:
         return assign({}, state, {select: [], changes: []});

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -8,8 +8,7 @@
 
 const expect = require('expect');
 const {
-    selectedFeatures
-} = require('../highlight');
+    selectedFeatures, filteredspatialObject, filteredspatialObjectCoord, filteredGeometry, filteredSpatialObjectId, filteredSpatialObjectCrs, filteredspatialObjectType} = require('../highlight');
 
 const idFt1 = "idFt1";
 const idFt2 = "idFt2";
@@ -40,10 +39,24 @@ const initialState = {
     featuregrid: {
         mode: modeEdit,
         select: [feature1, feature2],
-        changes: [feature2]
+        changes: [feature2],
+        showFilteredObject: true
     },
     highlight: {
         featuresPath: "featuregrid.select"
+    },
+    query: {
+        filterObj: {
+            spatialField: {
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [[ 1, 2]],
+                    projection: 'EPSG:3857',
+                    id: 'spatial_object'
+
+                }
+            }
+        }
     }
 };
 
@@ -59,5 +72,41 @@ describe('Test highlight selectors', () => {
         const features = selectedFeatures(initialState);
         expect(features).toExist();
         expect(features.length).toBe(0);
+    });
+    it('test filteredspatialObject', () => {
+        const spatialObject = initialState.query.filterObj.spatialField;
+        const features = filteredspatialObject(initialState);
+        expect(features).toExist();
+        expect(features).toBe(spatialObject);
+    });
+    it('test filteredGeometry', () => {
+        const geometry = initialState.query.filterObj.spatialField.geometry;
+        const features = filteredGeometry(initialState);
+        expect(features).toExist();
+        expect(features).toBe(geometry);
+    });
+    it('test filteredspatialObjectCoord', () => {
+        const coordinates = initialState.query.filterObj.spatialField.geometry.coordinates;
+        const features = filteredspatialObjectCoord(initialState);
+        expect(features).toExist();
+        expect(features).toBe(coordinates);
+    });
+    it('test filteredSpatialObjectId', () => {
+        const geometryId = initialState.query.filterObj.spatialField.geometry.id;
+        const features = filteredSpatialObjectId(initialState);
+        expect(features).toExist();
+        expect(features).toBe(geometryId);
+    });
+    it('test filteredSpatialObjectCrs', () => {
+        const geometryCrs = initialState.query.filterObj.spatialField.geometry.projection;
+        const features = filteredSpatialObjectCrs(initialState);
+        expect(features).toExist();
+        expect(features).toBe(geometryCrs);
+    });
+    it('test filteredspatialObjectType', () => {
+        const geometryType = initialState.query.filterObj.spatialField.geometry.type;
+        const features = filteredspatialObjectType(initialState);
+        expect(features).toExist();
+        expect(features).toBe(geometryType);
     });
 });

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -40,7 +40,8 @@ const initialState = {
         mode: modeEdit,
         select: [feature1, feature2],
         changes: [feature2],
-        showFilteredObject: true
+        showFilteredObject: true,
+        open: true
     },
     highlight: {
         featuresPath: "featuregrid.select"

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -8,7 +8,9 @@
 
 const expect = require('expect');
 const {
-    selectedFeatures, filteredspatialObject, filteredspatialObjectCoord, filteredGeometry, filteredSpatialObjectId, filteredSpatialObjectCrs, filteredspatialObjectType} = require('../highlight');
+    selectedFeatures, filteredspatialObject, filteredspatialObjectCoord,
+    filteredGeometry, filteredSpatialObjectId, filteredSpatialObjectCrs,
+    filteredspatialObjectType, filteredFeatures, highlighedFeatures} = require('../highlight');
 
 const idFt1 = "idFt1";
 const idFt2 = "idFt2";
@@ -35,6 +37,19 @@ let feature2 = {
         someProp: "someValue"
     }
 };
+
+let feature3 = [{
+    type: "Feature",
+    geometry: {
+        type: 'Polygon',
+        coordinates: [ [ 0.000008983152841195214, 0.000017966305681987637 ] ]
+    },
+    style: {
+        fillColor: 'rgba(255, 255, 255, 0.2)',
+        color: '#ffcc33'
+    },
+    id: 'spatial_object'
+}];
 const initialState = {
     featuregrid: {
         mode: modeEdit,
@@ -109,5 +124,17 @@ describe('Test highlight selectors', () => {
         const features = filteredspatialObjectType(initialState);
         expect(features).toExist();
         expect(features).toBe(geometryType);
+    });
+    it('test filteredFeatures', () => {
+        const features = filteredFeatures(initialState);
+        expect(features).toExist();
+        expect(features).toEqual(feature3);
+    });
+    it('test highlighedFeatures', () => {
+        const features = highlighedFeatures(initialState);
+        const featuresSelected = initialState.featuregrid.select;
+        const combinedFeatures = [...featuresSelected, ...feature3];
+        expect(features).toExist();
+        expect(features).toEqual(combinedFeatures);
     });
 });

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -1,7 +1,14 @@
 const {get} = require('lodash');
-
+const filteredspatialObject = state => get(state, state && state.featuregrid.showFilteredObject && "query.filterObj.spatialField");
+const filteredGeometry = state => get(state, "query.filterObj.spatialField.geometry");
 
 module.exports = {
-    selectedFeatures: (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures")
+    selectedFeatures: (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures"),
+    filteredspatialObjectType: (state) => filteredspatialObject(state) && filteredGeometry(state).type || "Polygon",
+    filteredspatialObjectCoord: (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [],
+    filteredSpatialObjectCrs: (state) => filteredGeometry(state) && filteredGeometry(state).projection,
+    filteredSpatialObjectId: (state) => filteredGeometry(state) && filteredGeometry(state).id,
+    filteredspatialObject,
+    filteredGeometry
 
 };

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -1,14 +1,53 @@
 const {get} = require('lodash');
-const filteredspatialObject = state => get(state, state && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
-const filteredGeometry = state => filteredspatialObject(state) && filteredspatialObject(state).geometry;
+const {createSelector} = require('reselect');
+const {reprojectGeoJson} = require('../utils/CoordinatesUtils');
+
+const selectedFeatures = (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures");
+const filteredspatialObject = (state) => get(state, state && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
+const filteredGeometry = (state) => filteredspatialObject(state) && filteredspatialObject(state).geometry;
+const filteredspatialObjectType = (state) => filteredGeometry(state) && filteredGeometry(state).type || "Polygon";
+const filteredspatialObjectCoord = (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [];
+const filteredSpatialObjectCrs = (state) => filteredGeometry(state) && filteredGeometry(state).projection || "EPSG:3857";
+const filteredSpatialObjectId = (state) => filteredGeometry(state) && filteredGeometry(state).id || "spatial_object";
+const filteredFeatures = createSelector(
+    [
+        filteredspatialObjectCoord,
+        filteredspatialObjectType,
+        filteredSpatialObjectId,
+        filteredSpatialObjectCrs
+    ],
+    ( geometryCoordinates, geometryType, geometryId, geometryCrs) => {
+        let geometry = {
+            type: "FeatureCollection",
+            features: [
+                {
+                    type: "Feature",
+                    geometry: {
+                        type: geometryType,
+                        coordinates: geometryCoordinates
+                    },
+                    style: {
+                        fillColor: 'rgba(255, 255, 255, 0.2)',
+                        color: '#ffcc33'
+                    },
+                    id: geometryId
+                }
+            ]
+        };
+        return geometryCoordinates.length > 0 && geometryType ? reprojectGeoJson(geometry, geometryCrs, 'EPSG:4326').features : [];
+    }
+
+);
+
+const highlighedFeatures = createSelector(
+    [
+        filteredFeatures,
+        selectedFeatures
+    ],
+    (featuresFiltered, featuresSelected) => [ ...featuresSelected, ...featuresFiltered]
+);
 
 module.exports = {
-    selectedFeatures: (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures"),
-    filteredspatialObjectType: (state) => filteredspatialObject(state) && filteredGeometry(state).type || "Polygon",
-    filteredspatialObjectCoord: (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [],
-    filteredSpatialObjectCrs: (state) => filteredGeometry(state) && filteredGeometry(state).projection || "EPSG:3857",
-    filteredSpatialObjectId: (state) => filteredGeometry(state) && filteredGeometry(state).id || "spatial_object",
-    filteredspatialObject,
-    filteredGeometry
-
+    selectedFeatures, filteredFeatures, filteredSpatialObjectId, filteredSpatialObjectCrs, filteredspatialObjectCoord,
+    filteredspatialObjectType, filteredGeometry, filteredspatialObject, highlighedFeatures
 };

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -1,13 +1,13 @@
 const {get} = require('lodash');
-const filteredspatialObject = state => get(state, state && state.featuregrid.showFilteredObject && "query.filterObj.spatialField");
-const filteredGeometry = state => get(state, "query.filterObj.spatialField.geometry");
+const filteredspatialObject = state => get(state, state && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
+const filteredGeometry = state => filteredspatialObject(state) && filteredspatialObject(state).geometry;
 
 module.exports = {
     selectedFeatures: (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures"),
     filteredspatialObjectType: (state) => filteredspatialObject(state) && filteredGeometry(state).type || "Polygon",
     filteredspatialObjectCoord: (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [],
-    filteredSpatialObjectCrs: (state) => filteredGeometry(state) && filteredGeometry(state).projection,
-    filteredSpatialObjectId: (state) => filteredGeometry(state) && filteredGeometry(state).id,
+    filteredSpatialObjectCrs: (state) => filteredGeometry(state) && filteredGeometry(state).projection || "EPSG:3857",
+    filteredSpatialObjectId: (state) => filteredGeometry(state) && filteredGeometry(state).id || "spatial_object",
     filteredspatialObject,
     filteredGeometry
 


### PR DESCRIPTION
## Description
Showing/hiding spatial filter selection area can be configured in localConfig, if configured spatial filter selection area will be displayed when FeatureGrid is open.

## Issues
 - Fix https://github.com/geosolutions-it/MapStore2-C028/issues/46

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)


 - [x] Feature







**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

