### PR TITLE
Fix #3473 - Style Editor - Style list shows missing styles alert after back to homepage

### DIFF
--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -146,6 +146,58 @@ describe('styleeditor Epics', () => {
         state);
 
     });
+    it('test toggleStyleEditorEpic enabled in state true but availableStyles missing from settings', (done) => {
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        url: '/geoserver/'
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ],
+                settings: {
+                    options: {
+                        opacity: 1
+                    }
+                }
+            },
+            styleeditor: {
+                enabled: true
+            }
+        };
+        const NUMBER_OF_ACTIONS = 1;
+
+        const results = (actions) => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            try {
+                actions.map((action) => {
+                    switch (action.type) {
+                        case LOADING_STYLE:
+                            expect(action.status).toBe('global');
+                            break;
+                        default:
+                            expect(true).toBe(false);
+                    }
+                });
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            toggleStyleEditorEpic,
+            NUMBER_OF_ACTIONS,
+            toggleStyleEditor(undefined, true),
+            results,
+        state);
+
+    });
     it('test updateLayerOnStatusChangeEpic status template', (done) => {
 
         const state = {

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -146,7 +146,7 @@ describe('styleeditor Epics', () => {
         state);
 
     });
-    it('test toggleStyleEditorEpic enabled in state true but availableStyles missing from settings', (done) => {
+    it('toggleStyleEditorEpic: missing availableStyles starts the styles retrieval', (done) => {
 
         const state = {
             layers: {

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -7,7 +7,7 @@
  */
 
 const Rx = require('rxjs');
-const { head, isArray, template } = require('lodash');
+const { get, head, isArray, template } = require('lodash');
 const { success, error } = require('../actions/notifications');
 const { UPDATE_NODE, updateNode, updateSettingsParams } = require('../actions/layers');
 const { updateAdditionalLayer, removeAdditionalLayer, updateOptionsByOwner } = require('../actions/additionallayers');
@@ -49,7 +49,7 @@ const {
     getUpdatedLayer
 } = require('../selectors/styleeditor');
 
-const { getSelectedLayer } = require('../selectors/layers');
+const { getSelectedLayer, layerSettingSelector } = require('../selectors/layers');
 const { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts } = require('../utils/StyleEditorUtils');
 const { normalizeUrl } = require('../utils/PrintUtils');
 const { initialSettingsSelector, originalSettingsSelector } = require('../selectors/controls');
@@ -200,9 +200,11 @@ module.exports = {
             .switchMap((action) => {
 
                 const state = store.getState();
+                const settings = layerSettingSelector(state);
+                const isInitialized = !!get(settings, 'options.availableStyles');
 
                 if (!action.enabled) return resetStyleEditorObservable(state);
-                if (enabledStyleEditorSelector(state)) return Rx.Observable.empty();
+                if (enabledStyleEditorSelector(state) && isInitialized) return Rx.Observable.empty();
 
                 const layer = action.layer || getSelectedLayer(state);
                 if (!layer || layer && !layer.url) return Rx.Observable.empty();


### PR DESCRIPTION
## Description
Style list shows missing styles alert after back to homepage

## Issues
 - Fix #3473

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
issues #3473

**What is the new behavior?**
Style Editor will try to load style list if availableStyles are missing from settings

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
