### PR TITLE
#3193: fixes disablePluginIf via configuration on root plugins

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -118,9 +118,9 @@ class PluginsContainer extends React.Component {
         return plugins
             .filter((Plugin) => !PluginsUtils.handleExpression(this.getState, this.props.plugins && this.props.plugins.requires, Plugin.hide))
             .map(this.getPluginDescriptor)
-            .filter(plugin => PluginsUtils.filterDisabledPlugins({plugin: plugin && plugin.impl || plugin}, this.getState))
+            .filter(plugin => PluginsUtils.filterDisabledPlugins({plugin: plugin && plugin.impl || plugin, cfg: plugin && plugin.cfg || {}}, this.getState))
             .filter((Plugin) => Plugin && !Plugin.impl.loadPlugin)
-            .filter(plugin => PluginsUtils.filterDisabledPlugins({plugin: plugin && plugin.impl || plugin}, this.getState))
+            .filter(plugin => PluginsUtils.filterDisabledPlugins({plugin: plugin && plugin.impl || plugin, cfg: plugin && plugin.cfg || {}}, this.getState))
             .filter(this.filterPlugins)
             .map((Plugin) => <Plugin.impl key={Plugin.id}
                 {...this.props.params} {...Plugin.cfg} pluginCfg={Plugin.cfg} items={Plugin.items}/>);
@@ -155,7 +155,7 @@ class PluginsContainer extends React.Component {
         (this.props.pluginsConfig && this.props.pluginsConfig[this.props.mode] || [])
             .map((plugin) => PluginsUtils.getPluginDescriptor(getState, this.props.plugins,
                 this.props.pluginsConfig[this.props.mode], plugin, this.state.loadedPlugins))
-            .filter(plugin => PluginsUtils.filterDisabledPlugins({plugin: plugin && plugin.impl || plugin}, getState))
+            .filter(plugin => PluginsUtils.filterDisabledPlugins({ plugin: plugin && plugin.impl || plugin, cfg: plugin && plugin.cfg || {}}, getState))
             .filter((plugin) => plugin && plugin.impl.loadPlugin).forEach((plugin) => {
                 if (!this.state.loadedPlugins[plugin.name]) {
                     if (!plugin.impl.enabler || plugin.impl.enabler(state)) {

--- a/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
+++ b/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const PluginsContainer = require('../PluginsContainer');
+
+class My extends React.Component {
+    render() {
+        return <div/>;
+    }
+}
+const plugins = {
+    MyPlugin: My,
+    OtherPlugin: My
+};
+
+const pluginsCfg = {
+    desktop: [ "My", {
+        name: "Other",
+        cfg: {
+            disablePluginIf: "{true}"
+        }
+    }]
+};
+
+const pluginsCfg2 = {
+    desktop: ["My", "Other"]
+};
+
+describe('PluginsContainer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('checks filterDisabledPlugins one disabled', () => {
+        const cmp = ReactDOM.render(<PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
+                plugins={plugins} pluginsConfig={pluginsCfg}/>, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        const rendered = cmpDom.getElementsByTagName("div");
+        expect(rendered.length).toBe(1);
+    });
+
+    it('checks filterDisabledPlugins no disabled', () => {
+        const cmp = ReactDOM.render(<PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
+            plugins={plugins} pluginsConfig={pluginsCfg2} />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        const rendered = cmpDom.getElementsByTagName("div");
+        expect(rendered.length).toBe(2);
+    });
+});


### PR DESCRIPTION
## Description
disablePluginIf is not working for root level plugins (only the ones contained in other plugins) if used in plugin configuration.

## Issues
 - In the context of #3193 enables using the property on root plugins

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
disablePluginIf is not working for root level plugins (only the ones contained in other plugins) if used in plugin configuration (cfg was not passed down to the filtering function)

**What is the new behavior?**
disablePluginIf is working also for root level plugins when specified in plugin configuration (cfg is now passed down to the filtering function)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No
 - [x] Hopefully no

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
