### PR TITLE
fix 2934 removed singlePage option, change default value virtualScroll

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -47,7 +47,7 @@ class DownloadDialog extends React.Component {
             {name: "native", label: "Native"},
             {name: "EPSG:4326", label: "WGS84"}
         ],
-        virtualScroll: false
+        virtualScroll: true
     };
 
     componentDidMount() {

--- a/web/client/components/data/download/DownloadOptions.jsx
+++ b/web/client/components/data/download/DownloadOptions.jsx
@@ -42,7 +42,7 @@ module.exports = class extends React.Component {
         wfsFormats: [],
         formats: [],
         srsList: [],
-        virtualScroll: false
+        virtualScroll: true
     };
 
     getSelectedFormat = () => {
@@ -82,6 +82,8 @@ module.exports = class extends React.Component {
                 value={this.getSelectedSRS()}
                 onChange={(sel) => this.props.onChange("selectedSrs", sel.value)}
                 options={this.props.srsList.map(f => ({value: f.name, label: f.label || f.name}))} />
+
+            {/* TODO for the future remove the virtualScroll prop since is no longer used*/}
             {this.props.virtualScroll ? null : <Checkbox checked={this.props.downloadOptions.singlePage} onChange={() => this.props.onChange("singlePage", !this.props.downloadOptions.singlePage ) }>
                 <Message msgId="wfsdownload.downloadonlycurrentpage" />
             </Checkbox>}

--- a/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
+++ b/web/client/components/data/download/__tests__/DownloadOptions-test.jsx
@@ -43,16 +43,22 @@ describe('Test for DownloadOptions component', () => {
             onChange: () => {}
         };
         spyOn(events, "onChange");
-        ReactDOM.render(<DownloadOptions onChange={events.onChange} downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        ReactDOM.render(<DownloadOptions onChange={events.onChange} virtualScroll={false} downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
         const check = document.querySelector('input[type=checkbox]');
         check.click();
         expect(events.onChange).toHaveBeenCalled();
 
     });
-    it('singlePage checkbox not to render in virtualScroll mode', () => {
-        ReactDOM.render(<DownloadOptions virtualScroll downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+    it('singlePage checkbox not to render: virtualScroll=true', () => {
+        ReactDOM.render(<DownloadOptions downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
         const check = document.querySelector('input[type=checkbox]');
         expect(check).toNotExist();
+
+    });
+    it('singlePage checkbox to render: virtualScroll=false', () => {
+        ReactDOM.render(<DownloadOptions virtualScroll={false} downloadOptions={{selectedFormat: "test"}} formats={[{name: "test"}]}/>, document.getElementById("container"));
+        const check = document.querySelector('input[type=checkbox]');
+        expect(check).toExist();
 
     });
 });


### PR DESCRIPTION
## Description
see title

## Issues
 - Fix #2934


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
actually by default it appears the single page download checkbox

**What is the new behavior?**
single page checkbox no longer appears as default, virtual scroll must be disabled

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
