### PR TITLE
Fix #3496. Add attribution support for WMS layers

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -116,7 +116,12 @@ i.e.
     "title": "Open Street Map",
     "name": "mapnik",
     "group": "background",
-    "visibility": false
+    "visibility": false,
+    "credits": { // optional
+        "imageUrl": "somePic.png", // URL for the image to put in attribution
+        "link": "http://someURL.org", // URL where attribution have to link to
+        "title": "text to render" // title to show (as image title or as text)
+    }
 }
 ```
 

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -131,6 +131,22 @@ describe('Test correctness of the WMS APIs', () => {
             }
         });
     });
+    it('GetRecords attribution creates the credits object', (done) => {
+        // note: maxRecords = 2 because of strange pagination system. Need to restore this when fixed
+        API.getRecords('base/web/client/test-resources/wms/attribution.xml', 0, 2, '').then((result) => {
+            try {
+                expect(result).toExist();
+                expect(result.service).toExist();
+                expect(result.numberOfRecordsMatched).toBe(2);
+                expect(result.records[0]).toExist();
+                expect(result.records[0].credits).toExist();
+                expect(result.records[0].credits.imageUrl).toBe('logo.png');
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
     it('GetRecords 1.1.1', (done) => {
         API.getRecords('base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml', 0, 1, '').then((result) => {
             try {

--- a/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
@@ -162,6 +162,28 @@ describe('Cesium layer', () => {
         expect(map.imageryLayers._layers[0]._imageryProvider._tileProvider._subdomains.length).toBe(1);
         expect(map.imageryLayers._layers[0]._imageryProvider.proxy.proxy).toExist();
     });
+    it('wms layer with credits', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://demo.geo-solutions.it/geoserver/wms",
+            credits: {
+                imageUrl: "test.png",
+                title: "test"
+            }
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <CesiumLayer type="wms"
+                 options={options} map={map}/>, document.getElementById("container"));
+
+        expect(layer).toExist();
+        expect(map.imageryLayers.length).toBe(1);
+        expect(map.imageryLayers._layers[0].imageryProvider.credit).toExist();
+    });
     it('creates a wms layer with caching for Cesium map', () => {
         var options = {
             "type": "wms",

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -82,9 +82,12 @@ function wmsToCesiumOptions(options) {
     if (proxyUrl) {
         proxy = ProxyUtils.needProxy(options.url) && proxyUrl;
     }
+    const cr = options.credits;
+    const credit = cr ? new Cesium.Credit(cr.text, cr.imageUrl, cr.link) : options.attribution;
     // NOTE: can we use opacity to manage visibility?
     return assign({
         url: "{s}",
+        credit,
         subdomains: getURLs(isArray(options.url) ? options.url : [options.url]),
         proxy: proxy && new WMSProxy(proxy) || new NoProxy(),
         layers: options.name,

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -83,7 +83,7 @@ function wmsToCesiumOptions(options) {
         proxy = ProxyUtils.needProxy(options.url) && proxyUrl;
     }
     const cr = options.credits;
-    const credit = cr ? new Cesium.Credit(cr.text, cr.imageUrl, cr.link) : options.attribution;
+    const credit = cr ? new Cesium.Credit(cr.text || cr.title, cr.imageUrl, cr.link) : options.attribution;
     // NOTE: can we use opacity to manage visibility?
     return assign({
         url: "{s}",

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -209,6 +209,27 @@ describe('Leaflet layer', () => {
         map.eachLayer((l) => elevationFunc = l.getElevation);
         expect(elevationFunc).toExist();
     });
+    it('creates a wms layer with credits', () => {
+        const CREDITS1 = {
+            title: "test"
+        };
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms",
+            credits: CREDITS1
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <LeafLetLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+        expect(layer).toExist();
+        // count layers
+        map.eachLayer( l => expect(l.getAttribution()).toBe(CREDITS1.title));
+    });
 
     it('creates a wmts layer for leaflet map', () => {
         var options = {

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -17,6 +17,8 @@ const objectAssign = require('object-assign');
 const {isArray, isNil} = require('lodash');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const ElevationUtils = require('../../../../utils/ElevationUtils');
+const { creditsToAttribution } = require('../../../../utils/LayersUtils');
+
 require('leaflet.nontiledlayer');
 
 L.NonTiledLayer.WMSCustom = L.NonTiledLayer.WMS.extend({
@@ -156,12 +158,12 @@ const removeNulls = (obj = {}) => {
     }, {});
 };
 
-
 function wmsToLeafletOptions(options) {
     var opacity = options.opacity !== undefined ? options.opacity : 1;
     const params = optionsToVendorParams(options);
     // NOTE: can we use opacity to manage visibility?
     const result = objectAssign({}, options.baseParams, {
+        attribution: options.credits && creditsToAttribution(options.credits),
         layers: options.name,
         styles: options.style || "",
         format: options.format || 'image/png',

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -148,6 +148,63 @@ describe('Openlayers layer', () => {
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
         expect(map.getLayers().item(0).getSource().urls.length).toBe(1);
+        expect(map.getLayers().item(0).getSource().getAttributions()).toNotExist();
+    });
+
+    it('wms layer attribution with credits - create and update layer', () => {
+        const TEXT1 = "some attribution";
+        const TEXT2 = "some other attibution";
+        const CREDITS1 = {
+            imageUrl: "test.jpg",
+            title: "test"
+        };
+
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            credits: {
+                title: TEXT1
+            },
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/wms"
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+
+        expect(layer).toExist();
+        // check creation
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(map.getLayers().item(0).getSource().urls.length).toBe(1);
+        expect(map.getLayers().item(0).getSource().getAttributions()).toExist();
+        expect(map.getLayers().item(0).getSource().getAttributions()[0].getHTML()).toBe(TEXT1);
+        // check remove
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={{...options, credits: undefined}} map={map} />, document.getElementById("container"));
+        expect(map.getLayers().item(0).getSource().getAttributions()).toNotExist();
+        // check update
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={{ ...options, credits: {title: TEXT2} }} map={map} />, document.getElementById("container"));
+        expect(map.getLayers().item(0).getSource().getAttributions()).toExist();
+        expect(map.getLayers().item(0).getSource().getAttributions()[0].getHTML()).toBe(TEXT2);
+        // check content update
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+        expect(map.getLayers().item(0).getSource().getAttributions()).toExist();
+        expect(map.getLayers().item(0).getSource().getAttributions()[0].getHTML()).toBe(TEXT1);
+        // check complex contents
+        ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={{...options, credits: CREDITS1}} map={map} />, document.getElementById("container"));
+        expect(map.getLayers().item(0).getSource().getAttributions()).toExist();
+        expect(map.getLayers().item(0).getSource().getAttributions()[0].getHTML()).toBe('<img src="test.jpg" title="test">');
     });
 
     it('creates a wms elevation layer for openlayers map', () => {
@@ -190,6 +247,31 @@ describe('Openlayers layer', () => {
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
         expect(map.getLayers().item(0).getSource().getUrl()).toExist();
+        expect(map.getLayers().item(0).getSource().getAttributions()).toNotExist();
+    });
+    it('creates a single tile credits', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "credits": {
+                title: "some attribution"
+            },
+            "singleTile": true,
+            "url": "http://sample.server/geoserver/wms"
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(map.getLayers().item(0).getSource().getUrl()).toExist();
+        expect(map.getLayers().item(0).getSource().getAttributions()).toExist();
     });
 
     it('creates a single tile wms layer for openlayers map ratio', (done) => {

--- a/web/client/examples/rasterstyler/assets/css/viewer.css
+++ b/web/client/examples/rasterstyler/assets/css/viewer.css
@@ -60,7 +60,7 @@ html, body, #container, .fill {
     display:none;
     visibility: hidden;
 }
-.leaflet-control-attribution a:first-child{
+.leaflet-control-attribution > a:first-child{
     display:none;
     visibility: hidden;
 }

--- a/web/client/examples/styler/assets/css/viewer.css
+++ b/web/client/examples/styler/assets/css/viewer.css
@@ -61,7 +61,7 @@ html, body, #container, .fill {
     display:none;
     visibility: hidden;
 }
-.leaflet-control-attribution a:first-child{
+.leaflet-control-attribution > a:first-child{
     display:none;
     visibility: hidden;
 }

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -195,6 +195,9 @@ const API = {
 };
 /**
  * MetadataExplorer plugin. Shows the catalogs results (CSW, WMS and WMTS).
+ * Some useful flags in `localConfig.json`:
+ * - `noCreditsFromCatalog`: avoid add credits (attribution) from catalog
+ *
  * @class
  * @name MetadataExplorer
  * @memberof plugins

--- a/web/client/product/assets/css/viewer.css
+++ b/web/client/product/assets/css/viewer.css
@@ -30,7 +30,7 @@ html, body, #container, .fill {
     float: left;
 }
 
-.ol-attribution li:first-child, .leaflet-control-attribution a:first-child{
+.ol-attribution li:first-child, .leaflet-control-attribution > a:first-child{
     display: none;
     visibility: hidden;
 }

--- a/web/client/test-resources/wms/attribution.xml
+++ b/web/client/test-resources/wms/attribution.xml
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
+
+<!-- MapServer version 7.0.6 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=RSVG SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=THREADS SUPPORTS=GEOS SUPPORTS=POINT_Z_M INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
+
+<Service>
+  <Name>WMS</Name>
+  <Title>geoserver_wms CTR</Title>
+  <Abstract>Sample ogc service</Abstract>
+  <KeywordList>
+      <Keyword>test12</Keyword>
+      <Keyword>test</Keyword>
+      <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+  </KeywordList>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/>
+  <ContactInformation>
+    <ContactPersonPrimary>
+      <ContactPerson>TEST</ContactPerson>
+      <ContactOrganization>Organization</ContactOrganization>
+    </ContactPersonPrimary>
+      <ContactPosition>custodian</ContactPosition>
+    <ContactAddress>
+        <AddressType>postal</AddressType>
+        <Address>Some street</Address>
+        <City>Some city</City>
+        <StateOrProvince>Some Province</StateOrProvince>
+        <PostCode>12345</PostCode>
+        <Country>Italy</Country>
+    </ContactAddress>
+  <ContactElectronicMailAddress>some@contact.it</ContactElectronicMailAddress>
+  </ContactInformation>
+  <Fees>none</Fees>
+  <AccessConstraints>none</AccessConstraints>
+  <LayerLimit>15</LayerLimit>
+  <MaxWidth>5000</MaxWidth>
+  <MaxHeight>5000</MaxHeight>
+</Service>
+
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/png</Format>
+      <Format>image/png; mode=8bit</Format>
+      <Format>image/jpeg</Format>
+      <Format>application/x-pdf</Format>
+      <Format>image/svg+xml</Format>
+      <Format>image/tiff</Format>
+      <Format>application/vnd.google-earth.kml+xml</Format>
+      <Format>application/vnd.google-earth.kmz</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/gml</Format>
+      <Format>text/html</Format>
+      <Format>text/plain</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://some.server/wms?"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+  </Request>
+  <Exception>
+    <Format>XML</Format>
+    <Format>INIMAGE</Format>
+    <Format>BLANK</Format>
+  </Exception>
+  <Layer>
+    <Name>rt_ctr</Name>
+    <Title>geoserver_wms CTR</Title>
+    <Abstract>SOME OGC Service</Abstract>
+    <KeywordList>
+        <Keyword>cartografia</Keyword>
+        <Keyword>toscana</Keyword>
+        <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+    </KeywordList>
+    <CRS>EPSG:3003</CRS>
+    <CRS>EPSG:3004</CRS>
+    <CRS>EPSG:6706</CRS>
+    <CRS>EPSG:6707</CRS>
+    <CRS>EPSG:6708</CRS>
+    <CRS>EPSG:25832</CRS>
+    <CRS>EPSG:25833</CRS>
+    <CRS>EPSG:4326</CRS>
+    <CRS>EPSG:3857</CRS>
+    <CRS>EPSG:32632</CRS>
+    <CRS>EPSG:32633</CRS>
+    <EX_GeographicBoundingBox>
+        <westBoundLongitude>9.54974</westBoundLongitude>
+        <eastBoundLongitude>12.4747</eastBoundLongitude>
+        <southBoundLatitude>42.1617</southBoundLatitude>
+        <northBoundLatitude>44.5034</northBoundLatitude>
+    </EX_GeographicBoundingBox>
+    <BoundingBox CRS="EPSG:25832"
+                minx="545379" miny="4.67316e+06" maxx="776461" maxy="4.92794e+06" />
+    <Attribution>
+        <LogoURL width="160" height="70">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="logo.png"/>
+          </LogoURL>
+    </Attribution>
+    <MinScaleDenominator>1</MinScaleDenominator>
+    <MaxScaleDenominator>5e+06</MaxScaleDenominator>
+    <Layer queryable="1" opaque="0" cascaded="0">
+        <Name>some_layer</Name>
+        <Title>some layer</Title>
+        <Abstract>Some description</Abstract>
+        <CRS>EPSG:3003</CRS>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>9.363</westBoundLongitude>
+            <eastBoundLongitude>12.7825</eastBoundLongitude>
+            <southBoundLatitude>42.079</southBoundLatitude>
+            <northBoundLatitude>44.7022</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3003"
+                    minx="1.53e+06" miny="4.665e+06" maxx="1.8e+06" maxy="4.95e+06" />
+        <BoundingBox CRS="EPSG:3004"
+                    minx="2.05405e+06" miny="4.66136e+06" maxx="2.34413e+06" maxy="4.96532e+06" />
+        <BoundingBox CRS="EPSG:6706"
+                    minx="42.079" miny="9.363" maxx="44.7022" maxy="12.7825" />
+        <BoundingBox CRS="EPSG:6707"
+                    minx="4.66492e+06" miny="529999" maxx="4.94998e+06" maxy="799986" />
+        <BoundingBox CRS="EPSG:6708"
+                    minx="4.66128e+06" miny="34075.2" maxx="4.96523e+06" maxy="324138" />
+        <BoundingBox CRS="EPSG:25832"
+                    minx="529999" miny="4.66492e+06" maxx="799986" maxy="4.94998e+06" />
+        <BoundingBox CRS="EPSG:25833"
+                    minx="34075.2" miny="4.66128e+06" maxx="324138" maxy="4.96523e+06" />
+        <BoundingBox CRS="EPSG:4326"
+                    minx="42.079" miny="9.363" maxx="44.7022" maxy="12.7825" />
+        <BoundingBox CRS="EPSG:3857"
+                    minx="1.04228e+06" miny="5.17282e+06" maxx="1.42295e+06" maxy="5.57476e+06" />
+        <BoundingBox CRS="EPSG:32632"
+                    minx="529999" miny="4.66492e+06" maxx="799986" maxy="4.94998e+06" />
+        <BoundingBox CRS="EPSG:32633"
+                    minx="34075.2" miny="4.66128e+06" maxx="324138" maxy="4.96523e+06" />
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="109" height="122">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://some.server/wms?version=1.3.0&amp;service=WMS&amp;request=GetLegendGraphic&amp;sld_version=1.1.0&amp;layer=some_layer&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+        <MinScaleDenominator>1</MinScaleDenominator>
+        <MaxScaleDenominator>5e+06</MaxScaleDenominator>
+    </Layer>
+  </Layer>
+</Capability>
+</WMS_Capabilities>

--- a/web/client/themes/default/less/cesium.less
+++ b/web/client/themes/default/less/cesium.less
@@ -1,0 +1,8 @@
+/**
+ * Customization for cesium
+ */
+.cesium-widget-credits .cesium-credit-imageContainer {
+    img {
+        max-height: 3em; // max size of images in credits
+    }
+}

--- a/web/client/themes/default/less/leaflet.less
+++ b/web/client/themes/default/less/leaflet.less
@@ -37,6 +37,10 @@
 
 .leaflet-control-attribution {
     color: @ms2-color-text;
+    max-height: 2.6em;
+    img {
+        max-height: 2.6em;
+    }
     a {
         color: @ms2-color-primary;
     }

--- a/web/client/themes/default/less/map-footer.less
+++ b/web/client/themes/default/less/map-footer.less
@@ -22,10 +22,15 @@
         span {
             color: @ms2-color-text-primary;
         }
-        
+
     }
 
     .leaflet-control-attribution {
+        display: flex;
+        max-height: 2.6em;
+        img {
+            max-height: 2.6em;
+        }
         position: absolute;
         width: 50%;
         height: 30px;
@@ -37,6 +42,16 @@
    }
 
    .ol-attribution.ol-uncollapsible {
+        ul {
+            display: flex;
+            li {
+                margin: auto 2px;
+            }
+        }
+       max-height: 2.6em;
+       img {
+           max-height: 2.6em;
+       }
        position: absolute;
        left: 0;
        height: 30px;
@@ -58,7 +73,7 @@
 
 .ms-prj-selector {
     border: none;
-    
+
     .dropdown-toggle-primary {
         .btn-primary;
         box-shadow: none;

--- a/web/client/themes/default/ms2-theme.less
+++ b/web/client/themes/default/ms2-theme.less
@@ -28,6 +28,7 @@
 @import "./less/mouse-position.less";
 @import "./less/navbar.less";
 @import "./less/ol.less";
+@import "./less/cesium.less";
 @import "./less/panels.less";
 @import "./less/print.less";
 @import "./less/query-panel.less";

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -195,7 +195,8 @@ const converters = {
                     params: {
                         name: record.Name
                     }
-                }]
+                }],
+                credits: record.credits
                 };
             });
         }
@@ -359,6 +360,7 @@ const CatalogUtils = {
             matrixIds: type === "wmts" ? record.matrixIds || [] : undefined,
             description: record.description || "",
             tileMatrixSet: type === "wmts" ? record.tileMatrixSet || [] : undefined,
+            credits: record.credits,
             bbox: {
                 crs: record.boundingBox.crs,
                 bounds: {

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -360,7 +360,7 @@ const CatalogUtils = {
             matrixIds: type === "wmts" ? record.matrixIds || [] : undefined,
             description: record.description || "",
             tileMatrixSet: type === "wmts" ? record.tileMatrixSet || [] : undefined,
-            credits: record.credits,
+            credits: !ConfigUtils.getConfigProp("noCreditsFromCatalog") && record.credits,
             bbox: {
                 crs: record.boundingBox.crs,
                 bounds: {

--- a/web/client/utils/ConfigProvider.js
+++ b/web/client/utils/ConfigProvider.js
@@ -554,8 +554,8 @@ const CONFIGPROVIDER = {
         url: '//map1.vis.earthdata.nasa.gov/wmts-webmerc/{variant}/default/{time}/{tilematrixset}9/{z}/{y}/{x}.{format}',
         options: {
             attribution:
-                    'Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System ' +
-                    '(<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.',
+                    '<span>Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System ' +
+                    '(<a href="https://earthdata.nasa.gov">ESDIS</a>) with funding provided by NASA/HQ.</span>',
             credits: {
                 text: 'Black Marble imagery courtesy NASA Earth Observatory'
             },

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -361,7 +361,7 @@ const LayersUtils = {
         };
     },
     saveLayer: (layer) => {
-        return {
+        return assign({
             id: layer.id,
             features: layer.features,
             format: layer.format,
@@ -400,10 +400,10 @@ const LayersUtils = {
             useForElevation: layer.useForElevation || false,
             hidden: layer.hidden || false,
             origin: layer.origin,
-            thematic: layer.thematic,
-            credits: layer.credits,
-            ...assign({}, layer.params ? {params: layer.params} : {})
-        };
+            thematic: layer.thematic
+        },
+        layer.params ? { params: layer.params } : {},
+        layer.credits ? { credits: layer.credits } : {});
     },
     /**
     * default regex rule for searching for a /geoserver/ string in a url

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -401,6 +401,7 @@ const LayersUtils = {
             hidden: layer.hidden || false,
             origin: layer.origin,
             thematic: layer.thematic,
+            credits: layer.credits,
             ...assign({}, layer.params ? {params: layer.params} : {})
         };
     },
@@ -502,6 +503,11 @@ const LayersUtils = {
 
         }
         return layers;
+    },
+    creditsToAttribution: ({ imageUrl, link, title }) => {
+        // TODO: check if format is valid for an img (svg, for instance, may not work)
+        const html = imageUrl ? `<img src="${imageUrl}" ${title ? `title="${title}"` : ``}>` : title;
+        return link && html ? `<a href="${link}" target="_blank">${html}</a>` : html;
     }
 };
 

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -457,5 +457,18 @@ describe('LayersUtils', () => {
         expect(RES_4[0].visibility).toBe(true);
 
     });
+    it('creditsToAttribution', () => {
+        const TESTS = [
+            [{ title: "test"}, 'test'], // text only
+            [{ imageUrl: "image.png" }, '<img src="image.png" >'], // image and text
+            [{ title: "test", imageUrl: "image.png" }, '<img src="image.png" title="test">'], // image and text
+            [{ title: "test", link: "http://url.com" }, '<a href="http://url.com" target="_blank">test</a>'], // text with link
+            [{ title: "test", link: "http://url.com", imageUrl: "image.png" }, '<a href="http://url.com" target="_blank"><img src="image.png" title="test"></a>'], // text, image, link
+            [[], undefined], // no data returns undefined
+            [[{}], undefined], // empty object returns undefined
+            [{ link: "http://url.com" }, undefined] // only link returns undefined
+        ];
+        TESTS.map(([credits, expectedResult]) => expect(LayersUtils.creditsToAttribution(credits)).toBe(expectedResult));
+    });
 
 });

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -481,10 +481,10 @@ describe('LayersUtils', () => {
                 },
                 l => {
                     expect(l.params).toNotExist();
-                    Object.keys(l).map( k => expect(k).toNotBe("params"));
-                    Object.keys(l).map(k => expect(k).toNotBe("credits"));
-                    Object.keys(l).map(k => expect(k).toNotBe("id"));
-                    expect(l).toEqual(layers[0][0]);
+                    const keys = Object.keys(l);
+                    expect(keys).toContain('id');
+                    expect(keys).toNotContain('params');
+                    expect(keys).toNotContain('credits');
                 }
             ],
             // save params if present
@@ -511,7 +511,7 @@ describe('LayersUtils', () => {
                 }
             ]
         ];
-        layers.map(([layer, test]) => test(layer) );
+        layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );
     });
 
 });

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -470,5 +470,48 @@ describe('LayersUtils', () => {
         ];
         TESTS.map(([credits, expectedResult]) => expect(LayersUtils.creditsToAttribution(credits)).toBe(expectedResult));
     });
+    it('saveLayer', () => {
+        const layers = [
+            // no params if not present
+            [
+                {
+                    name: "test",
+                    title: "test",
+                    type: "wms"
+                },
+                l => {
+                    expect(l.params).toNotExist();
+                    Object.keys(l).map( k => expect(k).toNotBe("params"));
+                    Object.keys(l).map(k => expect(k).toNotBe("credits"));
+                    Object.keys(l).map(k => expect(k).toNotBe("id"));
+                    expect(l).toEqual(layers[0][0]);
+                }
+            ],
+            // save params if present
+            [
+                {
+                    params: {
+                        viewParams: "a:b"
+                    }
+                },
+                l => {
+                    expect(l.params).toExist();
+                    expect(l.params.viewParams).toExist();
+                }
+            ],
+            // save credits if present
+            [
+                {
+                    credits: {
+                        title: "test"
+                    }
+                },
+                l => {
+                    expect(l.credits).toExist();
+                }
+            ]
+        ];
+        layers.map(([layer, test]) => test(layer) );
+    });
 
 });


### PR DESCRIPTION
## Description
This PR implements "credits" support for layers (to display as attribution in the map's attribution section), and allow to create credits object from GetCapabilities. 

## Issues
 - Fix #3496 (not yet implemented disable overlays option)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
No Attribution for WMS layers

**What is the new behavior?**
Credits are visible, for WMS layers, if attributions are coming from WMS getCapabilities

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
The attribute has been called "credits" because the object returned by WMS GetCapabilities is structured in : 
- title
- image (with some metadata about it)
- link

In a similar shape `ConfigProvider` provides a structured object to support attribution when they are not simple html (like cesium). This attribute is called "credits", indeed. 

Keeping this form allows WMS attribution to be viible in openlayers, leaflet and cesium