### PR TITLE
Fix #3309 Hints doesn't show up in style editor

### DIFF
--- a/web/client/components/styleeditor/Editor.jsx
+++ b/web/client/components/styleeditor/Editor.jsx
@@ -149,7 +149,8 @@ class Editor extends React.Component {
         const cur = instance.getCursor();
         const token = instance.getTokenAt(cur);
         if (token.string && (endsWith(token.string, '-') || token.string.match(/^[.`\w@]\w*$/)) && token.string.length > 0) {
-            CM.commands.autocomplete(instance, null, { completeSingle: false });
+            const wrapperElement = this.editor && this.editor.getWrapperElement && this.editor.getWrapperElement() || null;
+            CM.commands.autocomplete(instance, null, { completeSingle: false, container: wrapperElement });
         }
     };
 
@@ -183,7 +184,6 @@ class Editor extends React.Component {
                     </div>
                 }>
                 <Codemirror
-                    ref={cmp => { this.cfgEditor = cmp; }}
                     key="style-editor"
                     value={this.state.code}
                     editorDidMount={editor => {

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -110,6 +110,9 @@
             }
         }
     }
+    .CodeMirror-hints {
+        position: fixed;
+    }
 }
 
 ul.CodeMirror-hints {


### PR DESCRIPTION
## Description
Modified hints container in style editor

## Issues
 - Fix #3309

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Hints doesn't show up in geonode integration

**What is the new behavior?**
Changed hints container

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
