### PR TITLE
Fix #3407. Disabled time from capabilties

### DIFF
--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -271,7 +271,9 @@ module.exports = {
                 .switchMap(({time: actionTime}) => {
                     // get current time in case of SELECT_LAYER
                     const time = actionTime || currentTimeSelector(getState());
-                    return Rx.Observable.forkJoin( // TODO: find out a way to optimize and do only one request
+                    return Rx.Observable.forkJoin(
+                        // TODO: find out a way to optimize and do only one request
+                        // TODO: support for local list of values (in case of missing multidim-extension)
                         getDomainValues(...domainArgs(getState, { sort: "asc", limit: 1, fromValue: time }))
                             .map(res => res.DomainValues.Domain.split(","))
                             .map(([tt]) => tt).catch(err => err && Rx.Observable.of(null)),

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -171,8 +171,23 @@ const converters = {
                 service: records.service,
                 boundingBox: WMS.getBBox(record),
                 dimensions: (record.Dimension && castArray(record.Dimension) || []).map((dim) => assign({}, {
-                    values: dim._ && dim._.split(',') || []
-                }, dim.$ || {})),
+                        values: dim._ && dim._.split(',') || []
+                    }, dim.$ || {}))
+                    // TODO: re-enable when support to inline values is full (now timeline miss snap, auto-select and forward-backward buttons enabled/disabled for this kind of values)
+                    // TODO: replace with capabilities URL service. something like this:
+                    /*
+                    .map(dim => dim && dim.name !== "time" ? dim : {
+                        ...dim,
+                        values: undefined, <-- remove values (they can be removed from dimension's epic instead, using them as initial value)
+                        source: { <-- add the source
+                            type: "wms-capabilities",
+                            url: options.url
+                        }
+                    })
+                    */
+                    // excludes time from dimensions. TODO: remove when time from WMS capabilities is supported
+                    .filter(dim => dim && dim.name !== "time"),
+
                 references: [{
                     type: "OGC:WMS",
                     url: options && options.url,

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -44,7 +44,7 @@ describe('Test the CatalogUtils', () => {
             records: [{
                 Dimension: [{
                     $: {
-                        name: 'time'
+                        name: 'elevation'
                     }
                 }]
             }]
@@ -59,7 +59,7 @@ describe('Test the CatalogUtils', () => {
             records: [{
                 Dimension: [{
                     $: {
-                        name: 'time'
+                        name: 'elevation'
                     },
                     _: '1,2'
                 }]
@@ -68,6 +68,21 @@ describe('Test the CatalogUtils', () => {
         expect(records.length).toBe(1);
         expect(records[0].dimensions.length).toBe(1);
         expect(records[0].dimensions[0].values.length).toBe(2);
+    });
+    // this is needed to avoid to show time values for timeline, until support for time values is fully implemented
+    it('wms dimensions time is excluded', () => {
+        const records = CatalogUtils.getCatalogRecords('wms', {
+            records: [{
+                Dimension: [{
+                    $: {
+                        name: 'time'
+                    },
+                    _: '2008-10-31T00:00:00.000Z,2008-11-04T00:00:00.000Z'
+                }]
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+        expect(records[0].dimensions.length).toBe(0);
     });
 
     it('wms limited srs', () => {


### PR DESCRIPTION
## Description
This PR disables time dimensions from WMS capabilities, to avoid values to be added to the layer's configuration and so used in the timeline. In the future, we can re-enable it when the support is full or when add the getCapabilities as source of time values

## Issues
 - Fix #3407

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
When you add a layer with time dimension from a server that don't have the "multidim-extension", the layer is added to the timeline too. 
Anyway some features do not work. see #3407

**What is the new behavior?**
The layer is not added to the timeline

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

Now time values will not be saved anymore in map (other dimensions will continue to do what they want)

