### PR TITLE
Fix #3375 Set default style of layer from UI [Style Editor], Fix #3374 Remove icons from available styles from Style list [Style Editor]

### DIFF
--- a/web/client/actions/__tests__/styleeditor-test.js
+++ b/web/client/actions/__tests__/styleeditor-test.js
@@ -24,6 +24,7 @@ const {
     DELETE_STYLE,
     INIT_STYLE_SERVICE,
     SET_EDIT_PERMISSION,
+    SET_DEFAULT_STYLE,
     updateTemporaryStyle,
     updateStatus,
     toggleStyleEditor,
@@ -38,7 +39,8 @@ const {
     editStyleCode,
     deleteStyle,
     initStyleService,
-    setEditPermissionStyleEditor
+    setEditPermissionStyleEditor,
+    setDefaultStyle
 } = require('../styleeditor');
 
 describe('Test the styleeditor actions', () => {
@@ -167,5 +169,10 @@ describe('Test the styleeditor actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(SET_EDIT_PERMISSION);
         expect(retval.canEdit).toBe(canEdit);
+    });
+    it('setDefaultStyle', () => {
+        const retval = setDefaultStyle();
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_DEFAULT_STYLE);
     });
 });

--- a/web/client/actions/styleeditor.js
+++ b/web/client/actions/styleeditor.js
@@ -21,6 +21,7 @@ const EDIT_STYLE_CODE = 'STYLEEDITOR:EDIT_STYLE_CODE';
 const DELETE_STYLE = 'STYLEEDITOR:DELETE_STYLE';
 const INIT_STYLE_SERVICE = 'STYLEEDITOR:INIT_STYLE_SERVICE';
 const SET_EDIT_PERMISSION = 'STYLEEDITOR:SET_EDIT_PERMISSION';
+const SET_DEFAULT_STYLE = 'STYLEEDITOR:SET_DEFAULT_STYLE';
 
 /**
 * Toggle style editor, it triggers an epic to initialize or stop the style editor
@@ -204,6 +205,16 @@ function setEditPermissionStyleEditor(canEdit) {
         canEdit
     };
 }
+/**
+* Set default style of the current selected layer
+* @memberof actions.styleeditor
+* @return {object} of type `SET_DEFAULT_STYLE`
+*/
+function setDefaultStyle() {
+    return {
+        type: SET_DEFAULT_STYLE
+    };
+}
 
 /**
 * Actions for styleeditor
@@ -225,6 +236,7 @@ module.exports = {
     DELETE_STYLE,
     INIT_STYLE_SERVICE,
     SET_EDIT_PERMISSION,
+    SET_DEFAULT_STYLE,
     updateTemporaryStyle,
     updateStatus,
     toggleStyleEditor,
@@ -239,5 +251,6 @@ module.exports = {
     editStyleCode,
     deleteStyle,
     initStyleService,
-    setEditPermissionStyleEditor
+    setEditPermissionStyleEditor,
+    setDefaultStyle
 };

--- a/web/client/api/geoserver/Layers.js
+++ b/web/client/api/geoserver/Layers.js
@@ -79,6 +79,45 @@ const Api = {
                 return layerObj;
             })
             .then(layerObj => axios.put(url, layerObj).then(() => layerObj));
+    },
+    /**
+    * Update default styles of geoserver layer object
+    * @memberof api.geoserver
+    * @param {object} params {baseUrl, layerName, styleName, options = {}}
+    * @param {string} params.baseUrl base url of GeoServer eg: /geoserver/
+    * @param {array} params.styleName name of the new default style
+    * @param {string} params.layerName name of layer
+    * @return {object} geoserver layer object with updated styles
+    */
+    updateDefaultStyle: ({baseUrl, layerName, styleName, options = {}}) => {
+        const { name, workspace } = getNameParts(layerName);
+        const url = `${baseUrl}rest/${workspace && `workspaces/${workspace}/` || ''}layers/${name}.json`;
+        return axios.get(url, options)
+            .then(({ data }) => {
+                const layer = data.layer || {};
+                const currentAvailableStyle = layer.styles && layer.styles.style || {};
+                const defaultStyle = layer.defaultStyle || {};
+                const newAvailableStyle = currentAvailableStyle.filter(({ name: sName }) => {
+                    return sName !== styleName;
+                });
+                const layerObj = {
+                    'layer': {
+                        ...layer,
+                        defaultStyle: {
+                            name: styleName
+                        },
+                        'styles': {
+                            '@class': 'linked-hash-set',
+                            'style': [
+                                defaultStyle,
+                                ...newAvailableStyle
+                            ]
+                        }
+                    }
+                };
+                return layerObj;
+            })
+            .then(layerObj => axios.put(url, layerObj).then(() => layerObj));
     }
 };
 module.exports = Api;

--- a/web/client/api/geoserver/__tests__/Layers-test.js
+++ b/web/client/api/geoserver/__tests__/Layers-test.js
@@ -46,4 +46,23 @@ describe('Test layers rest API', () => {
             done();
         });
     });
+
+    it('test updateDefaultStyle', (done) => {
+        const LAYER_NAME = "TEST_LAYER_2";
+        const newDefaultStyle = 'point';
+        API.updateDefaultStyle({
+            baseUrl: 'base/web/client/test-resources/geoserver/',
+            layerName: LAYER_NAME,
+            styleName: newDefaultStyle
+        }).then((layerObj)=> {
+            expect(layerObj).toExist();
+            expect(layerObj.layer.defaultStyle.name).toBe(newDefaultStyle);
+            expect(layerObj.layer.styles.style.length).toBe(2);
+            expect(layerObj.layer.styles.style[0].name).toBe('test_TEST_LAYER_1');
+            expect(layerObj.layer.styles.style[1].name).toBe('generic');
+            done();
+        }).catch(e => {
+            done(e);
+        });
+    });
 });

--- a/web/client/components/styleeditor/StyleList.jsx
+++ b/web/client/components/styleeditor/StyleList.jsx
@@ -32,6 +32,7 @@ const SideGrid = emptyState(
  * @memberof components.styleeditor
  * @name StyleList
  * @class
+ * @prop {bool} showDefaultStyleIcon show icon near default style
  * @prop {string} enabledStyle name of style in use
  * @prop {string} defaultStyle name of default style
  * @prop {array} availableStyles array of all available styles, eg: [{TYPE_NAME: "WMS_1_3_0.Style", filename: "style.sld", format: "sld", languageVersion: {version: "1.0.0"}, legendURL: [{…}], name: "point", title: "Title", _abstract: ""}]
@@ -42,6 +43,7 @@ const SideGrid = emptyState(
  */
 
 const StyleList = ({
+    showDefaultStyleIcon,
     enabledStyle,
     defaultStyle,
     availableStyles = [],
@@ -87,9 +89,7 @@ const StyleList = ({
                                             fontWeight: 'bold'
                                         }
                                     }]}/> || <Glyphicon glyph="geoserver" />,
-                        tools: defaultStyle === style.name &&
-                        <Glyphicon glyph="star" tooltipId="styleeditor.defaultStyle"/>
-                        || <Glyphicon glyph="ok" tooltipId="styleeditor.availableStyle"/>
+                        tools: showDefaultStyleIcon && defaultStyle === style.name ? <Glyphicon glyph="star" tooltipId="styleeditor.defaultStyle"/> : null
                     }))} />
         </BorderLayout>
     );

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -21,6 +21,7 @@ const { Alert } = require('react-bootstrap');
  * @prop {array|node} buttons additional buttons, array of buttons object or toolbar node
  * @prop {bool} editEnabled enable/disable edit/templates buttons
  * @prop {array} defaultStyles array of style names not editable
+ * @prop {bool} enableSetDefaultStyle enable/disable set default style button
  * @prop {bool} loading loading state
  */
 
@@ -35,6 +36,7 @@ const StyleToolbar = ({
     loading,
     selectedStyle,
     editEnabled,
+    enableSetDefaultStyle,
     defaultStyles = [
         'generic',
         'point',
@@ -48,7 +50,8 @@ const StyleToolbar = ({
     onDelete = () => {},
     onSelectStyle = () => {},
     onEditStyle = () => {},
-    onUpdate = () => {}
+    onUpdate = () => {},
+    onSetDefault = () => {}
 }) => (
     <div>
         <Toolbar
@@ -138,6 +141,13 @@ const StyleToolbar = ({
                             ]
                         });
                     }
+                },
+                {
+                    glyph: 'star',
+                    tooltipId: 'styleeditor.setDefaultStyle',
+                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1 || !selectedStyle,
+                    visible: enableSetDefaultStyle && !status && editEnabled ? true : false,
+                    onClick: () => onSetDefault()
                 },
                 ...(!!status ? [] : buttons)
             ]} />

--- a/web/client/components/styleeditor/__tests__/StyleList-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleList-test.jsx
@@ -160,4 +160,49 @@ describe('test StyleList module component', () => {
 
         expect(spyOnSelect).toHaveBeenCalledWith({style: ''}, true);
     });
+
+
+    it('test StyleList showDefaultStyleIcon', () => {
+
+        ReactDOM.render(<StyleList
+            defaultStyle="point"
+            enabledStyle="square"
+            showDefaultStyleIcon
+            availableStyles={
+                [
+                    {
+                        name: 'point',
+                        filename: 'default_point.sld',
+                        format: 'sld',
+                        title: 'A boring default style',
+                        _abstract: 'A sample style that just prints out a purple square'
+                    },
+                    {
+                        name: 'square',
+                        filename: 'square.css',
+                        format: 'css',
+                        title: 'Square',
+                        _abstract: 'Simple square'
+                    },
+                    {
+                        name: 'circle',
+                        filename: 'circle.css',
+                        format: 'css',
+                        title: 'Circle',
+                        _abstract: 'Simple circle'
+                    }
+                ]
+            }/>, document.getElementById("container"));
+        const cards = document.querySelectorAll('.mapstore-side-card');
+        expect(cards.length).toBe(3);
+
+        const iconDefault = cards[0].querySelectorAll('.glyphicon');
+        expect(iconDefault.length).toBe(1);
+
+        const icon1 = cards[1].querySelectorAll('.glyphicon');
+        expect(icon1.length).toBe(0);
+
+        const icon2 = cards[1].querySelectorAll('.glyphicon');
+        expect(icon2.length).toBe(0);
+    });
 });

--- a/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
@@ -53,4 +53,10 @@ describe('test StyleToolbar module component', () => {
         expect(disabledButtons.length).toBe(0);
     });
 
+    it('test StyleToolbar show set default style', () => {
+        ReactDOM.render(<StyleToolbar editEnable enableSetDefaultStyle editEnabled/>, document.getElementById("container"));
+        const buttons = document.querySelectorAll('.btn');
+        expect(buttons.length).toBe(4);
+    });
+
 });

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -39,7 +39,8 @@ const {
     createStyle,
     updateStyleCode,
     deleteStyle,
-    UPDATE_STATUS
+    UPDATE_STATUS,
+    setDefaultStyle
 } = require('../../actions/styleeditor');
 
 const {
@@ -48,7 +49,8 @@ const {
     updateTemporaryStyleEpic,
     createStyleEpic,
     updateStyleCodeEpic,
-    deleteStyleEpic
+    deleteStyleEpic,
+    setDefaultStyleEpic
 } = require('../styleeditor');
 
 const { testEpic } = require('./epicTestUtils');
@@ -610,5 +612,95 @@ describe('styleeditor Epics', () => {
             deleteStyle('test_style'),
             results,
         state);
+    });
+
+    it('test setDefaultStyleEpic', (done) => {
+
+        const selectedStyle = 'point';
+        const currentAvailableStyles = [
+            // default style is on first position pf array
+            {
+                name: 'test_TEST_LAYER_1'
+            },
+            //
+            {
+                name: 'point'
+            },
+            {
+                name: 'generic'
+            }
+        ];
+        const updatedAvailableStyles = [
+            // default style is on first position pf array
+            {
+                name: 'point'
+            },
+            //
+            {
+                name: 'test_TEST_LAYER_1'
+            },
+            {
+                name: 'generic'
+            }
+        ];
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'TEST_LAYER_2',
+                        url: 'base/web/client/test-resources/geoserver/',
+                        describeFeatureType: {},
+                        style: ''
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ],
+                settings: {
+                    node: 'layerId',
+                    nodeType: 'layers',
+                    options: {
+                        availableStyles: currentAvailableStyles,
+                        style: selectedStyle
+                    }
+                }
+            },
+            styleeditor: {
+                service: {
+                    baseUrl: 'base/web/client/test-resources/geoserver/'
+                }
+            }
+        };
+        const NUMBER_OF_ACTIONS = 4;
+        const results = (actions) => {
+            try {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+
+                expect(actions[0].type).toBe(LOADING_STYLE);
+
+                expect(actions[1].type).toBe(UPDATE_SETTINGS_PARAMS);
+                expect(actions[1].newParams.availableStyles).toEqual(updatedAvailableStyles);
+
+                expect(actions[2].type).toBe(SHOW_NOTIFICATION);
+
+                expect(actions[3].type).toBe(LOADED_STYLE);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+        try {
+            testEpic(
+                setDefaultStyleEpic,
+                NUMBER_OF_ACTIONS,
+                setDefaultStyle(),
+                results,
+            state);
+
+        } catch(e) {
+            done(e);
+        }
     });
 });

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -24,7 +24,8 @@ const {
     statusStyleSelector,
     loadingStyleSelector,
     getUpdatedLayer,
-    errorStyleSelector
+    errorStyleSelector,
+    canEditStyleSelector
 } = require('../selectors/styleeditor');
 
 const { userRoleSelector } = require('../selectors/security');
@@ -49,7 +50,9 @@ class StyleEditorPanel extends React.Component {
         onInit: PropTypes.func,
         styleService: PropTypes.object,
         userRole: PropTypes.string,
-        editingAllowedRoles: PropTypes.array
+        editingAllowedRoles: PropTypes.array,
+        enableSetDefaultStyle: PropTypes.bool,
+        canEdit: PropTypes.bool
     };
 
     static defaultProps = {
@@ -84,12 +87,16 @@ class StyleEditorPanel extends React.Component {
                     this.props.showToolbar ? <div className="ms-style-editor-container-header">
                         {this.props.header}
                         <div className="text-center">
-                            <StyleToolbar />
+                            <StyleToolbar
+                                enableSetDefaultStyle={this.props.enableSetDefaultStyle}/>
                         </div>
                     </div> : null
                 }
                 footer={<div style={{ height: 25 }} />}>
-                {this.props.isEditing ? <StyleCodeEditor /> : <StyleSelector />}
+                {this.props.isEditing
+                    ? <StyleCodeEditor />
+                    : <StyleSelector
+                        showDefaultStyleIcon={this.props.canEdit && this.props.enableSetDefaultStyle}/>}
             </BorderLayout>
         );
     }
@@ -106,7 +113,8 @@ class StyleEditorPanel extends React.Component {
  * @prop {string} cfg.styleService.baseUrl base url of service eg: '/geoserver/'
  * @prop {array} cfg.styleService.availableUrls a list of urls that can access directly to the style service
  * @prop {array} cfg.styleService.formats supported formats, could be one of [ 'sld' ] or [ 'sld', 'css' ]
- * @prop {array} cfg.editingAllowedRoles all roles with edit permission eg: ['ADMIN'], if null all roles have edit permission
+ * @prop {array} cfg.editingAllowedRoles all roles with edit permission eg: [ 'ADMIN' ], if null all roles have edit permission
+ * @prop {array} cfg.enableSetDefaultStyle enable set default style functionality
  * @memberof plugins
  * @class StyleEditor
  */
@@ -128,14 +136,16 @@ const StyleEditorPlugin = compose(
                 loadingStyleSelector,
                 getUpdatedLayer,
                 errorStyleSelector,
-                userRoleSelector
+                userRoleSelector,
+                canEditStyleSelector
             ],
-            (status, loading, layer, error, userRole) => ({
+            (status, loading, layer, error, userRole, canEdit) => ({
                 isEditing: status === 'edit',
                 loading,
                 layer,
                 error: !!(error && error.availableStyles),
-                userRole
+                userRole,
+                canEdit
             })
         ),
         {

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -20,7 +20,8 @@ const {
     createStyle,
     updateStyleCode,
     editStyleCode,
-    deleteStyle
+    deleteStyle,
+    setDefaultStyle
 } = require('../../actions/styleeditor');
 
 const { updateOptionsByOwner } = require('../../actions/additionallayers');
@@ -205,7 +206,8 @@ const StyleToolbar = compose(
             onReset: updateOptionsByOwner.bind(null, STYLE_OWNER_NAME, [{}]),
             onAdd: addStyle.bind(null, true),
             onUpdate: updateStyleCode,
-            onDelete: deleteStyle
+            onDelete: deleteStyle,
+            onSetDefault: setDefaultStyle
         }
     )
 )(require('../../components/styleeditor/StyleToolbar'));

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -175,7 +175,11 @@ module.exports = ({showFeatureInfoTab = true, ...props}, {plugins, pluginsConfig
                     })
                 }
             ],
-            toolbarComponent: settingsPlugins.StyleEditor && settingsPlugins.StyleEditor.ToolbarComponent
+            toolbarComponent: settingsPlugins && settingsPlugins.StyleEditor && settingsPlugins.StyleEditor.ToolbarComponent &&
+                (
+                    settingsPlugins.StyleEditor.cfg && defaultProps(settingsPlugins.StyleEditor.cfg)(settingsPlugins.StyleEditor.ToolbarComponent)
+                    || settingsPlugins.StyleEditor.ToolbarComponent
+                )
         },
         {
             id: 'feature',

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -158,7 +158,7 @@
         },
         "home":{
             "open": "Öffnen",
-            "shortDescription": "Modern webmapping mit OL3, Leaflet und React<br/><small>besuchen sie die <a href=\"/mapstore/docs/\">dokumentationsseite</a></small>",
+            "shortDescription": "Modern webmapping mit OpenLayers, Leaflet und React<br/><small>besuchen sie die <a href=\"/mapstore/docs/\">dokumentationsseite</a></small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore wurde entwickelt, um auf einfache und intuitive Weise Karten und Mashups zu erstellen, zu speichern und zu teilen die auf Inhalten von bekannten Quellen wie Google Maps und OpenStreetMap oder von Diensten die auf offenen Protokollen wie OGC WMS, WFS, WMTS or TMS und so weiter basieren.<br/>Besuche die <a href=\"/mapstore/docs/\">Homepage</a> für mehr Details.",
             "Applications": "Anwendungen",

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1487,7 +1487,12 @@
             "createStyleErrorMessage": "Stil konnte nicht im Stildienst gespeichert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
             "updateStyleErrorTitle": "Stil bearbeiten",
             "updateStyleErrorMessage": "Der Stil konnte im Stildienst nicht aktualisiert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
-            "genericValidationError": "Stil ist nicht gültig und konnte nicht angewendet werden."
+            "genericValidationError": "Stil ist nicht gültig und konnte nicht angewendet werden.",
+            "setDefaultStyle": "Legen Sie den ausgewählten Stil als Standard für die aktuelle Ebene fest",
+            "setDefaultStyleSuccessTitle": "Erfolg beim Setzen des Standardstils",
+            "setDefaultStyleSuccessMessage": "Der Standardstil wurde erfolgreich angewendet",
+            "setDefaultStyleErrorTitle": "Fehler beim Festlegen des Standardstils",
+            "setDefaultStyleErrorMessage": "Es ist nicht möglich, den ausgewählten Stil als Standard anzuwenden"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1488,7 +1488,12 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
-            "genericValidationError": "Style is not valid and it could not be applied."
+            "genericValidationError": "Style is not valid and it could not be applied.",
+            "setDefaultStyle": "Set selected style as default for the current layer",
+            "setDefaultStyleSuccessTitle": "Success on set default style",
+            "setDefaultStyleSuccessMessage": "Default Style has been successfully applied",
+            "setDefaultStyleErrorTitle": "Error on set default style",
+            "setDefaultStyleErrorMessage": "It's not possible apply selected style as default"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -158,7 +158,7 @@
         },
         "home":{
             "open": "Open",
-            "shortDescription": "Modern webmapping with OL3, Leaflet and React<br/><small>visit the <a href=\"/mapstore/docs/\">documentation</a> page</small>",
+            "shortDescription": "Modern webmapping with OpenLayers, Leaflet and React<br/><small>visit the <a href=\"/mapstore/docs/\">documentation</a> page</small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore has been developed to create, save and share in a simple and intuitive way maps and mashups created selecting contents coming from well-known sources like Google Maps and OpenStreetMap or from services provided by organizations using open protocols like OGC WMS, WFS, WMTS or TMS and so on.<br/>Visit the <a href=\"/mapstore/docs/\">home page</a> for more details.",
             "Applications": "Applications",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -158,7 +158,7 @@
         },
         "home":{
             "open": "Abrir",
-            "shortDescription": "Modern webmapping con OL3, Leaflet y React<br/><small>visite la página de <a href=\"/mapstore/docs/\">documentación</a></small>",
+            "shortDescription": "Modern webmapping con OpenLayers, Leaflet y React<br/><small>visite la página de <a href=\"/mapstore/docs/\">documentación</a></small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore está hecho para crear, guardar y compartir de forma simple e intuitiva mapas y composiciones creados a partir de contenidos de servidores tales como OpenStreetMap, Google Maps, MapQuest o  cualquier otro servidor que propocionone protocolos estandar tales como OGC WMS, WFS, WMTS o TMS y otros.<br/>Visite nuestra <a href=\"/mapstore/docs/\">página principal</a> para más detalles.",
             "Applications": "Aplicaciones",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1487,7 +1487,12 @@
             "createStyleErrorMessage": "El estilo no se pudo guardar en el servicio de estilo. Esto podría estar en formato de estilo no compatible o problema de conexión.",
             "updateStyleErrorTitle": "Editar estilo",
             "updateStyleErrorMessage": "El estilo no se pudo actualizar en el servicio de estilo. Esto podría estar en formato de estilo no compatible o problema de conexión.",
-            "genericValidationError": "El estilo no es válido y no se pudo aplicar."
+            "genericValidationError": "El estilo no es válido y no se pudo aplicar.",
+            "setDefaultStyle": "Establecer el estilo seleccionado como predeterminado para la capa actual",
+            "setDefaultStyleSuccessTitle": "Éxito en el estilo por defecto establecido",
+            "setDefaultStyleSuccessMessage": "El estilo predeterminado se ha aplicado con éxito",
+            "setDefaultStyleErrorTitle": "Error en el estilo predeterminado del set",
+            "setDefaultStyleErrorMessage": "No es posible aplicar el estilo seleccionado por defecto."
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1488,7 +1488,12 @@
             "createStyleErrorMessage": "Le style n'a pas pu être enregistré sur le service de style. Cela pourrait être sur un format de style non pris en charge ou un problème de connexion.",
             "updateStyleErrorTitle": "Modifier le style",
             "updateStyleErrorMessage": "Le style n'a pas pu être mis à jour sur le service de style. Cela pourrait être sur un format de style non pris en charge ou un problème de connexion.",
-            "genericValidationError": "Le style n'est pas valide et il n'a pas pu être appliqué."
+            "genericValidationError": "Le style n'est pas valide et il n'a pas pu être appliqué.",
+            "setDefaultStyle": "Définir le style sélectionné par défaut pour le calque actuel",
+            "setDefaultStyleSuccessTitle": "Succès sur le style par défaut",
+            "setDefaultStyleSuccessMessage": "Le style par défaut a été appliqué avec succès",
+            "setDefaultStyleErrorTitle": "Erreur sur le style par défaut",
+            "setDefaultStyleErrorMessage": "Il n'est pas possible d'appliquer le style sélectionné par défaut"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -159,7 +159,7 @@
         },
         "home":{
             "open": "Ouvrir",
-            "shortDescription": "Modern webmapping avec OL3, Leaflet et React<br/><small>consultez la page <a href=\"/mapstore/docs/\"> documentation </a> </ small>",
+            "shortDescription": "Modern webmapping avec OpenLayers, Leaflet et React<br/><small>consultez la page <a href=\"/mapstore/docs/\"> documentation </a> </ small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore est développé pour créer, sauvegarder et partager de façon simple et intuitive cartes et assemblages créés à partir du contenu de serveurs tel que OpenStreetMap, Google Maps, MapQuest ou tout autre serveur spécifique fourni par votre organisation ou une organisation tierce.<br/>Visitez notre <a href=\"/mapstore/docs/\">page d'accueil</a> pour plus de détails.",
             "Applications": "Applications",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1488,7 +1488,12 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
-            "genericValidationError": "Style is not valid and it could not be applied."
+            "genericValidationError": "Style is not valid and it could not be applied.",
+            "setDefaultStyle": "Set selected style as default for the current layer",
+            "setDefaultStyleSuccessTitle": "Success on set default style",
+            "setDefaultStyleSuccessMessage": "Default Style has been successfully applied",
+            "setDefaultStyleErrorTitle": "Error on set default style",
+            "setDefaultStyleErrorMessage": "It's not possible apply selected style as default"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -158,7 +158,7 @@
         },
         "home":{
             "open": "Otvori",
-            "shortDescription": "Moderan webmapping pomoću OL3, Leaflet i React<br/><small>pregledaj stranicu sa <a href=\"/mapstore/docs/\">dokumentacijom</a></small>",
+            "shortDescription": "Moderan webmapping pomoću OpenLayers, Leaflet i React<br/><small>pregledaj stranicu sa <a href=\"/mapstore/docs/\">dokumentacijom</a></small>",
             "forkMeOnGitHub": "Forkaj me na GitHub-u",
             "description": "MapStore je razvijen za jednostavno i intuitivno kreiranje, spremanje i dijeljenje karata i kombinacija podataka dobivenih odabirom sadržaja koji dolaze iz standardnih izvora kao što su Google Maps i OpenStreetMap ili putem servisa koje pružaju organizacije koristeći otvorene protokole kao što su OGC WMS, WFS, WMTS ili TMS itd.<br/>Posjetite <a href=\"/mapstore/docs/\">početnu stranicu</a> za više informacija.",
             "Applications": "Aplikacije",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -158,7 +158,7 @@
         },
         "home":{
             "open": "Apri",
-            "shortDescription": "Modern webmapping con OL3, Leaflet e React<br/><small>visita la pagina di <a href=\"/mapstore/docs/\">documentazione</a></small>",
+            "shortDescription": "Modern webmapping con OpenLayers, Leaflet e React<br/><small>visita la pagina di <a href=\"/mapstore/docs/\">documentazione</a></small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore è sviluppato per creare, salvare e condividere in modo semplice ed intuitivo mappe e mashup creati selezionando contenuti da server come Google Maps, OpenStreetMap, MapQuest o da server specifici forniti dalla propria organizzazione o da terzi. <br/> Visita la <a href=\"/mapstore/docs/\">home page</a> per maggiori dettagli.",
             "Applications": "Applicazioni",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1487,7 +1487,12 @@
             "createStyleErrorMessage": "Lo stile non può essere salvato. Questo potrebbe essere dovuto al formato di stile non supportato o ad un problema di connessione.",
             "updateStyleErrorTitle": "Modifica stile",
             "updateStyleErrorMessage": "Lo stile non può essere aggiornato . Questo potrebbe essere dovuto ad un formato di stile non supportato o ad un problema di connessione.",
-            "genericValidationError": "Lo stile non è valido e non è stato possibile applicarlo."
+            "genericValidationError": "Lo stile non è valido e non è stato possibile applicarlo.",
+            "setDefaultStyle": "Imposta lo stile selezionato come predefinito per il layer corrente",
+            "setDefaultStyleSuccessTitle": "Stile predefinito aggiornamento",
+            "setDefaultStyleSuccessMessage": "Lo stile predefinito è stato aggiornato con successo",
+            "setDefaultStyleErrorTitle": "Errore nell'aggiornamento dello stile predefinito",
+            "setDefaultStyleErrorMessage": "Non è possibile aggiornare lo stile selezionato come predefinito"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1176,7 +1176,12 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
-            "genericValidationError": "Style is not valid and it could not be applied."
+            "genericValidationError": "Style is not valid and it could not be applied.",
+            "setDefaultStyle": "Set selected style as default for the current layer",
+            "setDefaultStyleSuccessTitle": "Success on set default style",
+            "setDefaultStyleSuccessMessage": "Default Style has been successfully applied",
+            "setDefaultStyleErrorTitle": "Error on set default style",
+            "setDefaultStyleErrorMessage": "It's not possible apply selected style as default"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -132,7 +132,7 @@
         },
         "home":{
             "open": "Openen",
-            "shortDescription": "Modern webmapping with OL3, Leaflet and React<br/><small>visit the <a href=\"/mapstore/docs/\">documentation</a> page</small>",
+            "shortDescription": "Modern webmapping with OpenLayers, Leaflet and React<br/><small>visit the <a href=\"/mapstore/docs/\">documentation</a> page</small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore is ontwikkeld om op een eenvoudige en intuïtieve manier kaarten en assemblages te maken, te bewaren en te delen. Kaarten op basis van inhoud van van servers zoals OpenStreetMap, Google Maps, MapQuest en iedere andere specifieke server van uw of van een andere organisatie. <br/>Bezoek onze <a href=\"/mapstore/docs/\">homepage</a> voor meer detail.",
             "Applications": "Toepassingen",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -158,7 +158,7 @@
         },
         "home":{
             "open": "Abrir",
-            "shortDescription": "Modern webmapping com OL3, Leaflet e React<br/><small>visite a página de <a href=\"/mapstore/docs/\">documentação</a></small>",
+            "shortDescription": "Modern webmapping com OpenLayers, Leaflet e React<br/><small>visite a página de <a href=\"/mapstore/docs/\">documentação</a></small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore 2 foi desenvolvido para criar, guardar e partilhar de uma maneira simples e intuitiva mapas e mashups criados seleccionando conteudos de fontes populares como o Google Maps e OpenStreetMap ou de serviços fornecidos por organisações utilizando protocolos livre como OGC WMS, WFS, WMTS ou TMS, etc.<br/>Visite <a href=\"http://geosolutions-it.github.io/MapStore2/\">home page</a> para mais detalhes.",
             "Applications": "Aplicações",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -131,7 +131,7 @@
         },
         "home":{
             "open": "打开",
-            "shortDescription": "Modern webmapping with OL3, Leaflet and React<br/><small>visit the <a href=\"/mapstore/docs/\">documentation</a> page</small>",
+            "shortDescription": "Modern webmapping with OpenLayers, Leaflet and React<br/><small>visit the <a href=\"/mapstore/docs/\">documentation</a> page</small>",
             "forkMeOnGitHub": "Fork me on GitHub",
             "description": "MapStore 2的开发旨在以简单直观的方式创建，保存和共享地图和混搭，这些地图和混搭创建的内容来自知名来源，如Google Maps和OpenStreetMap，或者由使用开放协议的组织提供的服务，如OGC WMS，WFS，WMTS 或TMS等等。<br/>有关更多详细信息，请访问<a href=\"/mapstore/docs/\">主页</a>。",
             "Applications": "应用",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1239,7 +1239,12 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
-            "genericValidationError": "Style is not valid and it could not be applied."
+            "genericValidationError": "Style is not valid and it could not be applied.",
+            "setDefaultStyle": "Set selected style as default for the current layer",
+            "setDefaultStyleSuccessTitle": "Success on set default style",
+            "setDefaultStyleSuccessMessage": "Default Style has been successfully applied",
+            "setDefaultStyleErrorTitle": "Error on set default style",
+            "setDefaultStyleErrorMessage": "It's not possible apply selected style as default"
         },
         "playback": {
             "settings": {


### PR DESCRIPTION
## Description
This PR introduces the possibility to enable set default style functionality for a GeoServer layer.
Current flag needs to be true to activate it:
```
{
    "name": "StyleEditor",
    "cfg": {
        "enableSetDefaultStyle": true
    }
}
```
This is a preview of style list when `enableSetDefaultStyle` is `true`
![_asas](https://user-images.githubusercontent.com/19175505/51467266-76e67900-1d6c-11e9-8641-09c4351eb49c.png)


This is a preview of style list when `enableSetDefaultStyle ` is `false`

![2019-01-21 11_04_01-window](https://user-images.githubusercontent.com/19175505/51467279-7d74f080-1d6c-11e9-9195-756c2a0c872d.png)


## Issues
 - Fix #3375 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
issue #3375

**What is the new behavior?**
It's possible to set the default style of GeoServer from the UI and icon related to the style (default) are visible only when the set default functionality is enable

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Note: this functionality is disabled on master but it will be enable on geonode interation

