### PR TITLE
rendering widgets only in 2d view

### DIFF
--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -25,6 +25,7 @@ const getWidgetGroups = (groups = [], w) => groups.filter(g => find(g.widgets, i
 require('react-grid-layout-resize-prevent-collision/css/styles.css');
 
 module.exports = pure(({
+    type,
     id,
     style,
     className = "",
@@ -49,7 +50,7 @@ module.exports = pure(({
     onLayoutChange = () => { },
     ...actions
 } = {}) =>
-    (<ResponsiveReactGridLayout
+    (type ? null : <ResponsiveReactGridLayout
         key={id || "widgets-view"}
         useDefaultWidthProvider={useDefaultWidthProvider}
         measureBeforeMount={measureBeforeMount}

--- a/web/client/components/widgets/view/__tests__/WidgetsView-test.jsx
+++ b/web/client/components/widgets/view/__tests__/WidgetsView-test.jsx
@@ -27,7 +27,7 @@ describe('WidgetsView component', () => {
         expect(el).toExist();
     });
     it('Test WidgetsView with widgets', () => {
-        ReactDOM.render(<WidgetsView widgets={[{
+        ReactDOM.render(<WidgetsView type={false} widgets={[{
             title: "TEST",
             id: "TEST",
             layer: {
@@ -44,5 +44,24 @@ describe('WidgetsView component', () => {
         const container = document.getElementById('container');
         const el = container.querySelector('.mapstore-widget-card');
         expect(el).toExist();
+    });
+    it('WidgetsView should not be rendered in 3D mode', () => {
+        ReactDOM.render(<WidgetsView type widgets={[{
+            title: "TEST",
+            id: "TEST",
+            layer: {
+                name: "test",
+                url: 'base/web/client/test-resources/widgetbuilder/aggregate',
+                wpsUrl: 'base/web/client/test-resources/widgetbuilder/aggregate',
+                search: {url: 'base/web/client/test-resources/widgetbuilder/aggregate'}},
+            options: {
+                aggregateFunction: "Count",
+                aggregationAttribute: "test",
+                groupByAttributes: "test"
+            }
+        }]}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.mapstore-widget-card');
+        expect(el).toBe(null);
     });
 });

--- a/web/client/epics/__tests__/widgets-test.js
+++ b/web/client/epics/__tests__/widgets-test.js
@@ -51,12 +51,40 @@ describe('widgets Epics', () => {
                 return count++
                     ? {
                         routing: {
-                            location: "new"
+                            location: { pathname: "new/3012"}
                         }
                     }
                     : {
                         routing: {
-                            location: "old"
+                            location: { pathname: "old/2013"}
+                        }
+                    };
+            });
+    });
+    it('clearWidgetsOnLocationChange does not trigger CLEAR_WIDGETS when change maptype', (done) => {
+        const checkActions = actions => {
+            expect(actions.length).toBe(1);
+            const action = actions[0];
+            expect(action.type).toBe(CLEAR_WIDGETS);
+            done();
+        };
+        let count = 0;
+        testEpic(clearWidgetsOnLocationChange,
+            1,
+            [configureMap(), { type: LOCATION_CHANGE, payload: {
+                pathname: "newPath"
+            }}],
+            checkActions,
+            () => {
+                return count++
+                    ? {
+                        routing: {
+                            location: { pathname: "new-map-type/3012"}
+                        }
+                    }
+                    : {
+                        routing: {
+                            location: { pathname: "old-map-type/2013"}
                         }
                     };
             });
@@ -86,12 +114,12 @@ describe('widgets Epics', () => {
                 return count++
                     ? {
                         routing: {
-                            location: "new"
+                            location: { pathname: "new/3012"}
                         }
                     }
                     : {
                         routing: {
-                            location: "old"
+                            location: { pathname: "old/2013"}
                         }
                     };
             });
@@ -125,12 +153,12 @@ describe('widgets Epics', () => {
                 return count++
                     ? {
                         routing: {
-                            location: "new"
+                            location: { pathname: "new/3012"}
                         }
                     }
                     : {
                         routing: {
-                            location: "old"
+                            location: { pathname: "old/2013"}
                         }
                     };
             });

--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -122,11 +122,13 @@ module.exports = {
 
     clearWidgetsOnLocationChange: (action$, {getState = () => {}} = {}) =>
         action$.ofType(MAP_CONFIG_LOADED).switchMap( () => {
-            const location = get(getState(), "routing.location");
+            const location = get(getState(), "routing.location").pathname.split('/');
+            const loctionDifference = location[location.length - 1];
             return action$.let(getValidLocationChange)
                 .filter( () => {
-                    const newLocation = get(getState(), "routing.location");
-                    return newLocation !== location;
+                    const newLocation = get(getState(), "routing.location").pathname.split('/');
+                    const newLocationDefderence = newLocation [newLocation.length - 1];
+                    return newLocationDefderence !== loctionDifference;
                 }).switchMap( ({payload = {}} = {}) => {
                     if (payload && payload.pathname) {
                         return Rx.Observable.of(clearWidgets());

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -11,6 +11,7 @@ const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
 const { compose, withProps} = require('recompose');
 const {mapIdSelector} = require('../selectors/map');
+const {isCesium} = require('../selectors/maptype');
 const {getFloatingWidgets, dependenciesSelector, getFloatingWidgetsLayout} = require('../selectors/widgets');
 const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage} = require('../actions/widgets');
 const {rightPanelOpenSelector, bottomPanelOpenSelector} = require('../selectors/maplayout');
@@ -22,11 +23,13 @@ const WidgetsView =
 compose(
     connect(
         createSelector(
+            isCesium,
             mapIdSelector,
             getFloatingWidgets,
             getFloatingWidgetsLayout,
             dependenciesSelector,
-            (id, widgets, layouts, dependencies) => ({
+            (type, id, widgets, layouts, dependencies) => ({
+                type,
                 id,
                 widgets,
                 layouts,


### PR DESCRIPTION
## Description
renders the widgets components only if the maptype is "not" Cesium, at the same time trigger " CLEAR_WIDGETS on LOCATION_CHANGE " only when the map id is change in the pathname "not the maptype"  

## Issues
 - Fix #3160
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see #3160

**What is the new behavior?**
when switching back to 2d the widgets is shown again

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
