### PR TITLE
Fixes #2441: introduces scale parameter for WMS GetLegendGraphic in print

### DIFF
--- a/buildConfig.js
+++ b/buildConfig.js
@@ -158,20 +158,32 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
     devServer: {
         proxy: {
             '/rest/geostore': {
-                target: "https://dev.mapstore2.geo-solutions.it/mapstore",
-                secure: false
+                target: "https://dev.mapstore.geo-solutions.it/mapstore",
+                secure: false,
+                headers: {
+                    host: "dev.mapstore.geo-solutions.it"
+                }
             },
             '/pdf': {
-                target: "https://dev.mapstore2.geo-solutions.it/mapstore",
-                secure: false
+                target: "https://dev.mapstore.geo-solutions.it/mapstore",
+                secure: false,
+                headers: {
+                    host: "dev.mapstore.geo-solutions.it"
+                }
             },
             '/mapstore/pdf': {
-                target: "https://dev.mapstore2.geo-solutions.it",
-                secure: false
+                target: "https://dev.mapstore.geo-solutions.it",
+                secure: false,
+                headers: {
+                    host: "dev.mapstore.geo-solutions.it"
+                }
             },
             '/proxy': {
-                target: "https://dev.mapstore2.geo-solutions.it/mapstore",
-                secure: false
+                target: "https://dev.mapstore.geo-solutions.it/mapstore",
+                secure: false,
+                headers: {
+                    host: "dev.mapstore.geo-solutions.it"
+                }
             },
             '/docs': {
                 target: "http://localhost:8081",

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -215,6 +215,7 @@ const PrintUtils = {
                                  REQUEST: "GetLegendGraphic",
                                  LAYER: layer.name,
                                  STYLE: layer.style || '',
+                                 SCALE: spec.scale,
                                  height: spec.iconSize,
                                  width: spec.iconSize,
                                  minSymbolSize: spec.iconSize,

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -143,10 +143,18 @@ describe('PrintUtils', () => {
         expect(specs.length).toBe(1);
         expect(specs[0].geoJson.features[0].geometry.coordinates[0], mapFishVectorLayer).toBe(mapFishVectorLayer.geoJson.features[0].geometry.coordinates[0]);
     });
-    it('vector layer generation for legend', () => {
+    it('wms layer generation for legend', () => {
         const specs = PrintUtils.getMapfishLayersSpecification([layer], {projection: "EPSG:3857"}, 'legend');
         expect(specs).toExist();
         expect(specs.length).toBe(1);
+    });
+    it('wms layer generation for legend includes scale', () => {
+        const specs = PrintUtils.getMapfishLayersSpecification([layer], testSpec, 'legend');
+        expect(specs).toExist();
+        expect(specs.length).toBe(1);
+        expect(specs[0].classes.length).toBe(1);
+        expect(specs[0].classes[0].icons.length).toBe(1);
+        expect(specs[0].classes[0].icons[0].indexOf('SCALE=50000') !== -1).toBe(true);
     });
     it('vector layer default point style', () => {
         const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "Point"}}]});


### PR DESCRIPTION
## Description
See title

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
WMS GetLegendGraphic in print does not have a scale parameter

**What is the new behavior?**
WMS GetLegendGraphic in print includes a scale parameter

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
