### PR TITLE
Porting of support for external close of feature info

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -28,6 +28,7 @@ const CLEAR_WARNING = 'CLEAR_WARNING';
 const FEATURE_INFO_CLICK = 'FEATURE_INFO_CLICK';
 const TOGGLE_MAPINFO_STATE = 'TOGGLE_MAPINFO_STATE';
 const UPDATE_CENTER_TO_MARKER = 'UPDATE_CENTER_TO_MARKER';
+const CLOSE_IDENTIFY = 'IDENTIFY:CLOSE_IDENTIFY';
 
 /**
  * Private
@@ -207,6 +208,7 @@ function updateCenterToMarker(status) {
         status
     };
 }
+
 function featureInfoClick(point, layer) {
     return {
         type: FEATURE_INFO_CLICK,
@@ -214,6 +216,10 @@ function featureInfoClick(point, layer) {
         layer
     };
 }
+
+const closeIdentify = () => ({
+    type: CLOSE_IDENTIFY
+});
 
 module.exports = {
     ERROR_FEATURE_INFO,
@@ -233,6 +239,8 @@ module.exports = {
     FEATURE_INFO_CLICK,
     TOGGLE_MAPINFO_STATE,
     UPDATE_CENTER_TO_MARKER,
+    CLOSE_IDENTIFY,
+    closeIdentify,
     getFeatureInfo,
     changeMapInfoState,
     newMapInfoRequest,

--- a/web/client/components/I18N/Number.jsx
+++ b/web/client/components/I18N/Number.jsx
@@ -11,7 +11,7 @@ var {FormattedNumber} = require('react-intl');
 
 class NumberFormat extends React.Component {
     static propTypes = {
-        value: PropTypes.oneOf(PropTypes.object, PropTypes.number),
+        value: PropTypes.oneOf([PropTypes.object, PropTypes.number]),
         numberParams: PropTypes.object
     };
 

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -10,7 +10,7 @@ const expect = require('expect');
 
 const {ZOOM_TO_POINT, clickOnMap} = require('../../actions/map');
 const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, loadFeatureInfo, featureInfoClick, closeIdentify} = require('../../actions/mapInfo');
-const { zoomToVisibleAreaEpic, onMapClick, closeFeatureInfoOnEdit} = require('../identify');
+const { zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing} = require('../identify');
 const { CLOSE_ANNOTATIONS } = require('../../actions/annotations');
 const {testEpic, TEST_TIMEOUT, addTimeoutEpic} = require('./epicTestUtils');
 const {registerHook} = require('../../utils/MapUtils');
@@ -154,7 +154,7 @@ describe('identify Epics', () => {
                 }
             });
     });
-    it('closeFeatureInfoOnEdit', (done) => {
+    it('closeFeatureAndAnnotationEditing closes annotations', (done) => {
 
         const sentActions = closeIdentify();
 
@@ -171,9 +171,9 @@ describe('identify Epics', () => {
             });
         };
 
-        testEpic(closeFeatureInfoOnEdit, 1, sentActions, expectedAction, { annotations: { editing: true } });
+        testEpic(closeFeatureAndAnnotationEditing, 1, sentActions, expectedAction, { annotations: { editing: true } });
     });
-    it('closeFeatureInfoOnEdit', (done) => {
+    it('closeFeatureAndAnnotationEditing purges mapinfo results', (done) => {
 
         const sentActions = closeIdentify();
 
@@ -190,7 +190,7 @@ describe('identify Epics', () => {
             });
         };
 
-        testEpic(closeFeatureInfoOnEdit, 1, sentActions, expectedAction);
+        testEpic(closeFeatureAndAnnotationEditing, 1, sentActions, expectedAction);
     });
 
 });

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -8,10 +8,11 @@
 
 const expect = require('expect');
 
-const { ZOOM_TO_POINT, clickOnMap} = require('../../actions/map');
-const { UPDATE_CENTER_TO_MARKER, FEATURE_INFO_CLICK, loadFeatureInfo, featureInfoClick} = require('../../actions/mapInfo');
-const {zoomToVisibleAreaEpic, onMapClick} = require('../identify');
-const {testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
+const {ZOOM_TO_POINT, clickOnMap} = require('../../actions/map');
+const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, loadFeatureInfo, featureInfoClick, closeIdentify} = require('../../actions/mapInfo');
+const { zoomToVisibleAreaEpic, onMapClick, closeFeatureInfoOnEdit} = require('../identify');
+const { CLOSE_ANNOTATIONS } = require('../../actions/annotations');
+const {testEpic, TEST_TIMEOUT, addTimeoutEpic} = require('./epicTestUtils');
 const {registerHook} = require('../../utils/MapUtils');
 
 describe('identify Epics', () => {
@@ -152,6 +153,44 @@ describe('identify Epics', () => {
                     disableAlwaysOn: false
                 }
             });
+    });
+    it('closeFeatureInfoOnEdit', (done) => {
+
+        const sentActions = closeIdentify();
+
+        const expectedAction = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case CLOSE_ANNOTATIONS:
+                        done();
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+        };
+
+        testEpic(closeFeatureInfoOnEdit, 1, sentActions, expectedAction, { annotations: { editing: true } });
+    });
+    it('closeFeatureInfoOnEdit', (done) => {
+
+        const sentActions = closeIdentify();
+
+        const expectedAction = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case PURGE_MAPINFO_RESULTS:
+                        done();
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+        };
+
+        testEpic(closeFeatureInfoOnEdit, 1, sentActions, expectedAction);
     });
 
 });

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -39,7 +39,7 @@ module.exports = {
      * If so, as to the proper tool to close (annotations)
      * Otherwise it closes by itself.
      */
-    closeFeatureInfoOnEdit: (action$, {getState = () => {}} = {}) =>
+    closeFeatureInfoOrAnnotations: (action$, {getState = () => {}} = {}) =>
         action$.ofType(CLOSE_IDENTIFY).switchMap( () =>
             get(getState(), "annotations.editing")
                 ? Rx.Observable.of(closeAnnotations())

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -39,7 +39,7 @@ module.exports = {
      * If so, as to the proper tool to close (annotations)
      * Otherwise it closes by itself.
      */
-    closeFeatureInfoOrAnnotations: (action$, {getState = () => {}} = {}) =>
+    closeFeatureAndAnnotationEditing: (action$, {getState = () => {}} = {}) =>
         action$.ofType(CLOSE_IDENTIFY).switchMap( () =>
             get(getState(), "annotations.editing")
                 ? Rx.Observable.of(closeAnnotations())

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -6,10 +6,14 @@
  * LICENSE file in the root directory of this source tree.
 */
 const Rx = require('rxjs');
+const {get} = require('lodash');
 
-const { LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLICK, featureInfoClick, updateCenterToMarker} = require('../actions/mapInfo');
+
+const { LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLICK, CLOSE_IDENTIFY, featureInfoClick, updateCenterToMarker, purgeMapInfoResults} = require('../actions/mapInfo');
+
 const {closeFeatureGrid} = require('../actions/featuregrid');
 const {CHANGE_MOUSE_POINTER, CLICK_ON_MAP, zoomToPoint} = require('../actions/map');
+const { closeAnnotations } = require('../actions/annotations');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
 const {stopGetFeatureInfoSelector} = require('../selectors/mapinfo');
 const {centerToMarkerSelector} = require('../selectors/layers');
@@ -30,6 +34,17 @@ module.exports = {
         .switchMap(() => {
             return Rx.Observable.of(closeFeatureGrid());
         }),
+    /**
+     * Check if something is editing in feature info.
+     * If so, as to the proper tool to close (annotations)
+     * Otherwise it closes by itself.
+     */
+    closeFeatureInfoOnEdit: (action$, {getState = () => {}} = {}) =>
+        action$.ofType(CLOSE_IDENTIFY).switchMap( () =>
+            get(getState(), "annotations.editing")
+                ? Rx.Observable.of(closeAnnotations())
+                : Rx.Observable.of(purgeMapInfoResults())
+            ),
     changeMapPointer: (action$, store) =>
         action$.ofType(CHANGE_MOUSE_POINTER)
         .filter(() => !(store.getState()).map)

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -14,12 +14,10 @@ const {createSelector} = require('reselect');
 
 const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
-const {on} = require('../actions/controls');
 
-const {getFeatureInfo, getVectorInfo, purgeMapInfoResults, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState} = require('../actions/mapInfo');
-const {closeAnnotations} = require('../actions/annotations');
+const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState} = require('../actions/mapInfo');
 const {changeMousePointer} = require('../actions/map');
-const {changeMapInfoFormat, updateCenterToMarker} = require('../actions/mapInfo');
+const {changeMapInfoFormat, updateCenterToMarker, closeIdentify} = require('../actions/mapInfo');
 const {currentLocaleSelector} = require('../selectors/locale');
 
 const {compose, defaultProps} = require('recompose');
@@ -54,9 +52,6 @@ const selector = createSelector([
 }));
 // result panel
 
-const conditionalToggle = on.bind(null, purgeMapInfoResults(), (state) =>
-    !(state.annotations && state.annotations.editing)
-, closeAnnotations);
 
 const DefaultViewer = compose(
     switchControlledDefaultViewer,
@@ -170,7 +165,7 @@ const IdentifyPlugin = compose(
     connect(selector, {
         sendRequest: getFeatureInfo,
         localRequest: getVectorInfo,
-        purgeResults: conditionalToggle,
+        purgeResults: closeIdentify,
         changeMousePointer,
         showMarker: showMapinfoMarker,
         noQueryableLayers,


### PR DESCRIPTION
## Description
This is a porting of functionalities introduced in c125 for close feature info on demand. 
NOTE: this PR have to be merged soon, but may need some checks and tests


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
An external plugin couldn't close feature info without duplicating code

**What is the new behavior?**
Feature info close is now wrapped in a single action with an epic that supports it. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No
