### PR TITLE
Fix #3113 featuregrid synch popover updates its position accordingly

### DIFF
--- a/web/client/components/data/featuregrid/enhancers/withPopover.js
+++ b/web/client/components/data/featuregrid/enhancers/withPopover.js
@@ -16,8 +16,11 @@ module.exports = (Wrapped) => class WithPopover extends React.Component {
         const {popoverOptions, keyProp, ...props} = this.props;
         return (
             <span className="mapstore-info-popover">
-                <Wrapped {...(omit(props, ["renderPopover", "tooltipId"])) } key={keyProp} ref={button => { target = button; }} />
-                <Overlay placement={popoverOptions.placement} show target={() => ReactDOM.findDOMNode(target)}>
+                <Wrapped {...(omit(props, ["renderPopover", "tooltipId"])) } key={keyProp} ref={button => {
+                    target = button;
+                }} />
+            <Overlay placement={popoverOptions.placement} shouldUpdatePosition show
+                target={() => ReactDOM.findDOMNode(target) }>
                     <Popover
                         {...popoverOptions.props}>
                         {popoverOptions.content}

--- a/web/client/components/data/featuregrid/toolbars/toolbar.css
+++ b/web/client/components/data/featuregrid/toolbars/toolbar.css
@@ -3,3 +3,7 @@
     margin-top: 5px;
     margin-bottom: 5px;
 }
+
+#featuregrid-toolbar .btn {
+    overflow: hidden;
+}

--- a/web/client/components/data/featuregrid/toolbars/toolbar.css
+++ b/web/client/components/data/featuregrid/toolbars/toolbar.css
@@ -3,8 +3,3 @@
     margin-top: 5px;
     margin-bottom: 5px;
 }
-
-#featuregrid-toolbar .btn {
-    overflow: hidden;
-    transition: all 0.3s linear;
-}

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -174,11 +174,13 @@ describe('Test the featuregrid reducer', () => {
         expect(state.multiselect).toBeTruthy();
         expect(state.mode).toBe(MODES.EDIT);
         expect(state.tools.settings).toBeFalsy();
+        expect(state.showPopoverSync).toBe(false);
     });
     it('toggleViewMode view', () => {
         let state = featuregrid( {}, toggleViewMode());
         expect(state.multiselect).toBeFalsy();
         expect(state.mode).toBe(MODES.VIEW);
+        expect(state.showPopoverSync).toBe(true);
     });
     it('featureSaving', () => {
         let state = featuregrid( {}, featureSaving());

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -212,6 +212,7 @@ function featuregrid(state = emptyResultsState, action) {
         });
     case TOGGLE_MODE: {
         return assign({}, state, {
+            showPopoverSync: localStorage && localStorage.getItem("showPopoverSync") !== null ? localStorage.getItem("showPopoverSync") === "true" : action.mode !== MODES.EDIT,
             tools: action.mode === MODES.EDIT ? {} : state.tools,
             mode: action.mode,
             multiselect: action.mode === MODES.EDIT,


### PR DESCRIPTION
## Description
There were the transition of the toolbar in the feature grid that were causing a problem in the correct rendering of the synch popover so I decided to remove it.
The popover also hides when entering edit mode.

## Issues
 - Fix #3113

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see issue #3113

**What is the new behavior?**
Now entering in edit mode of the feature grid the popover hides. It comes back if you return to view mode (exit edit mode). The only way to remove "permanently" the popover is to close the popover with the checkbox checked.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
