### PR TITLE
Fixes #3070: thematic style removed on opacity change, fixes #3071: validation of thematic classes ranges

### DIFF
--- a/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
+++ b/web/client/components/TOC/fragments/settings/ThematicLayer.jsx
@@ -359,6 +359,7 @@ class ThematicLayer extends React.Component {
                         </Row>
                         <Row><Col xs={12}>
                         {this.props.classificationLoading.status ? <LoadingView width={this.props.loaderSize} height={this.props.loaderSize}/> : null}
+                        {this.renderInputError('classification')}
                         <ThemaClassesEditor className={this.props.classificationLoading.status ? "loading" : ""} classification={this.getClassification()} onUpdateClasses={this.updateClassification}/>
                         {this.props.classificationLoading.error ? this.renderError(this.props.classificationLoading.error, 'classification_error') : null}
                         </Col></Row>
@@ -480,7 +481,18 @@ class ThematicLayer extends React.Component {
                 classification
             })
         }));
+        if (!this.validClassification(classification)) {
+            this.props.onInvalidInput('classification', 'toc.thematic.invalid_classes');
+        } else {
+            this.props.onValidInput('classification');
+        }
         this.props.onDirtyStyle();
+    };
+
+    validClassification = (classification = []) => {
+        return !classification.reduce((previous, current) => {
+            return previous || (current.max < current.min);
+        }, false);
     };
 
     createRamp = (item) => item.colors;

--- a/web/client/components/TOC/fragments/settings/__tests__/ThematicLayer-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/ThematicLayer-test.jsx
@@ -685,4 +685,22 @@ describe('test ThematicLayer module component', () => {
         TestUtils.Simulate.mouseDown(intervalsPicker.querySelector('.rw-btn'));
         expect(spyInvalid).toHaveBeenCalled();
     });
+
+    it('tests ThematicLayer component with configured thematic thema style invalid classification', () => {
+        const actions = {
+            onInvalidInput: () => { }
+        };
+        const spyInvalid = expect.spyOn(actions, 'onInvalidInput');
+
+        const comp = ReactDOM.render(<ThematicLayer
+            onInvalidInput={actions.onInvalidInput}
+            maxClasses={3}
+            layer={layerWithConfiguredThematic} adminCfg={{ open: false, current: "{}" }} classification={classification} />, document.getElementById("container"));
+
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        const input = domNode.querySelectorAll('input.rw-input')[7];
+        TestUtils.Simulate.change(input, { "target": { "value": "5" } });
+        expect(spyInvalid).toHaveBeenCalled();
+    });
 });

--- a/web/client/epics/__tests__/thematic-test.js
+++ b/web/client/epics/__tests__/thematic-test.js
@@ -7,7 +7,7 @@
  */
 
 const expect = require('expect');
-const { testEpic ,TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
+const { testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
 
 const {
     FIELDS_LOADED, FIELDS_ERROR, CLASSIFICATION_LOADED, CLASSIFICATION_ERROR, loadFields, loadClassification

--- a/web/client/epics/__tests__/thematic-test.js
+++ b/web/client/epics/__tests__/thematic-test.js
@@ -7,7 +7,7 @@
  */
 
 const expect = require('expect');
-const { testEpic } = require('./epicTestUtils');
+const { testEpic ,TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
 
 const {
     FIELDS_LOADED, FIELDS_ERROR, CLASSIFICATION_LOADED, CLASSIFICATION_ERROR, loadFields, loadClassification
@@ -148,6 +148,44 @@ describe('thematic epic', () => {
                         expect(action.params).toExist();
                         expect(action.params.SLD).toNotExist();
                         expect(action.params.viewparams).toNotExist();
+                        done();
+                        break;
+                    default:
+                        done(new Error("Action not recognized"));
+                }
+            });
+            done();
+        }, BASE_STATE);
+    });
+
+    it('removeStyleEpic', (done) => {
+        const startActions = [updateNode('mylayer', 'layer', { thematic: null })];
+        testEpic(removeThematicEpic, 1, startActions, actions => {
+            expect(actions.length).toBe(1);
+            actions.forEach((action) => {
+                switch (action.type) {
+                    case CHANGE_LAYER_PARAMS:
+                        expect(action.layer).toExist();
+                        expect(action.params).toExist();
+                        expect(action.params.SLD).toNotExist();
+                        expect(action.params.viewparams).toNotExist();
+                        done();
+                        break;
+                    default:
+                        done(new Error("Action not recognized"));
+                }
+            });
+            done();
+        }, BASE_STATE);
+    });
+
+    it('removeStyleEpic not run', (done) => {
+        const startActions = [updateNode('mylayer', 'layer', { })];
+        testEpic(addTimeoutEpic(removeThematicEpic), 1, startActions, actions => {
+            expect(actions.length).toBe(1);
+            actions.forEach((action) => {
+                switch (action.type) {
+                    case TEST_TIMEOUT:
                         done();
                         break;
                     default:

--- a/web/client/epics/thematic.js
+++ b/web/client/epics/thematic.js
@@ -36,7 +36,7 @@ module.exports = (config) => ({
         action$.ofType(UPDATE_NODE)
             .switchMap((action) => {
                 const layer = head(store.getState().layers.flat.filter(l => l.id === action.node));
-                if (layer && !action.options.thematic && config.hasThematicStyle(layer)) {
+                if (layer && action.options.thematic === null && config.hasThematicStyle(layer)) {
                     const newParams = config.removeThematicStyle(layer.params);
                     return Rx.Observable.of(changeLayerParams(action.node, newParams));
                 }

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -437,7 +437,8 @@
                 "fields_error": "Fehler beim Laden der Felderliste: {message}",
                 "interval_limit": "Intervalle sollten eine Zahl zwischen {min} und {max} sein",
                 "invalid_object": "Ungültige Serviceantwort",
-                "invalid_geometry": "Der Geometrietyp ist nicht gültig, kein Punkt, Linie oder Polygon"
+                "invalid_geometry": "Der Geometrietyp ist nicht gültig, kein Punkt, Linie oder Polygon",
+                "invalid_classes": "Max muss in jeder Klasse größer als min sein"
             }
         },
         "print":{

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -437,7 +437,8 @@
                 "fields_error": "Error loading fields list: {message}",
                 "interval_limit": "Intervals should be a number between {min} and {max}",
                 "invalid_object": "Invalid service response",
-                "invalid_geometry": "Geometry type is not valid, not a point, line or polygon"
+                "invalid_geometry": "Geometry type is not valid, not a point, line or polygon",
+                "invalid_classes": "Max must be greater than min in every class"
             }
         },
         "print":{

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -437,7 +437,8 @@
                 "fields_error": "Error al cargar la lista de campos: {message}",
                 "interval_limit": "Los intervalos deben ser un número entre {min} y {max}",
                 "invalid_object": "Respuesta de servicio inválida",
-                "invalid_geometry": "El tipo de geometría no es válido, no es un punto, línea o polígono"
+                "invalid_geometry": "El tipo de geometría no es válido, no es un punto, línea o polígono",
+                "invalid_classes": "Max debe ser mayor que min en todas las clases"
             }
         },
         "print":{

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -438,7 +438,8 @@
                 "fields_error": "Erreur lors du chargement de la liste des champs: {message}",
                 "interval_limit": "Les intervalles doivent être compris entre {min} et {max}",
                 "invalid_object": "Réponse au service non valide",
-                "invalid_geometry": "Le type de géométrie n'est pas valide, pas un point, une ligne ou un polygone"
+                "invalid_geometry": "Le type de géométrie n'est pas valide, pas un point, une ligne ou un polygone",
+                "invalid_classes": "Max doit être supérieur à min dans chaque classe"
             }
         },
         "print":{

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -437,7 +437,8 @@
                 "fields_error": "Errore durante il caricamento dell'elenco dei campi: {message}",
                 "interval_limit": "Inserisci un valore tra {min} e {max}",
                 "invalid_object": "Risposta del servizio non valida",
-                "invalid_geometry": "Il tipo di geometria non è valido, deve essere un punto, una linea o un poligono"
+                "invalid_geometry": "Il tipo di geometria non è valido, deve essere un punto, una linea o un poligono",
+                "invalid_classes": "Il valore massimo di ogni classe deve essere maggiore del relativo minimo"
             }
         },
         "print":{


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #3070
 - Fix #3071

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Opacity change on a thematic layer removes thematic style.
Thematic classes are not validated, so can happen that max < min and the user can still apply the style

**What is the new behavior?**
Opacity change on a thematic layer does not remove thematic style.
Thematic classes are validated, so it cannot happen that max < min and the user can apply the style

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
