### PR TITLE
fixed #2990 custom styles and added tests

### DIFF
--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -27,7 +27,7 @@ const image = new ol.style.Circle({
  * @param {boolean} options.applyToPolygon tells if this style can be applied to a polygon
  * @return {ol.style.Style} style of the point
 */
-const firstPointOfPolylineStyle = ({radius = 5, fillColor = 'green', applyToPolygon = false}) => new ol.style.Style({
+const firstPointOfPolylineStyle = ({radius = 5, fillColor = 'green', applyToPolygon = false} = {}) => new ol.style.Style({
     image: new ol.style.Circle({
         radius,
         fill: new ol.style.Fill({
@@ -53,7 +53,7 @@ const firstPointOfPolylineStyle = ({radius = 5, fillColor = 'green', applyToPoly
  * @param {boolean} options.applyToPolygon tells if this style can be applied to a polygon
  * @return {ol.style.Style} style of the point
 */
-const lastPointOfPolylineStyle = ({radius = 5, fillColor = 'red', applyToPolygon = false}) => new ol.style.Style({
+const lastPointOfPolylineStyle = ({radius = 5, fillColor = 'red', applyToPolygon = false} = {}) => new ol.style.Style({
     image: new ol.style.Circle({
         radius,
         fill: new ol.style.Fill({
@@ -74,7 +74,7 @@ const lastPointOfPolylineStyle = ({radius = 5, fillColor = 'red', applyToPolygon
 /**
     creates styles to highlight/customize start and end point of a polylin
 */
-const startEndPolylineStyle = (startPointOptions, endPointOptions) => {
+const startEndPolylineStyle = (startPointOptions = {}, endPointOptions = {}) => {
     return [firstPointOfPolylineStyle(startPointOptions), lastPointOfPolylineStyle(endPointOptions)];
 };
 

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -219,6 +219,7 @@ describe('Test VectorStyle', () => {
 
     it('test styleFunction with MultiPolygon', () => {
 
+
         const multiPolygon = new ol.Feature({
             geometry: new ol.geom.MultiPolygon([
                 [
@@ -284,6 +285,35 @@ describe('Test VectorStyle', () => {
         expect(olStroke.getWidth()).toBe(10);
         expect(olStroke.getLineDash()).toEqual(['10', '5']);
 
+    });
+
+    it('test firstPointOfPolylineStyle defaults', () => {
+        let olStyle = VectorStyle.firstPointOfPolylineStyle();
+        expect(olStyle.getImage().getRadius()).toBe(5);
+        expect(olStyle.getImage().getFill().getColor()).toBe("green");
+    });
+    it('test lastPointOfPolylineStyle defaults', () => {
+        let olStyle = VectorStyle.lastPointOfPolylineStyle();
+        expect(olStyle.getImage().getRadius()).toBe(5);
+        expect(olStyle.getImage().getFill().getColor()).toBe("red");
+    });
+
+    it('test firstPointOfPolylineStyle {radius: 4}', () => {
+        let olStyle = VectorStyle.firstPointOfPolylineStyle({radius: 4});
+        expect(olStyle.getImage().getRadius()).toBe(4);
+        expect(olStyle.getImage().getFill().getColor()).toBe("green");
+    });
+    it('test lastPointOfPolylineStyle {radius: 4}', () => {
+        let olStyle = VectorStyle.lastPointOfPolylineStyle({radius: 4});
+        expect(olStyle.getImage().getRadius()).toBe(4);
+        expect(olStyle.getImage().getFill().getColor()).toBe("red");
+    });
+    it('test startEndPolylineStyle defaults', () => {
+        let styles = VectorStyle.startEndPolylineStyle();
+        expect(styles[0].getImage().getRadius()).toBe(5);
+        expect(styles[0].getImage().getFill().getColor()).toBe("green");
+        expect(styles[1].getImage().getRadius()).toBe(5);
+        expect(styles[1].getImage().getFill().getColor()).toBe("red");
     });
 
 });


### PR DESCRIPTION
## Description
Fixed an error if startEndPoint was set to true.
added tests

## Issues
 - Fix #2990

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
actually a problem occurs when trying to draw the length if in config is set like this
startEndPoint: true

**What is the new behavior?**
you can draw with defaults styles

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
