### PR TITLE
Fix #3251 add autoSelect option to force guide layer selection

### DIFF
--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -5,7 +5,6 @@ const moment = require('moment');
 
 const { SELECT_TIME, RANGE_CHANGED, ENABLE_OFFSET, timeDataLoading, rangeDataLoaded, onRangeChanged, selectLayer } = require('../actions/timeline');
 const { setCurrentTime, UPDATE_LAYER_DIMENSION_DATA, setCurrentOffset } = require('../actions/dimension');
-const {MAP_CONFIG_LOADED} = require('../actions/config');
 
 const {getLayerFromId} = require('../selectors/layers');
 const { rangeSelector, selectedLayerName, selectedLayerUrl, isAutoSelectEnabled } = require('../selectors/timeline');

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -7,6 +7,9 @@ const { set } = require('../utils/ImmutableUtils');
  * Provides state for the timeline. Example:
  * ```
  * {
+ *     settings: {
+ *         autoSelect: true // true by defaults, if set the first layer available will be selected on startup
+ *     },
  *     range: {
  *         start: // start date of the current range
  *         end: // end date of the current range
@@ -42,7 +45,9 @@ const { set } = require('../utils/ImmutableUtils');
  * @param {action} action
 
  */
-module.exports = (state = {}, action) => {
+module.exports = (state = {
+    settings: {autoSelect: true} // selects the first layer available as guide layer. This is a configuration only setting for now
+}, action) => {
     switch (action.type) {
         case RANGE_CHANGED: {
             return set(`range`, {

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -10,6 +10,7 @@ const rangeDataSelector = state => get(state, 'timeline.rangeData');
 // items
 const MAX_ITEMS = 50;
 
+const isAutoSelectEnabled = state => get(state, 'timeline.settings.autoSelect');
 /**
  * Converts the list of timestamps into timeline items.
  * If a timestamp is a start/end/resolution, and items in viewRange are less than MAX_ITEMS, returns tha array of items,
@@ -143,6 +144,7 @@ module.exports = {
     mouseEventSelector,
     itemsSelector,
     rangeSelector,
+    isAutoSelectEnabled,
     loadingSelector,
     selectedLayerSelector,
     calculateOffsetTimeSelector,


### PR DESCRIPTION
# Description

This PR introduces a `settings.autoSelect` entry in `timeline` state. If set to true (true by default) if the leading layer is not selected, it will be selected as soon as the time data is loaded. This happens on map open or on add layer

- Fix #3251