### PR TITLE
Fix #2765: Loading missing features when featuregrid is opened

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -13,21 +13,21 @@ const proj4 = Proj4js;
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
 const { hideMapinfoMarker, featureInfoClick} = require('../../actions/mapInfo');
 
-const { toggleEditMode, toggleViewMode, openFeatureGrid, OPEN_FEATURE_GRID, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch, moreFeatures, GRID_QUERY_RESULT } = require('../../actions/featuregrid');
+const { toggleEditMode, toggleViewMode, openFeatureGrid, OPEN_FEATURE_GRID, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch, moreFeatures, GRID_QUERY_RESULT, LOAD_MORE_FEATURES} = require('../../actions/featuregrid');
 const {SET_HIGHLIGHT_FEATURES_PATH} = require('../../actions/highlight');
 const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 const {RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl} = require('../../actions/controls');
 const {ZOOM_TO_EXTENT} = require('../../actions/map');
 const {PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
-const {toggleSyncWms, QUERY, querySearchResponse} = require('../../actions/wfsquery');
+const {toggleSyncWms, QUERY, querySearchResponse, featureLoading} = require('../../actions/wfsquery');
 const {CHANGE_LAYER_PROPERTIES} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
 
 const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery');
 
 
-const { setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrollLoadFeatures, removeWmsFilterOnGridClose, autoReopenFeatureGridOnFeatureInfoClose} = require('../featuregrid');
+const { setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrollLoadFeatures, removeWmsFilterOnGridClose, autoReopenFeatureGridOnFeatureInfoClose, loadMoreFeatureGridFeatures} = require('../featuregrid');
 
 
 const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
@@ -1601,5 +1601,25 @@ describe('featuregrid Epics', () => {
             featureInfoClick(),
             hideMapinfoMarker()],
         epicResult);
+    });
+    it('it loads missing features when featuregrid is opened', done => {
+        testEpic(loadMoreFeatureGridFeatures, 1, featureLoading(false), (actions) => {
+            actions.map((action) => {
+                switch (action.type) {
+                    case LOAD_MORE_FEATURES:
+                        expect(action.pages).toEqual({startPage: 0, endPage: 10});
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                }
+            });
+        }, {
+            featuregrid: {
+                pages: [0],
+                dockSize: 0.6,
+                pagination: {page: 0, size: 10}
+            }
+        });
+        done();
     });
 });

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -68,7 +68,7 @@ const emptyResultsState = {
     changes: [],
     pagination: {
         page: 0,
-        size: 20
+        size: 10
     },
     select: [],
     multiselect: false,
@@ -127,7 +127,7 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
  *     changes: [],
  *     pagination: {
  *         page: 0,
- *         size: 20
+ *         size: 10
  *     },
  *     select: [],
  *     multiselect: false,

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -31,6 +31,7 @@ const {
     showPopoverSyncSelector,
     hasSupportedGeometry,
     getDockSize,
+    pagesSelector,
     selectedLayerNameSelector
 } = require('../featuregrid');
 
@@ -317,6 +318,7 @@ describe('Test featuregrid selectors', () => {
                 drawing: true,
                 mode: modeEdit,
                 select: [feature1, feature2],
+                pages: [0],
                 changes: [{id: feature2.id, updated: {geometry: null}}],
                 attributes: {
                 name: {
@@ -491,5 +493,8 @@ describe('Test featuregrid selectors', () => {
         expect(selectedLayerNameSelector(state)).toBe('editing:polygons');
         expect(selectedLayerNameSelector({})).toBe('');
     });
-
+    it('test pagesSelector', () => {
+        expect(pagesSelector(initialState).length).toBe(1);
+        expect(pagesSelector(initialState)[0]).toBe(0);
+    });
 });

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -142,6 +142,7 @@ module.exports = {
      */
     hasSupportedGeometry,
     getDockSize: state => state.featuregrid && state.featuregrid.dockSize,
+    pagesSelector: state => state.featuregrid && state.featuregrid.pages,
     /**
      * get selected layer name
      * @function


### PR DESCRIPTION
## Description
Loading missing features when featuregrid is opened
## Issues
 - Fix #2765 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

