### PR TITLE
Fixes #3046: do not change chosen field on saved thematic

### DIFF
--- a/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
+++ b/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
@@ -173,8 +173,10 @@ class ThematicLayer extends React.Component {
             this.switchLayer(newProps.layer);
         }
         if (newProps.fields && newProps.fields.length && !isEqual(newProps.fields, this.props.fields)) {
-            // set first field in field combobox on fields loading
-            this.updateStyle('field', newProps.fields[0].name, true);
+            // set actual field value or first field in combobox on fields loading
+            const fieldValue = newProps.layer.thematic.applied && newProps.layer.thematic.applied.field ||
+                newProps.fields[0].name;
+            this.updateStyle('field', fieldValue, true);
         }
         this.checkInitialStyle(newProps);
     }


### PR DESCRIPTION
## Description
Quick fix for thematic layers.

## Issues
 - Fix #3046 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Chosen field is reset to first in combo when thematic style settings is open on a saved thematic.

**What is the new behavior?**
Chosen field is NOT reset to first in combo when thematic style settings is open on a saved thematic.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
