### PR TITLE
Fix #3138 Repeated get feature info requests cause visual glitch if widgets are on map 

### DIFF
--- a/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
+++ b/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
@@ -369,4 +369,31 @@ describe("test identify enhancers", () => {
         expect(spySetIndex.calls.length).toEqual(0);
     });
 
+    it("test identifyLifecycle on close", () => {
+        const Component = identifyLifecycle(({onClose = () => {}}) => <div id="test-component" onClick={() => onClose()}></div>);
+        const testHandlers = {
+            closeIdentify: () => {},
+            purgeResults: () => {},
+            hideMarker: () => {}
+        };
+        const spyCloseIdentify = expect.spyOn(testHandlers, 'closeIdentify');
+        const spyPurgeResults = expect.spyOn(testHandlers, 'purgeResults');
+        const spyHideMarker = expect.spyOn(testHandlers, 'hideMarker');
+        ReactDOM.render(
+            <Component
+                enabled
+                responses={[{}]}
+                closeIdentify={testHandlers.closeIdentify}
+                purgeResults={testHandlers.purgeResults}
+                hideMarker={testHandlers.hideMarker}/>,
+            document.getElementById("container")
+        );
+
+        const testComponent = document.getElementById('test-component');
+        TestUtils.Simulate.click(testComponent);
+        expect(spyCloseIdentify).toHaveBeenCalled();
+        expect(spyPurgeResults).toHaveBeenCalled();
+        expect(spyHideMarker).toHaveBeenCalled();
+    });
+
 });

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -43,9 +43,10 @@ const identifyHandlers = withHandlers({
         }
         return false;
     },
-    onClose: ({hideMarker, purgeResults}) => () => {
+    onClose: ({hideMarker = () => {}, purgeResults = () => {}, closeIdentify = () => {}}) => () => {
         hideMarker();
         purgeResults();
+        closeIdentify();
     }
 });
 

--- a/web/client/epics/__tests__/maplayout-test.js
+++ b/web/client/epics/__tests__/maplayout-test.js
@@ -10,6 +10,8 @@ const expect = require('expect');
 
 const {toggleControl} = require('../../actions/controls');
 const {UPDATE_MAP_LAYOUT} = require('../../actions/maplayout');
+const {closeIdentify} = require('../../actions/mapInfo');
+
 const {updateMapLayoutEpic} = require('../maplayout');
 const {testEpic} = require('./epicTestUtils');
 
@@ -52,5 +54,21 @@ describe('map layout epics', () => {
         };
         const state = {mode: 'embedded', controls: { drawer: {enabled: true}}};
         testEpic(updateMapLayoutEpic, 1, toggleControl("queryPanel"), epicResult, state);
+    });
+
+    it('tests on close identify', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(1);
+                actions.map((action) => {
+                    expect(action.type).toBe(UPDATE_MAP_LAYOUT);
+                });
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+        const state = {};
+        testEpic(updateMapLayoutEpic, 1, closeIdentify(), epicResult, state);
     });
 });

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -10,7 +10,7 @@ const {updateMapLayout} = require('../actions/maplayout');
 const {TOGGLE_CONTROL, SET_CONTROL_PROPERTY} = require('../actions/controls');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
 const {SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID} = require('../actions/featuregrid');
-const {PURGE_MAPINFO_RESULTS, ERROR_FEATURE_INFO} = require('../actions/mapInfo');
+const {CLOSE_IDENTIFY, ERROR_FEATURE_INFO, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO} = require('../actions/mapInfo');
 const {SHOW_SETTINGS, HIDE_SETTINGS} = require('../actions/layers');
 const {mapInfoRequestsSelector} = require('../selectors/mapinfo');
 
@@ -24,19 +24,21 @@ const {head, get} = require('lodash');
 const {isFeatureGridOpen, getDockSize} = require('../selectors/featuregrid');
 
 /**
- * Gets `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `PURGE_MAPINFO_RESULTS`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY` events.
+ * Gets `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `CLOSE_IDENTIFY`, `LOAD_FEATURE_INFO`, `TOGGLE_MAPINFO_STATE`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY` events.
  * Configures a map layout based on state of panels.
- * @param {external:Observable} action$ manages `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `PURGE_MAPINFO_RESULTS`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY`.
+ * @param {external:Observable} action$ manages `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `CLOSE_IDENTIFY`, `LOAD_FEATURE_INFO`, `TOGGLE_MAPINFO_STATE`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY`.
  * @memberof epics.mapLayout
  * @return {external:Observable} emitting {@link #actions.map.updateMapLayout} action
  */
 
 const updateMapLayoutEpic = (action$, store) =>
-    action$.ofType(MAP_CONFIG_LOADED, SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID, PURGE_MAPINFO_RESULTS, TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SHOW_SETTINGS, HIDE_SETTINGS, ERROR_FEATURE_INFO)
+    action$.ofType(MAP_CONFIG_LOADED, SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID, CLOSE_IDENTIFY, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SHOW_SETTINGS, HIDE_SETTINGS, ERROR_FEATURE_INFO)
         .switchMap(() => {
 
-            if (get(store.getState(), "browser.mobile")) {
-                const bottom = mapInfoRequestsSelector(store.getState()).length > 0 ? {bottom: '50%'} : {bottom: undefined};
+            const state = store.getState();
+
+            if (get(state, "browser.mobile")) {
+                const bottom = mapInfoRequestsSelector(state).length > 0 ? {bottom: '50%'} : {bottom: undefined};
                 const boundingMapRect = {
                     ...bottom
                 };
@@ -47,9 +49,9 @@ const updateMapLayoutEpic = (action$, store) =>
 
             const mapLayout = {left: {sm: 300, md: 500, lg: 600}, right: {md: 658}, bottom: {sm: 30}};
 
-            if (get(store.getState(), "mode") === 'embedded') {
+            if (get(state, "mode") === 'embedded') {
                 const height = {height: 'calc(100% - ' + mapLayout.bottom.sm + 'px)'};
-                const bottom = mapInfoRequestsSelector(store.getState()).length > 0 ? {bottom: '50%'} : {bottom: undefined};
+                const bottom = mapInfoRequestsSelector(state).length > 0 ? {bottom: '50%'} : {bottom: undefined};
                 const boundingMapRect = {
                     ...bottom
                 };
@@ -60,23 +62,23 @@ const updateMapLayoutEpic = (action$, store) =>
             }
 
             const leftPanels = head([
-                get(store.getState(), "controls.queryPanel.enabled") && {left: mapLayout.left.lg} || null,
-                get(store.getState(), "controls.widgetBuilder.enabled") && {left: mapLayout.left.md} || null,
-                get(store.getState(), "layers.settings.expanded") && {left: mapLayout.left.md} || null,
-                get(store.getState(), "controls.drawer.enabled") && {left: mapLayout.left.sm} || null
+                get(state, "controls.queryPanel.enabled") && {left: mapLayout.left.lg} || null,
+                get(state, "controls.widgetBuilder.enabled") && {left: mapLayout.left.md} || null,
+                get(state, "layers.settings.expanded") && {left: mapLayout.left.md} || null,
+                get(state, "controls.drawer.enabled") && {left: mapLayout.left.sm} || null
             ].filter(panel => panel)) || {left: 0};
 
             const rightPanels = head([
-                get(store.getState(), "controls.details.enabled") && {right: mapLayout.right.md} || null,
-                get(store.getState(), "controls.annotations.enabled") && {right: mapLayout.right.md} || null,
-                get(store.getState(), "controls.metadataexplorer.enabled") && {right: mapLayout.right.md} || null,
-                mapInfoRequestsSelector(store.getState()).length > 0 && {right: mapLayout.right.md} || null
+                get(state, "controls.details.enabled") && {right: mapLayout.right.md} || null,
+                get(state, "controls.annotations.enabled") && {right: mapLayout.right.md} || null,
+                get(state, "controls.metadataexplorer.enabled") && {right: mapLayout.right.md} || null,
+                get(state, "mapInfo.enabled") && mapInfoRequestsSelector(state).length > 0 && {right: mapLayout.right.md} || null
             ].filter(panel => panel)) || {right: 0};
 
-            const dockSize = getDockSize(store.getState()) * 100;
-            const bottom = isFeatureGridOpen(store.getState()) && {bottom: dockSize + '%', dockSize} || {bottom: mapLayout.bottom.sm};
+            const dockSize = getDockSize(state) * 100;
+            const bottom = isFeatureGridOpen(state) && {bottom: dockSize + '%', dockSize} || {bottom: mapLayout.bottom.sm};
 
-            const transform = isFeatureGridOpen(store.getState()) && {transform: 'translate(0, -' + mapLayout.bottom.sm + 'px)'} || {transform: 'none'};
+            const transform = isFeatureGridOpen(state) && {transform: 'translate(0, -' + mapLayout.bottom.sm + 'px)'} || {transform: 'none'};
             const height = {height: 'calc(100% - ' + mapLayout.bottom.sm + 'px)'};
 
             const boundingMapRect = {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -17,7 +17,7 @@ const {layersSelector} = require('../selectors/layers');
 
 const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState} = require('../actions/mapInfo');
 const {changeMousePointer} = require('../actions/map');
-const {changeMapInfoFormat, updateCenterToMarker, closeIdentify} = require('../actions/mapInfo');
+const {changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults} = require('../actions/mapInfo');
 const {currentLocaleSelector} = require('../selectors/locale');
 
 const {compose, defaultProps} = require('recompose');
@@ -165,7 +165,8 @@ const IdentifyPlugin = compose(
     connect(selector, {
         sendRequest: getFeatureInfo,
         localRequest: getVectorInfo,
-        purgeResults: closeIdentify,
+        purgeResults: purgeMapInfoResults,
+        closeIdentify,
         changeMousePointer,
         showMarker: showMapinfoMarker,
         noQueryableLayers,


### PR DESCRIPTION
## Description
This PR updates close identify action to check when identify panel will be closed and update correctly the layout.
Added also `TOGGLE_MAPINFO_STATE` to maplayout epic to update layout also when Identify plugin will be enable/disable.

## Issues
 - Fix #3138

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
#3138

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
