### PR TITLE
Fix #3021 Advanced search button should be in active status if a filter is applied

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -16,7 +16,7 @@ const getSaveMessageId = ({saving, saved}) => {
     }
     return "featuregrid.toolbar.saveChanges";
 };
-module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: "32.2%"}, mode = "VIEW", showChartButton = true, selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, disableZoomAll = false} = {}) => {
+module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: "32.2%"}, mode = "VIEW", showChartButton = true, selectedCount, hasChanges, hasGeometry, hasNewFeatures, isSimpleGeom, isDrawing = false, isEditingAllowed, saving = false, saved = false, isDownloadOpen, isColumnsOpen, disableToolbar, isSearchAllowed, disableDownload, displayDownload, isSyncActive = false, hasSupportedGeometry = true, disableZoomAll = false, isFilterActive = false} = {}) => {
     return (<ButtonGroup id="featuregrid-toolbar" className="featuregrid-toolbar featuregrid-toolbar-margin">
         <TButton
             id="edit-mode"
@@ -30,6 +30,7 @@ module.exports = ({events = {}, syncPopover = {showPopoverSync: true, dockSize: 
             id="search"
             keyProp="search"
             tooltipId="featuregrid.toolbar.advancedFilter"
+            active={isFilterActive}
             disabled={disableToolbar || !isSearchAllowed}
             visible={mode === "VIEW"}
             onClick={events.showQueryPanel}

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -21,7 +21,7 @@ const {deleteFeatures, toggleTool, clearChangeConfirmed, closeFeatureGridConfirm
 const {toolbarEvents, pageEvents} = require('../index');
 const {getAttributeFields} = require('../../../utils/FeatureGridUtils');
 const {getFilterRenderer} = require('../../../components/data/featuregrid/filterRenderers');
-const {isDescribeLoaded} = require('../../../selectors/query');
+const {isDescribeLoaded, isFilterActive} = require('../../../selectors/query');
 
 const filterEditingAllowedUser = (role, editingAllowedRoles = ["ADMIN"]) => {
     return editingAllowedRoles.indexOf(role) !== -1;
@@ -55,7 +55,8 @@ const Toolbar = connect(
         disableZoomAll: (state) => state && state.featuregrid.virtualScroll || featureCollectionResultSelector(state).features.length === 0,
         isSearchAllowed: (state) => !isCesium(state),
         isEditingAllowed: (state) => (filterEditingAllowedUser(userRoleSelector(state), editingAllowedRolesSelector(state)) || canEditSelector(state)) && !isCesium(state),
-        hasSupportedGeometry
+        hasSupportedGeometry,
+        isFilterActive
     }),
     (dispatch) => ({events: bindActionCreators(toolbarEvents, dispatch)})
 )(require('../../../components/data/featuregrid/toolbars/Toolbar'));

--- a/web/client/selectors/__tests__/query-test.js
+++ b/web/client/selectors/__tests__/query-test.js
@@ -20,7 +20,8 @@ const {
     describeSelector,
     getFeatureById,
     attributesSelector,
-    isSyncWmsActive
+    isSyncWmsActive,
+    isFilterActive
 } = require('../query');
 
 const idFt1 = "idFt1";
@@ -390,5 +391,95 @@ describe('Test query selectors', () => {
         expect(fc.features.length).toBe(4);
     });
 
+    it('test isFilterActive selector', () => {
 
+        let isFilterActiveState = isFilterActive({});
+        expect(isFilterActiveState).toBe(false);
+
+        const emptyState = {
+            query: {
+                filterObj: {
+                    filterFields: [],
+                    spatialField: {
+                        method: null,
+                        attribute: 'the_geom',
+                        operation: 'INTERSECTS',
+                        geometry: null
+                    },
+                    crossLayerFilter: null
+                }
+            }
+        };
+
+        isFilterActiveState = isFilterActive(emptyState);
+        expect(isFilterActiveState).toBe(false);
+
+        const spatialState = {
+            query: {
+                filterObj: {
+                    filterFields: [],
+                    spatialField: {
+                        method: 'Circle',
+                        attribute: 'the_geom',
+                        operation: 'INTERSECTS',
+                        geometry: {
+                            type: 'Polygon',
+                            extent: [],
+                            center: [],
+                            coordinates: [],
+                            radius: 424941.79896156304,
+                            projection: 'EPSG:4326'
+                        }
+                    },
+                    crossLayerFilter: null
+                }
+            }
+        };
+
+        isFilterActiveState = isFilterActive(spatialState);
+        expect(isFilterActiveState).toBe(true);
+
+        const attributeState = {
+            query: {
+                filterObj: {
+                    filterFields: [
+                        {rowId: 1, groupId: 1, attribute: 'name', operator: "=", value: 'value'}
+                    ],
+                    spatialField: {
+                        method: null,
+                        attribute: 'the_geom',
+                        operation: 'INTERSECTS',
+                        geometry: null
+                    },
+                    crossLayerFilter: null
+                }
+            }
+        };
+
+        isFilterActiveState = isFilterActive(attributeState);
+        expect(isFilterActiveState).toBe(true);
+
+        const crossLayerState = {
+            query: {
+                filterObj: {
+                    filterFields: [],
+                    spatialField: {
+                        method: null,
+                        attribute: 'the_geom',
+                        operation: 'INTERSECTS',
+                        geometry: null
+                    },
+                    crossLayerFilter: {
+                        attribute: 'the_geom',
+                        operation: 'INTERSECTS',
+                        collectGeometries: {typeName: 'topp:states', filterFields: [], geometryName: 'the_geom'}
+                    }
+                }
+            }
+        };
+
+        isFilterActiveState = isFilterActive(crossLayerState);
+        expect(isFilterActiveState).toBe(true);
+
+    });
 });

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -1,4 +1,12 @@
 const {isNil, get, head} = require('lodash');
+
+/**
+ * selects query state
+ * @name query
+ * @memberof selectors
+ * @static
+ */
+
 module.exports = {
     wfsURL: state => state && state.query && state.query.searchUrl,
     wfsURLSelector: state => state && state.query && state.query.url,
@@ -34,6 +42,12 @@ module.exports = {
     layerDescribeSelector: (state, featureTypeName) =>get(state, `query.featureTypes.[${featureTypeName}].original`),
     featureLoadingSelector: (state) => get(state, "query.featureLoading"),
     isSyncWmsActive: (state) => get(state, "query.syncWmsFilter", false),
+    /**
+     * return true if a filter is applied to query
+     * @memberof selectors.query
+     * @param  {object} state the state
+     * @return {boolean}
+     */
     isFilterActive: state => {
         const crossLayerFilter = get(state, 'query.filterObj.crossLayerFilter');
         const spatialField = get(state, 'query.filterObj.spatialField');

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -33,5 +33,13 @@ module.exports = {
     describeSelector: (state) => get(state, `query.featureTypes.${get(state, "query.filterObj.featureTypeName")}.original`),
     layerDescribeSelector: (state, featureTypeName) =>get(state, `query.featureTypes.[${featureTypeName}].original`),
     featureLoadingSelector: (state) => get(state, "query.featureLoading"),
-    isSyncWmsActive: (state) => get(state, "query.syncWmsFilter", false)
+    isSyncWmsActive: (state) => get(state, "query.syncWmsFilter", false),
+    isFilterActive: state => {
+        const crossLayerFilter = get(state, 'query.filterObj.crossLayerFilter');
+        const spatialField = get(state, 'query.filterObj.spatialField');
+        const filterFields = get(state, 'query.filterObj.filterFields');
+        return !!(filterFields && head(filterFields)
+        || spatialField && spatialField.method && spatialField.operation && spatialField.geometry
+        || crossLayerFilter && crossLayerFilter.collectGeometries && crossLayerFilter.operation);
+    }
 };


### PR DESCRIPTION
## Description
![active](https://user-images.githubusercontent.com/19175505/41713261-e46045ec-754c-11e8-9899-339284c87cc7.gif)


## Issues
 - Fix #3021

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
#3021

**What is the new behavior?**
Advance search button is active if a filter is applied to query

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
