### PR TITLE
Fix #3466. Used textContent instead of innerText in tests

### DIFF
--- a/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDM-test.js
+++ b/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDM-test.js
@@ -38,17 +38,17 @@ describe('MousePositionLabelDM', () => {
 
         let spans = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmp, "span");
         expect(spans.length).toBe(11);
-        expect(spans[1].innerText).toBe("Lat: ");
-        expect(spans[2].innerText).toBe("");
-        expect(spans[3].innerText).toBe("° ");
-        expect(spans[4].innerText).toBe("");
-        expect(spans[5].innerText).toBe("\' ");
+        expect(spans[1].textContent).toBe("Lat: ");
+        expect(spans[2].textContent).toBe("");
+        expect(spans[3].textContent).toBe("° ");
+        expect(spans[4].textContent).toBe("");
+        expect(spans[5].textContent).toBe("\' ");
 
-        expect(spans[6].innerText).toBe("Lng: ");
-        expect(spans[7].innerText).toBe("");
-        expect(spans[8].innerText).toBe("° ");
-        expect(spans[9].innerText).toBe("");
-        expect(spans[10].innerText).toBe("\'");
+        expect(spans[6].textContent).toBe("Lng: ");
+        expect(spans[7].textContent).toBe("");
+        expect(spans[8].textContent).toBe("° ");
+        expect(spans[9].textContent).toBe("");
+        expect(spans[10].textContent).toBe("\' ");
     });
 
     it('a position with defaults', () => {

--- a/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
+++ b/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
@@ -48,7 +48,7 @@ describe('MousePositionLabelDMS', () => {
 
         expect(spans[8].className).toBe("mouseposition-separator");
 
-        expect(spans[9].innerText).toBe("Lng: ");
+        expect(spans[9].textContent).toBe(" Lng: ");
         expect(spans[10].innerText).toBe("");
         expect(spans[11].innerText).toBe("° ");
         expect(spans[12].innerText).toBe("");


### PR DESCRIPTION
## Description
Fixed tests failing with Chrome > 70

## Issues
 - Fix  #3466

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
 - task was failing using chrome > 70

**What is the new behavior?**
 - tests pass using chrome > 70


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
@randomorder maybe we need to update chrome instance on build server? Let's see also if we can add latest chrome to travis build