### PR TITLE
Fix #3313 Style Editor doesn't work after building the application

### DIFF
--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -10,7 +10,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const { connect } = require('react-redux');
 const { createSelector } = require('reselect');
-const { compose, branch } = require('recompose');
+const { compose, branch, toClass } = require('recompose');
 const assign = require('object-assign');
 
 const Loader = require('../components/misc/Loader');
@@ -100,10 +100,13 @@ class StyleEditorPanel extends React.Component {
  * @class StyleEditor
  */
 const StyleEditorPlugin = compose(
+    // Plugin needs to be a class
+    // in this case 'branch' return always a functional component and PluginUtils expects a class
+    toClass,
     // No rendering if not active
     // eg: now only TOCItemsSettings can active following plugin
     branch(
-        ({ active }) => !active,
+        ({ active } = {}) => !active,
         () => () => null
     ),
     // end


### PR DESCRIPTION
## Description
Wrapped StyleEditorPlugin in a class before to exports it.
All plugins need to be a class before the assignment in the export object.
In this case 'branch' from recompose return always a functional component and PluginUtils expects a class.

## Issues
 - Fix #3313

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
StyleEditor plugin is initialized as a functional component but it needs to be a class

**What is the new behavior?**
StyleEditor plugin is initialized as class

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
