### PR TITLE
Fix #2926 Selector of highlight throws an error on embedded

### DIFF
--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -94,6 +94,8 @@ describe('Test highlight selectors', () => {
         const features = filteredspatialObject(initialState);
         expect(features).toExist();
         expect(features).toBe(spatialObject);
+
+        expect(filteredspatialObject({})).toBe('emptyObject');
     });
     it('test filteredGeometry', () => {
         const geometry = initialState.query.filterObj.spatialField.geometry;

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -94,8 +94,9 @@ describe('Test highlight selectors', () => {
         const features = filteredspatialObject(initialState);
         expect(features).toExist();
         expect(features).toBe(spatialObject);
-
-        expect(filteredspatialObject({})).toBe('emptyObject');
+    });
+    it('test filteredspatialObject with empty state', () => {
+        expect(filteredspatialObject({})).toBe(undefined);
     });
     it('test filteredGeometry', () => {
         const geometry = initialState.query.filterObj.spatialField.geometry;

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -3,7 +3,7 @@ const {createSelector} = require('reselect');
 const {reprojectGeoJson} = require('../utils/CoordinatesUtils');
 
 const selectedFeatures = (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures");
-const filteredspatialObject = (state) => get(state, state.featuregrid && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
+const filteredspatialObject = (state) => get(state, state && state.featuregrid && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
 const filteredGeometry = (state) => filteredspatialObject(state) && filteredspatialObject(state).geometry;
 const filteredspatialObjectType = (state) => filteredGeometry(state) && filteredGeometry(state).type || "Polygon";
 const filteredspatialObjectCoord = (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [];

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -3,7 +3,7 @@ const {createSelector} = require('reselect');
 const {reprojectGeoJson} = require('../utils/CoordinatesUtils');
 
 const selectedFeatures = (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures");
-const filteredspatialObject = (state) => get(state, state && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
+const filteredspatialObject = (state) => get(state, state.featuregrid && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
 const filteredGeometry = (state) => filteredspatialObject(state) && filteredspatialObject(state).geometry;
 const filteredspatialObjectType = (state) => filteredGeometry(state) && filteredGeometry(state).type || "Polygon";
 const filteredspatialObjectCoord = (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [];


### PR DESCRIPTION
## Description
Fixed highlight selector.
State of featuregrid was missing in embedded so it throwed an error and map didn't works

## Issues
 - Fix #2926

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#2926

**What is the new behavior?**
embedded works

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
@Mloweedgar 