### PR TITLE
Fix #3487 Timeline - Snapping doesn't work if the cursor is outside of the timeline

### DIFF
--- a/web/client/components/time/enhancers/__tests__/customTimesHandlers-test.js
+++ b/web/client/components/time/enhancers/__tests__/customTimesHandlers-test.js
@@ -38,6 +38,7 @@ describe('customTimesHandlers enhancer', () => {
         const spyCallback = expect.spyOn(actions, 'setCurrentTime');
         const DATE = "2018-12-20T15:07:42.981Z";
         const LAYER = "LAYER";
+        const SELECTED_LAYER = "SELECTED_LAYER";
         const Sink = clickHandlers(createSink(props => {
             props.clickHandler({
                 time: new Date(DATE),
@@ -47,11 +48,11 @@ describe('customTimesHandlers enhancer', () => {
                 }});
 
         }));
-        const cmp = ReactDOM.render(<Sink setCurrentTime={actions.setCurrentTime} />, document.getElementById("container"));
+        const cmp = ReactDOM.render(<Sink selectedLayer={SELECTED_LAYER} setCurrentTime={actions.setCurrentTime} />, document.getElementById("container"));
         expect(cmp).toExist();
         expect(spyCallback).toHaveBeenCalled();
         expect(spyCallback.calls[0].arguments[0]).toBe(DATE);
-        expect(spyCallback.calls[0].arguments[1]).toBe(LAYER);
+        expect(spyCallback.calls[0].arguments[1]).toBe(SELECTED_LAYER);
     });
     it('click triggers selectGroup', () => {
         const actions = {
@@ -139,6 +140,28 @@ describe('customTimesHandlers enhancer', () => {
         expect(cmp).toExist();
         expect(spyCallback).toHaveBeenCalled();
         expect(spyCallback.calls[0].arguments[0]).toBe(DATE);
+        expect(spyCallback.calls[0].arguments[1]).toBe(undefined);
+    });
+    it('timechangedHandler for currentTime with selected layer', () => {
+        const actions = {
+            setCurrentTime: () => { }
+        };
+        const spyCallback = expect.spyOn(actions, 'setCurrentTime');
+        const DATE = "2018-12-20T15:07:42.981Z";
+        const CURSOR = "currentTime";
+        const SELECTED_LAYER = "SELECTED_LAYER";
+        const Sink = clickHandlers(createSink(props => {
+            props.timechangedHandler({
+                time: new Date(DATE),
+                id: CURSOR
+            });
+
+        }));
+        const cmp = ReactDOM.render(<Sink selectedLayer={SELECTED_LAYER} setCurrentTime={actions.setCurrentTime} />, document.getElementById("container"));
+        expect(cmp).toExist();
+        expect(spyCallback).toHaveBeenCalled();
+        expect(spyCallback.calls[0].arguments[0]).toBe(DATE);
+        expect(spyCallback.calls[0].arguments[1]).toBe(SELECTED_LAYER);
     });
     it('timechangedHandler with range', () => {
         const actions = {

--- a/web/client/components/time/enhancers/customTimesHandlers.js
+++ b/web/client/components/time/enhancers/customTimesHandlers.js
@@ -45,7 +45,7 @@ module.exports = withHandlers({
                 const className = target && target.getAttribute('class');
                 const timeId = className && trim(className.replace('vis-custom-time', ''));
                 if (time && !offsetEnabled && timeId !== "startPlaybackTime" && timeId !== "endPlaybackTime") {
-                    setCurrentTime(time.toISOString(), group || selectedLayer);
+                    setCurrentTime(time.toISOString(), selectedLayer);
                 }
                 break;
             }
@@ -61,7 +61,8 @@ module.exports = withHandlers({
         setCurrentTime = () => { },
         currentTimeRange = {},
         playbackRange,
-        setPlaybackRange = () => { }
+        setPlaybackRange = () => { },
+        selectedLayer
     }) => ({ time, id } = {}) => {
         // playback range change
         if (id === 'startPlaybackTime' || id === 'endPlaybackTime') {
@@ -78,7 +79,7 @@ module.exports = withHandlers({
 
         if (id === 'currentTime' ) {
             if (!currentTimeRange.end) {
-                setCurrentTime(time.toISOString(), null);
+                setCurrentTime(time.toISOString(), selectedLayer);
             } else if (isValidOffset(time, currentTimeRange.end)) {
                 setCurrentTime(time.toISOString(), null);
             } else {

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -154,6 +154,7 @@ module.exports = {
      */
     setTimelineCurrentTime: (action$, {getState = () => {}} = {}) =>
         action$.ofType(SELECT_TIME)
+        .throttleTime(100) // avoid multiple request in case of mouse events drag and click
         .switchMap( ({time, group}) => {
             const state = getState();
 


### PR DESCRIPTION
## Description
Fix Snapping doesn't work if the cursor is outside of the timeline

## Issues
 - Fix #3487

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3487

**What is the new behavior?**
Snap is applied also when the mouse cursor is outside of the timeline container

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
