### PR TITLE
Fix #3289. Fixed openlayers glitch

### DIFF
--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -192,11 +192,15 @@ Layers.registerType('wms', {
                         [key]: undefined
                     });
                 }, {})));
-                if (layer.getSource().refresh) {
-                    layer.getSource().refresh();
-                }
             }
             if (oldOptions.singleTile !== newOptions.singleTile || oldOptions.securityToken !== newOptions.securityToken || oldOptions.ratio !== newOptions.ratio) {
+                // this forces cache empty, required when auth permission changed to avoid caching when unauthorized
+                // Moved here to avoid the layer disappearing during animations
+                if (changed) {
+                    if (layer.getSource().refresh) {
+                        layer.getSource().refresh();
+                    }
+                }
                 const urls = getWMSURLs(isArray(newOptions.url) ? newOptions.url : [newOptions.url]);
                 const queryParameters = wmsToOpenlayersOptions(newOptions) || {};
                 urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters, newOptions.securityToken));

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1494,7 +1494,7 @@
                 "title": "Playback Settings",
                 "frameDuration": "Frame Duration",
                 "range": {
-                    "title": "Animation Rage",
+                    "title": "Animation Range",
                     "zoomTooltip": "Zoom to current animation range",
                     "animationStart": "Animation start",
                     "animationEnd": "Animation end"


### PR DESCRIPTION
## Description
Openlayers not refreshes only if params changed and some particular variable changed (like authkey and so on). This avoids the refresh in the animation case.
