### PR TITLE
#3237 Removes the use of StandardRouter from MapStore 2 jsapi

### DIFF
--- a/web/client/components/app/StandardContainer.jsx
+++ b/web/client/components/app/StandardContainer.jsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+const React = require('react');
+const {connect} = require('react-redux');
+const PropTypes = require('prop-types');
+const Debug = require('../development/Debug');
+
+const Localized = require('../I18N/Localized');
+
+const assign = require('object-assign');
+
+const Theme = connect((state) => ({
+    theme: state.theme && state.theme.selectedTheme && state.theme.selectedTheme.id
+}), {}, (stateProps, dispatchProps, ownProps) => {
+    return assign({}, stateProps, dispatchProps, ownProps);
+})(require('../theme/Theme'));
+
+class StandardContainer extends React.Component {
+    static propTypes = {
+        plugins: PropTypes.object,
+        locale: PropTypes.object,
+        componentConfig: PropTypes.object,
+        className: PropTypes.string,
+        themeCfg: PropTypes.object,
+        version: PropTypes.string,
+        loadAfterTheme: PropTypes.bool
+    };
+
+    static defaultProps = {
+        plugins: {},
+        locale: {messages: {}, current: 'en-US'},
+        className: "fill",
+        themeCfg: {
+            path: 'dist/themes'
+        },
+        loadAfterTheme: false
+    };
+    state = {
+        themeLoaded: false
+    }
+    renderComponent = () => {
+        const {componentConfig} = this.props;
+        if (!componentConfig) {
+            return null;
+        }
+        const Component = componentConfig.component;
+        const config = componentConfig.config || {};
+        return (<Component {...config} plugins={this.props.plugins}/>);
+    };
+
+    renderAfterTheme() {
+        return (
+            <div className={this.props.className}>
+                <Theme {...this.props.themeCfg} version={this.props.version} onLoad={this.themeLoaded}>
+                    {this.state.themeLoaded ? (<Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
+                        {this.renderComponent()}
+                    </Localized>) :
+                        (<span><div className="_ms2_init_spinner _ms2_init_center"><div></div></div>
+                        <div className="_ms2_init_text _ms2_init_center">Loading MapStore</div></span>)}
+                </Theme>
+                <Debug/>
+            </div>
+        );
+    }
+    renderWithTheme() {
+        return (
+            <div className={this.props.className}>
+                <Theme {...this.props.themeCfg} version={this.props.version}/>
+                <Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
+                    {this.renderComponent()}
+                </Localized>
+                <Debug/>
+            </div>);
+    }
+    render() {
+        return this.props.loadAfterTheme ? this.renderAfterTheme() : this.renderWithTheme();
+    }
+    themeLoaded = () => {
+        this.setState({
+            themeLoaded: true
+        });
+    }
+}
+
+module.exports = StandardContainer;

--- a/web/client/components/app/__tests__/StandardContainer-test.jsx
+++ b/web/client/components/app/__tests__/StandardContainer-test.jsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const PropTypes = require('prop-types');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {Provider} = require('react-redux');
+
+const StandardContainer = require('../StandardContainer');
+
+const ConfigUtils = require('../../../utils/ConfigUtils');
+
+class mycomponent extends React.Component {
+    static propTypes = {
+        plugins: PropTypes.object
+    };
+
+    static defaultProps = {
+        plugins: {}
+    };
+
+    renderPlugins = () => {
+        return Object.keys(this.props.plugins).map((plugin) => <div className={plugin}/>);
+    };
+
+    render() {
+        return (<div className="mycomponent">
+                {this.renderPlugins()}
+                </div>);
+    }
+}
+
+describe('StandardContainer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        ConfigUtils.setLocalConfigurationFile('base/web/client/test-resources/localConfig.json');
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        ConfigUtils.setLocalConfigurationFile('localConfig.json');
+        setTimeout(done);
+    });
+
+
+    it('creates a default app with component and plugins', () => {
+        const plugins = {
+            MyPlugin: {}
+        };
+
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({})
+        };
+
+        const componentConfig = {
+            component: mycomponent
+        };
+
+        const app = ReactDOM.render(<Provider store={store}><StandardContainer plugins={plugins} componentConfig={componentConfig}/></Provider>, document.getElementById("container"));
+        expect(app).toExist();
+        const dom = ReactDOM.findDOMNode(app);
+        expect(dom.getElementsByClassName('mycomponent').length).toBe(1);
+        expect(dom.getElementsByClassName('MyPlugin').length).toBe(1);
+    });
+});

--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -109,6 +109,7 @@ const getInitialActions = (options) => {
 const MapStore2 = {
     /**
      * Instantiates an embedded MapStore2 application in the given container.
+     * MapStore2 api doesn't use StandardRouter but It relies on StandardContainer
      * @memberof MapStore2
      * @static
      * @param {string} container id of the DOM element that should contain the embedded MapStore2
@@ -166,21 +167,17 @@ const MapStore2 = {
         const {versionSelector} = require('../selectors/version');
         const {loadAfterThemeSelector} = require('../selectors/config');
 
-        const pages = [{
-            name: "embedded",
-            path: "/",
-            component: component || embedded,
-            pageConfig: {
-                pluginsConfig: options.plugins || defaultPlugins
-            }
-        }];
-
-        const StandardRouter = connect((state) => ({
+        const StandardContainer = connect((state) => ({
             locale: state.locale || {},
-            pages,
+            componentConfig: {
+                component: component || embedded,
+                config: {
+                    pluginsConfig: options.plugins || defaultPlugins
+                }
+            },
             version: versionSelector(state),
             loadAfterTheme: loadAfterThemeSelector(state)
-        }))(require('../components/app/StandardRouter'));
+        }))(require('../components/app/StandardContainer'));
         const actionTrigger = generateActionTrigger(options.startAction || "CHANGE_MAP_VIEW");
         triggerAction = actionTrigger.trigger;
         const appStore = require('../stores/StandardStore').bind(null, initialState || {}, {
@@ -194,7 +191,7 @@ const MapStore2 = {
             appStore,
             pluginsDef,
             initialActions,
-            appComponent: StandardRouter,
+            appComponent: StandardContainer,
             printingEnabled: options.printingEnabled || false
         };
         if (options.style) {


### PR DESCRIPTION
## Description
StandardRouter is removed in favour of StandardContainer.
## Issues
 -  #3237


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
