### PR TITLE
fix #2861 extra scrollbar when dragging down layer metadata modal

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -145,6 +145,7 @@
             }, "Home", {
                 "name": "TOC",
                 "cfg": {
+                    "activateMetedataTool": false,
                     "activateMapTitle": false,
                     "activateSortLayer": false
                 }
@@ -268,6 +269,7 @@
                 "cfg": {
                     "activateQueryTool": true,
                     "activateAddLayerButton": true,
+                    "activateMetedataTool": false,
                     "spatialOperations": [
                         {"id": "INTERSECTS", "name": "queryform.spatialfilter.operations.intersects"},
                         {"id": "BBOX", "name": "queryform.spatialfilter.operations.bbox"},
@@ -429,6 +431,7 @@
                 "cfg": {
                     "activateMapTitle": false,
                     "activateSettingsTool": false,
+                    "activateMetedataTool": false,
                     "activateRemoveLayer": false
                 }
 

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -1,3 +1,7 @@
+#container {
+    overflow: hidden;
+}
+
 .shadow {
 	-webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
 	-moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -1,7 +1,3 @@
-#container {
-    overflow: hidden;
-}
-
 .shadow {
 	-webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
 	-moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -1,4 +1,8 @@
 
+#mapstore-layer-settings-metadata {
+    position: fixed;
+}
+
 .ms-resizable-modal {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
## Description
it appears a scrollbar to the whole body when dragging down the layer metadata modal 

## Issues
 - Fix #2861 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see description

**What is the new behavior?**
scrollbar no longer appears

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
