### PR TITLE
Fix #3418 made month date input read only

### DIFF
--- a/web/client/components/time/InlineDateTimeSelector.jsx
+++ b/web/client/components/time/InlineDateTimeSelector.jsx
@@ -68,6 +68,7 @@ class InlineDateTimeSelector extends React.Component {
             {
                 name: 'month',
                 placeholder: 'MM',
+                readOnly: true,
                 value: currentTime && currentTime.month(),
                 format: value => !isNil(value) && value !== '' && moment.monthsShort(value),
                 parseValue: value => value - 1
@@ -152,6 +153,7 @@ class InlineDateTimeSelector extends React.Component {
                             </Button>}
                             <FormControl
                                 type="text"
+                                readOnly={el.readOnly}
                                 placeholder={el.placeholder || el.name}
                                 disabled={!this.props.date}
                                 value={el.format && el.format(el.value) || el.value}

--- a/web/client/components/time/InlineDateTimeSelector.jsx
+++ b/web/client/components/time/InlineDateTimeSelector.jsx
@@ -45,9 +45,12 @@ class InlineDateTimeSelector extends React.Component {
     };
 
     onChange = (key, value, parseValue = val => val) => {
-        const currentTime = moment(this.props.date).utc();
-        const newTime = currentTime[key] && currentTime[key](parseValue(value));
-        this.props.onUpdate(newTime.toISOString());
+        if (value !== "") {
+            const currentTime = moment(this.props.date).utc();
+            const newTime = currentTime[key === "day" ? "date" : key]
+                && moment(currentTime)[key === "day" ? "date" : key](parseValue(value));
+            this.props.onUpdate(newTime.toISOString());
+        }
     };
 
     getForm = () => {

--- a/web/client/components/time/__tests__/InlineDateTimeSelector-test.jsx
+++ b/web/client/components/time/__tests__/InlineDateTimeSelector-test.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
-const ReactTestUtils = require('react-dom/test-utils');
+const TestUtils = require('react-dom/test-utils');
 const expect = require('expect');
 const InlineDateTimeSelector = require('../InlineDateTimeSelector');
 describe('InlineDateTimeSelector component', () => {
@@ -28,7 +28,18 @@ describe('InlineDateTimeSelector component', () => {
         const spyonIconClick = expect.spyOn(actions, 'onIconClick');
         ReactDOM.render(<InlineDateTimeSelector onIconClick={actions.onIconClick} />, document.getElementById("container"));
         const el = document.querySelector('.ms-inline-datetime-icon');
-        ReactTestUtils.Simulate.click(el); // <-- trigger event callback
+        TestUtils.Simulate.click(el); // <-- trigger event callback
         expect(spyonIconClick).toHaveBeenCalled();
+    });
+    it('Test InlineDateTimeSelector edit days', () => {
+        const actions = {
+            onUpdate: () => { }
+        };
+        const spyonUpdate = expect.spyOn(actions, 'onUpdate');
+        ReactDOM.render(<InlineDateTimeSelector date="2018-12-21T15:00:00.000Z" onUpdate={actions.onUpdate} />, document.getElementById("container"));
+        const input = document.querySelectorAll('input');
+        TestUtils.Simulate.change(input[0], { target: { value: '2' } });
+        expect(spyonUpdate).toHaveBeenCalled();
+        expect(spyonUpdate.calls[0].arguments[0]).toBe("2018-12-02T15:00:00.000Z");
     });
 });

--- a/web/client/components/time/__tests__/InlineDateTimeSelector-test.jsx
+++ b/web/client/components/time/__tests__/InlineDateTimeSelector-test.jsx
@@ -1,0 +1,34 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactTestUtils = require('react-dom/test-utils');
+const expect = require('expect');
+const InlineDateTimeSelector = require('../InlineDateTimeSelector');
+describe('InlineDateTimeSelector component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('InlineDateTimeSelector rendering with defaults', () => {
+        ReactDOM.render(<InlineDateTimeSelector />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const inputs = container.querySelectorAll('input');
+        expect(inputs).toExist();
+        expect(inputs[0]).toExist();
+        expect(inputs[1].readOnly).toBe(true); // month should not be editable
+    });
+    it('Test InlineDateTimeSelector onIconClick', () => {
+        const actions = {
+            onIconClick: () => {}
+        };
+        const spyonIconClick = expect.spyOn(actions, 'onIconClick');
+        ReactDOM.render(<InlineDateTimeSelector onIconClick={actions.onIconClick} />, document.getElementById("container"));
+        const el = document.querySelector('.ms-inline-datetime-icon');
+        ReactTestUtils.Simulate.click(el); // <-- trigger event callback
+        expect(spyonIconClick).toHaveBeenCalled();
+    });
+});

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -185,7 +185,7 @@ const TimelinePlugin = compose(
                 glyph="range-start"
                 onIconClick= {(time, type) => status !== "PLAY" && zoomToCurrent(time, type, viewRange, currentTimeRange)}
                 tooltip={<Message msgId="timeline.rangeStart"/>}
-                showButtons={!collapsed}
+                showButtons
                 date={currentTime || currentTimeRange && currentTimeRange.start}
                 onUpdate={start => (currentTimeRange && isValidOffset(start, currentTimeRange.end) || !currentTimeRange) && status !== "PLAY" && setCurrentTime(start)}
                 className="shadow-soft"
@@ -205,12 +205,12 @@ const TimelinePlugin = compose(
                         onIconClick= {(time, type) => status !== "PLAY" && zoomToCurrent(time, type, viewRange, currentTimeRange)}
                         tooltip={<Message msgId="timeline.rangeEnd"/>}
                         date={currentTimeRange.end}
-                        showButtons={!collapsed}
+                        showButtons
                         onUpdate={end => status !== "PLAY" && isValidOffset(currentTime, end) && setOffset(end)} />
                     : // show current time if using single time
                     <InlineDateTimeSelector
                         glyph={'time-current'}
-                        showButtons={!collapsed}
+                        showButtons
                         onIconClick= {(time, type) => status !== "PLAY" && zoomToCurrent(time, type, viewRange)}
                         tooltip={<Message msgId="timeline.currentTime"/>}
                         date={currentTime || currentTimeRange && currentTimeRange.start}


### PR DESCRIPTION
## Description
Disabled editing for month in inline editor. As discussed I enabled again buttons in compact mode to allow month selection and fixed issues editing days. Now month editing is disabled, and 
![image](https://user-images.githubusercontent.com/1279510/50350043-09adb100-053e-11e9-898c-8f069ab98aec.png)

## Issues
 - Fix #3418

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
See #3418, month is editable and trying to edit it cause an error

**What is the new behavior?**
month can not be edited anymore.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No


