### PR TITLE
Adding arcgis layer from geonode csw catalog

### DIFF
--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -110,6 +110,24 @@ const longDescriptioRecord = {
     }]
 };
 
+const esriRecord = {
+    title: "Esri Title",
+    description: "Atlantic Hurricanes 2000",
+    identifier: "f4bed551-faa2-4e9c-9820-e623098ba526",
+    tags: "",
+    boundingBox: {
+        extent: [-100.999999999, 10.3000000376, -3.9999999715, 70.7000000118],
+        crs: "EPSG:4326"
+    },
+    references: [{
+        type: "arcgis",
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer",
+        SRS: [],
+        params: {
+            name: "0-Atlantic Hurricanes 2000"}
+        }]
+    };
+
 describe('This test for RecordItem', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -169,6 +187,31 @@ describe('This test for RecordItem', () => {
         expect(actionsSpy.calls.length).toBe(1);
         expect(actionsSpy2.calls.length).toBe(1);
     });
+    it('check esri resource', () => {
+        let actions = {
+            onLayerAdd: () => {
+
+            }
+        };
+        let actionsSpy = expect.spyOn(actions, "onLayerAdd");
+
+        const item = ReactDOM.render(<ReactItem
+            record={esriRecord}
+            onLayerAdd={actions.onLayerAdd}/>, document.getElementById("container"));
+        expect(item).toExist();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toExist();
+        expect(itemDom.className).toBe('record-item panel panel-default');
+        let button = TestUtils.findRenderedDOMComponentWithTag(
+            item, 'button'
+        );
+        expect(button).toExist();
+        button.click();
+        expect(actionsSpy.calls.length).toBe(1);
+    });
+
+
     // test handlers
     it('check event handlers', () => {
         let actions = {

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -44,7 +44,7 @@ const filterOnMatrix = (SRS, matrixIds) => {
 const getThumb = (dc) => {
     let refs = Array.isArray(dc.references) ? dc.references : [dc.references];
     return head([].filter.call( refs, (ref) => {
-        return ref.scheme === "WWW:LINK-1.0-http--image-thumbnail" || ref.scheme === "thumbnail" || (ref.scheme === "WWW:DOWNLOAD-1.0-http--download" && (ref.value || "").indexOf(`${dc.identifier || ""}-thumb`) !== -1);
+        return ref.scheme === "WWW:LINK-1.0-http--image-thumbnail" || ref.scheme === "thumbnail" || (ref.scheme === "WWW:DOWNLOAD-1.0-http--download" && (ref.value || "").indexOf(`${dc.identifier || ""}-thumb`) !== -1) || (ref.scheme === "WWW:DOWNLOAD-REST_MAP" && (ref.value || "").indexOf(`${dc.identifier || ""}-thumb`) !== -1);
     }));
 };
 
@@ -57,6 +57,7 @@ const converters = {
                 let dc = record.dc;
                 let thumbURL;
                 let wms;
+                let esri;
                 // look in URI objects for wms and thumbnail
                 if (dc && dc.URI) {
                     const URI = isArray(dc.URI) ? dc.URI : (dc.URI && [dc.URI] || []);
@@ -72,6 +73,14 @@ const converters = {
                         let urlObj = urlUtil.parse(wms.value, true);
                         let layerName = urlObj.query && urlObj.query.layers || dc.alternative;
                         wms = assign({}, wms, {name: layerName} );
+                    }
+                }// checks for esri arcgis in geonode csw
+                if (!wms && dc && dc.references && dc.references.length) {
+                    let refs = Array.isArray(dc.references) ? dc.references : [dc.references];
+                    esri = head([].filter.call(refs, (ref) => { return ref.scheme && ref.scheme === "WWW:DOWNLOAD-REST_MAP"; }));
+                    if (esri) {
+                        let layerName = dc.alternative;
+                        esri = assign({}, esri, {name: layerName} );
                     }
                 }
                 if (!thumbURL && dc && dc.references) {
@@ -117,6 +126,18 @@ const converters = {
                     };
                     references.push(wmsReference);
                 }
+                if (esri && esri.name) {
+                    let esriReference = {
+                        type: 'arcgis',
+                        url: esri.value,
+                        SRS: [],
+                        params: {
+                            name: esri.name
+                        }
+                    };
+                    references.push(esriReference);
+                }
+
                 if (thumbURL) {
                     let absolute = (thumbURL.indexOf("http") === 0);
                     if (!absolute) {
@@ -248,6 +269,10 @@ const extractOGCServicesReferences = (record = { references: [] }) => ({
     wmts: head(record.references.filter(reference => reference.type && (reference.type === "OGC:WMTS"
         || reference.type.indexOf("OGC:WMTS") > -1 && reference.type.indexOf("http-get-map") > -1)))
 });
+const extractEsriReferences = (record = { references: [] }) => ({
+    esri: head(record.references.filter(reference => reference.type && (reference.type === "ESRI:SERVER"
+        || reference.type === "arcgis" )))
+});
 const getRecordLinks = (record) => {
     let wmsGetCap = head(record.references.filter(reference => reference.type &&
         reference.type.indexOf("OGC:WMS") > -1 && reference.type.indexOf("http-get-capabilities") > -1));
@@ -288,6 +313,7 @@ const CatalogUtils = {
     removeParameters,
     getRecordLinks,
     extractOGCServicesReferences,
+    extractEsriReferences,
     /**
      * Convert a record into a MS2 layer
      * @param  {Object} record            The record
@@ -335,6 +361,31 @@ const CatalogUtils = {
     },
     getCatalogRecords: (format, records, options) => {
         return converters[format] && converters[format](records, options) || null;
+    },
+    esriToLayer: (record) => {
+        if (!record || !record.references) {
+            // we don't have a valid record so no buttons to add
+            return null;
+        }
+        // let's extract the references we need
+        const {esri} = extractEsriReferences(record);
+        return {
+            type: esri.type,
+            url: esri.url,
+            visibility: true,
+            dimensions: record.dimensions || [],
+            name: esri.params && esri.params.name,
+            bbox: {
+                crs: record.boundingBox.crs,
+                bounds: {
+                    minx: record.boundingBox.extent[0],
+                    miny: record.boundingBox.extent[1],
+                    maxx: record.boundingBox.extent[2],
+                    maxy: record.boundingBox.extent[3]
+                }
+            }
+        };
+
     }
 };
 module.exports = CatalogUtils;

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -384,15 +384,30 @@ describe('Test the CatalogUtils', () => {
                     identifier: "09d4e114-74a0-11e8-9c12-20c9d079dc21"
 
                 }
+            },
+            {
+                dc: {
+                    alternative: "1-Hurricane Track",
+                    identifier: "e5efb394-aac2-432e-b784-f18a6f663915",
+                    references: [{
+                            scheme: "WWW:DOWNLOAD-REST_MAP",
+                            value: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer"
+                        }]
+                    }
             }]
         }, {});
-        expect(records.length).toBe(1);
+        expect(records.length).toBe(2);
         const r = records[0];
         expect(r.thumbnail).toExist();
         expect(r.references.length).toBe(1);
         const ref = r.references[0];
         expect(ref.type).toBe("OGC:WMS");
         expect(ref.params.name).toBe("layer.name");
+        const esri = records[1];
+        expect(esri).toExist();
+        expect(esri.references[0]).toExist();
+        expect(esri.references[0].type).toBe("arcgis");
+        expect(esri.references[0].params.name).toBe("1-Hurricane Track");
     });
 
 });


### PR DESCRIPTION
## Description
This is a fix to adapt catalog code to geonode csw catalog. It's a specific implementation and has not to be merged in master.
It's now possible to add an arcgis layer from the catalog

## Issues
 - #geonode-mapstore-client/52 #geonode-mapstore-client/98
 - ...

