### PR TITLE
Fix #3089. Support for CQL_FILTER in feature grid

### DIFF
--- a/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
@@ -666,4 +666,110 @@ describe('Cesium layer', () => {
         expect(url.match(/ms2-authkey=########-####-\$\$\$\$-####-###########/g).length).toBe(1);
 
     });
+    it('test cql_filter param to be passed to the layer', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                CQL_FILTER: "prop = 'value'"
+            }
+        };
+
+        let layer = ReactDOM.render(<CesiumLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        const cqlFilter = decodeURIComponent(/cql_filter=([^&#]+)/.exec(layer.layer._tileProvider.url)[1]);
+
+        expect(cqlFilter).toBe("prop = 'value'");
+    });
+    it('test filterObj paramto be transformed into cql_filter', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+
+        let layer = ReactDOM.render(<CesiumLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        const cqlFilter = decodeURIComponent(/cql_filter=([^&#]+)/.exec(layer.layer._tileProvider.url)[1]);
+
+        expect(cqlFilter).toBe("(\"prop2\" = 'value2')");
+    });
+    it('test filterObj and cql_filter combination (featuregrid active filter use this combination)', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                CQL_FILTER: "prop = 'value'"
+            },
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+
+        let layer = ReactDOM.render(<CesiumLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+        const cqlFilter = decodeURIComponent(/cql_filter=([^&#]+)/.exec(layer.layer._tileProvider.url)[1]);
+
+        expect(layer).toExist();
+
+        expect(cqlFilter).toBe("((\"prop2\" = 'value2')) AND (prop = 'value')");
+    });
 });

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -15,7 +15,7 @@ const assign = require('object-assign');
 const {isArray} = require('lodash');
 const WMSUtils = require('../../../../utils/cesium/WMSUtils');
 const {getAuthenticationParam, getURLs} = require('../../../../utils/LayersUtils');
-const FilterUtils = require('../../../../utils/FilterUtils');
+const { optionsToVendorParams } = require('../../../../utils/VendorParamsUtils');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 
 function splitUrl(originalUrl) {
@@ -54,7 +54,7 @@ function getQueryString(parameters) {
 
 function wmsToCesiumOptionsSingleTile(options) {
     const opacity = options.opacity !== undefined ? options.opacity : 1;
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
+    const params = optionsToVendorParams(options);
     const parameters = assign({
         styles: options.style || "",
         format: options.format || 'image/png',
@@ -66,7 +66,7 @@ function wmsToCesiumOptionsSingleTile(options) {
         height: options.size || 2000,
         bbox: "-180.0,-90,180.0,90",
         srs: "EPSG:4326"
-    }, (CQL_FILTER ? {CQL_FILTER} : {}), options.params || {}, getAuthenticationParam(options));
+    }, params || {}, getAuthenticationParam(options));
 
     return {
         url: (isArray(options.url) ? options.url[Math.round(Math.random() * (options.url.length - 1))] : options.url) + '?service=WMS&version=1.1.0&request=GetMap&'
@@ -76,7 +76,7 @@ function wmsToCesiumOptionsSingleTile(options) {
 
 function wmsToCesiumOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
+    const params = optionsToVendorParams(options);
     let proxyUrl = ConfigUtils.getProxyUrl({});
     let proxy;
     if (proxyUrl) {
@@ -98,9 +98,8 @@ function wmsToCesiumOptions(options) {
 
         }, assign(
             {},
-            (CQL_FILTER ? {CQL_FILTER} : {}),
             (options._v_ ? {_v_: options._v_} : {}),
-            (options.params || {}),
+            (params || {}),
             getAuthenticationParam(options)
         ))
     });

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -43,7 +43,6 @@ describe('Leaflet layer', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
-
     it('missing layer', () => {
         var source = {
             "P_TYPE": "wrong ptype key"
@@ -638,7 +637,6 @@ describe('Leaflet layer', () => {
         expect(layer.layer.wmsParams['ms2-authkey']).toBe("########-####-####-####-###########");
         expect(layer.layer.wmsParams.SLD).toBe("http://sample.server/geoserver/rest/sld?test1=aaa&ms2-authkey=" + encodeURIComponent("########-####-####-####-###########"));
     });
-
     it('test wms security token', () => {
         const options = {
             type: "wms",
@@ -792,5 +790,114 @@ describe('Leaflet layer', () => {
         map.eachLayer(function() {lcount++; });
         expect(lcount).toBe(1);
         expect(layer.layer.options.maxZoom).toBe(23);
+    });
+    it('test cql_filter param to be passed to the layer object', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                CQL_FILTER: "prop = 'value'"
+            }
+        };
+
+        let layer = ReactDOM.render(<LeafLetLayer
+            type="wms"
+            options={options}
+            map={map}
+            />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        let lcount = 0;
+        map.eachLayer(() => { lcount++; });
+        expect(lcount).toBe(1);
+        expect(layer.layer.wmsParams.CQL_FILTER).toBe("prop = 'value'");
+    });
+    it('test filterObj param to be transformed in cql_filter', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+
+        let layer = ReactDOM.render(<LeafLetLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        let lcount = 0;
+        map.eachLayer(() => { lcount++; });
+        expect(lcount).toBe(1);
+        expect(layer.layer.wmsParams.CQL_FILTER).toBe("(\"prop2\" = 'value2')");
+    });
+    it('test filterObj and cql_filter combination (featuregrid active filter use this combination)', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                CQL_FILTER: "prop = 'value'"
+            },
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+
+        let layer = ReactDOM.render(<LeafLetLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        let lcount = 0;
+        map.eachLayer(() => { lcount++; });
+        expect(lcount).toBe(1);
+        expect(layer.layer.wmsParams.CQL_FILTER).toBe("((\"prop2\" = 'value2')) AND (prop = 'value')");
     });
 });

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -9,7 +9,8 @@ const React = require('react');
 const Message = require('../../../../components/I18N/Message');
 const Layers = require('../../../../utils/leaflet/Layers');
 const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
-const FilterUtils = require('../../../../utils/FilterUtils');
+const { optionsToVendorParams } = require('../../../../utils/VendorParamsUtils');
+
 const WMSUtils = require('../../../../utils/leaflet/WMSUtils');
 const L = require('leaflet');
 const objectAssign = require('object-assign');
@@ -158,7 +159,7 @@ const removeNulls = (obj = {}) => {
 
 function wmsToLeafletOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
-    const CQL_FILTER = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
+    const params = optionsToVendorParams(options);
     // NOTE: can we use opacity to manage visibility?
     const result = objectAssign({}, options.baseParams, {
         layers: options.name,
@@ -175,9 +176,8 @@ function wmsToLeafletOptions(options) {
         maxZoom: options.maxZoom || 23,
         maxNativeZoom: options.maxNativeZoom || 18
     }, objectAssign(
-        (CQL_FILTER ? {CQL_FILTER} : {}),
         (options._v_ ? {_v_: options._v_} : {}),
-        (options.params || {})
+        (params || {})
     ));
     return SecurityUtils.addAuthenticationToSLD(result, options);
 }

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1304,4 +1304,106 @@ describe('Openlayers layer', () => {
 
 
     });
+    it('test cql_filter param to be passed to the layer object', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                CQL_FILTER: "prop = 'value'"
+            }
+        };
+
+        let layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        expect(layer.layer.getSource().getParams().CQL_FILTER).toBe("prop = 'value'");
+    });
+    it('test filterObj param to be transformed in cql_filter', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+
+        let layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+
+        expect(layer.layer.getSource().getParams().CQL_FILTER).toBe("(\"prop2\" = 'value2')");
+    });
+    it('test filterObj and cql_filter combination (featuregrid active filter use this combination)', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            params: {
+                CQL_FILTER: "prop = 'value'"
+            },
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+
+        let layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+
+        expect(layer).toExist();
+
+        expect(layer.layer.getSource().getParams().CQL_FILTER).toBe("((\"prop2\" = 'value2')) AND (prop = 'value')");
+    });
 });

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -492,7 +492,7 @@ describe('Test featuregrid selectors', () => {
         expect(selectedLayerNameSelector(state)).toBe('editing:polygons');
         expect(selectedLayerNameSelector({})).toBe('');
     });
-    it('test queryOptionsSelector', () => {
+    it('queryOptionsSelector gets viewParams', () => {
         const state = {
             ...initialState, layers: {
                 flat: [{
@@ -512,5 +512,26 @@ describe('Test featuregrid selectors', () => {
             }
         };
         expect(queryOptionsSelector(state).viewParams).toBe("a:b");
+    });
+    it('queryOptionsSelector gets CQL_FILTER', () => {
+        const state = {
+            ...initialState, layers: {
+                flat: [{
+                    id: "TEST_LAYER",
+                    title: "Test Layer",
+                    name: 'editing:polygons',
+                    params: {
+                        CQL_FILTER: "a:b"
+                    }
+                }]
+            }, featuregrid: {
+                open: true,
+                selectedLayer: "TEST_LAYER",
+                mode: modeEdit,
+                select: [feature1, feature2],
+                changes: [{ id: feature2.id, updated: { geometry: null } }]
+            }
+        };
+        expect(queryOptionsSelector(state).cqlFilter).toBe("a:b");
     });
 });

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -154,14 +154,17 @@ module.exports = {
         return layer && layer.name || '';
 
     },
+    /**
+     * Returns well known vendor params of the selected layer to be used in feature grid.
+     * returns an object that contains `viewParams` and `cqlFilter` getting them from the params object of the layer
+     */
     queryOptionsSelector: state => {
         const params = selectedLayerParamsSelector(state);
         const viewParams = params && (params.VIEWPARAMS || params.viewParams || params.viewparams);
-        if (viewParams) {
-            return {
-                viewParams
-            };
-        }
-        return {};
+        const cqlFilter = params && (params.CQL_FILTER || params.cqlFilter || params.cql_filter);
+        return {
+            viewParams,
+            cqlFilter
+        };
     }
 };

--- a/web/client/utils/VendorParamsUtils.js
+++ b/web/client/utils/VendorParamsUtils.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const FilterUtils = require('./FilterUtils');
+
+
+module.exports = {
+    optionsToVendorParams: (options) => {
+        const cqlFilterFromObject = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
+        const { CQL_FILTER: cqlFilterFromParams, ...params } = options && options.params || {};
+        let CQL_FILTER;
+        if (cqlFilterFromObject && cqlFilterFromParams) {
+            CQL_FILTER = `(${cqlFilterFromObject}) AND (${cqlFilterFromParams})`;
+        } else {
+            CQL_FILTER = cqlFilterFromObject || cqlFilterFromParams;
+        }
+        return {
+            CQL_FILTER,
+            ...params
+        };
+    }
+};

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -219,6 +219,170 @@ describe('FilterUtils', () => {
         let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
         expect(filterParts).toEqual([]);
     });
+    it('Check  for options.cqlFilter add parts to the query', () => {
+        const versionOGC = "1.1.0";
+        const nsplaceholder = "ogc";
+        const objFilter = {
+            featureTypeName: "topp:states",
+            groupFields: [{
+                id: 1,
+                logic: "OR",
+                index: 0
+            }],
+            filterFields: [],
+            spatialField: {
+                method: null,
+                operation: "INTERSECTS",
+                geometry: null,
+                attribute: "the_geom"
+            },
+            pagination: {
+                startIndex: 0,
+                maxFeatures: 20
+            },
+            filterType: "OGC",
+            ogcVersion: "1.1.0",
+            sortOptions: null,
+            options: { cqlFilter: "prop = 'value'"},
+            crossLayerFilter: {
+                attribute: "the_geom",
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "topp:states",
+                        filterFields: [],
+                        geometryName: "the_geom",
+                        groupFields: [{
+                            id: 1,
+                            index: 0,
+                            logic: "OR"
+                        }]
+                    }
+                }
+            },
+            hits: false
+        };
+
+        let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
+        expect(filterParts[0]).toEqual('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
+    });
+    it('Check  for options.cqlFilter are merged with existing fields', () => {
+        const versionOGC = "1.1.0";
+        const nsplaceholder = "ogc";
+        const objFilter = {
+            featureTypeName: "topp:states",
+            groupFields: [{
+                id: 1,
+                logic: "OR",
+                index: 0
+            }],
+            filterFields: [{
+                attribute: "attributeEmpty",
+                groupId: 1,
+                exception: null,
+                operator: "=",
+                rowId: "1",
+                type: "string",
+                value: ''
+            }],
+            spatialField: {
+                method: null,
+                operation: "INTERSECTS",
+                geometry: null,
+                attribute: "the_geom"
+            },
+            pagination: {
+                startIndex: 0,
+                maxFeatures: 20
+            },
+            filterType: "OGC",
+            ogcVersion: "1.1.0",
+            sortOptions: null,
+            options: { cqlFilter: "prop = 'value'" },
+            crossLayerFilter: {
+                attribute: "the_geom",
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "topp:states",
+                        filterFields: [],
+                        geometryName: "the_geom",
+                        groupFields: [{
+                            id: 1,
+                            index: 0,
+                            logic: "OR"
+                        }]
+                    }
+                }
+            },
+            hits: false
+        };
+
+        let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
+        const R1 = '<ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>attributeEmpty</ogc:PropertyName><ogc:Literal></ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or>';
+        const R2 = '<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>';
+        expect(filterParts[0]).toEqual(R1);
+        expect(filterParts[1]).toEqual(R2);
+        let filter = FilterUtils.toOGCFilter("ft_name_test", objFilter, versionOGC, nsplaceholder);
+        expect(filter.split("<ogc:Filter>")[1].split("</ogc:Filter>")[0]).toBe(`<ogc:And>${R1}${R2}</ogc:And>`);
+    });
+    it('Check  for options.cqlFilter are merged with existing fields (wfs 2.0)', () => {
+        const versionOGC = "2.0";
+        const nsplaceholder = "fes";
+        const objFilter = {
+            featureTypeName: "topp:states",
+            groupFields: [{
+                id: 1,
+                logic: "OR",
+                index: 0
+            }],
+            filterFields: [{
+                attribute: "attributeEmpty",
+                groupId: 1,
+                exception: null,
+                operator: "=",
+                rowId: "1",
+                type: "string",
+                value: ''
+            }],
+            spatialField: {
+                method: null,
+                operation: "INTERSECTS",
+                geometry: null,
+                attribute: "the_geom"
+            },
+            pagination: {
+                startIndex: 0,
+                maxFeatures: 20
+            },
+            filterType: "OGC",
+            ogcVersion: "2.0",
+            sortOptions: null,
+            options: { cqlFilter: "prop = 'value'" },
+            crossLayerFilter: {
+                attribute: "the_geom",
+                collectGeometries: {
+                    queryCollection: {
+                        typeName: "topp:states",
+                        filterFields: [],
+                        geometryName: "the_geom",
+                        groupFields: [{
+                            id: 1,
+                            index: 0,
+                            logic: "OR"
+                        }]
+                    }
+                }
+            },
+            hits: false
+        };
+
+        let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
+        const R1 = '<fes:Or><fes:PropertyIsEqualTo><fes:ValueReference>attributeEmpty</fes:ValueReference><fes:Literal></fes:Literal></fes:PropertyIsEqualTo></fes:Or>';
+        const R2 = '<fes:PropertyIsEqualTo><fes:ValueReference>prop</fes:ValueReference><fes:Literal>value</fes:Literal></fes:PropertyIsEqualTo>';
+        expect(filterParts[0]).toEqual(R1);
+        expect(filterParts[1]).toEqual(R2);
+        let filter = FilterUtils.toOGCFilter("ft_name_test", objFilter, versionOGC, nsplaceholder);
+        expect(filter.split("<fes:Filter>")[1].split("</fes:Filter>")[0]).toBe(`<fes:And>${R1}${R2}</fes:And>`);
+    });
     it('Check for pagination wfs 2.0', () => {
         let filterObj = {
             pagination: {

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -9,7 +9,8 @@
 const MapUtils = require('../MapUtils');
 const CoordinatesUtils = require('../CoordinatesUtils');
 const {isArray, isObject, head} = require('lodash');
-const FilterUtils = require('../FilterUtils');
+const { optionsToVendorParams } = require('../VendorParamsUtils');
+
 const SecurityUtils = require('../SecurityUtils');
 const assign = require('object-assign');
 
@@ -17,7 +18,7 @@ module.exports = {
     buildRequest: (layer, props, infoFormat, viewer, featureInfo) => {
         /* In order to create a valid feature info request
          * we create a bbox of 101x101 pixel that wrap the point.
-         * center point is repojected then is built a box of 101x101pixel around it
+         * center point is re-projected then is built a box of 101x101pixel around it
          */
         const heightBBox = props && props.sizeBBox && props.sizeBBox.height || 101;
         const widthBBox = props && props.sizeBBox && props.sizeBBox.width || 101;
@@ -37,7 +38,10 @@ module.exports = {
 
         const locale = props.currentLocale ? head(props.currentLocale.split('-')) : null;
         const ENV = locale ? 'locale:' + locale : '';
-        const CQL_FILTER = FilterUtils.isFilterValid(layer.filterObj) && FilterUtils.toCQLFilter(layer.filterObj);
+        const params = optionsToVendorParams({
+            filterObj: layer.filterObj,
+            params: assign({}, layer.baseParams, layer.params, props.params)
+        });
         return {
             request: SecurityUtils.addAuthenticationToSLD({
                 service: 'WMS',
@@ -60,7 +64,7 @@ module.exports = {
                 feature_count: props.maxItems,
                 info_format: infoFormat,
                 ENV,
-                ...assign({}, (CQL_FILTER ? {CQL_FILTER} : {}), layer.baseParams, layer.params, props.params)
+                ...assign({}, params)
             }, layer),
             metadata: {
                 title: isObject(layer.title) ? layer.title[props.currentLocale] || layer.title.default : layer.title,

--- a/web/client/utils/mapinfo/wmts.js
+++ b/web/client/utils/mapinfo/wmts.js
@@ -9,7 +9,7 @@
 const MapUtils = require('../MapUtils');
 const CoordinatesUtils = require('../CoordinatesUtils');
 const WMTSUtils = require('../WMTSUtils');
-const FilterUtils = require('../FilterUtils');
+const {optionsToVendorParams} = require('../VendorParamsUtils');
 
 const {isArray, isObject} = require('lodash');
 
@@ -43,7 +43,10 @@ module.exports = {
 
         const matrixIds = WMTSUtils.limitMatrix(layer.matrixIds && WMTSUtils.getMatrixIds(layer.matrixIds, tileMatrixSet || srs) || WMTSUtils.getDefaultMatrixId(layer), resolutions.length);
 
-        const CQL_FILTER = FilterUtils.isFilterValid(layer.filterObj) && FilterUtils.toCQLFilter(layer.filterObj);
+        const params = optionsToVendorParams({
+            filterObj: layer.filterObj,
+            params: assign({}, layer.baseParams, layer.params, props.params)
+        });
 
         return {
             request: {
@@ -52,7 +55,7 @@ module.exports = {
                 layer: layer.name,
                 infoformat: props.format,
                 style: layer.style || '',
-                ...assign({}, (CQL_FILTER ? {CQL_FILTER} : {}), layer.baseParams, layer.params, props.params),
+                ...assign({}, params),
                 tilecol: tileCol,
                 tilerow: tileRow,
                 tilematrix: matrixIds[Math.round(props.map.zoom)],


### PR DESCRIPTION
## Description
This pull request makes the featuregrid use a cql_filter in layer `params` object to be used inside the featuregrid as additional filter.
## Issues
 - Fix #3089

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
a `CQL_FILTER` in custom projects applied to the layer didn't affect the results in featuregrid. 

**What is the new behavior?**
 - if `params.CQL_FILTER` is present in the layer, it will be parsed and added to the OGC filter of the featuregrid.
 - When the user activates FeatureGrid's sync with map, CQL_FILTER is merged with current grid filter, converted in a CQL_FILTER to make the map completely aligned to the results of the feature grid. 

 **Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No


**Other information**:
 - **note**: the conversion doesn't support spatial filters, but only logical and comparison filters. Support to conversion from/to wkt is a plus, not required at the moment. 
