### PR TITLE
TimeLine initial setup 

### DIFF
--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -52,7 +52,7 @@ const TimelinePlugin = compose(
             setPlaybackRange: selectPlaybackRange
         }),
     branch(({ layers = [] }) => Object.keys(layers).length === 0, renderNothing),
-    withState('options', 'setOptions', {})
+    withState('options', 'setOptions', {collapsed: true})
 )(
     ({
         items,


### PR DESCRIPTION
## Description
2 parts:
- the code used to do nothing if rangeSelector returns nothing, this PR uses the data's domain (if  rangeSelector returns nothing ) then continues the stream.
- Probably caused by the **react-visjs-timeline**, the component needs some change in its props to re-render. As a workaround collapse/expand does the trick (once the user expands timeline it will rerender).

## Issues
 - Fix #3251 
-  Fix #3284  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see #3251 

**What is the new behavior?**
When rendered, the plugin starts in a collapsed state ( loading pre-saved map or adding a timed layer ).
once the user click the (full size ) button the timeline is expanded and works normally.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
