### PR TITLE
Removes console logs from browser from karma testing output

### DIFF
--- a/testConfig.js
+++ b/testConfig.js
@@ -33,7 +33,10 @@ module.exports = ({files, path, testFile, singleRun}) => ({
             istanbul: { noCompact: true }
         }
     },
-
+    browserConsoleLogOptions: {
+        terminal: true,
+        level: 'DISABLE'
+    },
     webpack: {
         devtool: 'eval',
         module: {


### PR DESCRIPTION
## Description
Alternative solution for https://github.com/geosolutions-it/MapStore2/pull/3161.
Completely removes console.log output from browser from karma-runner output during tests, so that test report is clean and does not contain browser generated stuff.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
A lot of noise in test running output, mostly setState error from react-widgets NumberPicker, but not limited to that.

**What is the new behavior?**
No noise from browser output, and a cleaner report.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
