### PR TITLE
 fixing the elevation altering bug and rang/playback conflict

### DIFF
--- a/web/client/epics/dimension.js
+++ b/web/client/epics/dimension.js
@@ -52,9 +52,16 @@ module.exports = {
                     .switchMap( domains => {
                         const dimensions = domainsToDimensionsObject(domains, layer);
                         if (dimensions && dimensions.length > 0) {
+                            /**
+                             * updating the time object in state.layers (from describeDomains),
+                             * while maintaning other dimensions information in state.layer,
+                             * it also creates a list of dimensions (from descibeDomains) in state.dimensions.
+                             *  */
+                            const timeDimensionData = dimensions.filter(d => d.name === 'time').reduce(el => el);
+                            const newDimensions = layer.dimensions.map(dimension => dimension.name === 'time' && timeDimensionData ? timeDimensionData : dimension );
                             return Observable.of(
                                 changeLayerProperties(layer.id, {
-                                    dimensions: dimensions.map(d => pick(d, ['source', 'name']))
+                                    dimensions: newDimensions.map(d => d.name === 'time' ? pick(d, ['source', 'name']) : d )
                                 }),
                                 ...dimensions.map(d => updateLayerDimensionData(layer.id, d.name, d)));
                         }

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -9,7 +9,7 @@ const { setCurrentTime, UPDATE_LAYER_DIMENSION_DATA, setCurrentOffset } = requir
 
 const {getLayerFromId} = require('../selectors/layers');
 const { rangeSelector, selectedLayerName, selectedLayerUrl } = require('../selectors/timeline');
-const { layerTimeSequenceSelectorCreator, offsetEnabledSelector, timeDataSelector, layersWithTimeDataSelector, offsetTimeSelector, currentTimeSelector } = require('../selectors/dimension');
+const { layerTimeSequenceSelectorCreator, timeDataSelector, layersWithTimeDataSelector, offsetTimeSelector, currentTimeSelector } = require('../selectors/dimension');
 
 const { getNearestDate, roundRangeResolution, isTimeDomainInterval } = require('../utils/TimeUtils');
 const { getHistogram, describeDomains, getDomainValues } = require('../api/MultiDim');
@@ -140,12 +140,6 @@ const loadRangeData = (id, timeData, getState) => {
     });
 };
 
-const getTimestamp = (time, offsetEnabled, state) => {
-    if (!offsetEnabled) return time;
-    const offset = offsetTimeSelector(state);
-    const calculatedOffsetTime = moment(time).add(offset);
-    return time + '/' + calculatedOffsetTime.toISOString();
-};
 
 module.exports = {
     /**
@@ -155,12 +149,11 @@ module.exports = {
         action$.ofType(SELECT_TIME)
         .switchMap( ({time, group}) => {
             const state = getState();
-            const offsetEnabled = offsetEnabledSelector(state);
 
             if (snap && group) {
-                return snapTime(state, group, time).map( t => setCurrentTime(getTimestamp(t, offsetEnabled, state)));
+                return snapTime(state, group, time).map( t => setCurrentTime(t));
             }
-            return Rx.Observable.of(setCurrentTime(getTimestamp(time, offsetEnabled, state)));
+            return Rx.Observable.of(setCurrentTime(time));
         }),
      /**
      * When offset is initiated this epic sets both initial current time and offset if any does not exist


### PR DESCRIPTION
## Description
 - the timeline epic on(layer_add), overrides the layer dimensions information in the state with one that it gets from describeDomains request, the original elevation data is used to render the elevation component. This PR updates only the time data in the epic.
-  this PR solves an additional bug related to time selection epic  which creates a new form of currentTime " it returns curruntTime = **"00:00:00/00:00:00"** " that causes some issues because other functions expects **"00:00:00"**

## Issues
 - Fix #3338
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
see #3338

**What is the new behavior?**
elevation data is rendered normally

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
