### PR TITLE
Added parameters to enable printing end to load version in MapStore2 api

### DIFF
--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -188,7 +188,7 @@ const MapStore2 = {
         }, {
             jsAPIEpic: actionTrigger.epic
         });
-        const initialActions = [...getInitialActions(options), loadVersion(options.versionURL)];
+        const initialActions = [...getInitialActions(options), loadVersion.bind(null, options.versionURL)];
         const appConfig = {
             storeOpts: assign({}, storeOpts, {notify: true}),
             appStore,

--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -188,14 +188,14 @@ const MapStore2 = {
         }, {
             jsAPIEpic: actionTrigger.epic
         });
-        const initialActions = [...getInitialActions(options), loadVersion];
+        const initialActions = [...getInitialActions(options), loadVersion(options.versionURL)];
         const appConfig = {
             storeOpts: assign({}, storeOpts, {notify: true}),
             appStore,
             pluginsDef,
             initialActions,
             appComponent: StandardRouter,
-            printingEnabled: false
+            printingEnabled: options.printingEnabled || false
         };
         if (options.style) {
             let dom = document.getElementById('custom_theme');


### PR DESCRIPTION
## Description
Added parameters to enable printing end to load version in MapStore2 api

## Issues
 - Changes needed to integrate by geonode-mapstore integration
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
In MapStore2 api it's impossible to change version url and to enable printing

**What is the new behavior?**
It's now possible to change version url and to enable printing

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
