### PR TITLE
Fix #3018 Number input field in query panel doesn't work (>< operator)

### DIFF
--- a/web/client/components/data/query/NumberField.jsx
+++ b/web/client/components/data/query/NumberField.jsx
@@ -78,7 +78,7 @@ class NumberField extends React.Component {
                             <NumberPicker
                                 style={style}
                                 value={this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null}
-                                onChange={(value) => this.changeNumber({lowBound: value, upBound: this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null})}
+                                onChange={(value) => !isNaN(value) && this.changeNumber({lowBound: value, upBound: this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null})}
                                 {...this.props.options}
                             />
                         </Col>
@@ -87,7 +87,7 @@ class NumberField extends React.Component {
                             <NumberPicker
                                 style={style}
                                 value={this.props.fieldValue && (this.props.fieldValue.upBound !== null && this.props.fieldValue.upBound !== undefined ) ? this.props.fieldValue.upBound : null}
-                                onChange={(value) => this.changeNumber({upBound: value, lowBound: this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null})}
+                                onChange={(value) => !isNaN(value) && this.changeNumber({upBound: value, lowBound: this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : null})}
                                 {...this.props.options}
                             />
                         </Col>
@@ -100,7 +100,7 @@ class NumberField extends React.Component {
                         <NumberPicker
                         style={style}
                         value={this.props.fieldValue && (this.props.fieldValue.lowBound !== null && this.props.fieldValue.lowBound !== undefined) ? this.props.fieldValue.lowBound : this.props.fieldValue}
-                        onChange={this.changeNumber}
+                        onChange={(value) => !isNaN(value) && this.changeNumber(value)}
                         {...this.props.options}
                         />
                     </Col>
@@ -141,7 +141,8 @@ class NumberField extends React.Component {
                 this.props.onUpdateExceptionField(this.props.fieldRowId, null);
             }
         }
-        this.props.onUpdateField(this.props.fieldRowId, this.props.fieldName, isNaN(value) ? null : value, this.props.attType);
+
+        this.props.onUpdateField(this.props.fieldRowId, this.props.fieldName, value, this.props.attType);
     };
 }
 

--- a/web/client/components/data/query/__tests__/NumberField-test.jsx
+++ b/web/client/components/data/query/__tests__/NumberField-test.jsx
@@ -8,7 +8,7 @@
 const expect = require('expect');
 const React = require('react');
 const ReactDOM = require('react-dom');
-
+const TestUtils = require('react-dom/test-utils');
 const NumberField = require('../NumberField');
 
 describe('NumberField', () => {
@@ -75,7 +75,7 @@ describe('NumberField', () => {
 
     });
 
-    it('create number field with null  if value is NaN', () => {
+    it('if value is NaN changeNumber should not be called', () => {
         const actions = {
             onUpdateField: () => {}
         };
@@ -86,7 +86,26 @@ describe('NumberField', () => {
         onUpdateField={actions.onUpdateField}
             />, document.getElementById("container"));
         expect(cmp).toExist();
-        cmp.changeNumber('a');
-        expect(spyOnUpdateField).toHaveBeenCalledWith(null, null, null, 'number');
+        const node = ReactDOM.findDOMNode(cmp);
+        const input = node.getElementsByTagName('INPUT');
+        TestUtils.Simulate.change(input[0], {target: {value: 'aaa'}});
+        expect(spyOnUpdateField).toNotHaveBeenCalled();
+    });
+
+    it('if value is number changeNumber should be called', () => {
+        const actions = {
+            onUpdateField: () => {}
+        };
+
+        const spyOnUpdateField = expect.spyOn(actions, 'onUpdateField');
+        const cmp = ReactDOM.render(
+        <NumberField
+        onUpdateField={actions.onUpdateField}
+            />, document.getElementById("container"));
+        expect(cmp).toExist();
+        const node = ReactDOM.findDOMNode(cmp);
+        const input = node.getElementsByTagName('INPUT');
+        TestUtils.Simulate.change(input[0], {target: {value: '7'}});
+        expect(spyOnUpdateField).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Description
Object values of range operator was maraked as NaN so set to null in onUpdateField function.

## Issues
 - Fix #3018

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3018

**What is the new behavior?**
It's possible to type also in range inputs in Query Panel

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
