### PR TITLE
add authenticationRule to support browser credentials (i.e. Cookies).

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -31,11 +31,11 @@ This is the main structure:
   "translationsPath",
   // if true, every ajax and mapping request will be authenticated with the configurations if match a rule
   "useAuthenticationRules": true
-  // the athentication rules to match
+  // the authentication rules to match
   "authenticationRules": [
   { // every rule has a `urlPattern` regex to match
     "urlPattern": ".*geostore.*",
-    // and a authentication `method` to use (basic, authkey)
+    // and a authentication `method` to use (basic, authkey, browserWithCredentials)
     "method": "basic"
   }, {
     "urlPattern": "\\/geoserver.*",

--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -359,31 +359,29 @@ describe('Tests ajax library', () => {
     });
 
     it('does set withCredentials on the request', (done)=> {
-      expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
-      expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
+        expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
+        expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
 
-      axios.get('http://www.useBrowserCredentials.com/useBrowserCredentials?parameter1=value1&parameter2=value2').then(() => {
-        done();
-      }).catch( (exception) => {
-        console.log(exception.config);
-        expect(exception.config).toExist();
-        expect(exception.config.withCredentials).toExist();
-        expect(exception.config.withCredentials).toBeTruthy();
-        done();
-      });
+        axios.get('http://www.useBrowserCredentials.com/useBrowserCredentials?parameter1=value1&parameter2=value2').then(() => {
+            done();
+        }).catch( (exception) => {
+            expect(exception.config).toExist();
+            expect(exception.config.withCredentials).toExist();
+            expect(exception.config.withCredentials).toBeTruthy();
+            done();
+        });
     });
 
     it('does not set withCredentials on the request', (done)=> {
-      expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
-      expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
+        expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
+        expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
 
-      axios.get('http://www.skipBrowserCredentials.com/geoserver?parameter1=value1&parameter2=value2').then(() => {
-        done();
-      }).catch( (exception) => {
-        console.log(exception.config);
-        expect(exception.config).toExist();
-        expect(exception.config.withCredentials).toNotExist();
-        done();
-      });
+        axios.get('http://www.skipBrowserCredentials.com/geoserver?parameter1=value1&parameter2=value2').then(() => {
+            done();
+        }).catch( (exception) => {
+            expect(exception.config).toExist();
+            expect(exception.config.withCredentials).toNotExist();
+            done();
+        });
     });
 });

--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -70,6 +70,10 @@ const authenticationRules = [
     {
       "urlPattern": ".*imtokenized.*",
       "method": "bearer"
+    },
+    {
+      "urlPattern": ".*useBrowserCredentials.*",
+      "method": "browserWithCredentials"
     }
 ];
 
@@ -352,5 +356,34 @@ describe('Tests ajax library', () => {
         }).catch(() => {
             done();
         });
+    });
+
+    it('does set withCredentials on the request', (done)=> {
+      expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
+      expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
+
+      axios.get('http://www.useBrowserCredentials.com/useBrowserCredentials?parameter1=value1&parameter2=value2').then(() => {
+        done();
+      }).catch( (exception) => {
+        console.log(exception.config);
+        expect(exception.config).toExist();
+        expect(exception.config.withCredentials).toExist();
+        expect(exception.config.withCredentials).toBeTruthy();
+        done();
+      });
+    });
+
+    it('does not set withCredentials on the request', (done)=> {
+      expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
+      expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
+
+      axios.get('http://www.skipBrowserCredentials.com/geoserver?parameter1=value1&parameter2=value2').then(() => {
+        done();
+      }).catch( (exception) => {
+        console.log(exception.config);
+        expect(exception.config).toExist();
+        expect(exception.config.withCredentials).toNotExist();
+        done();
+      });
     });
 });

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -44,7 +44,7 @@ function addAuthenticationToAxios(axiosConfig) {
     switch (rule && rule.method) {
         case 'browserWithCredentials':
         {
-            axiosConfig.withCredentials=true;
+            axiosConfig.withCredentials = true;
             return axiosConfig;
         }
         case 'authkey':

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -42,6 +42,11 @@ function addAuthenticationToAxios(axiosConfig) {
     const rule = SecurityUtils.getAuthenticationRule(axiosConfig.url);
 
     switch (rule && rule.method) {
+        case 'browserWithCredentials':
+        {
+            axiosConfig.withCredentials=true;
+            return axiosConfig;
+        }
         case 'authkey':
         {
             const token = SecurityUtils.getToken();

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -23,9 +23,6 @@
       }
     },
     "authenticationRules": [{
-        "urlPattern": "https://someendpoint.*",
-        "method": "browserWithCredentials"
-    },{
         "urlPattern": ".*geostore.*",
         "method": "bearer"
     }],

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -23,6 +23,9 @@
       }
     },
     "authenticationRules": [{
+        "urlPattern": "https://someendpoint.*",
+        "method": "browserWithCredentials"
+    },{
         "urlPattern": ".*geostore.*",
         "method": "bearer"
     }],


### PR DESCRIPTION
## Description
Accessing services via CORS that are protected with some sort of session require that cookies are sent when requesting data. For all images and tiles the browser does this already, but not for the ajax service calls.

This patch adds an option to authenticationRules in the configuration to enable the "withCredentials" options for requests.


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)

Ajax requests do not send cookies set in the browser.

**What is the new behavior?**

For configured services, the browser will send cookies to the called service with AJAX (for CORS).

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [N] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

As I do not have a public service the tests are only checking if the required property on the request config object is set.