### PR TITLE
Fixes #3046: fixed translation for classification errors

### DIFF
--- a/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
+++ b/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
@@ -223,7 +223,7 @@ class ThematicLayer extends React.Component {
     renderError = (error, type) => {
         return (<Alert bsStyle="danger">
             <Message msgId={'toc.thematic.' + type} msgParams={{
-                message: error.message
+                message: this.localizedItem(error.message, '')
             }}/>
         </Alert>);
     };


### PR DESCRIPTION
## Description
Error message not translated on classification error.

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
msgId is shown instead of the translated message for classification errors

**What is the new behavior?**
Translated message is shown for classification errors

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
