### PR TITLE
Fix #3088 viewparams support for widgets

### DIFF
--- a/web/client/components/widgets/builder/wizard/ChartWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/ChartWizard.jsx
@@ -21,12 +21,14 @@ const sampleData = require('../../enhancers/sampleChartData');
 const wpsChart = require('../../enhancers/wpsChart');
 const dependenciesToWidget = require('../../enhancers/dependenciesToWidget');
 const dependenciesToFilter = require('../../enhancers/dependenciesToFilter');
+const dependenciesToOptions = require('../../enhancers/dependenciesToOptions');
 const emptyChartState = require('../../enhancers/emptyChartState');
 const errorChartState = require('../../enhancers/errorChartState');
 const { compose, lifecycle } = require('recompose');
 const enhancePreview = compose(
     dependenciesToWidget,
     dependenciesToFilter,
+    dependenciesToOptions,
     wpsChart,
     loadingState,
     errorChartState,

--- a/web/client/components/widgets/builder/wizard/CounterWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/CounterWizard.jsx
@@ -19,6 +19,7 @@ const WidgetOptions = require('./common/WidgetOptions');
 
 const wpsCounter = require('../../enhancers/wpsCounter');
 const dependenciesToFilter = require('../../enhancers/dependenciesToFilter');
+const dependenciesToOptions = require('../../enhancers/dependenciesToOptions');
 const dependenciesToWidget = require('../../enhancers/dependenciesToWidget');
 const emptyChartState = require('../../enhancers/emptyChartState');
 const errorChartState = require('../../enhancers/errorChartState');
@@ -37,6 +38,7 @@ const triggerSetValid = compose(
 const enhancePreview = compose(
     dependenciesToWidget,
     dependenciesToFilter,
+    dependenciesToOptions,
     wpsCounter,
     triggerSetValid,
     loadingState,

--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToOptions-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToOptions-test.jsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {createSink} = require('recompose');
+const expect = require('expect');
+const dependenciesToOptions = require('../dependenciesToOptions');
+
+describe('widgets dependenciesToOptions enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('dependenciesToOptions default', (done) => {
+        const Sink = dependenciesToOptions(createSink( props => {
+            expect(props).toExist();
+            expect(props.options).toBe(undefined);
+            done();
+        }));
+        ReactDOM.render(<Sink />, document.getElementById("container"));
+    });
+    it('dependenciesToOptions default', (done) => {
+        const options = {
+            a: "a"
+        };
+        const Sink = dependenciesToOptions(createSink( props => {
+            expect(props).toExist();
+            expect(props.options).toBe(options);
+            done();
+        }));
+        ReactDOM.render(<Sink options={options}/>, document.getElementById("container"));
+    });
+    it('dependenciesToOptions with viewParams', (done) => {
+        const options = {
+            a: "a"
+        };
+        const Sink = dependenciesToOptions(createSink( props => {
+            expect(props).toExist();
+            expect(props.options.a).toBe("a");
+            expect(props.options.viewParams).toBe("a:b");
+            done();
+        }));
+        ReactDOM.render(<Sink
+            mapSync
+            geomProp={"geometry"}
+            // this is the layer saved in config (copy)
+            layer={{id: 1}}
+            dependencies={ {
+            // retrieves the view params from layers (original list)
+            layers: [{
+                id: 1,
+                params: { viewParams: "a:b" }
+            }]
+            } }
+            options={options}/>, document.getElementById("container"));
+    });
+});

--- a/web/client/components/widgets/enhancers/dependenciesToOptions.js
+++ b/web/client/components/widgets/enhancers/dependenciesToOptions.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {compose, withPropsOnChange} = require('recompose');
+
+/**
+ * Merges filter object and dependencies map into an ogc filter
+ */
+module.exports = compose(
+    withPropsOnChange(
+        ({dependencies = {}} = {}, nextProps = {}) =>
+            dependencies.viewParams !== (nextProps.dependencies && nextProps.dependencies.viewParams),
+        ({dependencies = {}, options} = {}) => {
+            return {
+                options: dependencies.viewParams ? {
+                    ...options,
+                    viewParams: dependencies.viewParams
+                } : options
+            };
+        }
+    )
+
+);

--- a/web/client/components/widgets/enhancers/dependenciesToOptions.js
+++ b/web/client/components/widgets/enhancers/dependenciesToOptions.js
@@ -12,8 +12,7 @@ const {compose, withPropsOnChange} = require('recompose');
  */
 module.exports = compose(
     withPropsOnChange(
-        ({dependencies = {}} = {}, nextProps = {}) =>
-            dependencies.viewParams !== (nextProps.dependencies && nextProps.dependencies.viewParams),
+        ['dependencies', 'options'],
         ({dependencies = {}, options} = {}) => {
             return {
                 options: dependencies.viewParams ? {

--- a/web/client/components/widgets/enhancers/dependenciesToOptions.js
+++ b/web/client/components/widgets/enhancers/dependenciesToOptions.js
@@ -6,18 +6,30 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {compose, withPropsOnChange} = require('recompose');
-
+const {get, find} = require('lodash');
 /**
- * Merges filter object and dependencies map into an ogc filter
+ * Merges options and original layer's data to get the final options (with viewParams added)
  */
 module.exports = compose(
     withPropsOnChange(
         ['dependencies', 'options'],
-        ({dependencies = {}, options} = {}) => {
+        ({ dependencies = {}, options, layer = {}} = {}) => {
+            const params =
+                layer
+                    && layer.id
+                    && get(
+                        find(dependencies.layers || [], {
+                            id: layer.id
+                        }),
+                        "params",
+                        {}
+                    );
+            const viewParamsKey = find(Object.keys(params || {}), (k = "") => k.toLowerCase() === "viewparams");
+            const viewParams = params && viewParamsKey && params[viewParamsKey];
             return {
-                options: dependencies.viewParams ? {
+                options: viewParams ? {
                     ...options,
-                    viewParams: dependencies.viewParams
+                    viewParams
                 } : options
             };
         }

--- a/web/client/components/widgets/enhancers/wfsTable/__tests__/triggerFetch-test.js
+++ b/web/client/components/widgets/enhancers/wfsTable/__tests__/triggerFetch-test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const Rx = require('rxjs');
+
+const expect = require('expect');
+const triggerFetch = require('../triggerFetch');
+
+describe('triggerFetch stream', () => {
+
+    it('triggerFetch triggers on viewParams changes', (done) => {
+        const base = {
+            layer: { name: "TEST" },
+            options: {propertyName: ["A"]}
+        };
+        const propsChanges = [base, base, {...base, someUnusedProp: "TEST"}, {
+            ...base,
+            options: {
+                propertyName: base.options.propertyName,
+                viewParams: "a:b"
+            }
+        }];
+        triggerFetch(Rx.Observable.from(propsChanges))
+            .bufferCount(3)
+            .subscribe(
+                ([p1, p2]) => {
+                    expect(p1.options.viewParams).toNotExist();
+                    expect(p2.options.viewParams).toExist();
+                    done();
+                }
+            );
+    });
+    it('triggerFetch triggers on filter changes', (done) => {
+        const base = {
+            layer: {name: "TEST"},
+            filter: "TEST",
+            options: { propertyName: ["A"] }
+        };
+        const propsChanges = [base, base, { ...base, someUnusedProp: "TEST" }, {
+            ...base,
+            filter: "TEST2"
+        }];
+        triggerFetch(Rx.Observable.from(propsChanges))
+            .bufferCount(2)
+            .subscribe(
+                ([p1, p2]) => {
+                    expect(p1.filter).toBe("TEST");
+                    expect(p2.filter).toBe("TEST2");
+                    done();
+                }
+            );
+    });
+
+});

--- a/web/client/components/widgets/enhancers/wfsTable/noPaginationFetch.js
+++ b/web/client/components/widgets/enhancers/wfsTable/noPaginationFetch.js
@@ -15,14 +15,14 @@ const { getLayerJSONFeature } = require('../../../../observables/wfs');
 module.exports = props$ => props$.switchMap(
     ({
         layer = {},
-        options,
+        options = {},
         filter,
         onLoad = () => { },
         onLoadError = () => { }
     }) =>
         getLayerJSONFeature(layer, filter, {
             timeout: 15000,
-            params: { propertyName: options.propertyName }
+            params: { propertyName: options.propertyName, viewParams: options.viewParams }
             // TODO totalFeatures
             // TODO sortOptions - default
         })

--- a/web/client/components/widgets/enhancers/wfsTable/triggerFetch.js
+++ b/web/client/components/widgets/enhancers/wfsTable/triggerFetch.js
@@ -10,7 +10,8 @@ require('rxjs');
 const { getSearchUrl } = require('../../../../utils/LayersUtils');
 const sameFilter = (f1, f2) => f1 === f2;
 const sameOptions = (o1 = {}, o2 = {}) =>
-    o1.propertyName === o2.propertyName;
+    o1.propertyName === o2.propertyName
+    && o1.viewParams === o2.viewParams;
 const sameSortOptions = (o1 = {}, o2 = {}) =>
     o1.sortBy === o2.sortBy
     && o1.sortOrder === o2.sortOrder;

--- a/web/client/components/widgets/enhancers/wfsTable/virtualScrollFetch.js
+++ b/web/client/components/widgets/enhancers/wfsTable/virtualScrollFetch.js
@@ -16,7 +16,7 @@ const { getCurrentPaginationOptions, updatePages } = require('../../../../utils/
  * props to retrieve data using virtual scroll.
  */
 module.exports = pages$ => props$ => props$.switchMap(({
-            layer = {},
+    layer = {},
     size = 20,
     maxStoredPages = 5,
     filter,
@@ -29,7 +29,8 @@ module.exports = pages$ => props$ => props$.switchMap(({
         ...getCurrentPaginationOptions(pagesRange, pages, size),
         timeout: 15000,
         totalFeatures: pagination.totalFeatures, // this is needed to allow workaround of GEOS-7233
-        propertyName: options.propertyName
+        propertyName: options.propertyName,
+        viewParams: options.viewParams
         // TODO: defaultSortOptions - to skip primary-key issues
     })
         .do(data => onLoad({

--- a/web/client/components/widgets/enhancers/wpsChart.js
+++ b/web/client/components/widgets/enhancers/wpsChart.js
@@ -31,7 +31,8 @@ const sameFilter = (f1, f2) => f1 === f2;
 const sameOptions = (o1 = {}, o2 = {}) =>
     o1.aggregateFunction === o2.aggregateFunction
     && o1.aggregationAttribute === o2.aggregationAttribute
-    && o1.groupByAttributes === o2.groupByAttributes;
+    && o1.groupByAttributes === o2.groupByAttributes
+    && o1.viewParams === o2.viewParams;
 
 const getLayerUrl = l => l && l.wpsUrl || (l.search && l.search.url) || l.url;
 const dataStreamFactory = ($props) =>

--- a/web/client/components/widgets/enhancers/wpsCounter.js
+++ b/web/client/components/widgets/enhancers/wpsCounter.js
@@ -17,9 +17,17 @@ const wpsAggregateToCounterData = ({AggregationResults = [], GroupByAttributes =
 const sameFilter = (f1, f2) => f1 === f2;
 const sameOptions = (o1 = {}, o2 = {}) =>
     o1.aggregateFunction === o2.aggregateFunction
-    && o1.aggregationAttribute === o2.aggregationAttribute;
+    && o1.aggregationAttribute === o2.aggregationAttribute
+    && o1.viewParams === o2.viewParams;
 
 const getLayerUrl = l => l && l.wpsUrl || (l.search && l.search.url) || l.url;
+
+/**
+ * Stream of props -> props to retrieve data from WPS aggregate process on params changes.
+ * Can be used with widgets and charts to auto-update data on property changes.
+ * When new data is retrieved, calls also onLoad handler, or onLoadError if something went wrong.
+ *
+ */
 const dataStreamFactory = ($props) =>
     $props
         .filter(({layer = {}, options}) => layer.name && getLayerUrl(layer) && options && options.aggregateFunction && options.aggregationAttribute)

--- a/web/client/components/widgets/widget/DefaultWidget.jsx
+++ b/web/client/components/widgets/widget/DefaultWidget.jsx
@@ -13,11 +13,13 @@ const legendWidget = require('../enhancers/legendWidget');
 const wpsChart = require('../enhancers/wpsChart');
 const {compose} = require('recompose');
 const dependenciesToFilter = require('../enhancers/dependenciesToFilter');
+const dependenciesToOptions = require('../enhancers/dependenciesToOptions');
 const dependenciesToWidget = require('../enhancers/dependenciesToWidget');
 const dependenciesToMapProp = require('../enhancers/dependenciesToMapProp');
 const ChartWidget = compose(
     dependenciesToWidget,
     dependenciesToFilter,
+    dependenciesToOptions,
     wpsChart,
     enhanceChartWidget
 )(require('./ChartWidget'));
@@ -30,6 +32,7 @@ const MapWidget = compose(
 )(require('./MapWidget'));
 const TableWidget = compose(
     dependenciesToWidget,
+    dependenciesToOptions,
     dependenciesToFilter,
     enhanceTableWidget
 )(require('./TableWidget'));
@@ -37,6 +40,7 @@ const enhanceCounter = require('../enhancers/counterWidget');
 const CounterWidget = compose(
     dependenciesToWidget,
     dependenciesToFilter,
+    dependenciesToOptions,
     enhanceCounter
 )(require("./CounterWidget"));
 

--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -83,7 +83,7 @@ module.exports = {
             [m === "map" ? "viewport" : `${m}.viewport`]: `${m}.bbox`, // {viewport: "map.bbox"} or {"widgets[ID_W].viewport": "widgets[ID_W].bbox"}
             [m === "map" ? "center" : `${m}.center`]: `${m}.center`, // {center: "map.center"} or {"widgets[ID_W].center": "widgets[ID_W].center"}
             [m === "map" ? "zoom" : `${m}.zoom`]: `${m}.zoom`,
-            [m === "map" ? "layers" : `${m}.layers`]: `${m}.layers`
+            [m === "map" ? "layers" : `${m}.layers`]: m === "map" ? `layers.flat` : `${m}.layers`
         }), {}))
     ),
     /**

--- a/web/client/observables/wps/aggregate.js
+++ b/web/client/observables/wps/aggregate.js
@@ -7,7 +7,7 @@
  */
 
 const {castArray} = require('lodash');
-const applyTemplate = ({featureType, aggregationAttribute, groupByAttributes = [], aggregateFunction, filter=""}) => `<?xml version="1.0" encoding="UTF-8"?>
+const applyTemplate = ({featureType, aggregationAttribute, groupByAttributes = [], aggregateFunction, viewParams, filter=""}) => `<?xml version="1.0" encoding="UTF-8"?>
 <wps:Execute service="WPS"   version="1.0.0"
     xmlns="http://www.opengis.net/wps/1.0.0"
     xmlns:gml="http://www.opengis.net/gml"
@@ -24,7 +24,7 @@ const applyTemplate = ({featureType, aggregationAttribute, groupByAttributes = [
             <ows:Identifier>features</ows:Identifier>
             <wps:Reference method="POST" mimeType="text/xml" xlink:href="http://geoserver/wfs">
                 <wps:Body>
-                    <wfs:GetFeature outputFormat="GML2" service="WFS" version="1.0.0">
+                    <wfs:GetFeature ${viewParams ? `viewParams="${viewParams}"` : ""} outputFormat="GML2" service="WFS" version="1.0.0">
                         <wfs:Query typeName="${featureType}">
                         ${filter}
                         </wfs:Query>

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -13,7 +13,11 @@ const isShallowEqual = (el1, el2) => {
     }
     return el1 === el2;
 };
-
+/**
+ * Custom version of createSelector with custom compare function.
+ * The previous compare function checks if values are arrays, then compares each element of the array.
+ * This allows to avoid re-render when dependencies if the dependency keys do not change
+ */
 const createShallowSelector = createSelectorCreator(
   defaultMemoize,
   (a, b) => isEqualWith(a, b, isShallowEqual)
@@ -80,7 +84,7 @@ module.exports = {
     dashBoardDependenciesSelector: () => ({}), // TODO dashboard dependencies
     /**
      * transforms dependencies in the form `{ k1: "path1", k1, "path2" }` into
-     * a map like `{k1: v1, k2: v2}` where `v1 = get("path1, state)`.
+     * a map like `{k1: v1, k2: v2}` where `v1 = get("path1", state)`.
      * Dependencies paths map comes from getDependenciesMap.
      * map.... is a special path that brings to the map of mapstore.
      */

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -89,17 +89,14 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS="wf
     };
     const propertyName = (property) =>
         castArray(property)
-        .map(p => `<${wfsNS}:PropertyName>${p}</${wfsNS}:PropertyName>`)
-        .join("");
+            .map(p => `<${wfsVersion === "2.0" ? "fes" : "ogc"}:PropertyName>${p}</${wfsVersion === "2.0" ? "fes" : "ogc"}:PropertyName>`)
+            .join("");
     return {
         propertyName,
         ...filterBuilder({gmlVersion: gmlV, wfsVersion, filterNS: filterNS || wfsVersion === "2.0" ? "fes" : "ogc"}),
         getFeature: (content, opts) => `<${wfsNS}:GetFeature ${requestAttributes(opts)}>${Array.isArray(content) ? content.join("") : content}</${wfsNS}:GetFeature>`,
         sortBy: (property, order = "ASC") =>
-            `<${wfsNS}:SortBy><${wfsNS}:SortProperty>` +
-            `${propertyName(property)}` +
-            `<${wfsNS}:SortOrder>${order}</${wfsNS}:SortOrder>`
-            `</${wfsNS}:SortProperty></${wfsNS}:SortBy>`,
+            `<${wfsNS}:SortBy><${wfsNS}:SortProperty>${propertyName(property)}<${wfsNS}:SortOrder>${order}</${wfsNS}:SortOrder></${wfsNS}:SortProperty></${wfsNS}:SortBy>`,
         query: (featureName, content, {srsName ="EPSG:4326"} = {}) =>
             `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" srsName="${srsName}">`
             + `${Array.isArray(content) ? content.join("") : content}`


### PR DESCRIPTION
## Description
This PR sync `viewParams` of the layer with the widget. When `viewParams` change table widget, counters and charts will retry automatically. 
## Issues
 - Fix #3088 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Viewparams were ignored by widgets

**What is the new behavior?**
`Viewparams` are used in sync the chars


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No


**Other information**:

**important note**: charts will not work with GeoServer < 2.12 because of [GEOS-8267](https://osgeo-org.atlassian.net/browse/GEOS-8267)

**For developers**: With these changes I added the `layers` dependency mapping also in full map context (it was present only in dashboard context, for map widgets). This means that adding the legend widgets to the list of available widget in map view should be straight forward. 
