### PR TITLE
Support for WMS dimension

### DIFF
--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -22,6 +22,7 @@ var {
     HIDE_SETTINGS,
     UPDATE_SETTINGS,
     REFRESH_LAYERS,
+    UPDATE_LAYERS_DIMENSION,
     LAYERS_REFRESHED,
     LAYERS_REFRESH_ERROR,
     BROWSE_DATA,
@@ -44,6 +45,7 @@ var {
     hideSettings,
     updateSettings,
     refreshLayers,
+    updateLayerDimension,
     layersRefreshed,
     layersRefreshError,
     browseData,
@@ -111,6 +113,14 @@ describe('Test correctness of the layers actions', () => {
         expect(retval.error).toBe('err');
     });
 
+    it('updateLayerDimension', () => {
+        const retval = updateLayerDimension( "time", "2016-02-24T03:00:00.000Z", null, "A");
+        expect(retval).toExist();
+        expect(retval.type).toBe(UPDATE_LAYERS_DIMENSION);
+        expect(retval.layers).toBe("A");
+        expect(retval.dimension).toBe("time");
+        expect(retval.value).toBe("2016-02-24T03:00:00.000Z");
+    });
     it('toggleNode', () => {
         var retval = toggleNode('sample', 'groups', true);
 

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -7,6 +7,7 @@
  */
 
 const CHANGE_LAYER_PROPERTIES = 'CHANGE_LAYER_PROPERTIES';
+const CHANGE_LAYER_PARAMS = 'LAYERS:CHANGE_LAYER_PARAMS';
 const CHANGE_GROUP_PROPERTIES = 'CHANGE_GROUP_PROPERTIES';
 const TOGGLE_NODE = 'TOGGLE_NODE';
 const CONTEXT_NODE = 'CONTEXT_NODE';
@@ -22,6 +23,7 @@ const SHOW_SETTINGS = 'SHOW_SETTINGS';
 const HIDE_SETTINGS = 'HIDE_SETTINGS';
 const UPDATE_SETTINGS = 'UPDATE_SETTINGS';
 const REFRESH_LAYERS = 'REFRESH_LAYERS';
+const UPDATE_LAYERS_DIMENSION = 'LAYERS:UPDATE_LAYERS_DIMENSION';
 const LAYERS_REFRESHED = 'LAYERS_REFRESHED';
 const LAYERS_REFRESH_ERROR = 'LAYERS_REFRESH_ERROR';
 const BROWSE_DATA = 'LAYERS:BROWSE_DATA';
@@ -60,6 +62,20 @@ function changeLayerProperties(layer, properties) {
         newProperties: properties,
         layer: layer
 
+    };
+}
+/**
+ * Change params for a layer. Useful for WMS layers, when you need to change only the params (i.e. dimension) merging with existing ones.
+ * @memberof actions.layers
+ * @function
+ * @param {string|string[]} layer id(s) of the layers to change
+ * @param {object} params the params to change
+ */
+function changeLayerParams(layer, params) {
+    return {
+        type: CHANGE_LAYER_PARAMS,
+        layer,
+        params
     };
 }
 
@@ -184,6 +200,15 @@ function layersRefreshError(layers, error) {
         error
     };
 }
+function updateLayerDimension(dimension, value, options, layers) {
+    return {
+        type: UPDATE_LAYERS_DIMENSION,
+        dimension,
+        value,
+        options,
+        layers
+    };
+}
 function browseData(layer) {
     return {
         type: BROWSE_DATA,
@@ -232,12 +257,13 @@ function hideLayerMetadata() {
     };
 }
 
-module.exports = {changeLayerProperties, changeGroupProperties, toggleNode, sortNode, removeNode, contextNode,
+module.exports = {
+    changeLayerProperties, changeLayerParams, changeGroupProperties, toggleNode, sortNode, removeNode, contextNode,
     updateNode, layerLoading, layerLoad, layerError, addLayer, removeLayer, showSettings, hideSettings, updateSettings, refreshLayers,
-    layersRefreshed, layersRefreshError, refreshLayerVersion, browseData, clearLayers, selectNode, filterLayers, showLayerMetadata,
+    layersRefreshed, layersRefreshError, refreshLayerVersion, updateLayerDimension, browseData, clearLayers, selectNode, filterLayers, showLayerMetadata,
     hideLayerMetadata, download,
-    CHANGE_LAYER_PROPERTIES, CHANGE_GROUP_PROPERTIES, TOGGLE_NODE, SORT_NODE,
+    CHANGE_LAYER_PROPERTIES, CHANGE_LAYER_PARAMS, CHANGE_GROUP_PROPERTIES, TOGGLE_NODE, SORT_NODE,
     REMOVE_NODE, UPDATE_NODE, LAYER_LOADING, LAYER_LOAD, LAYER_ERROR, ADD_LAYER, REMOVE_LAYER,
-    SHOW_SETTINGS, HIDE_SETTINGS, UPDATE_SETTINGS, CONTEXT_NODE, REFRESH_LAYERS, LAYERS_REFRESHED, LAYERS_REFRESH_ERROR, BROWSE_DATA, DOWNLOAD,
+    SHOW_SETTINGS, HIDE_SETTINGS, UPDATE_SETTINGS, CONTEXT_NODE, REFRESH_LAYERS, LAYERS_REFRESHED, LAYERS_REFRESH_ERROR, UPDATE_LAYERS_DIMENSION, BROWSE_DATA, DOWNLOAD,
     CLEAR_LAYERS, SELECT_NODE, FILTER_LAYERS, SHOW_LAYER_METADATA, HIDE_LAYER_METADATA
 };

--- a/web/client/plugins/AutoMapUpdate.jsx
+++ b/web/client/plugins/AutoMapUpdate.jsx
@@ -12,7 +12,6 @@ const {connect} = require('react-redux');
 const {manageAutoMapUpdate} = require('../epics/automapupdate');
 const {autoMapUpdateSelector} = require('../selectors/automapupdate');
 const {setControlProperty} = require('../actions/controls');
-const {refresh} = require('../epics/layers');
 
 const OverlayProgressBar = require('../components/misc/progressbars/OverlayProgressBar/OverlayProgressBar');
 
@@ -78,5 +77,5 @@ const AutoMapUpdatePlugin = connect(autoMapUpdateSelector, {
 module.exports = {
     AutoMapUpdatePlugin,
     reducers: {},
-    epics: {manageAutoMapUpdate, refresh}
+    epics: {manageAutoMapUpdate}
 };

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -7,6 +7,8 @@
  */
 var expect = require('expect');
 var layers = require('../layers');
+const { changeLayerParams } = require('../../actions/layers');
+
 
 describe('Test the layers reducer', () => {
 
@@ -178,7 +180,44 @@ describe('Test the layers reducer', () => {
         expect(state.flat[0].visibility).toBe(false);
         expect(state.flat[1].visibility).toBe(true);
     });
+    it('changeLayerParams', () => {
+        const state = {
+            flat: [{
+                "type": "osm",
+                "title": "Open Street Map",
+                "name": "mapnik",
+                "id": "mapnik",
+                "group": "background",
+                "visibility": true
+            }, {
+                "type": "wms",
+                "url": "/reflector/open/service",
+                "visibility": false,
+                "title": "e-Geos Ortofoto RealVista 1.0",
+                "name": "rv1",
+                "id": "rv1",
+                "group": "background",
+                "format": "image/png"
+            }, {
+                "type": "wms",
+                "url": "/reflector/open/service",
+                "visibility": false,
+                "title": "e-Geos Ortofoto RealVista 1.0",
+                "name": "rv2",
+                "id": "rv2",
+                "group": "background",
+                "format": "image/png"
+            }]
+        };
+        const state1 = layers(state, changeLayerParams("rv1", {elevation: 200}));
+        expect(state1.flat[1].params).toExist();
+        expect(state1.flat[1].params.elevation).toBe(200);
+        expect(state1.flat[2].params).toNotExist();
+        const state2 = layers(state, changeLayerParams(["rv1", "rv2"], { elevation: 200 }));
+        expect(state2.flat[1].params.elevation).toBe(200);
+        expect(state2.flat[2].params.elevation).toBe(200);
 
+    });
     it('a layer is loading, loading flag is updated', () => {
         const action1 = {
             type: 'LAYER_LOADING',

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -8,7 +8,7 @@
 
 const expect = require('expect');
 const {layersSelector, layerSelectorWithMarkers, groupsSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector,
-    layerMetadataSelector, wfsDownloadSelector, backgroundControlsSelector, currentBackgroundSelector, tempBackgroundSelector, centerToMarkerSelector} = require('../layers');
+    layerMetadataSelector, wfsDownloadSelector, backgroundControlsSelector, currentBackgroundSelector, tempBackgroundSelector, centerToMarkerSelector, getLayersWithDimension} = require('../layers');
 
 describe('Test layers selectors', () => {
     it('test layersSelector from config', () => {
@@ -404,6 +404,33 @@ describe('Test layers selectors', () => {
             }
         });
         expect(props).toEqual(true);
+    });
+    it('test getLayerWidDimension', () => {
+        const state = {
+            layers: {
+                flat: [{
+                    group: 'test',
+                    id: 'layer001',
+                    visibility: true,
+                    dimensions: [{
+                        name: 'time'
+                    }]
+                },
+                {
+                    group: 'test',
+                    id: 'layer002',
+                    visibility: true,
+                    dimensions: [{
+                        name: 'time'
+                    }, {
+                        name: 'elevation'
+                    }]
+                }]
+            }
+        };
+        expect(getLayersWithDimension(state, 'time').length).toBe(2);
+        expect(getLayersWithDimension(state, 'elevation').length).toBe(1);
+        expect(getLayersWithDimension(state, 'reference').length).toBe(0);
     });
 
 });

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -11,7 +11,7 @@ const {createSelector} = require('reselect');
 const MapInfoUtils = require('../utils/MapInfoUtils');
 const LayersUtils = require('../utils/LayersUtils');
 const {getNormalizedLatLon} = require('../utils/CoordinatesUtils');
-const {get, head, isEmpty, find, isObject} = require('lodash');
+const {get, head, isEmpty, find, isObject, castArray} = require('lodash');
 
 const layersSelector = state => state.layers && state.layers.flat || state.layers || state.config && state.config.layers || [];
 const currentBackgroundLayerSelector = state => head(layersSelector(state).filter(l => l && l.visibility && l.group === "background"));
@@ -81,7 +81,12 @@ const tempBackgroundSelector = (state) => {
     const layers = allBackgroundLayerSelector(state) || [];
     return controls.tempLayer && !isEmpty(controls.tempLayer) ? controls.tempLayer : head(layers.filter((l) => l.visibility)) || {};
 };
-
+const getLayersWithDimension = (state, dimension) =>
+    (layersSelector(state) || [])
+        .filter(l =>
+            l
+            && l.dimensions
+            && find(castArray(l.dimensions), {name: dimension}));
 module.exports = {
     layersSelector,
     layerSelectorWithMarkers,
@@ -89,6 +94,7 @@ module.exports = {
     currentBackgroundLayerSelector,
     allBackgroundLayerSelector,
     getLayerFromId,
+    getLayersWithDimension,
     selectedNodesSelector,
     getSelectedLayer,
     getSelectedLayers,

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -30,8 +30,11 @@ const history = routerCreateHistory();
 
 // Build the middleware for intercepting and dispatching navigation actions
 const reduxRouterMiddleware = routerMiddleware(history);
+const layersEpics = require('../epics/layers');
+const controlsEpics = require('../epics/controls');
 const standardEpics = {
-    ...require('../epics/controls')
+    ...layersEpics,
+    ...controlsEpics
 };
 
 module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {}, appEpics = {}, plugins, storeOpts = {}) => {


### PR DESCRIPTION
## Description
This PR add utiity actions and epics for an initial support to time dimension. 
`changeLayerParams` provies a shortcut to update to a list of layers the possibility to update params leaving the other untouched. 
`updateDimension` triggers an epic that update the `dimension` parameter to the layers that have the indicated dimension (or a list of layers provided in the action) with the given value.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature



