### PR TITLE
Fix #3428 Panel of layer settings is automatically saved and closed after adding layers from catalog

### DIFF
--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -7,7 +7,7 @@
  */
 var expect = require('expect');
 var layers = require('../layers');
-const { changeLayerParams } = require('../../actions/layers');
+const { changeLayerParams, addLayer } = require('../../actions/layers');
 
 
 describe('Test the layers reducer', () => {
@@ -488,6 +488,33 @@ describe('Test the layers reducer', () => {
         expect(state.groups[0].name).toBe("test");
         expect(state.groups[0].nodes[0]).toBe("test_id3");
         expect(state.groups[0].nodes[1]).toBe("test_id1");
+    });
+
+    it('add new layer and verify old state', () => {
+        const testAction = addLayer({ group: "test", id: "test_id1" });
+
+        const state = layers(
+            {
+                flat: [
+                    {
+                        id: "layer"
+                    }
+                ],
+                settings: {
+                    options: {
+                        opacity: 0.8
+                    }
+                },
+                selected: [
+                    "layer"
+                ]
+            },
+            testAction
+        );
+
+        expect(state.settings).toExist();
+        expect(state.selected).toExist();
+
     });
 
     it('remove layer', () => {

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -228,10 +228,10 @@ function layers(state = { flat: [] }, action) {
                 newGroups = moveNode(newGroups, newLayer.id, groupId, newLayers, action.foreground);
             }
             let orderedNewLayers = LayersUtils.sortLayers ? LayersUtils.sortLayers(newGroups, newLayers) : newLayers;
-            return {
-                    flat: orderedNewLayers,
-                    groups: newGroups
-            };
+            return assign({}, state, {
+                flat: orderedNewLayers,
+                groups: newGroups
+            });
         }
         case REMOVE_LAYER: {
             const newGroups = deepRemove(state.groups, action.layerId);


### PR DESCRIPTION
## Description
Assigned old state on add layer action

## Issues
 - Fix #3428

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issue #3428

**What is the new behavior?**
Panel of layer settings will be open after adding a layer from catalog.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
