### PR TITLE
Add possibility to extend and reconfigure pluginsConfigs

### DIFF
--- a/web/client/containers/MapViewer.jsx
+++ b/web/client/containers/MapViewer.jsx
@@ -18,7 +18,7 @@ const ConfigUtils = require('../utils/ConfigUtils');
 const PluginsUtils = require('../utils/PluginsUtils');
 
 const PluginsContainer = connect((state) => ({
-    pluginsConfig: state.plugins || ConfigUtils.getConfigProp('plugins') || null,
+    statePluginsConfig: state.plugins,
     mode: urlQuery.mode || state.mode || (state.browser && state.browser.mobile ? 'mobile' : 'desktop'),
     pluginsState: assign({}, state && state.controls, state && state.layers && state.layers.settings && {
         layerSettings: state.layers.settings
@@ -29,6 +29,8 @@ const PluginsContainer = connect((state) => ({
 class MapViewer extends React.Component {
     static propTypes = {
         params: PropTypes.object,
+        statePluginsConfig: PropTypes.object,
+        pluginsConfig: PropTypes.object,
         loadMapConfig: PropTypes.func,
         plugins: PropTypes.object
     };
@@ -44,6 +46,7 @@ class MapViewer extends React.Component {
 
     render() {
         return (<PluginsContainer key="viewer" id="viewer" className="viewer"
+            pluginsConfig={this.props.pluginsConfig || this.props.statePluginsConfig || ConfigUtils.getConfigProp('plugins')}
             plugins={this.props.plugins}
             params={this.props.params}
             />);

--- a/web/client/product/components/viewer/MapViewerCmp.jsx
+++ b/web/client/product/components/viewer/MapViewerCmp.jsx
@@ -19,6 +19,7 @@ class MapViewerComponent extends React.Component {
         loadMapConfig: PropTypes.func,
         onInit: PropTypes.func,
         plugins: PropTypes.object,
+        pluginsConfig: PropTypes.object,
         wrappedContainer: PropTypes.object,
         location: PropTypes.object
     };
@@ -54,6 +55,7 @@ class MapViewerComponent extends React.Component {
     render() {
         const WrappedContainer = this.props.wrappedContainer;
         return (<WrappedContainer
+            pluginsConfig={this.props.pluginsConfig}
             plugins={this.props.plugins}
             params={this.props.match.params}
             />);


### PR DESCRIPTION
## Description
This pull request modifies the existing MapViewer to allow pluginsConfig customization.

Actually the `MapViewer` container and `MapViewerCmp` can not be extended, it getting  the `pluginsConfig` object from `ConfigUtils`. This allows to pass `pluginConfig` as a property of the component, keeping the existing behavior as default.