### PR TITLE
#3285 & #3251 enhancing vertical scroll logic

### DIFF
--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -44,7 +44,8 @@ const layerData = compose(
             const { layers: nextLayers, loading: nextLoading, selectedLayer: nextSelectedLayer } = nextProps;
             return loading !== nextLoading
                 || selectedLayer !== nextSelectedLayer
-                || differenceBy(layers, nextLayers || [], ({id, title, name} = {}) => id + title + name).length > 0;
+                || differenceBy(layers, nextLayers || [], ({id, title, name} = {}) => id + title + name).length > 0
+                || layers.length !== nextLayers.length;
         },
         // (props = {}, nextProps = {}) => Object.keys(props.data).length !== Object.keys(nextProps.data).length,
         ({ layers = [], loading = {}, selectedLayer }) => ({
@@ -248,8 +249,7 @@ const enhance = compose(
     defaultProps({
         key: 'timeline',
         options: {
-            maxHeight: '90%',
-            verticalScroll: true,
+            maxHeight: '300px',
             stack: false,
             showMajorLabels: true,
             showCurrentTime: false,
@@ -270,9 +270,11 @@ const enhance = compose(
         }
     }),
     // add view range to the options, to sync current range with state one and allow to control it
-    withPropsOnChange(['viewRange', 'options'], ({ viewRange = {}, options}) => ({
+    withPropsOnChange(['viewRange', 'options', 'status', 'layers'], ({ viewRange = {}, options, status, layers}) => ({
         options: {
             ...options,
+            moveable: status !== "PLAY",
+            verticalScroll: (56 + 28 * Object.keys(layers).length) > 300,
             ...(viewRange) // TODO: if the new view range is very far from the current one, the animation takes a lot. We should allow also to disable animation (animation: false in the options)
         }
     })),


### PR DESCRIPTION
## Description
 - setting an improved policy for timeline size and scrolling through layers in timeline #3285.
 - updating timeline when loading a new layer to the map didn't work for all the scenarios (related to #3251)

## Issues
 - Fix #3285
 - Fix #3251

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see the discretion

**What is the new behavior?**
- setting a  max size for timeline, once the number of layers requires more height than the max-height, the scroll is enabled.
- when adding new layers the timeline re-renders.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
