### PR TITLE
Support for TOC indicators

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -9,13 +9,17 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const Node = require('./Node');
-const {isObject, isArray} = require('lodash');
-const {Grid, Row, Col} = require('react-bootstrap');
+const { isObject, isArray, castArray, find} = require('lodash');
+const { Grid, Row, Col, Glyphicon} = require('react-bootstrap');
 const VisibilityCheck = require('./fragments/VisibilityCheck');
 const Title = require('./fragments/Title');
 const WMSLegend = require('./fragments/WMSLegend');
 const LayersTool = require('./fragments/LayersTool');
 const Slider = require('../misc/Slider');
+const withTooltip = require('../data/featuregrid/enhancers/withTooltip');
+const localizedProps = require('../misc/enhancers/localizedProps');
+
+const GlyphIndicator = localizedProps('tooltip')(withTooltip(Glyphicon));
 
 class DefaultLayer extends React.Component {
     static propTypes = {
@@ -28,6 +32,7 @@ class DefaultLayer extends React.Component {
         sortableStyle: PropTypes.object,
         activateLegendTool: PropTypes.bool,
         activateOpacityTool: PropTypes.bool,
+        indicators: PropTypes.array,
         visibilityCheckType: PropTypes.string,
         currentZoomLvl: PropTypes.number,
         scales: PropTypes.array,
@@ -51,6 +56,7 @@ class DefaultLayer extends React.Component {
         onSelect: () => {},
         activateLegendTool: false,
         activateOpacityTool: true,
+        indicators: [],
         visibilityCheckType: "glyph",
         additionalTools: [],
         currentLocale: 'en-US',
@@ -125,7 +131,13 @@ class DefaultLayer extends React.Component {
                 glyph="chevron-left"
                 onClick={(node) => this.props.onToggle(node.id, node.expanded)} />);
     }
-
+    renderIndicators = () => {
+        /** initial support to render icons in TOC nodes (now only type = "dimension" supported) */
+        return castArray(this.props.indicators).map( indicator =>
+            (indicator.type === "dimension" ? find(this.props.node && this.props.node.dimensions || [], indicator.condition) : false)
+                ? indicator.glyph && <GlyphIndicator key={indicator.key} glyph={indicator.glyph} {...indicator.props} />
+                : null);
+    }
     renderNode = (grab, hide, selected, error, warning, other) => {
         const isEmpty = !this.props.activateLegendTool && !this.props.showFullTitleOnExpand;
         return (
@@ -135,6 +147,7 @@ class DefaultLayer extends React.Component {
                     {this.renderVisibility()}
                     <Title tooltip={this.props.titleTooltip} filterText={this.props.filterText} node={this.props.node} currentLocale={this.props.currentLocale} onClick={this.props.onSelect} onContextMenu={this.props.onContextMenu} />
                     {this.props.node.loading ? <div className="toc-inline-loader"></div> : this.renderToolsLegend(isEmpty)}
+                    {this.props.indicators ? this.renderIndicators() : null}
                 </div>
                 {!this.props.activateOpacityTool || this.props.node.expanded || !this.props.node.visibility || this.props.node.loadingError === 'Error' ? null : this.renderOpacitySlider()}
                 {isEmpty ? null : this.renderCollapsible()}

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -255,5 +255,36 @@ describe('test DefaultLayer module component', () => {
         expect(title.length).toBe(0);
 
     });
+    it('support for indicators', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: false,
+            storeIndex: 9,
+            type: 'wms',
+            opacity: 0.5,
+            expanded: true,
+            dimensions: [{
+                name: "time"
+            }]
+        };
+        const indicators = [{
+            "type": "dimension",
+            "key": "calendar",
+            "glyph": "calendar",
+            "props": {
+                className: "TIME_INDICATOR"
+            },
+            "condition": {
+                "name": "time"
+            }
+        }];
+        const comp = ReactDOM.render(<Layer indicators={indicators} node={l} />,
+            document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const title = domNode.getElementsByClassName("TIME_INDICATOR");
+        expect(title.length).toBe(1);
+    });
 
 });

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -468,7 +468,28 @@ class LayerTree extends React.Component {
  *    }
  *   }
  *  }
-```
+ * ```
+ * Another layerOptionS entry can be `indicators`. `indicators` is an array of icons to add to the TOC. They must satisfy a condition to be shown in the TOC.
+ * For the moment only indiators of type `dimension` are supported.
+ * example :
+ * ```
+ *  "indicators: [{
+ *      "key": "dimension", // key: required id for the entry to render
+ *      "type": "dimension", // type: only one supported is dimension
+ *      "glyph": "calendar", // glyph to use
+ *      "props": { // props to pass to the indicator
+ *          "style": {
+ *          "color": "#dddddd",
+ *          "float": "right"
+ *          },
+ *          "tooltip": "dateFilter.supportedDateFilter", // tooltip (can be also a localized msgId)
+ *          "placement": "bottom" // tooltip position
+ *      },
+ *      "condition": { // condition (lodash style) to satifsfy ( for type dimension, the condition is to match at least one of the "dimensions" )
+ *          "name": "time"
+ *      }
+ *  }]
+ * ```
  */
 const TOCPlugin = connect(tocSelector, {
     groupPropertiesChangeHandler: changeGroupProperties,

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -479,13 +479,13 @@ class LayerTree extends React.Component {
  *      "glyph": "calendar", // glyph to use
  *      "props": { // props to pass to the indicator
  *          "style": {
- *          "color": "#dddddd",
- *          "float": "right"
+ *               "color": "#dddddd",
+ *               "float": "right"
  *          },
  *          "tooltip": "dateFilter.supportedDateFilter", // tooltip (can be also a localized msgId)
  *          "placement": "bottom" // tooltip position
  *      },
- *      "condition": { // condition (lodash style) to satifsfy ( for type dimension, the condition is to match at least one of the "dimensions" )
+ *      "condition": { // condition (lodash style) to satisfy ( for type dimension, the condition is to match at least one of the "dimensions" )
  *          "name": "time"
  *      }
  *  }]

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -470,7 +470,7 @@ class LayerTree extends React.Component {
  *  }
  * ```
  * Another layerOptionS entry can be `indicators`. `indicators` is an array of icons to add to the TOC. They must satisfy a condition to be shown in the TOC.
- * For the moment only indiators of type `dimension` are supported.
+ * For the moment only indicators of type `dimension` are supported.
  * example :
  * ```
  *  "indicators: [{


### PR DESCRIPTION
## Description
Add indicators support for layers in TOC. Indicators are icons for TOC layers, that can be configured to be shown under specific conditions.
![image](https://user-images.githubusercontent.com/1279510/40922383-52fb12cc-6812-11e8-90ff-b8588a13285e.png)

Actually the only indicators supported are "dimension". 
Can be configured in layerOptions entry in TOC plugins
```
"layerOptions": {
                      "indicators": [{
                        "key": "dimension",
                        "type": "dimension",
                        "glyph": "calendar",
                        "props": {
                          "style": {
                            "color": "#dddddd",
                            "float": "right"
                          },
                          "tooltip": "dateFilter.supportedDateFilter",
                          "placement": "bottom"
                        },
                        "condition": {
                          "name": "time"
                        }
                      }]
```

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature



**Does this PR introduce a breaking change?** (check one with "x", remove the other)


 - [x] No

