### PR TITLE
Fix #3311 fix mouse positions roundings

### DIFF
--- a/web/client/components/I18N/Number.jsx
+++ b/web/client/components/I18N/Number.jsx
@@ -1,18 +1,19 @@
-var PropTypes = require('prop-types');
 /**
- * Copyright 2015, GeoSolutions Sas.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree.
- */
-var React = require('react');
-var {FormattedNumber} = require('react-intl');
-
+* Copyright 2015, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+const PropTypes = require('prop-types');
+const React = require('react');
+const {FormattedNumber} = require('react-intl');
+const { checkRounding } = require('../../utils/CoordinatesUtils');
 class NumberFormat extends React.Component {
     static propTypes = {
         value: PropTypes.oneOf([PropTypes.object, PropTypes.number]),
-        numberParams: PropTypes.object
+        numberParams: PropTypes.object,
+        roundingBehaviour: PropTypes.string
     };
 
     static contextTypes = {
@@ -20,11 +21,16 @@ class NumberFormat extends React.Component {
     };
 
     static defaultProps = {
-        value: new Date()
+        value: new Date(),
+        roundingBehaviour: "round"
     };
 
     render() {
-        return this.context.intl ? <FormattedNumber value={this.props.value} {...this.props.numberParams}/> : <span>{this.props.value && this.props.value.toString() || ''}</span>;
+        const {value, roundingBehaviour, numberParams} = this.props;
+        const {maximumFractionDigits} = numberParams;
+
+        const roundingOptions = {value, roundingBehaviour, maximumFractionDigits};
+        return this.context.intl ? <FormattedNumber value={checkRounding(roundingOptions)} {...numberParams}/> : <span>{value && value.toString() || ''}</span>;
     }
 }
 

--- a/web/client/components/mapcontrols/mouseposition/MousePositionLabelDM.jsx
+++ b/web/client/components/mapcontrols/mouseposition/MousePositionLabelDM.jsx
@@ -38,10 +38,10 @@ class MousePositionLabelDM extends React.Component {
         return (
                 <h5>
                 <Label bsSize="lg" bsStyle="info">
-                    <span>Lat: </span><NumberFormat key="latD" numberParams={integerFormat} value={pos.lat} />
+                    <span>Lat: </span><NumberFormat key="latD" numberParams={integerFormat} value={pos.lat} roundingBehaviour="floor"/>
                     <span>° </span><NumberFormat key="latM" numberParams={decimalFormat} value={pos.latM} />
                     <span>&apos; </span>
-                    <span>Lng: </span><NumberFormat key="lngD" numberParams={lngDFormat} value={pos.lng} />
+                    <span>Lng: </span><NumberFormat key="lngD" numberParams={lngDFormat} value={pos.lng} roundingBehaviour="floor"/>
                     <span>° </span><NumberFormat key="lngM" numberParams={decimalFormat} value={pos.lngM} />
                     <span>&apos; </span>
                 </Label>

--- a/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMS.jsx
+++ b/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMS.jsx
@@ -41,14 +41,14 @@ class MousePositionLabelDMS extends React.Component {
         return (
                 <h5>
                 <Label bsSize="lg" bsStyle="info">
-                    <span>Lat: </span><NumberFormat key="latD" numberParams={integerFormat} value={pos.lat} />
-                    <span>° </span><NumberFormat key="latM" numberParams={integerFormat} value={pos.latM} />
-                    <span>&apos; </span><NumberFormat key="latS" numberParams={decimalFormat} value={pos.latS} />
+                    <span>Lat: </span><NumberFormat key="latD" numberParams={integerFormat} value={pos.lat} roundingBehaviour="floor"/>
+                    <span>° </span><NumberFormat key="latM" numberParams={integerFormat} value={pos.latM} roundingBehaviour="floor"/>
+                    <span>&apos; </span><NumberFormat key="latS" numberParams={decimalFormat} value={pos.latS}/>
                     <span>&apos;&apos;</span>
                     <span className="mouseposition-separator"/>
-                    <span> Lng: </span><NumberFormat key="lngD" numberParams={lngDFormat} value={pos.lng} />
-                    <span>° </span><NumberFormat key="lngM" numberParams={integerFormat} value={pos.lngM} />
-                    <span>&apos; </span><NumberFormat key="lngS" numberParams={decimalFormat} value={pos.lngS} /><span>''</span>
+                    <span> Lng: </span><NumberFormat key="lngD" numberParams={lngDFormat} value={pos.lng} roundingBehaviour="floor" />
+                    <span>° </span><NumberFormat key="lngM" numberParams={integerFormat} value={pos.lngM} roundingBehaviour="floor"/>
+                    <span>&apos; </span><NumberFormat key="lngS" numberParams={decimalFormat} value={pos.lngS}/><span>''</span>
                 </Label>
                 </h5>);
     }

--- a/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMSNW.jsx
+++ b/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMSNW.jsx
@@ -40,13 +40,12 @@ class MousePositionLabelDMS extends React.Component {
         let lngDFormat = {style: "decimal", minimumIntegerDigits: 3, maximumFractionDigits: 0};
         return (
                 <h5>
-
                 <Label bsSize="lg" bsStyle="info">
-                    <NumberFormat key="latD" numberParams={integerFormat} value={Math.abs(pos.lat)} />
-                    <span>° </span><NumberFormat key="latM" numberParams={integerFormat} value={pos.latM} />
+                    <NumberFormat key="latD" numberParams={integerFormat} value={Math.abs(pos.lat)} roundingBehaviour="floor"/>
+                    <span>° </span><NumberFormat key="latM" numberParams={integerFormat} value={pos.latM} roundingBehaviour="floor"/>
                     <span>&apos; </span><NumberFormat key="latS" numberParams={decimalFormat} value={pos.latS} />
-                    <span>&apos;&apos; {pos.lat > 0 ? "N" : "S"} </span><NumberFormat key="lngD" numberParams={lngDFormat} value={Math.abs(pos.lng)} />
-                    <span>° </span><NumberFormat key="lngM" numberParams={integerFormat} value={pos.lngM} />
+                    <span>&apos;&apos; {pos.lat > 0 ? "N" : "S"} </span><NumberFormat key="lngD" numberParams={lngDFormat} value={Math.abs(pos.lng)} roundingBehaviour="floor" />
+                    <span>° </span><NumberFormat key="lngM" numberParams={integerFormat} value={pos.lngM} roundingBehaviour="floor"/>
                     <span>&apos; </span><NumberFormat key="lngS" numberParams={decimalFormat} value={pos.lngS} /><span>'' {pos.lng > 0 ? "E" : "W"}</span>
                 </Label>
                 </h5>);

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -797,7 +797,7 @@ const CoordinatesUtils = {
      * @return the rounded value or the orignal one
     */
     checkRounding: ({ roundingBehaviour = "round", value = 0, maximumFractionDigits = 0 } = {}) => {
-        if (maximumFractionDigits === 0 && !!Math[roundingBehaviour]) {
+        if (maximumFractionDigits === 0 && Math[roundingBehaviour]) {
             return Math[roundingBehaviour](value);
         }
         return value;

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -791,6 +791,16 @@ const CoordinatesUtils = {
             zoom: map.zoom,
             crs: 'EPSG:4326'
         };
+    },
+    /**
+     * choose to round or floor value incase of 0 fractional digits
+     * @return the rounded value or the orignal one
+    */
+    checkRounding: ({ roundingBehaviour = "round", value = 0, maximumFractionDigits = 0 } = {}) => {
+        if (maximumFractionDigits === 0 && !!Math[roundingBehaviour]) {
+            return Math[roundingBehaviour](value);
+        }
+        return value;
     }
 };
 

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -653,4 +653,29 @@ describe('CoordinatesUtils', () => {
         expect(newCenter.crs).toBe('EPSG:4326');
     });
 
+    it("test rounding of a number 28.45", () => {
+        const value = 28.45;
+        const roundingBehaviour = "floor";
+        const maximumFractionDigits = 0;
+
+        const roundingOptions = {value, roundingBehaviour, maximumFractionDigits};
+        const res = CoordinatesUtils.checkRounding(roundingOptions);
+        expect(res).toBe(28);
+    });
+    it("test rounding of a number 28.55", () => {
+        const value = 28.55;
+        const roundingBehaviour = "floor";
+        const maximumFractionDigits = 0;
+        const roundingOptions = {value, roundingBehaviour, maximumFractionDigits};
+        const res = CoordinatesUtils.checkRounding(roundingOptions);
+        expect(res).toBe(28);
+    });
+    it("test rounding of a number 28.55 with fractional digits", () => {
+        const value = 28.55;
+        const roundingBehaviour = "floor";
+        const maximumFractionDigits = 2;
+        const roundingOptions = {value, roundingBehaviour, maximumFractionDigits};
+        const res = CoordinatesUtils.checkRounding(roundingOptions);
+        expect(res).toBe(28.55);
+    });
 });


### PR DESCRIPTION
## Description
There was an unintended rounding when using 0 fractional digits in numberFormat when the values were fractional like 25.506 and so on.


## Issues
 - Fix #3311

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
there are problems with mouse position where minutes are not updated correctly (see issue #3311)
because it were using a fractional number 

**What is the new behavior?**
It does not rounds up the number if MaximumFractionalDigits is set to 0, but it uses an integer number

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No 

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

One possible alternative solution were to put the roundingBehaviour inside numberParams object.