### PR TITLE
Fix #3267. Sync with map layout. other minor fixes

### DIFF
--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -253,6 +253,7 @@ module.exports = {
         action$
             .ofType(SET_CURRENT_TIME, MOVE_TIME, SET_OFFSET_TIME)
             .filter(() => statusSelector(getState()) === STATUS.PLAY && isOutOfRange(currentTimeSelector(getState()), rangeSelector(getState())))
+            .filter(() => get(playbackSettingsSelector(getState()), "following") )
             .switchMap(() => Rx.Observable.of(
                 onRangeChanged(
                     (() => {


### PR DESCRIPTION
## Description
This PR sync the timeline with map layout. 

NOTE: Actually the widgets and the timeline are overlapping. We have to find out a way to avoid this in the future. @giohappy can we skip widgets/timeline overlapping issues in favor of other tasks for the moment?

other minor fixes: 
 - Following toggle is sync with animation
 - Temporary disabled resize button hiding during loading to avoid issues found with some layers. 
