### PR TITLE
Fix build issue with uglify plugin

### DIFF
--- a/web/client/components/time/TimelineComponent.jsx
+++ b/web/client/components/time/TimelineComponent.jsx
@@ -8,7 +8,8 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 
-const vis = require('vis/index-timeline-graph2d');
+// const vis = require('vis/index-timeline-graph2d'); // debug version. Doesn't work with uglify plugin, probably because of this issue: https://github.com/almende/vis/issues/3290
+const vis = require('vis/dist/vis-timeline-graph2d.min');
 /*
  * This override enables editing for BackgroundItem
  */


### PR DESCRIPTION
## Description
When the final build is executed, uglify plugin causes this error: 

```
4915] (webpack)/hot/only-dev-server.js 2.29 kB {23} [built]
    + 5249 hidden modules

ERROR in minifying 9.df56446f7cb329955707.chunk.js
Unexpected token operator «=», expected punc «,»

ERROR in minifying mapstore2.js
Unexpected token operator «=», expected punc «,»
Child html-webpack-plugin for "index.html":
...

...
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! mapstore2@0.1.0 compile: `npm run clean && mkdirp ./web/client/dist && webpack --progress --config prod-webpack.config.js`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the mapstore2@0.1.0 compile script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/offtherailz/.npm/_logs/2019-01-24T15_30_45_764Z-debug.log
```

Probably it is because of [this issue](https://github.com/almende/vis/issues/3290). Including the minified version solved the issue.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Build in jenkins do not work

**What is the new behavior?**
Build in jenkins works again

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

