### PR TITLE
Fix #2914 Mismatch between DrawSupport radius length and distance length of Measure Plugin (openlayers) 

### DIFF
--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -26,7 +26,7 @@ class GeometryDetails extends React.Component {
         onChangeDrawingStatus: PropTypes.func,
         onEndDrawing: PropTypes.func,
         zoom: PropTypes.number,
-        enableGeodesicCircle: PropTypes.bool
+        enableGeodesic: PropTypes.bool
     };
 
     static defaultProps = {
@@ -100,7 +100,7 @@ class GeometryDetails extends React.Component {
             projection: this.props.geometry.projection
         };
 
-        this.props.onChangeDrawingStatus("replace", undefined, "queryform", [geometry], {geodesicCircle: this.props.enableGeodesicCircle});
+        this.props.onChangeDrawingStatus("replace", undefined, "queryform", [geometry], {geodesic: this.props.enableGeodesic});
     };
 
     onModifyGeometry = () => {

--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -85,7 +85,7 @@ class GeometryDetails extends React.Component {
     onUpdateCircle = (value, name) => {
         this.tempCircle[name] = parseFloat(value);
 
-        let center = !this.props.useMapProjection ?
+        let center = !this.props.useMapProjection && !isNaN(parseFloat(this.tempCircle.x)) && !isNaN(parseFloat(this.tempCircle.y)) ?
             CoordinatesUtils.reproject([this.tempCircle.x, this.tempCircle.y], 'EPSG:4326', this.props.geometry.projection) : [this.tempCircle.x, this.tempCircle.y];
 
         center = center.x === undefined ? {x: center[0], y: center[1]} : center;

--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -25,7 +25,8 @@ class GeometryDetails extends React.Component {
         onShowPanel: PropTypes.func,
         onChangeDrawingStatus: PropTypes.func,
         onEndDrawing: PropTypes.func,
-        zoom: PropTypes.number
+        zoom: PropTypes.number,
+        enableGeodesicCircle: PropTypes.bool
     };
 
     static defaultProps = {
@@ -89,16 +90,17 @@ class GeometryDetails extends React.Component {
             CoordinatesUtils.reproject([this.tempCircle.x, this.tempCircle.y], 'EPSG:4326', this.props.geometry.projection) : [this.tempCircle.x, this.tempCircle.y];
 
         center = center.x === undefined ? {x: center[0], y: center[1]} : center;
+        const validateCenter = {x: !isNaN(center.x) ? center.x : 0, y: !isNaN(center.y) ? center.y : 0};
 
         let geometry = {
             type: this.props.geometry.type,
-            center: center,
-            coordinates: [center.x, center.y],
-            radius: this.tempCircle.radius,
+            center: validateCenter,
+            coordinates: [validateCenter.x, validateCenter.y],
+            radius: !isNaN(this.tempCircle.radius) ? this.tempCircle.radius : 0,
             projection: this.props.geometry.projection
         };
 
-        this.props.onChangeDrawingStatus("replace", undefined, "queryform", [geometry]);
+        this.props.onChangeDrawingStatus("replace", undefined, "queryform", [geometry], {geodesicCircle: this.props.enableGeodesicCircle});
     };
 
     onModifyGeometry = () => {

--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -269,10 +269,11 @@ class SpatialFilter extends React.Component {
                 ? (<span><div className="m-label m-caption text-center"><I18N.Message msgId={"queryform.spatialfilter.draw_start_label"}/></div></span>)
                 : null;
         }
-
+        const selectedMethod = this.getMethodFromId(this.props.spatialField.method);
         const detailsPanel = this.props.showDetailsPanel ?
             (<GeometryDetails
                 useMapProjection={this.props.useMapProjection}
+                enableGeodesicCircle={selectedMethod && selectedMethod.geodesicCircle}
                 geometry={this.props.spatialField.geometry}
                 type={this.props.spatialField.method}
                 onShowPanel={this.props.actions.onShowSpatialSelectionDetails}
@@ -333,6 +334,7 @@ class SpatialFilter extends React.Component {
             }
         })[0].id;
 
+        const selectedMethod = this.getMethodFromId(method);
         this.props.actions.onSelectSpatialMethod(method, name);
 
         if (this.getMethodFromId(method).type !== "wfsGeocoder") {
@@ -346,7 +348,7 @@ class SpatialFilter extends React.Component {
                     break;
                 }
                 default: {
-                    this.changeDrawingStatus('start', method, "queryform", [], {stopAfterDrawing: true});
+                    this.changeDrawingStatus('start', method, "queryform", [], {geodesicCircle: selectedMethod && selectedMethod.geodesicCircle, stopAfterDrawing: true});
                 }
             }
         } else {

--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -273,7 +273,7 @@ class SpatialFilter extends React.Component {
         const detailsPanel = this.props.showDetailsPanel ?
             (<GeometryDetails
                 useMapProjection={this.props.useMapProjection}
-                enableGeodesicCircle={selectedMethod && selectedMethod.geodesicCircle}
+                enableGeodesic={selectedMethod && selectedMethod.geodesic}
                 geometry={this.props.spatialField.geometry}
                 type={this.props.spatialField.method}
                 onShowPanel={this.props.actions.onShowSpatialSelectionDetails}
@@ -348,7 +348,7 @@ class SpatialFilter extends React.Component {
                     break;
                 }
                 default: {
-                    this.changeDrawingStatus('start', method, "queryform", [], {geodesicCircle: selectedMethod && selectedMethod.geodesicCircle, stopAfterDrawing: true});
+                    this.changeDrawingStatus('start', method, "queryform", [], {geodesic: selectedMethod && selectedMethod.geodesic, stopAfterDrawing: true});
                 }
             }
         } else {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -26,6 +26,7 @@ const wgs84Sphere = new ol.Sphere(6378137);
  * @prop {string} drawStatus the status that allows to do different things. see componentWillReceiveProps method
  * @prop {string} drawMethod the method used to draw different geometries. can be Circle,BBOX, or a geomType from Point to MultiPolygons
  * @prop {object} options it contains the params used to enable the interactions or simply stop the DrawSupport after a ft is drawn
+ * @prop {boolean} options.geodesic enable to draw a geodesic geometry (supported only for Circle)
  * @prop {object[]} features an array of geojson features used as a starting point for drawing new shapes or edit them
  * @prop {func} onChangeDrawingStatus method use to change the status of the DrawSupport
  * @prop {func} onGeometryChanged when a features is edited or drawn this methos is fired
@@ -323,7 +324,7 @@ class DrawSupport extends React.Component {
             }
             case "Circle": {
                 roiProps.maxPoints = 100;
-                if (newProps.options && newProps.options.geodesicCircle) {
+                if (newProps.options && newProps.options.geodesic) {
                     roiProps.geometryFunction = (coordinates, geometry) => {
                         let geom = geometry;
                         if (!geom) {
@@ -541,7 +542,7 @@ class DrawSupport extends React.Component {
         }
 
         if (this.props.drawMethod === "Circle") {
-            if (this.props.options.geodesicCircle) {
+            if (this.props.options.geodesic) {
                 const wgs84Coordinates = [[...center], [...coordinates[0][0]]].map((coordinate) => {
                     return this.reprojectCoordinatesToWGS84(coordinate, projection);
                 });
@@ -699,7 +700,7 @@ class DrawSupport extends React.Component {
                 && center
                 && !isNaN(parseFloat(center.x))
                 && !isNaN(parseFloat(center.y)) ?
-                options.geodesicCircle ?
+                options.geodesic ?
                 ol.geom.Polygon.circular(wgs84Sphere, this.reprojectCoordinatesToWGS84([center.x, center.y], projection), radius, 100).clone().transform('EPSG:4326', projection)
                 : ol.geom.Polygon.fromCircle(new ol.geom.Circle([center.x, center.y], radius), 100)
                     : new ol.geom.Polygon(coordinates && isArray(coordinates[0]) ? coordinates : []);

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -1110,4 +1110,91 @@ describe('Test DrawSupport', () => {
         expect(spyChangeStatus.calls.length).toBe(1);
         expect(spyChange.calls.length).toBe(1);
     });
+
+    it('test createOLGeometry type Circle', () => {
+        const support = ReactDOM.render(<DrawSupport/>, document.getElementById("container"));
+        const type = 'Circle';
+        const coordinates = [];
+        const radius = 50;
+        const center = {
+            x: 0,
+            y: 0
+        };
+        const projection = 'EPSG:3857';
+        const geometry = support.createOLGeometry({type, coordinates, radius, center, projection});
+        const geometryCoordinates = geometry.getCoordinates();
+        expect(geometryCoordinates[0].length).toBe(101);
+    });
+
+    it('test createOLGeometry type Circle missing param', () => {
+        const support = ReactDOM.render(<DrawSupport/>, document.getElementById("container"));
+        const type = 'Circle';
+        const radius = 50;
+        const projection = 'EPSG:3857';
+        const center = {
+            x: 0,
+            y: 0
+        };
+
+        const geometryMissingCenter = support.createOLGeometry({type, radius, projection});
+        let geometryCoordinates = geometryMissingCenter.getCoordinates();
+        expect(geometryCoordinates.length).toBe(0);
+
+        const geometryMissingProjection = support.createOLGeometry({type, radius, center});
+        geometryCoordinates = geometryMissingProjection.getCoordinates();
+        expect(geometryCoordinates.length).toBe(0);
+
+        const geometryMissingRadius = support.createOLGeometry({type, projection, center});
+        geometryCoordinates = geometryMissingRadius.getCoordinates();
+        expect(geometryCoordinates.length).toBe(0);
+    });
+
+    it('test createOLGeometry type Circle wrong center', () => {
+        const support = ReactDOM.render(<DrawSupport/>, document.getElementById("container"));
+        const type = 'Circle';
+        const radius = 50;
+        const center = {
+            x: 'AAAA',
+            y: 0
+        };
+        const projection = 'EPSG:3857';
+        const geometry = support.createOLGeometry({type, radius, center, projection});
+        const geometryCoordinates = geometry.getCoordinates();
+        expect(geometryCoordinates.length).toBe(0);
+    });
+
+    it('test fromOLFeature verify radius', () => {
+
+        const fakeMap = {
+            addLayer: () => {},
+            removeLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:3857'
+                })
+            })
+        };
+
+        const simplifiedCircle = new ol.Feature({
+            geometry: new ol.geom.Polygon([[
+                [1260844.6064174946, 5858067.29727681],
+                [1260960.7874218025, 5857951.114737838],
+                [1260844.6064174946, 5857834.9352681665],
+                [1260728.4254131867, 5857951.114737838],
+                [1260844.6064174946, 5858067.29727681]
+            ]])
+        });
+
+        const support = ReactDOM.render(<DrawSupport drawMethod="Circle" map={fakeMap}/>, document.getElementById("container"));
+        const featureData = support.fromOLFeature(simplifiedCircle);
+
+        expect(Math.round(featureData.radius)).toBe(80);
+    });
 });

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -1111,8 +1111,8 @@ describe('Test DrawSupport', () => {
         expect(spyChange.calls.length).toBe(1);
     });
 
-    it('test createOLGeometry type Circle', () => {
-        const support = ReactDOM.render(<DrawSupport/>, document.getElementById("container"));
+    it('test createOLGeometry type Circle geodesic', () => {
+        const support = ReactDOM.render(<DrawSupport options={{geodesicCircle: true}}/>, document.getElementById("container"));
         const type = 'Circle';
         const coordinates = [];
         const radius = 50;
@@ -1127,7 +1127,7 @@ describe('Test DrawSupport', () => {
     });
 
     it('test createOLGeometry type Circle missing param', () => {
-        const support = ReactDOM.render(<DrawSupport/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport options={{geodesicCircle: true}}/>, document.getElementById("container"));
         const type = 'Circle';
         const radius = 50;
         const projection = 'EPSG:3857';
@@ -1150,7 +1150,7 @@ describe('Test DrawSupport', () => {
     });
 
     it('test createOLGeometry type Circle wrong center', () => {
-        const support = ReactDOM.render(<DrawSupport/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport options={{geodesicCircle: true}}/>, document.getElementById("container"));
         const type = 'Circle';
         const radius = 50;
         const center = {
@@ -1192,7 +1192,7 @@ describe('Test DrawSupport', () => {
             ]])
         });
 
-        const support = ReactDOM.render(<DrawSupport drawMethod="Circle" map={fakeMap}/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport drawMethod="Circle" map={fakeMap} options={{geodesicCircle: true}}/>, document.getElementById("container"));
         const featureData = support.fromOLFeature(simplifiedCircle);
 
         expect(Math.round(featureData.radius)).toBe(80);

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -1112,7 +1112,7 @@ describe('Test DrawSupport', () => {
     });
 
     it('test createOLGeometry type Circle geodesic', () => {
-        const support = ReactDOM.render(<DrawSupport options={{geodesicCircle: true}}/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport options={{geodesic: true}}/>, document.getElementById("container"));
         const type = 'Circle';
         const coordinates = [];
         const radius = 50;
@@ -1127,7 +1127,7 @@ describe('Test DrawSupport', () => {
     });
 
     it('test createOLGeometry type Circle missing param', () => {
-        const support = ReactDOM.render(<DrawSupport options={{geodesicCircle: true}}/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport options={{geodesic: true}}/>, document.getElementById("container"));
         const type = 'Circle';
         const radius = 50;
         const projection = 'EPSG:3857';
@@ -1150,7 +1150,7 @@ describe('Test DrawSupport', () => {
     });
 
     it('test createOLGeometry type Circle wrong center', () => {
-        const support = ReactDOM.render(<DrawSupport options={{geodesicCircle: true}}/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport options={{geodesic: true}}/>, document.getElementById("container"));
         const type = 'Circle';
         const radius = 50;
         const center = {
@@ -1192,7 +1192,7 @@ describe('Test DrawSupport', () => {
             ]])
         });
 
-        const support = ReactDOM.render(<DrawSupport drawMethod="Circle" map={fakeMap} options={{geodesicCircle: true}}/>, document.getElementById("container"));
+        const support = ReactDOM.render(<DrawSupport drawMethod="Circle" map={fakeMap} options={{geodesic: true}}/>, document.getElementById("container"));
         const featureData = support.fromOLFeature(simplifiedCircle);
 
         expect(Math.round(featureData.radius)).toBe(80);

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -300,6 +300,7 @@ class QueryPanel extends React.Component {
  * - name: label used in the DropdownList
  * - type: must be wfsGeocoder
  * - customItemClassName: a custom class for used for this method in the DropdownList
+ * - geodesic: {bool} draw a geodesic geometry for filter (supported only for Circle)
  * - filterProps:
  *   - blacklist {string[]} a list of banned words excluded from the wfs search
  *   - maxFeatures {number} the maximum features fetched per request


### PR DESCRIPTION
## Description
Added haversine radius calculation on openlayer circles

QueryPanel
Needs to be configured in spatialMethodOptions of Circle to enable the same function to measure distances and draw a geodesic circle

`"geodesic":  true`

 ```
{
              "name": "QueryPanel",
              "cfg": {
                  "activateQueryTool": true,
                  "spatialOperations": [
                      {"id": "INTERSECTS", "name": "queryform.spatialfilter.operations.intersects"},
                      {"id": "BBOX", "name": "queryform.spatialfilter.operations.bbox"},
                      {"id": "CONTAINS", "name": "queryform.spatialfilter.operations.contains"},
                      {"id": "WITHIN", "name": "queryform.spatialfilter.operations.within"}
                  ],
                  "spatialMethodOptions": [
                      {"id": "Viewport", "name": "queryform.spatialfilter.methods.viewport"},
                      {"id": "BBOX", "name": "queryform.spatialfilter.methods.box"},
                      {"id": "Circle", "name": "queryform.spatialfilter.methods.circle", "geodesic":  true},
                      {"id": "Polygon", "name": "queryform.spatialfilter.methods.poly"}
                  ]
              }
            }
```

## Issues
 - Fix #2914

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issue #2914

**What is the new behavior?**
Matching between DrawSupport radius length and distance length of Measure Plugin 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
