### PR TITLE
TimeLine animation range

### DIFF
--- a/web/client/api/MultiDim.js
+++ b/web/client/api/MultiDim.js
@@ -89,6 +89,7 @@ const getHistogram = (url, layer, histogram, dimensionIdentifiers, resolution, {
  * @param {options} param4 other options
  */
 const getDomainValues = (url, layer, domain, {
+    time,
     fromValue,
     sort = "asc",
     limit = 20
@@ -109,7 +110,8 @@ const getDomainValues = (url, layer, domain, {
             domain,
             fromValue,
             sort,
-            limit
+            limit,
+            time
         })
     }))
     .let(interceptOGCError)

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -29,6 +29,8 @@ const INTERVAL = 2000;
 
 const BUFFER_SIZE = 20;
 const PRELOAD_BEFORE = 10;
+const toAbsoluteInterval = (start, end) => `${start}/${end}`;
+
 const domainArgs = (getState, paginationOptions = {}) => {
     // const timeData = timeDataSelector(getState()) || {};
     const layerName = selectedLayerName(getState());
@@ -36,17 +38,16 @@ const domainArgs = (getState, paginationOptions = {}) => {
 
     return [layerUrl, layerName, "time", {
         limit: BUFFER_SIZE,
+        time: toAbsoluteInterval(playbackRangeSelector(getState()).startPlaybackTime, playbackRangeSelector(getState()).endPlaybackTime),
         ...paginationOptions
     }];
 };
-const domainRangeIdentify = (start, end) => `${start}/${end}`;
+
 
 module.exports = {
     retrieveFramesForPlayback: (action$, { getState = () => { } } = {}) =>
         action$.ofType(PLAY).exhaustMap( () =>
-            getDomainValues(...domainArgs(getState, {
-                time: domainRangeIdentify(playbackRangeSelector(getState()).startPlaybackTime, playbackRangeSelector(getState()).endPlaybackTime)
-            }))
+            getDomainValues(...domainArgs(getState))
                 .map(res => res.DomainValues.Domain.split(","))
                 .map((frames) => setFrames(frames))
                 .let(wrapStartStop(framesLoading(true), framesLoading(false)))

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -39,10 +39,14 @@ const domainArgs = (getState, paginationOptions = {}) => {
         ...paginationOptions
     }];
 };
+const domainRangeIdentify = (start, end) => `${start}/${end}`;
+
 module.exports = {
     retrieveFramesForPlayback: (action$, { getState = () => { } } = {}) =>
         action$.ofType(PLAY).exhaustMap( () =>
-            getDomainValues(...domainArgs(getState))
+            getDomainValues(...domainArgs(getState, {
+                time: domainRangeIdentify(playbackRangeSelector(getState()).startPlaybackTime, playbackRangeSelector(getState()).endPlaybackTime)
+            }))
                 .map(res => res.DomainValues.Domain.split(","))
                 .map((frames) => setFrames(frames))
                 .let(wrapStartStop(framesLoading(true), framesLoading(false)))

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -16,7 +16,7 @@ const {
 } = require('../actions/dimension');
 const { LOCATION_CHANGE } = require('react-router-redux');
 
-const { currentFrameSelector, currentFrameValueSelector, lastFrameSelector} = require('../selectors/playback');
+const { currentFrameSelector, currentFrameValueSelector, lastFrameSelector, playbackRangeSelector} = require('../selectors/playback');
 const {selectedLayerName, selectedLayerUrl} = require('../selectors/timeline');
 
 const pausable = require('../observables/pausable');

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -13,7 +13,7 @@ const Timeline = require('./timeline/Timeline');
 const InlineDateTimeSelector = require('./timeline/InlineDateTimeSelector');
 const Toolbar = require('../components/misc/toolbar/Toolbar');
 const { currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
-const { offsetEnabledSelector, calculateOffsetTimeSelector } = require('../selectors/timeline');
+const { offsetEnabledSelector, calculateOffsetTimeSelector, selectedLayerSelector } = require('../selectors/timeline');
 const { withState, compose, branch, renderNothing } = require('recompose');
 const { selectTime, enableOffset, selectOffset } = require('../actions/timeline');
 const { selectPlaybackRange } = require('../actions/playback');
@@ -34,12 +34,14 @@ const TimelinePlugin = compose(
     connect(
         createSelector(
             layersWithTimeDataSelector,
+            selectedLayerSelector,
             currentTimeSelector,
             calculateOffsetTimeSelector,
             offsetEnabledSelector,
             playbackRangeSelector,
-            (layers, currentTime, calculateOffsetTime, offsetEnabled, playbackRange) => ({
+            (layers, selectedLayer, currentTime, calculateOffsetTime, offsetEnabled, playbackRange) => ({
                 layers,
+                selectedLayer,
                 currentTime,
                 calculateOffsetTime,
                 offsetEnabled,
@@ -130,8 +132,11 @@ const TimelinePlugin = compose(
                             active: offsetEnabled,
                             tooltip: offsetEnabled ? 'Disable current time with offset' : 'Enable current time with offset',
                             onClick: () => {
-                                onOffsetEnabled(!offsetEnabled);
-                                setOptions({ ...options, playbackEnabled: false });
+                                if (selectedLayer) {
+                                    onOffsetEnabled(!offsetEnabled);
+                                    setOptions({ ...options, playbackEnabled: false });
+                                }
+
                             }
                         },
                         {
@@ -141,9 +146,12 @@ const TimelinePlugin = compose(
                             active: playbackEnabled,
                             visible: !!Playback,
                             onClick: () => {
-                                onOffsetEnabled(false);
-                                setOptions({ ...options, playbackEnabled: !playbackEnabled });
-                                setPlaybackRange(playbackRange);
+                                if (selectedLayer) {
+                                    onOffsetEnabled(false);
+                                    setOptions({ ...options, playbackEnabled: !playbackEnabled });
+                                    setPlaybackRange(playbackRange);
+                                }
+
                             }
                         }
                     ]} />

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -57,6 +57,7 @@ const TimelinePlugin = compose(
     withState('options', 'setOptions', {})
 )(
     ({
+        selectedLayer,
         items,
         options,
         setOptions,

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -179,7 +179,7 @@ const enhance = compose(
     }),
     // items enhancer
     withPropsOnChange(
-        ['currentTime', 'offsetEnabled', 'calculatedOffsetTime', 'hideLayersName', 'playbackRange', 'playbackEnabled'],
+        ['items', 'currentTime', 'offsetEnabled', 'calculatedOffsetTime', 'hideLayersName', 'playbackRange', 'playbackEnabled'],
         ({
             currentTime,
             calculatedOffsetTime,

--- a/web/client/selectors/playback.js
+++ b/web/client/selectors/playback.js
@@ -6,8 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const { currentTimeSelector } = require('../selectors/dimension');
-const moment = require('moment');
+const { histogramTimeRange } = require('../selectors/timeline');
 
 const statusSelector = state => state && state.playback && state.playback.status;
 const framesSelector = state => state && state.playback && state.playback.frames;
@@ -20,10 +19,10 @@ const loadingSelector = state => state && state.playback && state.playback.frame
 const currentFrameSelector = state => state && state.playback && state.playback.currentFrame;
 const range = state => state && state.playback && state.playback.playbackRange;
 const playbackRangeSelector = state => {
-    const currentFrame = currentTimeSelector(state);
+    const histogramRange = histogramTimeRange(state);
     return range(state) || {
-        startPlaybackTime: moment(currentFrame).subtract(6, 'month'),
-        endPlaybackTime: moment(currentFrame).add(6, 'month')
+        startPlaybackTime: histogramRange[0],
+        endPlaybackTime: histogramRange[1]
     };
 };
 const currentFrameValueSelector = state => (framesSelector(state) || [])[currentFrameSelector(state)];

--- a/web/client/selectors/playback.js
+++ b/web/client/selectors/playback.js
@@ -6,7 +6,9 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const { histogramTimeRange } = require('../selectors/timeline');
+const { selectedLayerSelector } = require('../selectors/timeline');
+const {layerDimensionDataSelectorCreator} = require('../selectors/dimension');
+
 
 const statusSelector = state => state && state.playback && state.playback.status;
 const framesSelector = state => state && state.playback && state.playback.frames;
@@ -19,10 +21,12 @@ const loadingSelector = state => state && state.playback && state.playback.frame
 const currentFrameSelector = state => state && state.playback && state.playback.currentFrame;
 const range = state => state && state.playback && state.playback.playbackRange;
 const playbackRangeSelector = state => {
-    const histogramRange = histogramTimeRange(state);
-    return range(state) || {
-        startPlaybackTime: histogramRange[0],
-        endPlaybackTime: histogramRange[1]
+    const layerID = selectedLayerSelector(state);
+    const timeRange = layerDimensionDataSelectorCreator(layerID, "time")(state);
+    const dataRange = timeRange && timeRange.domain && timeRange.domain.split('--');
+    return range(state) || dataRange && {
+        startPlaybackTime: dataRange[0],
+        endPlaybackTime: dataRange[1]
     };
 };
 const currentFrameValueSelector = state => (framesSelector(state) || [])[currentFrameSelector(state)];

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -129,7 +129,6 @@ const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(s
 const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
 const selectedLayerUrl = state => selectedLayerData(state) && selectedLayerData(state).dimensions && selectedLayerData(state).dimensions.filter((x) => x.name === "time").map((l) => l.source.url);
 
-
 module.exports = {
     itemsSelector,
     rangeSelector,

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -129,6 +129,13 @@ const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(s
 const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
 const selectedLayerUrl = state => selectedLayerData(state) && selectedLayerData(state).dimensions && selectedLayerData(state).dimensions.filter((x) => x.name === "time").map((l) => l.source.url);
 
+const histogramTimeRange = (state) => {
+    const histogramRange = rangeDataSelector(state);
+    const selectedLayer = selectedLayerSelector(state);
+    return histogramRange && selectedLayer && histogramRange[selectedLayer].histogram && histogramRange[selectedLayer].histogram.domain
+    && histogramRange[selectedLayer].histogram.domain.split('/') || [];
+};
+
 module.exports = {
     itemsSelector,
     rangeSelector,

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -129,12 +129,6 @@ const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(s
 const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
 const selectedLayerUrl = state => selectedLayerData(state) && selectedLayerData(state).dimensions && selectedLayerData(state).dimensions.filter((x) => x.name === "time").map((l) => l.source.url);
 
-const histogramTimeRange = (state) => {
-    const histogramRange = rangeDataSelector(state);
-    const selectedLayer = selectedLayerSelector(state);
-    return histogramRange && selectedLayer && histogramRange[selectedLayer].histogram && histogramRange[selectedLayer].histogram.domain
-    && histogramRange[selectedLayer].histogram.domain.split('/') || [];
-};
 
 module.exports = {
     itemsSelector,


### PR DESCRIPTION
## Description
 - Animations ( in the mockup ) were played without setting a range ( uses the data range ), this PR sets a the the playback within the animation range. The initial value of the range is aligned to the data range.
 - play / range options are disabled when no layer is selected.
 - fix a minor bug ( once layer is loaded, the histogram won't  change until currentTime/ selectedLayer / playbackRange values are changed. Meaning zoom in/out won't reload the histogram unless one of the mentioned props is changed )
## Issues
 - Fix #3280

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see the description

**What is the new behavior?**
see the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
