### PR TITLE
Fix #2982 If search params are missing from layers features grid doesn't work

### DIFF
--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -7,6 +7,7 @@
 */
 
 const urlParts = (url) => {
+    if (!url) return {};
     let isRelativeUrl = !(url.indexOf("http") === 0);
     let urlPartsArray = isRelativeUrl ? [] : url.match(/([^:]*:)\/\/([^:]*:?[^@]*@)?([^:\/\?]*):?([^\/\?]*)/);
     if (isRelativeUrl) {

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -23,6 +23,10 @@ describe('URLUtils', () => {
         const data = urlParts(url1);
         expect(data).toEqual(urlPartsResult1);
     });
+    it('test urlParts undefined url', () => {
+        const data = urlParts();
+        expect(data).toEqual({});
+    });
     it('test isSameUrl', () => {
         const data = isSameUrl(url1, url2);
         expect(data).toBeTruthy();


### PR DESCRIPTION
## Description
Added an if statement to handle undefined url in urlParts function.

## Issues
 - Fix #2982

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
#2982

**What is the new behavior?**
feature grid works

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
