### PR TITLE
fix #3391 update backgrounds for standard template and i18n doc

### DIFF
--- a/docs/developer-guide/internationalization.md
+++ b/docs/developer-guide/internationalization.md
@@ -26,13 +26,15 @@ You can configure MapStore2 to provide to the user only a restricted list of sel
 "defaultState":
 {
     "locales": {
-        "en": {
-            code: "en-EN",
-            description: "English"
-        },
-        "it": {
-            code: "it-IT",
-            description: "Italiano"
+        "supportedLocales": {
+            "en": {
+                "code": "en-EN",
+                "description": "English"
+            },
+            "it": {
+                "code": "it-IT",
+                "description": "Italiano"
+            }
         }
     }
 }

--- a/project/standard/templates/new.json
+++ b/project/standard/templates/new.json
@@ -18,22 +18,6 @@
         "visibility": true
 			},
       {
-        "type": "google",
-        "title": "Google HYBRID",
-        "name": "HYBRID",
-        "source": "google",
-        "group": "background",
-        "visibility": false
-      },
-      {
-        "type": "mapquest",
-        "title": "MapQuest OSM",
-        "name": "osm",
-        "source": "mapquest",
-        "group": "background",
-        "visibility": false
-      },
-      {
         "type": "tileprovider",
         "title": "NASAGIBS Night 2012",
         "provider": "NASAGIBS.ViirsEarthAtNight2012",
@@ -50,6 +34,33 @@
         "source": "OpenTopoMap",
         "group": "background",
         "visibility": false
+      },
+      {
+        "format": "image/jpeg",
+        "group": "background",
+        "name": "s2cloudless:s2cloudless",
+        "opacity": 1,
+        "title": "Sentinel 2 Cloudless",
+        "type": "wms",
+        "url": [
+          "https://1maps.geo-solutions.it/geoserver/wms", "https://2maps.geo-solutions.it/geoserver/wms", "https://3maps.geo-solutions.it/geoserver/wms", "https://4maps.geo-solutions.it/geoserver/wms", "https://5maps.geo-solutions.it/geoserver/wms", "https://6maps.geo-solutions.it/geoserver/wms"
+        ],
+        "source": "s2cloudless",
+        "visibility": false,
+        "singleTile": false
+      },
+      {
+        "source": "ol",
+        "group": "background",
+        "title": "Empty Background",
+        "fixed": true,
+        "type": "empty",
+        "visibility": false,
+        "args": [
+          "Empty Background", {
+            "visibility": false
+          }
+        ]
       }
 		]
 	}


### PR DESCRIPTION
## Description
Added backgrounds for standard template

this is a non testable issue, unless you create a new project from master and this is merged.
to check then you can have a look at the new.json files

## Issues
 - Fix #3391 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: update standard project template


**What is the current behavior?** (You can also link to an open issue here)
When you create a new standard project you do not have the new backgrounds when creating a new map, 

**What is the new behavior?**
Backgrounds are updated for project created from standard template.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


Also updated internationalization doc with a correct example