### PR TITLE
Fix range operator "><" for ogcDateField

### DIFF
--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -78,7 +78,7 @@ const ogcDateField = (attribute, operator, value, nsplaceholder) => {
     if (operator === "><") {
         if (value.startDate && value.endDate) {
             const startIso = value.startDate.toISOString ? value.startDate.toISOString() : value.startDate; // for Compatibility reasons. We should use ISO string to store data.
-            const endIso = value.startDate.toISOString ? value.startDate.toISOString() : value.startDate; // for Compatibility reasons. We should use ISO string to store data.
+            const endIso = value.endDate.toISOString ? value.endDate.toISOString() : value.endDate; // for Compatibility reasons. We should use ISO string to store data.
             fieldFilter =
                         ogcComparisonOperators[operator](nsplaceholder,
                             propertyTagReference[nsplaceholder].startTag +

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -265,7 +265,7 @@ describe('FilterUtils', () => {
         let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
         expect(filterParts[0]).toEqual('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
     });
-    it('Check date field', () => {
+    it('Check date field >< operator', () => {
         const versionOGC = "1.1.0";
         const nsplaceholder = "ogc";
         const startDate = "2000-01-01T00:00:00.000Z";

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -265,6 +265,52 @@ describe('FilterUtils', () => {
         let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
         expect(filterParts[0]).toEqual('<ogc:PropertyIsEqualTo><ogc:PropertyName>prop</ogc:PropertyName><ogc:Literal>value</ogc:Literal></ogc:PropertyIsEqualTo>');
     });
+    it('Check date field', () => {
+        const versionOGC = "1.1.0";
+        const nsplaceholder = "ogc";
+        const startDate = "2000-01-01T00:00:00.000Z";
+        const endDate = "3000-01-01T00:00:00.000Z";
+        const objFilter = {
+            featureTypeName: "topp:states",
+            groupFields: [{
+                id: 1,
+                logic: "OR",
+                index: 0
+            }],
+            filterFields: [{
+                attribute: "attributeEmpty",
+                groupId: 1,
+                exception: null,
+                operator: "><",
+                rowId: "1",
+                type: "date",
+                value: {
+                    startDate: new Date(startDate),
+                    endDate: new Date(endDate)
+                }
+            }],
+            spatialField: {
+                method: null,
+                operation: "INTERSECTS",
+                geometry: null,
+                attribute: "the_geom"
+            },
+            pagination: {
+                startIndex: 0,
+                maxFeatures: 20
+            },
+            filterType: "OGC",
+            ogcVersion: "1.1.0",
+            sortOptions: null
+        };
+
+        let filterParts = FilterUtils.toOGCFilterParts(objFilter, versionOGC, nsplaceholder);
+        expect(filterParts[0]).toEqual('<ogc:Or><ogc:PropertyIsBetween>'
+            + '<ogc:PropertyName>attributeEmpty</ogc:PropertyName>'
+                + '<ogc:LowerBoundary><ogc:Literal>' + startDate + '</ogc:Literal></ogc:LowerBoundary>'
+                + '<ogc:UpperBoundary><ogc:Literal>' + endDate + '</ogc:Literal></ogc:UpperBoundary>'
+            + '</ogc:PropertyIsBetween></ogc:Or>');
+    });
     it('Check  for options.cqlFilter are merged with existing fields', () => {
         const versionOGC = "1.1.0";
         const nsplaceholder = "ogc";


### PR DESCRIPTION
There is a simple typo during assignement of const endIso.

## Description
Fix the use of daterange picker while filtering on datetime column

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
- [X] No