### PR TITLE
Configurable "New dashboard" button visibility 

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -199,6 +199,7 @@
                 "web/client/plugins/AutoMapUpdate.jsx",
                 "web/client/plugins/BackgroundSelector.jsx",
                 "web/client/plugins/BackgroundSwitcher.jsx",
+                "web/client/plugins/CreateNewMap.jsx",
                 "web/client/plugins/DrawerMenu.jsx",
                 "web/client/plugins/FeatureEditor.jsx",
                 "web/client/plugins/GlobeViewSwitcher.jsx",

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -18,7 +18,7 @@ const {mapTypeSelector} = require('../selectors/maptype');
 class CreateNewMap extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
-        dashboardsAvailable: PropTypes.bool,
+        showNewDashboard: PropTypes.bool,
         colProps: PropTypes.object,
         isLoggedIn: PropTypes.bool,
         allowedRoles: PropTypes.array,
@@ -32,7 +32,7 @@ class CreateNewMap extends React.Component {
 
     static defaultProps = {
         mapType: "leaflet",
-        dashboardsAvailable: false,
+        showNewDashboard: false,
         isLoggedIn: false,
         allowedRoles: ["ADMIN", "USER"],
         colProps: {
@@ -52,7 +52,7 @@ class CreateNewMap extends React.Component {
             <Button tooltipId="newMap" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/viewer/" + this.props.mapType + "/new"); }}>
                 <Glyphicon glyph="add-map" />
             </Button>
-            {this.props.dashboardsAvailable ?
+            {this.props.showNewDashboard ?
                 <Button tooltipId="resources.dashboards.newDashboard" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/dashboard/"); }}>
                     <Glyphicon glyph="add-dashboard" />
                 </Button>
@@ -63,10 +63,17 @@ class CreateNewMap extends React.Component {
     }
     isAllowed = () => this.props.isLoggedIn && this.props.allowedRoles.indexOf(this.props.user && this.props.user.role) >= 0;
 }
-const {areDashboardsAvailable} = require('../selectors/dashboards');
+
+/**
+ * Button bar to create a new map or dashboard.
+ * @memberof plugins
+ * @class CreateNewMap
+ * @static
+ * @prop {boolean} cfg.showNewDashboard show/hide th create new dashboard button.
+ * @prop {string[]} cfg.allowedRoles array of users roles allowed to create maps and/or dashboards. default: `["ADMIN", "USER"]`. Users that don't have these roles will never see the buttons.
+ */
 module.exports = {
     CreateNewMapPlugin: connect((state) => ({
-        dashboardsAvailable: areDashboardsAvailable(state),
         mapType: mapTypeSelector(state),
         isLoggedIn: state && state.security && state.security.user && state.security.user.enabled && !(state.browser && state.browser.mobile) && true || false,
         user: state && state.security && state.security.user

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -32,7 +32,7 @@ class CreateNewMap extends React.Component {
 
     static defaultProps = {
         mapType: "leaflet",
-        showNewDashboard: false,
+        showNewDashboard: true,
         isLoggedIn: false,
         allowedRoles: ["ADMIN", "USER"],
         colProps: {


### PR DESCRIPTION
## Description
This changes make the visibility of the button "Create New Dashgbconfigurable. This also avoid to make the button dependent from dashboards plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) - **Configuration**
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
the button appears only when the Dashboards plugin is rendered

**What is the new behavior?**
The button appears by default. You can Hide it in localConfig.json

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

