### PR TITLE
Fix #3214. Remove duplicated ? from request in download

### DIFF
--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -50,26 +50,6 @@ const getConfigurationOptions = function(query, defaultName, extension, geoStore
         legacy: !!mapId
     };
 };
-
-/**
- * it removes some params from the query string
- * return the shrinked url
-*/
-const getUrlWithoutParameters = (urlToFilter, skip) => {
-    const urlparts = urlToFilter.split('?');
-    let paramsFiltered = "";
-    if (urlparts.length >= 2 && urlparts[1]) {
-        const pars = urlparts[1].split(/[&;]/g).filter( p => !!p);
-        pars.forEach((par, i) => {
-            const param = par.split('=');
-            if (skip.indexOf(param[0].toLowerCase()) === -1) {
-                let addAnd = i === (pars.length - 1) ? "" : "&";
-                paramsFiltered += param.join("=") + addAnd;
-            }
-        });
-    }
-    return !!paramsFiltered ? urlparts[0] + "?" + paramsFiltered : urlparts[0];
-};
 /**
  * WORKAROUND: it removes the extra ? when the authkey param is present
  * the url was like         http......?authkey=....?service=....&otherparam
@@ -95,6 +75,26 @@ const cleanDuplicatedQuestionMarks = (urlToNormalize) => {
     }
     return urlToNormalize;
 };
+/**
+ * it removes some params from the query string
+ * return the shrinked url
+*/
+const getUrlWithoutParameters = (urlToFilter, skip) => {
+    const urlparts = cleanDuplicatedQuestionMarks(urlToFilter).split('?');
+    let paramsFiltered = "";
+    if (urlparts.length >= 2 && urlparts[1]) {
+        const pars = urlparts[1].split(/[&;]/g).filter( p => !!p);
+        pars.forEach((par, i) => {
+            const param = par.split('=');
+            if (skip.indexOf(param[0].toLowerCase()) === -1) {
+                let addAnd = i === (pars.length - 1) ? "" : "&";
+                paramsFiltered += param.join("=") + addAnd;
+            }
+        });
+    }
+    return !!paramsFiltered ? urlparts[0] + "?" + paramsFiltered : urlparts[0];
+};
+
 var ConfigUtils = {
     defaultSourceType: "gxp_wmssource",
     backgroundGroup: "background",

--- a/web/client/utils/__tests__/ConfigUtils-test.js
+++ b/web/client/utils/__tests__/ConfigUtils-test.js
@@ -337,6 +337,11 @@ describe('ConfigUtils', () => {
         let shrinkedUrl = ConfigUtils.getUrlWithoutParameters(match, ["authkey"]);
         expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms?service=WMS&otherparam=OTHERVALUE");
     });
+    it('getUrlWithoutParameters from a normalized url with double ??', () => {
+        const match = "http://somesite.com/geoserver/wms??authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
+        let shrinkedUrl = ConfigUtils.getUrlWithoutParameters(match, ["authkey"]);
+        expect(shrinkedUrl).toBe("http://somesite.com/geoserver/wms?service=WMS&otherparam=OTHERVALUE");
+    });
     it('getUrlWithoutParameters from a normalized url without passing params ', () => {
         const match = "http://somesite.com/geoserver/wms?authkey=someautkeyvalue&service=WMS&otherparam=OTHERVALUE";
         let shrinkedUrl = ConfigUtils.getUrlWithoutParameters(match, []);


### PR DESCRIPTION
## Description
This removes duplicated question marks when adding the authkey to the URL, so the other parameters of the URL are not removed. 


## Issues
 - Fix #3214


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3214 . 

**What is the new behavior?**
The parameters of the url are not all removed if a `??` is in the URL, so authkey requests to wfs services are correctly forwarded with `outputFormat` param

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

**Other information**:
We could also remove it from wfsdownload, where the problem is generated. Tomorrow I'll check if it is easy to add a fix there, too. 