### PR TITLE
Fix #3373. Support for disable playback buttons

### DIFF
--- a/web/client/actions/playback.js
+++ b/web/client/actions/playback.js
@@ -11,6 +11,7 @@ const SELECT_PLAYBACK_RANGE = "PLAYBACK:SELECT_PLAYBACK_RANGE";
 const CHANGE_SETTING = "PLAYBACK:SETTINGS_CHANGE";
 const TOGGLE_ANIMATION_MODE = "PLAYBACK:TOGGLE_ANIMATION_MODE";
 const ANIMATION_STEP_MOVE = "PLAYBACK:ANIMATION_STEP_MOVE";
+const UPDATE_METADATA = "PLAYBACK:UPDATE_METADATA";
 
 const STATUS = {
     PLAY: "PLAY",
@@ -64,6 +65,13 @@ const animationStepMove = (direction) => ({
     direction
 });
 
+const updateMetadata = ({next, previous, forTime}) => ({
+    type: UPDATE_METADATA,
+    forTime,
+    next,
+    previous
+});
+
 module.exports = {
     play,
     stop,
@@ -76,6 +84,7 @@ module.exports = {
     changeSetting,
     toggleAnimationMode,
     animationStepMove,
+    updateMetadata,
     PLAY,
     PAUSE,
     STOP,
@@ -87,5 +96,6 @@ module.exports = {
     SELECT_PLAYBACK_RANGE,
     CHANGE_SETTING,
     TOGGLE_ANIMATION_MODE,
-    ANIMATION_STEP_MOVE
+    ANIMATION_STEP_MOVE,
+    UPDATE_METADATA
 };

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -20,7 +20,11 @@ const TIME_DIMENSION = "time";
 const MAX_ITEMS_PER_LAYER = 20;
 const MAX_HISTOGRAM = 20;
 
-
+/**
+ * Gets the getDomain args for retrieve **single** value surrounding current time for the selected layer
+ * @param {object} state application state
+ * @param {object} paginationOptions
+ */
 const domainArgs = (state, paginationOptions = {}) => {
 
     const layerName = selectedLayerName(state);
@@ -40,6 +44,7 @@ const snapTime = (state, group, time) => {
     if (selectedLayerName(state)) {
         // do parallel request and return and observable that emit the correct value/ time as it is by default
         return Rx.Observable.forkJoin(
+                // TODO: find out a way to optimize and do only one request
                 getDomainValues(...domainArgs(state, { sort: "asc", fromValue: time }))
                     .map(res => res.DomainValues.Domain.split(","))
                     .map(([tt])=> tt).catch(err => err && Rx.Observable.of(null)),
@@ -72,7 +77,7 @@ const toISOString = date => isString(date) ? date : date.toISOString();
  */
 const loadRangeData = (id, timeData, getState) => {
     /**
-     * when there is no timeline state rangeSelector(getState()) returns undefiend, so instead we use the timeData[id] range
+     * when there is no timeline state rangeSelector(getState()) returns undefined, so instead we use the timeData[id] range
      */
     const dataRange = timeData.domain.split('--');
 

--- a/web/client/plugins/playback/Settings.jsx
+++ b/web/client/plugins/playback/Settings.jsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { connect } = require('react-redux');
+const { createSelector } = require('reselect');
+const moment = require('moment');
+const { compose, withProps, withHandlers } = require('recompose');
+const { playbackSettingsSelector, playbackRangeSelector } = require('../../selectors/playback');
+const { selectedLayerSelector, rangeSelector, selectedLayerDataRangeSelector } = require('../../selectors/timeline');
+const { selectPlaybackRange, changeSetting, toggleAnimationMode } = require('../../actions/playback');
+const { onRangeChanged } = require('../../actions/timeline');
+
+/**
+ * Playback settings component connected to the state
+ */
+module.exports = compose(
+    connect(createSelector(
+        playbackSettingsSelector,
+        selectedLayerSelector,
+        playbackRangeSelector,
+        (settings, selectedLayer, playbackRange) => ({
+            fixedStep: !selectedLayer,
+            playbackRange,
+            ...settings
+        })
+    ), {
+            setPlaybackRange: selectPlaybackRange,
+            onSettingChange: changeSetting,
+            toggleAnimationMode
+        }
+
+    ),
+    // playback buttons
+    compose(
+        connect(createSelector(
+            rangeSelector,
+            selectedLayerDataRangeSelector,
+            (viewRange, layerRange) => ({
+                layerRange,
+                viewRange
+            })
+        ), {
+                moveTo: onRangeChanged
+            }),
+        withHandlers({
+            toggleAnimationRange: ({ fixedStep, layerRange, viewRange = {}, setPlaybackRange = () => { } }) => (enabled) => {
+                let currentPlaybackRange = fixedStep ? viewRange : layerRange;
+                // when view range is collapsed, nothing may be initialized yet, so by default 1 day before and after today
+                currentPlaybackRange = {
+                    startPlaybackTime: moment(currentPlaybackRange && currentPlaybackRange.start || new Date()).subtract(1, 'days').toISOString(),
+                    endPlaybackTime: moment(currentPlaybackRange && currentPlaybackRange.end || new Date()).add(1, 'days').toISOString()
+                };
+                setPlaybackRange(enabled ? currentPlaybackRange : undefined);
+            },
+            setPlaybackToCurrentViewRange: ({ viewRange = {}, setPlaybackRange = () => { } }) => () => {
+                if (viewRange.start && viewRange.end) {
+                    setPlaybackRange({
+                        startPlaybackTime: moment(viewRange.start).toISOString(),
+                        endPlaybackTime: moment(viewRange.end).toISOString()
+                    });
+                }
+            },
+            setPlaybackToCurrentLayerDataRange: ({ setPlaybackRange = () => { }, layerRange }) => () => layerRange && setPlaybackRange({
+                startPlaybackTime: layerRange.start,
+                endPlaybackTime: layerRange.end
+            })
+        }),
+        withProps(({ playbackRange, fixedStep, moveTo = () => { }, setPlaybackToCurrentViewRange = () => { }, setPlaybackToCurrentLayerDataRange = () => { } }) => {
+            return {
+                playbackButtons: [{
+                    glyph: "search",
+                    tooltipId: "playback.settings.range.zoomToCurrentPlayackRange",
+                    onClick: () => moveTo({ start: playbackRange.startPlaybackTime, end: playbackRange.endPlaybackTime })
+                }, {
+                    glyph: "resize-horizontal",
+                    tooltipId: "playback.settings.range.setToCurrentViewRange",
+                    onClick: () => setPlaybackToCurrentViewRange()
+                }, {
+                    glyph: "1-layer",
+                    visible: !fixedStep,
+                    tooltipId: "playback.settings.range.fitToSelectedLayerRange",
+                    onClick: () => setPlaybackToCurrentLayerDataRange()
+                }]
+            };
+        })
+    )
+
+)(require("../../components/playback/PlaybackSettings"));

--- a/web/client/reducers/__tests__/playback-test.js
+++ b/web/client/reducers/__tests__/playback-test.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var expect = require('expect');
+const { updateMetadata, play, pause, stop, setFrames, appendFrames, setCurrentFrame, changeSetting, STATUS } = require('../../actions/playback');
+const playback = require('../playback');
+describe('playback reducer', () => {
+    it('playback play', () => {
+        const action = play();
+        const state = playback( undefined, action);
+        expect(state).toExist();
+        expect(state.status).toBe(STATUS.PLAY);
+    });
+    it('playback stop', () => {
+        const action = stop();
+        const state = playback(undefined, action);
+        expect(state).toExist();
+        expect(state.status).toBe(STATUS.STOP);
+    });
+    it('playback pause', () => {
+        const action = pause();
+        const state = playback(undefined, action);
+        expect(state).toExist();
+        expect(state.status).toBe(STATUS.PAUSE);
+    });
+    it('playback setFrames', () => {
+        const D = "2017-11-29T16:17:46.520Z";
+        const action = setFrames([D]);
+        const state = playback(undefined, action);
+        expect(state).toExist();
+        expect(state.frames.length).toBe(1);
+        expect(state.frames[0]).toBe(D);
+        expect(state.currentFrame).toBe(-1);
+    });
+    it('playback appendFrames', () => {
+        const D0 = "2015-11-29T16:17:46.520Z";
+        const D1 = "2017-11-29T16:17:46.520Z";
+        const action = appendFrames([D1]);
+        const state = playback({ frames: [D0], currentFrame: 0}, action);
+        expect(state).toExist();
+        expect(state.frames.length).toBe(2);
+        expect(state.frames[0]).toBe(D0);
+        expect(state.frames[1]).toBe(D1);
+        expect(state.currentFrame).toBe(0);
+    });
+    it('playback setCurrentFrame', () => {
+        const D0 = "2015-11-29T16:17:46.520Z";
+        const D1 = "2017-11-29T16:17:46.520Z";
+        const action = setCurrentFrame(1);
+        const state = playback({ frames: [D0, D1], currentFrame: 0 }, action);
+        expect(state).toExist();
+        expect(state.frames.length).toBe(2);
+        expect(state.frames[0]).toBe(D0);
+        expect(state.frames[1]).toBe(D1);
+        expect(state.currentFrame).toBe(1);
+    });
+    it('playback changeSetting', () => {
+        const action = changeSetting("name", "value");
+        const state = playback( undefined, action);
+        expect(state).toExist();
+        expect(state.settings.name).toBe("value");
+    });
+    it('playback updateMetadata', () => {
+        const next = "2017-11-29T16:17:46.520Z";
+        const previous = "2015-11-29T16:17:46.520Z";
+        const forTime = "2016-7-29T16:17:46.520Z";
+        const action = updateMetadata({ next, previous, forTime});
+        const state = playback( undefined, action);
+        expect(state).toExist();
+        expect(state.metadata.next).toBe(next);
+        expect(state.metadata.previous).toBe(previous);
+        expect(state.metadata.forTime).toBe(forTime);
+    });
+});

--- a/web/client/reducers/playback.js
+++ b/web/client/reducers/playback.js
@@ -1,4 +1,4 @@
-const { PLAY, PAUSE, STOP, STATUS, SET_FRAMES, APPEND_FRAMES, FRAMES_LOADING, SET_CURRENT_FRAME, SELECT_PLAYBACK_RANGE, CHANGE_SETTING } = require('../actions/playback');
+const { PLAY, PAUSE, STOP, STATUS, SET_FRAMES, APPEND_FRAMES, FRAMES_LOADING, SET_CURRENT_FRAME, SELECT_PLAYBACK_RANGE, CHANGE_SETTING, UPDATE_METADATA } = require('../actions/playback');
 const { set } = require('../utils/ImmutableUtils');
 
 module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: {
@@ -41,6 +41,9 @@ module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: {
         }
         case CHANGE_SETTING: {
             return set(`settings[${action.name}]`, action.value, state);
+        }
+        case UPDATE_METADATA: {
+            return set('metadata', { next: action.next, previous: action.previous, forTime: action.forTime}, state);
         }
         default:
             return state;

--- a/web/client/selectors/playback.js
+++ b/web/client/selectors/playback.js
@@ -5,6 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
+const { createSelector} = require('reselect');
+
 const playbackSettingsSelector = state => state && state.playback && state.playback.settings;
 const frameDurationSelector = state => ((playbackSettingsSelector(state) || {}).frameDuration || 5); // seconds
 const statusSelector = state => state && state.playback && state.playback.status;
@@ -22,6 +24,18 @@ const playbackRangeSelector = state => {
 };
 
 const currentFrameValueSelector = state => (framesSelector(state) || [])[currentFrameSelector(state)];
+
+const playbackMetadataSelector = state => state && state.playback && state.playback.metadata;
+
+const hasPrevNextAnimationSteps = createSelector(
+    framesSelector,
+    currentFrameSelector,
+    (frames = [], index) => ({
+        hasNext: frames[index + 1],
+        hasPrevious: frames[index - 1]
+    })
+);
+
 module.exports = {
     playbackSettingsSelector,
     frameDurationSelector,
@@ -31,5 +45,7 @@ module.exports = {
     framesSelector,
     currentFrameSelector,
     currentFrameValueSelector,
-    playbackRangeSelector
+    playbackRangeSelector,
+    playbackMetadataSelector,
+    hasPrevNextAnimationSteps
 };


### PR DESCRIPTION
## Description
This changes improve the timeline to disable previous-next buttons when there is no previous or next step. This happens only when a guide layer is selected.


## Issues
 - Fix #3373

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
The buttons are always enabled

**What is the new behavior?**
The buttons are disabled when the next/previous step is not present (the user is on the first/last time of the current data (limited by playback-range, if enabled)
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
When animation is active, the next and previous values are from the animation frames array, that is downloaded is chunks. 
When instead the user instead uses the timeline manually (not animating), next and previous values have to be reloaded on every time selection to enable/disable the buttons accordingly. 

So when a user clicks, we will have 4 requests.
 - 2 for snap (in timeline)
 - 2 to get the next/previous values (in playback)

**note**: We can not expand and reuse snap request because `fromValue` is excluded from the response of the server, but it may be a valid value. So after snapping, you have to get the effective next and previous value of the current element anyway. The only thing we could optimize is to reduce the number of requests to 1, with a specific service. 


# Some notes about possible optimization using new services
Actually  double `getDomainValues` for 2 different purposes: 
 - Get nearest value (for snapping). This could optimized getting only nearest value, in whatever direction it is. 
 - Get next previous values (for playback buttons enable/disable). This can be reduced to one request, but even in this case, it is very specific. GeoServer should implement a service that get the Domain neighbourhood of max X elements for each side.

Both services are very application-specific. Lets evaluate if they are really needed.