### PR TITLE
Fix #3031 Missing projection in WFS filter geometry

### DIFF
--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -516,6 +516,24 @@ describe('Test the queryform reducer', () => {
         expect(newState.spatialField.value).toBe(args.value);
     });
 
+    it('test CHANGE_SPATIAL_FILTER_VALUE with srsName', () => {
+        const initialState = { spatialField: {geometry: {}} };
+        const args = {
+            collectGeometries: {},
+            value: "SELECTED_VALUE",
+            srsName: 'EPSG:4326',
+            feature: {
+                geometry: {
+                    type: "Point",
+                    coordinates: [1, 1]
+                }
+            }
+        };
+        const action = changeSpatialFilterValue(args);
+        const newState = queryform(initialState, action);
+        expect(newState.spatialField.geometry).toEqual({...args.feature.geometry, projection: 'EPSG:4326'});
+    });
+
     it('test CHANGE_DRAWING_STATUS', () => {
         const initialState = { toolbarEnabled: true };
         const testAction1 = {

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -291,7 +291,7 @@ function queryform(state = initialState, action) {
             return assign({}, state, {toolbarEnabled: true, spatialField: assign({}, state.spatialField, {
                 value: action.value,
                 collectGeometries: action.collectGeometries,
-                geometry: action.geometry
+                geometry: action.srsName ? {...action.geometry, projection: action.srsName} : action.geometry
             })});
         }
         case END_DRAWING: {


### PR DESCRIPTION
## Description
Added projection if present in WFS response

## Issues
 - Fix #3031

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
#3031

**What is the new behavior?**
Filter geometries are correctly displayed based on their projection and not on the default one

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No


