### PR TITLE
Fix#2978 Catalog panel hides identify panel (2018.02.00)

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -50,7 +50,8 @@ module.exports = props => {
         draggable,
         setIndex,
         warning,
-        clearWarning
+        clearWarning,
+        zIndex
     } = props;
 
     const latlng = point && point.latlng || null;
@@ -86,6 +87,7 @@ module.exports = props => {
                 dock={dock}
                 style={dockStyle}
                 showFullscreen={showFullscreen}
+                zIndex={zIndex}
                 header={[
                     <GeocodeViewer latlng={latlng} revGeocodeDisplayName={revGeocodeDisplayName} {...props}/>,
                     buttons.length > 0 ? (

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -108,4 +108,11 @@ describe("test IdentifyContainer", () => {
         expect(spyClearWarning).toHaveBeenCalled();
 
     });
+
+    it('test component with z index', () => {
+        ReactDOM.render(<IdentifyContainer enabled requests={[{}]} zIndex={7777}/>, document.getElementById("container"));
+        const sidePanel = document.getElementsByClassName('ms-side-panel');
+        expect(sidePanel.length).toBe(1);
+        expect(sidePanel[0].children[0].style.zIndex).toBe('7777');
+    });
 });

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -124,7 +124,8 @@ const identifyDefaultProps = defaultProps({
     size: 660,
     getButtons: defaultIdentifyButtons,
     showFullscreen: false,
-    validator: MapInfoUtils.getValidator
+    validator: MapInfoUtils.getValidator,
+    zIndex: 1050
 });
 
 /**
@@ -148,6 +149,7 @@ const identifyDefaultProps = defaultProps({
  * @prop cfg.viewerOptions.container {expression} the container of the viewer, expression from the context
  * @prop cfg.viewerOptions.header {expression} the geader of the viewer, expression from the context{expression}
  * @prop cfg.disableCenterToMarker {bool} disable zoom to marker action
+ * @prop cfg.zIndex {number} component z index order
  *
  * @example
  * {


### PR DESCRIPTION
## Description
Added z index to display Identify

## Issues
 - Fix #2978

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#2978

**What is the new behavior?**
Identify panel is displayed over catalog panel

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
