### PR TITLE
long title and discription

### DIFF
--- a/web/client/themes/default/bootstrap-theme.less
+++ b/web/client/themes/default/bootstrap-theme.less
@@ -151,3 +151,13 @@ button.close {
 .tooltip-inner {
     word-wrap: break-word;
 }
+
+//popover
+.popover-title{
+    word-wrap: break-word;
+}
+
+.popover-content{
+    word-wrap: break-word;
+}
+

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -84,6 +84,7 @@
             font-size: 18px;
             color: @ms2-color-primary;
             right: 20px;
+            top: 10px;
         }
         .widget-menu {
             border: none;

--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -83,7 +83,7 @@
             position: absolute;
             font-size: 18px;
             color: @ms2-color-primary;
-            right: 20px;
+            right: 7px;
             top: 10px;
         }
         .widget-menu {


### PR DESCRIPTION
## Description
fixing the position of the options button by adding a css "top" property for it's position

## Issues
 - Fix #2707

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
when using a very long title, the title div overlays on top of the edit button it, which means users can longer access any options (save, edit ....etc)  

**What is the new behavior?**
When using a long title, nothing changes in the widget appearance and the options button remains visible.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
