### PR TITLE
Fix #3059. Remove auth params from param object

### DIFF
--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -187,13 +187,15 @@ class RecordItem extends React.Component {
     };
 
     addLayer = (wms) => {
-        const {url} = removeParameters(ConfigUtils.cleanDuplicatedQuestionMarks(wms.url), ["request", "layer", "service", "version"].concat(this.props.authkeyParamNames));
+        const removeParams = ["request", "layer", "layers", "service", "version"].concat(this.props.authkeyParamNames);
+        const { url } = removeParameters(ConfigUtils.cleanDuplicatedQuestionMarks(wms.url), removeParams );
         const allowedSRS = buildSRSMap(wms.SRS);
         if (wms.SRS.length > 0 && !CoordinatesUtils.isAllowedSRS(this.props.crs, allowedSRS)) {
             this.props.onError('catalog.srs_not_allowed');
         } else {
             this.props.onLayerAdd(
                 recordToLayer(this.props.record, "wms", {
+                    removeParams,
                     url,
                     catalogURL: this.props.catalogType === 'csw' && this.props.catalogURL ? this.props.catalogURL + "?request=GetRecordById&service=CSW&version=2.0.2&elementSetName=full&id=" + this.props.record.identifier : null
                 }));
@@ -206,12 +208,14 @@ class RecordItem extends React.Component {
     };
 
     addwmtsLayer = (wmts) => {
-        const {url} = removeParameters(ConfigUtils.cleanDuplicatedQuestionMarks(wmts.url), ["request", "layer"].concat(this.props.authkeyParamNames));
+        const removeParams = ["request", "layer"].concat(this.props.authkeyParamNames);
+        const { url } = removeParameters(ConfigUtils.cleanDuplicatedQuestionMarks(wmts.url), removeParams);
         const allowedSRS = buildSRSMap(wmts.SRS);
         if (wmts.SRS.length > 0 && !CoordinatesUtils.isAllowedSRS(this.props.crs, allowedSRS)) {
             this.props.onError('catalog.srs_not_allowed');
         } else {
             this.props.onLayerAdd(recordToLayer(this.props.record, "wmts", {
+                removeParams,
                 url
             }));
             if (this.props.record.boundingBox && this.props.zoomToLayer) {

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -12,13 +12,14 @@ const expect = require('expect');
 const assign = require('object-assign');
 
 const TestUtils = require('react-dom/test-utils');
+const SAMPLE_IMAGE = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
 const sampleRecord = {
     identifier: "test-identifier",
     title: "sample title",
     tags: ["subject1", "subject2"],
     description: "sample abstract",
-    thumbnail: "img.jpg",
+    thumbnail: SAMPLE_IMAGE,
     boundingBox: {
         extent: [10.686,
             44.931,
@@ -40,7 +41,7 @@ const sampleRecord2 = {
     title: "sample title",
     tags: ["subject1", "subject2"],
     description: "sample abstract",
-    thumbnail: "img.jpg",
+    thumbnail: SAMPLE_IMAGE,
     boundingBox: {
         extent: [10.686,
             44.931,
@@ -62,7 +63,7 @@ const sampleRecord3 = {
     title: "sample title",
     tags: ["subject1", "subject2"],
     description: "sample abstract",
-    thumbnail: "img.jpg",
+    thumbnail: SAMPLE_IMAGE,
     boundingBox: {
         extent: [10.686,
             44.931,
@@ -96,7 +97,7 @@ const longDescriptioRecord = {
     identifier: "test-identifier",
     tags: ["subject1", "subject2"],
     description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa, quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt, explicabo. Nemo enim ipsam voluptatem, quia voluptas sit, aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos, qui ratione voluptatem sequi nesciunt, neque porro quisquam est, qui dolorem ipsum, quia dolor sit, amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt, ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat, quo voluptas nulla pariatur? [33] At vero eos et accusamus et iusto odio dignissimos ducimus, qui blanditiis praesentium voluptatum deleniti atque corrupti, quos dolores et quas molestias excepturi sint, obcaecati cupiditate non provident, similique sunt in culpa, qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio, cumque nihil impedit, quo minus id, quod maxime placeat, facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet, ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat",
-    thumbnail: "img.jpg",
+    thumbnail: SAMPLE_IMAGE,
     boundingBox: {
         extent: [10.686, 44.931, 46.693, 12.54],
         crs: "EPSG:4326"
@@ -161,7 +162,7 @@ describe('This test for RecordItem', () => {
         expect(itemDom).toExist();
         expect(itemDom.className).toBe('record-item panel panel-default');
         let button = TestUtils.findRenderedDOMComponentWithTag(
-           item, 'button'
+            item, 'button'
         );
         expect(button).toExist();
         button.click();
@@ -252,6 +253,110 @@ describe('This test for RecordItem', () => {
         expect(actionsSpy.calls.length).toBe(1);
         expect(actionsSpy.calls[0].arguments.length).toBe(1);
         expect(actionsSpy.calls[0].arguments[0].catalogURL).toNotExist();
+    });
+    it('check auth params to be removed (WMS)', () => {
+        const recordToClean = {
+            identifier: "test-identifier",
+            title: "sample title",
+            tags: ["subject1", "subject2"],
+            description: "sample abstract",
+            thumbnail: SAMPLE_IMAGE,
+            boundingBox: {
+                extent: [10.686,
+                    44.931,
+                    46.693,
+                    12.54],
+                crs: "EPSG:4326"
+
+            },
+            references: [{
+                type: "OGC:WMS",
+                url: "http://wms.sample.service:80/geoserver/wms?SERVICE=WMS&ms2-authkey=TEST&requiredParam=REQUIRED",
+                SRS: [],
+                params: { name: "workspace:layername" }
+            }]
+        };
+        let actions = {
+            onLayerAdd: () => {
+
+            }
+        };
+        let actionsSpy = expect.spyOn(actions, "onLayerAdd");
+        const item = ReactDOM.render(<ReactItem
+            authkeyParamNames={["ms2-authkey"]}
+            record={recordToClean}
+            onLayerAdd={actions.onLayerAdd}
+            catalogURL="fakeURL"
+            catalogType="wms"
+        />, document.getElementById("container"));
+        expect(item).toExist();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toExist();
+        expect(itemDom.className).toBe('record-item panel panel-default');
+        let button = TestUtils.findRenderedDOMComponentWithTag(
+            item, 'button'
+        );
+        expect(button).toExist();
+        button.click();
+        expect(actionsSpy.calls.length).toBe(1);
+        expect(actionsSpy.calls[0].arguments.length).toBe(1);
+        expect(actionsSpy.calls[0].arguments[0].catalogURL).toNotExist();
+        expect(actionsSpy.calls[0].arguments[0].params).toExist();
+        expect(actionsSpy.calls[0].arguments[0].params.requiredParam).toBe("REQUIRED");
+        expect(actionsSpy.calls[0].arguments[0].params["ms2-authkey"]).toNotExist("auth param is passed in params list but it shouldn't");
+    });
+    it('check auth params to be removed (WMTS)', () => {
+        const recordToClean = {
+            identifier: "test-identifier",
+            title: "sample title",
+            tags: ["subject1", "subject2"],
+            description: "sample abstract",
+            thumbnail: SAMPLE_IMAGE,
+            boundingBox: {
+                extent: [10.686,
+                    44.931,
+                    46.693,
+                    12.54],
+                crs: "EPSG:4326"
+
+            },
+            references: [{
+                type: "OGC:WMTS",
+                url: "http://wms.sample.service:80/geoserver/gwc/service/wmts?ms2-authkey=TEST&requiredParam=REQUIRED",
+                SRS: ['EPSG:4326', 'EPSG:3857'],
+                params: { name: "workspace:layername" }
+            }]
+        };
+        let actions = {
+            onLayerAdd: () => {
+
+            }
+        };
+        let actionsSpy = expect.spyOn(actions, "onLayerAdd");
+        const item = ReactDOM.render(<ReactItem
+            authkeyParamNames={["ms2-authkey"]}
+            record={recordToClean}
+            onLayerAdd={actions.onLayerAdd}
+            catalogURL="fakeURL"
+            catalogType="wms"
+        />, document.getElementById("container"));
+        expect(item).toExist();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toExist();
+        expect(itemDom.className).toBe('record-item panel panel-default');
+        let button = TestUtils.findRenderedDOMComponentWithTag(
+            item, 'button'
+        );
+        expect(button).toExist();
+        button.click();
+        expect(actionsSpy.calls.length).toBe(1);
+        expect(actionsSpy.calls[0].arguments.length).toBe(1);
+        expect(actionsSpy.calls[0].arguments[0].catalogURL).toNotExist();
+        expect(actionsSpy.calls[0].arguments[0].params).toExist();
+        expect(actionsSpy.calls[0].arguments[0].params.requiredParam).toBe("REQUIRED");
+        expect(actionsSpy.calls[0].arguments[0].params["ms2-authkey"]).toNotExist("auth param is passed in params list but it shouldn't");
     });
 
     it('test create record item with no get capabilities links', () => {
@@ -348,7 +453,7 @@ describe('This test for RecordItem', () => {
         identifier: "test-identifier",
         tags: ["subject1", "subject2"],
         description: "sample abstract",
-        thumbnail: "img.jpg",
+        thumbnail: SAMPLE_IMAGE,
         boundingBox: {
             extent: [10.686, 44.931, 46.693, 12.54],
             crs: "EPSG:4326"
@@ -411,7 +516,7 @@ describe('This test for RecordItem', () => {
             title: "sample title",
             tags: ["subject1", "subject2"],
             description: "sample abstract",
-            thumbnail: "img.jpg",
+            thumbnail: SAMPLE_IMAGE,
             boundingBox: {
                 extent: [10.686,
                     44.931,


### PR DESCRIPTION
## Description
This fixes the issue of adding ms2-authkey and layers to the "params". Now the authkey params are excluded from the params.
Also layers has been removed from this list.
## Issues
 - Fix #3059

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 

 - [x] Bugfix
 
**What is the current behavior?** 
`ms2-authkey` is added to the layer's `params` object

**What is the new behavior?**
`ms2-authkey` is not added anymore n `params`

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

