### PR TITLE
Fix #3112. Removed old configuration from localConfig

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -253,7 +253,6 @@
                   "activateQueryTool": true,
                   "spatialOperations": [
                       {"id": "INTERSECTS", "name": "queryform.spatialfilter.operations.intersects"},
-                      {"id": "BBOX", "name": "queryform.spatialfilter.operations.bbox"},
                       {"id": "CONTAINS", "name": "queryform.spatialfilter.operations.contains"},
                       {"id": "WITHIN", "name": "queryform.spatialfilter.operations.within"}
                   ],
@@ -269,19 +268,7 @@
                 "cfg": {
                     "activateQueryTool": true,
                     "activateAddLayerButton": true,
-                    "activateMetedataTool": false,
-                    "spatialOperations": [
-                        {"id": "INTERSECTS", "name": "queryform.spatialfilter.operations.intersects"},
-                        {"id": "BBOX", "name": "queryform.spatialfilter.operations.bbox"},
-                        {"id": "CONTAINS", "name": "queryform.spatialfilter.operations.contains"},
-                        {"id": "WITHIN", "name": "queryform.spatialfilter.operations.within"}
-                    ],
-                    "spatialMethodOptions": [
-                        {"id": "Viewport", "name": "queryform.spatialfilter.methods.viewport"},
-                        {"id": "BBOX", "name": "queryform.spatialfilter.methods.box"},
-                        {"id": "Circle", "name": "queryform.spatialfilter.methods.circle"},
-                        {"id": "Polygon", "name": "queryform.spatialfilter.methods.poly"}
-                    ]
+                    "activateMetedataTool": false
                 }
             },
             "TOCItemsSettings",


### PR DESCRIPTION
## Description

This pull request remove an old configuration that make appear bbox in the list of available operations for query panel

## Issues

 - Fix #3112

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 

 - [x] Bugfix

**What is the current behavior?** 

 - See #3112

**What is the new behavior?**

- No bounding box operation anymore. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
This is a config-only change.
