### PR TITLE
enabling cesium background and setting background color to white #3386

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -79,6 +79,7 @@ class CesiumMap extends React.Component {
             navigationHelpButton: false,
             navigationInstructionsInitiallyVisible: false
         }, this.getMapOptions(this.props.mapOptions)));
+        map.scene.globe.baseColor = Cesium.Color.WHITE;
         map.imageryLayers.removeAll();
         map.camera.moveEnd.addEventListener(this.updateMapInfoState);
         this.hand = new Cesium.ScreenSpaceEventHandler(map.scene.canvas);

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -74,7 +74,7 @@ const isSupportedLayer = (layer, maptype) => {
      * previously was checking for types
     */
     if (layer.type === 'empty') {
-        return maptype === 'openlayers' || maptype === 'leaflet';
+        return true;
     }
     return Layers.isSupported(layer.type) && !layer.invalid;
 };

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -335,9 +335,9 @@ describe('LayersUtils', () => {
             const res = LayersUtils.isSupportedLayer(emptyBackground, "openlayers");
             expect(res).toBeTruthy();
         });
-        it('type: ' + typeV1 + '  maptype: cesium, not supported', () => {
+        it('type: ' + typeV1 + '  maptype: cesium, supported', () => {
             const res = LayersUtils.isSupportedLayer(emptyBackground, "cesium");
-            expect(res).toBeFalsy();
+            expect(res).toBeTruthy();
         });
         it('type: wms  maptype: leaflet, supported', () => {
             const maptype = "leaflet";


### PR DESCRIPTION
## Description
this PR enables the user to select empty backgrounds in 3D mode, and changes background color to (white), which matches empty backgrounds in leaflet and openlayers.   

## Issues
 - Fix #3386
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3386

**What is the new behavior?**
see the discribtion.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
