### PR TITLE
adding map.mapID as a selector

### DIFF
--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -29,7 +29,8 @@ const mapSelector = (state) => state.map && state.map.present || state.map || st
 const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
 
 const projectionSelector = createSelector([mapSelector], (map) => map && map.projection);
-const mapIdSelector = (state) => get(state, "mapInitialConfig.mapId") && parseInt(get(state, "mapInitialConfig.mapId"), 10) || null;
+const stateMapIdSelector = (state) => get(mapSelector(state), "mapId") && parseInt(get(mapSelector(state), "mapId"), 10) || null;
+const mapIdSelector = (state) => get(state, "mapInitialConfig.mapId") && parseInt(get(state, "mapInitialConfig.mapId"), 10) || stateMapIdSelector(state);
 const mapInfoDetailsUriFromIdSelector = (state) => mapSelector(state) && mapSelector(state).info && mapSelector(state).info.details;
 
 /**


### PR DESCRIPTION
## Description
When a new map is created (MAP_CREATED) action updates the "map.present.mapId" state, not the mapInitialConfig.mapId, the PR adds the "map.present.mapId" selector ( if mapInitialConfig = undignified )

## Issues
 - Fix #3197
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

see #3197

**What is the new behavior?**

when re-login to the freshly created map the pre-configs are loaded again 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
