### PR TITLE
fix #3345 adding a check for timeline data before expanding the component

### DIFF
--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -152,5 +152,6 @@ module.exports = {
     selectedLayerTimeDimensionConfiguration,
     selectedLayerDataRangeSelector,
     selectedLayerName,
-    selectedLayerUrl
+    selectedLayerUrl,
+    rangeDataSelector
 };


### PR DESCRIPTION
## Description
 fix #3345 when the user expand the timeline component immediately after opening a pre-loaded map the component tries render itself, the problem its main props are not generated yet , and so it renders nothing, this PR assigns the visibility of the expand button to the existence of the timeline.rangeData.
The final outcome : 
The expand button will appear only after timeline.rangeData is created.


## Issues
 - Fix #3345
 - fixing an additional issue with setting the current time using inlineTimeline 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
see #3345

**What is the new behavior?**
see the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
