### PR TITLE
Fix #3019. Stop listening when feature grid is closed

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1586,4 +1586,20 @@ describe('featuregrid Epics', () => {
         };
         testEpic(autoReopenFeatureGridOnFeatureInfoClose, 1, [openFeatureGrid(), featureInfoClick(), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
     });
+    it('autoReopenFeatureGridOnFeatureInfoClose: feature info doesn\'t reopen feature grid after close', done => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(2);
+            expect(actions[0].type).toBe(OPEN_FEATURE_GRID);
+            expect(actions[1].type).toBe(TEST_TIMEOUT);
+            done();
+        };
+        testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose, 20), 2, [
+            openFeatureGrid(),
+            featureInfoClick(),
+            hideMapinfoMarker(),
+            closeFeatureGrid(),
+            featureInfoClick(),
+            hideMapinfoMarker()],
+        epicResult);
+    });
 });


### PR DESCRIPTION
## Description
Now feature grid re-open stream stops listening when feature grid is closed

## Issues
 - Fix  #3019

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
 - Open the feature grid
 - Click on map
 - Close feature info
 - Close feature grid
 - Click on Map 
 - The feature grid opens again

**What is the new behavior?**
The feature grid doesn't re-open at the end, as expected

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
