### PR TITLE
Fix various issue on c125 project

### DIFF
--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -486,7 +486,7 @@ class AnnotationsEditor extends React.Component {
                         <Toolbar
                             btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary'}}
                             buttons={[ {
-                                glyph: 'back',
+                                glyph: 'arrow-left',
                                 tooltipId: "annotations.back",
                                 visible: true,
                                 onClick: () => {

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -207,7 +207,7 @@ class CoordinateEditor extends React.Component {
                     </Col>
                     <Col xs={1}/>
                 </Row>
-                <Row style={{flex: 1, overflowY: 'auto'}}>
+                <Row style={{flex: 1, overflowY: 'auto', overflowX: 'hidden'}}>
                     {this.props.components.map((component, idx) => <CoordinatesRow
                         format={this.props.format}
                         sortId={idx}

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -96,7 +96,8 @@ class CoordinateEditor extends React.Component {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray));
                             } else if (radius !== "") {
                                 this.props.onChangeRadius(parseFloat(radius), []);
-                            } else if (this.props.properties.isValidFeature) {
+                            } else {
+                                this.props.onChangeRadius(null, this.props.components.map(coordToArray));
                                 this.props.onSetInvalidSelected("radius", this.props.components.map(coordToArray));
                             }
                         }}
@@ -121,7 +122,8 @@ class CoordinateEditor extends React.Component {
                                 this.props.onChangeText(valueText, this.props.components.map(coordToArray));
                             } else if (valueText !== "") {
                                 this.props.onChangeText(valueText, this.props.components.map(coordToArray));
-                            } else if (this.props.properties.isValidFeature) {
+                            } else {
+                                this.props.onChangeText("", this.props.components.map(coordToArray));
                                 this.props.onSetInvalidSelected("text", this.props.components.map(coordToArray));
                             }
                         }}

--- a/web/client/components/mapcontrols/annotations/CoordinatesRow.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesRow.jsx
@@ -27,8 +27,9 @@ class CoordinatesRowComponent extends React.Component {
 
     render() {
         const {idx} = this.props;
+        const rowStyle =/* this.props.type === "LineString" || "Polygon" ? { marginLeft: -5, marginRight: -5} :*/ {marginLeft: -5, marginRight: -5};
         return (
-            <Row style={{marginLeft: 0, marginRight: 0}} onMouseEnter={() => {
+            <Row className="coordinateRow" style={rowStyle} onMouseEnter={() => {
                 this.props.onMouseEnter(this.props.component);
             }} onMouseLeave={this.props.onMouseLeave}>
                 <Col xs={1}>

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -24,13 +24,13 @@ const {TOGGLE_CONTROL, toggleControl} = require('../../actions/controls');
 const {addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic, newAnnotationEpic, addAnnotationEpic,
     disableInteractionsEpic, cancelEditAnnotationEpic, startDrawingMultiGeomEpic, endDrawGeomEpic, endDrawTextEpic, cancelTextAnnotationsEpic,
     setStyleEpic, restoreStyleEpic, highlighAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
-    downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusTextEpic,
+    downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusEpic, redrawOnChangeTextEpic,
     editSelectedFeatureEpic, editCircleFeatureEpic, closeMeasureToolEpic
 } = require('../annotations')({});
 const rootEpic = combineEpics(addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic, newAnnotationEpic, addAnnotationEpic,
     disableInteractionsEpic, cancelEditAnnotationEpic, startDrawingMultiGeomEpic, endDrawGeomEpic, endDrawTextEpic, cancelTextAnnotationsEpic,
     setStyleEpic, restoreStyleEpic, highlighAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
-    downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusTextEpic,
+    downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusEpic, redrawOnChangeTextEpic,
     editSelectedFeatureEpic, editCircleFeatureEpic, closeMeasureToolEpic
 );
 const epicMiddleware = createEpicMiddleware(rootEpic);
@@ -485,7 +485,7 @@ describe('annotations Epics', () => {
         }, selected);
         selected = set("properties", { id: "Polygon1"}, selected);
         store = mockStore(
-            set("annotations.selected", selected, set("annotations.editing.features", defaultState.annotations.editing.features.concat(selected), defaultState))
+            set("annotations.selected", selected, set("annotations.editing.features", defaultState.annotations.editing.features.concat([selected]), defaultState))
         );
 
         store.subscribe(() => {
@@ -506,9 +506,9 @@ describe('annotations Epics', () => {
             type: "Text",
             coordinates: textCoords
         }, selected);
-        selected = set("properties", { id: "text1", isText: true, valueText: "text"}, selected);
+        selected = set("properties", { id: "text1", isText: true, isValidFeature: true, valueText: "text"}, selected);
         store = mockStore(
-            set("annotations.selected", selected, set("annotations.editing.features", defaultState.annotations.editing.features.concat(selected), defaultState))
+            set("annotations.selected", selected, set("annotations.editing.features", defaultState.annotations.editing.features.concat([selected]), defaultState))
         );
 
         store.subscribe(() => {
@@ -532,7 +532,7 @@ describe('annotations Epics', () => {
         selected = set("geometry", polygonGeom, selected);
         selected = set("properties", { id: "text1", radius: 200, center: [2, 2], isCircle: true, polygonGeom}, selected);
         store = mockStore(
-            set("annotations.selected", selected, set("annotations.editing.features", defaultState.annotations.editing.features.concat(selected), defaultState))
+            set("annotations.selected", selected, set("annotations.editing.features", defaultState.annotations.editing.features.concat([selected]), defaultState))
         );
 
         store.subscribe(() => {

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -479,6 +479,10 @@ module.exports = (viewer) => ({
                 } else {
                     feature = set(`features[${selectedIndex}]`, selected, feature);
                 }
+            } else {
+                if (selectedIndex !== -1) {
+                    feature = set(`features`, feature.features.filter((f, i) => i !== selectedIndex ), feature);
+                }
             }
             const action = changeDrawingStatus("drawOrEdit", "Text", "annotations", [feature], {
                 featureProjection: "EPSG:4326",

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -408,20 +408,29 @@ module.exports = (viewer) => ({
                     selected = set("geometry.coordinates", [selected.geometry.coordinates].filter(validateCoordsArray)[0] || [], selected);
                 }
             }
+            let method = selected.properties.isCircle ? "Circle" : selected.geometry.type;
+
             if (selected.properties && selected.properties.isCircle) {
                 selected = set("geometry", selected.properties.polygonGeom, selected);
             }
-            let method = selected.properties.isCircle ? "Circle" : selected.geometry.type;
 
             // TODO update selected feature in editing features
 
             let selectedIndex = findIndex(feature.features, (f) => f.properties.id === selected.properties.id);
-            if (selectedIndex === -1) {
-                feature = set(`features`, feature.features.concat([selected]), feature);
-
-            } else {
-                feature = set(`features[${selectedIndex}]`, selected, feature);
+            if (selected.properties.isValidFeature || selected.geometry.type === "LineString" || selected.geometry.type === "Polygon") {
+                if (selectedIndex === -1) {
+                    feature = set(`features`, feature.features.concat([selected]), feature);
+                } else {
+                    feature = set(`features[${selectedIndex}]`, selected, feature);
+                }
             }
+            if (selectedIndex !== -1 && !selected.properties.isValidFeature && (selected.geometry.type !== "LineString" && selected.geometry.type !== "Polygon")) {
+                feature = set(`features`, feature.features.filter((f, i) => i !== selectedIndex ), feature);
+            }
+
+            /*if (!selected.properties.isValidFeature) {
+                feature = feature.features.filter((f, i) => selectedIndex !== i);
+            }*/
             const multiGeometry = state.annotations.config.multiGeometry;
             const style = feature.style;
             const action = changeDrawingStatus("drawOrEdit", method, "annotations", [feature], {
@@ -453,8 +462,8 @@ module.exports = (viewer) => ({
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of(action);
         }),
-    redrawOnChangeRadiusTextEpic: (action$, {getState}) => action$.ofType( CHANGE_RADIUS, CHANGE_TEXT )
-        .switchMap((a) => {
+    redrawOnChangeTextEpic: (action$, {getState}) => action$.ofType( CHANGE_TEXT )
+        .switchMap(() => {
             const state = getState();
             let feature = state.annotations.editing;
             let selected = state.annotations.selected;
@@ -464,13 +473,51 @@ module.exports = (viewer) => ({
             selected = set("geometry.coordinates", [selected.geometry.coordinates].filter(validateCoordsArray)[0] || [], selected);
             selected = set("geometry.type", "Point", selected);
             let selectedIndex = findIndex(feature.features, (f) => f.properties.id === selected.properties.id);
+            if (selected.properties.isValidFeature) {
+                if (selectedIndex === -1) {
+                    feature = set(`features`, feature.features.concat([selected]), feature);
+                } else {
+                    feature = set(`features[${selectedIndex}]`, selected, feature);
+                }
+            }
+            const action = changeDrawingStatus("drawOrEdit", "Text", "annotations", [feature], {
+                featureProjection: "EPSG:4326",
+                stopAfterDrawing: !multiGeometry,
+                editEnabled: true,
+                translateEnabled: false,
+                editFilter: (f) => f.getProperties().canEdit,
+                drawEnabled: false,
+                useSelectedStyle: true,
+                transformToFeatureCollection: true
+            }, assign({}, style, {highlight: false}));
+            return Rx.Observable.of(action);
+        }),
+    redrawOnChangeRadiusEpic: (action$, {getState}) => action$.ofType( CHANGE_RADIUS )
+        .switchMap(() => {
+            const state = getState();
+            let feature = state.annotations.editing;
+            let selected = state.annotations.selected;
+            const multiGeometry = state.annotations.config.multiGeometry;
+            const style = feature.style;
+
+            // selected = set("geometry.coordinates", [selected.geometry.coordinates].filter(validateCoordsArray)[0] || [], selected);
+            // selected = set("geometry.type", "Polygon", selected);
+            let selectedIndex = findIndex(feature.features, (f) => f.properties.id === selected.properties.id);
+            if (!selected.properties.isValidFeature) {
+                selected = set("geometry", {
+                    type: "Polygon",
+                    coordinates: [[]]
+                }, selected);
+            } else {
+                selected = set("geometry", selected.properties.polygonGeom, selected);
+            }
             if (selectedIndex === -1) {
                 feature = set(`features`, feature.features.concat([selected]), feature);
             } else {
                 feature = set(`features[${selectedIndex}]`, selected, feature);
             }
             // this should run only if the feature has a valid geom
-            const action = changeDrawingStatus("drawOrEdit", a.type === CHANGE_TEXT ? "Text" : "Circle", "annotations", [feature], {
+            const action = changeDrawingStatus("drawOrEdit", "Circle", "annotations", [feature], {
                 featureProjection: "EPSG:4326",
                 stopAfterDrawing: !multiGeometry,
                 editEnabled: true,

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -804,8 +804,41 @@ describe('Test the annotations reducer', () => {
         expect(state.selected).toBe(null);
         expect(state.drawing).toBe(false);
         expect(state.showUnsavedGeometryModal).toBe(false);
-        expect(state.editing.features.length).toBe(1);
-        expect(state.editing.features[0].geometry.coordinates[0]).toBe(1);
+        expect(state.editing.features.length).toBe(0);
+
+    });
+
+    it('resetCoordEditor in edit mode of a Circle, with no Changes ', () => {
+
+        const featureChanged = {
+            properties: {
+                id: '1',
+                isCircle: true
+            },
+            geometry: {
+                type: "Point",
+                coordinates: [10, 1]
+            }
+        };
+        const featureColl = {
+            type: "FeatureCollection",
+            features: [],
+            properties: {
+                id: '1asdfads'
+            },
+            featureType: "Circle",
+            style: {}
+        };
+        const state = annotations({
+            editing: featureColl,
+            selected: featureChanged,
+            unsavedGeometry: false
+        }, resetCoordEditor());
+        expect(state.unsavedGeometry).toBe(false);
+        expect(state.selected).toBe(null);
+        expect(state.drawing).toBe(false);
+        expect(state.showUnsavedGeometryModal).toBe(false);
+        expect(state.editing.features.length).toBe(0);
 
     });
 

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -16,7 +16,7 @@ const {
     EDIT_ANNOTATION, CANCEL_EDIT_ANNOTATION, SAVE_ANNOTATION, TOGGLE_ADD,
     VALIDATION_ERROR, REMOVE_ANNOTATION_GEOMETRY,
     TOGGLE_STYLE, SET_STYLE, NEW_ANNOTATION, SHOW_ANNOTATION, CANCEL_SHOW_ANNOTATION,
-    FILTER_ANNOTATIONS, CLOSE_ANNOTATIONS, CONFIRM_CLOSE_ANNOTATIONS,
+    FILTER_ANNOTATIONS, CLOSE_ANNOTATIONS, CONFIRM_CLOSE_ANNOTATIONS, CANCEL_CLOSE_ANNOTATIONS,
     toggleDeleteFtModal, confirmDeleteFeature,
     changeStyler, addText, setUnsavedChanges, setUnsavedStyle,
     toggleUnsavedChangesModal, toggleUnsavedGeometryModal, toggleUnsavedStyleModal, changedProperties,
@@ -242,9 +242,11 @@ describe('Test the annotations reducer', () => {
             }]
             }}, {
                 type: TOGGLE_ADD,
-                featureType: "MultiPolygon"
+                featureType: "Polygon"
             });
         expect(state.coordinateEditorEnabled).toBe(true);
+        expect(state.stylerType).toBe("polygon");
+        expect(state.featureType).toBe("Polygon");
         expect(state.drawing).toBe(true);
         state = annotations({drawing: true, editing: {
             features: [{
@@ -254,6 +256,23 @@ describe('Test the annotations reducer', () => {
             type: TOGGLE_ADD
         });
         expect(state.drawing).toBe(false);
+    });
+    it('toggle add text', () => {
+        let state = annotations({
+            drawing: false,
+            editing: {
+                features: [{
+                style: {"Polygon": DEFAULT_ANNOTATIONS_STYLES.Polygon, type: "Polygon"}
+            }]
+            }}, {
+                type: TOGGLE_ADD,
+                featureType: "Text"
+            });
+        expect(state.coordinateEditorEnabled).toBe(true);
+        expect(state.stylerType).toBe("text");
+        expect(state.editing.style.type).toBe("FeatureCollection");
+        expect(state.featureType).toBe("Text");
+        expect(state.drawing).toBe(true);
     });
     it('validate error', () => {
         const state = annotations({validationErrors: {}}, {
@@ -328,6 +347,13 @@ describe('Test the annotations reducer', () => {
     it('confirm close annotations', () => {
         const state = annotations({}, {
             type: CONFIRM_CLOSE_ANNOTATIONS
+        });
+        expect(state.closing).toBe(false);
+        expect(state.coordinateEditorEnabled).toBe(false);
+    });
+    it('cancel close annotations', () => {
+        const state = annotations({}, {
+            type: CANCEL_CLOSE_ANNOTATIONS
         });
         expect(state.closing).toBe(false);
     });

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -440,7 +440,12 @@ function annotations(state = { validationErrors: {} }, action) {
             return assign({}, state, {
                 unsavedStyle: action.unsavedStyle
             });
-        case CONFIRM_CLOSE_ANNOTATIONS:
+        case CONFIRM_CLOSE_ANNOTATIONS: {
+            return assign({}, state, {
+                closing: false,
+                coordinateEditorEnabled: false
+            });
+        }
         case CANCEL_CLOSE_ANNOTATIONS:
             return assign({}, state, {
                 closing: false
@@ -538,6 +543,7 @@ function annotations(state = { validationErrors: {} }, action) {
                             [type]: newState.editing.style && newState.editing.style[type] || DEFAULT_ANNOTATIONS_STYLES[type]
                         })
                 }),
+                stylerType: head(getAvailableStyler(convertGeoJSONToInternalModel(selected.geometry))),
                 selected
             });
         }

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -43,8 +43,8 @@
     margin-bottom: 0;
 }
 #mapstore-annotations-panel .items-list.row {
-    margin-left: 0px;
-    margin-right: 0px;
+    margin-left: 5px;
+    margin-right: 5px;
 }
 
 

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -42,6 +42,10 @@
 #mapstore-annotations-panel {
     margin-bottom: 0;
 }
+#mapstore-annotations-panel .items-list.row {
+    margin-left: 0px;
+    margin-right: 0px;
+}
 
 
 .mapstore-side-card:hover {
@@ -273,6 +277,8 @@
 
 
         .msSideGrid {
+            height: ~'calc(100% - 161px)';
+            overflow: auto;
             margin: 0 30px;
             .mapstore-side-preview {
                 display: flex;


### PR DESCRIPTION
## Description
Fixed the bugs in the following issues

## Issues
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/73
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/74
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/76
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/77
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/80
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/81
 - see https://github.com/geosolutions-it/austrocontrol-C125/issues/79

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see issues in description

**What is the new behavior?**
- for circle, text and marker if a lat or lon is invalid the features is removed from the map
- for circle, if radius is invalid the circle is being removed from the map, if then becomes valid is being drawn again.
- if text becomes invalid (for the value not for the coordinates) it removes the text from the map, not the circle. You can still move it, but if you click again on the map the default value for text is used.
- polygons and linestring works as before, if a point becomes invalid, it is excluded from the drawn feature, these are the only cases where an invalid feature is still being drawn.
- you can scroll in list mode
- no error adding features from the form and opening the styler
- styler icon appear only if a feature is saved or there is at least one feature in the annotation

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
