### PR TITLE
Fixes #3479: Allow appConfig override in custom app

### DIFF
--- a/web/client/product/__tests__/main-test.jsx
+++ b/web/client/product/__tests__/main-test.jsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const mainApp = require('../main');
+const expect = require('expect');
+const assign = require('object-assign');
+const ConfigUtils = require('../../utils/ConfigUtils');
+
+class AppComnponent extends React.Component {
+    render() {
+        return <div>TEST</div>;
+    }
+}
+
+describe('standard application runner', () => {
+    beforeEach((done) => {
+        window.__DEVTOOLS__ = {};
+        global.Intl = {};
+        ConfigUtils.setLocalConfigurationFile("base/web/client/test-resources/localConfig.json");
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        delete window.__DEVTOOLS__;
+        global.Intl = null;
+        ConfigUtils.setLocalConfigurationFile("localConfig.json");
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('allows overriding appConfig', (done) => {
+        const overrideCfg = (config) => {
+            return assign({}, config, {
+                appComponent: AppComnponent,
+                onStoreInit: () => {
+                    setTimeout(() => {
+                        expect(document.body.innerHTML).toContain("TEST");
+                        done();
+                    }, 0);
+                }
+            });
+        };
+        mainApp({}, {plugins: {}}, overrideCfg);
+    });
+
+});

--- a/web/client/product/main.jsx
+++ b/web/client/product/main.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = (config, pluginsDef) => {
+module.exports = (config, pluginsDef, overrideConfig = cfg => cfg) => {
     const React = require('react');
     const ReactDOM = require('react-dom');
     const {connect} = require('react-redux');
@@ -44,7 +44,7 @@ module.exports = (config, pluginsDef) => {
             loadVersion
         ];
 
-        const appConfig = {
+        const appConfig = overrideConfig({
             storeOpts,
             appEpics,
             appStore,
@@ -53,7 +53,7 @@ module.exports = (config, pluginsDef) => {
             appComponent: StandardRouter,
             printingEnabled: true,
             themeCfg
-        };
+        });
 
         ReactDOM.render(
             <StandardApp {...appConfig}/>,


### PR DESCRIPTION
## Description
Allow custom application extending main product to override appConfig programmatically.

## Issues
 - Fix #3479

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
appConfig can be only statically defined in the application appConfig.js file.

**What is the new behavior?**
appConfig values can be overridden using code by a custom application extending the product main.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
