### PR TITLE
Fixes #3068: correct monitoring of plugins state to limit re-renderings

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -12,7 +12,7 @@ const PluginsUtils = require('../../utils/PluginsUtils');
 
 const assign = require('object-assign');
 
-const {get} = require('lodash');
+const {get, isEqual} = require('lodash');
 const {componentFromProp} = require('recompose');
 const Component = componentFromProp('component');
 
@@ -89,6 +89,19 @@ class PluginsContainer extends React.Component {
 
     componentWillReceiveProps(newProps) {
         this.loadPlugins(newProps.pluginsState, newProps);
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        return nextProps.pluginsConfig !== this.props.pluginsConfig
+            || nextProps.plugins !== this.props.plugins
+            || nextProps.params !== this.props.params
+            || nextProps.mode !== this.props.mode
+            || nextProps.monitoredState !== this.props.monitoredState
+            || nextProps.className !== this.props.className
+            || nextProps.style !== this.props.style
+            || nextProps.defaultMode !== this.props.defaultMode
+            || !isEqual(nextProps.pluginsState, this.props.pluginsState)
+            || !isEqual(nextState.loadedPlugins, this.state.loadedPlugins);
     }
 
     getState = (path, newProps) => {


### PR DESCRIPTION
## Description
Fixes PluginsContainer to re-render only when needed.

## Issues
 - See title

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Too many re-renderings due to assign creating a new merged plugins state object each time.

**What is the new behavior?**
re-renderings only when plugins state really changes.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
