### PR TITLE
Fix #2960 WMTS/Vector node in TOC shows empty collapsible panel + Minor fix on widgetBuilderAvailable selector

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -127,7 +127,8 @@ class DefaultLayer extends React.Component {
     }
 
     renderNode = (grab, hide, selected, error, warning, other) => {
-        const isEmpty = !this.props.activateLegendTool && !this.props.showFullTitleOnExpand;
+        const isEmpty = this.props.node.type !== 'wmts' && !this.props.activateLegendTool && !this.props.showFullTitleOnExpand
+        || this.props.node.type === 'wmts' && !this.props.showFullTitleOnExpand;
         return (
             <Node className={'toc-default-layer' + hide + selected + error + warning} sortableStyle={this.props.sortableStyle} style={this.props.style} type="layer" {...other}>
                 <div className="toc-default-layer-head">

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -127,8 +127,8 @@ class DefaultLayer extends React.Component {
     }
 
     renderNode = (grab, hide, selected, error, warning, other) => {
-        const isEmpty = this.props.node.type !== 'wmts' && !this.props.activateLegendTool && !this.props.showFullTitleOnExpand
-        || this.props.node.type === 'wmts' && !this.props.showFullTitleOnExpand;
+        const isEmpty = this.props.node.type === 'wms' && !this.props.activateLegendTool && !this.props.showFullTitleOnExpand
+        || this.props.node.type !== 'wms' && !this.props.showFullTitleOnExpand;
         return (
             <Node className={'toc-default-layer' + hide + selected + error + warning} sortableStyle={this.props.sortableStyle} style={this.props.style} type="layer" {...other}>
                 <div className="toc-default-layer-head">

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -256,4 +256,21 @@ describe('test DefaultLayer module component', () => {
 
     });
 
+    it('test wmts', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            storeIndex: 9,
+            type: 'wmts',
+            opacity: 0.5
+        };
+        const comp = ReactDOM.render(<Layer showFullTitleOnExpand={false} node={l} />,
+        document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const title = domNode.getElementsByClassName("chevron-left");
+        expect(title.length).toBe(0);
+    });
+
 });

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -55,6 +55,10 @@ describe('Test controls selectors', () => {
         expect(retVal).toExist();
         expect(retVal).toBe(true);
     });
+    it('test widgetBuilderAvailable no widgetBuilder in state', () => {
+        const retVal = widgetBuilderAvailable({});
+        expect(retVal).toBe(false);
+    });
     it('test widgetBuilderSelector', () => {
         const retVal = widgetBuilderSelector(state);
         expect(retVal).toExist();

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -4,6 +4,6 @@ module.exports = {
     queryPanelSelector: (state) => get(state, "controls.queryPanel.enabled"),
     wfsDownloadAvailable: state => !!get(state, "controls.wfsdownload.available"),
     wfsDownloadSelector: state => !!get(state, "controls.wfsdownload.enabled"),
-    widgetBuilderAvailable: state => get(state, "controls.widgetBuilder.available"),
+    widgetBuilderAvailable: state => get(state, "controls.widgetBuilder.available", false),
     widgetBuilderSelector: (state) => get(state, "controls.widgetBuilder.enabled")
 };


### PR DESCRIPTION
## Description
![2018-05-30 10_55_09-mapstore homepage](https://user-images.githubusercontent.com/19175505/40710072-f6dab506-63f7-11e8-95d0-45a851f742ed.png)
and improved widgetBuilderAvailable selector

## Issues
 - Fix #2960

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#2960

**What is the new behavior?**
hide collapsible panel for WMTS

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
