### PR TITLE
Enhancement #2603: details on map cards can be enabled/disabled from localConfig

### DIFF
--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -38,6 +38,7 @@ const {
     MAP_ERROR, mapError, updatePermissions,
     MAP_METADATA_UPDATED, mapMetadataUpdated,
     METADATA_CHANGED, metadataChanged,
+    setShowMapDetails, SHOW_DETAILS,
     updateAttribute, saveAll
 } = require('../maps');
 
@@ -283,6 +284,13 @@ describe('Test correctness of the maps actions', () => {
         const a = toggleDetailsSheet(detailsSheetReadOnly);
         expect(a.type).toBe(TOGGLE_DETAILS_SHEET);
         expect(a.detailsSheetReadOnly).toBeTruthy();
+
+    });
+    it('setShowMapDetails', () => {
+        const showMapDetails = true;
+        const action = setShowMapDetails(showMapDetails);
+        expect(action.type).toBe(SHOW_DETAILS);
+        expect(action.showMapDetails).toBe(showMapDetails);
 
     });
     it('toggleGroupProperties', () => {

--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -48,6 +48,7 @@ const UPDATE_DETAILS = 'MAPS:UPDATE_DETAILS';
 const SAVE_DETAILS = 'MAPS:SAVE_DETAILS';
 const DELETE_DETAILS = 'MAPS:DELETE_DETAILS';
 const SET_DETAILS_CHANGED = 'MAPS:SET_DETAILS_CHANGED';
+const SHOW_DETAILS = 'MAPS:SHOW_DETAILS';
 const SAVE_RESOURCE_DETAILS = 'MAPS:SAVE_RESOURCE_DETAILS';
 const DO_NOTHING = 'MAPS:DO_NOTHING';
 const DELETE_MAP = 'MAPS:DELETE_MAP';
@@ -121,6 +122,19 @@ function mapsLoaded(maps, params, searchText) {
         params,
         maps,
         searchText
+    };
+}
+
+/**
+ * shows or hides map details, type `MAPS:SHOW_DETAILS`
+ * @memberof actions.maps
+ * @prop {boolean} showMapDetails flag used to trigger the showing/hiding of the map details
+ * @return {action}        type `MAPS:SHOW_DETAILS`
+*/
+function setShowMapDetails(showMapDetails) {
+    return {
+        type: SHOW_DETAILS,
+        showMapDetails
     };
 }
 
@@ -952,6 +966,7 @@ module.exports = {
     detailsSaving, DETAILS_SAVING,
     toggleDetailsEditability, TOGGLE_DETAILS_EDITABILITY,
     setFeaturedMapsEnabled, FEATURED_MAPS_SET_ENABLED,
+    setShowMapDetails, SHOW_DETAILS,
     metadataChanged,
     loadMaps,
     mapsLoading,

--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -38,6 +38,7 @@ class MapCard extends React.Component {
     };
 
     static defaultProps = {
+        showMapDetails: true,
         style: {
             backgroundImage: 'url(' + thumbUrl + ')',
             backgroundSize: "cover",

--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -21,6 +21,7 @@ class MapCard extends React.Component {
         // props
         style: PropTypes.object,
         map: PropTypes.object,
+        showMapDetails: PropTypes.bool,
         detailsSheetActions: PropTypes.object,
         // CALLBACKS
         viewerUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -115,7 +116,7 @@ class MapCard extends React.Component {
                 }
             },
             {
-                visible: !!(this.props.map.details && this.props.map.details !== 'NODATA'),
+                visible: !!(this.props.showMapDetails && this.props.map.details && this.props.map.details !== 'NODATA'),
                 glyph: 'sheet',
                 tooltipId: this.props.tooltips.showDetails,
                 onClick: evt => {

--- a/web/client/components/maps/MapGrid.jsx
+++ b/web/client/components/maps/MapGrid.jsx
@@ -18,6 +18,7 @@ class MapGrid extends React.Component {
         panelProps: PropTypes.object,
         bottom: PropTypes.node,
         loading: PropTypes.bool,
+        showMapDetails: PropTypes.bool,
         maps: PropTypes.array,
         currentMap: PropTypes.object,
         fluid: PropTypes.bool,
@@ -98,6 +99,7 @@ class MapGrid extends React.Component {
                     <MapCard viewerUrl={viewerUrl} mapType={mapType}
                         map={map}
                         onEdit={this.props.editMap}
+                        showMapDetails={this.props.showMapDetails}
                         detailsSheetActions={this.props.detailsSheetActions}
                         onMapDelete={this.props.deleteMap}
                         onUpdateAttribute={this.props.onUpdateAttribute}/>

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -476,7 +476,7 @@
           {
             "name": "Maps",
             "cfg": {
-              "showMapDetails":true,
+              "showMapDetails": true,
               "mapsOptions": {
                 "start": 0,
                 "limit": 12

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -476,7 +476,6 @@
           {
             "name": "Maps",
             "cfg": {
-              "showMapDetails": true,
               "mapsOptions": {
                 "start": 0,
                 "limit": 12

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -476,6 +476,7 @@
           {
             "name": "Maps",
             "cfg": {
+              "showMapDetails":true,
               "mapsOptions": {
                 "start": 0,
                 "limit": 12

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -23,7 +23,7 @@ const {createSelector} = require('reselect');
 const MapsGrid = require('./maps/MapsGrid');
 const MetadataModal = require('./maps/MetadataModal');
 
-const {loadMaps} = require('../actions/maps');
+const {loadMaps, setShowMapDetails} = require('../actions/maps');
 
 const PaginationToolbar = connect((state) => {
     if (!state.maps ) {
@@ -58,6 +58,8 @@ class Maps extends React.Component {
         title: PropTypes.any,
         onGoToMap: PropTypes.func,
         loadMaps: PropTypes.func,
+        setShowMapDetails: PropTypes.func,
+        showMapDetails: PropTypes.bool,
         maps: PropTypes.object,
         searchText: PropTypes.string,
         mapsOptions: PropTypes.object,
@@ -73,6 +75,7 @@ class Maps extends React.Component {
         mapType: "leaflet",
         onGoToMap: () => {},
         loadMaps: () => {},
+        setShowMapDetails: () => {},
         fluid: false,
         title: <h3><Message msgId="manager.maps_title" /></h3>,
         mapsOptions: {start: 0, limit: 12},
@@ -89,6 +92,7 @@ class Maps extends React.Component {
     componentDidMount() {
         // if there is a change in the search text it uses that before the initialMapFilter
         this.props.loadMaps(ConfigUtils.getDefaults().geoStoreUrl, this.props.searchText || ConfigUtils.getDefaults().initialMapFilter || "*", this.props.mapsOptions);
+        this.props.setShowMapDetails(this.props.showMapDetails);
     }
 
     render() {
@@ -117,7 +121,7 @@ const mapsPluginSelector = createSelector([
 }));
 
 const MapsPlugin = connect(mapsPluginSelector, {
-    loadMaps
+    loadMaps, setShowMapDetails
 })(Maps);
 
 module.exports = {

--- a/web/client/plugins/maps/MapsGrid.jsx
+++ b/web/client/plugins/maps/MapsGrid.jsx
@@ -19,6 +19,7 @@ const MapsGrid = connect((state) => {
     return {
         bsSize: "small",
         currentMap: state.currentMap,
+        showMapDetails: state.maps && state.maps.showMapDetails,
         loading: state.maps && state.maps.loading,
         mapType: mapTypeSelector(state)
     };

--- a/web/client/plugins/maps/MapsGrid.jsx
+++ b/web/client/plugins/maps/MapsGrid.jsx
@@ -14,12 +14,13 @@ const {loadMaps, updateMapMetadata, deleteMap, createThumbnail,
     backDetails, undoDetails, updateAttribute} = require('../../actions/maps');
 const {editMap, updateCurrentMap, errorCurrentMap, removeThumbnail, resetCurrentMap} = require('../../actions/currentMap');
 const {mapTypeSelector} = require('../../selectors/maptype');
+const {showMapDetailsSelector} = require('../../selectors/maps.js');
 
 const MapsGrid = connect((state) => {
     return {
         bsSize: "small",
         currentMap: state.currentMap,
-        showMapDetails: state.maps && state.maps.showMapDetails,
+        showMapDetails: showMapDetailsSelector(state),
         loading: state.maps && state.maps.loading,
         mapType: mapTypeSelector(state)
     };

--- a/web/client/plugins/maps/MetadataModal.jsx
+++ b/web/client/plugins/maps/MetadataModal.jsx
@@ -15,6 +15,7 @@ const {setControlProperty} = require('../../actions/controls');
 const MetadataModal = connect(
     (state = {}) => ({
         metadata: state.currentMap.metadata,
+        showDetailsRow: state.maps && state.maps.showMapDetails,
         availableGroups: state.currentMap && state.currentMap.availableGroups || [ ], // TODO: add message when array is empty
         newGroup: state.controls && state.controls.permissionEditor && state.controls.permissionEditor.newGroup,
         newPermission: state.controls && state.controls.permissionEditor && state.controls.permissionEditor.newPermission || "canRead",

--- a/web/client/plugins/maps/MetadataModal.jsx
+++ b/web/client/plugins/maps/MetadataModal.jsx
@@ -11,11 +11,12 @@ const {metadataChanged} = require('../../actions/maps');
 const {loadPermissions, updatePermissions, loadAvailableGroups} = require('../../actions/maps');
 const {updateCurrentMapPermissions, addCurrentMapPermission} = require('../../actions/currentMap');
 const {setControlProperty} = require('../../actions/controls');
+const {showMapDetailsSelector} = require('../../selectors/maps.js');
 
 const MetadataModal = connect(
     (state = {}) => ({
         metadata: state.currentMap.metadata,
-        showDetailsRow: state.maps && state.maps.showMapDetails,
+        showDetailsRow: showMapDetailsSelector(state),
         availableGroups: state.currentMap && state.currentMap.availableGroups || [ ], // TODO: add message when array is empty
         newGroup: state.controls && state.controls.permissionEditor && state.controls.permissionEditor.newGroup,
         newPermission: state.controls && state.controls.permissionEditor && state.controls.permissionEditor.newPermission || "canRead",

--- a/web/client/reducers/__tests__/maps-test.js
+++ b/web/client/reducers/__tests__/maps-test.js
@@ -12,10 +12,11 @@ const {
     mapsLoaded, mapsLoading, loadError, mapCreated, mapUpdating,
     mapMetadataUpdated, mapDeleting, mapDeleted, attributeUpdated, thumbnailError, permissionsLoading,
     permissionsLoaded, saveMap, permissionsUpdated, resetUpdating,
-    mapsSearchTextChanged} = require('../../actions/maps');
+    mapsSearchTextChanged, setShowMapDetails} = require('../../actions/maps');
 
 const sampleMap = {
     canDelete: false,
+    showMapDetails: true,
     canEdit: false,
     canCopy: true,
     creation: '2017-01-16 12:16:09.538',
@@ -49,6 +50,11 @@ describe('Test the maps reducer', () => {
     it('on mapsSearchTextChanged action', () => {
         let state = maps(null, mapsSearchTextChanged("TEST"));
         expect(state.searchText).toBe("TEST");
+    });
+    it('on setShowMapDetails action', () => {
+        let bool = false;
+        let state = maps({showMapDetails: true}, setShowMapDetails(bool));
+        expect(state.showMapDetails).toBe(bool);
     });
     it('on mapSearchText', () => {
         let state = maps(null, mapsLoading("TEST", {

--- a/web/client/reducers/maps.js
+++ b/web/client/reducers/maps.js
@@ -10,7 +10,7 @@ const {
     MAPS_LIST_LOADED, MAPS_LIST_LOADING, MAPS_LIST_LOAD_ERROR, MAP_CREATED, MAP_UPDATING,
     MAP_METADATA_UPDATED, MAP_DELETING, MAP_DELETED, ATTRIBUTE_UPDATED, PERMISSIONS_LIST_LOADING,
     PERMISSIONS_LIST_LOADED, SAVE_MAP, PERMISSIONS_UPDATED, THUMBNAIL_ERROR, RESET_UPDATING,
-    MAPS_SEARCH_TEXT_CHANGED, METADATA_CHANGED} = require('../actions/maps');
+    MAPS_SEARCH_TEXT_CHANGED, METADATA_CHANGED, SHOW_DETAILS} = require('../actions/maps');
 const {
     EDIT_MAP, RESET_CURRENT_MAP} = require('../actions/currentMap');
 const assign = require('object-assign');
@@ -62,6 +62,7 @@ const {isArray, isNil} = require('lodash');
  */
 function maps(state = {
     enabled: false,
+    showMapDetails: true,
     errors: [],
     searchText: ""}, action) {
     switch (action.type) {
@@ -74,6 +75,9 @@ function maps(state = {
         return assign({}, state, {
             metadata: assign({}, state.metadata, {[action.prop]: action.value })
         });
+    }
+    case SHOW_DETAILS: {
+        return assign({}, state, {showMapDetails: action.showMapDetails});
     }
     case EDIT_MAP: {
         return assign({}, state, {

--- a/web/client/selectors/__tests__/maps-test.js
+++ b/web/client/selectors/__tests__/maps-test.js
@@ -14,6 +14,7 @@ const {
     mapMetadataSelector,
     isMapsLastPageSelector,
     mapDescriptionSelector,
+    showMapDetailsSelector,
     mapDetailsUriFromIdSelector,
     mapPermissionsFromIdSelector,
     mapThumbnailsUriFromIdSelector
@@ -28,6 +29,7 @@ const mapId = 1;
 const creation = '2017-12-01 10:58:46.337';
 const mapsState = {
     maps: {
+        showMapDetails: true,
         metadata: {
             name,
             description
@@ -63,6 +65,10 @@ describe('Test maps selectors', () => {
     it('test mapFromIdSelector no state', () => {
         const props = mapFromIdSelector(mapsState, mapId);
         expect(props.creation).toBe(creation);
+    });
+    it('test showMapDetailsSelector no state', () => {
+        const props = showMapDetailsSelector(mapsState);
+        expect(props).toBe(mapsState.maps.showMapDetails);
     });
     it('test mapNameSelector no state', () => {
         const props = mapNameSelector(mapsState, mapId);

--- a/web/client/selectors/maps.js
+++ b/web/client/selectors/maps.js
@@ -24,10 +24,19 @@ const mapDescriptionSelector = (state, id) => mapFromIdSelector(state, id) && ma
 const mapDetailsUriFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).details || "";
 const mapPermissionsFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).permissions || "";
 const mapThumbnailsUriFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).thumbnail || "";
+/**
+ * Get flag for enable/disable of the map card details
+ * @function
+ * @memberof selectors.map
+ * @param  {object} state the state
+ * @return {boolean} showMapDetails flag for the map card details
+ */
+const showMapDetailsSelector = (state) => get(state, "maps.showMapDetails");
 
 module.exports = {
     mapNameSelector,
     mapFromIdSelector,
+    showMapDetailsSelector,
     mapsResultsSelector,
     totalCountSelector,
     mapMetadataSelector,


### PR DESCRIPTION
## Description
details on map cards can be enabled/disabled from localConfig.

## Issues
 - Fix #2603 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)


 - [x] Feature





**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
