### PR TITLE
Fix #2983 remove + button when loading an existing dashboard (#2983)

### DIFF
--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -14,9 +14,8 @@ const PropTypes = require('prop-types');
 
 const { isDashboardEditing } = require('../selectors/dashboard');
 const { isLoggedIn } = require('../selectors/security');
-const {pathnameSelector} = require('../selectors/routing');
 const { dashboardHasWidgets, getWidgetsDependenciesGroups } = require('../selectors/widgets');
-const { showConnectionsSelector, dashboardResource, isDashboardLoading } = require('../selectors/dashboard');
+const { showConnectionsSelector, dashboardResource, isDashboardLoading, buttonCanEdit } = require('../selectors/dashboard');
 const { dashboardSelector } = require('./widgetbuilder/commons');
 
 const { createWidget, toggleConnection } = require('../actions/widgets');
@@ -42,12 +41,12 @@ const Toolbar = compose(
             dashboardResource,
             dashboardHasWidgets,
             getWidgetsDependenciesGroups,
-            pathnameSelector,
-            (showConnections, logged, resource, hasWidgets, groups, path = []) => ({
+            buttonCanEdit,
+            (showConnections, logged, resource, hasWidgets, groups, edit = []) => ({
                 showConnections,
                 hasConnections: groups.length > 0,
                 hasWidgets,
-                canEdit: (resource ? resource.canEdit : (isNaN(path.substr(-4))) ? true : false),
+                canEdit: edit,
                 canSave: logged && hasWidgets && (resource ? resource.canEdit : true)
             })
         ),

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -14,6 +14,7 @@ const PropTypes = require('prop-types');
 
 const { isDashboardEditing } = require('../selectors/dashboard');
 const { isLoggedIn } = require('../selectors/security');
+const {pathnameSelector} = require('../selectors/routing');
 const { dashboardHasWidgets, getWidgetsDependenciesGroups } = require('../selectors/widgets');
 const { showConnectionsSelector, dashboardResource, isDashboardLoading } = require('../selectors/dashboard');
 const { dashboardSelector } = require('./widgetbuilder/commons');
@@ -41,11 +42,12 @@ const Toolbar = compose(
             dashboardResource,
             dashboardHasWidgets,
             getWidgetsDependenciesGroups,
-            (showConnections, logged, resource, hasWidgets, groups = []) => ({
+            pathnameSelector,
+            (showConnections, logged, resource, hasWidgets, groups, path = []) => ({
                 showConnections,
                 hasConnections: groups.length > 0,
                 hasWidgets,
-                canEdit: (resource ? resource.canEdit : true),
+                canEdit: (resource ? resource.canEdit : (isNaN(path.substr(-4))) ? true : false),
                 canSave: logged && hasWidgets && (resource ? resource.canEdit : true)
             })
         ),

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -40,9 +40,9 @@ const Toolbar = compose(
             isLoggedIn,
             dashboardResource,
             dashboardHasWidgets,
-            getWidgetsDependenciesGroups,
             buttonCanEdit,
-            (showConnections, logged, resource, hasWidgets, groups, edit = []) => ({
+            getWidgetsDependenciesGroups,
+            (showConnections, logged, resource, hasWidgets, edit, groups = []) => ({
                 showConnections,
                 hasConnections: groups.length > 0,
                 hasWidgets,
@@ -83,7 +83,7 @@ const Toolbar = compose(
             glyph: showConnections ? 'bulb-on' : 'bulb-off',
             tooltipId: showConnections ? 'dashboard.editor.hideConnections' : 'dashboard.editor.showConnections',
             bsStyle: showConnections ? 'success' : 'primary',
-            visible: !!hasWidgets && !!hasConnections,
+            visible: !!hasWidgets && !!hasConnections || !canEdit,
             onClick: () => onShowConnections(!showConnections)
         }]
     }))

--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -14,7 +14,8 @@ const {
     isShowSaveOpen,
     dashboardResource,
     isDashboardLoading,
-    getDashboardSaveErrors
+    getDashboardSaveErrors,
+    buttonCanEdit
 } = require('../dashboard');
 describe('dashboard selectors', () => {
     it('test isDashboardAvailable selector', () => {
@@ -59,5 +60,23 @@ describe('dashboard selectors', () => {
                 saveErrors: [{}]
             }
         }).length).toBe(1);
+    });
+    it('test buttonCanEdit with a new dashboared', () => {
+        expect(buttonCanEdit({
+            routing: {
+                location: {
+                    pathname: '/dashboard/'
+                }
+            }
+        })).toBe(true);
+    });
+    it('test buttonCanEdit when load a dashboared', () => {
+        expect(buttonCanEdit({
+            routing: {
+                location: {
+                    pathname: '/dashboard/0000'
+                }
+            }
+        })).toBe(false);
     });
 });

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -1,3 +1,6 @@
+const {createSelector} = require('reselect');
+const {pathnameSelector} = require('../selectors/routing');
+
 const isDashboardAvailable = state => state && state.dashboard && state.dashboard.editor && state.dashboard.editor.available;
 const isShowSaveOpen = state => state && state.dashboard && state.dashboard.showSaveModal;
 const isDashboardEditing = state => state && state.dashboard && state.dashboard.editing;
@@ -5,6 +8,9 @@ const showConnectionsSelector = state => state && state.dashboard && state.dashb
 const dashboardResource = state => state && state.dashboard && state.dashboard.resource;
 const isDashboardLoading = state => state && state.dashboard && state.dashboard.loading;
 const getDashboardSaveErrors = state => state && state.dashboard && state.dashboard.saveErrors;
+const buttonCanEdit = createSelector(pathnameSelector, dashboardResource,
+    (path, resource) => resource && resource.canEdit || isNaN(path.substr(-4)));
+
 module.exports = {
     isDashboardAvailable,
     isShowSaveOpen,
@@ -12,5 +18,6 @@ module.exports = {
     showConnectionsSelector,
     dashboardResource,
     isDashboardLoading,
-    getDashboardSaveErrors
+    getDashboardSaveErrors,
+    buttonCanEdit
 };


### PR DESCRIPTION
## Description
This PR provide a fix for the issue below

## Issues
 - Fix #2983 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#2983

**What is the new behavior?**
dashboard editor with the connect button, when the page is loading. In the case of new dashboard entry point it appears normally 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
the test was conducted in chromium 