### PR TITLE
Fixes #3355: relative public path in webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-react": "3.3.2",
     "expect": "1.20.1",
     "extract-text-webpack-plugin": "2.1.0",
-    "file-loader": "0.8.5",
+    "file-loader": "2.0.0",
     "glob": "7.1.1",
     "html-loader": "0.5.1",
     "html-webpack-plugin": "2.17.0",

--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -24,7 +24,7 @@ module.exports = require('./buildConfig')(
     paths,
     extractThemesPlugin,
     true,
-    "/mapstore/dist/",
+    "dist/",
     undefined,
     [
         new HtmlWebpackPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,5 +18,5 @@ module.exports = require('./buildConfig')(
     },
     extractThemesPlugin,
     false,
-    "/dist/"
+    "dist/"
 );


### PR DESCRIPTION
## Description
Allows renaming the built war to anything, without patching the bundles and html files.

## Issues
 - Fix #3355

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Renaming the built war requires patching JS bundles and HTML files.

**What is the new behavior?**
Renaming the built war works without patching

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
