### PR TITLE
Modify SaveLayer in order to take the custom origin of a wms layer

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -399,6 +399,7 @@ const LayersUtils = {
             catalogURL: layer.catalogURL,
             useForElevation: layer.useForElevation || false,
             hidden: layer.hidden || false,
+            origin: layer.origin,
             ...assign({}, layer.params ? {params: layer.params} : {})
         };
     },

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -194,6 +194,23 @@ describe('Test the MapUtils', () => {
                 url: "",
                 visibility: true,
                 catalogURL: "url"
+            },
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer004",
+                loading: true,
+                name: "layer004",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer004",
+                type: "wms",
+                url: "",
+                visibility: true,
+                catalogURL: "url",
+                origin: [100000, 100000]
             }
         ];
 
@@ -264,7 +281,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 },
                 {
                     allowedSRS: {},
@@ -304,7 +322,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 },
                 {
                     allowedSRS: {},
@@ -344,7 +363,49 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
+                },
+                {
+                    allowedSRS: {},
+                    thumbURL: undefined,
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    description: undefined,
+                    dimensions: [],
+                    nativeCrs: undefined,
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer004",
+                    matrixIds: undefined,
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer004",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: undefined,
+                    tiled: undefined,
+                    title: "layer004",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url",
+                    hidden: false,
+                    useForElevation: false,
+                    origin: [100000, 100000]
                 }],
                 mapOptions: {},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -506,7 +567,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 },
                 {
                     allowedSRS: {},
@@ -546,7 +608,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 },
                 {
                     allowedSRS: {},
@@ -586,7 +649,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 }],
                 mapOptions: {
                     view: {
@@ -766,7 +830,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 },
                 {
                     allowedSRS: {},
@@ -806,7 +871,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 },
                 {
                     allowedSRS: {},
@@ -846,7 +912,8 @@ describe('Test the MapUtils', () => {
                     visibility: true,
                     catalogURL: "url",
                     hidden: false,
-                    useForElevation: false
+                    useForElevation: false,
+                    origin: undefined
                 }],
                 mapOptions: {},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],


### PR DESCRIPTION
## Description

This pr allow savelayer to take in account custom wms origin for tiled layer.

It is usefull to give corret parameters to openlayer wms layer with custom origin

see https://github.com/geosolutions-it/MapStore2/blob/master/web/client/components/map/openlayers/plugins/WMSLayer.js#L142

## Issues
 - Fix #2916 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x ] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
custom origin not saved

**What is the new behavior?**

custom origin saved

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x ] No

**Other information**:
