### PR TITLE
Fixes #3046: security token is not applied correctly to SLD params

### DIFF
--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -145,7 +145,7 @@ const API = {
         const parts = urlParts(isArray(layer.url) ? layer.url[0] : layer.url);
         return url.format(assign(getUrl(parts), {
             pathname: parts.applicationRootPath + "/rest/sldservice/" + layer.name + "/classify.xml",
-            query: assign({}, SecurityUtils.addAuthenticationParameter(layer.url, mapParams(layer, params)), { fullSLD: true })
+            query: assign({}, layer.url, mapParams(layer, params), { fullSLD: true })
         }));
     },
     /**

--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -7,7 +7,6 @@
  */
 
 const { urlParts } = require('../utils/URLUtils');
-const SecurityUtils = require('../utils/SecurityUtils');
 const url = require('url');
 const { isArray, sortBy, head, castArray, isNumber } = require('lodash');
 const assign = require('object-assign');

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -16,6 +16,7 @@ const {isArray} = require('lodash');
 const WMSUtils = require('../../../../utils/cesium/WMSUtils');
 const {getAuthenticationParam, getURLs} = require('../../../../utils/LayersUtils');
 const FilterUtils = require('../../../../utils/FilterUtils');
+const SecurityUtils = require('../../../../utils/SecurityUtils');
 
 function splitUrl(originalUrl) {
     let url = originalUrl;
@@ -68,7 +69,8 @@ function wmsToCesiumOptionsSingleTile(options) {
     }, (CQL_FILTER ? {CQL_FILTER} : {}), options.params || {}, getAuthenticationParam(options));
 
     return {
-        url: (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&' + getQueryString(parameters)
+        url: (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'
+            + getQueryString(SecurityUtils.addAuthenticationToSLD(parameters, options))
     };
 }
 

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -16,6 +16,7 @@ const objectAssign = require('object-assign');
 const {isArray} = require('lodash');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const ElevationUtils = require('../../../../utils/ElevationUtils');
+const urlUtils = require('url');
 require('leaflet.nontiledlayer');
 
 L.NonTiledLayer.WMSCustom = L.NonTiledLayer.WMS.extend({
@@ -152,7 +153,7 @@ function wmsToLeafletOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
     const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     // NOTE: can we use opacity to manage visibility?
-    return objectAssign({}, options.baseParams, {
+    const result = objectAssign({}, options.baseParams, {
         layers: options.name,
         styles: options.style || "",
         format: options.format || 'image/png',
@@ -171,6 +172,7 @@ function wmsToLeafletOptions(options) {
         (options._v_ ? {_v_: options._v_} : {}),
         (options.params || {})
     ));
+    return SecurityUtils.addAuthenticationToSLD(result, options);
 }
 
 function getWMSURLs( urls ) {

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -16,7 +16,6 @@ const objectAssign = require('object-assign');
 const {isArray} = require('lodash');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const ElevationUtils = require('../../../../utils/ElevationUtils');
-const urlUtils = require('url');
 require('leaflet.nontiledlayer');
 
 L.NonTiledLayer.WMSCustom = L.NonTiledLayer.WMS.extend({

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1087,6 +1087,50 @@ describe('Openlayers layer', () => {
                  options={assign({}, options, {params: {cql_filter: "EXCLUDE"}})} map={map}/>, document.getElementById("container"));
         expect(layer.layer.getSource().getParams().cql_filter).toBe("EXCLUDE");
     });
+    it('test wms security token on SLD param', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                SLD: "http://sample.server/geoserver/rest/sld?test1=aaa"
+            }
+        };
+        ConfigUtils.setConfigProp('useAuthenticationRules', true);
+        ConfigUtils.setConfigProp('authenticationRules', [
+            {
+                urlPattern: '.*geostore.*',
+                method: 'bearer'
+            }, {
+                urlPattern: '\\/geoserver.*',
+                authkeyParamName: 'ms2-authkey',
+                method: 'authkey'
+            }
+        ]);
+
+        SecurityUtils.setStore({
+            getState: () => ({
+                security: {
+                    token: "########-####-####-####-###########"
+                }
+            })
+        });
+        let layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={options}
+            map={map}
+            securityToken="########-####-####-####-###########" />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(layer.layer.getSource()).toExist();
+        expect(layer.layer.getSource().getParams()['ms2-authkey']).toBe("########-####-####-####-###########");
+        expect(layer.layer.getSource().getParams().SLD).toBe("http://sample.server/geoserver/rest/sld?test1=aaa&ms2-authkey=" + encodeURIComponent("########-####-####-####-###########"));
+    });
     it('test wms security token', () => {
         const options = {
             type: "wms",

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -26,7 +26,7 @@ const ElevationUtils = require('../../../../utils/ElevationUtils');
 function wmsToOpenlayersOptions(options) {
     const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
     // NOTE: can we use opacity to manage visibility?
-    return objectAssign({}, options.baseParams, {
+    const result = objectAssign({}, options.baseParams, {
         LAYERS: options.name,
         STYLES: options.style || "",
         FORMAT: options.format || 'image/png',
@@ -41,6 +41,7 @@ function wmsToOpenlayersOptions(options) {
         (options._v_ ? {_v_: options._v_} : {}),
         (options.params || {})
     ));
+    return SecurityUtils.addAuthenticationToSLD(result, options);
 }
 
 function getWMSURLs( urls ) {

--- a/web/client/plugins/ThematicLayer.jsx
+++ b/web/client/plugins/ThematicLayer.jsx
@@ -29,7 +29,7 @@ const { isAdminUserSelector } = require('../selectors/security');
  * @memberof plugins
  * @name ThematicLayer
  * @class
- * @prop {boolean} enableRemoveStyle, enables the remove style button (disabled by default)
+ * @prop {boolean} enableRemoveStyle enables the remove style button (disabled by default)
  * @prop {array} cfg.colors list of base color palettes the user can choose to create the style (they can be extended via
  *    layer configuration)
  * @prop {number} cfg.colorSamples number of samples to show in the color palette list

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -183,6 +183,19 @@ const SecurityUtils = {
             return parameters;
         }
     },
+    addAuthenticationToSLD: function(layerOptions, options) {
+        if (layerOptions.SLD) {
+            const parsed = URL.parse(layerOptions.SLD, true);
+            const params = SecurityUtils.addAuthenticationParameter(layerOptions.SLD, parsed.query, options.securityToken);
+            return assign({}, layerOptions, {
+                SLD: URL.format(assign({}, parsed, {
+                    query: params,
+                    search: undefined
+                }))
+            });
+        }
+        return layerOptions;
+    },
     getAuthKeyParameter: function(url) {
         const foundRule = this.getAuthenticationRule(url);
         return foundRule && foundRule.authkeyParamName ? foundRule.authkeyParamName : 'authkey';


### PR DESCRIPTION
## Description
Fixes a bug with authentication token in SLD param generated by ThematicLayer.

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
authentication token is stored with the layer params, so it does not update when tokens expire

**What is the new behavior?**
authentication token is NOT stored with the layer params, and applied for each layer update, so the current token is always used.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
