### PR TITLE
Fix #2962 WMTS with custom gridset causes CanvasRenderingContext2D error at zoom 0 (ol)

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -261,6 +261,95 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().item(0).getSource().urls.length).toBe(1);
     });
 
+    it('test wmts max and min resolutions', () => {
+        var options = {
+            "type": "wmts",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "matrixIds": {
+                'EPSG:900913': [
+                    {
+                        identifier: "EPSG:900913:0",
+                        ranges: {
+                            cols: {min: "0", max: "0"},
+                            rows: {min: "0", max: "0"}
+                        }
+
+                    },
+                    {
+                        identifier: "EPSG:900913:1",
+                        ranges: {
+                            cols: {min: "0", max: "1"},
+                            rows: {min: "0", max: "1"}
+                        }
+
+                    },
+                    {
+                        identifier: "EPSG:900913:2",
+                        ranges: {
+                            cols: {min: "0", max: "3"},
+                            rows: {min: "1", max: "2"}
+                        }
+
+                    }
+                ]
+
+            },
+
+            "tileMatrixSet": [
+                {
+                    "TileMatrix": [
+                        {
+                            "MatrixHeight": "1",
+                            "MatrixWidth": "1",
+                            "ScaleDenominator": "5.590822639508929E8",
+                            "TileHeight": "256",
+                            "TileWidth": "256",
+                            "TopLeftCorner": "-2.003750834E7 2.0037508E7",
+                            "ows:Identifier": "EPSG:900913:0"
+                        },
+                        {
+                            "MatrixHeight": "2",
+                            "MatrixWidth": "2",
+                            "ScaleDenominator": "2.7954113197544646E8",
+                            "TileHeight": "256",
+                            "TileWidth": "256",
+                            "TopLeftCorner": "-2.003750834E7 2.0037508E7",
+                            "ows:Identifier": "EPSG:900913:1"
+                        },
+                        {
+                            "MatrixHeight": "4",
+                            "MatrixWidth": "4",
+                            "ScaleDenominator": "1.3977056598772323E8",
+                            "TileHeight": "256",
+                            "TileWidth": "256",
+                            "TopLeftCorner": "-2.003750834E7 2.0037508E7",
+                            "ows:Identifier": "EPSG:900913:2"
+                        }
+                    ],
+                    "ows:Identifier": "EPSG:900913",
+                    "ows:SupportedCRS": "urn:ogc:def:crs:EPSG:900913"
+                }
+            ],
+            "url": "http://sample.server/geoserver/gwc/service/wmts"
+        };
+        // create layers
+        const layer = ReactDOM.render(
+            <OpenlayersLayer type="wmts"
+                 options={options} map={map}/>, document.getElementById("container"));
+
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+
+        const wmtsLayer = map.getLayers().item(0);
+        expect(Math.round(wmtsLayer.getMinResolution())).toBe(39136);
+        expect(Math.round(wmtsLayer.getMaxResolution())).toBe(156543);
+    });
+
     it('creates a wmts layer with multiple urls for openlayers map', () => {
         var options = {
             "type": "wmts",

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -79,7 +79,7 @@ const createLayer = options => {
     urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters, options.securityToken));
     const queryParametersString = urlParser.format({ query: {...queryParameters}});
 
-    const maxResolution	= resolutions[0]; // exclusive
+    const maxResolution = resolutions[0]; // exclusive
     const minResolution = resolutions[resolutions.length - 1]; // inclusive
 
     return new ol.layer.Tile({

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -79,11 +79,16 @@ const createLayer = options => {
     urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters, options.securityToken));
     const queryParametersString = urlParser.format({ query: {...queryParameters}});
 
+    const maxResolution	= resolutions[0]; // exclusive
+    const minResolution = resolutions[resolutions.length - 1]; // inclusive
+
     return new ol.layer.Tile({
         opacity: options.opacity !== undefined ? options.opacity : 1,
         zIndex: options.zIndex,
         extent: extent,
         visible: options.visibility !== false,
+        maxResolution,
+        minResolution,
         source: new ol.source.WMTS(assign({
             urls: urls.map(u => u + queryParametersString),
             layer: options.name,


### PR DESCRIPTION
## Description
Added max and min resolution to prevent CanvasRenderingContext2D error in openlayers

## Issues
 - Fix #2962

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#2962

**What is the new behavior?**
application doesn't crash at zoom 0 with WMTS (custom gridset)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
