### PR TITLE
Fix #2997 Make default print options overridable

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -216,6 +216,7 @@
                 "web/client/plugins/Login.jsx",
                 "web/client/plugins/MousePosition.jsx",
                 "web/client/plugins/Notifications.jsx",
+                "web/client/plugins/Print.jsx",
                 "web/client/plugins/QueryPanel.jsx",
                 "web/client/plugins/ScaleBox.jsx",
                 "web/client/plugins/ScrollTop.jsx",

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -36,6 +36,28 @@ const Message = require('../components/I18N/Message');
 
 require('./print/print.css');
 
+/**
+ * Print plugin. This plugin allows to print current map view.
+ *
+ * @class Print
+ * @memberof plugins
+ * @static
+ *
+ * @prop {object} cfg.overrideOptions overrides print options, this will override options created from current state of map
+ * @prop {bool} cfg.overrideOptions.gedetic print in geodetic mode
+ * @prop {string} cfg.overrideOptions.outputFilename name of output file
+ *
+ * @example
+ * {
+ *   "name": "Print",
+ *   "cfg": {
+ *       "overrideOptions": {
+ *          "gedetic": true
+ *       }
+ *    }
+ * }
+ */
+
 module.exports = {
     PrintPlugin: assign({
         loadPlugin: (resolve) => {
@@ -99,7 +121,8 @@ module.exports = {
                         closeGlyph: PropTypes.string,
                         submitConfig: PropTypes.object,
                         previewOptions: PropTypes.object,
-                        currentLocale: PropTypes.string
+                        currentLocale: PropTypes.string,
+                        overrideOptions: PropTypes.object
                     };
 
                     static contextTypes = {
@@ -159,7 +182,8 @@ module.exports = {
                             buttonStyle: "primary"
                         },
                         style: {},
-                        currentLocale: 'en-US'
+                        currentLocale: 'en-US',
+                        overrideOptions: {}
                     };
 
                     componentWillMount() {
@@ -347,7 +371,7 @@ module.exports = {
                         const spec = this.props.getPrintSpecification(this.props.printSpec);
                         this.props.setPage(0);
                         this.props.onBeforePrint();
-                        this.props.onPrint(this.props.capabilities.createURL, spec);
+                        this.props.onPrint(this.props.capabilities.createURL, {...spec, ...this.props.overrideOptions});
                     };
                 }
 

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -52,7 +52,7 @@ require('./print/print.css');
  *   "name": "Print",
  *   "cfg": {
  *       "overrideOptions": {
- *          "gedetic": true
+ *          "gedetic": false
  *       }
  *    }
  * }

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -151,7 +151,7 @@ const PrintUtils = {
             "layout": PrintUtils.getLayoutName(spec),
             "dpi": parseInt(spec.resolution, 10),
             "outputFilename": "mapstore-print",
-            "geodetic": false,
+            "geodetic": true,
             "mapTitle": spec.name || '',
             "comment": spec.description || '',
             "layers": PrintUtils.getMapfishLayersSpecification(spec.layers, spec, 'map'),

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -197,6 +197,7 @@ describe('PrintUtils', () => {
         expect(printSpec).toExist();
         expect(printSpec.dpi).toBe(96);
         expect(printSpec.layers.length).toBe(1);
+        expect(printSpec.geodetic).toBe(true);
     });
     it('from rgba to rgb', () => {
         const rgb = PrintUtils.rgbaTorgb("rgba(255, 255, 255, 0.1)");


### PR DESCRIPTION
## Description
Added overrideOptions object to Print plugin configuration to override default options

## Issues
 - Fix #2997

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
#2997

**What is the new behavior?**
Print options are overradible

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
