### PR TITLE
Fix #3153 Embedded doesn't work on ie11 

### DIFF
--- a/buildConfig.js
+++ b/buildConfig.js
@@ -11,15 +11,7 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
     entry: assign({
         'webpack-dev-server': 'webpack-dev-server/client?http://0.0.0.0:8081', // WebpackDevServer host and port
         'webpack': 'webpack/hot/only-dev-server' // "only" prevents reload on syntax errors
-    },
-    // add polyfill library to all bundle
-    Object.keys(bundles).reduce((bundlesEntry, key) =>
-        assign({}, bundlesEntry,
-            {[key]: [
-                'element-closest', // node.closest polyfill for ie11
-            bundles[key]]}),
-    {}),
-    themeEntries),
+    }, bundles, themeEntries),
     output: {
         path: paths.dist,
         publicPath,

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "create-react-class": "15.6.2",
     "css-tree": "1.0.0-alpha24",
     "element-closest": "2.0.2",
+    "es6-object-assign": "1.1.0",
     "es6-promise": "2.3.0",
     "eventlistener": "0.0.1",
     "file-saver": "1.3.3",

--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -25,6 +25,8 @@ const {isObject, isArray} = require('lodash');
 
 const urlQuery = url.parse(window.location.href, true).query;
 
+require('./appPolyfill');
+
 class StandardApp extends React.Component {
     static propTypes = {
         appStore: PropTypes.func,

--- a/web/client/components/app/appPolyfill.js
+++ b/web/client/components/app/appPolyfill.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, GeoSolutions Sas.
+ * Copyright 2018, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/web/client/components/app/appPolyfill.js
+++ b/web/client/components/app/appPolyfill.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// issue #3147 Element.closest is not supported in ie11
+require('element-closest');
+
+// issue #3153  Embedded doesn't work on ie11
+require('es6-object-assign').polyfill();


### PR DESCRIPTION
## Description
Added a file where list and require polyfills.

## Issues
 - Fix #3153

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Embedded  dosn't work in ie11 because missing Object.assign polyfill
error related to file `react-dock/lib/Dock.js`

**What is the new behavior?**
Embedded  loads the map viewer

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Verify use and location of StandardApp in others projects

