### PR TITLE
#3359 Timeline delete

### DIFF
--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -20,7 +20,7 @@ const {
     onRangeChanged
 } = require('../actions/timeline');
 
-const { changeLayerProperties } = require('../actions/layers');
+const { changeLayerProperties, REMOVE_NODE } = require('../actions/layers');
 
 const { error } = require('../actions/notifications');
 
@@ -29,7 +29,7 @@ const { currentTimeSelector, layersWithTimeDataSelector, layerTimeSequenceSelect
 const { LOCATION_CHANGE } = require('react-router-redux');
 
 const { currentFrameSelector, currentFrameValueSelector, lastFrameSelector, playbackRangeSelector, playbackSettingsSelector, frameDurationSelector, statusSelector } = require('../selectors/playback');
-const { selectedLayerName, selectedLayerUrl, selectedLayerData, selectedLayerTimeDimensionConfiguration, rangeSelector } = require('../selectors/timeline');
+const { selectedLayerName, selectedLayerUrl, selectedLayerData, selectedLayerTimeDimensionConfiguration, rangeSelector, selectedLayerSelector } = require('../selectors/timeline');
 
 const pausable = require('../observables/pausable');
 const { wrapStartStop } = require('../observables/epics');
@@ -267,5 +267,18 @@ module.exports = {
                         };
                     })()
                 )
-            ))
+            )),
+
+    playbackStopWhenDeleteLayer: (action$, { getState = () => {} }= {}) =>
+        action$
+        .ofType(REMOVE_NODE)
+        .switchMap( action =>
+            selectedLayerSelector(getState()) === action.node || selectedLayerSelector(getState()) === ""
+            ? Rx.Observable.of(
+                stop()
+            ) :
+            Rx.Observable.empty()
+            )
+
+
 };

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -272,13 +272,11 @@ module.exports = {
     playbackStopWhenDeleteLayer: (action$, { getState = () => {} }= {}) =>
         action$
         .ofType(REMOVE_NODE)
-        .switchMap( action =>
-            selectedLayerSelector(getState()) === action.node || selectedLayerSelector(getState()) === ""
-            ? Rx.Observable.of(
-                stop()
-            ) :
-            Rx.Observable.empty()
-            )
+        .filter( () =>
+                !selectedLayerSelector(getState())
+                && statusSelector(getState()) === "PLAY"
+        )
+        .switchMap( () => Rx.Observable.of(stop()))
 
 
 };

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -158,8 +158,8 @@ module.exports = {
      * Initializes the time line
      */
     setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, UPDATE_LAYER_DIMENSION_DATA)
-        .exhaustMap(action => isAutoSelectEnabled(getState()) && !selectedLayerName(getState()) && get(layersWithTimeDataSelector(getState()), "[0].id")
-        && (selectedLayerSelector(getState()) === '' || selectedLayerSelector(getState()) === action.node)
+        .exhaustMap(() => isAutoSelectEnabled(getState()) && get(layersWithTimeDataSelector(getState()), "[0].id")
+        && !selectedLayerSelector(getState())
             ? Rx.Observable.of(selectLayer(get(layersWithTimeDataSelector(getState()), "[0].id")))
                 .concat(
                     Rx.Observable.of(1).switchMap( () =>

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -5,9 +5,9 @@ const moment = require('moment');
 
 const { SELECT_TIME, RANGE_CHANGED, ENABLE_OFFSET, timeDataLoading, rangeDataLoaded, onRangeChanged, selectLayer } = require('../actions/timeline');
 const { setCurrentTime, UPDATE_LAYER_DIMENSION_DATA, setCurrentOffset } = require('../actions/dimension');
-
+const {REMOVE_NODE} = require('../actions/layers');
 const {getLayerFromId} = require('../selectors/layers');
-const { rangeSelector, selectedLayerName, selectedLayerUrl, isAutoSelectEnabled } = require('../selectors/timeline');
+const { rangeSelector, selectedLayerName, selectedLayerUrl, isAutoSelectEnabled, selectedLayerSelector } = require('../selectors/timeline');
 const { layerTimeSequenceSelectorCreator, timeDataSelector, offsetTimeSelector, currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
 
 const { getNearestDate, roundRangeResolution, isTimeDomainInterval } = require('../utils/TimeUtils');
@@ -157,8 +157,9 @@ module.exports = {
     /**
      * Initializes the time line
      */
-    setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(UPDATE_LAYER_DIMENSION_DATA)
-        .exhaustMap(() => isAutoSelectEnabled(getState()) && !selectedLayerName(getState()) && get(layersWithTimeDataSelector(getState()), "[0].id")
+    setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, UPDATE_LAYER_DIMENSION_DATA)
+        .exhaustMap(action => isAutoSelectEnabled(getState()) && !selectedLayerName(getState())
+        || (selectedLayerSelector(getState()) === '' || selectedLayerSelector(getState()) === action.node) && get(layersWithTimeDataSelector(getState()), "[0].id")
             ? Rx.Observable.of(selectLayer(get(layersWithTimeDataSelector(getState()), "[0].id")))
                 .concat(
                     Rx.Observable.of(1).switchMap( () =>

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -158,8 +158,8 @@ module.exports = {
      * Initializes the time line
      */
     setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, UPDATE_LAYER_DIMENSION_DATA)
-        .exhaustMap(action => isAutoSelectEnabled(getState()) && !selectedLayerName(getState())
-        || (selectedLayerSelector(getState()) === '' || selectedLayerSelector(getState()) === action.node) && get(layersWithTimeDataSelector(getState()), "[0].id")
+        .exhaustMap(action => isAutoSelectEnabled(getState()) && !selectedLayerName(getState()) && get(layersWithTimeDataSelector(getState()), "[0].id")
+        && (selectedLayerSelector(getState()) === '' || selectedLayerSelector(getState()) === action.node)
             ? Rx.Observable.of(selectLayer(get(layersWithTimeDataSelector(getState()), "[0].id")))
                 .concat(
                     Rx.Observable.of(1).switchMap( () =>

--- a/web/client/reducers/__tests__/dimension-test.js
+++ b/web/client/reducers/__tests__/dimension-test.js
@@ -22,3 +22,35 @@ it('dimension updateLayerDimensionData', () => {
         dimension: state
     }).name).toBe("time");
 });
+it('removing a layer-related data from dimensin state', () => {
+    const action = {
+        type: 'REMOVE_NODE',
+        node: 'sample1'
+    };
+    const initialState = {
+      currentTime: '00:00:00z',
+      data: {
+          dimension1: { sample1: {}, sample2: {}},
+          dimension2: { sample2: {}}
+      }
+    };
+    const state = dimension(initialState, action);
+    expect(state).toExist();
+    expect(layerDimensionDataSelectorCreator('sample1', 'dimension1')( {
+        dimension: state
+    })).toNotExist();
+    expect(layerDimensionDataSelectorCreator('sample2', 'dimension1')( {
+        dimension: state
+    })).toExist();
+});
+it('removing a layer when there is no data in dimensin state', () => {
+    const action = {
+        type: 'REMOVE_NODE',
+        node: 'sample'
+    };
+    const initialState = {
+      currentTime: '00:00:00z'
+    };
+    const state = dimension(initialState, action);
+    expect(state).toExist();
+});

--- a/web/client/reducers/__tests__/dimension-test.js
+++ b/web/client/reducers/__tests__/dimension-test.js
@@ -11,46 +11,49 @@ var dimension = require('../dimension');
 const { updateLayerDimensionData } = require('../../actions/dimension');
 const { layerDimensionDataSelectorCreator } = require('../../selectors/dimension');
 
-it('dimension updateLayerDimensionData', () => {
-    const action = updateLayerDimensionData("TEST_LAYER", "time", {
-        name: "time",
-        domain: "123--123"
+describe('Test the dimension reducer', () => {
+    it('dimension updateLayerDimensionData', () => {
+        const action = updateLayerDimensionData("TEST_LAYER", "time", {
+            name: "time",
+            domain: "123--123"
+        });
+        const state = dimension( undefined, action);
+        expect(state).toExist();
+        expect(layerDimensionDataSelectorCreator("TEST_LAYER", "time")( {
+            dimension: state
+        }).name).toBe("time");
     });
-    const state = dimension( undefined, action);
-    expect(state).toExist();
-    expect(layerDimensionDataSelectorCreator("TEST_LAYER", "time")( {
-        dimension: state
-    }).name).toBe("time");
-});
-it('removing a layer-related data from dimensin state', () => {
-    const action = {
-        type: 'REMOVE_NODE',
-        node: 'sample1'
-    };
-    const initialState = {
-      currentTime: '00:00:00z',
-      data: {
-          dimension1: { sample1: {}, sample2: {}},
-          dimension2: { sample2: {}}
-      }
-    };
-    const state = dimension(initialState, action);
-    expect(state).toExist();
-    expect(layerDimensionDataSelectorCreator('sample1', 'dimension1')( {
-        dimension: state
-    })).toNotExist();
-    expect(layerDimensionDataSelectorCreator('sample2', 'dimension1')( {
-        dimension: state
-    })).toExist();
-});
-it('removing a layer when there is no data in dimensin state', () => {
-    const action = {
-        type: 'REMOVE_NODE',
-        node: 'sample'
-    };
-    const initialState = {
-      currentTime: '00:00:00z'
-    };
-    const state = dimension(initialState, action);
-    expect(state).toExist();
+    it('removing a layer-related data from dimensin state', () => {
+        const action = {
+            type: 'REMOVE_NODE',
+            node: 'sample1'
+        };
+        const initialState = {
+          currentTime: '00:00:00z',
+          data: {
+              dimension1: { sample1: {}, sample2: {}},
+              dimension2: { sample2: {}}
+          }
+        };
+        const state = dimension(initialState, action);
+        expect(state).toExist();
+        expect(layerDimensionDataSelectorCreator('sample1', 'dimension1')( {
+            dimension: state
+        })).toNotExist();
+        expect(layerDimensionDataSelectorCreator('sample2', 'dimension1')( {
+            dimension: state
+        })).toExist();
+    });
+    it('removing a layer when there is no data in dimensin state', () => {
+        const action = {
+            type: 'REMOVE_NODE',
+            node: 'sample'
+        };
+        const initialState = {
+          currentTime: '00:00:00z'
+        };
+        const state = dimension(initialState, action);
+        expect(state).toExist();
+    });
+
 });

--- a/web/client/reducers/__tests__/timeline-test.js
+++ b/web/client/reducers/__tests__/timeline-test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const timeline = require('../timeline');
+const {rangeDataLoaded, selectLayer, timeDataLoading} = require('../../actions/timeline');
+const expect = require('expect');
+
+
+it('change the layer histogram and rangedata', () => {
+    const initialState = {
+      rangeData: {
+          layer1: { range: 'old range', histogram: 'old histogram'},
+          layer2: { }
+      }
+    };
+    const state = timeline(initialState, rangeDataLoaded('layer1', 'new Range', 'new histogram', 'domain'));
+    expect(state).toExist();
+    expect(state.rangeData.layer1.range).toBe('new Range');
+    expect(state.rangeData.layer1.histogram).toBe('new histogram');
+    expect(state.rangeData.layer1.domain).toBe('domain');
+});
+it('select a layer', () => {
+    const initialState = {
+      rangeData: {
+          layer1: { range: 'old range', histogram: 'old histogram'},
+          layer2: { }
+      }
+    };
+    const state = timeline(initialState, selectLayer('layer1'));
+    expect(state).toExist();
+    expect(state.selectedLayer).toBe('layer1');
+});
+it('layer is loading', () => {
+    const initialState = {
+      rangeData: {
+          layer1: { range: 'old range', histogram: 'old histogram'},
+          layer2: { }
+      }
+    };
+    const state = timeline(initialState, timeDataLoading('layer1', true));
+    expect(state).toExist();
+    expect(state.loading.layer1).toBe(true);
+});
+it('remove a layer', () => {
+    const initialState = {
+      rangeData: {
+          layer1: { range: 'old range', histogram: 'old histogram'},
+          layer2: { }
+      }
+    };
+    const action = {
+        type: 'REMOVE_NODE',
+        node: 'layer1'
+    };
+    const state = timeline(initialState, action);
+    expect(state).toExist();
+    expect(state.rangeData.layer1).toNotExist();
+
+});
+it('remove a layer that is not selected', () => {
+    const initialState = {
+      selectedLayer: 'layer2',
+      rangeData: {
+          layer1: { range: 'old range', histogram: 'old histogram'},
+          layer2: { }
+      }
+    };
+    const action = {
+        type: 'REMOVE_NODE',
+        node: 'layer1'
+    };
+    const state = timeline(initialState, action);
+    expect(state).toExist();
+    expect(state.rangeData.layer1).toNotExist();
+    expect(state.selectedLayer).toBe('layer2');
+    expect(state.rangeData.layer2).toExist();
+
+});
+it('remove a selected layer with no rangeData or loading data', () => {
+    const initialState = {
+      selectedLayer: 'layer3',
+      rangeData: {
+          layer1: { range: 'old range', histogram: 'old histogram'},
+          layer2: { }
+      }
+    };
+    const action = {
+        type: 'REMOVE_NODE',
+        node: 'layer3'
+    };
+    const state = timeline(initialState, action);
+    expect(state).toExist();
+    expect(state.rangeData.layer1).toExist();
+    expect(state.rangeData.layer2).toExist();
+    expect(state.selectedLayer).toNotExist();
+
+});

--- a/web/client/reducers/__tests__/timeline-test.js
+++ b/web/client/reducers/__tests__/timeline-test.js
@@ -10,93 +10,92 @@ const timeline = require('../timeline');
 const {rangeDataLoaded, selectLayer, timeDataLoading} = require('../../actions/timeline');
 const expect = require('expect');
 
+describe('Test the timeline reducer', () => {
+    it('change the layer histogram and rangedata', () => {
+        const initialState = {
+          rangeData: {
+              layer1: { range: 'old range', histogram: 'old histogram'},
+              layer2: { }
+          }
+        };
+        const state = timeline(initialState, rangeDataLoaded('layer1', 'new Range', 'new histogram', 'domain'));
+        expect(state).toExist();
+        expect(state.rangeData.layer1.range).toBe('new Range');
+        expect(state.rangeData.layer1.histogram).toBe('new histogram');
+        expect(state.rangeData.layer1.domain).toBe('domain');
+    });
+    it('select a layer', () => {
+        const initialState = {
+          rangeData: {
+              layer1: { range: 'old range', histogram: 'old histogram'},
+              layer2: { }
+          }
+        };
+        const state = timeline(initialState, selectLayer('layer1'));
+        expect(state).toExist();
+        expect(state.selectedLayer).toBe('layer1');
+    });
+    it('layer is loading', () => {
+        const initialState = {
+          rangeData: {
+              layer1: { range: 'old range', histogram: 'old histogram'},
+              layer2: { }
+          }
+        };
+        const state = timeline(initialState, timeDataLoading('layer1', true));
+        expect(state).toExist();
+        expect(state.loading.layer1).toBe(true);
+    });
+    it('remove a layer', () => {
+        const initialState = {
+          rangeData: {
+              layer1: { range: 'old range', histogram: 'old histogram'},
+              layer2: { }
+          }
+        };
+        const action = {
+            type: 'REMOVE_NODE',
+            node: 'layer1'
+        };
+        const state = timeline(initialState, action);
+        expect(state).toExist();
+        expect(state.rangeData.layer1).toNotExist();
 
-it('change the layer histogram and rangedata', () => {
-    const initialState = {
-      rangeData: {
-          layer1: { range: 'old range', histogram: 'old histogram'},
-          layer2: { }
-      }
-    };
-    const state = timeline(initialState, rangeDataLoaded('layer1', 'new Range', 'new histogram', 'domain'));
-    expect(state).toExist();
-    expect(state.rangeData.layer1.range).toBe('new Range');
-    expect(state.rangeData.layer1.histogram).toBe('new histogram');
-    expect(state.rangeData.layer1.domain).toBe('domain');
-});
-it('select a layer', () => {
-    const initialState = {
-      rangeData: {
-          layer1: { range: 'old range', histogram: 'old histogram'},
-          layer2: { }
-      }
-    };
-    const state = timeline(initialState, selectLayer('layer1'));
-    expect(state).toExist();
-    expect(state.selectedLayer).toBe('layer1');
-});
-it('layer is loading', () => {
-    const initialState = {
-      rangeData: {
-          layer1: { range: 'old range', histogram: 'old histogram'},
-          layer2: { }
-      }
-    };
-    const state = timeline(initialState, timeDataLoading('layer1', true));
-    expect(state).toExist();
-    expect(state.loading.layer1).toBe(true);
-});
-it('remove a layer', () => {
-    const initialState = {
-      rangeData: {
-          layer1: { range: 'old range', histogram: 'old histogram'},
-          layer2: { }
-      }
-    };
-    const action = {
-        type: 'REMOVE_NODE',
-        node: 'layer1'
-    };
-    const state = timeline(initialState, action);
-    expect(state).toExist();
-    expect(state.rangeData.layer1).toNotExist();
-
-});
-it('remove a layer that is not selected', () => {
-    const initialState = {
-      selectedLayer: 'layer2',
-      rangeData: {
-          layer1: { range: 'old range', histogram: 'old histogram'},
-          layer2: { }
-      }
-    };
-    const action = {
-        type: 'REMOVE_NODE',
-        node: 'layer1'
-    };
-    const state = timeline(initialState, action);
-    expect(state).toExist();
-    expect(state.rangeData.layer1).toNotExist();
-    expect(state.selectedLayer).toBe('layer2');
-    expect(state.rangeData.layer2).toExist();
-
-});
-it('remove a selected layer with no rangeData or loading data', () => {
-    const initialState = {
-      selectedLayer: 'layer3',
-      rangeData: {
-          layer1: { range: 'old range', histogram: 'old histogram'},
-          layer2: { }
-      }
-    };
-    const action = {
-        type: 'REMOVE_NODE',
-        node: 'layer3'
-    };
-    const state = timeline(initialState, action);
-    expect(state).toExist();
-    expect(state.rangeData.layer1).toExist();
-    expect(state.rangeData.layer2).toExist();
-    expect(state.selectedLayer).toNotExist();
-
+    });
+    it('remove a layer that is not selected', () => {
+        const initialState = {
+          selectedLayer: 'layer2',
+          rangeData: {
+              layer1: { range: 'old range', histogram: 'old histogram'},
+              layer2: { }
+          }
+        };
+        const action = {
+            type: 'REMOVE_NODE',
+            node: 'layer1'
+        };
+        const state = timeline(initialState, action);
+        expect(state).toExist();
+        expect(state.rangeData.layer1).toNotExist();
+        expect(state.selectedLayer).toBe('layer2');
+        expect(state.rangeData.layer2).toExist();
+    });
+    it('remove a selected layer with no rangeData or loading data', () => {
+        const initialState = {
+          selectedLayer: 'layer3',
+          rangeData: {
+              layer1: { range: 'old range', histogram: 'old histogram'},
+              layer2: { }
+          }
+        };
+        const action = {
+            type: 'REMOVE_NODE',
+            node: 'layer3'
+        };
+        const state = timeline(initialState, action);
+        expect(state).toExist();
+        expect(state.rangeData.layer1).toExist();
+        expect(state.rangeData.layer2).toExist();
+        expect(state.selectedLayer).toNotExist();
+    });
 });

--- a/web/client/reducers/dimension.js
+++ b/web/client/reducers/dimension.js
@@ -1,7 +1,8 @@
 const { UPDATE_LAYER_DIMENSION_DATA, SET_CURRENT_TIME, SET_OFFSET_TIME, MOVE_TIME } = require('../actions/dimension');
+const { REMOVE_NODE } = require('../actions/layers');
 const { set } = require('../utils/ImmutableUtils');
 const moment = require('moment');
-
+const {mapValues, pickBy } = require('lodash');
 
 /**
  * Provide state for current time and dimension info.
@@ -48,6 +49,10 @@ module.exports = (state = {}, action) => {
                 return set(`currentTime`, action.time, set('offsetTime', nextOffsetTime.toISOString(), state));
             }
             return set(`currentTime`, action.time, state);
+        }
+        case REMOVE_NODE: {
+            const newData = mapValues(state.data, (o) => pickBy(o, (values, keys) => keys !== action.node));
+            return set(`data`, newData, state);
         }
         default:
             return state;

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -76,9 +76,9 @@ module.exports = (state = {
         case REMOVE_NODE: {
             let newState = state;
             return assign({}, state, {
-                rangeData: has(newState.rangeData, action.node) && pickBy(newState.rangeData, (values, key) => key !== action.node),
-                loading: has(newState.rangeData, action.node) && pickBy(newState.loading, (values, key) => key !== action.node),
-                selectedLayer: state.selectedLayer === action.node && undefined
+                rangeData: has(newState.rangeData, action.node) ? pickBy(newState.rangeData, (values, key) => key !== action.node) : newState.rangeData,
+                loading: has(newState.rangeData, action.node) ? pickBy(newState.loading, (values, key) => key !== action.node) : newState.loading,
+                selectedLayer: state.selectedLayer === action.node ? undefined : state.selectedLayer
                 });
         }
         default:

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -2,7 +2,7 @@ const { RANGE_CHANGED } = require('../actions/timeline');
 const { REMOVE_NODE } = require('../actions/layers');
 const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, MOUSE_EVENT } = require('../actions/timeline');
 const { set } = require('../utils/ImmutableUtils');
-const { assign, pickBy } = require('lodash');
+const { assign, pickBy, has } = require('lodash');
 
 /**
  * Provides state for the timeline. Example:
@@ -74,14 +74,12 @@ module.exports = (state = {
             return set('mouseEvent', action.eventData, state);
         }
         case REMOVE_NODE: {
-            if (state.selectedLayer === action.node) {
-                let newState = state;
-                return assign({}, state, {
-                     rangeData: pickBy(newState.rangeData, (values, key) => key !== action.node),
-                     loading: pickBy(newState.loading, (values, key) => key !== action.node),
-                     selectedLayer: ''
+            let newState = state;
+            return assign({}, state, {
+                rangeData: has(newState.rangeData, action.node) && pickBy(newState.rangeData, (values, key) => key !== action.node),
+                loading: has(newState.rangeData, action.node) && pickBy(newState.loading, (values, key) => key !== action.node),
+                selectedLayer: state.selectedLayer === action.node && undefined
                 });
-            }
         }
         default:
             return state;

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -1,7 +1,8 @@
 const { RANGE_CHANGED } = require('../actions/timeline');
+const { REMOVE_NODE } = require('../actions/layers');
 const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, MOUSE_EVENT } = require('../actions/timeline');
 const { set } = require('../utils/ImmutableUtils');
-
+const { assign, pickBy } = require('lodash');
 
 /**
  * Provides state for the timeline. Example:
@@ -71,6 +72,16 @@ module.exports = (state = {
         }
         case MOUSE_EVENT: {
             return set('mouseEvent', action.eventData, state);
+        }
+        case REMOVE_NODE: {
+            if (state.selectedLayer === action.node) {
+                let newState = state;
+                return assign({}, state, {
+                     rangeData: pickBy(newState.rangeData, (values, key) => key !== action.node),
+                     loading: pickBy(newState.loading, (values, key) => key !== action.node),
+                     selectedLayer: ''
+                });
+            }
         }
         default:
             return state;


### PR DESCRIPTION
## Description
this PR introduce the following actions for layer removal:
 - remove the related data from state's "dimensions.data".
 - remove layer-related data from timeline.
 - if the deleted layer is being animated ( stop the animation )
 - if the deleted layer is selected => re-select (the first layer in the list ).
  
## Issues
 - Fix #3359
 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
