### PR TITLE
Improved dashboard viewmode style

### DIFF
--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -61,7 +61,7 @@ module.exports = pure(({
         preventCollision
         layouts={layouts ? JSON.parse(JSON.stringify(layouts)) : undefined}
         style={style}
-        className={`widget-container ${className}`}
+        className={`widget-container ${className} ${canEdit ? '' : 'no-drag'}`}
         rowHeight={rowHeight}
         autoSize
         verticalCompact={verticalCompact}

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -5,6 +5,9 @@
     cursor: -ms-grab;
     cursor: grab;
 }
+.no-drag .draggableHandle {
+    cursor: inherit;
+}
 .widget-container {
     &.react-grid-layout.on-map {
         pointer-events: none;
@@ -27,7 +30,11 @@
             }
         }
     }
-
+    &.no-drag .mapstore-widget-card {
+         -webkit-box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.2);
+        -moz-box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.2);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
     .mapstore-widget-card {
         background: @ms2-color-background;
         margin: 20px 0;
@@ -36,9 +43,7 @@
         height: 100%;
         width: 100%;
         margin: 0;
-        -webkit-box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
-        -moz-box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
-        box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+        .shadow-far;
         .mapstore-widget-layer {
             text-align: center;
             margin: 10px 5%;


### PR DESCRIPTION

## Description
 - Changed card's shadows for view mode
 - Removed hadler cursor in view mode

![view_mode_shadow](https://user-images.githubusercontent.com/1279510/40238053-6df0b752-5ab2-11e8-99a3-c42ac9e617bd.gif)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
No difference between edit and view mode in style

**What is the new behavior?**
No cursor and lighter shadows in view mode.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
