### PR TITLE
Fix #2881 Visualization of percentage in opacity slider, Fix #2250 Duplicated slider component on layers and opacity support 

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -9,13 +9,13 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const Node = require('./Node');
-const {isObject, isArray} = require('lodash');
+const {isObject} = require('lodash');
 const {Grid, Row, Col} = require('react-bootstrap');
 const VisibilityCheck = require('./fragments/VisibilityCheck');
 const Title = require('./fragments/Title');
 const WMSLegend = require('./fragments/WMSLegend');
 const LayersTool = require('./fragments/LayersTool');
-const Slider = require('../misc/Slider');
+const OpacitySlider = require('./fragments/OpacitySlider');
 
 class DefaultLayer extends React.Component {
     static propTypes = {
@@ -39,7 +39,8 @@ class DefaultLayer extends React.Component {
         onUpdateNode: PropTypes.func,
         titleTooltip: PropTypes.bool,
         filter: PropTypes.func,
-        showFullTitleOnExpand: PropTypes.bool
+        showFullTitleOnExpand: PropTypes.bool,
+        hideOpacityTooltip: PropTypes.bool
     };
 
     static defaultProps = {
@@ -59,7 +60,8 @@ class DefaultLayer extends React.Component {
         onUpdateNode: () => {},
         filter: () => true,
         titleTooltip: false,
-        showFullTitleOnExpand: false
+        showFullTitleOnExpand: false,
+        hideOpacityTooltip: false
     };
 
     getTitle = (layer) => {
@@ -67,19 +69,14 @@ class DefaultLayer extends React.Component {
         return translation || layer.name;
     };
 
-    renderOpacitySlider = () => {
-        const layerOpacity = this.props.node.opacity !== undefined ? Math.round(this.props.node.opacity * 100) : 100;
-        return this.props.activateOpacityTool ?
-            <Slider
+    renderOpacitySlider = (hideOpacityTooltip) => {
+        return this.props.activateOpacityTool ? (
+            <OpacitySlider
+                opacity={this.props.node.opacity}
                 disabled={!this.props.node.visibility}
-                start={[layerOpacity]}
-                range={{min: 0, max: 100}}
-                onChange={(opacity) => {
-                    if (isArray(opacity) && opacity[0]) {
-                        this.props.onUpdateNode(this.props.node.id, 'layers', { opacity: parseFloat(opacity[0].replace(' %', '')) / 100 });
-                    }
-                }}/>
-        : null;
+                hideTooltip={hideOpacityTooltip}
+                onChange={opacity => this.props.onUpdateNode(this.props.node.id, 'layers', {opacity})}/>
+        ) : null;
     }
 
     renderCollapsible = () => {
@@ -94,7 +91,7 @@ class DefaultLayer extends React.Component {
                             </Col>
                         </Row> : null}
                 </Grid>
-                {this.renderOpacitySlider()}
+                {this.renderOpacitySlider(this.props.hideOpacityTooltip)}
             </div>);
     };
 
@@ -137,7 +134,7 @@ class DefaultLayer extends React.Component {
                     <Title tooltip={this.props.titleTooltip} filterText={this.props.filterText} node={this.props.node} currentLocale={this.props.currentLocale} onClick={this.props.onSelect} onContextMenu={this.props.onContextMenu} />
                     {this.props.node.loading ? <div className="toc-inline-loader"></div> : this.renderToolsLegend(isEmpty)}
                 </div>
-                {!this.props.activateOpacityTool || this.props.node.expanded || !this.props.node.visibility || this.props.node.loadingError === 'Error' ? null : this.renderOpacitySlider()}
+                {!this.props.activateOpacityTool || this.props.node.expanded || !this.props.node.visibility || this.props.node.loadingError === 'Error' ? null : this.renderOpacitySlider(this.props.hideOpacityTooltip)}
                 {isEmpty ? null : this.renderCollapsible()}
             </Node>
         );

--- a/web/client/components/TOC/FloatingLegend.jsx
+++ b/web/client/components/TOC/FloatingLegend.jsx
@@ -9,7 +9,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const PropTypes = require('prop-types');
-const {isNil, isEqual, delay} = require('lodash');
+const {isEqual, delay} = require('lodash');
 
 const {Glyphicon, Panel, Grid, Row, Col, Button: ButtonB} = require('react-bootstrap');
 const {Resizable} = require('react-resizable');
@@ -17,7 +17,7 @@ const ContainerDimensions = require('react-container-dimensions').default;
 const tooltip = require('../misc/enhancers/tooltip');
 const Button = tooltip(ButtonB);
 const SideGrid = require('../misc/cardgrids/SideGrid');
-const Slider = require('../misc/Slider');
+const OpacitySlider = require('./fragments/OpacitySlider');
 const WMSLegend = require('./fragments/WMSLegend');
 
 /**
@@ -44,6 +44,7 @@ const WMSLegend = require('./fragments/WMSLegend');
  * @prop {array} scales array of supported scales
  * @prop {bool} disableOpacitySlider disable and hide opacity slider
  * @prop {bool} expandedOnMount show expanded legend when component did mount
+ * @prop {bool} hideOpacityTooltip hide toolip on opacity sliders
  */
 
 class FloatingLegend extends React.Component {
@@ -66,7 +67,8 @@ class FloatingLegend extends React.Component {
         scales: PropTypes.array,
         disableOpacitySlider: PropTypes.bool,
         deltaHeight: PropTypes.number,
-        expandedOnMount: PropTypes.bool
+        expandedOnMount: PropTypes.bool,
+        hideOpacityTooltip: PropTypes.bool
     };
 
     static defaultProps = {
@@ -200,13 +202,13 @@ class FloatingLegend extends React.Component {
                                                             </Col>
                                                         </Row>
                                                     </Grid>
-                                                    {!this.props.disableOpacitySlider && <div className="mapstore-slider" onClick={(e) => { e.stopPropagation(); }}>
-                                                        <Slider
+                                                    {!this.props.disableOpacitySlider &&
+                                                        <OpacitySlider
+                                                            opacity={layer.opacity}
                                                             disabled={!layer.visibility}
-                                                            start={[isNil(layer.opacity) ? 100 : Math.round(layer.opacity * 100) ]}
-                                                            range={{min: 0, max: 100}}
-                                                            onChange={(value) => this.props.onChange(layer.id, 'layers', {opacity: parseFloat((value[0] / 100).toFixed(2))}) }/>
-                                                    </div>}
+                                                            hideTooltip={this.props.hideOpacityTooltip}
+                                                            onChange={opacity => this.props.onChange(layer.id, 'layers', {opacity})}/>
+                                                    }
                                                 </div>
                                             )
                                     })

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -273,4 +273,39 @@ describe('test DefaultLayer module component', () => {
         expect(title.length).toBe(0);
     });
 
+    it('show tooltip', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            opacity: 0.5
+        };
+        const comp = ReactDOM.render(<Layer node={l}/>,
+        document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const tooltips = domNode.getElementsByClassName('noUi-tooltip');
+        expect(tooltips.length).toBe(1);
+        expect(tooltips[0].innerHTML).toBe('50 %');
+    });
+
+    it('hide tooltip', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            opacity: 0.5
+        };
+        const comp = ReactDOM.render(<Layer hideOpacityTooltip node={l}/>,
+        document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const tooltips = domNode.getElementsByClassName('noUi-tooltip');
+        expect(tooltips.length).toBe(0);
+    });
+
 });

--- a/web/client/components/TOC/__tests__/FloatingLegend-test.jsx
+++ b/web/client/components/TOC/__tests__/FloatingLegend-test.jsx
@@ -223,4 +223,71 @@ describe('tests FloatingLegend component', () => {
                 ]}
                 onResize={onResize}/>, document.getElementById("container"));
     });
+
+    it('show tooltips', () => {
+        const cmp = ReactDOM.render(
+            <FloatingLegend
+                expanded
+                layers={[
+                    {
+                        name: 'layer:00',
+                        title: 'Layer',
+                        visibility: true,
+                        type: 'wms',
+                        opacity: 0.6
+                    },
+                    {
+                        name: 'layer:01',
+                        title: 'Layer:01',
+                        visibility: false,
+                        type: 'wms',
+                        opacity: 0.5
+                    },
+                    {
+                        name: 'layer:02',
+                        title: 'layer:02',
+                        visibility: true,
+                        type: 'wms'
+                    }
+                ]}/>, document.getElementById("container"));
+
+        expect(cmp).toExist();
+        const tooltips = document.getElementsByClassName('noUi-tooltip');
+        expect(tooltips.length).toBe(2);
+        expect(tooltips[0].innerHTML).toBe('60 %');
+        expect(tooltips[1].innerHTML).toBe('100 %');
+    });
+
+    it('hide tooltips', () => {
+        const cmp = ReactDOM.render(
+            <FloatingLegend
+                expanded
+                hideOpacityTooltip
+                layers={[
+                    {
+                        name: 'layer:00',
+                        title: 'Layer',
+                        visibility: true,
+                        type: 'wms',
+                        opacity: 0.6
+                    },
+                    {
+                        name: 'layer:01',
+                        title: 'Layer:01',
+                        visibility: false,
+                        type: 'wms',
+                        opacity: 0.5
+                    },
+                    {
+                        name: 'layer:02',
+                        title: 'layer:02',
+                        visibility: true,
+                        type: 'wms'
+                    }
+                ]}/>, document.getElementById("container"));
+
+        expect(cmp).toExist();
+        const tooltips = document.getElementsByClassName('noUi-tooltip');
+        expect(tooltips.length).toBe(0);
+    });
 });

--- a/web/client/components/TOC/fragments/OpacitySlider.jsx
+++ b/web/client/components/TOC/fragments/OpacitySlider.jsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const Slider = require('../../misc/Slider');
+const {isNil, isArray} = require('lodash');
+
+class OpacitySlider extends React.Component {
+    static propTypes = {
+        opacity: PropTypes.number,
+        disabled: PropTypes.bool,
+        hideTooltip: PropTypes.bool,
+        onChange: PropTypes.func
+    };
+
+    static defaultProps= {
+        opacity: 1,
+        onChange: () => {},
+        visibility: true
+    };
+
+    render() {
+
+        return (
+            <div
+                className={`mapstore-slider ${this.props.hideTooltip ? '' : 'with-tooltip'}`}
+                onClick={(e) => { e.stopPropagation(); }}>
+                {this.props.hideTooltip &&
+                <Slider
+                    disabled={this.props.disabled}
+                    start={[isNil(this.props.opacity) ? 100 : Math.round(this.props.opacity * 100)]}
+                    range={{min: 0, max: 100}}
+                    onChange={(opacity) => {
+                        if (isArray(opacity) && opacity[0]) {
+                            this.props.onChange(parseFloat(opacity[0].replace(' %', '') / 100));
+                        }
+                    }}/>
+                ||
+                <Slider
+                    disabled={this.props.disabled}
+                    start={[isNil(this.props.opacity) ? 100 : Math.round(this.props.opacity * 100)]}
+                    tooltips={[true]}
+                    format={{
+                        from: value => Math.round(value),
+                        to: value => Math.round(value) + ' %'
+                    }}
+                    range={{min: 0, max: 100}}
+                    onChange={(opacity) => this.props.onChange(parseFloat(opacity[0].replace(' %', '')) / 100)}/>}
+            </div>
+        );
+    }
+
+}
+
+module.exports = OpacitySlider;

--- a/web/client/components/TOC/fragments/__tests__/OpacitySlider-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/OpacitySlider-test.jsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const OpacitySlider = require('../OpacitySlider');
+const expect = require('expect');
+
+describe('test OpacitySlider module component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('render component', () => {
+        const cmp = ReactDOM.render(<OpacitySlider />, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(cmp);
+        expect(domNode).toExist();
+        const target = document.getElementsByClassName('noUi-target');
+        expect(target.length).toBe(1);
+        expect(target[0].getAttribute('disabled')).toBe(null);
+    });
+
+    it('show tooltip', () => {
+        const cmp = ReactDOM.render(<OpacitySlider opacity={0.6}/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(cmp);
+        expect(domNode).toExist();
+        const tooltips = document.getElementsByClassName('noUi-tooltip');
+        expect(tooltips.length).toBe(1);
+        expect(tooltips[0].innerHTML).toBe('60 %');
+    });
+
+    it('hide tooltip', () => {
+        const cmp = ReactDOM.render(<OpacitySlider hideTooltip opacity={0.6}/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(cmp);
+        expect(domNode).toExist();
+        const tooltips = document.getElementsByClassName('noUi-tooltip');
+        expect(tooltips.length).toBe(0);
+    });
+
+    it('disable component', () => {
+        const cmp = ReactDOM.render(<OpacitySlider disabled opacity={0.6}/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(cmp);
+        expect(domNode).toExist();
+        const target = document.getElementsByClassName('noUi-target');
+        expect(target.length).toBe(1);
+        expect(target[0].getAttribute('disabled')).toBe('true');
+    });
+});

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -8,12 +8,13 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const Slider = require('react-nouislider');
-const {Label, Checkbox} = require('react-bootstrap');
 const {DropdownList} = require('react-widgets');
 const Message = require('../../../I18N/Message');
-const {Grid} = require('react-bootstrap');
+const {Grid, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox} = require('react-bootstrap');
+const {clamp, isNil} = require('lodash');
+
 require('react-widgets/lib/less/react-widgets.less');
+
 module.exports = class extends React.Component {
     static propTypes = {
         opacityText: PropTypes.node,
@@ -28,40 +29,78 @@ module.exports = class extends React.Component {
         opacityText: <Message msgId="opacity"/>
     };
 
+    state = {
+        opacity: 100
+    };
+
+    componentDidMount() {
+        if (this.props.settings && this.props.settings.options && !isNil(this.props.settings.options.opacity)) {
+            this.setState({ opacity: Math.round(this.props.settings.options.opacity * 100)});
+        }
+    }
+
     render() {
-        return (<Grid fluid style={{paddingTop: 15, paddingBottom: 15}}>
-            {this.props.element.type === "wms" ?
-            [(<label key="format-label" className="control-label"><Message msgId="layerProperties.format" /></label>),
-            (<DropdownList
-                key="format-dropdown"
-                data={this.props.formats || ["image/png", "image/png8", "image/jpeg", "image/vnd.jpeg-png", "image/gif"]}
-                value={this.props.element && this.props.element.format || "image/png"}
-                onChange={(value) => {
-                    this.props.onChange("format", value);
-                }} />)] : null}
-            <div key="opacity">
-            <label key="opacity-label" className="control-label">{this.props.opacityText}</label>
-            <Slider key="opacity-slider" start={[Math.round(this.props.settings.options.opacity * 100)]}
-                range={{min: 0, max: 100}}
-                onChange={(opacity) => {this.props.onChange("opacity", opacity / 100); }}/>
-            <Label key="opacity-percent" >{Math.round(this.props.settings.options.opacity * 100) + "%"}</Label>
-            </div>
-            {this.props.element.type === "wms" ?
-                [(<div key="transparent-check">
-                    <Checkbox key="transparent" checked={this.props.element && (this.props.element.transparent === undefined ? true : this.props.element.transparent)} onChange={(event) => {this.props.onChange("transparent", event.target.checked); }}>
-                        <Message msgId="layerProperties.transparent"/></Checkbox>
-                    <Checkbox key="cache" value="tiled" key="tiled"
-                        disabled={!!this.props.element.singleTile}
-                        onChange={(e) => this.props.onChange("tiled", e.target.checked)}
-                        checked={this.props.element && this.props.element.tiled !== undefined ? this.props.element.tiled : true} >
-                        <Message msgId="layerProperties.cached"/>
-                    </Checkbox>
-                    <Checkbox key="singleTile" value="singleTile" key="singleTile"
-                        checked={this.props.element && (this.props.element.singleTile !== undefined ? this.props.element.singleTile : false )}
-                        onChange={(e) => this.props.onChange("singleTile", e.target.checked)}>
-                        <Message msgId="layerProperties.singleTile"/>
-                    </Checkbox>
-                </div>)] : null}
-        </Grid>);
+        return (
+            <Grid
+                fluid
+                style={{paddingTop: 15, paddingBottom: 15}}>
+                {this.props.element.type === "wms" &&
+                <Row>
+                    <Col xs={12}>
+                        <FormGroup>
+                            <ControlLabel><Message msgId="layerProperties.format" /></ControlLabel>
+                            <DropdownList
+                                key="format-dropdown"
+                                data={this.props.formats || ["image/png", "image/png8", "image/jpeg", "image/vnd.jpeg-png", "image/gif"]}
+                                value={this.props.element && this.props.element.format || "image/png"}
+                                onChange={(value) => {
+                                    this.props.onChange("format", value);
+                                }}/>
+                        </FormGroup>
+                    </Col>
+                </Row>}
+
+                <Row>
+                    <Col xs={12}>
+                        <FormGroup>
+                            <ControlLabel>{this.props.opacityText} %</ControlLabel>
+                            <FormControl
+                                type="number"
+                                min={0}
+                                max={100}
+                                value={this.state.opacity}
+                                onChange={event => {
+                                    const value = event.target.value;
+                                    const opacity = value && clamp(Math.round(value), 0, 100);
+                                    this.setState({opacity});
+                                    this.props.onChange("opacity", opacity && (opacity / 100) || 0);
+                                }}/>
+                        </FormGroup>
+                    </Col>
+                </Row>
+
+                {this.props.element.type === "wms" &&
+                <Row>
+                    <Col xs={12}>
+                        <hr/>
+                        <FormGroup>
+                            <Checkbox key="transparent" checked={this.props.element && (this.props.element.transparent === undefined ? true : this.props.element.transparent)} onChange={(event) => {this.props.onChange("transparent", event.target.checked); }}>
+                                <Message msgId="layerProperties.transparent"/></Checkbox>
+                            <Checkbox key="cache" value="tiled" key="tiled"
+                                disabled={!!this.props.element.singleTile}
+                                onChange={(e) => this.props.onChange("tiled", e.target.checked)}
+                                checked={this.props.element && this.props.element.tiled !== undefined ? this.props.element.tiled : true} >
+                                <Message msgId="layerProperties.cached"/>
+                            </Checkbox>
+                            <Checkbox key="singleTile" value="singleTile" key="singleTile"
+                                checked={this.props.element && (this.props.element.singleTile !== undefined ? this.props.element.singleTile : false )}
+                                onChange={(e) => this.props.onChange("singleTile", e.target.checked)}>
+                                <Message msgId="layerProperties.singleTile"/>
+                            </Checkbox>
+                        </FormGroup>
+                    </Col>
+                </Row>}
+            </Grid>
+        );
     }
 };

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -44,7 +44,9 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(0);
+        expect(inputs.length).toBe(1);
+        expect(inputs[0].getAttribute('type')).toBe('number');
+        expect(inputs[0].value).toBe('100');
     });
     it('tests Display component for wms', () => {
         const l = {
@@ -56,7 +58,7 @@ describe('test Layer Properties Display module component', () => {
             url: 'fakeurl'
         };
         const settings = {
-            options: {opacity: 1}
+            options: {opacity: 0.7}
         };
         const handlers = {
             onChange() {}
@@ -68,8 +70,10 @@ describe('test Layer Properties Display module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(3);
-        inputs[0].click();
+        expect(inputs.length).toBe(4);
+        expect(inputs[0].getAttribute('type')).toBe('number');
+        expect(inputs[0].value).toBe('70');
+        inputs[1].click();
         expect(spy.calls.length).toBe(1);
     });
 

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -24,7 +24,7 @@ const createLayer = options => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     const srs = CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS);
     const tilMatrixSetName = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
-    const tileMatrixSet = options.tileMatrixSet && head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tilMatrixSetName));
+    const tileMatrixSet = head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tilMatrixSetName));
     const scales = tileMatrixSet && tileMatrixSet.TileMatrix.map(t => t.ScaleDenominator);
     const mapResolutions = options.resolutions || mapUtils.getResolutions();
     const matrixResolutions = options.resolutions || scales && mapUtils.getResolutionsForScales(scales, srs, 96) || [];

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -24,7 +24,7 @@ const createLayer = options => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     const srs = CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS);
     const tilMatrixSetName = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
-    const tileMatrixSet = head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tilMatrixSetName));
+    const tileMatrixSet = options.tileMatrixSet && head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tilMatrixSetName));
     const scales = tileMatrixSet && tileMatrixSet.TileMatrix.map(t => t.ScaleDenominator);
     const mapResolutions = options.resolutions || mapUtils.getResolutions();
     const matrixResolutions = options.resolutions || scales && mapUtils.getResolutionsForScales(scales, srs, 96) || [];

--- a/web/client/plugins/FloatingLegend.jsx
+++ b/web/client/plugins/FloatingLegend.jsx
@@ -31,9 +31,10 @@ const {getLocalizedProp} = require('../utils/LocaleUtils');
  * @memberof plugins
  * @name FloatingLegend
  * @class
- * @prop {bool} cfg.disableOpacitySlider disable and hide opacity slider
- * @prop {bool} expandedOnMount show expanded legend when component did mount
- * @prop {number} width width dimension of legend
+ * @prop {boolean} cfg.disableOpacitySlider disable and hide opacity slider
+ * @prop {boolean} cfg.expandedOnMount show expanded legend when component did mount
+ * @prop {number} cfg.width width dimension of legend
+ * @prop {boolean} cfg.hideOpacityTooltip hide toolip on opacity sliders
  */
 
 class FloatingLegendComponent extends React.Component {

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -198,7 +198,8 @@ class LayerTree extends React.Component {
         hideLayerMetadata: PropTypes.func,
         activateAddLayerButton: PropTypes.bool,
         catalogActive: PropTypes.bool,
-        refreshLayerVersion: PropTypes.func
+        refreshLayerVersion: PropTypes.func,
+        hideOpacityTooltip: PropTypes.bool
     };
 
     static contextTypes = {
@@ -312,6 +313,7 @@ class LayerTree extends React.Component {
                 selectedNodes={this.props.selectedNodes}
                 filterText={this.props.filterText}
                 onUpdateNode={this.props.updateNode}
+                hideOpacityTooltip={this.props.hideOpacityTooltip}
                 />);
     }
 
@@ -454,6 +456,7 @@ class LayerTree extends React.Component {
  * @prop {boolean} cfg.activateAddLayerButton: activate a button to open the catalog, default `false`
  * @prop {object} cfg.layerOptions: options to pass to the layer.
  * @prop {boolean} cfg.showFullTitleOnExpand shows full length title in the legend. default `false`.
+ * @prop {boolean} cfg.hideOpacityTooltip hide toolip on opacity sliders
  * Some of the layerOptions are: `legendContainerStyle`, `legendStyle`. These 2 allow to customize the legend:
  * For instance you can pass some styling props to the legend.
  * this example is to make the legend scrollable horizontally

--- a/web/client/themes/default/less/sliders.less
+++ b/web/client/themes/default/less/sliders.less
@@ -13,38 +13,16 @@
             .noUi-origin {
                 background-color: @ms2-color-shade-lighter;
                 .noUi-handle {
-                    width: @square-btn-small-size;
-                    height: @square-btn-small-size;
-                    left: -(@square-btn-small-size)/2;
-                    top: -((@square-btn-small-size - 4) / 2);
-                    -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
-        	        -moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
-        	        box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
                     border: none;
+                    border-top: 1px solid @ms2-color-background;
+                    width: 10px;
+                    height: 15px;
+                    left: -5px;
+                    top: -8px;
+                    .shadow;
                     background-color: @ms2-color-primary;
                     cursor: pointer;
                     border-radius: @border-radius-base;
-                    .noUi-tooltip {
-                        top: 0;
-                        left: @square-btn-small-size / 2;
-                        transform: translate(-50%, 0);
-                        padding: 0;
-                        font-size: @font-size-small;
-                        border: none;
-                        border-radius: @border-radius-base;
-                        background-color: @ms2-color-primary;
-                        color: @ms2-color-text-primary;
-                        height: @square-btn-small-size;
-                        width: 45px;
-                        line-height: @square-btn-small-size;
-                        -webkit-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
-            	        -moz-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
-            	        box-shadow: 0 3px 6px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.24);
-                        cursor: pointer;
-                        &:hover {
-                            background-color: darken(@ms2-color-primary, 10%);
-                        }
-                    }
 
                     &:hover {
                         background-color: darken(@ms2-color-primary, 10%);
@@ -61,6 +39,12 @@
                         font-family: 'mapstore2';
                         text-align: center;
                         color: @ms2-color-text-primary;
+                    }
+                    .noUi-tooltip {
+                        cursor: pointer;
+                        &:hover {
+                            background-color: darken(@ms2-color-primary, 10%);
+                        }
                     }
                 }
             }
@@ -109,15 +93,53 @@
     &.with-tooltip {
         .noUi-target {
             &.noUi-horizontal {
+                @ms-slider-margin: 13px;
+                padding: 0 @ms-slider-margin;
                 .noUi-base {
+                    &:before,
+                    &:after {
+                        content: "";
+                        position: absolute;
+                        top: 0;
+                        height: 100%;
+                        display: block;
+                    }
+                    &:before {
+                        left: -@ms-slider-margin;
+                        width: @ms-slider-margin;
+                        
+                    }
+                    &:after {
+                        right: -@ms-slider-margin;
+                        /* hide primary color background */
+                        width: @ms-slider-margin + 4;
+                        background-color: @ms2-color-shade-lighter;
+                    }
                     .noUi-origin {
                         .noUi-handle {
-                            -webkit-box-shadow: none;
-                            -moz-box-shadow: none;
-                            box-shadow: none;
                             &:before,
                             &:after {
                                 display: none;
+                            }
+                            left: -18px;
+                            width: 36px;
+                            height: 16px;
+                            top: -8px;
+                            .noUi-tooltip {
+                                padding: 0;
+                                top: 0;
+                                left: 0;
+                                font-size: 10px;
+                                border: none;
+                                border-radius: @border-radius-base;
+                                background-color: @ms2-color-primary;
+                                color: @ms2-color-text-primary;
+                                height: 15px;
+                                width: 36px;
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                                line-height: @square-btn-small-size;
                             }
                         }
                     }

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -333,17 +333,6 @@
             background-color: @ms2-color-primary;
             &.noUi-horizontal {
                 margin: 0;
-                .noUi-base {
-                    .noUi-origin {
-                        .noUi-handle {
-                            border-top: 1px solid @ms2-color-background;
-                            width: 10px;
-                            height: 15px;
-                            left: -5px;
-                            top: -8px;
-                        }
-                    }
-                }
             }
         }
 
@@ -388,6 +377,7 @@
 
         .collapsible-toc {
             padding: 10px 0 0 0;
+            overflow: visible;
             .row {
                 margin-bottom: 10px;
 
@@ -631,17 +621,6 @@
         background-color: @ms2-color-primary;
         &.noUi-horizontal {
             margin: 0;
-            .noUi-base {
-                .noUi-origin {
-                    .noUi-handle {
-                        border-top: 1px solid @ms2-color-background;
-                        width: 10px;
-                        height: 15px;
-                        left: -5px;
-                        top: -8px;
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Description
Added flag hideOpacityTooltip on FloatingLegend and TOC to hide tooltips.

opacity slider TOC
![2018-06-07 11_52_55-](https://user-images.githubusercontent.com/19175505/41094287-122c83be-6a4e-11e8-8572-0bcbc5bef06a.png)

opacity slider FloatingLegend
![2018-06-07 11_53_17-window](https://user-images.githubusercontent.com/19175505/41094289-13814c4a-6a4e-11e8-821f-f31eed4bbe41.png)

opacity input Settings
![2018-06-07 11_53_43-window](https://user-images.githubusercontent.com/19175505/41094291-1540275e-6a4e-11e8-9606-e0b2243f670d.png)

opacity slider TOC Dashboard
![2018-06-07 12_15_17-window](https://user-images.githubusercontent.com/19175505/41094294-173cb6c6-6a4e-11e8-8039-2e492c6c1f7c.png)


## Issues
 - Fix #2250
 - Fix #2881

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature:


**What is the current behavior?** (You can also link to an open issue here)
#2250
#2881

**What is the new behavior?**
simple input in settings for opacity slider
and possibility to hide/show opacity value on sliders

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
