### PR TITLE
Fix #3062 update default print style for polygons

### DIFF
--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -16,7 +16,7 @@ const image = new ol.style.Circle({
 const Icons = require('../../../utils/openlayers/Icons');
 
 
-const strokeStyle = (options, defaultsStyle = {color: 'blue', width: 3, lineDash: [4]}) => ({
+const strokeStyle = (options, defaultsStyle = {color: 'blue', width: 3, lineDash: [6]}) => ({
     stroke: new ol.style.Stroke(
         options.style ?
         options.style.stroke || {

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -181,7 +181,7 @@ describe('Test VectorStyle', () => {
         expect(olFill.getColor()).toBe('rgba(0, 0, 255, 0.1)');
         expect(olStroke.getColor()).toBe('blue');
         expect(olStroke.getWidth()).toBe(3);
-        expect(olStroke.getLineDash()).toEqual([4]);
+        expect(olStroke.getLineDash()).toEqual([6]);
 
         const options = {
             style: {
@@ -250,7 +250,7 @@ describe('Test VectorStyle', () => {
         expect(olFill.getColor()).toBe('rgba(0, 0, 255, 0.1)');
         expect(olStroke.getColor()).toBe('blue');
         expect(olStroke.getWidth()).toBe(3);
-        expect(olStroke.getLineDash()).toEqual([4]);
+        expect(olStroke.getLineDash()).toEqual([6]);
 
         const options = {
             style: {

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -373,50 +373,52 @@ const PrintUtils = {
      */
     getOlDefaultStyle(layer) {
         switch (getGeomType(layer)) {
-        case 'Polygon':
-        case 'MultiPolygon': {
-            return {
-                "fillColor": "#0000FF",
-                "fillOpacity": 0.1,
-                "strokeColor": "#0000FF",
-                "strokeOpacity": 1,
-                "strokeWidth": 3
-            };
-        }
-        case 'MultiLineString':
-        case 'LineString':
-            return {
-                "strokeColor": "#0000FF",
-                "strokeOpacity": 1,
-                "strokeWidth": 3
-            };
-        case 'Point':
-        case 'MultiPoint': {
-            return layer.styleName === "marker" ? {
-                "externalGraphic": "http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/images/marker-icon.png",
-                "graphicWidth": 25,
-                "graphicHeight": 41,
-                "graphicXOffset": -12, // different offset
-                "graphicYOffset": -41
-            } : {
-                "fillColor": "#FF0000",
-                "fillOpacity": 0,
-                "strokeColor": "#FF0000",
-                "pointRadius": 5,
-                "strokeOpacity": 1,
-                "strokeWidth": 1
-            };
-        }
-        default: {
-            return {
-                "fillColor": "#0000FF",
-                "fillOpacity": 0.1,
-                "strokeColor": "#0000FF",
-                "pointRadius": 5,
-                "strokeOpacity": 1,
-                "strokeWidth": 1
-            };
-        }
+            case 'Polygon':
+            case 'MultiPolygon': {
+                return {
+                    "fillColor": "#0000FF",
+                    "fillOpacity": 0.1,
+                    "strokeColor": "#0000FF",
+                    "strokeOpacity": 1,
+                    "strokeWidth": 3,
+                    "strokeDashstyle": "dash",
+                    "strokeLinecap": "round"
+                };
+            }
+            case 'MultiLineString':
+            case 'LineString':
+                return {
+                    "strokeColor": "#0000FF",
+                    "strokeOpacity": 1,
+                    "strokeWidth": 3
+                };
+            case 'Point':
+            case 'MultiPoint': {
+                return layer.styleName === "marker" ? {
+                    "externalGraphic": "http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/images/marker-icon.png",
+                    "graphicWidth": 25,
+                    "graphicHeight": 41,
+                    "graphicXOffset": -12, // different offset
+                    "graphicYOffset": -41
+                } : {
+                    "fillColor": "#FF0000",
+                    "fillOpacity": 0,
+                    "strokeColor": "#FF0000",
+                    "pointRadius": 5,
+                    "strokeOpacity": 1,
+                    "strokeWidth": 1
+                };
+            }
+            default: {
+                return {
+                    "fillColor": "#0000FF",
+                    "fillOpacity": 0.1,
+                    "strokeColor": "#0000FF",
+                    "pointRadius": 5,
+                    "strokeOpacity": 1,
+                    "strokeWidth": 1
+                };
+            }
         }
     }
 };

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -170,7 +170,12 @@ describe('PrintUtils', () => {
         const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "Polygon"}}]});
         expect(style).toExist();
         expect(style.strokeWidth).toBe(3);
-
+        expect(style.strokeDashstyle).toBe("dash");
+        expect(style.strokeLinecap).toBe("round");
+        expect(style.strokeColor).toBe("#0000FF");
+        expect(style.fillColor).toBe("#0000FF");
+        expect(style.fillOpacity).toBe(0.1);
+        expect(style.strokeOpacity).toBe(1);
     });
     it('vector layer default line style', () => {
         const style = PrintUtils.getOlDefaultStyle({features: [{geometry: {type: "LineString"}}]});


### PR DESCRIPTION
## Description
This pr aligns default print style for polygons to the vector one.

## Issues
 - Fix #3062

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
dashed style for polygons was not printed

**What is the new behavior?**
dashed style for polygons are now printed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
