### PR TITLE
Fix #2945: Fix error caused by Layer Filter when operation field is empty

### DIFF
--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -282,7 +282,7 @@ const FilterUtils = {
 
             filters.push(spatialFilter);
         }
-        if (objFilter.crossLayerFilter) {
+        if (objFilter.crossLayerFilter && objFilter.crossLayerFilter.operation) {
             let crossLayerFilter = {
                 ...objFilter.crossLayerFilter,
                 attribute: objFilter.crossLayerFilter.attribute // || (objFilter.spatialField && objFilter.spatialField.attribute)

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -173,6 +173,52 @@ describe('FilterUtils', () => {
         expect(filter.indexOf('maxFeatures="20"') !== -1).toBe(true);
         expect(filter.indexOf('startIndex="1"') !== -1).toBe(true);
     });
+
+    it('Check  for no oparation', () => {
+        const versionOGC = "1.1.0";
+        const nsplaceholder = "ogc";
+        const objFilter = {
+            featureTypeName: "topp:states",
+            groupFields: [{
+                id: 1,
+                logic: "OR",
+                index: 0
+            }],
+            filterFields: [],
+            spatialField: {
+                method: null,
+                operation: "INTERSECTS",
+                geometry: null,
+                attribute: "the_geom"
+            },
+            pagination: {
+                startIndex: 0,
+                maxFeatures: 20
+            },
+            filterType: "OGC",
+            ogcVersion: "1.1.0",
+            sortOptions: null,
+            crossLayerFilter: {
+                attribute: "the_geom",
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "topp:states",
+                        filterFields: [],
+                        geometryName: "the_geom",
+                        groupFields: [{
+                            id: 1,
+                            index: 0,
+                            logic: "OR"
+                        }]
+                    }
+            }
+            },
+            hits: false
+        };
+
+        let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
+        expect(filterParts).toEqual([]);
+    });
     it('Check for pagination wfs 2.0', () => {
         let filterObj = {
             pagination: {


### PR DESCRIPTION

## Description
Fix error caused by Layer Filter when operation field is empty

## Issues
 - Fix #2945 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 

 - [x] Bugfix


**Does this PR introduce a breaking change?**

 - [x] No
