### PR TITLE
Fix #3404. Full screen lib update

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "reselect": "2.5.1",
     "resize-observer-polyfill": "1.5.0",
     "rxjs": "5.1.1",
-    "screenfull": "3.1.0",
+    "screenfull": "4.0.0",
     "shpjs": "3.4.2",
     "tinycolor2": "1.4.1",
     "turf-bbox": "3.0.10",


### PR DESCRIPTION
## Description
Full screen didn't work because of this issue in `screenfull` lib. Updating the link fixes the problem
## Issues
 - Fix #3404.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
- The full screen mode do not work

**What is the new behavior?**
- Full screen works again

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

