### PR TITLE
Fixes #3057: TOCItemsSettings original settings handling, Fixes #3058: leaflet WMS layers visibility on login / logout

### DIFF
--- a/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
+++ b/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
@@ -294,7 +294,7 @@ describe("test updateSettingsLifecycle", () => {
 
         const testUpdateParams = document.getElementById('test-update-params');
         TestUtils.Simulate.click(testUpdateParams);
-        expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
+        expect(spyOnUpdateOriginalSettings.calls.length).toBe(1);
         expect(spyOnUpdateSettings).toHaveBeenCalled();
         expect(spyOnUpdateNode).toHaveBeenCalled();
     });
@@ -321,7 +321,7 @@ describe("test updateSettingsLifecycle", () => {
 
         const testUpdateParams = document.getElementById('test-update-params');
         TestUtils.Simulate.click(testUpdateParams);
-        expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
+        expect(spyOnUpdateOriginalSettings.calls.length).toBe(1);
         expect(spyOnUpdateSettings).toHaveBeenCalled();
         expect(spyOnUpdateNode).toNotHaveBeenCalled();
     });

--- a/web/client/components/TOC/enhancers/tocItemsSettings.js
+++ b/web/client/components/TOC/enhancers/tocItemsSettings.js
@@ -43,7 +43,6 @@ const settingsLifecycle = compose(
             settings = {},
             initialSettings = {},
             originalSettings: orig,
-            onUpdateOriginalSettings = () => {},
             onUpdateSettings = () => {},
             onUpdateNode = () => {}
         }) => (newParams, update = true) => {
@@ -52,7 +51,6 @@ const settingsLifecycle = compose(
             Object.keys(newParams).forEach((key) => {
                 originalSettings[key] = initialSettings && initialSettings[key];
             });
-            onUpdateOriginalSettings(originalSettings);
             onUpdateSettings(newParams);
             if (update) {
                 onUpdateNode(

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -192,7 +192,7 @@ Layers.registerType('wms', {
         return L.tileLayer.multipleUrlWMS(urls, queryParameters);
     },
     update: function(layer, newOptions, oldOptions) {
-        if (oldOptions.singleTile !== newOptions.singleTile || oldOptions.securityToken !== newOptions.securityToken) {
+        if (oldOptions.singleTile !== newOptions.singleTile || oldOptions.securityToken !== newOptions.securityToken && newOptions.visibility) {
             let newLayer;
             const urls = getWMSURLs(isArray(newOptions.url) ? newOptions.url : [newOptions.url]);
             const queryParameters = wmsToLeafletOptions(newOptions) || {};


### PR DESCRIPTION
## Description
A couple of fixes to:
 * TOCItemSettings, wrong handling of original settings, sometimes crashes on close without saving
 * leaflet wms layers are all shown on login / logout also if visibility is false

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
2 Bugs

**What is the new behavior?**
2 Bugs solved

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
