### PR TITLE
Fix #3282. Implemented range animation

### DIFF
--- a/web/client/actions/__tests__/timeline-test.js
+++ b/web/client/actions/__tests__/timeline-test.js
@@ -15,8 +15,10 @@ const {
     RANGE_DATA_LOADED,
     rangeDataLoaded,
     LOADING,
-    timeDataLoading
- } = require('../timeline');
+    timeDataLoading,
+    ENABLE_OFFSET,
+    enableOffset
+} = require('../timeline');
 
 describe('timeline actions', () => {
     it('onRangeChanged', () => {
@@ -38,5 +40,11 @@ describe('timeline actions', () => {
         const retVal = timeDataLoading();
         expect(retVal).toExist();
         expect(retVal.type).toBe(LOADING);
+    });
+    it('enableOffset', () => {
+        const retval = enableOffset(true);
+        expect(retval).toExist();
+        expect(retval.type).toBe(ENABLE_OFFSET);
+        expect(retval.enabled).toBe(true);
     });
 });

--- a/web/client/actions/dimension.js
+++ b/web/client/actions/dimension.js
@@ -8,6 +8,7 @@
 const UPDATE_LAYER_DIMENSION_DATA = "DIMENSION:UPDATE_LAYER_DIMENSION_DATA";
 const SET_CURRENT_TIME = "TIME_MANAGER:SET_CURRENT_TIME";
 const SET_OFFSET_TIME = "TIME_MANAGER:SET_OFFSET_TIME";
+const MOVE_TIME = "TIME_MANAGER:MOVE_TIME";
 
 /**
  *
@@ -20,7 +21,16 @@ const updateLayerDimensionData = (layerId, dimension, data) => ({ type: UPDATE_L
  * @param {string|date} time the current time to set
  */
 const setCurrentTime = time => ({ type: SET_CURRENT_TIME, time });
+/**
+ * Set the current offset.
+ * @param {string} time the current offset time in ISO format. If undefined, the current time is implicit set to single time mode. (against range)
+ */
 const setCurrentOffset = offsetTime => ({ type: SET_OFFSET_TIME, offsetTime });
+/**
+ * Set the current time and shift the current offset to maintain the same interval.
+ * @param {string} time the current time to set in ISO format
+ */
+const moveTime = time => ({ type: MOVE_TIME, time});
 
 
 module.exports = {
@@ -29,6 +39,7 @@ module.exports = {
     setCurrentTime,
     SET_CURRENT_TIME,
     setCurrentOffset,
-    SET_OFFSET_TIME
-
+    SET_OFFSET_TIME,
+    moveTime,
+    MOVE_TIME
 };

--- a/web/client/actions/timeline.js
+++ b/web/client/actions/timeline.js
@@ -56,10 +56,11 @@ const SELECT_LAYER = "TIMELINE:SELECT_LAYER";
  */
 const selectLayer = layerId => ({ type: SELECT_LAYER, layerId});
 
-const SELECT_OFFSET = "TIMELINE:SELECT_OFFSET";
-const selectOffset = offset => ({ type: SELECT_OFFSET, offset});
-
 const ENABLE_OFFSET = "TIMELINE:ENABLE_OFFSET";
+/**
+ * Toggles ranged(offset) vs single time mode
+ * @param {boolean} enabled if true, enables ranged mode
+ */
 const enableOffset = enabled => ({ type: ENABLE_OFFSET, enabled});
 
 /**
@@ -83,8 +84,6 @@ module.exports = {
     timeDataLoading,
     SELECT_LAYER,
     selectLayer,
-    SELECT_OFFSET,
-    selectOffset,
     ENABLE_OFFSET,
     enableOffset
 };

--- a/web/client/epics/dimension.js
+++ b/web/client/epics/dimension.js
@@ -3,8 +3,8 @@ const { Observable } = require('rxjs');
 const { updateLayerDimension, changeLayerProperties, ADD_LAYER} = require('../actions/layers');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
 
-const { SET_CURRENT_TIME, updateLayerDimensionData} = require('../actions/dimension');
-const { layersWithTimeDataSelector } = require('../selectors/dimension');
+const { SET_CURRENT_TIME, MOVE_TIME, SET_OFFSET_TIME, updateLayerDimensionData} = require('../actions/dimension');
+const { layersWithTimeDataSelector, offsetTimeSelector, currentTimeSelector } = require('../selectors/dimension');
 const {describeDomains} = require('../api/MultiDim');
 const { castArray, pick, find } = require('lodash');
 
@@ -28,8 +28,13 @@ module.exports = {
     /**
      * Sync current time param of the layer with the current time element
      */
-    updateLayerDimensionOnCurrentTimeSelection: action$ =>
-        action$.ofType(SET_CURRENT_TIME).switchMap(({time}) => Observable.of(updateLayerDimension('time', time))),
+    updateLayerDimensionOnCurrentTimeSelection: (action$, { getState = () => { } } = {}) =>
+        action$.ofType(SET_CURRENT_TIME, SET_OFFSET_TIME, MOVE_TIME).switchMap(() => {
+            const currentTime = currentTimeSelector(getState());
+            const offsetTime = offsetTimeSelector(getState());
+            const time = offsetTime ? `${currentTime}/${offsetTime}` : currentTime;
+            return Observable.of(updateLayerDimension('time', time));
+        }),
 
     /**
      * Check the presence of Multidimensional API extension, then setup layers properly.

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -13,7 +13,7 @@ const {
     framesLoading
 } = require('../actions/playback');
 const {
-    setCurrentTime, SET_CURRENT_TIME
+    moveTime, SET_CURRENT_TIME, MOVE_TIME, SET_OFFSET_TIME
 } = require('../actions/dimension');
 const {
     selectLayer,
@@ -116,10 +116,10 @@ module.exports = {
     updateCurrentTimeFromAnimation: (action$, { getState = () => { } } = {}) =>
         action$.ofType(SET_CURRENT_FRAME)
             .map(() => currentFrameValueSelector(getState()))
-            .map(t => t ? setCurrentTime(t) : stop()),
+            .map(t => t ? moveTime(t) : stop()),
     timeDimensionPlayback: (action$, { getState = () => { } } = {}) =>
         action$.ofType(SET_FRAMES).exhaustMap(() =>
-            Rx.Observable.interval(frameDurationSelector(getState()) * 1000)
+            Rx.Observable.interval(frameDurationSelector(getState()) * 1000).startWith(0) // start immediately
                 .let(pausable(
                     action$
                         .ofType(PLAY, PAUSE)
@@ -155,7 +155,7 @@ module.exports = {
      */
     playbackFollowCursor: (action$, { getState = () => { } } = {}) =>
         action$
-            .ofType(SET_CURRENT_TIME)
+            .ofType(SET_CURRENT_TIME, MOVE_TIME, SET_OFFSET_TIME)
             .filter(() => statusSelector(getState()) === STATUS.PLAY && isOutOfRange(currentTimeSelector(getState()), rangeSelector(getState())))
             .switchMap(() => Rx.Observable.of(
                 onRangeChanged(

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -12,9 +12,8 @@ const { createSelector } = require('reselect');
 const Timeline = require('./timeline/Timeline');
 const InlineDateTimeSelector = require('../components/time/InlineDateTimeSelector');
 const Toolbar = require('../components/misc/toolbar/Toolbar');
-const { currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
-
-const { offsetEnabledSelector, selectedLayerSelector, currentTimeRangeSelector } = require('../selectors/timeline');
+const { offsetEnabledSelector, currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
+const { selectedLayerSelector, currentTimeRangeSelector } = require('../selectors/timeline');
 const { withState, compose, branch, renderNothing } = require('recompose');
 const { selectTime, enableOffset, selectOffset } = require('../actions/timeline');
 const { selectPlaybackRange } = require('../actions/playback');
@@ -86,7 +85,8 @@ const TimelinePlugin = compose(
             }}
             className={`timeline-plugin${hideLayersName ? ' hide-layers-name' : ''}${offsetEnabled ? ' with-time-offset' : ''}`}>
 
-            {offsetEnabled && <InlineDateTimeSelector
+            {offsetEnabled // if range is present and configured, show the floating start point.
+                && <InlineDateTimeSelector
                 glyph="range-start"
                 tooltip="timeline.currentTime"
                 date={currentTime || currentTimeRange && currentTimeRange.start}
@@ -99,12 +99,14 @@ const TimelinePlugin = compose(
                 }} />}
 
             <div className="timeline-plugin-toolbar">
-                {offsetEnabled && currentTimeRange ?
-                    <InlineDateTimeSelector
+                {offsetEnabled && currentTimeRange
+                    // if range enabled, show time end in the timeline
+                    ? <InlineDateTimeSelector
                         glyph={'range-end'}
                         tooltip="Offset time"
                         date={currentTimeRange.end}
-                        onUpdate={end => isValidOffset(currentTime, end) && setOffset(end)} /> :
+                        onUpdate={end => isValidOffset(currentTime, end) && setOffset(end)} />
+                    : // show current time if using single time
                     <InlineDateTimeSelector
                         glyph={'time-current'}
                         tooltip="timeline.currentTime"
@@ -132,7 +134,6 @@ const TimelinePlugin = compose(
                             tooltip: offsetEnabled ? 'Disable current time with offset' : 'Enable current time with offset',
                             onClick: () => {
                                 onOffsetEnabled(!offsetEnabled);
-                                setOptions({ ...options, playbackEnabled: false });
 
                             }
                         },
@@ -143,7 +144,6 @@ const TimelinePlugin = compose(
                             active: playbackEnabled,
                             visible: !!Playback,
                             onClick: () => {
-                                onOffsetEnabled(false);
                                 setOptions({ ...options, playbackEnabled: !playbackEnabled });
                                 setPlaybackRange(playbackRange);
                             }

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -15,7 +15,9 @@ const Toolbar = require('../components/misc/toolbar/Toolbar');
 const { offsetEnabledSelector, currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
 const { selectedLayerSelector, currentTimeRangeSelector } = require('../selectors/timeline');
 const { withState, compose, branch, renderNothing } = require('recompose');
-const { selectTime, enableOffset, selectOffset } = require('../actions/timeline');
+const { selectTime, enableOffset } = require('../actions/timeline');
+const { setCurrentOffset } = require('../actions/dimension');
+
 const { selectPlaybackRange } = require('../actions/playback');
 const { playbackRangeSelector } = require('../selectors/playback');
 
@@ -50,7 +52,7 @@ const TimelinePlugin = compose(
         ), {
             setCurrentTime: selectTime,
             onOffsetEnabled: enableOffset,
-            setOffset: selectOffset,
+            setOffset: setCurrentOffset,
             setPlaybackRange: selectPlaybackRange
         }),
     branch(({ layers = [] }) => Object.keys(layers).length === 0, renderNothing),

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -267,13 +267,14 @@ const enhance = compose(
             moment: date => moment(date).utc()
         }
     }),
+    // add view range to the options, to sync current range with state one and allow to control it
     withPropsOnChange(['viewRange', 'options'], ({ viewRange = {}, options}) => ({
         options: {
             ...options,
-            ...(viewRange)
+            ...(viewRange) // TODO: if the new view range is very far from the current one, the animation takes a lot. We should allow also to disable animation (animation: false in the options)
         }
     })),
-    // items enhancer
+    // items enhancer. Add background items for playback and time ranges
     withPropsOnChange(
         ['items', 'currentTime', 'offsetEnabled', 'hideLayersName', 'playbackRange', 'playbackEnabled', 'selectedLayer', 'currentTimeRange'],
         ({

--- a/web/client/reducers/dimension.js
+++ b/web/client/reducers/dimension.js
@@ -1,5 +1,7 @@
-const { UPDATE_LAYER_DIMENSION_DATA, SET_CURRENT_TIME, SET_OFFSET_TIME } = require('../actions/dimension');
+const { UPDATE_LAYER_DIMENSION_DATA, SET_CURRENT_TIME, SET_OFFSET_TIME, MOVE_TIME } = require('../actions/dimension');
 const { set } = require('../utils/ImmutableUtils');
+const moment = require('moment');
+
 
 /**
  * Provide state for current time and dimension info.
@@ -38,6 +40,14 @@ module.exports = (state = {}, action) => {
         }
         case SET_OFFSET_TIME: {
             return set('offsetTime', action.offsetTime, state);
+        }
+        case MOVE_TIME: { // same as SET_CURRENT_TIME, but if offsetTime is defined, it moves it together with time
+            if (state.offsetTime && state.currentTime) {
+                const currentRange = moment(state.offsetTime).diff(state.currentTime);
+                const nextOffsetTime = moment(action.time).add(currentRange);
+                return set(`currentTime`, action.time, set('offsetTime', nextOffsetTime.toISOString(), state));
+            }
+            return set(`currentTime`, action.time, state);
         }
         default:
             return state;

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -1,5 +1,5 @@
 const { RANGE_CHANGED } = require('../actions/timeline');
-const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, ENABLE_OFFSET, SELECT_OFFSET, MOUSE_EVENT } = require('../actions/timeline');
+const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, SELECT_OFFSET, MOUSE_EVENT } = require('../actions/timeline');
 const { set } = require('../utils/ImmutableUtils');
 
 
@@ -66,9 +66,6 @@ module.exports = (state = {}, action) => {
         }
         case SELECT_OFFSET: {
             return set('offsetTime', action.offset, state);
-        }
-        case ENABLE_OFFSET: {
-            return set('offsetEnabled', action.enabled, state);
         }
         case MOUSE_EVENT: {
             return set('mouseEvent', action.eventData, state);

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -1,5 +1,5 @@
 const { RANGE_CHANGED } = require('../actions/timeline');
-const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, SELECT_OFFSET, MOUSE_EVENT } = require('../actions/timeline');
+const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, MOUSE_EVENT } = require('../actions/timeline');
 const { set } = require('../utils/ImmutableUtils');
 
 
@@ -63,9 +63,6 @@ module.exports = (state = {}, action) => {
         }
         case SELECT_LAYER: {
             return set('selectedLayer', action.layerId, state);
-        }
-        case SELECT_OFFSET: {
-            return set('offsetTime', action.offset, state);
         }
         case MOUSE_EVENT: {
             return set('mouseEvent', action.eventData, state);

--- a/web/client/selectors/dimension.js
+++ b/web/client/selectors/dimension.js
@@ -39,6 +39,8 @@ const currentTimeSelector = state => {
 };
 
 const offsetTimeSelector = state => get(state, 'dimension.offsetTime');
+
+const offsetEnabledSelector = state => !!offsetTimeSelector(state);
 // get times sorted by date
 const timeSequenceSelector = createSelector(
     timeDataSelector,
@@ -79,5 +81,6 @@ module.exports = {
     currentTimeSelector,
     layersWithTimeDataSelector,
     timeDataSelector,
-    offsetTimeSelector
+    offsetTimeSelector,
+    offsetEnabledSelector
 };

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -2,7 +2,7 @@ const { get } = require('lodash');
 const { createShallowSelector } = require('../utils/ReselectUtils');
 const { timeIntervalToSequence, timeIntervalToIntervalSequence, analyzeIntervalInRange, isTimeDomainInterval } = require('../utils/TimeUtils');
 const moment = require('moment');
-const { timeDataSelector, currentTimeSelector, layerDimensionRangeSelector, offsetTimeSelector } = require('../selectors/dimension');
+const { timeDataSelector, currentTimeSelector, offsetTimeSelector } = require('../selectors/dimension');
 const {getLayerFromId} = require('../selectors/layers');
 const rangeSelector = state => get(state, 'timeline.range');
 const rangeDataSelector = state => get(state, 'timeline.rangeData');

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -122,7 +122,6 @@ const calculateOffsetTimeSelector = (state) => {
     const time = currentTimeSelector(state);
     return time && offset && moment(time).add(offset) || time && moment(time).add(1, 'month');
 };
-const offsetEnabledSelector = state => get(state, "timeline.offsetEnabled");
 
 const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(state));
 const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
@@ -131,11 +130,9 @@ const selectedLayerUrl = state => selectedLayerData(state) && selectedLayerData(
 const mouseEventSelector = state => get(state, "timeline.mouseEvent");
 
 const currentTimeRangeSelector = state => {
-    const layerID = selectedLayerSelector(state);
-    const dataRange = layerDimensionRangeSelector(state, layerID);
-    const time = currentTimeSelector(state);
-    const offsetTime = offsetTimeSelector(state);
-    return dataRange && { start: time && time || dataRange.start, end: offsetTime ? offsetTime : dataRange.end };
+    const start = currentTimeSelector(state);
+    const end = offsetTimeSelector(state);
+    return start && end && {start, end};
 };
 
 module.exports = {
@@ -145,7 +142,6 @@ module.exports = {
     rangeSelector,
     loadingSelector,
     selectedLayerSelector,
-    offsetEnabledSelector,
     calculateOffsetTimeSelector,
     selectedLayerName,
     selectedLayerUrl


### PR DESCRIPTION
## Description
This pull request implements range animation.
Now the currentTime and offsetTime are centralized in `dimension` reducer. The presence of offsetTime is the flag to understand if the mode is ranged or single time. 

Implemented a MOVE_TIME action that moves allow to move the current time, if an offsetTime is present, it will be shifted together with current time. 

Another major change is about initialization. If the user clicks on "range" button, the missing required variables in state will be initialized : 
 - `dimension.currentTime` and `dimension.offsetTime` (extremities of the range)
 - timeline.range (to make the point visible)

## Issues
 - Fix #3282.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Range can not be animated

**What is the new behavior?**
Range can be animated

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
