### PR TITLE
Automatic definition of proj codes from configuration in OpenLayers maps

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -64,7 +64,7 @@ class OpenlayersMap extends React.Component {
     componentDidMount() {
         var center = CoordinatesUtils.reproject([this.props.center.x, this.props.center.y], 'EPSG:4326', this.props.projection);
         this.props.projectionDefs.forEach(p => {
-            projUtils.addProjections(p.code, p.extent, p.worldExtent);
+            projUtils.addProjections(ol, p.code, p.extent, p.worldExtent);
         });
         let interactionsOptions = assign(this.props.interactive ? {} : {
             doubleClickZoom: false,

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -13,6 +13,7 @@ const assign = require('object-assign');
 const CoordinatesUtils = require('../../../utils/CoordinatesUtils');
 const ConfigUtils = require('../../../utils/ConfigUtils');
 const mapUtils = require('../../../utils/MapUtils');
+const projUtils = require('../../../utils/openlayers/projUtils');
 
 const {isEqual, throttle} = require('lodash');
 
@@ -24,6 +25,7 @@ class OpenlayersMap extends React.Component {
         zoom: PropTypes.number.isRequired,
         mapStateSource: ConfigUtils.PropTypes.mapStateSource,
         projection: PropTypes.string,
+        projectionDefs: PropTypes.array,
         onMapViewChanges: PropTypes.func,
         onClick: PropTypes.func,
         mapOptions: PropTypes.object,
@@ -50,6 +52,7 @@ class OpenlayersMap extends React.Component {
         onMouseMove: () => {},
         mapOptions: {},
         projection: 'EPSG:3857',
+        projectionDefs: [],
         onLayerLoading: () => {},
         onLayerLoad: () => {},
         onLayerError: () => {},
@@ -60,7 +63,9 @@ class OpenlayersMap extends React.Component {
 
     componentDidMount() {
         var center = CoordinatesUtils.reproject([this.props.center.x, this.props.center.y], 'EPSG:4326', this.props.projection);
-
+        this.props.projectionDefs.forEach(p => {
+            projUtils.addProjections(p.code, p.extent, p.worldExtent);
+        });
         let interactionsOptions = assign(this.props.interactive ? {} : {
             doubleClickZoom: false,
             dragPan: false,

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -12,6 +12,7 @@ const OpenlayersLayer = require('../Layer.jsx');
 const expect = require('expect');
 const assign = require('object-assign');
 const ol = require('openlayers');
+const proj = require('proj4').default;
 const mapUtils = require('../../../../utils/MapUtils');
 
 require('../../../../utils/openlayers/Layers');
@@ -94,6 +95,22 @@ describe('OpenlayersMap', () => {
         const map = ReactDOM.render(comp, document.getElementById("map"));
         expect(map).toExist();
         expect(map.map.getView().getProjection().getCode()).toBe('EPSG:3857');
+    });
+
+    it('custom projection', () => {
+        proj.defs("EPSG:25830", "+proj=utm +zone=30 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs");
+        const projectionDefs = [{
+            code: "EPSG:25830",
+            extent: [-1300000, 4000000, 1900000, 7500000],
+            worldExtent: [-6.0000, 35.9500, 0.0000, 63.9500]
+        }];
+        const comp = (<OpenlayersMap projection="EPSG:25830" projectionDefs={projectionDefs} center={{ y: 43.9, x: 10.3 }} zoom={11}
+        />);
+
+        const map = ReactDOM.render(comp, document.getElementById("map"));
+        expect(map).toExist();
+        expect(map.map.getView().getProjection().getCode()).toBe('EPSG:25830');
+        expect(ol.proj.get('EPSG:25830')).toExist();
     });
 
     it('check if the handler for "click" event is called with elevation', () => {

--- a/web/client/utils/openlayers/projUtils.js
+++ b/web/client/utils/openlayers/projUtils.js
@@ -10,8 +10,7 @@ const projUtils = {
     /**
     * function needed in openlayer for adding new projection
     */
-    addProjections: function(code, extent, worldExtent) {
-        const ol = window.ol;
+    addProjections: function(ol, code, extent, worldExtent) {
         if (!ol.proj.get(code)) {
             ol.proj.addProjection(new ol.proj.Projection({
                     code,

--- a/web/client/utils/openlayers/projUtils.js
+++ b/web/client/utils/openlayers/projUtils.js
@@ -12,12 +12,14 @@ const projUtils = {
     */
     addProjections: function(code, extent, worldExtent) {
         const ol = window.ol;
-        ol.proj.addProjection(new ol.proj.Projection({
-            code,
-            extent,
-            worldExtent
-            })
-        );
+        if (!ol.proj.get(code)) {
+            ol.proj.addProjection(new ol.proj.Projection({
+                    code,
+                    extent,
+                    worldExtent
+                })
+            );
+        }
     }
 };
 


### PR DESCRIPTION
## Description
Custom projections are not initialized for ol, so they don't work if used for a map.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
proj4 is initialized with custom defined projections, but ol is not in synch.

**What is the new behavior?**
ol is synchronized with custom projections definitions in localConfig

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
