### PR TITLE
Fix #3316 Style editor role management, Fix #3317 TOCItemSettings doesn't save from alert modal

### DIFF
--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -148,7 +148,7 @@ const TOCItemSettings = (props, context) => {
                         {
                             bsStyle: 'primary',
                             text: <Message msgId="save"/>,
-                            onClick: onSave
+                            onClick: () => onSave(tabsCloseActions)
                         }
                     ]}>
                     <div className="ms-alert">

--- a/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
+++ b/web/client/components/TOC/enhancers/__tests__/tocitemssettings-test.js
@@ -290,4 +290,130 @@ describe("test updateSettingsLifecycle", () => {
         expect(spyOnUpdateOriginalSettings).toHaveBeenCalled();
         expect(spyOnUpdateInitialSettings).toHaveBeenCalled();
     });
+
+    it('test component on close with tabCloseActions (forced close)', () => {
+        const testHandlers = {
+            tabCloseAction: () => {}
+        };
+
+        const spyTabCloseAction = expect.spyOn(testHandlers, 'tabCloseAction');
+
+        const tabCloseActions = [
+            testHandlers.tabCloseAction
+        ];
+
+        const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose(true, tabCloseActions)}></div>);
+        ReactDOM.render(<Component
+            originalSettings={{}}
+            settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
+             />, document.getElementById("container"));
+
+        const testClose = document.getElementById('test-close');
+        TestUtils.Simulate.click(testClose);
+        expect(spyTabCloseAction).toHaveBeenCalled();
+    });
+
+    it('test component on close with tabCloseActions but not function (forced close)', () => {
+        const testHandlers = {
+            tabCloseAction: () => {}
+        };
+
+        const spyTabCloseAction = expect.spyOn(testHandlers, 'tabCloseAction');
+
+        const tabCloseActions = [
+            "not a function"
+        ];
+
+        const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose(true, tabCloseActions)}></div>);
+        ReactDOM.render(<Component
+            originalSettings={{}}
+            settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
+             />, document.getElementById("container"));
+
+        const testClose = document.getElementById('test-close');
+        TestUtils.Simulate.click(testClose);
+        expect(spyTabCloseAction).toNotHaveBeenCalled();
+    });
+
+    it('test component on close with arg different from array (forced close)', () => {
+        const testHandlers = {
+            tabCloseAction: () => {}
+        };
+
+        const spyTabCloseAction = expect.spyOn(testHandlers, 'tabCloseAction');
+
+        const tabCloseActions = {
+            tabCloseAction: testHandlers.tabCloseAction
+        };
+
+        const Component = settingsLifecycle(({onClose}) => <div id="test-close" onClick={() => onClose(true, tabCloseActions)}></div>);
+        ReactDOM.render(<Component
+            originalSettings={{}}
+            settings={{node: '0', nodeType: 'layer', options: { style: 'new-style' }}}
+             />, document.getElementById("container"));
+
+        const testClose = document.getElementById('test-close');
+        TestUtils.Simulate.click(testClose);
+        expect(spyTabCloseAction).toNotHaveBeenCalled();
+    });
+
+    it('test component on save with tabCloseActions', () => {
+        const testHandlers = {
+            tabCloseAction: () => {}
+        };
+
+        const spyTabCloseAction = expect.spyOn(testHandlers, 'tabCloseAction');
+
+        const tabCloseActions = [
+            testHandlers.tabCloseAction
+        ];
+
+        const Component = settingsLifecycle(({onSave}) => <div id="test-save" onClick={() => onSave(tabCloseActions)}></div>);
+        ReactDOM.render(<Component />, document.getElementById("container"));
+
+        const testSave = document.getElementById('test-save');
+        TestUtils.Simulate.click(testSave);
+
+        expect(spyTabCloseAction).toHaveBeenCalled();
+    });
+
+    it('test component on save with tabCloseActions but not function', () => {
+        const testHandlers = {
+            tabCloseAction: () => {}
+        };
+
+        const spyTabCloseAction = expect.spyOn(testHandlers, 'tabCloseAction');
+
+        const tabCloseActions = [
+            "not a function"
+        ];
+        const Component = settingsLifecycle(({onSave}) => <div id="test-save" onClick={() => onSave(tabCloseActions)}></div>);
+        ReactDOM.render(<Component />, document.getElementById("container"));
+
+        const testSave = document.getElementById('test-save');
+        TestUtils.Simulate.click(testSave);
+
+        expect(spyTabCloseAction).toNotHaveBeenCalled();
+    });
+
+    it('test component on save with arg different from array', () => {
+        const testHandlers = {
+            tabCloseAction: () => {}
+        };
+
+        const spyTabCloseAction = expect.spyOn(testHandlers, 'tabCloseAction');
+
+        const tabCloseActions = {
+            tabCloseAction: testHandlers.tabCloseAction
+        };
+
+        const Component = settingsLifecycle(({onSave}) => <div id="test-save" onClick={() => onSave(tabCloseActions)}></div>);
+        ReactDOM.render(<Component />, document.getElementById("container"));
+
+        const testSave = document.getElementById('test-save');
+        TestUtils.Simulate.click(testSave);
+
+        expect(spyTabCloseAction).toNotHaveBeenCalled();
+    });
+
 });

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -50,7 +50,6 @@ const {
 } = require('../selectors/styleeditor');
 
 const { getSelectedLayer } = require('../selectors/layers');
-const { isAdminUserSelector } = require('../selectors/security');
 const { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts } = require('../utils/StyleEditorUtils');
 const { normalizeUrl } = require('../utils/PrintUtils');
 const { initialSettingsSelector, originalSettingsSelector } = require('../selectors/controls');
@@ -216,7 +215,6 @@ module.exports = {
                     [getLayerCapabilities(layer)],
                     (updatedLayer) => {
 
-                        // layer groups have not available styles
                         if (!updatedLayer.availableStyles) {
                             return Rx.Observable.of(errorStyle('availableStyles', { status: 401 }));
                         }
@@ -226,10 +224,6 @@ module.exports = {
                             updateSettingsParams({ availableStyles }),
                             loadedStyle()
                         );
-                        if (!isAdminUserSelector(state)) {
-                            return setAdditionalLayers(updatedLayer.availableStyles);
-                        }
-
                         return Rx.Observable.defer(() =>
                             StylesAPI.getStylesInfo({
                                 baseUrl: `${parsedUrl.protocol}//${parsedUrl.host}/geoserver/`,

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -53,7 +53,6 @@ const {
     getUpdatedLayer
 } = require('../../selectors/styleeditor');
 
-const { isAdminUserSelector } = require('../../selectors/security');
 const { getEditorMode, STYLE_OWNER_NAME, getStyleTemplates } = require('../../utils/StyleEditorUtils');
 
 const stylesTemplates = getStyleTemplates();
@@ -186,17 +185,16 @@ const StyleToolbar = compose(
                 codeStyleSelector,
                 loadingStyleSelector,
                 selectedStyleSelector,
-                isAdminUserSelector,
                 canEditStyleSelector
             ],
-            (status, templateId, error, initialCode, code, loading, selectedStyle, isAdmin, canEdit) => ({
+            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit) => ({
                 status,
                 templateId,
                 error,
                 isCodeChanged: initialCode !== code,
                 loading,
                 selectedStyle,
-                editEnabled: isAdmin && canEdit
+                editEnabled: canEdit
             })
         ),
         {


### PR DESCRIPTION
## Description
Add editingAllowedRoles to define roles with permission

eg:
editingAllowedRoles: ['ADMIN'] only admin can edit
editingAllowedRoles: null all roles can edit

This PR fixes also a bug while saving from modal in TOCItemSettings

## Issues
 - Fix #3316
 - Fix #3317

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
only ADMIN can edit in style editor

**What is the new behavior?**
MapStore can be configured to set roles with edit permission in style editor

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
