### PR TITLE
Fix #3019 Integration of FeatureGrid/FeatureInfo

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -207,6 +207,13 @@ function updateCenterToMarker(status) {
         status
     };
 }
+function featureInfoClick(point, layer) {
+    return {
+        type: FEATURE_INFO_CLICK,
+        point,
+        layer
+    };
+}
 
 module.exports = {
     ERROR_FEATURE_INFO,
@@ -242,5 +249,6 @@ module.exports = {
     errorFeatureInfo,
     loadFeatureInfo,
     toggleMapInfoState,
-    updateCenterToMarker
+    updateCenterToMarker,
+    featureInfoClick
 };

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -11,7 +11,9 @@ const assign = require('object-assign');
 const Proj4js = require('proj4').default;
 const proj4 = Proj4js;
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
-const {toggleEditMode, toggleViewMode, openFeatureGrid, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch, moreFeatures, GRID_QUERY_RESULT} = require('../../actions/featuregrid');
+const { hideMapinfoMarker, featureInfoClick} = require('../../actions/mapInfo');
+
+const { toggleEditMode, toggleViewMode, openFeatureGrid, OPEN_FEATURE_GRID, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch, moreFeatures, GRID_QUERY_RESULT } = require('../../actions/featuregrid');
 const {SET_HIGHLIGHT_FEATURES_PATH} = require('../../actions/highlight');
 const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
@@ -25,7 +27,7 @@ const {geometryChanged} = require('../../actions/draw');
 const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery');
 
 
-const {setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrollLoadFeatures} = require('../featuregrid');
+const { setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrollLoadFeatures, removeWmsFilterOnGridClose, autoReopenFeatureGridOnFeatureInfoClose} = require('../featuregrid');
 
 
 const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
@@ -517,7 +519,6 @@ const stateWithGmlGeometry = {
 };
 
 describe('featuregrid Epics', () => {
-
     it('test startSyncWmsFilter with nativeCrs absent in layer props, but no definition registered in proj4 defs', (done) => {
         const stateFeaturegrid = {
             featuregrid: {
@@ -691,17 +692,17 @@ describe('featuregrid Epics', () => {
 
         const newState = assign({}, stateWithGmlGeometry, stateFeaturegrid);
 
-        testEpic(addTimeoutEpic(triggerDrawSupportOnSelectionChange), 1, toggleEditMode(), actions => {
+        testEpic(addTimeoutEpic(triggerDrawSupportOnSelectionChange, 50), 1, toggleEditMode(), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
                     case TEST_TIMEOUT:
+                        done();
                         break;
                     default:
                         expect(false).toBe(true);
                 }
             });
-            done();
         }, newState);
     });
 
@@ -1530,4 +1531,59 @@ describe('featuregrid Epics', () => {
         }, newState);
     });
 
+    it('removeWmsFilterOnGridClose', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === CHANGE_LAYER_PROPERTIES) {
+                    expect(action.layer).toBe("TEST");
+                    done();
+                }
+            });
+        };
+
+        testEpic(addTimeoutEpic(removeWmsFilterOnGridClose), 1, [openFeatureGrid(), closeFeatureGrid()], epicResult, {
+            query: { syncWmsFilter: true},
+            featuregrid: { selectedLayer: "TEST"}
+        });
+    });
+    it('removeWmsFilterOnGridClose does not remove filter on featureinfo open', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === TEST_TIMEOUT) {
+                    done();
+                }
+            });
+        };
+        testEpic(addTimeoutEpic(removeWmsFilterOnGridClose, 60), 1, [openFeatureGrid(), featureInfoClick(), closeFeatureGrid()], epicResult, {
+            query: { syncWmsFilter: true },
+            featuregrid: { selectedLayer: "TEST" }
+        });
+    });
+    it('removeWmsFilterOnGridClose does not remove filter on advanced search open', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === TEST_TIMEOUT) {
+                    done();
+                }
+            });
+        };
+        testEpic(addTimeoutEpic(removeWmsFilterOnGridClose, 60), 1, [openFeatureGrid(), openAdvancedSearch(), closeFeatureGrid()], epicResult, {
+            query: { syncWmsFilter: true },
+            featuregrid: { selectedLayer: "TEST" }
+        });
+    });
+    it('autoReopenFeatureGridOnFeatureInfoClose', done => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === OPEN_FEATURE_GRID) {
+                    done();
+                }
+            });
+        };
+        testEpic(autoReopenFeatureGridOnFeatureInfoClose, 1, [openFeatureGrid(), featureInfoClick(), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
+    });
 });

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -8,10 +8,10 @@
 
 const expect = require('expect');
 
-const {ZOOM_TO_POINT} = require('../../actions/map');
-const {FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, loadFeatureInfo} = require('../../actions/mapInfo');
-const {zoomToVisibleAreaEpic} = require('../identify');
-const {testEpic} = require('./epicTestUtils');
+const { ZOOM_TO_POINT, clickOnMap} = require('../../actions/map');
+const { UPDATE_CENTER_TO_MARKER, FEATURE_INFO_CLICK, loadFeatureInfo, featureInfoClick} = require('../../actions/mapInfo');
+const {zoomToVisibleAreaEpic, onMapClick} = require('../identify');
+const {testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
 const {registerHook} = require('../../utils/MapUtils');
 
 describe('identify Epics', () => {
@@ -52,7 +52,7 @@ describe('identify Epics', () => {
             }
         };
 
-        const sentActions = [{type: FEATURE_INFO_CLICK, point: {latlng: {lat: 36.95, lng: -79.84}}}, loadFeatureInfo()];
+        const sentActions = [featureInfoClick({latlng: {lat: 36.95, lng: -79.84}}), loadFeatureInfo()];
 
         const expectedAction = actions => {
             expect(actions.length).toBe(2);
@@ -112,7 +112,7 @@ describe('identify Epics', () => {
             }
         };
 
-        const sentActions = [{type: FEATURE_INFO_CLICK, point: {latlng: {lat: 36.95, lng: -79.84}}}, loadFeatureInfo()];
+        const sentActions = [featureInfoClick({latlng: {lat: 36.95, lng: -79.84}}), loadFeatureInfo()];
 
         const expectedAction = actions => {
             expect(actions.length).toBe(1);
@@ -129,6 +129,29 @@ describe('identify Epics', () => {
         };
 
         testEpic(zoomToVisibleAreaEpic, 1, sentActions, expectedAction, state);
+    });
+    it('onMapClick triggers featureinfo when selected', done => {
+        testEpic(onMapClick, 1, [clickOnMap()], ([action]) => {
+            expect(action.type === FEATURE_INFO_CLICK);
+            done();
+        }, {
+            mapInfo: {
+                enabled: true,
+                disableAlwaysOn: false
+            }
+        });
+    });
+    it('onMapClick do not trigger when mapinfo is not elabled', done => {
+        testEpic(addTimeoutEpic(onMapClick, 10), 1, [clickOnMap()], ([action]) => {
+            if (action.type === TEST_TIMEOUT ) {
+                done();
+            }
+        }, {
+                mapInfo: {
+                    enabled: false,
+                    disableAlwaysOn: false
+                }
+            });
     });
 
 });

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -525,7 +525,7 @@ module.exports = {
                 .takeUntil(action$.ofType(CLOSE_FEATURE_GRID, LOCATION_CHANGE))
         ),
     askChangesConfirmOnFeatureGridClose: (action$, store) => action$.ofType(CLOSE_FEATURE_GRID_CONFIRM).switchMap( () => {
-        const stat e = store.getState();
+        const state = store.getState();
         if (hasChangesSelector(state) || hasNewFeaturesSelector(state)) {
             return Rx.Observable.of(toggleTool("featureCloseConfirm", true));
         }

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -7,7 +7,7 @@
 */
 const Rx = require('rxjs');
 
-const {LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLICK, updateCenterToMarker} = require('../actions/mapInfo');
+const { LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLICK, featureInfoClick, updateCenterToMarker} = require('../actions/mapInfo');
 const {closeFeatureGrid} = require('../actions/featuregrid');
 const {CHANGE_MOUSE_POINTER, CLICK_ON_MAP, zoomToPoint} = require('../actions/map');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
@@ -39,7 +39,7 @@ module.exports = {
             const {disableAlwaysOn = false} = (store.getState()).mapInfo;
             return disableAlwaysOn || !stopGetFeatureInfoSelector(store.getState() || {});
         })
-        .map(({point, layer}) => ({type: FEATURE_INFO_CLICK, point, layer})),
+        .map(({point, layer}) => featureInfoClick(point, layer)),
     /**
      * Centers marker on visible map if it's hidden by layout
      * @param {external:Observable} action$ manages `FEATURE_INFO_CLICK` and `LOAD_FEATURE_INFO`.

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -8,6 +8,7 @@
 
 const expect = require('expect');
 const mapInfo = require('../mapInfo');
+const { featureInfoClick } = require('../../actions/mapInfo');
 const assign = require('object-assign');
 
 require('babel-polyfill');
@@ -194,11 +195,11 @@ describe('Test the mapInfo reducer', () => {
     });
 
     it('set a new point on map which has been clicked', () => {
-        let state = mapInfo({}, {type: 'FEATURE_INFO_CLICK', point: "p"});
+        let state = mapInfo({}, featureInfoClick("p"));
         expect(state.clickPoint).toExist();
         expect(state.clickPoint).toBe('p');
 
-        state = mapInfo({clickPoint: 'oldP'}, {type: 'FEATURE_INFO_CLICK', point: "p"});
+        state = mapInfo({ clickPoint: 'oldP' }, featureInfoClick("p"));
         expect(state.clickPoint).toExist();
         expect(state.clickPoint).toBe('p');
     });

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -52,8 +52,21 @@ const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false)
  * @return {boolean} true if the get feature info has to stop the request
  */
 
-const stopGetFeatureInfoSelector = createSelector(mapInfoDisabledSelector, measureActiveSelector, drawSupportActiveSelector, gridEditingSelector, annotationsEditingSelector, queryPanelSelector,
-    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isGridEditing, isAnnotationsEditing, isQueryPanelActive) => isMapInfoDisabled || !!isMeasureActive || isDrawSupportActive || isGridEditing || !!isAnnotationsEditing || !!isQueryPanelActive);
+const stopGetFeatureInfoSelector = createSelector(
+    mapInfoDisabledSelector,
+    measureActiveSelector,
+    drawSupportActiveSelector,
+    gridEditingSelector,
+    annotationsEditingSelector,
+    queryPanelSelector,
+    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isGridEditing, isAnnotationsEditing, isQueryPanelActive) =>
+        isMapInfoDisabled
+        || !!isMeasureActive
+        || isDrawSupportActive
+        || isGridEditing
+        || !!isAnnotationsEditing
+        || !!isQueryPanelActive
+    );
 
 module.exports = {
     generalInfoFormatSelector,


### PR DESCRIPTION
## Description
This pull request synchronize Feature Grid to allow Feature Info on filtered data
## Issues
 - Fix #3019 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
The feature info closes the feature grid and removes the current filter

**What is the new behavior?**
The feature info closes the feature grid temporary, keeping the current filter on WMS, when the featureinfo is closed, the get feature info is opened again. 


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
Added missing actionCreators and for featureInfoClick action, with related tests on epics, that was missing. 