### PR TITLE
Fix #3235 CQL_FILTER is removed correctly when sync tool is de-selected

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1365,6 +1365,49 @@ describe('Openlayers layer', () => {
 
         expect(layer.layer.getSource().getParams().CQL_FILTER).toBe("(\"prop2\" = 'value2')");
     });
+    it('test reset of cql_filter (after filterObj gets removed)', () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            url: "http://sample.server/geoserver/wms",
+            filterObj: {
+                filterFields: [
+                    {
+                        groupId: 1,
+                        attribute: "prop2",
+                        exception: null,
+                        operator: "=",
+                        rowId: "3",
+                        type: "number",
+                        value: "value2"
+                    }],
+                groupFields: [{
+                    id: 1,
+                    index: 0,
+                    logic: "OR"
+                }]
+            }
+        };
+        let layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+        expect(layer).toExist();
+        expect(layer.layer.getSource().getParams().CQL_FILTER).toBe("(\"prop2\" = 'value2')");
+        layer = ReactDOM.render(<OpenlayersLayer
+            type="wms"
+            options={{...options, filterObj: undefined}}
+            map={map}
+        />, document.getElementById("container"));
+        expect(layer).toExist();
+        expect(layer.layer.getSource().getParams().CQL_FILTER).toBe(undefined);
+    });
+
     it('test filterObj and cql_filter combination (featuregrid active filter use this combination)', () => {
         const options = {
             type: "wms",

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -187,7 +187,7 @@ Layers.registerType('wms', {
             }
             if (changed) {
                 const params = objectAssign(newParams, SecurityUtils.addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
-                layer.getSource().updateParams(objectAssign(params, Object.keys(oldOptions.params || {}).reduce((previous, key) => {
+                layer.getSource().updateParams(objectAssign(params, Object.keys(oldParams || {}).reduce((previous, key) => {
                     return params[key] ? previous : objectAssign(previous, {
                         [key]: undefined
                     });


### PR DESCRIPTION
## Description
This PR fixes the problem with filtering ans synch tool.

## Issues
 - Fix #3235 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
the layer is not refreshed correctly, the filter of synch tool remains active

**What is the new behavior?**
the layer is refreshed correctly

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
