### PR TITLE
Closes #3183 Save and SaveAs plugins - Persistence Api

### DIFF
--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -39,7 +39,8 @@ const {
     MAP_METADATA_UPDATED, mapMetadataUpdated,
     METADATA_CHANGED, metadataChanged,
     setShowMapDetails, SHOW_DETAILS,
-    updateAttribute, saveAll
+    updateAttribute, saveAll,
+    SAVE_MAP_RESOURCE, saveMapResource
 } = require('../maps');
 
 let GeoStoreDAO = require('../../api/GeoStoreDAO');
@@ -379,6 +380,12 @@ describe('Test correctness of the maps actions', () => {
         expect(a.type).toBe(DETAILS_LOADED);
         expect(a.detailsUri).toBe(detailsUri);
         expect(a.mapId).toBe(mapId);
+    });
+    it('saveMapResource', () => {
+        const resource = {};
+        const a = saveMapResource(resource);
+        expect(a.type).toBe(SAVE_MAP_RESOURCE);
+        expect(a.resource).toBe(resource);
     });
 
 });

--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -12,12 +12,7 @@ const ConfigUtils = require('../utils/ConfigUtils');
 const {userGroupSecuritySelector, userSelector} = require('../selectors/security');
 const {currentMapDetailsChangedSelector} = require('../selectors/currentmap');
 const {resetCurrentMap} = require('./currentMap');
-const assign = require('object-assign');
-
-const {error: notificationError, success: notificationSuccess} = require('./notifications');
-const {getErrorMessage} = require('../utils/LocaleUtils');
 const {findIndex, isNil} = require('lodash');
-
 const MAPS_LIST_LOADED = 'MAPS_LIST_LOADED';
 const MAPS_LIST_LOADING = 'MAPS_LIST_LOADING';
 const MAPS_LIST_LOAD_ERROR = 'MAPS_LIST_LOAD_ERROR';
@@ -486,35 +481,6 @@ function loadAvailableGroups(user) {
 }
 
 /**
- * updates a map
- * @memberof actions.maps
- * @param  {number} resourceId the id of the map to update
- * @param  {object} content    the new content
- * @param  {object} [options]   options for the request
- * @return {thunk}  dispatches notificationSuccess or loadError and notificationError
- */
-function updateMap(resourceId, content, options) {
-    return (dispatch) => {
-        dispatch(mapUpdating(resourceId, content));
-        GeoStoreApi.putResource(resourceId, content, options).then(() => {
-            dispatch(notificationSuccess({
-                title: 'map.savedMapTitle',
-                message: 'map.savedMapMessage',
-                autoDismiss: 6,
-                position: 'tc'
-            }));
-        }).catch((e) => {
-            dispatch(loadError(e));
-            dispatch(notificationError({
-                ...getErrorMessage(e, 'geostore', 'mapsError'),
-                autoDismiss: 6,
-                position: 'tc'
-            }));
-        });
-    };
-}
-
-/**
  * updates metadata for a map
  * @memberof actions.maps
  * @param  {number} resourceId     the id of the map to updates
@@ -707,42 +673,6 @@ function deleteThumbnail(resourceId, resourceIdMap, options, reset) {
                 dispatch(onDisplayMetadataEdit(true));
                 dispatch(thumbnailError(resourceIdMap, e));
             }
-        });
-    };
-}
-/**
- * Creates a new map.
- * @memberof actions.maps
- * @param  {object} metadata    metadata for the new map
- * @param  {object} content     the map object itself
- * @param  {object} [thumbnail] the thumbnail
- * @param  {object} [options]   options for the request
- * @return {thunk}              creates the map and dispatches  createThumbnail, mapCreated and so on
- */
-function createMap(metadata, content, thumbnail, options) {
-    return (dispatch) => {
-        dispatch(savingMap(metadata));
-        GeoStoreApi.createResource(metadata, content, "MAP", options).then((response) => {
-            let resourceId = response.data;
-            if (thumbnail && thumbnail.data) {
-                dispatch(createThumbnail(null, null, thumbnail.name, thumbnail.data, thumbnail.category, resourceId, options));
-            }
-
-            dispatch(mapCreated(response.data, assign({id: response.data, canDelete: true, canEdit: true, canCopy: true}, metadata), content));
-            dispatch(onDisplayMetadataEdit(false));
-            dispatch(notificationSuccess({
-                title: 'map.savedMapTitle',
-                message: 'map.savedMapMessage',
-                autoDismiss: 6,
-                position: 'tc'
-            }));
-        }).catch((e) => {
-            dispatch(mapError(e));
-            dispatch(notificationError({
-                ...getErrorMessage(e, 'geostore', 'mapsError'),
-                autoDismiss: 6,
-                position: 'tc'
-            }));
         });
     };
 }
@@ -1005,7 +935,6 @@ module.exports = {
     mapCreated,
     mapDeleted,
     mapDeleting,
-    updateMap,
     updateMapMetadata,
     mapMetadataUpdated,
     deleteThumbnail,
@@ -1019,7 +948,6 @@ module.exports = {
     savingMap,
     saveMap,
     thumbnailError,
-    createMap,
     loadError,
     loadPermissions,
     loadAvailableGroups,

--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -64,6 +64,7 @@ const DETAILS_LOADED = 'DETAILS:DETAILS_LOADED';
 const DETAILS_SAVING = 'DETAILS:DETAILS_SAVING';
 const NO_DETAILS_AVAILABLE = "NO_DETAILS_AVAILABLE";
 const FEATURED_MAPS_SET_ENABLED = "FEATURED_MAPS:SET_ENABLED";
+const SAVE_MAP_RESOURCE = "SAVE_MAP_RESOURCE";
 
 
 /**
@@ -936,6 +937,15 @@ const setFeaturedMapsEnabled = (enabled) => ({
     type: FEATURED_MAPS_SET_ENABLED,
     enabled
 });
+/**
+ * Save or update the map resource using geostore observables
+ * @memberof actions.maps
+ * @param {boolean} enabled the `enabled` flag
+ */
+const saveMapResource = (resource) => ({
+    type: SAVE_MAP_RESOURCE,
+    resource
+});
 
 /**
  * Actions for maps
@@ -966,6 +976,7 @@ module.exports = {
     MAPS_SEARCH_TEXT_CHANGED,
     METADATA_CHANGED,
     NO_DETAILS_AVAILABLE,
+    SAVE_MAP_RESOURCE,
     toggleDetailsSheet, TOGGLE_DETAILS_SHEET,
     toggleGroupProperties, TOGGLE_GROUP_PROPERTIES,
     toggleUnsavedChanges, TOGGLE_UNSAVED_CHANGES,
@@ -1017,5 +1028,6 @@ module.exports = {
     resetUpdating,
     mapError,
     mapsSearchTextChanged,
-    updateAttribute
+    updateAttribute,
+    saveMapResource
 };

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -338,7 +338,7 @@ const createMapResource = (resource) => Persistence.createResource(resource)
                 position: 'tc'
             })
         ))
-        .startWith(savingMap(resource.id, resource.data));
+        .startWith(savingMap(resource.metadata));
 /**
  * Create or update map reosurce with persistence api
  */

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -302,43 +302,43 @@ const storeDetailsInfoEpic = (action$, store) =>
     });
 // UPDATE MAP_RESOURCE FLOW
 const updateMapResource = (resource) => Persistence.updateResource(resource)
-            .switchMap(() =>
-        Rx.Observable.of(basicSuccess({
-                                    title: 'map.savedMapTitle',
-                                    message: 'map.savedMapMessage',
-                                    autoDismiss: 6,
-                                    position: 'tc'
-                                })
-                            )
-                )
-    .catch((e) => Rx.Observable.of(loadError(e), basicError({
-                ...getErrorMessage(e, 'geostore', 'mapsError'),
-                autoDismiss: 6,
-                position: 'tc'
-            })
-    ))
-    .startWith(mapUpdating(resource.metadata));
-// CREATE MAP_RESOURCE FLOW
-const createMapResource = (resource) => Persistence.createResource(resource)
-    .switchMap((rid) =>
-Rx.Observable.of(
-        mapCreated(rid, assign({id: rid, canDelete: true, canEdit: true, canCopy: true}, resource.metadata), resource.data),
-        onDisplayMetadataEdit(false),
-        basicSuccess({
+        .switchMap(() =>
+            Rx.Observable.of(basicSuccess({
                     title: 'map.savedMapTitle',
                     message: 'map.savedMapMessage',
                     autoDismiss: 6,
                     position: 'tc'
-                    })
+                        })
+            )
         )
+        .catch((e) => Rx.Observable.of(loadError(e), basicError({
+            ...getErrorMessage(e, 'geostore', 'mapsError'),
+            autoDismiss: 6,
+            position: 'tc'
+        })
+        ))
+        .startWith(mapUpdating(resource.metadata));
+// CREATE MAP_RESOURCE FLOW
+const createMapResource = (resource) => Persistence.createResource(resource)
+        .switchMap((rid) =>
+            Rx.Observable.of(
+                mapCreated(rid, assign({id: rid, canDelete: true, canEdit: true, canCopy: true}, resource.metadata), resource.data),
+                onDisplayMetadataEdit(false),
+                basicSuccess({
+                    title: 'map.savedMapTitle',
+                    message: 'map.savedMapMessage',
+                    autoDismiss: 6,
+                    position: 'tc'
+                })
+                )
         )
-.catch((e) => Rx.Observable.of(mapError(e), basicError({
-        ...getErrorMessage(e, 'geostore', 'mapsError'),
-        autoDismiss: 6,
-        position: 'tc'
-    })
-))
-.startWith(savingMap(resource.id, resource.data));
+        .catch((e) => Rx.Observable.of(mapError(e), basicError({
+                ...getErrorMessage(e, 'geostore', 'mapsError'),
+                autoDismiss: 6,
+                position: 'tc'
+            })
+        ))
+        .startWith(savingMap(resource.id, resource.data));
 /**
  * Create or update map reosurce with persistence api
  */

--- a/web/client/plugins/Save.jsx
+++ b/web/client/plugins/Save.jsx
@@ -15,7 +15,8 @@ const {Glyphicon} = require('react-bootstrap');
 const Message = require('../components/I18N/Message');
 const {toggleControl} = require('../actions/controls');
 const {loadMapInfo} = require('../actions/config');
-const {updateMap} = require('../actions/maps');
+const {saveMapResource} = require('../actions/maps');
+
 const ConfirmModal = require('../components/maps/modals/ConfirmModal');
 const ConfigUtils = require('../utils/ConfigUtils');
 
@@ -90,7 +91,8 @@ class Save extends React.Component {
         if (this.props.mapId) {
             if (this.props.map && this.props.layers) {
                 const resultingmap = MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions);
-                this.props.onMapSave(this.props.mapId, resultingmap);
+                const {name, description} = this.props.map.info;
+                this.props.onMapSave({id: this.props.mapId, data: resultingmap, metadata: {name, description}, category: "MAP"});
                 this.props.onClose();
             }
         }
@@ -101,7 +103,7 @@ module.exports = {
     SavePlugin: connect(selector,
         {
             onClose: toggleControl.bind(null, 'save', false),
-            onMapSave: updateMap,
+            onMapSave: saveMapResource,
             loadMapInfo
         })(assign(Save, {
             BurgerMenu: {

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -144,7 +144,7 @@ class SaveAs extends React.Component {
     };
 
     saveMap = (id, name, description) => {
-        this.props.editMap(this.props.map);
+        this.props.editMap(this.props.currentMap);
         let thumbComponent = this.refs.metadataModal.refs.thumbnail;
         let attributes = {"owner": this.props.user && this.props.user.name || null};
         let metadata = {

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -15,13 +15,14 @@ const {Glyphicon} = require('react-bootstrap');
 const Message = require('../components/I18N/Message');
 const {loadMapInfo} = require('../actions/config');
 const MetadataModal = require('../components/maps/modals/MetadataModal');
-const {createMap, createThumbnail, onDisplayMetadataEdit, metadataChanged} = require('../actions/maps');
+const {saveMapResource, createThumbnail, onDisplayMetadataEdit, metadataChanged} = require('../actions/maps');
 const {editMap, updateCurrentMap, errorCurrentMap, resetCurrentMap} = require('../actions/currentMap');
 const {mapSelector} = require('../selectors/map');
 const {layersSelector, groupsSelector} = require('../selectors/layers');
 const {mapOptionsToSaveSelector} = require('../selectors/mapsave');
 const {mapTypeSelector} = require('../selectors/maptype');
 const {indexOf} = require('lodash');
+const uuid = require('uuid/v1');
 
 const MapUtils = require('../utils/MapUtils');
 
@@ -153,11 +154,12 @@ class SaveAs extends React.Component {
         };
         if (metadata.name !== "") {
             thumbComponent.getThumbnailDataUri( (data) => {
-                this.props.onMapSave(metadata, this.createV2Map(), {
+                this.props.onMapSave({category: "MAP", data: this.createV2Map(), metadata, linkedResources: data && {thumbnail: {
                     data,
                     category: "THUMBNAIL",
-                    name: thumbComponent.generateUUID()
-                });
+                    name: thumbComponent.generateUUID(),
+                    tail: `/raw?decode=datauri&v=${uuid()}`
+                }} || {}});
             });
         }
     };
@@ -170,7 +172,7 @@ module.exports = {
             onClose: () => onDisplayMetadataEdit(false),
             onUpdateCurrentMap: updateCurrentMap,
             onErrorCurrentMap: errorCurrentMap,
-            onMapSave: createMap,
+            onMapSave: saveMapResource,
             loadMapInfo,
             metadataChanged,
             editMap,

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -98,6 +98,7 @@ describe('Test the mapConfig reducer', () => {
         }, {type: MAP_CREATED, resourceId: 2})).toEqual({
             map: {
                 mapId: 2,
+                info: { name: undefined, description: undefined },
                 version: 2
             }
         });
@@ -108,6 +109,7 @@ describe('Test the mapConfig reducer', () => {
         }, {type: MAP_CREATED, resourceId: 2})).toEqual({
             map: {
                 mapId: 2,
+                info: { name: undefined, description: undefined },
                 version: 2
             }
         });

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -98,7 +98,7 @@ describe('Test the mapConfig reducer', () => {
         }, {type: MAP_CREATED, resourceId: 2})).toEqual({
             map: {
                 mapId: 2,
-                info: { name: undefined, description: undefined },
+                info: { name: undefined, description: undefined, canEdit: false, canCopy: false, canDelete: false},
                 version: 2
             }
         });
@@ -109,7 +109,7 @@ describe('Test the mapConfig reducer', () => {
         }, {type: MAP_CREATED, resourceId: 2})).toEqual({
             map: {
                 mapId: 2,
-                info: { name: undefined, description: undefined },
+                info: { name: undefined, description: undefined, canEdit: false, canCopy: false, canDelete: false },
                 version: 2
             }
         });

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -74,8 +74,9 @@ function mapConfig(state = null, action) {
     case MAP_CREATED: {
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         if (map) {
+            const {name, description} = action.metadata || {};
             // version needed to avoid automapupdate to start
-            map = assign({}, map, {mapId: action.resourceId, version: 2});
+            map = assign({}, map, {mapId: action.resourceId, info: {...map.info, name, description}, version: 2});
             return assign({}, state, {map: map});
         }
     }

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -74,9 +74,9 @@ function mapConfig(state = null, action) {
     case MAP_CREATED: {
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
         if (map) {
-            const {name, description} = action.metadata || {};
+            const {name, description, canDelete = false, canCopy = false, canEdit= false} = action.metadata || {};
             // version needed to avoid automapupdate to start
-            map = assign({}, map, {mapId: action.resourceId, info: {...map.info, name, description}, version: 2});
+            map = assign({}, map, {mapId: action.resourceId, info: {...map.info, name, description, canEdit, canDelete, canCopy}, version: 2});
             return assign({}, state, {map: map});
         }
     }


### PR DESCRIPTION
## Description
Save and SaveAs plugins now use persistence api to crete or update a map.
Fix map title in floating legend when a user saves as new map.
## Issues
 - Fix #3183


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
