### PR TITLE
check if the title is string

### DIFF
--- a/web/client/components/TOC/FloatingLegend.jsx
+++ b/web/client/components/TOC/FloatingLegend.jsx
@@ -182,7 +182,7 @@ class FloatingLegend extends React.Component {
                                 ref={list => { this.list = list; }}
                                 size="sm"
                                 items={this.props.layers.map(layer => ({
-                                        title: layer.title,
+                                        title: !layer.title || layer.title === '' ? layer.name : layer.title,
                                         preview: <Glyphicon className="text-primary"
                                             glyph={layer.visibility ? 'eye-open' : 'eye-close'}
                                             onClick={() => this.props.onChange(layer.id, 'layers', {visibility: !layer.visibility})}/>,

--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -15,7 +15,7 @@ const tooltip = require('../misc/enhancers/tooltip');
 const NavItemT = tooltip(NavItem);
 const ResizableModal = require('../misc/ResizableModal');
 const Portal = require('../misc/Portal');
-const {head, isObject} = require('lodash');
+const {head, isObject, isString} = require('lodash');
 const Message = require('../I18N/Message');
 
 /**
@@ -62,7 +62,7 @@ const TOCItemSettings = (props, context) => {
             <DockablePanel
                 open={settings.expanded}
                 glyph="wrench"
-                title={element.title && isObject(element.title) && (element.title[currentLocale] || element.title.default) || element.title || ''}
+                title={element.title && isObject(element.title) && (element.title[currentLocale] || element.title.default) || isString(element.title) && element.title || ''}
                 className={className}
                 onClose={onClose ? () => { onClose(); } : onHideSettings}
                 size={width}

--- a/web/client/components/TOC/__tests__/FloatingLegend-test.jsx
+++ b/web/client/components/TOC/__tests__/FloatingLegend-test.jsx
@@ -68,6 +68,24 @@ describe('tests FloatingLegend component', () => {
         expect(visibleLayer.length).toBe(1);
     });
 
+    it('render layers that have no title', () => {
+        const cmp = ReactDOM.render(
+            <FloatingLegend
+                expanded
+                layers={[
+                    {
+                        name: 'layer:00',
+                        visibility: true,
+                        type: 'wms'
+                    }
+                ]}/>, document.getElementById("container"));
+
+        expect(cmp).toExist();
+
+        const title = document.getElementsByClassName('mapstore-side-card-title')[0].childNodes[0].childNodes[0].data;
+        expect(title).toBe('layer:00');
+    });
+
     it('render width layers and disabled opacity slider', () => {
         const cmp = ReactDOM.render(
             <FloatingLegend

--- a/web/client/components/TOC/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/components/TOC/__tests__/TOCItemsSettings-test.jsx
@@ -10,6 +10,16 @@ const expect = require('expect');
 const ReactDOM = require('react-dom');
 const TOCItemsSettings = require('../TOCItemsSettings');
 
+const layers = [
+    {
+        name: 'layer:00',
+        title: {
+            'default': ''
+        },
+        visibility: true,
+        type: 'wms'
+    }
+];
 
 describe("test TOCItemsSettings", () => {
     beforeEach((done) => {
@@ -72,6 +82,28 @@ describe("test TOCItemsSettings", () => {
         ReactDOM.render(<TOCItemsSettings alertModal/>, document.getElementById("container"));
         const alertModal = document.getElementsByClassName('ms-resizable-modal');
         expect(alertModal.length).toBe(1);
+    });
+
+    it('test with a title ', () => {
+        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [
+            {
+                id: 'general',
+                titleId: 'layerProperties.general',
+                tooltipId: 'layerProperties.general',
+                glyph: 'wrench',
+                Component: () => <div id="test-general-body"></div>
+            },
+            {
+                id: 'display',
+                titleId: 'layerProperties.display',
+                tooltipId: 'layerProperties.display',
+                glyph: 'eye-open',
+                Component: () => <div id="test-display-body"></div>
+            }
+        ]} element={layers[0]}/>, document.getElementById("container"));
+        const baar = document.getElementsByClassName("container-fluid")[0].childNodes[0].childNodes[1].childNodes[0].textContent;
+        expect(baar).toBe(layers[0].title.default);
+
     });
 
 });


### PR DESCRIPTION
## Description
 -In the legend the layer name is displayed, in the absence of the title . And allowing for removing the title in the editor without the error massage by preventing the  DockablePanel component from rendering the title if it is an object.

## Issues
 - Fix #3040
 - Fix #3157

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3040  and #3157

**What is the new behavior?**
 -In the legend the layer name is displayed, in the absence of the title .
- Allowing for removing the title in the editor without the error massage.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
