### PR TITLE
Fix #3344 queryable layers not filtered anymore by clicked point layer

### DIFF
--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -137,8 +137,11 @@ class Identify extends React.Component {
                 this.props.purgeResults();
             }
             const queryableLayers = newProps.layers
-                .filter(newProps.queryableLayersFilter)
-                .filter(newProps.layer ? l => l.id === newProps.layer : () => true);
+                .filter(newProps.queryableLayersFilter);
+                /*
+                 * .filter(newProps.layer ? l => l.id === newProps.layer : () => true);
+                 * this line was filtering too much, i.e. see issue https://github.com/geosolutions-it/austrocontrol-C125/issues/97
+                */
             queryableLayers.forEach((layer) => {
                 const {url, request, metadata} = this.props.buildRequest(layer, newProps);
                 if (url) {

--- a/web/client/components/data/identify/Identify.jsx
+++ b/web/client/components/data/identify/Identify.jsx
@@ -9,7 +9,7 @@ const PropTypes = require('prop-types');
 
 const React = require('react');
 const {Panel, Glyphicon, Modal} = require('react-bootstrap');
-const {findIndex} = require('lodash');
+const {findIndex, isArray} = require('lodash');
 
 require('./css/identify.css');
 
@@ -136,11 +136,11 @@ class Identify extends React.Component {
             if (!newProps.point.modifiers || newProps.point.modifiers.ctrl !== true || !newProps.allowMultiselection) {
                 this.props.purgeResults();
             }
-            const queryableLayers = newProps.layers
-                .filter(newProps.queryableLayersFilter);
+            const queryableLayers = isArray(newProps.layers) && (newProps.queryableLayersFilter && newProps.layers
+                .filter(newProps.queryableLayersFilter) || newProps.layers) || [];
                 /*
                  * .filter(newProps.layer ? l => l.id === newProps.layer : () => true);
-                 * this line was filtering too much, i.e. see issue https://github.com/geosolutions-it/austrocontrol-C125/issues/97
+                 * this line was filtering too much, i.e. see issue #3344
                 */
             queryableLayers.forEach((layer) => {
                 const {url, request, metadata} = this.props.buildRequest(layer, newProps);

--- a/web/client/components/data/identify/__tests__/Identify-test.jsx
+++ b/web/client/components/data/identify/__tests__/Identify-test.jsx
@@ -116,6 +116,65 @@ describe('Identify', () => {
         expect(spySendRequest.calls.length).toEqual(2);
     });
 
+    it('creates the Identify component which sends requests on point and 2 other layers (toppstates and a background)', () => {
+        const testHandlers = {
+            sendRequest: () => {}
+        };
+
+        const spySendRequest = expect.spyOn(testHandlers, 'sendRequest');
+
+        ReactDOM.render(
+            <Identify
+                enabled layers={[{}, {}]} sendRequest={testHandlers.sendRequest} buildRequest={() => ({url: "myurl"})}
+                />,
+            document.getElementById("container")
+        );
+        const layers = [
+            {
+                id: 'OpenTopoMap__3',
+                group: 'background',
+                source: 'OpenTopoMap',
+                name: 'OpenTopoMap',
+                title: 'OpenTopoMap',
+                type: 'tileprovider',
+                visibility: false,
+                handleClickOnLayer: false,
+                hidden: false
+            },
+            {
+                id: 'topp:states__4',
+                name: 'topp:states',
+                title: 'USA Population',
+                type: 'wms',
+                url: 'https://demo.geo-solutions.it:443/geoserver/wms',
+                visibility: true,
+                handleClickOnLayer: false,
+                hidden: false
+            },
+            {
+                id: 'annotations',
+                features: [],
+                name: 'Annotations',
+                type: 'vector',
+                visibility: true,
+                handleClickOnLayer: true,
+                hidden: false
+            }
+        ];
+        ReactDOM.render(
+            <Identify
+                point={{pixel: {x: 1, y: 1}}}
+                layer="annotations"
+                enabled
+                layers={layers}
+                sendRequest={testHandlers.sendRequest}
+                buildRequest={() => ({url: "myurl"})}
+                />,
+            document.getElementById("container")
+        );
+        expect(spySendRequest.calls.length).toEqual(2);
+    });
+
     it('creates the Identify component sends local requess on point if no url is specified', () => {
         const testHandlers = {
             sendRequest: () => {}

--- a/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
+++ b/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
@@ -96,6 +96,65 @@ describe("test identify enhancers", () => {
         expect(spySendRequest.calls.length).toEqual(2);
     });
 
+    it('creates the Identify component which sends requests on point and another layer', () => {
+        const Component = identifyLifecycle(() => <div id="test-component"></div>);
+        const testHandlers = {
+            sendRequest: () => {}
+        };
+
+        const spySendRequest = expect.spyOn(testHandlers, 'sendRequest');
+
+        ReactDOM.render(
+            <Component
+                enabled layers={[{}, {}]} sendRequest={testHandlers.sendRequest} buildRequest={() => ({url: "myurl"})}
+                />,
+            document.getElementById("container")
+        );
+        const layers = [
+            {
+                id: 'OpenTopoMap__3',
+                group: 'background',
+                source: 'OpenTopoMap',
+                name: 'OpenTopoMap',
+                title: 'OpenTopoMap',
+                type: 'tileprovider',
+                visibility: false,
+                handleClickOnLayer: false,
+                hidden: false
+            },
+            {
+                id: 'topp:states__4',
+                name: 'topp:states',
+                title: 'USA Population',
+                type: 'wms',
+                url: 'https://demo.geo-solutions.it:443/geoserver/wms',
+                visibility: true,
+                handleClickOnLayer: false,
+                hidden: false
+            },
+            {
+                id: 'annotations',
+                features: [],
+                name: 'Annotations',
+                type: 'vector',
+                visibility: true,
+                handleClickOnLayer: true,
+                hidden: false
+            }
+        ];
+        ReactDOM.render(
+            <Component
+                point={{pixel: {x: 1, y: 1}}}
+                layer="annotations"
+                enabled
+                layers={layers}
+                sendRequest={testHandlers.sendRequest}
+                buildRequest={() => ({url: "myurl"})}
+                />,
+            document.getElementById("container")
+        );
+        expect(spySendRequest.calls.length).toEqual(3);
+    });
     it('test switchControlledIdentify component sends local requess on point if no url is specified', () => {
         const Component = identifyLifecycle(() => <div id="test-component"></div>);
         const testHandlers = {

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {lifecycle, withHandlers, branch, withState, compose} = require('recompose');
+const {lifecycle, withHandlers, branch, withState, compose, defaultProps} = require('recompose');
 const MapInfoUtils = require('../../../../utils/MapInfoUtils');
 const {isEqual, isArray} = require('lodash');
 
@@ -62,6 +62,9 @@ const identifyHandlers = withHandlers({
  */
 const identifyLifecycle = compose(
     identifyHandlers,
+    defaultProps({
+        queryableLayersFilter: () => true
+    }),
     lifecycle({
         componentDidMount() {
             const {
@@ -102,8 +105,11 @@ const identifyLifecycle = compose(
                     purgeResults();
                 }
                 const queryableLayers = isArray(newProps.layers) && newProps.layers
-                    .filter(newProps.queryableLayersFilter)
-                    .filter(newProps.layer ? l => l.id === newProps.layer : () => true);
+                    .filter(newProps.queryableLayersFilter);
+                    /*
+                     * .filter(newProps.layer ? l => l.id === newProps.layer : () => true);
+                     * this line was filtering too much, i.e. see issue https://github.com/geosolutions-it/austrocontrol-C125/issues/97
+                    */
                 if (queryableLayers) {
                     queryableLayers.forEach((layer) => {
                         const {url, request, metadata} = buildRequest(layer, newProps);

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -104,11 +104,11 @@ const identifyLifecycle = compose(
                 if (!newProps.point.modifiers || newProps.point.modifiers.ctrl !== true || !newProps.allowMultiselection) {
                     purgeResults();
                 }
-                const queryableLayers = isArray(newProps.layers) && newProps.layers
-                    .filter(newProps.queryableLayersFilter);
+                const queryableLayers = isArray(newProps.layers) && (newProps.queryableLayersFilter && newProps.layers
+                    .filter(newProps.queryableLayersFilter) || newProps.layers);
                     /*
                      * .filter(newProps.layer ? l => l.id === newProps.layer : () => true);
-                     * this line was filtering too much, i.e. see issue https://github.com/geosolutions-it/austrocontrol-C125/issues/97
+                     * this line was filtering too much, i.e. see issue #3344
                     */
                 if (queryableLayers) {
                     queryableLayers.forEach((layer) => {


### PR DESCRIPTION
## Description
Fixes get feature info requests on point layer (marker) and other layers

## Issues
 - Fix #3344

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
it was filtering the queryable layers too much, excluding all the layers exceptthe one clicked (marker layer)
See #3344 for more details

**What is the new behavior?**
for identify plugin the queryable layers are filtered using as a default the defaultQueryableFilter in MapInfoUtils

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
If using the identify enhancer alone, it needs some defaults for the functions "queryableLayersFilter" and "buildRequest" otherwise it will throw an error because they are undefined.
