### PR TITLE
Fix #2953 Expanding the filter panel for charts and tables

### DIFF
--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -52,7 +52,7 @@ module.exports = ({
 
     return (<SwitchPanel
         loading={loadingCapabilities}
-        expanded={crossLayerExpanded && !loadingCapabilities && !errorObj || (operation && queryCollection.typeName) }
+        expanded={operation && queryCollection.typeName ? true : crossLayerExpanded && !loadingCapabilities && !errorObj }
         error={errorObj}
         errorMsgId={"queryPanel"}
         buttons={[

--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -52,7 +52,7 @@ module.exports = ({
 
     return (<SwitchPanel
         loading={loadingCapabilities}
-        expanded={crossLayerExpanded && !loadingCapabilities && !errorObj}
+        expanded={crossLayerExpanded && !loadingCapabilities && !errorObj || (operation && queryCollection.typeName) }
         error={errorObj}
         errorMsgId={"queryPanel"}
         buttons={[

--- a/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
+++ b/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
@@ -97,6 +97,23 @@ describe('CrossLayerFilter component', () => {
         ReactTestUtils.Simulate.click(el);
         expect(spyexpandCrossLayerFilterPanel).toHaveBeenCalled();
     });
-
+    it('Test CrossLayerFilter with pre-filtered data and no "crossLayerExpanded" property ', () => {
+        const container = document.getElementById('container');
+        ReactDOM.render(<CrossLayerFilter
+            layers={[{name: "test"}]}
+            queryCollection={{
+                typeName: "test",
+                geometryName: "geometry"
+            }}
+            operation="WITHIN"
+            spatialOperations={[{
+                id: "WITHIN",
+                name: "Within"
+            }]}
+            />, document.getElementById("container"));
+        expect(container.querySelector('.geometry-operation-selector')).toExist();
+        expect(container.querySelector('.mapstore-conditions-group')).toExist();
+        expect(container.querySelector('.m-slider')).toExist();
+    });
 
 });


### PR DESCRIPTION
## Description
in the Switchpanel expand property: 
added a statement that returns true if there are pre-existed quires, otherwise it returns the inherited crossLayerExpanded  property (undefined for tables and charts, only with Featuregrid component ).


## Issues
 - Fix #2953
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #2953

**What is the new behavior?**
when editing an existing table/chart's filter, the cross-layer filter is enabled

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
