### PR TITLE
Fix #3087 support viewparams in featuregrid

### DIFF
--- a/web/client/actions/__tests__/wfsquery-test.js
+++ b/web/client/actions/__tests__/wfsquery-test.js
@@ -96,6 +96,13 @@ describe('wfsquery actions', () => {
         expect(searchUrl).toBe("searchUrl");
         expect(filterObj).toBe("filterObj");
     });
+    it('query with query options', () => {
+        let { type, searchUrl, filterObj, queryOptions } = query("searchUrl", "filterObj", "queryOptions");
+        expect(type).toBe(QUERY);
+        expect(searchUrl).toBe("searchUrl");
+        expect(filterObj).toBe("filterObj");
+        expect(queryOptions).toBe("queryOptions");
+    });
     it('resetQuery', () => {
         let {type} = resetQuery();
         expect(type).toBe(RESET_QUERY);

--- a/web/client/actions/wfsquery.js
+++ b/web/client/actions/wfsquery.js
@@ -132,11 +132,12 @@ function createQuery(searchUrl, filterObj) {
     };
 }
 
-function query(searchUrl, filterObj) {
+function query(searchUrl, filterObj, queryOptions) {
     return {
         type: QUERY,
         searchUrl,
-        filterObj
+        filterObj,
+        queryOptions
     };
 }
 

--- a/web/client/actions/wfsquery.js
+++ b/web/client/actions/wfsquery.js
@@ -85,12 +85,13 @@ function featureError(typeName, error) {
     };
 }
 
-function querySearchResponse(result, searchUrl, filterObj) {
+function querySearchResponse(result, searchUrl, filterObj, queryOptions) {
     return {
         type: QUERY_RESULT,
         searchUrl,
         filterObj,
-        result
+        result,
+        queryOptions
     };
 }
 function queryError(error) {

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -13,7 +13,36 @@ const proj4 = Proj4js;
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
 const { hideMapinfoMarker, featureInfoClick} = require('../../actions/mapInfo');
 
-const { toggleEditMode, toggleViewMode, openFeatureGrid, OPEN_FEATURE_GRID, SET_LAYER, DELETE_GEOMETRY_FEATURE, deleteGeometry, createNewFeatures, CLOSE_FEATURE_GRID, TOGGLE_MODE, MODES, closeFeatureGridConfirm, clearChangeConfirmed, CLEAR_CHANGES, TOGGLE_TOOL, closeFeatureGridConfirmed, zoomAll, START_SYNC_WMS, STOP_SYNC_WMS, startDrawingFeature, startEditingFeature, closeFeatureGrid, GEOMETRY_CHANGED, openAdvancedSearch, moreFeatures, GRID_QUERY_RESULT } = require('../../actions/featuregrid');
+const {
+    toggleEditMode,
+    toggleViewMode,
+    openFeatureGrid,
+    OPEN_FEATURE_GRID,
+    SET_LAYER,
+    DELETE_GEOMETRY_FEATURE,
+    deleteGeometry,
+    createNewFeatures,
+    CLOSE_FEATURE_GRID,
+    TOGGLE_MODE,
+    MODES,
+    closeFeatureGridConfirm,
+    clearChangeConfirmed,
+    CLEAR_CHANGES,
+    TOGGLE_TOOL,
+    closeFeatureGridConfirmed,
+    zoomAll,
+    START_SYNC_WMS,
+    STOP_SYNC_WMS,
+    startDrawingFeature,
+    startEditingFeature,
+    closeFeatureGrid,
+    GEOMETRY_CHANGED,
+    openAdvancedSearch,
+    moreFeatures,
+    GRID_QUERY_RESULT,
+    changePage,
+    sort
+} = require('../../actions/featuregrid');
 const {SET_HIGHLIGHT_FEATURES_PATH} = require('../../actions/highlight');
 const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
@@ -27,7 +56,37 @@ const {geometryChanged} = require('../../actions/draw');
 const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery');
 
 
-const { setHighlightFeaturesPath, triggerDrawSupportOnSelectionChange, featureGridLayerSelectionInitialization, closeRightPanelOnFeatureGridOpen, deleteGeometryFeature, onFeatureGridCreateNewFeature, resetGridOnLocationChange, resetQueryPanel, autoCloseFeatureGridEpicOnDrowerOpen, askChangesConfirmOnFeatureGridClose, onClearChangeConfirmedFeatureGrid, onCloseFeatureGridConfirmed, onFeatureGridZoomAll, resetControlsOnEnterInEditMode, closeIdentifyEpic, startSyncWmsFilter, stopSyncWmsFilter, handleDrawFeature, handleEditFeature, resetEditingOnFeatureGridClose, onFeatureGridGeometryEditing, syncMapWmsFilter, onOpenAdvancedSearch, virtualScrollLoadFeatures, removeWmsFilterOnGridClose, autoReopenFeatureGridOnFeatureInfoClose} = require('../featuregrid');
+const {
+    setHighlightFeaturesPath,
+    triggerDrawSupportOnSelectionChange,
+    featureGridLayerSelectionInitialization,
+    closeRightPanelOnFeatureGridOpen,
+    deleteGeometryFeature,
+    onFeatureGridCreateNewFeature,
+    resetGridOnLocationChange,
+    resetQueryPanel,
+    autoCloseFeatureGridEpicOnDrowerOpen,
+    askChangesConfirmOnFeatureGridClose,
+    onClearChangeConfirmedFeatureGrid,
+    onCloseFeatureGridConfirmed,
+    onFeatureGridZoomAll,
+    resetControlsOnEnterInEditMode,
+    closeIdentifyEpic,
+    startSyncWmsFilter,
+    stopSyncWmsFilter,
+    handleDrawFeature,
+    handleEditFeature,
+    resetEditingOnFeatureGridClose,
+    onFeatureGridGeometryEditing,
+    syncMapWmsFilter,
+    onOpenAdvancedSearch,
+    virtualScrollLoadFeatures,
+    removeWmsFilterOnGridClose,
+    autoReopenFeatureGridOnFeatureInfoClose,
+    featureGridChangePage,
+    featureGridSort
+}
+    = require('../featuregrid');
 
 
 const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
@@ -519,6 +578,7 @@ const stateWithGmlGeometry = {
 };
 
 describe('featuregrid Epics', () => {
+
     it('test startSyncWmsFilter with nativeCrs absent in layer props, but no definition registered in proj4 defs', (done) => {
         const stateFeaturegrid = {
             featuregrid: {
@@ -1458,6 +1518,7 @@ describe('featuregrid Epics', () => {
             done();
         }, newState);
     });
+
     it('test virtualScrollLoadFeatures to dispatch query action', (done) => {
         const stateFeaturegrid = {
             featuregrid: {
@@ -1483,6 +1544,50 @@ describe('featuregrid Epics', () => {
                     case QUERY:
                         expect(action.filterObj.pagination.startIndex).toBe(0);
                         expect(action.filterObj.pagination.maxFeatures).toBe(30);
+                        break;
+                    default:
+                        expect(true).toBe(true);
+                }
+            });
+            done();
+        }, newState);
+    });
+    it('test virtualScrollLoadFeatures to dispatch also viewparams', (done) => {
+        const stateFeaturegrid = {
+            layers: {
+                flat: [{
+                    id: "TEST__6",
+                    title: "Test Layer",
+                    name: 'editing:polygons',
+                    params: {
+                        viewParams: "a:b"
+                    }
+                }]
+            },
+            featuregrid: {
+                open: true,
+                selectedLayer: "TEST__6",
+                mode: 'EDIT',
+                select: [{ id: 'polygons.1', _new: 'polygons._new' }],
+                changes: [],
+                pages: [],
+                pagination: {
+                    size: 10
+                },
+                features: []
+            }
+        };
+
+        const newState = assign({}, state, stateFeaturegrid);
+        testEpic(virtualScrollLoadFeatures, 1, [moreFeatures({ startPage: 0, endPage: 2 })], actions => {
+
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                    case QUERY:
+                        expect(action.filterObj.pagination.startIndex).toBe(0);
+                        expect(action.filterObj.pagination.maxFeatures).toBe(30);
+                        expect(action.queryOptions.viewParams).toBe("a:b");
                         break;
                     default:
                         expect(true).toBe(true);
@@ -1602,4 +1707,95 @@ describe('featuregrid Epics', () => {
             hideMapinfoMarker()],
         epicResult);
     });
+
+    it('featureGridChangePage', done => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === QUERY) {
+                    done();
+                }
+            });
+        };
+        testEpic(featureGridChangePage, 1, [changePage(0, 10)], epicResult);
+    });
+    it('featureGridChangePage manages queryOptions viewparams', done => {
+
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === QUERY) {
+                    expect(action.queryOptions.viewParams).toBe("a:b");
+                    done();
+                }
+            });
+        };
+        testEpic(featureGridChangePage, 1, [changePage(0, 10)], epicResult, () => ({
+            layers: {
+                flat: [{
+                    id: "TEST_LAYER",
+                    title: "Test Layer",
+                    name: 'editing:polygons',
+                    params: {
+                        viewParams: "a:b"
+                    }
+                }]
+            }, featuregrid: {
+                open: true,
+                    selectedLayer: "TEST_LAYER",
+                        changes: []
+            }
+        }));
+    });
+
+    it('featureGridSort', done => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === QUERY) {
+                    done();
+                }
+            });
+        };
+        testEpic(featureGridSort, 1, [sort("ATTR", "ASC")], epicResult, {
+            featuregrid: {
+                pagination: {
+                    size: 10
+                }
+            }
+        });
+    });
+
+    it('featureGridSort manages queryOptions viewparams', done => {
+
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                if (action.type === QUERY) {
+                    expect(action.queryOptions.viewParams).toBe("a:b");
+                    done();
+                }
+            });
+        };
+        testEpic(featureGridSort, 1, [sort("ATTR", "ASC")], epicResult, () => ({
+            layers: {
+                flat: [{
+                    id: "TEST_LAYER",
+                    title: "Test Layer",
+                    name: 'editing:polygons',
+                    params: {
+                        viewParams: "a:b"
+                    }
+                }]
+            }, featuregrid: {
+                pagination: {
+                    size: 10
+                },
+                open: true,
+                selectedLayer: "TEST_LAYER",
+                changes: []
+            }
+        }));
+    });
+
 });

--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -62,9 +62,28 @@ describe('wfsquery Epics', () => {
             done();
         }, {});
     });
+    it('wfsQueryEpic passes query options', (done) => {
+        const expectedResult = require('json-loader!../../test-resources/wfs/museam.json');
+        testEpic(wfsQueryEpic, 2, query("base/web/client/test-resources/wfs/museam.json", { pagination: {} }, {viewParams: "a:b"}), actions => {
+            expect(actions.length).toBe(2);
+            actions.map((action) => {
+                switch (action.type) {
+                    case QUERY_RESULT:
+                        expect(action.result).toEqual(expectedResult);
+                        expect(action.queryOptions.viewParams).toEqual("a:b");
+                        break;
+                    case FEATURE_LOADING:
+                        break;
+                    default:
+                        expect(false).toBe(true);
+                }
+            });
+            done();
+        }, {});
+    });
     // this avoids race condition of state changes when update query is performed
     it('wfsQueryEpic stop on update query', (done) => {
-        testEpic(addTimeoutEpic(wfsQueryEpic), 2, [
+        testEpic(addTimeoutEpic(wfsQueryEpic, 50), 2, [
             query("base/web/client/test-resources/wfs/museam.json", {pagination: {} }),
             updateQuery()
             ], actions => {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -44,7 +44,7 @@ const {setHighlightFeaturesPath} = require('../actions/highlight');
 
 const {selectedFeaturesSelector, changesMapSelector, newFeaturesSelector, hasChangesSelector, hasNewFeaturesSelector,
     selectedFeatureSelector, selectedFeaturesCount, selectedLayerIdSelector, isDrawingSelector, modeSelector,
-    isFeatureGridOpen, hasSupportedGeometry} = require('../selectors/featuregrid');
+    isFeatureGridOpen, hasSupportedGeometry, queryOptionsSelector} = require('../selectors/featuregrid');
 const {queryPanelSelector} = require('../selectors/controls');
 
 const {error, warning} = require('../actions/notifications');
@@ -157,7 +157,6 @@ const createDeleteFlow = (features, describeFeatureType, url) => save(
     url,
     createDeleteTransaction(features, requestBuilder(describeFeatureType))
 );
-
 const createLoadPageFlow = (store) => ({page, size} = {}) => {
     const state = store.getState();
     return Rx.Observable.of( query(
@@ -166,7 +165,8 @@ const createLoadPageFlow = (store) => ({page, size} = {}) => {
                     ...(wfsFilter(state))
                 },
                 getPagination(state, {page, size})
-            )
+            ),
+            queryOptionsSelector(state)
     ));
 };
 
@@ -251,7 +251,8 @@ module.exports = {
                             sortOptions: {sortBy, sortOrder}
                         },
                         getPagination(store.getState())
-                    )
+                ),
+                queryOptionsSelector(store.getState())
             ))
             .merge(action$.ofType(QUERY_RESULT)
                     .map((ra) => fatureGridQueryResult(get(ra, "result.features", []), [get(ra, "filterObj.pagination.startIndex")]))
@@ -297,7 +298,8 @@ module.exports = {
                             ...wfsFilter(store.getState())
                         },
                         getPagination(store.getState(), {page: page, size})
-                    )
+                    ),
+                    queryOptionsSelector(store.getState())
                 ),
                 refreshLayerVersion(selectedLayerIdSelector(store.getState()))
             )
@@ -746,7 +748,8 @@ module.exports = {
                                 ...(wfsFilter(state))
                                 },
                                 {startIndex: nPs[0] * size, maxFeatures: needPages * size }
-                            )
+                    ),
+                    queryOptionsSelector(state)
                     )).filter(() => nPs.length > 0)
                 .merge( action$.ofType(QUERY_RESULT)
                     .filter(() => nPs.length > 0)

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -117,7 +117,7 @@ const wfsQueryEpic = (action$, store) =>
                         sortOptions,
                         ...queryOptions
                     })
-                    .map(data => querySearchResponse(data, action.searchUrl, action.filterObj))
+                    .map(data => querySearchResponse(data, action.searchUrl, action.filterObj, action.queryOptions))
                     .catch(error => Rx.Observable.of(queryError(error)))
                     .startWith(featureLoading(true))
                     .concat(Rx.Observable.of(featureLoading(false)))

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -109,11 +109,13 @@ const wfsQueryEpic = (action$, store) =>
         .switchMap(action => {
             const sortOptions = getDefaultSortOptions(getFirstAttribute(store.getState()));
             const totalFeatures = paginationInfo.totalFeatures(store.getState());
+            const queryOptions = action.queryOptions || {};
             const searchUrl = ConfigUtils.filterUrlParams(action.searchUrl, authkeyParamNameSelector(store.getState()));
             return Rx.Observable.merge(
                     getJSONFeatureWA(searchUrl, action.filterObj, {
                         totalFeatures,
-                        sortOptions
+                        sortOptions,
+                        ...queryOptions
                     })
                     .map(data => querySearchResponse(data, action.searchUrl, action.filterObj))
                     .catch(error => Rx.Observable.of(queryError(error)))

--- a/web/client/observables/wfs.js
+++ b/web/client/observables/wfs.js
@@ -90,7 +90,7 @@ const getPagination = (filterObj = {}, options = {}) =>
  * @return {Observable} a stream that emits the GeoJSON or an error.
  */
 const getJSONFeature = (searchUrl, filterObj, options = {}) => {
-    const data = FilterUtils.getWFSFilterData(filterObj);
+    const data = FilterUtils.getWFSFilterData(filterObj, options);
 
     const urlParsedObj = Url.parse(searchUrl, true);
     let params = isObject(urlParsedObj.query) ? urlParsedObj.query : {};
@@ -129,7 +129,7 @@ const getJSONFeatureWA = (searchUrl, filterObj, { sortOptions = {}, ...options }
                 return getJSONFeature(searchUrl, {
                     ...filterObj,
                     sortOptions
-                }, {options});
+                }, options);
             }
             throw error;
         });
@@ -172,9 +172,9 @@ module.exports = {
             Rx.Observable.defer( () => axios.get(toLayerCapabilitiesURL(layer)))
             .let(interceptOGCError)
             .switchMap( response => Rx.Observable.bindNodeCallback( (data, callback) => parseString(data, {
-                 tagNameProcessors: [stripPrefix],
-                 explicitArray: false,
-                 mergeAttrs: true
+                tagNameProcessors: [stripPrefix],
+                explicitArray: false,
+                mergeAttrs: true
             }, callback))(response.data)
         )
 

--- a/web/client/plugins/widgetbuilder/enhancers/connection/viewportBuilderConnect.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/viewportBuilderConnect.js
@@ -16,5 +16,5 @@ module.exports = compose(
         canConnect: editorData.geomProp,
         connected: editorData.mapSync
     })),
-    withMapConnect({viewport: "viewport"})
+    withMapConnect({viewport: "viewport", layers: "layers"})
 );

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -63,7 +63,6 @@ function widgetsReducer(state = emptyState, action) {
         case EDIT_NEW: {
             return set(`builder.editor`, action.widget,
                 set("builder.settings", action.settings || emptyState.settings, state));
-
         }
         case EDIT: {
             return set(`builder.editor`, {
@@ -80,15 +79,15 @@ function widgetsReducer(state = emptyState, action) {
             return set(`builder.editor.${action.key}`, action.value, state);
         }
         case INSERT:
-           let tempState = arrayUpsert(`containers[${action.target}].widgets`, {
-               id: action.id,
-               ...action.widget,
-               dataGrid: action.id && {y: 0, x: 0, w: 1, h: 1}
-           }, {
-               id: action.widget.id || action.id
-           }, state);
+            let tempState = arrayUpsert(`containers[${action.target}].widgets`, {
+                id: action.id,
+                ...action.widget,
+                dataGrid: action.id && {y: 0, x: 0, w: 1, h: 1}
+            }, {
+                id: action.widget.id || action.id
+            }, state);
 
-           return tempState;
+            return tempState;
         case UPDATE_PROPERTY:
             return arrayUpsert(`containers[${action.target}].widgets`,
                 // update the widget setting the value to the existing object

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -31,7 +31,8 @@ const {
     showPopoverSyncSelector,
     hasSupportedGeometry,
     getDockSize,
-    selectedLayerNameSelector
+    selectedLayerNameSelector,
+    queryOptionsSelector
 } = require('../featuregrid');
 
 const idFt1 = "idFt1";
@@ -482,14 +483,34 @@ describe('Test featuregrid selectors', () => {
                 name: 'editing:polygons'
             }]
         }, featuregrid: {
-          open: true,
-          selectedLayer: "TEST_LAYER",
-          mode: modeEdit,
-          select: [feature1, feature2],
-          changes: [{id: feature2.id, updated: {geometry: null}}]
+            open: true,
+            selectedLayer: "TEST_LAYER",
+            mode: modeEdit,
+            select: [feature1, feature2],
+            changes: [{id: feature2.id, updated: {geometry: null}}]
         }};
         expect(selectedLayerNameSelector(state)).toBe('editing:polygons');
         expect(selectedLayerNameSelector({})).toBe('');
     });
-
+    it('test queryOptionsSelector', () => {
+        const state = {
+            ...initialState, layers: {
+                flat: [{
+                    id: "TEST_LAYER",
+                    title: "Test Layer",
+                    name: 'editing:polygons',
+                    params: {
+                        viewParams: "a:b"
+                    }
+                }]
+            }, featuregrid: {
+                open: true,
+                selectedLayer: "TEST_LAYER",
+                mode: modeEdit,
+                select: [feature1, feature2],
+                changes: [{ id: feature2.id, updated: { geometry: null } }]
+            }
+        };
+        expect(queryOptionsSelector(state).viewParams).toBe("a:b");
+    });
 });

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -6,7 +6,7 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-const { head, get, pick, isObject} = require('lodash');
+const { head, get, isObject} = require('lodash');
 const {layersSelector} = require('./layers');
 const {findGeometryProperty} = require('../utils/ogc/WFS/base');
 const {currentLocaleSelector} = require('../selectors/locale');
@@ -77,8 +77,8 @@ module.exports = {
    * @param  {object}  state applications state
    * @return {Boolean}       true if the featuregrid is open, false otherwise
    */
-  isFeatureGridOpen: state => state && state.featuregrid && state.featuregrid.open,
-  getAttributeFilters,
+    isFeatureGridOpen: state => state && state.featuregrid && state.featuregrid.open,
+    getAttributeFilters,
   /**
    * get a filter for an attribute
    * @memberof selectors.featuregrid
@@ -86,19 +86,19 @@ module.exports = {
    * @param  {string} name  The name of the attribute
    * @return {object}       The filter for the attribute
    */
-  getAttributeFilter: (state, name) => get(getAttributeFilters(state), name),
-  selectedLayerIdSelector,
-  getCustomAttributeSettings,
+    getAttributeFilter: (state, name) => get(getAttributeFilters(state), name),
+    selectedLayerIdSelector,
+    getCustomAttributeSettings,
   /**
    * Get's the title of the selected layer
    * @memberof selectors.featuregrid
    * @param  {object} state the application's state
    * @return {startDrawingFeature} the title of the current selected layer
    */
-  getTitleSelector: state => {
-      const title = getTitle(getLayerById(state, selectedLayerIdSelector(state)));
-      return isObject(title) ? title[currentLocaleSelector(state)] || title.default || '' : title;
-  },
+    getTitleSelector: state => {
+        const title = getTitle(getLayerById(state, selectedLayerIdSelector(state)));
+        return isObject(title) ? title[currentLocaleSelector(state)] || title.default || '' : title;
+    },
     getCustomizedAttributes: state => {
         return (attributesSelector(state) || []).map(att => {
             const custom = getCustomAttributeSettings(state, att);

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -6,7 +6,7 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-const {head, get, isObject} = require('lodash');
+const { head, get, pick, isObject} = require('lodash');
 const {layersSelector} = require('./layers');
 const {findGeometryProperty} = require('../utils/ogc/WFS/base');
 const {currentLocaleSelector} = require('../selectors/locale');
@@ -63,7 +63,7 @@ const hasSupportedGeometry = state => head(notSupportedGeometries.filter(g => ge
 const hasChangesSelector = state => changesSelector(state) && changesSelector(state).length > 0;
 const hasNewFeaturesSelector = state => newFeaturesSelector(state) && newFeaturesSelector(state).length > 0;
 const getAttributeFilters = state => state && state.featuregrid && state.featuregrid.filters;
-
+const selectedLayerParamsSelector = state => get(getLayerById(state, selectedLayerIdSelector(state)), "params");
 /**
  * selects featuregrid state
  * @name featuregrid
@@ -152,5 +152,16 @@ module.exports = {
     selectedLayerNameSelector: state => {
         const layer = getLayerById(state, selectedLayerIdSelector(state));
         return layer && layer.name || '';
+
+    },
+    queryOptionsSelector: state => {
+        const params = selectedLayerParamsSelector(state);
+        const viewParams = params && (params.VIEWPARAMS || params.viewParams || params.viewparams);
+        if (viewParams) {
+            return {
+                viewParams
+            };
+        }
+        return {};
     }
 };

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -463,7 +463,7 @@ const FilterUtils = {
 
         return ogcSpatialOperators[objFilter.spatialField.operation](nsplaceholder, ogc);
     },
-    getGetFeatureBase: function(version, pagination, hits, format, options) {
+    getGetFeatureBase: function(version, pagination, hits, format, options = {}) {
         let ver = normalizeVersion(version);
 
         let getFeature = '<wfs:GetFeature ';

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -307,7 +307,7 @@ const FilterUtils = {
         const nsplaceholder = versionOGC === "2.0" ? "fes" : "ogc";
 
 
-        let ogcFilter = this.getGetFeatureBase(versionOGC, objFilter.pagination, hits, format);
+        let ogcFilter = this.getGetFeatureBase(versionOGC, objFilter.pagination, hits, format, json && json.options);
 
         let filters = this.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
         let filter = "";
@@ -463,13 +463,13 @@ const FilterUtils = {
 
         return ogcSpatialOperators[objFilter.spatialField.operation](nsplaceholder, ogc);
     },
-    getGetFeatureBase: function(version, pagination, hits, format) {
+    getGetFeatureBase: function(version, pagination, hits, format, options) {
         let ver = normalizeVersion(version);
 
         let getFeature = '<wfs:GetFeature ';
         getFeature += format ? 'outputFormat="' + format + '" ' : '';
         getFeature += pagination && (pagination.startIndex || pagination.startIndex === 0) ? 'startIndex="' + pagination.startIndex + '" ' : "";
-
+        getFeature += options.viewParams ? ` viewParams="${options.viewParams}" ` : "";
         switch (ver) {
         case "1.0.0":
             getFeature += pagination && pagination.maxFeatures ? 'maxFeatures="' + pagination.maxFeatures + '" ' : "";
@@ -893,13 +893,13 @@ const FilterUtils = {
     ogcListField,
     ogcBooleanField,
     ogcStringField,
-    getWFSFilterData: (filterObj) => {
+    getWFSFilterData: (filterObj, options) => {
         let data;
         if (typeof filterObj === 'string') {
             data = filterObj;
         } else {
             data = filterObj.filterType === "OGC"
-                ? FilterUtils.toOGCFilter(filterObj.featureTypeName, filterObj, filterObj.ogcVersion, filterObj.sortOptions, filterObj.hits)
+                ? FilterUtils.toOGCFilter(filterObj.featureTypeName, {...filterObj, options}, filterObj.ogcVersion, filterObj.sortOptions, filterObj.hits)
                 : FilterUtils.toCQLFilter(filterObj);
         }
         return data;

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -344,6 +344,12 @@ describe('FilterUtils', () => {
             }
         });
     });
+    it('getGetFeatureBase gets viewParams', () => {
+        const version = "2.0";
+        const base = FilterUtils.getGetFeatureBase(version, null, false, "application/json", {viewParams: "a:b"});
+        expect(base.indexOf('viewParams="a:b"') > 0).toBeTruthy();
+        expect(FilterUtils.getGetFeatureBase(version, null, false, "application/json", { cql_filter: "a:b" }).indexOf('viewParams="a:b"') > 0).toBeFalsy();
+    });
     it('Check for undefined or null values for string and number and list in ogc filter', () => {
         let filterObj = {
             filterFields: [{

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -73,6 +73,7 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wf
         gmlV = "3.1.1";
     }
     const requestAttributes = ({
+        viewParams,
         resultType,
         outputFormat,
         startIndex,
@@ -83,7 +84,8 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wf
             + (resultType ? ` resultType="${resultType}"` : "")
             + (outputFormat ? ` outputFormat="${outputFormat}"` : ``)
             + ((startIndex || startIndex === 0) ? ` startIndex="${startIndex}"` : "")
-            + ((maxFeatures || maxFeatures === 0) ? ` ${getMaxFeatures(maxFeatures)}` : "");
+            + ((maxFeatures || maxFeatures === 0) ? ` ${getMaxFeatures(maxFeatures)}` : "")
+            + (viewParams ? ` viewParams="${viewParams}"` : "");
     };
     const propertyName = (property) =>
         castArray(property)


### PR DESCRIPTION
## Description
Now if the selected layer has some viewparams, these params are used to perform the query also in feature grid.

## Issues
 - Fix #3087

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Viewparams are not supported in feature grid (see #2087)

**What is the new behavior?**
Introduced support for view params, when present, on featuregrid. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No


