### PR TITLE
#3078 Feature info settings are always saved

### DIFF
--- a/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
+++ b/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
@@ -148,22 +148,31 @@ describe("test updateSettingsLifecycle", () => {
     it('test component on save', () => {
         const testHandlers = {
             onHideSettings: () => {},
-            onShowAlertModal: () => {}
+            onShowAlertModal: () => {},
+            onUpdateOriginalSettings: () => {},
+            onUpdateInitialSettings: () => {}
         };
 
         const spyOnHideSettings = expect.spyOn(testHandlers, 'onHideSettings');
         const spyOnShowAlertModal = expect.spyOn(testHandlers, 'onShowAlertModal');
+        const spyOnUpdateOriginalSettings = expect.spyOn(testHandlers, 'onUpdateOriginalSettings');
+        const spyOnUpdateInitialSettings = expect.spyOn(testHandlers, 'onUpdateInitialSettings');
 
         const Component = settingsLifecycle(({onSave}) => <div id="test-save" onClick={onSave}></div>);
         ReactDOM.render(<Component
             onHideSettings={testHandlers.onHideSettings}
-            onShowAlertModal={testHandlers.onShowAlertModal} />, document.getElementById("container"));
+            onShowAlertModal={testHandlers.onShowAlertModal}
+            onUpdateOriginalSettings={testHandlers.onUpdateOriginalSettings}
+            onUpdateInitialSettings={testHandlers.onUpdateInitialSettings} />, document.getElementById("container"));
 
         const testSave = document.getElementById('test-save');
         TestUtils.Simulate.click(testSave);
         expect(spyOnHideSettings).toHaveBeenCalled();
         expect(spyOnShowAlertModal).toHaveBeenCalled();
         expect(spyOnShowAlertModal).toHaveBeenCalledWith(false);
+
+        expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
+        expect(spyOnUpdateInitialSettings).toHaveBeenCalled();
     });
 
     it('test component on close equal options', () => {
@@ -250,9 +259,14 @@ describe("test updateSettingsLifecycle", () => {
         const testHandlers = {
             onUpdateNode: () => {},
             onHideSettings: () => {},
-            onShowAlertModal: () => {}
+            onShowAlertModal: () => {},
+            onUpdateOriginalSettings: () => {},
+            onUpdateInitialSettings: () => {}
         };
         const spyOnUpdateNode = expect.spyOn(testHandlers, 'onUpdateNode');
+        const spyOnUpdateOriginalSettings = expect.spyOn(testHandlers, 'onUpdateOriginalSettings');
+        const spyOnUpdateInitialSettings = expect.spyOn(testHandlers, 'onUpdateInitialSettings');
+
         const spyOnHideSettings = expect.spyOn(testHandlers, 'onHideSettings');
         const spyOnShowAlertModal = expect.spyOn(testHandlers, 'onShowAlertModal');
 
@@ -262,7 +276,9 @@ describe("test updateSettingsLifecycle", () => {
             originalSettings={{}}
             settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
             onHideSettings={testHandlers.onHideSettings}
-            onShowAlertModal={testHandlers.onShowAlertModal} />, document.getElementById("container"));
+            onShowAlertModal={testHandlers.onShowAlertModal}
+            onUpdateOriginalSettings={testHandlers.onUpdateOriginalSettings}
+            onUpdateInitialSettings={testHandlers.onUpdateInitialSettings} />, document.getElementById("container"));
 
         const testClose = document.getElementById('test-close');
         TestUtils.Simulate.click(testClose);
@@ -270,6 +286,9 @@ describe("test updateSettingsLifecycle", () => {
         expect(spyOnUpdateNode).toHaveBeenCalled();
         expect(spyOnHideSettings).toHaveBeenCalled();
         expect(spyOnShowAlertModal).toHaveBeenCalled();
+
+        expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
+        expect(spyOnUpdateInitialSettings).toHaveBeenCalled();
     });
 
     it('test component on update params', () => {
@@ -294,7 +313,7 @@ describe("test updateSettingsLifecycle", () => {
 
         const testUpdateParams = document.getElementById('test-update-params');
         TestUtils.Simulate.click(testUpdateParams);
-        expect(spyOnUpdateOriginalSettings.calls.length).toBe(1);
+        expect(spyOnUpdateOriginalSettings.calls.length).toBe(2);
         expect(spyOnUpdateSettings).toHaveBeenCalled();
         expect(spyOnUpdateNode).toHaveBeenCalled();
     });
@@ -321,7 +340,7 @@ describe("test updateSettingsLifecycle", () => {
 
         const testUpdateParams = document.getElementById('test-update-params');
         TestUtils.Simulate.click(testUpdateParams);
-        expect(spyOnUpdateOriginalSettings.calls.length).toBe(1);
+        expect(spyOnUpdateOriginalSettings.calls.length).toBe(2);
         expect(spyOnUpdateSettings).toHaveBeenCalled();
         expect(spyOnUpdateNode).toNotHaveBeenCalled();
     });

--- a/web/client/components/TOC/enhancers/tocItemsSettings.js
+++ b/web/client/components/TOC/enhancers/tocItemsSettings.js
@@ -52,7 +52,9 @@ const settingsLifecycle = compose(
             Object.keys(newParams).forEach((key) => {
                 originalSettings[key] = initialSettings && initialSettings[key];
             });
+            // update changed keys to verify only modified values (internal state)
             onUpdateOriginalSettings(originalSettings);
+
             onUpdateSettings(newParams);
             if (update) {
                 onUpdateNode(
@@ -95,7 +97,9 @@ const settingsLifecycle = compose(
                 onUpdateInitialSettings = () => { }
             } = this.props;
 
+            // store changed keys
             onUpdateOriginalSettings({ ...element });
+            // store initial settings (internal state)
             onUpdateInitialSettings({ ...element });
         },
         componentWillReceiveProps(newProps) {

--- a/web/client/components/TOC/enhancers/tocItemsSettings.js
+++ b/web/client/components/TOC/enhancers/tocItemsSettings.js
@@ -43,6 +43,7 @@ const settingsLifecycle = compose(
             settings = {},
             initialSettings = {},
             originalSettings: orig,
+            onUpdateOriginalSettings = () => {},
             onUpdateSettings = () => {},
             onUpdateNode = () => {}
         }) => (newParams, update = true) => {
@@ -51,6 +52,7 @@ const settingsLifecycle = compose(
             Object.keys(newParams).forEach((key) => {
                 originalSettings[key] = initialSettings && initialSettings[key];
             });
+            onUpdateOriginalSettings(originalSettings);
             onUpdateSettings(newParams);
             if (update) {
                 onUpdateNode(
@@ -60,7 +62,7 @@ const settingsLifecycle = compose(
                 );
             }
         },
-        onClose: ({ onUpdateNode, originalSettings, settings, onHideSettings, onShowAlertModal }) => forceClose => {
+        onClose: ({ onUpdateInitialSettings = () => {}, onUpdateOriginalSettings = () => {}, onUpdateNode, originalSettings, settings, onHideSettings, onShowAlertModal }) => forceClose => {
             const originalOptions = Object.keys(settings.options).reduce((options, key) => ({ ...options, [key]: key === 'opacity' && !originalSettings[key] && 1.0 || originalSettings[key] }), {});
             if (!isEqual(originalOptions, settings.options) && !forceClose) {
                 onShowAlertModal(true);
@@ -72,11 +74,17 @@ const settingsLifecycle = compose(
                 );
                 onHideSettings();
                 onShowAlertModal(false);
+                // clean up internal settings state
+                onUpdateOriginalSettings({});
+                onUpdateInitialSettings({});
             }
         },
-        onSave: ({ onHideSettings = () => { }, onShowAlertModal = () => { } }) => () => {
+        onSave: ({ onUpdateInitialSettings = () => {}, onUpdateOriginalSettings = () => {}, onHideSettings = () => { }, onShowAlertModal = () => { } }) => () => {
             onHideSettings();
             onShowAlertModal(false);
+            // clean up internal settings state
+            onUpdateOriginalSettings({});
+            onUpdateInitialSettings({});
         }
     }),
     lifecycle({


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - Fix #3078
 - Fix #3057

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
#3078

**What is the new behavior?**
You can decide if save or close without save

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
