### PR TITLE
fix #3278 Disable tools during animation

### DIFF
--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -145,7 +145,7 @@ const TimelinePlugin = compose(
                             active: offsetEnabled,
                             tooltip: <Message msgId={offsetEnabled ? "timeline.enableOffset" : "timeline.disableOffset"} />,
                             onClick: () => {
-                                onOffsetEnabled(!offsetEnabled);
+                                if (status !== "PLAY") onOffsetEnabled(!offsetEnabled);
 
                             }
                         },

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -21,7 +21,7 @@ const { selectTime, enableOffset } = require('../actions/timeline');
 const { setCurrentOffset } = require('../actions/dimension');
 const Message = require('../components/I18N/Message');
 const { selectPlaybackRange } = require('../actions/playback');
-const { playbackRangeSelector } = require('../selectors/playback');
+const { playbackRangeSelector, statusSelector } = require('../selectors/playback');
 
 const { head } = require('lodash');
 const moment = require('moment');
@@ -43,13 +43,15 @@ const TimelinePlugin = compose(
             currentTimeRangeSelector,
             offsetEnabledSelector,
             playbackRangeSelector,
-            (layers, selectedLayer, currentTime, currentTimeRange, offsetEnabled, playbackRange) => ({
+            statusSelector,
+            (layers, selectedLayer, currentTime, currentTimeRange, offsetEnabled, playbackRange, status) => ({
                 layers,
                 selectedLayer,
                 currentTime,
                 currentTimeRange,
                 offsetEnabled,
-                playbackRange
+                playbackRange,
+                status
             })
         ), {
             setCurrentTime: selectTime,
@@ -74,7 +76,8 @@ const TimelinePlugin = compose(
         onOffsetEnabled,
         currentTimeRange,
         setOffset,
-        style
+        style,
+        status
     }) => {
 
         const { hideLayersName, collapsed, playbackEnabled } = options;
@@ -99,7 +102,7 @@ const TimelinePlugin = compose(
                 glyph="range-start"
                 tooltip={<Message msgId="timeline.currentTime"/>}
                 date={currentTime || currentTimeRange && currentTimeRange.start}
-                onUpdate={start => (currentTimeRange && isValidOffset(start, currentTimeRange.end) || !currentTimeRange) && setCurrentTime(start)}
+                onUpdate={start => (currentTimeRange && isValidOffset(start, currentTimeRange.end) || !currentTimeRange) && status !== "PLAY" && setCurrentTime(start)}
                 className="shadow-soft"
                 style={{
                     position: 'absolute',
@@ -114,13 +117,13 @@ const TimelinePlugin = compose(
                         glyph={'range-end'}
                         tooltip="Offset time"
                         date={currentTimeRange.end}
-                        onUpdate={end => isValidOffset(currentTime, end) && setOffset(end)} />
+                        onUpdate={end => status !== "PLAY" && isValidOffset(currentTime, end) && setOffset(end)} />
                     : // show current time if using single time
                     <InlineDateTimeSelector
                         glyph={'time-current'}
                         tooltip={<Message msgId="timeline.currentTime"/>}
                         date={currentTime || currentTimeRange && currentTimeRange.start}
-                        onUpdate={start => (currentTimeRange && isValidOffset(start, currentTimeRange.end) || !currentTimeRange) && setCurrentTime(start)} />}
+                        onUpdate={start => (currentTimeRange && isValidOffset(start, currentTimeRange.end) || !currentTimeRange) && status !== "PLAY" && setCurrentTime(start)} />}
 
                 <Toolbar
                     btnDefaultProps={{

--- a/web/client/plugins/playback/Playback.jsx
+++ b/web/client/plugins/playback/Playback.jsx
@@ -146,7 +146,7 @@ module.exports = playbackEnhancer(({
     onShowSettings = () => {}
 }) =>
 ( <div style={{display: 'flex'}}>
-        {showSettings && <PlaybackSettings />}
+        { (status !== statusMap.PLAY && status !== statusMap.PAUSE) && showSettings && <PlaybackSettings />}
         <Toolbar
             btnDefaultProps={{
                 className: 'square-button-md',
@@ -171,9 +171,9 @@ module.exports = playbackEnhancer(({
                     tooltip: <Message msgId={"playback.forwardStep"} />
                 }, {
                     glyph: "wrench",
-                    bsStyle: showSettings ? 'success' : 'primary',
-                    active: !!showSettings,
-                    onClick: () => onShowSettings(!showSettings),
+                    bsStyle: (status !== statusMap.PLAY && status !== statusMap.PAUSE) && showSettings ? 'success' : 'primary',
+                    active: (status !== statusMap.PLAY || status !== statusMap.PAUSE) && !!showSettings,
+                    onClick: () => status !== statusMap.PLAY && onShowSettings(!showSettings),
                     tooltip: <Message msgId={"playback.settings.title"} />
                 }
             ]}/>

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -266,6 +266,7 @@ const enhance = compose(
             showMajorLabels: true,
             showCurrentTime: false,
             zoomMin: 10,
+            zoomable: true,
             type: 'background',
             margin: {
                 item: 0,
@@ -281,10 +282,9 @@ const enhance = compose(
         }
     }),
     // add view range to the options, to sync current range with state one and allow to control it
-    withPropsOnChange(['viewRange', 'options', 'status'], ({ viewRange = {}, options, status}) => ({
+    withPropsOnChange(['viewRange', 'options'], ({ viewRange = {}, options}) => ({
         options: {
             ...options,
-            moveable: status !== "PLAY",
             ...(viewRange) // TODO: if the new view range is very far from the current one, the animation takes a lot. We should allow also to disable animation (animation: false in the options)
         }
     })),

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -14,7 +14,7 @@ const { selectTime, selectLayer, onRangeChanged, setMouseEventData } = require('
 const { itemsSelector, loadingSelector, selectedLayerSelector, mouseEventSelector, currentTimeRangeSelector, rangeSelector } = require('../../selectors/timeline');
 const { setCurrentOffset } = require('../../actions/dimension');
 const { selectPlaybackRange } = require('../../actions/playback');
-const { playbackRangeSelector } = require('../../selectors/playback');
+const { playbackRangeSelector, statusSelector } = require('../../selectors/playback');
 const { createStructuredSelector, createSelector } = require('reselect');
 const { compose, withHandlers, withPropsOnChange, defaultProps } = require('recompose');
 const moment = require('moment');
@@ -87,7 +87,8 @@ const currentTimeEnhancer = compose(
 const playbackRangeEnhancer = compose(
     connect(
         createStructuredSelector({
-            playbackRange: playbackRangeSelector
+            playbackRange: playbackRangeSelector,
+            status: statusSelector
         }),
         {
             setPlaybackRange: selectPlaybackRange
@@ -130,8 +131,12 @@ const getStartEnd = (startTime, endTime) => {
 const clickHandleEnhancer = withHandlers({
     mouseDownHandler: ({
         offsetEnabled,
+        status,
         setMouseData = () => { }
     }) => ({ time, event } = {}) => {
+        if (status === "PLAY") {
+            return;
+        }
         // initialize dragging range event
         let target = event && event.target && event.target.closest('.ms-current-range');
         if ( offsetEnabled && target) {
@@ -140,21 +145,25 @@ const clickHandleEnhancer = withHandlers({
             target = event && event.target && event.target.closest('.vis-custom-time');
             const className = target && target.getAttribute('class');
             const timeId = className && trim(className.replace('vis-custom-time', ''));
-            return timeId && setMouseData({dragging: false, borderID: timeId, startTime: time.toISOString()});
+            if (timeId) setMouseData({dragging: false, borderID: timeId, startTime: time.toISOString()});
         }
 
     },
     clickHandler: ({
         selectedLayer,
         offsetEnabled,
+        status,
         setCurrentTime = () => { },
         selectGroup = () => { },
         mouseEventProps= {}
     }) => ({ time, group, what } = {}) => {
+        if (status === "PLAY") {
+            return;
+        }
         switch (what) {
             // case "axis":
             case "group-label": {
-                if (group) selectGroup(group);
+                if (group && status !== "PLAY") selectGroup(group);
                 break;
             }
             default: {
@@ -168,6 +177,7 @@ const clickHandleEnhancer = withHandlers({
     },
     mouseUpHandler: ({
         currentTime,
+        status,
         setOffset = () => {},
         setCurrentTime = () => { },
         currentTimeRange = {},
@@ -178,7 +188,9 @@ const clickHandleEnhancer = withHandlers({
         setMouseData = () => {},
         setPlaybackRange = () => {}
     }) => ({ time, event } = {}) => {
-
+        if (status === "PLAY") {
+            return;
+        }
         let target = event && event.target && event.target.closest('.vis-center');
         const border = mouseEventProps.borderID;
         // sets the playbackRange range
@@ -225,7 +237,7 @@ const clickHandleEnhancer = withHandlers({
                 // normal click event
         }
         // reseting the mouse event data
-        return Object.keys(mouseEventProps).length > 0 && setMouseData({});
+        if (Object.keys(mouseEventProps).length > 0) setMouseData({});
     }
 
 
@@ -254,7 +266,6 @@ const enhance = compose(
             showMajorLabels: true,
             showCurrentTime: false,
             zoomMin: 10,
-            zoomable: true,
             type: 'background',
             margin: {
                 item: 0,
@@ -270,9 +281,10 @@ const enhance = compose(
         }
     }),
     // add view range to the options, to sync current range with state one and allow to control it
-    withPropsOnChange(['viewRange', 'options'], ({ viewRange = {}, options}) => ({
+    withPropsOnChange(['viewRange', 'options', 'status'], ({ viewRange = {}, options, status}) => ({
         options: {
             ...options,
+            moveable: status !== "PLAY",
             ...(viewRange) // TODO: if the new view range is very far from the current one, the animation takes a lot. We should allow also to disable animation (animation: false in the options)
         }
     })),

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -299,6 +299,7 @@
     }
 
     .vis-item.vis-background.ms-current-range {
+        cursor: grab;
         z-index: 60;
         background-color: fade(lighten(@ms2-color-text, 10%), 20%);
     }


### PR DESCRIPTION
## Description
This PR provides some UI rules based on  #3278 : 
 - Disabling InLineDateTime ability to change current time/ offset time.
 - Hiding/ disabling animation settings widget as long as animation is played or paused.
 - During animation disabling the following events : play, disabling zoom, drag timeline, layer select, change offset range, drag offset range,  switching the offset on / off.
 - Adding a grab cursor when mouse hover the offset range.

## Issues
 - Fix #3278

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see the decribtion

**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
