### PR TITLE
Fix #3051 toc group/layers problems

### DIFF
--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -17,7 +17,7 @@ const LocaleUtils = require('../../../../utils/LocaleUtils');
 const assign = require('object-assign');
 require('react-selectize/themes/index.css');
 const {Grid} = require('react-bootstrap');
-
+const {createFromSearch} = require('../../../../utils/TOCUtils');
 /**
  * General Settings form for layer
  */
@@ -121,17 +121,7 @@ class General extends React.Component {
                             this.updateEntry("group", {target: {value: value || "Default"}});
                         }}
                         theme = "bootstrap3"
-                        createFromSearch={function(options, search) {
-                            // only create an option from search if the length of the search string is > 0 and
-                            // it does no match the label property of an existing option
-                            if (search.length === 0 || (options.map(function(option) {
-                                return option.label;
-                            })).indexOf(search) > -1) {
-                                return null;
-                            }
-                            const val = search.replace(/\./g, '${dot}').replace(/\//g, '.');
-                            return {label: search, value: val};
-                        }}
+                        createFromSearch={createFromSearch}
 
                         onValueChange={function(item) {
                             // here, we add the selected item to the options array, the "new-option"

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -96,12 +96,38 @@ describe('Test the layers reducer', () => {
             nodeType: 'layers'
         };
         let initialState = {
-            groups: [{name: 'sample1', id: 'sample1'}, {name: 'sample2', id: 'sample2'}],
-            flat: [{id: 'layer1', group: 'sample1'}, {id: 'layer2', group: 'sample2'}]
+            groups: [
+                {name: 'sample1', nodes: ['layer1'], id: 'sample1'},
+                {name: 'sample2', nodes: ['layer2'], id: 'sample2'}
+            ],
+            flat: [
+                {id: 'layer1', group: 'sample1'},
+                {id: 'layer2', group: 'sample2'}
+            ]
+        };
+        let state = layers(initialState, testAction);
+        expect(state.groups.length).toBe(1);
+        expect(state.flat.length).toBe(1);
+    });
+    it('removeNode norGroupOrLayer', () => {
+        let testAction = {
+            type: 'REMOVE_NODE',
+            node: 'layer1',
+            nodeType: 'norGroupOrLayer'
+        };
+        let initialState = {
+            groups: [
+                {name: 'sample1', nodes: ['layer1'], id: 'sample1'},
+                {name: 'sample2', nodes: ['layer2'], id: 'sample2'}
+            ],
+            flat: [
+                {id: 'layer1', group: 'sample1'},
+                {id: 'layer2', group: 'sample2'}
+            ]
         };
         let state = layers(initialState, testAction);
         expect(state.groups.length).toBe(2);
-        expect(state.flat.length).toBe(1);
+        expect(state.flat.length).toBe(2);
     });
 
     it('removeNode nested', () => {

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -213,9 +213,10 @@ function layers(state = [], action) {
                 const newLayers = state.flat.filter((layer) => layer.id !== action.node);
                 return assign({}, state, {
                     flat: newLayers,
-                    groups: newGroups
+                    groups: LayersUtils.removeEmptyGroups(newGroups)
                 });
             }
+            return state;
         }
         case ADD_LAYER: {
             let newLayers = (state.flat || []).concat();

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+const TOCUtils = {
+    createFromSearch: function(options, search) {
+        /* only create an option from search if the length of the search string is > 0 and
+        it does no match the label property of an existing option
+        MV: it should also avoid the creation of group with an empty name therefore a new regex has been introduced
+        */
+        const filterWrongGroupRegex = RegExp('^\/|\/$|\/{2,}');
+        if (search.length === 0 || (options.map(function(option) {
+            return option.label;
+        })).indexOf(search) > -1 || filterWrongGroupRegex.test(search)) {
+            return null;
+        }
+
+        const val = search.replace(/\./g, '${dot}').replace(/\//g, '.');
+        return {label: search, value: val};
+    }
+};
+
+
+module.exports = TOCUtils;

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -6,16 +6,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 const expect = require('expect');
-const TOCUtils = require('../TOCUtils');
+const {createFromSearch} = require('../TOCUtils');
+let options = [{label: "lab1", value: "val1"}];
 
 describe('TOCUtils', () => {
     it('test createFromSearch for General Fragment with value not allowed', () => {
-        const val = TOCUtils.createFromSearch();
+        let val = createFromSearch(options, "/as");
+        expect(val).toBe(null);
+        val = createFromSearch(options, "a//s");
+        expect(val).toBe(null);
+        val = createFromSearch(options, "s/d&/");
         expect(val).toBe(null);
     });
 
-    it('test createFromSearch for General Fragment with valid value', () => {
-        const val = TOCUtils.createFromSearch();
-        expect(val).toBe(null);
+    it('test createFromSearch for General Fragment with new valid value', () => {
+        let val = createFromSearch(options, "lab2");
+        expect(val.label).toBe("lab2");
+        expect(val.value).toBe("lab2");
+        val = createFromSearch(options, "lab2/lab5");
+        expect(val.label).toBe("lab2/lab5");
+        expect(val.value).toBe("lab2.lab5");
     });
 });

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const TOCUtils = require('../TOCUtils');
+
+describe('TOCUtils', () => {
+    it('test createFromSearch for General Fragment with value not allowed', () => {
+        const val = TOCUtils.createFromSearch();
+        expect(val).toBe(null);
+    });
+
+    it('test createFromSearch for General Fragment with valid value', () => {
+        const val = TOCUtils.createFromSearch();
+        expect(val).toBe(null);
+    });
+});


### PR DESCRIPTION
## Description
This pr fixes some issues on the toc: on related to the way new groups are added and one on the delete of the layers and all the group hiearchy that has no layers in the sub-tree

- By doing that it also accomplish the group deletion if all layers of that group are selected and you hit delete all the levels trash button (maybe we can change the name with "Delete all the layers and groups"
- Maybe we can make the regex used to filter which groups name can be created configurable.
@tdipisa  opinions?


## Issues
 - Fix #3051 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**
It is not possible to create group with empty name.
if you delete a layer in a subgroup and no layers are left then all the group hierarchy is deleted along with the layer

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
I've added a TocUtils for all the stuff that is toc related