### PR TITLE
Closes #3209

### DIFF
--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -26,13 +26,15 @@ class General extends React.Component {
         onChange: PropTypes.func,
         element: PropTypes.object,
         groups: PropTypes.array,
-        nodeType: PropTypes.string
+        nodeType: PropTypes.string,
+        pluginCfg: PropTypes.object
     };
 
     static defaultProps = {
         element: {},
         onChange: () => {},
-        nodeType: 'layers'
+        nodeType: 'layers',
+        pluginCfg: {}
     };
 
     getGroups = (groups, idx = 0) => {
@@ -52,6 +54,7 @@ class General extends React.Component {
     render() {
         const locales = LocaleUtils.getSupportedLocales();
         const translations = isObject(this.props.element.title) ? assign({}, this.props.element.title) : { 'default': this.props.element.title };
+        const {hideTitleTranslations = false} = this.props.pluginCfg;
         return (
             <Grid fluid style={{paddingTop: 15, paddingBottom: 15}}>
             <form ref="settings">
@@ -63,7 +66,7 @@ class General extends React.Component {
                         type="text"
                         onChange={this.updateTranslation.bind(null, 'default')}/>
                 </FormGroup>
-                <FormGroup>
+                {hideTitleTranslations || (<FormGroup>
                     <ControlLabel><Message msgId="layerProperties.titleTranslations" /></ControlLabel>
                     {Object.keys(locales).map((a) => {
                         let flagImgSrc;
@@ -81,7 +84,7 @@ class General extends React.Component {
                                 onChange={this.updateTranslation.bind(null, locales[a].code)}/>
                     </InputGroup>) : null; }
                     )}
-                </FormGroup>
+                </FormGroup>)}
                 <FormGroup>
                     <ControlLabel><Message msgId="layerProperties.name" /></ControlLabel>
                     <FormControl

--- a/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
@@ -73,5 +73,31 @@ describe('test  Layer Properties General module component', () => {
         ReactTestUtils.Simulate.change(inputs[0]);
         expect(spy.calls.length).toBe(1);
     });
+    it('tests hidden title translations', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: {opacity: 1}
+        };
+        const handlers = {
+            onChange() {}
+        };
+        const pluginCfg = {
+            hideTitleTranslations: true
+        };
+        // wrap in a stateful component, stateless components render return null
+        // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
+        const comp = ReactDOM.render(<General pluginCfg={pluginCfg} element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
+        expect(comp).toExist();
+        const forms = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "form-group" );
+        expect(forms).toExist();
+        expect(forms.length).toBe(3);
+    });
 
 });

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -50,7 +50,7 @@ const tocItemsSettingsSelector = createSelector([
  * @prop cfg.width {number} width of panel
  * @prop cfg.showFeatureInfoTab {bool} enable/disbale feature info settings
  * @prop cfg.enableIFrameModule {bool} enable iframe in template editor of feature info, default true
- *
+ * @prop cfg.hideTitleTranslations {bool} if true hide the title translations tool
  * @example
  * {
  *   "name": "TOCItemsSettings",


### PR DESCRIPTION
## Description
If in TOCItemsSetting cfg the property hideTitleTranslations is set to true, the title translation tool isn't rendered.
## Issues
 - Fix #3209 


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


