### PR TITLE
Fix #2692 We should guide users through using the dashboard as well widgets

### DIFF
--- a/web/client/actions/__tests__/tutorial-test.js
+++ b/web/client/actions/__tests__/tutorial-test.js
@@ -59,7 +59,8 @@ describe('Test the tutorial actions', () => {
         const style = 'style';
         const checkbox = 'checkbox';
         const defaultStep = 'defaultStep';
-        const retval = setupTutorial(id, steps, style, checkbox, defaultStep);
+        const stop = true;
+        const retval = setupTutorial(id, steps, style, checkbox, defaultStep, stop);
         expect(retval).toExist();
         expect(retval.type).toBe(SETUP_TUTORIAL);
         expect(retval.id).toBe(id);
@@ -67,6 +68,7 @@ describe('Test the tutorial actions', () => {
         expect(retval.style).toBe(style);
         expect(retval.checkbox).toBe(checkbox);
         expect(retval.defaultStep).toBe(defaultStep);
+        expect(retval.stop).toBe(stop);
     });
 
     it('updateTutorial', () => {

--- a/web/client/actions/tutorial.js
+++ b/web/client/actions/tutorial.js
@@ -33,14 +33,15 @@ function initTutorial(id, steps, style, checkbox, defaultStep, presetList) {
     };
 }
 
-function setupTutorial(id, steps, style, checkbox, defaultStep) {
+function setupTutorial(id, steps, style, checkbox, defaultStep, stop) {
     return {
         type: SETUP_TUTORIAL,
         id,
         steps,
         style,
         checkbox,
-        defaultStep
+        defaultStep,
+        stop
     };
 }
 

--- a/web/client/components/tutorial/__tests__/Tutorial-test.jsx
+++ b/web/client/components/tutorial/__tests__/Tutorial-test.jsx
@@ -46,7 +46,7 @@ const actions = {
 describe("Test the Tutorial component", () => {
 
     beforeEach((done) => {
-        document.body.innerHTML = '<div id="container"></div>';
+        document.body.innerHTML = '<div><div id="container"></div><div id="target"></div></div>';
         setTimeout(done);
     });
 
@@ -93,7 +93,7 @@ describe("Test the Tutorial component", () => {
         expect(intro).toExist();
         expect(intro.length).toBe(1);
 
-        cmp.componentWillUpdate();
+        cmp.componentWillUpdate({}, {});
         expect(spyClose).toNotHaveBeenCalled();
         expect(spyStart).toNotHaveBeenCalled();
 
@@ -126,10 +126,10 @@ describe("Test the Tutorial component", () => {
         expect(intro).toExist();
         expect(intro.length).toBe(1);
 
-        cmp.componentWillUpdate({toggle: true});
+        cmp.componentWillUpdate({toggle: true}, {});
         expect(spyStart).toHaveBeenCalled();
 
-        cmp.componentWillUpdate({status: 'close'});
+        cmp.componentWillUpdate({status: 'close'}, {});
         expect(spyClose).toHaveBeenCalled();
 
         cmp.onTour({type: 'step:before'});
@@ -153,10 +153,10 @@ describe("Test the Tutorial component", () => {
         const cmp = ReactDOM.render(<Tutorial status={'error'} steps={presetList.test} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
         expect(cmp).toExist();
 
-        cmp.componentWillUpdate({status: 'error'});
+        ReactDOM.render(<Tutorial status={'error'} steps={presetList.test} stepIndex={1} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
 
-        expect(spyStart).toHaveBeenCalled();
-        expect(spyClose).toNotHaveBeenCalled();
+        expect(spyStart).toNotHaveBeenCalled();
+        expect(spyClose).toHaveBeenCalled();
     });
 
     it('test component with no data on update', () => {
@@ -166,9 +166,71 @@ describe("Test the Tutorial component", () => {
         const cmp = ReactDOM.render(<Tutorial steps={presetList.test} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
         expect(cmp).toExist();
 
-        cmp.componentWillUpdate({});
+        cmp.componentWillUpdate({}, {});
 
         expect(spyStart).toNotHaveBeenCalled();
         expect(spyClose).toNotHaveBeenCalled();
+    });
+
+    it('test component with error on update with action', () => {
+        const spyStart = expect.spyOn(actions, 'onStart');
+        const actionPreset = [
+            {
+                title: 'test',
+                text: 'test',
+                selector: '#intro-tutorial'
+            },
+            {
+                title: 'test',
+                text: 'test',
+                selector: '#target',
+                action: {
+                    start: {
+                        type: 'ACTION'
+                    }
+                }
+            }
+        ];
+
+        const cmp = ReactDOM.render(<Tutorial status={'error'} stepIndex={0} steps={actionPreset} preset={'actionPreset'} presetList={{actionPreset}} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        ReactDOM.render(<Tutorial status={'error'} steps={actionPreset} stepIndex={1} preset={'actionPreset'} presetList={{actionPreset}} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
+
+        expect(spyStart).toHaveBeenCalled();
+
+        expect(cmp.joyride.state.index).toBe(1);
+    });
+
+    it('test component with error on update with action', () => {
+        const spyStart = expect.spyOn(actions, 'onStart');
+        const actionPreset = [
+            {
+                title: 'test',
+                text: 'test',
+                selector: '#intro-tutorial'
+            },
+            {
+                title: 'test',
+                text: 'test',
+                selector: '#targe',
+                action: {
+                    start: {
+                        type: 'ACTION'
+                    }
+                }
+            },
+            {
+                title: 'test',
+                text: 'test',
+                selector: '#target'
+            }
+        ];
+
+        const cmp = ReactDOM.render(<Tutorial status={'error'} stepIndex={0} steps={actionPreset} preset={'actionPreset'} presetList={{actionPreset}} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+        ReactDOM.render(<Tutorial status={'error'} steps={actionPreset} stepIndex={1} preset={'actionPreset'} presetList={{actionPreset}} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
+
+        expect(spyStart).toHaveBeenCalled();
+
     });
 });

--- a/web/client/components/tutorial/__tests__/Tutorial-test.jsx
+++ b/web/client/components/tutorial/__tests__/Tutorial-test.jsx
@@ -93,7 +93,8 @@ describe("Test the Tutorial component", () => {
         expect(intro).toExist();
         expect(intro.length).toBe(1);
 
-        cmp.componentWillUpdate({}, {});
+        ReactDOM.render(<Tutorial introStyle={{}} defaultStep={{}} showCheckbox={false} actions={actions}/>, document.getElementById("container"));
+
         expect(spyClose).toNotHaveBeenCalled();
         expect(spyStart).toNotHaveBeenCalled();
 
@@ -126,17 +127,17 @@ describe("Test the Tutorial component", () => {
         expect(intro).toExist();
         expect(intro.length).toBe(1);
 
-        cmp.componentWillUpdate({toggle: true}, {});
+        ReactDOM.render(<Tutorial toggle introStyle={{}} error={{}} steps={presetList.test} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
         expect(spyStart).toHaveBeenCalled();
 
-        cmp.componentWillUpdate({status: 'close'}, {});
+        ReactDOM.render(<Tutorial status={'close'} introStyle={{}} error={{}} steps={presetList.test} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
         expect(spyClose).toHaveBeenCalled();
 
         cmp.onTour({type: 'step:before'});
         expect(spyUpdate).toHaveBeenCalled();
         expect(spyUpdate).toHaveBeenCalledWith({type: 'step:before'}, presetList.test);
 
-        cmp.componentWillUnmount();
+        ReactDOM.render(<span/>, document.getElementById("container"));
         expect(spyReset).toHaveBeenCalled();
 
         const next = cmp.checkFirstValidStep(0, 'next');
@@ -166,7 +167,7 @@ describe("Test the Tutorial component", () => {
         const cmp = ReactDOM.render(<Tutorial steps={presetList.test} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
         expect(cmp).toExist();
 
-        cmp.componentWillUpdate({}, {});
+        ReactDOM.render(<Tutorial steps={presetList.test} preset={'test'} presetList={presetList} defaultStep={{}} showCheckbox actions={actions}/>, document.getElementById("container"));
 
         expect(spyStart).toNotHaveBeenCalled();
         expect(spyClose).toNotHaveBeenCalled();

--- a/web/client/components/widgets/builder/WidgetTypeSelector.jsx
+++ b/web/client/components/widgets/builder/WidgetTypeSelector.jsx
@@ -15,32 +15,38 @@ const DEFAULT_TYPES = [{
     title: <Message msgId={"widgets.types.chart.title"} />,
     type: "chart",
     caption: <Message msgId={"widgets.types.chart.caption"} />,
-    glyph: "stats"
+    glyph: "stats",
+    className: "ms-widget-selector-chart"
 }, {
     title: <Message msgId={"widgets.types.text.title"} />,
     type: "text",
     glyph: "sheet",
-    caption: <Message msgId={"widgets.types.text.caption"} />
+    caption: <Message msgId={"widgets.types.text.caption"} />,
+    className: "ms-widget-selector-text"
 }, {
     title: <Message msgId={"widgets.types.table.title"} />,
     type: "table",
     glyph: "features-grid",
-    caption: <Message msgId={"widgets.types.table.caption"} />
+    caption: <Message msgId={"widgets.types.table.caption"} />,
+    className: "ms-widget-selector-table"
 }, {
     title: <Message msgId={"widgets.types.counter.title"} />,
     type: "counter",
     glyph: "counter",
-    caption: <Message msgId={"widgets.types.counter.caption"} />
+    caption: <Message msgId={"widgets.types.counter.caption"} />,
+    className: "ms-widget-selector-counter"
 }, {
     title: <Message msgId={"widgets.types.map.title"} />,
     type: "map",
     glyph: "1-map",
-    caption: <Message msgId={"widgets.types.map.caption"} />
+    caption: <Message msgId={"widgets.types.map.caption"} />,
+    className: "ms-widget-selector-map"
 }, {
     title: <Message msgId={"widgets.types.legend.title"} />,
     type: "legend",
     glyph: "list",
-    caption: <Message msgId={"widgets.types.legend.caption"} />
+    caption: <Message msgId={"widgets.types.legend.caption"} />,
+    className: "ms-widget-selector-legend"
 }];
 
 module.exports = ({widgetTypes = DEFAULT_TYPES, typeFilter = () => true, onSelect= () => {}}) =>

--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const {getActionsFromStepEpic, switchTutorialEpic} = require('../tutorial');
+const {SETUP_TUTORIAL, updateTutorial, initTutorial} = require('../../actions/tutorial');
+const {testEpic} = require('./epicTestUtils');
+
+describe('tutorial Epics', () => {
+    it('getActionsFromStepEpic with object action', (done) => {
+
+        const step = {
+            action: {
+                next: {
+                    type: 'TUTORIAL_ACTION',
+                    value: 'value'
+                }
+            }
+        };
+
+        testEpic(getActionsFromStepEpic, 1, updateTutorial({action: 'next', step}), (actions) => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case 'TUTORIAL_ACTION':
+                        expect(action.value).toBe('value');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+            }
+        });
+
+    });
+
+    it('getActionsFromStepEpic with array of actions', (done) => {
+
+        const step = {
+            action: {
+                next: [{
+                    type: 'TUTORIAL_ACTION',
+                    value: 'value'
+                }, {
+                    type: 'TUTORIAL_ACTION_2',
+                    value: 'value_2'
+                }]
+            }
+        };
+
+        testEpic(getActionsFromStepEpic, 2, updateTutorial({action: 'next', step}), (actions) => {
+            expect(actions.length).toBe(2);
+            actions.map((action) => {
+                switch (action.type) {
+                    case 'TUTORIAL_ACTION':
+                        expect(action.value).toBe('value');
+                        break;
+                    case 'TUTORIAL_ACTION_2':
+                        expect(action.value).toBe('value_2');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+            }
+        });
+
+    });
+
+    it('switchTutorialEpic with path', (done) => {
+
+        testEpic(switchTutorialEpic, 1, [
+            {
+                type: "@@router/LOCATION_CHANGE",
+                payload: {
+                    pathname: '/dashboard/'
+                }
+            },
+            initTutorial('id', [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case SETUP_TUTORIAL:
+                        expect(action.id).toBe('dashboard');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                    'dashboard_mobile_tutorial': [],
+                    'dashboard_tutorial': [],
+                    'default_tutorial': [],
+                    'default_mobile_tutorial': []
+                }
+            }
+        });
+
+    });
+
+    it('switchTutorialEpic with viewer path', (done) => {
+
+        testEpic(switchTutorialEpic, 1, [
+            {
+                type: "@@router/LOCATION_CHANGE",
+                payload: {
+                    pathname: '/viewer/cesium/001'
+                }
+            },
+            initTutorial('id', [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case SETUP_TUTORIAL:
+                        expect(action.id).toBe('cesium');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                    'cesium_mobile_tutorial': [],
+                    'cesium_tutorial': [],
+                    'default_tutorial': [],
+                    'default_mobile_tutorial': []
+                }
+            }
+        });
+
+    });
+
+    it('switchTutorialEpic with path and id', (done) => {
+
+        testEpic(switchTutorialEpic, 1, [
+            {
+                type: "@@router/LOCATION_CHANGE",
+                payload: {
+                    pathname: '/dashboard/001'
+                }
+            },
+            initTutorial('id', [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case SETUP_TUTORIAL:
+                        expect(action.id).toBe('dashboard');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                    'dashboard_mobile_tutorial': [],
+                    'dashboard_tutorial': [],
+                    'default_tutorial': [],
+                    'default_mobile_tutorial': []
+                }
+            }
+        });
+
+    });
+
+    it('switchTutorialEpic mobile', (done) => {
+
+        testEpic(switchTutorialEpic, 1, [
+            {
+                type: "@@router/LOCATION_CHANGE",
+                payload: {
+                    pathname: '/dashboard/001'
+                }
+            },
+            initTutorial('id', [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case SETUP_TUTORIAL:
+                        expect(action.id).toBe('dashboard_mobile');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                    'dashboard_mobile_tutorial': [],
+                    'dashboard_tutorial': [],
+                    'default_tutorial': [],
+                    'default_mobile_tutorial': []
+                }
+            },
+            browser: {
+                mobile: true
+            }
+        });
+
+    });
+
+    it('switchTutorialEpic missing preset steps', (done) => {
+
+        testEpic(switchTutorialEpic, 1, [
+            {
+                type: "@@router/LOCATION_CHANGE",
+                payload: {
+                    pathname: '/dashboard/001'
+                }
+            },
+            initTutorial('id', [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case SETUP_TUTORIAL:
+                        expect(action.id).toBe('default');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                    'default_tutorial': [],
+                    'default_mobile_tutorial': []
+                }
+            }
+        });
+
+    });
+});

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -507,7 +507,7 @@
                 "containerPosition": "header",
                 "className": "navbar shadow navbar-home"
             }
-        }, "ManagerMenu", "Login", "Language", "NavMenu", "Attribution", "Home", {
+        }, "Login", "Language", "NavMenu", "Attribution", "Home", {
           "name": "DashboardEditor",
           "cfg": {
              "catalog": {
@@ -527,7 +527,14 @@
             },
             "containerPosition": "columns"
           }
-        }, "Dashboard", "Notifications"],
+        }, "BurgerMenu", "Dashboard", "Notifications", {
+            "name": "Tutorial",
+            "cfg": {
+                "allowClicksThruHole": false,
+                "containerPosition": "header",
+                "preset": "dashboard_tutorial"
+            }
+        }],
         "manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"]
     }
 }

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -70,6 +70,7 @@ const Toolbar = compose(
             tooltipId: 'dashboard.editor.addACardToTheDashboard',
             bsStyle: 'primary',
             visible: canEdit,
+            id: 'ms-add-card-dashboard',
             onClick: () => onAddWidget()
         }, {
             glyph: 'floppy-disk',

--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -57,7 +57,7 @@ const DrawerButton = connect(state => ({
     id = '',
     menuButtonStyle = {},
     buttonStyle = 'primary',
-    buttonClassName = 'square-button',
+    buttonClassName = 'square-button ms-drawer-menu-button',
     toggleMenu = () => {},
     disabled = false,
     glyph = '1-layer',
@@ -122,7 +122,7 @@ class DrawerMenu extends React.Component {
         buttonStyle: "primary",
         menuOptions: {},
         singleSection: true,
-        buttonClassName: "square-button",
+        buttonClassName: "square-button ms-drawer-menu-button",
         disabled: false
     };
 

--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -16,7 +16,7 @@ const I18N = require('../components/I18N/I18N');
 const {Glyphicon} = require('react-bootstrap');
 const {createSelector} = require('reselect');
 const {tutorialSelector} = require('../selectors/tutorial');
-const {closeTutorialEpic, switchTutorialEpic} = require('../epics/tutorial');
+const {closeTutorialEpic, switchTutorialEpic, getActionsFromStepEpic} = require('../epics/tutorial');
 
 /**
  * Tutorial plugin. Enables the steps of tutorial.
@@ -86,6 +86,35 @@ const {closeTutorialEpic, switchTutorialEpic} = require('../epics/tutorial');
  *   ...
  *  }
  * ...
+ * // translation file example with actions
+ * // action param could be an object or array of objects
+ * // action type are triggered on tour actions and they could be `start`, `next` and `back`
+ * ...
+ *  "tutorial": {
+ *   ...
+ *   "myIntroTranslation": {
+ *    "title": "My intro title",
+ *    "text": "My intro description",
+ *    "action": { start: { type: 'MY_START_ACTION' }}
+ *   },
+ *    "myTranslation": {
+ *    "title": "My first step title",
+ *    "text": "My first step description",
+ *    "action": { back: { type: 'MY_BACK_ACTION' }}
+ *   },
+ *   "mySecondStepTranslation": {
+ *    "title": "My second step title",
+ *    "text": "My second step description",
+ *    "action": { next: { type: 'MY_NEXT_ACTION' }}
+ *   },
+ *   "myTranslationHTML": {
+ *    "title": "<div style="color:blue;">My html step title</div>",
+ *    "text": "<div style="color:red;">My html step description</div>",
+ *    "action": { next: [{ type: 'MY_FIRST_ACTION' }, { type: 'MY_SECOND_ACTION' }]}
+ *   }
+ *   ...
+ *  }
+ * ...
  */
 
 const tutorialPluginSelector = createSelector([tutorialSelector],
@@ -137,6 +166,7 @@ module.exports = {
     },
     epics: {
         closeTutorialEpic,
-        switchTutorialEpic
+        switchTutorialEpic,
+        getActionsFromStepEpic
     }
 };

--- a/web/client/plugins/tutorial/preset.js
+++ b/web/client/plugins/tutorial/preset.js
@@ -11,5 +11,6 @@ module.exports = {
     default_mobile_tutorial: require('./preset/default_mobile_tutorial'),
     home_tutorial: require('./preset/home_tutorial'),
     cesium_tutorial: require('./preset/cesium_tutorial'),
-    cesium_mobile_tutorial: require('./preset/cesium_mobile_tutorial')
+    cesium_mobile_tutorial: require('./preset/cesium_mobile_tutorial'),
+    dashboard_tutorial: require('./preset/dashboard_tutorial')
 };

--- a/web/client/plugins/tutorial/preset/cesium_mobile_tutorial.js
+++ b/web/client/plugins/tutorial/preset/cesium_mobile_tutorial.js
@@ -22,7 +22,7 @@ module.exports = [
     },
     {
         translation: 'drawerMenu',
-        selector: '#drawer-menu-button'
+        selector: '.ms-drawer-menu-button'
     },
     {
         translation: 'home',

--- a/web/client/plugins/tutorial/preset/cesium_tutorial.js
+++ b/web/client/plugins/tutorial/preset/cesium_tutorial.js
@@ -27,7 +27,7 @@ module.exports = [
     },
     {
         translationHTML: 'drawerMenu',
-        selector: '#drawer-menu-button'
+        selector: '.ms-drawer-menu-button'
     },
     {
         translation: 'searchBar',

--- a/web/client/plugins/tutorial/preset/dashboard_tutorial.js
+++ b/web/client/plugins/tutorial/preset/dashboard_tutorial.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = [
+    {
+        translation: 'dashboardIntro',
+        selector: '#intro-tutorial'
+    },
+    {
+        translation: 'dashboardNav',
+        selector: '#mapstore-navbar',
+        position: 'bottom',
+        action: {
+            start: {
+                type: 'DASHBOARD:SET_EDITING',
+                editing: false
+            }
+        }
+    },
+    {
+        translation: 'dashboardContainer',
+        selector: '.ms2-border-layout-content'
+    },
+    {
+        translation: 'dashboardAddWidget',
+        selector: '#ms-add-card-dashboard',
+        position: 'right',
+        action: {
+            back: {
+                type: 'DASHBOARD:SET_EDITING',
+                editing: false
+            }
+        }
+    },
+    {
+        translation: 'dashboardBuilder',
+        selector: '.dashboard-editor.de-builder',
+        position: 'right',
+        action: {
+            next: {
+                type: 'WIDGETS:NEW'
+            }
+        }
+    },
+    {
+        translationHTML: 'dashboardAddChart',
+        selector: '.ms-widget-selector-chart',
+        position: 'right'
+    },
+    {
+        translationHTML: 'dashboardAddText',
+        selector: '.ms-widget-selector-text',
+        position: 'right'
+    },
+    {
+        translationHTML: 'dashboardAddTable',
+        selector: '.ms-widget-selector-table',
+        position: 'right'
+    },
+    {
+        translationHTML: 'dashboardAddCounter',
+        selector: '.ms-widget-selector-counter',
+        position: 'right'
+    },
+    {
+        translationHTML: 'dashboardAddMap',
+        selector: '.ms-widget-selector-map',
+        position: 'right'
+    }
+];

--- a/web/client/plugins/tutorial/preset/dashboard_tutorial.js
+++ b/web/client/plugins/tutorial/preset/dashboard_tutorial.js
@@ -12,18 +12,7 @@ module.exports = [
         selector: '#intro-tutorial'
     },
     {
-        translation: 'dashboardNav',
-        selector: '#mapstore-navbar',
-        position: 'bottom',
-        action: {
-            start: {
-                type: 'DASHBOARD:SET_EDITING',
-                editing: false
-            }
-        }
-    },
-    {
-        translation: 'dashboardContainer',
+        translationHTML: 'dashboardContainer',
         selector: '.ms2-border-layout-content'
     },
     {
@@ -32,6 +21,10 @@ module.exports = [
         position: 'right',
         action: {
             back: {
+                type: 'DASHBOARD:SET_EDITING',
+                editing: false
+            },
+            next: {
                 type: 'DASHBOARD:SET_EDITING',
                 editing: false
             }
@@ -71,5 +64,10 @@ module.exports = [
         translationHTML: 'dashboardAddMap',
         selector: '.ms-widget-selector-map',
         position: 'right'
+    },
+    {
+        translation: 'dashboardNav',
+        selector: '#mapstore-navbar',
+        position: 'bottom'
     }
 ];

--- a/web/client/plugins/tutorial/preset/default_mobile_tutorial.js
+++ b/web/client/plugins/tutorial/preset/default_mobile_tutorial.js
@@ -9,7 +9,7 @@
 module.exports = [
     {
         translation: 'drawerMenu',
-        selector: '#drawer-menu-button'
+        selector: '.ms-drawer-menu-button'
     },
     {
         translation: 'home',

--- a/web/client/plugins/tutorial/preset/default_tutorial.js
+++ b/web/client/plugins/tutorial/preset/default_tutorial.js
@@ -9,7 +9,7 @@
 module.exports = [
     {
         translationHTML: 'drawerMenu',
-        selector: '#drawer-menu-button'
+        selector: '.ms-drawer-menu-button'
     },
     {
         translation: 'searchBar',

--- a/web/client/reducers/__tests__/tutorial-test.js
+++ b/web/client/reducers/__tests__/tutorial-test.js
@@ -256,4 +256,35 @@ describe('Test the tutorial reducer', () => {
         expect(state.enabled).toBe(true);
     });
 
+    it('setup the tutorial with intro but stop flag', () => {
+        const state = tutorial({}, {
+            type: SETUP_TUTORIAL,
+            steps: [{
+                title: 'test',
+                text: 'test',
+                selector: '#intro-tutorial'
+            },
+            {
+                translation: 'test',
+                selector: '.step-tutorial'
+            },
+            {
+                translationHTML: 'test',
+                selector: '#step-tutorial'
+            },
+            {
+                title: 'test',
+                text: 'test',
+                selector: 'step-tutorial'
+            }],
+            checkbox: 'checkbox',
+            style: {},
+            defaultStep: {},
+            stop: true
+        });
+        expect(state.run).toBe(false);
+        expect(state.start).toBe(false);
+        expect(state.status).toBe('close');
+    });
+
 });

--- a/web/client/reducers/tutorial.js
+++ b/web/client/reducers/tutorial.js
@@ -93,7 +93,7 @@ function tutorial(state = initialState, action) {
             setup.start = true;
             setup.status = 'run';
 
-            if (isDisabled === 'true' || !hasIntro) {
+            if (isDisabled === 'true' || !hasIntro || action.stop) {
                 setup.steps = setup.steps.filter((step) => {
                     return step.selector !== '#intro-tutorial';
                 }).map((step, index) => {

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1550,6 +1550,46 @@
             "cesiumNavigation": {
                 "title": "Navigation",
                 "text": "Hier finden Sie die Schaltflächen zum Vergrößern und Verkleinern"
+            },
+            "dashboardIntro": {
+                "title": "Dashboard Tutorial",
+                "text": "Überblick über die Funktionen des Dashboards"
+            },
+            "dashboardNav": {
+                "title": "Navigationsleiste",
+                "text": "Hier finden Sie Sprachauswahl, Login, Homepage-Link und Optionsmenü"
+            },
+            "dashboardContainer": {
+                "title": "Dashboard-Container",
+                "text": "Sie können Dashboard-Karten in diesem Bereich bearbeiten, in der Größe verändern, bestellen und verschieben"
+            },
+            "dashboardAddWidget": {
+                "title": "Widget hinzufügen",
+                "text": "Öffnen Sie die Widgetliste, indem Sie auf Hinzufügen klicken"
+            },
+            "dashboardBuilder": {
+                "title": "Widget Builder",
+                "text": "Klicken Sie auf Karten, um das zugehörige Widget zum Dashboard hinzuzufügen"
+            },
+            "dashboardAddChart": {
+                "title": "Diagramm hinzufügen",
+                "text": "<p> Fügen Sie dem Dashboard neue Diagramme hinzu, indem Sie zwischen balkendiagramm, kuchendiagramm und liniendiagramm typen wählen. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene </li> <li> Wählen Sie den Diagrammtyp </li> <li> Konfigurieren Sie die Diagrammdaten </li> <li> Speichern und zum Dashboard hinzufügen </li > </ul> </p>" 
+            },
+            "dashboardAddText": {
+                "title": "Text hinzufügen",
+                "text": "<p> Fügen Sie dem Dashboard neue Texte hinzu. </p> <p> Schritte: </p> <p> <ul> <li> Bearbeiten Sie Text im Editor </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddTable": {
+                "title": "Tabelle hinzufügen",
+                "text": "<p> Fügen Sie dem Dashboard neue Funktionstabellen hinzu. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene aus </li> <li> Tabellendaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Zähler hinzufügen",
+                "text": "<p> Fügen Sie neue Zähler zum Dashboard hinzu. Counter zeigt basierend auf ausgewählten Daten einen Wert an. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene aus </li> <li> Zählerdaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddMap": {
+                "title": "Karte hinzufügen",
+                "text": "<p> Fügen Sie eine neue interaktive Karte zum Dashboard hinzu. Nach dem Speichern der ersten Karte wird das Legenden-Widget zur Liste hinzugefügt. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Karte </ li> <li> Karte verbessern durch Hinzufügen neuer Ebenen </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
             }
         }
     }

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1560,36 +1560,36 @@
                 "text": "Hier finden Sie Sprachauswahl, Login, Homepage-Link und Optionsmenü"
             },
             "dashboardContainer": {
-                "title": "Dashboard-Container",
-                "text": "Sie können Dashboard-Karten in diesem Bereich bearbeiten, in der Größe verändern, bestellen und verschieben"
+                "title": "Instrumententafel",
+                "text": "<p> Ein Dashboard in MapStore2 bietet eine Reihe von Informationen, die passend gesammelt werden, um aggregierte Daten in der One-Shot-Ansicht anzuzeigen. Geodaten, die in einer Karte angezeigt werden, können Seite an Seite mit verwandten Attributtabellen, Diagrammen und anderen platziert werden, mit dem Ziel, verschiedene Arten von Informationen zu verbinden, statistische Details und textuelle Beschreibungen zu einem bestimmten Kontext anzuzeigen. </p> <p> Alle Benutzer können veröffentlichte Dashboards visualisieren und mit ihnen interagieren, aber nur Benutzer, die sie bearbeiten dürfen, können alle Widgets in einem Dashboard hinzufügen, anordnen, ihre Größe ändern oder löschen </ p>"
             },
             "dashboardAddWidget": {
                 "title": "Widget hinzufügen",
-                "text": "Öffnen Sie die Widgetliste, indem Sie auf Hinzufügen klicken"
+                "text": "Um ein Widget zum Dashboard hinzuzufügen, können Sie auf die Schaltfläche + klicken"
             },
             "dashboardBuilder": {
-                "title": "Widget Builder",
-                "text": "Klicken Sie auf Karten, um das zugehörige Widget zum Dashboard hinzuzufügen"
+                "title": "Erstelle ein neues Widget",
+                "text": "Sie können auswählen, welche Art von Widget Sie möchten und dann zum Dashboard hinzufügen, indem Sie eines der Elemente in der Liste auswählen"
             },
             "dashboardAddChart": {
-                "title": "Diagramm hinzufügen",
-                "text": "<p> Fügen Sie dem Dashboard neue Diagramme hinzu, indem Sie zwischen balkendiagramm, kuchendiagramm und liniendiagramm typen wählen. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene </li> <li> Wählen Sie den Diagrammtyp </li> <li> Konfigurieren Sie die Diagrammdaten </li> <li> Speichern und zum Dashboard hinzufügen </li > </ul> </p>" 
+                "title": "Diagramm Widget",
+                "text": "<p> Es ist ein Widget, das Daten in Kreis-, Linien- oder Balkendiagrammen anzeigt und aggregiert. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene </li> <li> Diagrammtyp auswählen </li> <li> Diagrammdaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
             },
             "dashboardAddText": {
-                "title": "Text hinzufügen",
-                "text": "<p> Fügen Sie dem Dashboard neue Texte hinzu. </p> <p> Schritte: </p> <p> <ul> <li> Bearbeiten Sie Text im Editor </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+                "title": "Text Widget",
+                "text": "<p> Fügen Sie Ihrem Dashboard Ihren eigenen Text hinzu. </p> <p> Schritte: </p> <p> <ul> <li> Bearbeiten Sie Text im Editor </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
             },
             "dashboardAddTable": {
-                "title": "Tabelle hinzufügen",
-                "text": "<p> Fügen Sie dem Dashboard neue Funktionstabellen hinzu. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene aus </li> <li> Tabellendaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+                "title": "Tabellen Widget",
+                "text": "<p> Fügen Sie dem Dashboard, das Daten von einer ausgewählten Vektorebene enthält, eine Attributtabelle hinzu. Sie können auch Daten filtern, um Ihre Tabelle anzupassen. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene aus </li> <li> Tabellendaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
             },
             "dashboardAddCounter": {
-                "title": "Zähler hinzufügen",
-                "text": "<p> Fügen Sie neue Zähler zum Dashboard hinzu. Counter zeigt basierend auf ausgewählten Daten einen Wert an. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene aus </li> <li> Zählerdaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+                "title": "Gegen Widget",
+                "text": "<p> Fügen Sie dem Dashboard einen neuen Zähler hinzu. Counter zeigt numerische Werte an, die Daten einer ausgewählten Vektorebene aggregieren. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorschicht </li> <li> Zählerdaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
             },
             "dashboardAddMap": {
-                "title": "Karte hinzufügen",
-                "text": "<p> Fügen Sie eine neue interaktive Karte zum Dashboard hinzu. Nach dem Speichern der ersten Karte wird das Legenden-Widget zur Liste hinzugefügt. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Karte </ li> <li> Karte verbessern durch Hinzufügen neuer Ebenen </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+                "title": "Karten Widget",
+                "text": "<p> Fügen Sie eine neue interaktive Karte zum Dashboard hinzu. Sie können mehr als eine Karte mit der Möglichkeit hinzufügen, andere Widgets mit ihnen zu verbinden. Nach dem Speichern der ersten Karte wird das Legenden-Widget zur Liste hinzugefügt. Das Legenden-Widget zeigt eine Legende zur verbundenen Karte. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Karte </li> <li> Verbessern Sie die Karte, indem Sie neue Ebenen hinzufügen </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
             }
         }
     }

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1552,6 +1552,46 @@
             "cesiumNavigation": {
                 "title": "Navigation",
                 "text": "Here you can find the zoom in and zoom out buttons"
+            },
+            "dashboardIntro": {
+                "title": "Dashboard Tutorial",
+                "text": "Overview of dashboard functionalities"
+            },
+            "dashboardNav": {
+                "title": "Navigation Bar",
+                "text": "Here you can find language selector, login, homepage link and options menu"
+            },
+            "dashboardContainer": {
+                "title": "Dashboard Container",
+                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+            },
+            "dashboardAddWidget": {
+                "title": "Add Widget",
+                "text": "Open widget list by clicking on add button"
+            },
+            "dashboardBuilder": {
+                "title": "Widget Builder",
+                "text": "Click on cards to add the related widget to dashboard"
+            },
+            "dashboardAddChart": {
+                "title": "Add Chart",
+                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddText": {
+                "title": "Add Text",
+                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddTable": {
+                "title": "Add Table",
+                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Add Counter",
+                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddMap": {
+                "title": "Add Map",
+                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
     }

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1562,36 +1562,36 @@
                 "text": "Here you can find language selector, login, homepage link and options menu"
             },
             "dashboardContainer": {
-                "title": "Dashboard Container",
-                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+                "title": "Dashboard",
+                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",
-                "text": "Open widget list by clicking on add button"
+                "text": "To add a widget to the dashboard, you can click on the + button"
             },
             "dashboardBuilder": {
-                "title": "Widget Builder",
-                "text": "Click on cards to add the related widget to dashboard"
+                "title": "Create a new widget",
+                "text": "You can select which type of widget you want and then add to the dashboard selecting one of the items in the list"
             },
             "dashboardAddChart": {
-                "title": "Add Chart",
-                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Chart Widget",
+                "text": "<p>It's a widget that show and aggregate data into pie, line or bar charts.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddText": {
-                "title": "Add Text",
-                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Text Widget",
+                "text": "<p>Add your own text to the dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddTable": {
-                "title": "Add Table",
-                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Table Widget",
+                "text": "<p>Add an attribute table to the dashboard that contains data from a selected vector layer. You can also filter data to customize your table.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddCounter": {
-                "title": "Add Counter",
-                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Counter Widget",
+                "text": "<p>Add a new counter to the dashboard. Counter will show numeric value aggregationg data from a selected vector layer.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddMap": {
-                "title": "Add Map",
-                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Map Widget",
+                "text": "<p>Add a new interactive map to the dashboard. You can add more than one map with the ability to connect other widgets to them. After saving the first map, the legend widget will be added to the list. Legend Widget will show a legend related to the connected map.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
     }

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1560,36 +1560,36 @@
                 "text": "Aquí puede encontrar el selector de idioma, el inicio de sesión, el enlace de la página de inicio y el menú de opciones"
             },
             "dashboardContainer": {
-                "title": "Contenedor del Tablero",
-                "text": "Puede editar, cambiar el tamaño, ordenar y mover tarjetas de panel dentro de esta área"
+                "title": "Tablero",
+                "text": "<p> Un Tablero en MapStore2 proporciona un conjunto de información recopilada adecuadamente para mostrar datos agregados en una vista de un solo disparo. Los datos geoespaciales mostrados en un mapa se pueden colocar uno al lado del otro en tablas de atributos relacionados, cuadros y otros, con el objetivo de conectar diferentes tipos de información, mostrar detalles estadísticos y descripciones textuales relacionadas con un contexto específico. </p> <p> Todos los usuarios pueden visualizar e interactuar con los paneles publicados, pero solo los usuarios a los que se les permite editar pueden agregar, organizar, cambiar el tamaño o eliminar todos los widgets dentro de un panel </p>"
             },
             "dashboardAddWidget": {
                 "title": "Agregar Widget",
-                "text": "Abra la lista de widgets haciendo clic en el botón Agregar"
+                "text": "Para agregar un widget al tablero, puede hacer clic en el botón +"
             },
             "dashboardBuilder": {
-                "title": "Constructor de widgets",
-                "text": "Haga clic en las tarjetas para agregar el widget relacionado al tablero"
+                "title": "Crea un nuevo widget",
+                "text": "Puede seleccionar el tipo de widget que desea y luego agregarlo al panel seleccionando uno de los elementos de la lista"
             },
             "dashboardAddChart": {
-                "title": "Agregar gráfico",
-                "text": "<p> Agregue gráficos nuevos al panel eligiendo entre los tipos barra, pie y línea. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Seleccione el tipo de gráfico </li> <li> Configure los datos del gráfico </li> <li> Guarde y agregue al tablero </li> </ul> </p>"
+                "title": "Widget de carta",
+                "text": "<p> Es un widget que muestra y agrega datos en gráficos circulares, de pie o de barras. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Seleccione el tipo de gráfico </li> <li> Configure los datos del gráfico </li> <li> Guarde y agregue al tablero </li> </ul> </p>"
             },
             "dashboardAddText": {
-                "title": "Añadir texto",
-                "text": "<p> Agregue nuevos textos al tablero. </p> <p> Pasos: </p> <p> <ul> <li> Edite el texto en el editor </li> <li> Guárdelo y agréguelo al tablero </li> </ul> </p>"
+                "title": "Widget de texto",
+                "text": "<p> Agregue su propio texto al tablero. </p> <p> Pasos: </p> <p> <ul> <li> Edite texto en el editor </li> <li> Guárdelo y agréguelo al tablero </li> </ul> </p>"
             },
             "dashboardAddTable": {
-                "title": "Agregar tabla",
-                "text": "<p> Agregue nuevas tablas de características al tablero. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Configure los datos de la tabla </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
+                "title": "Widget de mesa",
+                "text": "<p> Agregue una tabla de atributos al tablero que contenga datos de una capa vectorial seleccionada. También puede filtrar datos para personalizar su tabla. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Configure table data </​​li> <li> Guardar y agregar al tablero </li> </ul> </p>"
             },
             "dashboardAddCounter": {
-                "title": "Añadir contador",
-                "text": "<p> Agregue nuevos contadores al tablero. El contador mostrará un valor basado en los datos seleccionados. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Configure los datos del contador </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
+                "title": "Contador Widget",
+                "text": "<p> Agregue un nuevo contador al tablero. El contador mostrará los datos de agregación de valores numéricos de una capa vectorial seleccionada. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Configure los datos del contador </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
             },
             "dashboardAddMap": {
-                "title": "Añadir mapa",
-                "text": "<p> Agregue un nuevo mapa interactivo al tablero. Después de guardar el último mapa, el widget de la leyenda se agregará a la lista. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione un mapa </li> <li> Mejorar el mapa agregando nuevas capas </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
+                "title": "Widget del mapa",
+                "text": "<p> Agregue un nuevo mapa interactivo al tablero. Puede agregar más de un mapa con la capacidad de conectar otros widgets a ellos. Después de guardar el primer mapa, el widget de leyenda se agregará a la lista. El widget de leyenda mostrará una leyenda relacionada con el mapa conectado. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione un mapa </li> <li> Mejore el mapa agregando nuevas capas </li> <li> Guarde y agregue al tablero </li> </ul> </p>"
             }
         }
     }

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1550,6 +1550,46 @@
             "cesiumNavigation": {
                 "title": "Navegación",
                 "text": "Aquí puede encontrar los botones de zoom y zoom out"
+            },
+            "dashboardIntro": {
+                "title": "Tutorial del tablero",
+                "text": "Descripción general de las funciones del panel"
+            },
+            "dashboardNav": {
+                "title": "Barra de navegación",
+                "text": "Aquí puede encontrar el selector de idioma, el inicio de sesión, el enlace de la página de inicio y el menú de opciones"
+            },
+            "dashboardContainer": {
+                "title": "Contenedor del Tablero",
+                "text": "Puede editar, cambiar el tamaño, ordenar y mover tarjetas de panel dentro de esta área"
+            },
+            "dashboardAddWidget": {
+                "title": "Agregar Widget",
+                "text": "Abra la lista de widgets haciendo clic en el botón Agregar"
+            },
+            "dashboardBuilder": {
+                "title": "Constructor de widgets",
+                "text": "Haga clic en las tarjetas para agregar el widget relacionado al tablero"
+            },
+            "dashboardAddChart": {
+                "title": "Agregar gráfico",
+                "text": "<p> Agregue gráficos nuevos al panel eligiendo entre los tipos barra, pie y línea. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Seleccione el tipo de gráfico </li> <li> Configure los datos del gráfico </li> <li> Guarde y agregue al tablero </li> </ul> </p>"
+            },
+            "dashboardAddText": {
+                "title": "Añadir texto",
+                "text": "<p> Agregue nuevos textos al tablero. </p> <p> Pasos: </p> <p> <ul> <li> Edite el texto en el editor </li> <li> Guárdelo y agréguelo al tablero </li> </ul> </p>"
+            },
+            "dashboardAddTable": {
+                "title": "Agregar tabla",
+                "text": "<p> Agregue nuevas tablas de características al tablero. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Configure los datos de la tabla </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Añadir contador",
+                "text": "<p> Agregue nuevos contadores al tablero. El contador mostrará un valor basado en los datos seleccionados. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione una capa vectorial </li> <li> Configure los datos del contador </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
+            },
+            "dashboardAddMap": {
+                "title": "Añadir mapa",
+                "text": "<p> Agregue un nuevo mapa interactivo al tablero. Después de guardar el último mapa, el widget de la leyenda se agregará a la lista. </p> <p> Pasos: </p> <p> <ul> <li> Seleccione un mapa </li> <li> Mejorar el mapa agregando nuevas capas </li> <li> Guardar y agregar al tablero </li> </ul> </p>"
             }
         }
     }

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1550,6 +1550,46 @@
             "cesiumNavigation": {
                 "title": "Navigation",
                 "text": "Vous trouverez ici les boutons de zoom in et zoom out"
+            },
+            "dashboardIntro": {
+                "title": "Didacticiel du tableau de bord",
+                "text": "Vue d'ensemble des fonctionnalités du tableau de bord"
+            },
+            "dashboardNav": {
+                "title": "Barre de navigation",
+                "text": "Ici vous pouvez trouver le sélecteur de langue, le login, le lien de page d'accueil et le menu d'options"
+            },
+            "dashboardContainer": {
+                "title": "Tableau de bord",
+                "text": "Vous pouvez modifier, redimensionner, commander et déplacer des cartes de tableau de bord à l'intérieur de cette zone"
+            },
+            "dashboardAddWidget": {
+                "title": "Ajouter un widget",
+                "text": "Ouvrir la liste des widgets en cliquant sur le bouton Ajouter"
+            },
+            "dashboardBuilder": {
+                "text": "Cliquez sur les cartes pour ajouter le widget associé au tableau de bord",
+                "title": "Widget Builder"
+            },
+            "dashboardAddChart": {
+                "title": "Ajouter un graphique",
+                "text": "<p> Ajoutez de nouveaux graphiques au tableau de bord en choisissant entre les types barre, tarte et ligne. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionner une couche vectorielle </li> <li> Sélectionner un type de graphique </li> <li> Configurer des données de graphique </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+            },
+            "dashboardAddText": {
+                "title": "Ajouter du texte",
+                "text": "<p> Ajouter de nouveaux textes au tableau de bord. </p> <p> Étapes: </p> <p> <ul> <li> Modifier le texte dans l'éditeur </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+            },
+            "dashboardAddTable": {
+                "title": "Ajouter une table",
+                "text": "<p> Ajouter de nouveaux tableaux de caractéristiques au tableau de bord. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionner une couche vectorielle </li> <li> Configurer les données de table </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Ajouter un compteur",
+                "text": "<p> Ajoutez de nouveaux compteurs au tableau de bord. Le compteur affichera une valeur basée sur les données sélectionnées. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une couche vectorielle </li> <li> Configurez les données du compteur </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+            },
+            "dashboardAddMap": {
+                "title": "Ajouter une carte",
+                "text": "<p> Ajoutez une nouvelle carte interactive au tableau de bord. Après avoir sauvegardé la carte du début, le widget légende sera ajouté à la liste. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une carte </li> <li> Améliorer la carte en ajoutant de nouvelles couches </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
             }
         }
     }

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1561,35 +1561,35 @@
             },
             "dashboardContainer": {
                 "title": "Tableau de bord",
-                "text": "Vous pouvez modifier, redimensionner, commander et déplacer des cartes de tableau de bord à l'intérieur de cette zone"
+                "text": "<p> Un tableau de bord dans MapStore2 fournit un ensemble d'informations collectées de manière appropriée pour afficher des données agrégées dans une vue en une vue. Les données géospatiales affichées dans une carte peuvent être placées côte à côte avec des tableaux d'attributs, des graphiques et autres, dans le but de connecter différents types d'informations, de montrer des détails statistiques et des descriptions textuelles relatives à un contexte spécifique. </p> <p> Tous les utilisateurs peuvent visualiser et interagir avec les tableaux de bord publiés, mais seuls les utilisateurs autorisés à modifier peuvent ajouter, organiser, redimensionner ou supprimer tous les widgets dans un tableau de bord. </p>"
             },
             "dashboardAddWidget": {
                 "title": "Ajouter un widget",
-                "text": "Ouvrir la liste des widgets en cliquant sur le bouton Ajouter"
+                "text": "Pour ajouter un widget au tableau de bord, vous pouvez cliquer sur le bouton +"
             },
             "dashboardBuilder": {
-                "text": "Cliquez sur les cartes pour ajouter le widget associé au tableau de bord",
-                "title": "Widget Builder"
+                "title": "Créer un nouveau widget",
+                "text": "Vous pouvez sélectionner le type de widget que vous souhaitez, puis l'ajouter au tableau de bord en sélectionnant l'un des éléments de la liste"
             },
             "dashboardAddChart": {
-                "title": "Ajouter un graphique",
-                "text": "<p> Ajoutez de nouveaux graphiques au tableau de bord en choisissant entre les types barre, tarte et ligne. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionner une couche vectorielle </li> <li> Sélectionner un type de graphique </li> <li> Configurer des données de graphique </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+                "title": "Widget graphique",
+                "text": "<p> C'est un widget qui affiche et agrège les données dans des graphiques à secteurs, à lignes ou à barres. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une couche vectorielle </li> <li> Sélectionner un type de graphique </li> <li> Configurer des données de graphique </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
             },
             "dashboardAddText": {
-                "title": "Ajouter du texte",
-                "text": "<p> Ajouter de nouveaux textes au tableau de bord. </p> <p> Étapes: </p> <p> <ul> <li> Modifier le texte dans l'éditeur </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+                "title": "Widget de texte",
+                "text": "<p> Ajoutez votre propre texte au tableau de bord. </p> <p> Étapes: </p> <p> <ul> <li> Modifier le texte dans l'éditeur </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
             },
             "dashboardAddTable": {
-                "title": "Ajouter une table",
-                "text": "<p> Ajouter de nouveaux tableaux de caractéristiques au tableau de bord. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionner une couche vectorielle </li> <li> Configurer les données de table </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+                "title": "Widget de table",
+                "text": "<p> Ajoutez une table attributaire au tableau de bord contenant les données d'une couche vectorielle sélectionnée. Vous pouvez également filtrer les données pour personnaliser votre table. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une couche vectorielle </li> <li> Configurer les données de table </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
             },
             "dashboardAddCounter": {
-                "title": "Ajouter un compteur",
-                "text": "<p> Ajoutez de nouveaux compteurs au tableau de bord. Le compteur affichera une valeur basée sur les données sélectionnées. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une couche vectorielle </li> <li> Configurez les données du compteur </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+                "title": "Compteur Widget",
+                "text": "<p> Ajoutez un nouveau compteur au tableau de bord. Counter affiche les données d'agrégation de valeurs numériques d'une couche vectorielle sélectionnée. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une couche vectorielle </li> <li> Configurez les données du compteur </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
             },
             "dashboardAddMap": {
-                "title": "Ajouter une carte",
-                "text": "<p> Ajoutez une nouvelle carte interactive au tableau de bord. Après avoir sauvegardé la carte du début, le widget légende sera ajouté à la liste. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une carte </li> <li> Améliorer la carte en ajoutant de nouvelles couches </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
+                "title": "Widget Carte",
+                "text": "<p> Ajoutez une nouvelle carte interactive au tableau de bord. Vous pouvez ajouter plusieurs cartes avec la possibilité de leur connecter d'autres widgets. Après avoir enregistré la première carte, le widget légende sera ajouté à la liste. Legend Widget affichera une légende liée à la carte connectée. </p> <p> Étapes: </p> <p> <ul> <li> Sélectionnez une carte </li> <li> Améliorer la carte en ajoutant de nouveaux calques </li> <li> Enregistrer et ajouter au tableau de bord </li> </ul> </p>"
             }
         }
     }

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1421,36 +1421,36 @@
                 "text": "Here you can find language selector, login, homepage link and options menu"
             },
             "dashboardContainer": {
-                "title": "Dashboard Container",
-                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+                "title": "Dashboard",
+                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",
-                "text": "Open widget list by clicking on add button"
+                "text": "To add a widget to the dashboard, you can click on the + button"
             },
             "dashboardBuilder": {
-                "title": "Widget Builder",
-                "text": "Click on cards to add the related widget to dashboard"
+                "title": "Create a new widget",
+                "text": "You can select which type of widget you want and then add to the dashboard selecting one of the items in the list"
             },
             "dashboardAddChart": {
-                "title": "Add Chart",
-                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Chart Widget",
+                "text": "<p>It's a widget that show and aggregate data into pie, line or bar charts.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddText": {
-                "title": "Add Text",
-                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Text Widget",
+                "text": "<p>Add your own text to the dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddTable": {
-                "title": "Add Table",
-                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Table Widget",
+                "text": "<p>Add an attribute table to the dashboard that contains data from a selected vector layer. You can also filter data to customize your table.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddCounter": {
-                "title": "Add Counter",
-                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Counter Widget",
+                "text": "<p>Add a new counter to the dashboard. Counter will show numeric value aggregationg data from a selected vector layer.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddMap": {
-                "title": "Add Map",
-                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Map Widget",
+                "text": "<p>Add a new interactive map to the dashboard. You can add more than one map with the ability to connect other widgets to them. After saving the first map, the legend widget will be added to the list. Legend Widget will show a legend related to the connected map.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
     }

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1411,6 +1411,46 @@
             "cesiumNavigation": {
                 "title": "Navigacija",
                 "text": "Ovdje možete naći dugmad za približavanje i udaljavanje sadržaja karte"
+            },
+            "dashboardIntro": {
+                "title": "Dashboard Tutorial",
+                "text": "Overview of dashboard functionalities"
+            },
+            "dashboardNav": {
+                "title": "Navigation Bar",
+                "text": "Here you can find language selector, login, homepage link and options menu"
+            },
+            "dashboardContainer": {
+                "title": "Dashboard Container",
+                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+            },
+            "dashboardAddWidget": {
+                "title": "Add Widget",
+                "text": "Open widget list by clicking on add button"
+            },
+            "dashboardBuilder": {
+                "title": "Widget Builder",
+                "text": "Click on cards to add the related widget to dashboard"
+            },
+            "dashboardAddChart": {
+                "title": "Add Chart",
+                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddText": {
+                "title": "Add Text",
+                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddTable": {
+                "title": "Add Table",
+                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Add Counter",
+                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddMap": {
+                "title": "Add Map",
+                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
     }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1553,43 +1553,43 @@
                 },
                 "dashboardIntro": {
                     "title": "Dashboard Tutorial",
-                    "text": "Panoramica delle funzionalità del dashboard"
+                    "text": "Panoramica delle funzionalità della dashboard"
                 },
                 "dashboardNav": {
                     "title": "Barra di navigazione",
                     "text": "Qui puoi trovare il selettore della lingua, il login, il link della homepage e il menu delle opzioni"
                 },
                 "dashboardContainer": {
-                    "title": "Contenitore Dashboard",
-                    "text": "Puoi modificare, ridimensionare, ordinare e spostare le card della dashboard all'interno di quest'area"
+                    "title": "Cruscotto",
+                    "text": "<p> Una Dashboard in MapStore2 fornisce un insieme di informazioni raccolte in modo appropriato per mostrare i dati aggregati in un'unica visualizzazione. I dati geospaziali visualizzati in una mappa possono essere affiancati alle relative tabelle degli attributi, grafici ed altro, allo scopo di connettere diversi tipi di informazioni, mostrare dettagli statistici e descrizioni testuali relative ad un contesto specifico. </p> <p> Tutti gli utenti possono visualizzare e interagire con le dashboard pubblicate, ma solo gli utenti autorizzati a modificare possono aggiungere, organizzare, ridimensionare o eliminare tutti i widget all'interno di una dashboard </p>"
                 },
                 "dashboardAddWidget": {
                     "title": "Aggiungi widget",
-                    "text": "Apri l'elenco dei widget facendo clic sul pulsante aggiungi"
+                    "text": "Per aggiungere un widget alla dashboard, puoi cliccare sul pulsante +"
                 },
                 "dashboardBuilder": {
-                    "title": "Widget Builder",
-                    "text": "Fare clic sulle cards per aggiungere il relativo widget alla dashboard"
+                    "title": "Crea un nuovo widget",
+                    "text": "È possibile selezionare il tipo di widget desiderato e quindi aggiungerlo alla dashboard selezionando uno degli elementi nell'elenco"
                 },
                 "dashboardAddChart": {
-                    "title": "Aggiungi grafico",
-                    "text": "<p>Aggiungi nuovi grafici alla dashboard scegliendo tra istogramma, tortae linea.</p> <p> Passaggi: </p> <p> <ul> <li> Seleziona un livello vettoriale </li> <li> Seleziona il tipo di grafico </li> <li> Configura i dati del grafico </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                    "title": "Widget Grafico",
+                    "text": "<p> È un widget che mostra e aggrega i dati in grafici a torta, linea o a istogramma. </p> <p> Passaggi: </p> <p> <ul> <li> Seleziona un livello vettoriale </li> <li> Seleziona il tipo di grafico </li> <li> Configura i dati del grafico </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
                 },
                 "dashboardAddText": {
-                    "title": "Aggiungi testo",
-                    "text": "<p> Aggiungi nuovi testi alla dashboard. </p> <p> Passaggi: </p> <p> <ul> <li> Modifica il testo nell'editor </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                    "title": "Widget Testo",
+                    "text": "<p> Aggiungi un testo alla dashboard. </p> <p> Passaggi: </p> <p> <ul> <li> Modifica il testo nell'editor </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
                 },
                 "dashboardAddTable": {
-                    "title": "Aggiungi tabella",
-                    "text": "<p> Aggiungi nuove tabelle alla dashboard. </p> <p> Passaggi: </p> <p> <ul> <li> Seleziona un layer vettoriale </li> <li> Configura i dati della tabella </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                    "title": "Widget Tabella ",
+                    "text": "<p> Aggiungi una tabella di attributi alla dashboard che contiene dati di un livello vettoriale selezionato. Puoi anche filtrare i dati per personalizzare la tabella. </p> <p> Passaggi: </p> <p> <ul> <li> Seleziona un livello vettoriale </li> <li> Configura dati tabella </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
                 },
                 "dashboardAddCounter": {
-                    "title": "Aggiungi contatore",
-                    "text": "<p> Aggiungi nuovi contatori alla dashboard. Il contatore mostrerà un valore basato sui dati selezionati. </p> <p> Passi: </p> <p> <ul> <li> Seleziona un layer vettoriale </li> <li> Configura i dati del contatori </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                    "title": "Widget Contatore",
+                    "text": "<p> Aggiungi un nuovo contatore alla dashboard. Il contatore mostrerà il valore numerico aggregando i dati da un livello vettoriale selezionato. </p> <p> Passi: </p> <p> <ul> <li> Seleziona un livello vettoriale </li> <li> Configura i dati del contatore </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
                 },
                 "dashboardAddMap": {
-                    "title": "Aggiungi mappa",
-                    "text": "<p> Aggiungi una nuova mappa interattiva alla dashboard. Dopo aver salvato la prima mappa, il widget legenda verrà aggiunto all'elenco. </ P> <p> Passaggi: </ p> <p> <ul> <li> Seleziona una mappa </ li> <li> Migliora la mappa aggiungendo nuovi layer </ li> <li> Salva e aggiungi alla dashboard </ li> </ ul> </ p>"
+                    "title": "Widget Mappa",
+                    "text": "<p> Aggiungi una nuova mappa interattiva alla dashboard. È possibile aggiungere più di una mappa con la possibilità di collegare ad esse altri widget. Dopo aver salvato la prima mappa, il widget legenda verrà aggiunto all'elenco. Legend Widget mostrerà una legenda relativa alla mappa connessa. </p> <p> Passaggi: </p> <p> <ul> <li> Seleziona una mappa </li> <li> Migliora la mappa aggiungendo nuovi livelli </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
                 }
             }
     }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1550,6 +1550,46 @@
                 "cesiumNavigation": {
                     "title": "Navigazione",
                     "text": "Qui puoi trovare i pulsanti per lo zoom in e out"
+                },
+                "dashboardIntro": {
+                    "title": "Dashboard Tutorial",
+                    "text": "Panoramica delle funzionalità del dashboard"
+                },
+                "dashboardNav": {
+                    "title": "Barra di navigazione",
+                    "text": "Qui puoi trovare il selettore della lingua, il login, il link della homepage e il menu delle opzioni"
+                },
+                "dashboardContainer": {
+                    "title": "Contenitore Dashboard",
+                    "text": "Puoi modificare, ridimensionare, ordinare e spostare le card della dashboard all'interno di quest'area"
+                },
+                "dashboardAddWidget": {
+                    "title": "Aggiungi widget",
+                    "text": "Apri l'elenco dei widget facendo clic sul pulsante aggiungi"
+                },
+                "dashboardBuilder": {
+                    "title": "Widget Builder",
+                    "text": "Fare clic sulle cards per aggiungere il relativo widget alla dashboard"
+                },
+                "dashboardAddChart": {
+                    "title": "Aggiungi grafico",
+                    "text": "<p>Aggiungi nuovi grafici alla dashboard scegliendo tra istogramma, tortae linea.</p> <p> Passaggi: </p> <p> <ul> <li> Seleziona un livello vettoriale </li> <li> Seleziona il tipo di grafico </li> <li> Configura i dati del grafico </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                },
+                "dashboardAddText": {
+                    "title": "Aggiungi testo",
+                    "text": "<p> Aggiungi nuovi testi alla dashboard. </p> <p> Passaggi: </p> <p> <ul> <li> Modifica il testo nell'editor </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                },
+                "dashboardAddTable": {
+                    "title": "Aggiungi tabella",
+                    "text": "<p> Aggiungi nuove tabelle alla dashboard. </p> <p> Passaggi: </p> <p> <ul> <li> Seleziona un layer vettoriale </li> <li> Configura i dati della tabella </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                },
+                "dashboardAddCounter": {
+                    "title": "Aggiungi contatore",
+                    "text": "<p> Aggiungi nuovi contatori alla dashboard. Il contatore mostrerà un valore basato sui dati selezionati. </p> <p> Passi: </p> <p> <ul> <li> Seleziona un layer vettoriale </li> <li> Configura i dati del contatori </li> <li> Salva e aggiungi alla dashboard </li> </ul> </p>"
+                },
+                "dashboardAddMap": {
+                    "title": "Aggiungi mappa",
+                    "text": "<p> Aggiungi una nuova mappa interattiva alla dashboard. Dopo aver salvato la prima mappa, il widget legenda verrà aggiunto all'elenco. </ P> <p> Passaggi: </ p> <p> <ul> <li> Seleziona una mappa </ li> <li> Migliora la mappa aggiungendo nuovi layer </ li> <li> Salva e aggiungi alla dashboard </ li> </ ul> </ p>"
                 }
             }
     }

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1201,36 +1201,36 @@
                 "text": "Here you can find language selector, login, homepage link and options menu"
             },
             "dashboardContainer": {
-                "title": "Dashboard Container",
-                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+                "title": "Dashboard",
+                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",
-                "text": "Open widget list by clicking on add button"
+                "text": "To add a widget to the dashboard, you can click on the + button"
             },
             "dashboardBuilder": {
-                "title": "Widget Builder",
-                "text": "Click on cards to add the related widget to dashboard"
+                "title": "Create a new widget",
+                "text": "You can select which type of widget you want and then add to the dashboard selecting one of the items in the list"
             },
             "dashboardAddChart": {
-                "title": "Add Chart",
-                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Chart Widget",
+                "text": "<p>It's a widget that show and aggregate data into pie, line or bar charts.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddText": {
-                "title": "Add Text",
-                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Text Widget",
+                "text": "<p>Add your own text to the dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddTable": {
-                "title": "Add Table",
-                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Table Widget",
+                "text": "<p>Add an attribute table to the dashboard that contains data from a selected vector layer. You can also filter data to customize your table.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddCounter": {
-                "title": "Add Counter",
-                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Counter Widget",
+                "text": "<p>Add a new counter to the dashboard. Counter will show numeric value aggregationg data from a selected vector layer.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddMap": {
-                "title": "Add Map",
-                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Map Widget",
+                "text": "<p>Add a new interactive map to the dashboard. You can add more than one map with the ability to connect other widgets to them. After saving the first map, the legend widget will be added to the list. Legend Widget will show a legend related to the connected map.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
       }

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1191,6 +1191,46 @@
             "cesiumNavigation": {
                 "title": "Navigatie",
                 "text": "Hier kunt u de knoppen voor in- en uitzoomen vinden"
+            },
+            "dashboardIntro": {
+                "title": "Dashboard Tutorial",
+                "text": "Overview of dashboard functionalities"
+            },
+            "dashboardNav": {
+                "title": "Navigation Bar",
+                "text": "Here you can find language selector, login, homepage link and options menu"
+            },
+            "dashboardContainer": {
+                "title": "Dashboard Container",
+                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+            },
+            "dashboardAddWidget": {
+                "title": "Add Widget",
+                "text": "Open widget list by clicking on add button"
+            },
+            "dashboardBuilder": {
+                "title": "Widget Builder",
+                "text": "Click on cards to add the related widget to dashboard"
+            },
+            "dashboardAddChart": {
+                "title": "Add Chart",
+                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddText": {
+                "title": "Add Text",
+                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddTable": {
+                "title": "Add Table",
+                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Add Counter",
+                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddMap": {
+                "title": "Add Map",
+                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
       }

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1263,36 +1263,36 @@
                 "text": "Here you can find language selector, login, homepage link and options menu"
             },
             "dashboardContainer": {
-                "title": "Dashboard Container",
-                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+                "title": "Dashboard",
+                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",
-                "text": "Open widget list by clicking on add button"
+                "text": "To add a widget to the dashboard, you can click on the + button"
             },
             "dashboardBuilder": {
-                "title": "Widget Builder",
-                "text": "Click on cards to add the related widget to dashboard"
+                "title": "Create a new widget",
+                "text": "You can select which type of widget you want and then add to the dashboard selecting one of the items in the list"
             },
             "dashboardAddChart": {
-                "title": "Add Chart",
-                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Chart Widget",
+                "text": "<p>It's a widget that show and aggregate data into pie, line or bar charts.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddText": {
-                "title": "Add Text",
-                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Text Widget",
+                "text": "<p>Add your own text to the dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddTable": {
-                "title": "Add Table",
-                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Table Widget",
+                "text": "<p>Add an attribute table to the dashboard that contains data from a selected vector layer. You can also filter data to customize your table.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddCounter": {
-                "title": "Add Counter",
-                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Counter Widget",
+                "text": "<p>Add a new counter to the dashboard. Counter will show numeric value aggregationg data from a selected vector layer.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
             },
             "dashboardAddMap": {
-                "title": "Add Map",
-                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
+                "title": "Map Widget",
+                "text": "<p>Add a new interactive map to the dashboard. You can add more than one map with the ability to connect other widgets to them. After saving the first map, the legend widget will be added to the list. Legend Widget will show a legend related to the connected map.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
     }

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1253,6 +1253,46 @@
             "cesiumNavigation": {
                 "title": "Navigation",
                 "text": "Here you can find the zoom in and zoom out buttons"
+            },
+            "dashboardIntro": {
+                "title": "Dashboard Tutorial",
+                "text": "Overview of dashboard functionalities"
+            },
+            "dashboardNav": {
+                "title": "Navigation Bar",
+                "text": "Here you can find language selector, login, homepage link and options menu"
+            },
+            "dashboardContainer": {
+                "title": "Dashboard Container",
+                "text": "You can edit, resize, order and move dashboard cards inside of this area"
+            },
+            "dashboardAddWidget": {
+                "title": "Add Widget",
+                "text": "Open widget list by clicking on add button"
+            },
+            "dashboardBuilder": {
+                "title": "Widget Builder",
+                "text": "Click on cards to add the related widget to dashboard"
+            },
+            "dashboardAddChart": {
+                "title": "Add Chart",
+                "text": "<p>Add new charts to dashboard by choosing between bar, pie and line types.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Select chart type</li><li>Configure chart data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddText": {
+                "title": "Add Text",
+                "text": "<p>Add new texts to dashboard.</p><p>Steps:</p><p><ul><li>Edit text in editor</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddTable": {
+                "title": "Add Table",
+                "text": "<p>Add new tables of features to dashboard.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure table data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Add Counter",
+                "text": "<p>Add new counters to dashboard. Counter will show a value based on selected data.</p><p>Steps:</p><p><ul><li>Select a vector layer</li><li>Configure counter data</li><li>Save and add to dashboard</li></ul></p>"
+            },
+            "dashboardAddMap": {
+                "title": "Add Map",
+                "text": "<p>Add a new interactive map to dashboard. After saving the firt map, the legend widget will be added to the list.</p><p>Steps:</p><p><ul><li>Select a map</li><li>Improve map by adding new layers</li><li>Save and add to dashboard</li></ul></p>"
             }
         }
     }


### PR DESCRIPTION
## Description
This PR introduces actions for steps of tutorial. Now actions will be dispatched if declared in the step object.
This improvement is needed to open/close widget builder in dashboard tutorial
This PR add also a default dashboard tutorial.

```
// action param could be an object or array of objects
// action types are triggered on tour actions and they could be `start`, `next` and `back`
 ...
"tutorial": {
   ...
   "myIntroTranslation": {
    "title": "My intro title",
    "text": "My intro description",
    "action": { start: { type: 'MY_START_ACTION' }}
   },
    "myTranslation": {
    "title": "My first step title",
    "text": "My first step description",
    "action": { back: { type: 'MY_BACK_ACTION' }}
   },
   "mySecondStepTranslation": {
    "title": "My second step title",
    "text": "My second step description",
    "action": { next: { type: 'MY_NEXT_ACTION' }}
   },
   "myTranslationHTML": {
    "title": "<div style="color:blue;">My html step title</div>",
    "text": "<div style="color:red;">My html step description</div>",
    "action": { next: [{ type: 'MY_FIRST_ACTION' }, { type: 'MY_SECOND_ACTION' }]}
   }
   ...
  }
 ...
```


## Issues
 - Fix #2692

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Missing dashboard tutorial

**What is the new behavior?**
Added action to tutorial steps and a default tutorial for dashboard

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
