### PR TITLE
Fix #3395. Follow cursor on click/forward/backward. Increased unit tests

### DIFF
--- a/web/client/components/playback/__tests__/PlaybackSettings-test.jsx
+++ b/web/client/components/playback/__tests__/PlaybackSettings-test.jsx
@@ -82,12 +82,61 @@ describe('PlaybackSettings component', () => {
             playbackRange={{
                 startPlaybackTime: "2018-11-19T11:36:26.990Z", endPlaybackTime: "2019-11-19T11:36:26.990Z" // this have to be valid to show buttons
             }}
-         playbackButtons={[{
+        playbackButtons={[{
             className: "test_button",
             onClick: actions.onClick
         }]} />, document.getElementById("container"));
         ReactTestUtils.Simulate.click(document.querySelector(".mapstore-switch-panel .test_button")); // <-- trigger event callback
         expect(spyClick).toHaveBeenCalled();
     });
+    it('setPlaybackRange callback', () => {
+        const actions = {
+            setPlaybackRange: () => { }
+        };
+        const spyClick = expect.spyOn(actions, 'setPlaybackRange');
+        ReactDOM.render(<PlaybackSettings
+            playbackRange={{
+                startPlaybackTime: "2018-11-19T11:36:26.990Z", endPlaybackTime: "2019-11-19T11:36:26.990Z" // this have to be valid to show buttons
+            }}
+            setPlaybackRange={actions.setPlaybackRange}
+        />, document.getElementById("container"));
+        ReactTestUtils.Simulate.click(document.querySelectorAll(".ms-inline-datetime")[0].querySelector("button"));
+        expect(spyClick).toHaveBeenCalled();
+        expect(spyClick.calls[0].arguments[0].startPlaybackTime).toExist();
+        expect(spyClick.calls[0].arguments[0].endPlaybackTime).toExist();
+    });
+    it('setPlaybackRange callback for time end', () => {
+        const actions = {
+            setPlaybackRange: () => { }
+        };
+        const spyClick = expect.spyOn(actions, 'setPlaybackRange');
+        ReactDOM.render(<PlaybackSettings
+            playbackRange={{
+                startPlaybackTime: "2018-11-19T11:36:26.990Z", endPlaybackTime: "2019-11-19T11:36:26.990Z" // this have to be valid to show buttons
+            }}
+            setPlaybackRange={actions.setPlaybackRange}
+        />, document.getElementById("container"));
+        ReactTestUtils.Simulate.click(document.querySelectorAll(".ms-inline-datetime")[1].querySelector("button")); // <-- trigger event callback
+        expect(spyClick).toHaveBeenCalled();
+        expect(spyClick.calls[0].arguments[0].startPlaybackTime).toExist();
+        expect(spyClick.calls[0].arguments[0].endPlaybackTime).toExist();
+    });
+    it('follow button', () => {
+        const actions = {
+            onSettingChange: () => { }
+        };
+        const spyClick = expect.spyOn(actions, 'onSettingChange');
+        ReactDOM.render(<PlaybackSettings
+            playbackRange={{
+                startPlaybackTime: "2018-11-19T11:36:26.990Z", endPlaybackTime: "2019-11-19T11:36:26.990Z" // this have to be valid to show buttons
+            }}
+            onSettingChange={actions.onSettingChange}
+        />, document.getElementById("container"));
+        ReactTestUtils.Simulate.change(document.querySelectorAll('input[type=checkbox]')[2]); // <-- trigger event callback
+        expect(spyClick).toHaveBeenCalled();
+        expect(spyClick.calls[0].arguments[0]).toBe("following");
+        expect(spyClick.calls[0].arguments[1]).toBe(true);
+    });
+
 
 });

--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+
+const expect = require('expect');
+const moment = require('moment');
+const { testEpic } = require('./epicTestUtils');
+const { setTimelineCurrentTime, updateRangeDataOnRangeChange, settingInitialOffsetValue } = require('../timeline');
+const { selectTime, LOADING, RANGE_DATA_LOADED, RANGE_CHANGED, enableOffset} = require('../../actions/timeline');
+const { SET_CURRENT_TIME, SET_OFFSET_TIME, updateLayerDimensionData } = require('../../actions/dimension');
+
+describe('timeline Epics', () => {
+    it('setTimelineCurrentTime without selected layer', done => {
+        const t = new Date().toISOString();
+        testEpic(setTimelineCurrentTime, 1, selectTime(t), ([action]) => {
+            const { time, type } = action;
+            // no layer is clicked is selected, so no snapping operation is performed
+            expect(time).toBe(t);
+            expect(type).toBe(SET_CURRENT_TIME);
+            done();
+        });
+    });
+    it('setTimelineCurrentTime with selected layer ( with time in range)', done => {
+        const t = "2010-01-01T00:00:00.000Z";
+        testEpic(setTimelineCurrentTime, 1, selectTime(t, "TEST_LAYER"), ([action]) => {
+            const { time, type } = action;
+            // this time the current time will be set snapping to the data from DomainValues request
+            expect(time).toBe("2016-09-01T00:00:00.000Z");
+            expect(type).toBe(SET_CURRENT_TIME);
+            done();
+        }, {
+            timeline: {
+                selectedLayer: "TEST_LAYER",
+                range: {
+                    start: "2000-01-01T00:00:00.000Z",
+                    end: "2020-12-31T00:00:00.000Z"
+                }
+            },
+            layers: {
+                flat: [{
+                    id: 'TEST_LAYER',
+                    name: 'TEST_LAYER',
+                    type: 'wms',
+                    url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+                    dimensions: [
+                        {
+                            source: {
+                                type: 'multidim-extension',
+                                // this forces to load fixed values from the test file, ignoring parameters
+                                url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                            },
+                            name: 'time'
+                        }
+                    ],
+                    params: {
+                        time: '2000-06-08T00:00:00.000Z'
+                    }
+                }]
+            }
+        });
+    });
+    it('setTimelineCurrentTime with selected layer time out of range', done => {
+        const t = "2001-01-01T00:00:00.000Z";
+        const EXPECTED_TIME_DOMAIN = "2016-09-01T00:00:00.000Z";
+        testEpic(setTimelineCurrentTime, 2, selectTime(t, "TEST_LAYER"), ([action1, action2]) => {
+            const { start, end } = action1;
+            const { time, type } = action2;
+            // first action moves the current timeline view to center the current time
+            expect(moment(start).isBefore(time)).toBe(true);
+            expect(moment(end).isAfter(time)).toBe(true);
+            // the second action is the usual snap action
+            expect(time).toBe(EXPECTED_TIME_DOMAIN);
+            expect(type).toBe(SET_CURRENT_TIME);
+            done();
+        }, {
+                timeline: {
+                    selectedLayer: "TEST_LAYER",
+                    range: {
+                        start: "2000-01-01T00:00:00.000Z",
+                        end: "2001-12-31T00:00:00.000Z" // this range do not contains  EXPECTED_TIME_DOMAIN
+                    }
+                },
+                layers: {
+                    flat: [{
+                        id: 'TEST_LAYER',
+                        name: 'TEST_LAYER',
+                        type: 'wms',
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+                        dimensions: [
+                            {
+                                source: {
+                                    type: 'multidim-extension',
+                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                },
+                                name: 'time'
+                            }
+                        ],
+                        params: {
+                            time: '2000-06-08T00:00:00.000Z'
+                        }
+                    }]
+                }
+            });
+    });
+    it('settingInitialOffsetValue enable range', done => {
+        testEpic(settingInitialOffsetValue, 3, enableOffset(true), ([action1, action2, action3]) => {
+            const { time, type } = action1;
+            const { offsetTime, type: typeOff} = action2;
+            const { start, end, type: typeRange } = action3;
+            expect(time).toExist();
+            expect(type).toBe(SET_CURRENT_TIME);
+            expect(typeOff).toBe(SET_OFFSET_TIME);
+            expect(typeRange).toBe(RANGE_CHANGED);
+            // start and end of the new range must contain the current range
+            expect(moment(start).isSameOrBefore(time)).toBe(true);
+            expect(moment(end).isSameOrAfter(offsetTime)).toBe(true);
+            expect(moment(offsetTime).diff(time)).toBe(3600 * 1000 * 24); // offset time must be greater than current time, 1 day by default
+            done();
+        });
+    });
+    it('settingInitialOffsetValue disable range', done => {
+        testEpic(settingInitialOffsetValue, 1, enableOffset(false), ([action]) => {
+            const { time, type } = action;
+            expect(type).toBe(SET_OFFSET_TIME);
+            expect(time).toNotExist();
+            done();
+        });
+    });
+    it('updateRangeDataOnRangeChange', done => {
+        testEpic(updateRangeDataOnRangeChange, 4, updateLayerDimensionData(), ([action1, action2, action3, action4]) => {
+            const { type: startType } = action1;
+            const { type: range1Type, range } = action2;
+            const { type: range2Type } = action3;
+            const { type: endType } = action4;
+            // first action moves the current timeline view to center the current time
+            expect(startType).toBe(LOADING);
+            expect(endType).toBe(LOADING);
+            // in this case loading fixed file of domain values causes double trigger of range data loaded with domain
+            // in real world the 2nd response is histogram. TODO: test also histogram
+            expect(range1Type).toBe(RANGE_DATA_LOADED);
+            expect(range2Type).toBe(RANGE_DATA_LOADED);
+            expect(range.start).toBe("2000-01-01T00:00:00.000Z");
+            expect(range.end).toBe("2001-12-31T00:00:00.000Z");
+            done();
+        }, {
+                timeline: {
+                    selectedLayer: "TEST_LAYER",
+                    range: {
+                        start: "2000-01-01T00:00:00.000Z",
+                        end: "2001-12-31T00:00:00.000Z"
+                    }
+                },
+                dimension: {
+                    data: {
+                        time: {
+                            TEST_LAYER: {
+                                source: {
+                                    type: 'multidim-extension',
+                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                },
+                                name: "time",
+                                domain: "2000-03-01T00:00:00.000Z--2000-06-08T00:00:00.000Z"
+
+                            }
+                        }
+                    }
+                },
+                layers: {
+                    flat: [{
+                        id: 'TEST_LAYER',
+                        name: 'TEST_LAYER',
+                        type: 'wms',
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+                        dimensions: [
+                            {
+                                source: {
+                                    type: 'multidim-extension',
+                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                },
+                                name: 'time'
+                            }
+                        ],
+                        params: {
+                            time: '2000-06-08T00:00:00.000Z'
+                        }
+                    }]
+                }
+            });
+    });
+});

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -13,7 +13,7 @@ const {
     framesLoading, updateMetadata
 } = require('../actions/playback');
 const {
-    moveTime, SET_CURRENT_TIME, MOVE_TIME, SET_OFFSET_TIME
+    moveTime, SET_CURRENT_TIME, MOVE_TIME
 } = require('../actions/dimension');
 const {
     selectLayer,
@@ -288,8 +288,10 @@ module.exports = {
      */
     playbackFollowCursor: (action$, { getState = () => { } } = {}) =>
         action$
-            .ofType(SET_CURRENT_TIME, MOVE_TIME, SET_OFFSET_TIME)
-            .filter(() => statusSelector(getState()) === STATUS.PLAY && isOutOfRange(currentTimeSelector(getState()), rangeSelector(getState())))
+            .ofType(MOVE_TIME)
+            .filter(({type}) =>
+                (type === MOVE_TIME || statusSelector(getState()) === STATUS.PLAY )
+                && isOutOfRange(currentTimeSelector(getState()), rangeSelector(getState())))
             .filter(() => get(playbackSettingsSelector(getState()), "following") )
             .switchMap(() => Rx.Observable.of(
                 onRangeChanged(


### PR DESCRIPTION
## Description
This pull request makes the timeline: 
 - Center the timeline to the current time if snapped and the current time went out of view range
 - Positionate the time view range with the current time on the left (start time) in case of forward/backward animation ( at is goes during the animation). 

Note: the 2nd point places the point at the start following the animation strategy, instead the 1st point simply center the point.


## Issues
 - Fix #3395
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
- When the user click, the cursor may disappear from the viewport without any feedback, in case it snaps out of the current view range
- If the user click on forward/backward moving the current time out of the current view range, the cursor disappears out (if you're not animating)

**What is the new behavior?**
The timeline centers to the current time, if snapped out of the view range
- When the user click on the forward/backward buttons, the timeline moves to include the currentTime
- If the user click on forward/backward the timeline always follow the cursor if it goes out of the view range

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:

This PR contains also some unit tests to cover timeline epics and playback settings and so increase test coverage.