### PR TITLE
Fix #3389. Fixed subgroup to CQL Filter generation

### DIFF
--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -644,13 +644,14 @@ const FilterUtils = {
         return null;
     },
     processCQLFilterGroup: function(root, objFilter) {
-        let cql = this.processCQLFilterFields(root, objFilter);
+        let cql = FilterUtils.processCQLFilterFields(root, objFilter);
 
         let subGroups = this.findSubGroups(root, objFilter.groupFields);
         if (subGroups.length > 0) {
-            subGroups.forEach((subGroup) => {
-                cql += " " + root.logic + " (" + this.processFilterGroup(subGroup) + ")";
-            });
+            const subGroupCql = subGroups
+                .map((subGroup) => "(" + this.processCQLFilterGroup(subGroup, objFilter) + ")")
+                .join(" " + root.logic + " ");
+            return cql ? [cql, subGroupCql].join(" " + root.logic + " ") : subGroupCql;
         }
 
         return cql;

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -644,7 +644,7 @@ const FilterUtils = {
         return null;
     },
     processCQLFilterGroup: function(root, objFilter) {
-        let cql = FilterUtils.processCQLFilterFields(root, objFilter);
+        let cql = this.processCQLFilterFields(root, objFilter);
 
         let subGroups = this.findSubGroups(root, objFilter.groupFields);
         if (subGroups.length > 0) {

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -1175,6 +1175,144 @@ describe('FilterUtils', () => {
         expect(filter).toExist();
         expect(filter).toBe("(\"attribute3\" LIKE \'%val%\')");
     });
+    it('Calculate one single sub group CQL filter', () => {
+        const filterObject = {
+            "featureTypeName": "topp:states",
+            "groupFields": [
+                {
+                    "id": 1,
+                    "logic": "OR",
+                    "index": 0
+                },
+                {
+                    "id": 1545410762560,
+                    "logic": "OR",
+                    "groupId": 1,
+                    "index": 1
+                }
+            ],
+            "filterFields": [
+                {
+                    "rowId": 1545410763916,
+                    "groupId": 1545410762560,
+                    "attribute": "STATE_NAME",
+                    "operator": "=",
+                    "value": "Alabama",
+                    "type": "string",
+                    "fieldOptions": {
+                        "valuesCount": 0,
+                        "currentPage": 1
+                    },
+                    "exception": null,
+                    "openAutocompleteMenu": false,
+                    "loading": false,
+                    "options": {
+                        "STATE_NAME": []
+                    }
+                }
+            ],
+            "spatialField": {
+                "method": null,
+                "operation": "INTERSECTS",
+                "geometry": null,
+                "attribute": "the_geom"
+            },
+            "pagination": null,
+            "filterType": "OGC",
+            "ogcVersion": "1.1.0",
+            "sortOptions": null,
+            "crossLayerFilter": null,
+            "hits": false
+        };
+        expect(FilterUtils.toCQLFilter(filterObject)).toBe('(("STATE_NAME"=\'Alabama\'))');
+    });
+    it('Calculate multiple sub group CQL filter', () => {
+        const filterObject = {
+            "featureTypeName": "topp:states",
+            "groupFields": [
+                {
+                    "id": 1,
+                    "logic": "OR",
+                    "index": 0
+                },
+                {
+                    "id": 1545411893128,
+                    "logic": "OR",
+                    "groupId": 1,
+                    "index": 1
+                }
+            ],
+            "filterFields": [
+                {
+                    "rowId": 1545411885028,
+                    "groupId": 1,
+                    "attribute": "STATE_NAME",
+                    "operator": "=",
+                    "value": "Alabama",
+                    "type": "string",
+                    "fieldOptions": {
+                        "valuesCount": 0,
+                        "currentPage": 1
+                    },
+                    "exception": null,
+                    "openAutocompleteMenu": false,
+                    "loading": false,
+                    "options": {
+                        "STATE_NAME": []
+                    }
+                },
+                {
+                    "rowId": 1545411894600,
+                    "groupId": 1545411893128,
+                    "attribute": "STATE_NAME",
+                    "operator": "=",
+                    "value": "Arizona",
+                    "type": "string",
+                    "fieldOptions": {
+                        "valuesCount": 0,
+                        "currentPage": 1
+                    },
+                    "exception": null,
+                    "openAutocompleteMenu": false,
+                    "loading": false,
+                    "options": {
+                        "STATE_NAME": []
+                    }
+                },
+                {
+                    "rowId": 1545411900160,
+                    "groupId": 1545411893128,
+                    "attribute": "STATE_NAME",
+                    "operator": "=",
+                    "value": "Arkansas",
+                    "type": "string",
+                    "fieldOptions": {
+                        "valuesCount": 0,
+                        "currentPage": 1
+                    },
+                    "exception": null,
+                    "loading": false,
+                    "openAutocompleteMenu": false,
+                    "options": {
+                        "STATE_NAME": []
+                    }
+                }
+            ],
+            "spatialField": {
+                "method": null,
+                "operation": "INTERSECTS",
+                "geometry": null,
+                "attribute": "the_geom"
+            },
+            "pagination": null,
+            "filterType": "OGC",
+            "ogcVersion": "1.1.0",
+            "sortOptions": null,
+            "crossLayerFilter": null,
+            "hits": false
+        };
+        expect(FilterUtils.toCQLFilter(filterObject)).toBe("(\"STATE_NAME\"='Alabama' OR (\"STATE_NAME\"='Arizona' OR \"STATE_NAME\"='Arkansas'))");
+    });
     it('getCrossLayerCqlFilter', () => {
         const filter = FilterUtils.getCrossLayerCqlFilter({
             collectGeometries: {


### PR DESCRIPTION
## Description
Fixed support for subgroups in CQL filter generation. 

## Issues
 - Fix #3389

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
When enable the filter map functionality in feature grid and the advanced filter has subgrups, you have the issue in #3389 

**What is the new behavior?**
Not the filter is correctly generated and applied

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
