### PR TITLE
Use Alpine in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-FROM tomcat:7.0.75
+FROM tomcat:7.0.92-jre7-alpine
 MAINTAINER geosolutions<info@geo-solutions.it>
 
-RUN  export DEBIAN_FRONTEND=noninteractive
-ENV  DEBIAN_FRONTEND noninteractive
-RUN  dpkg-divert --local --rename --add /sbin/initctl
-
-# Set JAVA_HOME to /usr/lib/jvm/default-java and link it to OpenJDK installation
-RUN ln -s /usr/lib/jvm/java-1.7.0-openjdk-amd64/ /usr/lib/jvm/default-java
-ENV JAVA_HOME /usr/lib/jvm/default-java
-
 # Install utilities
-RUN  apt-get -y update \
-     && apt-get -y install vim \
-     && rm -rf /var/lib/apt/lists/*
+RUN  apk update \
+     && apk add vim \
+     && rm -rf /var/cache/apk/*
 
-ENV RESOURCES_DIR="/tmp/resources/"
-ADD docker/* "$RESOURCES_DIR"
-
-# Tomcat specific stuff
+# Tomcat specific options
 ENV CATALINA_BASE "$CATALINA_HOME"
 ENV JAVA_OPTS="${JAVA_OPTS}  -Xms512m -Xmx512m -XX:MaxPermSize=128m"
 
 # Optionally remove Tomcat manager, docs, and examples
 ARG TOMCAT_EXTRAS=false
 RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
-      find "${CATALINA_BASE}/webapps/" -type f | xargs -L1 rm -f \
+      find "${CATALINA_BASE}/webapps/" -delete;\
     ;fi
 
-# Customize Tomcat
-ARG INCLUDE_MS_WAR="false"
-ENV INCLUDE_MS_WAR "${INCLUDE_MS_WAR}"
-ARG APP_NAME=mapstore
-RUN if [ "$INCLUDE_MS_WAR" = true ]; then \
-      mv "${RESOURCES_DIR}/mapstore.war" \
-      "${CATALINA_BASE}/webapps/${APP_NAME}.war"; \
-    fi;
+# Add war files to be deployed
+COPY docker/*.war "${CATALINA_BASE}/webapps/"
 
 # Geostore externalization template. Disabled by default
-ADD docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
+COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
 ARG GEOSTORE_OVR_OPT=""
 ENV JAVA_OPTS="${JAVA_OPTS} ${GEOSTORE_OVR_OPT}"
 


### PR DESCRIPTION
This produces smaller docker images (50% less) because of Alpine, not Ubuntu.
Updates Tomcat to 7.0.92
Specifies jre7
EVERY war file in the docker folder will be copied to the tomcat instance.

**Breaking changes**
- I removed the APP_NAME build argument: if you need to rename your mapstore.war file, rename it before the docker build.
- I removed the INCLUDE_MS_WAR build argument: you can always override the webapps folder with a custom volume mount