### PR TITLE
Closes #3186

### DIFF
--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -32,6 +32,12 @@ describe('Test layers selectors', () => {
         expect(props[0].type).toBe("osm");
     });
 
+    it('test layersSelector without layers', () => {
+        const props = layersSelector({});
+        expect(props).toExist();
+        expect(props.length).toBe(0);
+    });
+
     it('test layerSelectorWithMarkers with no markers', () => {
         const props = layerSelectorWithMarkers({config: {layers: [{type: "osm"}]}});
 

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -11,9 +11,9 @@ const {createSelector} = require('reselect');
 const MapInfoUtils = require('../utils/MapInfoUtils');
 const LayersUtils = require('../utils/LayersUtils');
 const {getNormalizedLatLon} = require('../utils/CoordinatesUtils');
-const {get, head, isEmpty, find, isObject, castArray} = require('lodash');
+const {get, head, isEmpty, find, isObject, isArray, castArray} = require('lodash');
 
-const layersSelector = state => state.layers && state.layers.flat || state.layers || state.config && state.config.layers || [];
+const layersSelector = ({layers, config} = {}) => layers && isArray(layers) ? layers : layers && layers.flat || config && config.layers || [];
 const currentBackgroundLayerSelector = state => head(layersSelector(state).filter(l => l && l.visibility && l.group === "background"));
 const getLayerFromId = (state, id) => head(layersSelector(state).filter(l => l.id === id));
 const allBackgroundLayerSelector = state => layersSelector(state).filter(l => l.group === "background");


### PR DESCRIPTION
## Description
Fix layers state selector to avoid new Array.protprype.flat function conflict.
## Issues
 - Fix #3186


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
If state layers property is array the selector fails returning the flat function instead of an array of layers

**What is the new behavior?**
The selectors works correctly always returning an array of layers

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
