### PR TITLE
Fixed #2943 use https for nominatim URL

### DIFF
--- a/web/client/api/Nominatim.js
+++ b/web/client/api/Nominatim.js
@@ -23,7 +23,7 @@ const Api = {
     geocode: function(text, options) {
         var params = assign({q: text}, defaultOptions, options || {});
         var url = urlUtil.format({
-            protocol: window.location.protocol,
+            protocol: "https",
             host: DEFAULT_URL,
             query: params
         });
@@ -32,7 +32,7 @@ const Api = {
     reverseGeocode: function(coords, options) {
         const params = assign({lat: coords.lat, lon: coords.lng}, options || {}, defaultOptions);
         const url = urlUtil.format({
-            protocol: window.location.protocol,
+            protocol: "https",
             host: DEFAULT_REVERSE_URL,
             query: params
         });

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -1,7 +1,7 @@
 {
     "proxyUrl": {
         "url": "proxy/?url=",
-        "useCORS": ["http://demo.geo-solutions.it/geoserver", "https://demo.geo-solutions.it:443/geoserver", "https://demo.geo-solutions.it/geoserver"]
+        "useCORS": ["http://demo.geo-solutions.it/geoserver", "https://demo.geo-solutions.it:443/geoserver", "https://demo.geo-solutions.it/geoserver", "https://nominatim.openstreetmap.org"]
     },
     "geoStoreUrl": "rest/geostore/",
     "printUrl": "pdf/info.json",


### PR DESCRIPTION
## Description
Nominatim search doesn't work with normal http(not https). This because of recent changes nominatim services responses. 

## Issues
 - Fix #2943

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
Http version of nominatim do not work

**What is the new behavior?**
Http version of nominatim  works

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

