### PR TITLE
Fix #3147 Element.closest is not supported in ie11

### DIFF
--- a/buildConfig.js
+++ b/buildConfig.js
@@ -11,7 +11,15 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
     entry: assign({
         'webpack-dev-server': 'webpack-dev-server/client?http://0.0.0.0:8081', // WebpackDevServer host and port
         'webpack': 'webpack/hot/only-dev-server' // "only" prevents reload on syntax errors
-    }, bundles, themeEntries),
+    },
+    // add polyfill library to all bundle
+    Object.keys(bundles).reduce((bundlesEntry, key) =>
+        assign({}, bundlesEntry,
+            {[key]: [
+                'element-closest', // node.closest polyfill for ie11
+            bundles[key]]}),
+    {}),
+    themeEntries),
     output: {
         path: paths.dist,
         publicPath,

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "colorbrewer": "1.0.0",
     "create-react-class": "15.6.2",
     "css-tree": "1.0.0-alpha24",
+    "element-closest": "2.0.2",
     "es6-promise": "2.3.0",
     "eventlistener": "0.0.1",
     "file-saver": "1.3.3",


### PR DESCRIPTION
## Description
Added polyfill to add closest function if it's not supported in browser eg. ie11

## Issues
 - Fix #3147
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Missing closest function crashes the application in ie11, in particular widgets don't work

**What is the new behavior?**
Added  closest function with polyfill function to avoid errors

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

Probably some projects need update in buildConfig.js

**Other information**:
