### PR TITLE
#3348 resetting timeline/playback/dimension state when switching to a new map

### DIFF
--- a/web/client/reducers/__tests__/dimension-test.js
+++ b/web/client/reducers/__tests__/dimension-test.js
@@ -55,5 +55,16 @@ describe('Test the dimension reducer', () => {
         const state = dimension(initialState, action);
         expect(state).toExist();
     });
+    it('reset dimension data when switch to a new map', () => {
+        const action = {
+            type: 'RESET_CONTROLS'
+        };
+        const initialState = {
+            currentTime: '00:00:00z'
+          };
+        const state = dimension(initialState, action);
+        expect(state).toExist();
+        expect(state.currentTime).toNotExist();
+    });
 
 });

--- a/web/client/reducers/__tests__/playback-test.js
+++ b/web/client/reducers/__tests__/playback-test.js
@@ -75,4 +75,16 @@ describe('playback reducer', () => {
         expect(state.metadata.previous).toBe(previous);
         expect(state.metadata.forTime).toBe(forTime);
     });
+    it('reset playback data when switch to a new map', () => {
+        const action = {
+            type: 'RESET_CONTROLS'
+        };
+        const D0 = "2015-11-29T16:17:46.520Z";
+        const D1 = "2017-11-29T16:17:46.520Z";
+        const state = playback( {frames: [D0, D1], currentFrame: 0 }, action);
+        expect(state).toExist();
+        expect(state.frame).toNotExist();
+        expect(state.currentFrame).toBe(-1);
+    });
+
 });

--- a/web/client/reducers/__tests__/timeline-test.js
+++ b/web/client/reducers/__tests__/timeline-test.js
@@ -98,4 +98,20 @@ describe('Test the timeline reducer', () => {
         expect(state.rangeData.layer2).toExist();
         expect(state.selectedLayer).toNotExist();
     });
+    it('reset timeline data when switch to a new map', () => {
+        const action = {
+            type: 'RESET_CONTROLS'
+        };
+        const initialState = {
+            selectedLayer: 'layer3',
+            rangeData: {
+                layer1: { range: 'old range', histogram: 'old histogram'},
+                layer2: { }
+            }
+          };
+        const state = timeline(initialState, action);
+        expect(state).toExist();
+        expect(state.rangeData).toNotExist();
+        expect(state.selectedLayer).toNotExist();
+    });
 });

--- a/web/client/reducers/dimension.js
+++ b/web/client/reducers/dimension.js
@@ -1,5 +1,6 @@
 const { UPDATE_LAYER_DIMENSION_DATA, SET_CURRENT_TIME, SET_OFFSET_TIME, MOVE_TIME } = require('../actions/dimension');
 const { REMOVE_NODE } = require('../actions/layers');
+const { RESET_CONTROLS } = require('../actions/controls');
 const { set } = require('../utils/ImmutableUtils');
 const moment = require('moment');
 const {mapValues, pickBy } = require('lodash');
@@ -53,6 +54,9 @@ module.exports = (state = {}, action) => {
         case REMOVE_NODE: {
             const newData = mapValues(state.data, (o) => pickBy(o, (values, keys) => keys !== action.node));
             return set(`data`, newData, state);
+        }
+        case RESET_CONTROLS: {
+            return set('data', undefined, set('currentTime', undefined, set('offsetTime', undefined, state)));
         }
         default:
             return state;

--- a/web/client/reducers/playback.js
+++ b/web/client/reducers/playback.js
@@ -1,4 +1,5 @@
 const { PLAY, PAUSE, STOP, STATUS, SET_FRAMES, APPEND_FRAMES, FRAMES_LOADING, SET_CURRENT_FRAME, SELECT_PLAYBACK_RANGE, CHANGE_SETTING, UPDATE_METADATA } = require('../actions/playback');
+const { RESET_CONTROLS } = require('../actions/controls');
 const { set } = require('../utils/ImmutableUtils');
 
 module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: {
@@ -44,6 +45,16 @@ module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: {
         }
         case UPDATE_METADATA: {
             return set('metadata', { next: action.next, previous: action.previous, forTime: action.forTime}, state);
+        }
+        case RESET_CONTROLS: {
+            return set('metadata', undefined, set('framesLoading', undefined, set('playbackRange', undefined, set('frames', undefined,
+                       set('currentFrame', -1, set('status', "STOP", set('settings', {
+                        timeStep: 1,
+                        stepUnit: "days",
+                        frameDuration: 5,
+                        following: true
+                       }, state)
+            ))))));
         }
         default:
             return state;

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -1,5 +1,6 @@
 const { RANGE_CHANGED } = require('../actions/timeline');
 const { REMOVE_NODE } = require('../actions/layers');
+const { RESET_CONTROLS } = require('../actions/controls');
 const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, MOUSE_EVENT } = require('../actions/timeline');
 const { set } = require('../utils/ImmutableUtils');
 const { assign, pickBy, has } = require('lodash');
@@ -80,6 +81,9 @@ module.exports = (state = {
                 loading: has(newState.rangeData, action.node) ? pickBy(newState.loading, (values, key) => key !== action.node) : newState.loading,
                 selectedLayer: state.selectedLayer === action.node ? undefined : state.selectedLayer
                 });
+        }
+        case RESET_CONTROLS: {
+            return assign({}, state, { range: undefined, rangeData: undefined, selectedLayer: undefined, loading: undefined, MouseEvent: undefined});
         }
         default:
             return state;


### PR DESCRIPTION
## Description
resetting the state data related to timeline, when switching between maps 

## Issues
 - Fix #3348
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see #3348

**What is the new behavior?**
see the discription

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
