### PR TITLE
Fix #3042 Override geometry collection default style (ol)

### DIFF
--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -64,22 +64,17 @@ const defaultStyles = {
         strokeStyle(options),
         fillStyle(options)
     ))],
-    'GeometryCollection': () => [new ol.style.Style({
-      stroke: new ol.style.Stroke({
-        color: 'magenta',
-        width: 2
-      }),
-      fill: new ol.style.Fill({
-        color: 'magenta'
-      }),
-      image: new ol.style.Circle({
+    'GeometryCollection': options => [new ol.style.Style(assign({},
+        strokeStyle(options),
+        fillStyle(options),
+      {image: new ol.style.Circle({
         radius: 10,
         fill: null,
         stroke: new ol.style.Stroke({
           color: 'magenta'
         })
       })
-    })],
+    }))],
   'Circle': () => [new ol.style.Style({
     stroke: new ol.style.Stroke({
       color: 'red',

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -298,4 +298,76 @@ describe('Test VectorStyle', () => {
 
     });
 
+    it('test styleFunction with GeometryCollection', () => {
+
+        const multiPolygon = new ol.geom.MultiPolygon([
+            [
+                [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0] ]
+            ],
+            [
+                [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
+                [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
+            ]
+        ]);
+
+        const geometryCollection = new ol.Feature({
+            geometry: new ol.geom.GeometryCollection([multiPolygon])
+        });
+
+        let olStyle = VectorStyle.styleFunction(geometryCollection);
+
+        let olFill = olStyle[0].getFill();
+        let olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgba(0, 0, 255, 0.1)');
+        expect(olStroke.getColor()).toBe('blue');
+        expect(olStroke.getWidth()).toBe(3);
+        expect(olStroke.getLineDash()).toEqual([4]);
+
+        const options = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                dashArray: '',
+                fillColor: '#3388ff',
+                fillOpacity: 0.2
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(geometryCollection, options);
+        olFill = olStyle[0].getFill();
+        olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgba(51, 136, 255, 0.2)');
+        expect(olStroke.getColor()).toBe('#3388ff');
+        expect(olStroke.getWidth()).toBe(4);
+        expect(olStroke.getLineDash()).toEqual(['']);
+
+        const optionsWithFeatureType = {
+            style: {
+                color: '#3388ff',
+                weight: 4,
+                dashArray: '',
+                fillColor: '#3388ff',
+                fillOpacity: 0.2,
+                GeometryCollection: {
+                    color: '#ffaa33',
+                    weight: 10,
+                    dashArray: '10 5',
+                    fillColor: '#333333'
+                }
+            }
+        };
+
+        olStyle = VectorStyle.styleFunction(geometryCollection, optionsWithFeatureType);
+        olFill = olStyle[0].getFill();
+        olStroke = olStyle[0].getStroke();
+
+        expect(olFill.getColor()).toBe('rgb(51, 51, 51)');
+        expect(olStroke.getColor()).toBe('#ffaa33');
+        expect(olStroke.getWidth()).toBe(10);
+        expect(olStroke.getLineDash()).toEqual(['10', '5']);
+
+    });
+
 });


### PR DESCRIPTION
## Description
Added option to override GeometryCollection style in openlayers

## Issues
 - Fix #3042

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**
GeometryCollection style are overridable in openlayers

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
