### PR TITLE
Fix #3429. Fixed css for IE11 partial calc support

### DIFF
--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -191,9 +191,9 @@ const TimelinePlugin = compose(
                 className="shadow-soft"
                 style={{
                     position: 'absolute',
-                    top: 0,
+                    top: -5,
                     left: 2,
-                    transform: 'translateY(calc(-100% - 5px))'
+                    transform: 'translateY(-100%)'
                 }} />}
 
             <div

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -416,10 +416,11 @@
         position: absolute;
         overflow: auto;
         right: @square-btn-small-size * 2;
-        top: 0;
-        transform: ~"translateY(calc(-100% - 5px))";
+        top: -5px;
+        transform: ~"translateY(-100%)";
         padding: 8px;
         background-color: @ms2-color-background;
+        max-width: 400px;
         min-width: 300px;
         .shadow-far;
 


### PR DESCRIPTION
## Description
Changed CSS to show settings panel in the correct place also for IE11. This fix has been applied also to `InlineDateTimeSelector` (date/time indicator --> dd MM YYYY : hh:mm:ss) that was affected by the same problem

Also 

## Issues
 - Fix #3429

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Settings panel do not show correctly in IE11

**What is the new behavior?**
Setting panel is now correctly placed. (also range

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
IE11 do not support `calc` inside `translateY` in css. This PR use `top` to set the dinstance between window and  instead of calc.