### PR TITLE
setting the default layer as object

### DIFF
--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('./web', true, /(automapupdate-test\.jsx?)$/);
+var context = require.context('./web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('./web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('./web', true, /(automapupdate-test\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -12,6 +12,11 @@ const { changeLayerParams } = require('../../actions/layers');
 
 describe('Test the layers reducer', () => {
 
+    it('confirms that the default state is an object with "flat" as a property', () => {
+        let state = layers(undefined, {type: 'UNKNOWN'});
+        expect(state.flat.length).toBe(0);
+    });
+
     it('returns original state on unrecognized action', () => {
         let state = layers(1, {type: 'UNKNOWN'});
         expect(state).toBe(1);

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -57,7 +57,7 @@ const moveNode = (groups, node, groupId, newLayers, foreground = true) => {
     return LayersUtils.removeEmptyGroups(newGroups);
 };
 
-function layers(state = [], action) {
+function layers(state = { flat: [] }, action) {
     switch (action.type) {
         case TOGGLE_CONTROL: {
             if (action.control === 'RefreshLayers') {

--- a/web/client/selectors/__tests__/automapupdate-test.js
+++ b/web/client/selectors/__tests__/automapupdate-test.js
@@ -39,7 +39,7 @@ describe('Test automapupdate selectors', () => {
 
     it('getWMSLayers works with initial state', () => {
         const emptyState = {
-        layers: reducer(undefined, { type: "TEST" })
+            layers: reducer(undefined, { type: "TEST" })
         };
         expect(getWMSLayers(emptyState).length).toBe(0);
     });

--- a/web/client/selectors/__tests__/automapupdate-test.js
+++ b/web/client/selectors/__tests__/automapupdate-test.js
@@ -8,6 +8,7 @@
 
 const expect = require('expect');
 const {getWMSLayers, refreshingLayers} = require('../automapupdate');
+const reducer = require('../../reducers/layers');
 
 const state = {
     layers: {
@@ -34,5 +35,12 @@ describe('Test automapupdate selectors', () => {
         expect(layers).toExist();
 
         expect(layers.length).toBe(1);
+    });
+
+    it('getWMSLayers works with initial state', () => {
+        const emptyState = {
+        layers: reducer(undefined, { type: "TEST" })
+        };
+        expect(getWMSLayers(emptyState).length).toBe(0);
     });
 });


### PR DESCRIPTION
## Description
solving the error resulted from the new update of chrome and firefox 

## Issues
 - Fix #3192
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3192

**What is the new behavior?**
when the user  access a an authorized map. the login prompt pops up and an error loading map massage is rendered in the middle of the screen. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
The default value of layer was replaced into an object. No unit-test was added since in all the pre-existing tests the layers value is already an object.