### PR TITLE
Fix #3443. Various improvements to timeline UI

### DIFF
--- a/web/client/components/misc/enhancers/withMask.js
+++ b/web/client/components/misc/enhancers/withMask.js
@@ -12,10 +12,10 @@ const {branch, nest} = require('recompose');
  * @param {function} showMask gets props as argument and returns true if the enhancer should be applied
  * @param {*} maskContent the content of the mask
  */
-const maskEnhancer = (showMask, maskContent, { maskContainerStyle, maskStyle, className }) => (A) => nest(
+const maskEnhancer = (showMask, maskContent, { maskContainerStyle, maskStyle, className, white }) => (A) => nest(
     (props) => (<div className={`ms2-mask-container ${className || ''} ${!showMask(props) && 'ms2-mask-empty' || ''}`} style={maskContainerStyle} >
         {props.children}
-        {showMask(props) ? <div className="ms2-mask" style={maskStyle} >
+        {showMask(props) ? <div className={"ms2-mask" + (white ? " white-mask" : "")} style={maskStyle} >
             {maskContent(props)}
         </div> : null}
     </div>),
@@ -28,20 +28,21 @@ const maskEnhancer = (showMask, maskContent, { maskContainerStyle, maskStyle, cl
  * @param {object} options options for the mask:
  *  - alwaysWrap: true by default. if false, apply the enhancer only when showMask is true.
  *    This will cause a complete remount and re-render of the wrapped component, that may be a problem if you're using lifecycle methods, so by default is false
- *  -
+ *  - white: makes the mask background white, false by default
  */
 module.exports = (
         showMask = () => {},
         maskContent = () => {},
         {
             alwaysWrap = true,
+            white = false,
             maskContainerStyle = {},
             maskStyle = {},
             className
         } = {}
     ) => alwaysWrap
-        ? maskEnhancer(showMask, maskContent, { maskContainerStyle, maskStyle, className })
+        ? maskEnhancer(showMask, maskContent, { maskContainerStyle, maskStyle, className, white })
         : branch(
             showMask,
-            maskEnhancer(() => true, maskContent, { maskContainerStyle, maskStyle })
+            maskEnhancer(() => true, maskContent, { maskContainerStyle, maskStyle, white })
         );

--- a/web/client/components/time/InlineDateTimeSelector.jsx
+++ b/web/client/components/time/InlineDateTimeSelector.jsx
@@ -18,6 +18,7 @@ const moment = require('moment');
 class InlineDateTimeSelector extends React.Component {
     static propTypes = {
         date: PropTypes.string,
+        clickable: PropTypes.bool,
         onUpdate: PropTypes.func,
         onIconClick: PropTypes.func,
         glyph: PropTypes.string,
@@ -31,6 +32,7 @@ class InlineDateTimeSelector extends React.Component {
     static defaultProps = {
         date: '',
         onIconClick: () => {},
+        clickable: false,
         onUpdate: () => {},
         glyph: 'time',
         style: {},
@@ -41,7 +43,10 @@ class InlineDateTimeSelector extends React.Component {
     onUpdate = (key, add) => {
         const currentTime = moment(this.props.date).utc();
         const newTime = add ? moment(currentTime).add(1, key) : moment(currentTime).subtract(1, key);
-        this.props.onUpdate(newTime.toISOString());
+        // check validity of date. this can become NaN when time exceeds max time (+/-864e13 milliseconds -- from Apr 20 -271821 to 13 Sep 275760)
+        if (newTime.isValid() && !isNaN(newTime.toDate().getTime())) {
+            this.props.onUpdate(newTime.toISOString());
+        }
     };
 
     onChange = (key, value, parseValue = val => val) => {
@@ -49,7 +54,10 @@ class InlineDateTimeSelector extends React.Component {
             const currentTime = moment(this.props.date).utc();
             const newTime = currentTime[key === "day" ? "date" : key]
                 && moment(currentTime)[key === "day" ? "date" : key](parseValue(value));
-            this.props.onUpdate(newTime.toISOString());
+            // check validity of date. this can become NaN when time exceeds max time (+/-864e13 milliseconds -- from Apr 20 -271821 to 13 Sep 275760)
+            if (newTime.isValid() && !isNaN(newTime.toDate().getTime())) {
+                this.props.onUpdate(newTime.toISOString());
+            }
         }
     };
 
@@ -126,10 +134,10 @@ class InlineDateTimeSelector extends React.Component {
             <Form className={`ms-inline-datetime ${this.props.className}`} style={this.props.style}>
                 <FormGroup controlId="inlineDateTime">
                     {this.props.glyph &&
-                    <div style = {{"cursor": "pointer"}} onClick ={() => this.props.onIconClick(this.props.date, this.props.glyph) }>
+                        <div style={this.props.clickable ? { "cursor": "pointer" } : {}} onClick={() => this.props.clickable && this.props.onIconClick(this.props.date, this.props.glyph) }>
                         <Glyphicon
-                        tooltip={this.props.tooltip}
-                        tooltipId={this.props.tooltipId}
+                        tooltip={this.props.clickable ? this.props.tooltip : undefined}
+                        tooltipId={this.props.clickable ? this.props.tooltipId : undefined}
                         className="ms-inline-datetime-icon"
                         glyph={this.props.glyph}/>
                     </div>

--- a/web/client/components/time/__tests__/InlineDateTimeSelector-test.jsx
+++ b/web/client/components/time/__tests__/InlineDateTimeSelector-test.jsx
@@ -21,12 +21,22 @@ describe('InlineDateTimeSelector component', () => {
         expect(inputs[0]).toExist();
         expect(inputs[1].readOnly).toBe(true); // month should not be editable
     });
-    it('Test InlineDateTimeSelector onIconClick', () => {
+    it('Test InlineDateTimeSelector onIconClick (disabled by default)', () => {
         const actions = {
             onIconClick: () => {}
         };
         const spyonIconClick = expect.spyOn(actions, 'onIconClick');
         ReactDOM.render(<InlineDateTimeSelector onIconClick={actions.onIconClick} />, document.getElementById("container"));
+        const el = document.querySelector('.ms-inline-datetime-icon');
+        TestUtils.Simulate.click(el); // <-- trigger event callback
+        expect(spyonIconClick).toNotHaveBeenCalled();
+    });
+    it('Test InlineDateTimeSelector onIconClick when clickable flag is on', () => {
+        const actions = {
+            onIconClick: () => { }
+        };
+        const spyonIconClick = expect.spyOn(actions, 'onIconClick');
+        ReactDOM.render(<InlineDateTimeSelector clickable onIconClick={actions.onIconClick} />, document.getElementById("container"));
         const el = document.querySelector('.ms-inline-datetime-icon');
         TestUtils.Simulate.click(el); // <-- trigger event callback
         expect(spyonIconClick).toHaveBeenCalled();
@@ -41,5 +51,21 @@ describe('InlineDateTimeSelector component', () => {
         TestUtils.Simulate.change(input[0], { target: { value: '2' } });
         expect(spyonUpdate).toHaveBeenCalled();
         expect(spyonUpdate.calls[0].arguments[0]).toBe("2018-12-02T15:00:00.000Z");
+    });
+    it('Test InlineDateTimeSelector edit year too big ', () => {
+        // avoid to update when time exceeds min/max time (+/-864e13 milliseconds -- from Apr 20 -271821 to 13 Sep 275760)
+        const actions = {
+            onUpdate: () => { }
+        };
+        const spyonUpdate = expect.spyOn(actions, 'onUpdate');
+        ReactDOM.render(<InlineDateTimeSelector date="2018-12-21T15:00:00.000Z" onUpdate={actions.onUpdate} />, document.getElementById("container"));
+        const input = document.querySelectorAll('input');
+        TestUtils.Simulate.change(input[2], { target: { value: '275761' } });
+        TestUtils.Simulate.change(input[2], { target: { value: '-271822' } });
+        expect(spyonUpdate).toNotHaveBeenCalled();
+        TestUtils.Simulate.change(input[2], { target: { value: '275759' } });
+        TestUtils.Simulate.change(input[2], { target: { value: '-271820' } });
+        expect(spyonUpdate).toHaveBeenCalled();
+        expect(spyonUpdate.calls.length).toBe(2);
     });
 });

--- a/web/client/epics/__tests__/playback-test.js
+++ b/web/client/epics/__tests__/playback-test.js
@@ -16,7 +16,6 @@ const { setCurrentTime, moveTime } = require('../../actions/dimension');
 const { selectLayer, LOADING } = require('../../actions/timeline');
 describe('playback Epics', () => {
     it('retrieveFramesForPlayback', done => {
-        const time = '2016-09-04T00:00:00.000Z';
         testEpic(retrieveFramesForPlayback, 6, play(), ([a0, a1, a2, a3, a4, a5]) => {
             // set single tile
             expect(a0.type).toBe(CHANGE_LAYER_PROPERTIES);

--- a/web/client/epics/__tests__/playback-test.js
+++ b/web/client/epics/__tests__/playback-test.js
@@ -9,12 +9,51 @@
 const expect = require('expect');
 const { testEpic } = require('./epicTestUtils');
 const { UPDATE_METADATA } = require('../../actions/playback');
-const { playbackStopWhenDeleteLayer, playbackCacheNextPreviousTimes } = require('../playback');
-const { removeNode } = require('../../actions/layers');
-const { STOP, stop } = require('../../actions/playback');
+const { retrieveFramesForPlayback, playbackStopWhenDeleteLayer, playbackCacheNextPreviousTimes } = require('../playback');
+const { removeNode, CHANGE_LAYER_PROPERTIES } = require('../../actions/layers');
+const { STOP, play, stop, FRAMES_LOADING, SET_FRAMES } = require('../../actions/playback');
 const { setCurrentTime, moveTime } = require('../../actions/dimension');
-const { selectLayer } = require('../../actions/timeline');
+const { selectLayer, LOADING } = require('../../actions/timeline');
 describe('playback Epics', () => {
+    it('retrieveFramesForPlayback', done => {
+        const time = '2016-09-04T00:00:00.000Z';
+        testEpic(retrieveFramesForPlayback, 6, play(), ([a0, a1, a2, a3, a4, a5]) => {
+            // set single tile
+            expect(a0.type).toBe(CHANGE_LAYER_PROPERTIES);
+            expect(a0.newProperties.singleTile).toBe(true);
+            // loading events
+            expect(a1.type).toBe(LOADING);
+            expect(a2.type).toBe(FRAMES_LOADING);
+            expect(a3.type).toBe(SET_FRAMES);
+            expect(a4.type).toBe(FRAMES_LOADING);
+            expect(a5.type).toBe(LOADING);
+            done();
+        }, {
+                dimension: {
+                    currentTime: '2016-09-05T00:00:00.000Z'
+                },
+                layers: {
+                    flat: [
+                        {
+                            id: 'playback:selected_layer',
+                            name: 'playback_layer',
+                            dimensions: [
+                                {
+                                    name: 'time',
+                                    source: {
+                                        type: 'multidim-extension',
+                                        url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                timeline: {
+                    selectedLayer: 'playback:selected_layer'
+                }
+            });
+    });
     it('playbackCacheNextPreviousTimes with time arg setCurrentTime() action', done => {
         const time = '2016-09-04T00:00:00.000Z';
         testEpic(playbackCacheNextPreviousTimes, 1, setCurrentTime(time), ([ action ]) => {

--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -25,10 +25,14 @@ describe('timeline Epics', () => {
             done();
         });
     });
-    it('setTimelineCurrentTime with selected layer ( with time in range)', done => {
+    it('setTimelineCurrentTime with selected layer (with time in range)', done => {
         const t = "2010-01-01T00:00:00.000Z";
-        testEpic(setTimelineCurrentTime, 1, selectTime(t, "TEST_LAYER"), ([action]) => {
-            const { time, type } = action;
+        testEpic(setTimelineCurrentTime, 3, selectTime(t, "TEST_LAYER"), ([action1, action2, action3]) => {
+            const { type: loadingStartType } = action1;
+            const { time, type } = action2;
+            const { type: loadingEndType } = action3;
+            expect(loadingStartType).toBe(LOADING);
+            expect(loadingEndType).toBe(LOADING);
             // this time the current time will be set snapping to the data from DomainValues request
             expect(time).toBe("2016-09-01T00:00:00.000Z");
             expect(type).toBe(SET_CURRENT_TIME);
@@ -67,9 +71,13 @@ describe('timeline Epics', () => {
     it('setTimelineCurrentTime with selected layer time out of range', done => {
         const t = "2001-01-01T00:00:00.000Z";
         const EXPECTED_TIME_DOMAIN = "2016-09-01T00:00:00.000Z";
-        testEpic(setTimelineCurrentTime, 2, selectTime(t, "TEST_LAYER"), ([action1, action2]) => {
-            const { start, end } = action1;
-            const { time, type } = action2;
+        testEpic(setTimelineCurrentTime, 4, selectTime(t, "TEST_LAYER"), ([action1, action2, action3, action4]) => {
+            const { type: loadingStartType} = action1;
+            const { start, end } = action2;
+            const { time, type } = action3;
+            const { type: loadingStartEnd } = action4;
+            expect(loadingStartType).toBe(LOADING);
+            expect(loadingStartEnd).toBe(LOADING);
             // first action moves the current timeline view to center the current time
             expect(moment(start).isBefore(time)).toBe(true);
             expect(moment(end).isAfter(time)).toBe(true);

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -18,6 +18,7 @@ const {
 const {
     selectLayer,
     onRangeChanged,
+    timeDataLoading,
     SELECT_LAYER
 } = require('../actions/timeline');
 
@@ -30,6 +31,7 @@ const { currentTimeSelector, layersWithTimeDataSelector, layerTimeSequenceSelect
 const { LOCATION_CHANGE } = require('react-router-redux');
 
 const { currentFrameSelector, currentFrameValueSelector, lastFrameSelector, playbackRangeSelector, playbackSettingsSelector, frameDurationSelector, statusSelector, playbackMetadataSelector } = require('../selectors/playback');
+
 const { selectedLayerName, selectedLayerUrl, selectedLayerData, selectedLayerTimeDimensionConfiguration, rangeSelector, selectedLayerSelector } = require('../selectors/timeline');
 
 const pausable = require('../observables/pausable');
@@ -168,11 +170,13 @@ module.exports = {
                 .map((frames) => setFrames(frames))
                 .let(wrapStartStop(framesLoading(true), framesLoading(false)), () => Rx.Observable.of(
                     error({
-                        title: "There was an error retriving animation", // TODO: localize
+                        title: "There was an error retrieving animation", // TODO: localize
                         message: "Please contact the administrator" // TODO: localize
                     }),
                     stop()
                 ))
+                // show loading mask
+                .let(wrapStartStop(timeDataLoading(false, true), timeDataLoading(false, false)))
                 .concat(
                     action$
                         .ofType(SET_CURRENT_FRAME)

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -2,6 +2,7 @@
 const Rx = require('rxjs');
 const {isString, get, head, castArray} = require('lodash');
 const moment = require('moment');
+const {wrapStartStop} = require('../observables/epics');
 
 const { SELECT_TIME, RANGE_CHANGED, ENABLE_OFFSET, timeDataLoading, rangeDataLoaded, onRangeChanged, selectLayer } = require('../actions/timeline');
 const { setCurrentTime, UPDATE_LAYER_DIMENSION_DATA, setCurrentOffset } = require('../actions/dimension');
@@ -174,7 +175,9 @@ module.exports = {
                             })];
                         }
                         return Rx.Observable.from([...actions, setCurrentTime(t)]);
-                    });
+                    })
+                    // .let(wrapStartStop(timeDataLoading(false, true), timeDataLoading(false, false)))
+                    ;
             }
             return Rx.Observable.of(setCurrentTime(time));
         }),

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -176,7 +176,7 @@ module.exports = {
                         }
                         return Rx.Observable.from([...actions, setCurrentTime(t)]);
                     })
-                    // .let(wrapStartStop(timeDataLoading(false, true), timeDataLoading(false, false)))
+                    .let(wrapStartStop(timeDataLoading(false, true), timeDataLoading(false, false)))
                     ;
             }
             return Rx.Observable.of(setCurrentTime(time));

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -182,6 +182,7 @@ const TimelinePlugin = compose(
 
             {offsetEnabled // if range is present and configured, show the floating start point.
                 && <InlineDateTimeSelector
+                clickable={!collapsed}
                 glyph="range-start"
                 onIconClick= {(time, type) => status !== "PLAY" && zoomToCurrent(time, type, viewRange, currentTimeRange)}
                 tooltip={<Message msgId="timeline.rangeStart"/>}
@@ -201,6 +202,7 @@ const TimelinePlugin = compose(
                 {offsetEnabled && currentTimeRange
                     // if range enabled, show time end in the timeline
                     ? <InlineDateTimeSelector
+                        clickable={!collapsed}
                         glyph={'range-end'}
                         onIconClick= {(time, type) => status !== "PLAY" && zoomToCurrent(time, type, viewRange, currentTimeRange)}
                         tooltip={<Message msgId="timeline.rangeEnd"/>}
@@ -209,6 +211,7 @@ const TimelinePlugin = compose(
                         onUpdate={end => status !== "PLAY" && isValidOffset(currentTime, end) && setOffset(end)} />
                     : // show current time if using single time
                     <InlineDateTimeSelector
+                        clickable={!collapsed}
                         glyph={'time-current'}
                         showButtons
                         onIconClick= {(time, type) => status !== "PLAY" && zoomToCurrent(time, type, viewRange)}

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -5,6 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const React = require('react');
 const { connect } = require('react-redux');
 const { isString, differenceBy } = require('lodash');
 const { currentTimeSelector, layersWithTimeDataSelector } = require('../../selectors/dimension');
@@ -17,6 +18,8 @@ const { selectPlaybackRange } = require('../../actions/playback');
 const { playbackRangeSelector, statusSelector } = require('../../selectors/playback');
 const { createStructuredSelector, createSelector } = require('reselect');
 const { compose, withPropsOnChange, defaultProps } = require('recompose');
+const withMask = require('../../components/misc/enhancers/withMask');
+
 
 const clickHandleEnhancer = require('../../components/time/enhancers/clickHandlers');
 
@@ -213,6 +216,10 @@ const enhance = compose(
                 (offsetEnabled && currentTimeRange ? { offsetTime: currentTimeRange.end } : {})
             ].reduce((res, value) => value ? { ...res, ...value } : { ...res }, {}) // becomes an object
         })
+    ),
+    withMask(
+        ({loading}) => loading && loading.timeline,
+        () => <div style={{ margin: "auto" }} >Loading...</div>
     )
 );
 const Timeline = require('../../components/time/TimelineComponent');

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -19,6 +19,8 @@ const { playbackRangeSelector, statusSelector } = require('../../selectors/playb
 const { createStructuredSelector, createSelector } = require('reselect');
 const { compose, withPropsOnChange, defaultProps } = require('recompose');
 const withMask = require('../../components/misc/enhancers/withMask');
+const Message = require('../../components/I18N/Message');
+const LoadingSpinner = require('../../components/misc/LoadingSpinner');
 
 
 const clickHandleEnhancer = require('../../components/time/enhancers/clickHandlers');
@@ -219,7 +221,8 @@ const enhance = compose(
     ),
     withMask(
         ({loading}) => loading && loading.timeline,
-        () => <div style={{ margin: "auto" }} >Loading...</div>
+        () => <div style={{ margin: "auto" }} ><LoadingSpinner style={{ display: "inline-block", verticalAlign: "middle" }}/><Message msgId="loading" /></div>,
+        {white: true}
     )
 );
 const Timeline = require('../../components/time/TimelineComponent');

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -66,7 +66,7 @@ module.exports = (state = {
             }, state);
         }
         case LOADING: {
-            return set(`loading[${action.layerId}]`, action.loading, state);
+            return action.layerId ? set(`loading[${action.layerId}]`, action.loading, state) : set(`loading.timeline`, action.loading, state);
         }
         case SELECT_LAYER: {
             return set('selectedLayer', action.layerId, state);

--- a/web/client/themes/default/less/common.less
+++ b/web/client/themes/default/less/common.less
@@ -158,12 +158,17 @@ textarea {
     .ms2-mask {
         background-color: rgba(0, 0, 0, 0.7);
         color: #fff;
+        &.white-mask {
+            background-color:  rgba(255, 255, 255, 0.6);
+            color: @ms2-color-text;
+        }
         display: flex;
         z-index: 100000;
         width: 100%;
         height: 100%;
         position: absolute;
         top: 0;
+
     }
 }
 

--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -329,6 +329,9 @@
 
     .vis-item.vis-background.ms-current-range {
         cursor: grab;
+        &:active {
+            cursor: move;
+        }
         z-index: 60;
         background-color: fade(lighten(@ms2-color-text, 10%), 20%);
     }


### PR DESCRIPTION
## Description
This PR improve timeline with some minor changes: 
- Now during snap time the timeline has a loading mask (loading mask appears also when animation is initializing, to notify the user that something is happening) As required by @tdipisa i changed the mask background color to white. 
- Fixed issues  that sometime didn't snap 
- Other minor fixes notified by @gioscarda (#3451) : 
   - Cursor icon in time selector is now clickable only if the timeline is expanded (otherwise it doesn't make sense to move the view to the cursor, without view)
   - Editing the current time selector do not allow (and so do not trigger errors) when you try to set a date out of the max JavaScript date range ( from Apr 20 -271821 to 13 Sep 275760)


**Important Note**: drag-drop range issue notified in #3443 can not be fixed without customizing visjs-timeline library or changing the logic we manage ranges. I suggest avoid this in this phase and postpone this improvement in a second phase (opened issue #3463 for this purpose).

## Issues
 - Fix #3443
 - Fix  #3451

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
- See  #3443
- Inline time selector triggered errors when : 
    - Click on cursor icon with the timeline collapsed
    - Change the date out of max JavaScript date range ( **from** Apr 20 -271821 **to** 13 Sep 275760)

**What is the new behavior?**
- Now during snap time the timeline has a loading mask
- Snap always works
- Inline time selector errors above are fixed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No