### PR TITLE
Fix #3142. Don't add CQL_FILTER when not present

### DIFF
--- a/web/client/utils/VendorParamsUtils.js
+++ b/web/client/utils/VendorParamsUtils.js
@@ -10,8 +10,12 @@ const FilterUtils = require('./FilterUtils');
 
 module.exports = {
     /**
+     * Check layer options to manipulate and manage vendor params in case of GeoServer usage.
      * If you have a filterObj in options, this should be converted into a CQL_FILTER and joined with the existing cql filter, if any.
-     * (filterObj is the temp filter applied to the layer)
+     * (filterObj is the temp filter applied to the layer when you apply, for instance, sync with feature grid)
+     * @memberof Utils.VendorParamsUtils
+     * @param {object} options layer options
+     * @returns params for the layer's request, properly manipulated
      */
     optionsToVendorParams: (options = {}) => {
         const cqlFilterFromObject = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);

--- a/web/client/utils/VendorParamsUtils.js
+++ b/web/client/utils/VendorParamsUtils.js
@@ -9,7 +9,11 @@ const FilterUtils = require('./FilterUtils');
 
 
 module.exports = {
-    optionsToVendorParams: (options) => {
+    /**
+     * If you have a filterObj in options, this should be converted into a CQL_FILTER and joined with the existing cql filter, if any.
+     * (filterObj is the temp filter applied to the layer)
+     */
+    optionsToVendorParams: (options = {}) => {
         const cqlFilterFromObject = FilterUtils.isFilterValid(options.filterObj) && FilterUtils.toCQLFilter(options.filterObj);
         const { CQL_FILTER: cqlFilterFromParams, ...params } = options && options.params || {};
         let CQL_FILTER;
@@ -18,9 +22,9 @@ module.exports = {
         } else {
             CQL_FILTER = cqlFilterFromObject || cqlFilterFromParams;
         }
-        return {
+        return CQL_FILTER ? {
             CQL_FILTER,
             ...params
-        };
+        } : options.params;
     }
 };

--- a/web/client/utils/__tests__/VendorParamsUtils-test.js
+++ b/web/client/utils/__tests__/VendorParamsUtils-test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+const { optionsToVendorParams} = require('../VendorParamsUtils');
+describe('VendorParamUtils ', () => {
+
+    it('optionsToVendorParams', () => {
+        expect(optionsToVendorParams()).toNotExist();
+        expect(optionsToVendorParams({
+            params: {
+                CQL_FILTER: "INCLUDE"
+            }
+        }).CQL_FILTER).toBe("INCLUDE");
+    });
+    it('optionsToVendorParams', () => {
+        const params = optionsToVendorParams({ params: {viewParams: "a:1"}});
+        expect(Object.keys(params).length).toBe(1);
+    });
+
+});

--- a/web/client/utils/__tests__/VendorParamsUtils-test.js
+++ b/web/client/utils/__tests__/VendorParamsUtils-test.js
@@ -18,7 +18,7 @@ describe('VendorParamUtils ', () => {
             }
         }).CQL_FILTER).toBe("INCLUDE");
     });
-    it('optionsToVendorParams', () => {
+    it('optionsToVendorParams do not add other params to the request (#3142)', () => {
         const params = optionsToVendorParams({ params: {viewParams: "a:1"}});
         expect(Object.keys(params).length).toBe(1);
     });


### PR DESCRIPTION
## Description
This fixes the CQL_FILTER issue for ajax
## Issues
 - Fix #3142 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
 - See #3142 

**What is the new behavior?**
Now GetFeatureInfo works also using proxy 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
