### PR TITLE
Fix #2987 wrong ol default style for linestrings (green 1 -> blue 3)

### DIFF
--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -164,10 +164,10 @@ const defaultOLStyles = {
         image: image
     })],
     'LineString': options => [new ol.style.Style(assign({},
-        strokeStyle(options, {color: 'green', width: 1})
+        strokeStyle(options, {color: 'blue', width: 3})
     ))],
     'MultiLineString': options => [new ol.style.Style(assign({},
-        strokeStyle(options, {color: 'green', width: 1})
+        strokeStyle(options, {color: 'blue', width: 3})
     ))],
     'MultiPoint': () => [new ol.style.Style({
         image: image

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -72,8 +72,8 @@ describe('Test VectorStyle', () => {
         let olStyle = VectorStyle.styleFunction(lineString);
         let olStroke = olStyle[0].getStroke();
 
-        expect(olStroke.getColor()).toBe('green');
-        expect(olStroke.getWidth()).toBe(1);
+        expect(olStroke.getColor()).toBe('blue');
+        expect(olStroke.getWidth()).toBe(3);
 
         const options = {
             style: {
@@ -119,8 +119,8 @@ describe('Test VectorStyle', () => {
         let olStyle = VectorStyle.styleFunction(multiLineString);
         let olStroke = olStyle[0].getStroke();
 
-        expect(olStroke.getColor()).toBe('green');
-        expect(olStroke.getWidth()).toBe(1);
+        expect(olStroke.getColor()).toBe('blue');
+        expect(olStroke.getWidth()).toBe(3);
 
         const options = {
             style: {


### PR DESCRIPTION
## Description
OL default style for lines is green/1 instead of blue/3.

## Issues
 - Fix #2987

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
OL default style for lines is green/1.

**What is the new behavior?**
OL default style for lines is blue/3.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: if any part of the software was expecting green/1 lines, now they are blue/3

**Other information**:
