### PR TITLE
Fixes #3501: allow session login without basic auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "devDependencies": {
     "acorn-jsx": "https://github.com/geosolutions-it/acorn-jsx/tarball/master",
+    "axios-mock-adapter": "1.16.0",
     "babel-core": "6.8.0",
     "babel-eslint": "4.1.8",
     "babel-istanbul-loader": "0.1.0",

--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -105,12 +105,12 @@ const Api = {
     login: function(username, password, options) {
         const url = "session/login";
         let authData;
-        return axios.post(url, null, this.addBaseUrl(_.merge({
+        return axios.post(url, null, this.addBaseUrl(_.merge((username && password) ? {
             auth: {
                 username: username,
                 password: password
             }
-        }, options))).then((response) => {
+        } : {}, options))).then((response) => {
             authData = response.data;
             return axios.get("users/user/details", this.addBaseUrl(_.merge({
                 headers: {

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -8,6 +8,11 @@
 
 const expect = require('expect');
 const API = require('../GeoStoreDAO');
+const axios = require("../../libs/ajax");
+const MockAdapter = require("axios-mock-adapter");
+
+const mockAxios = new MockAdapter(axios);
+
 const SAMPLE_RULES = {
    "SecurityRuleList": {
       "SecurityRule": [
@@ -67,6 +72,15 @@ const SAMPLE_XML_RULES = "<SecurityRuleList>"
 
 describe('Test correctness of the GeoStore APIs', () => {
 
+    beforeEach(done => {
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.reset();
+        setTimeout(done);
+    });
+
     it('check the utility functions', () => {
         const result = API.addBaseUrl(null);
         expect(result).toIncludeKey("baseURL");
@@ -107,5 +121,27 @@ describe('Test correctness of the GeoStore APIs', () => {
     it('test generate meatadata', () => {
         const payload = API.generateMetadata("Special & chars", "&<>'\"");
         expect(payload).toBe('<description><![CDATA[&<>\'"]]></description><metadata></metadata><name><![CDATA[Special & chars]]></name>');
+    });
+
+    it('test login without credentials', (done) => {
+        mockAxios.onPost().reply(200, {
+            "access_token": "token"
+        });
+        mockAxios.onGet().reply(200);
+        API.login().then(() => {
+            expect(mockAxios.history.post[0].auth).toNotExist();
+            done();
+        });
+    });
+
+    it("test login with credentials", done => {
+        mockAxios.onPost().reply(200, { access_token: "token" });
+        mockAxios.onGet().reply(200);
+        API.login("user", "password").then(() => {
+            expect(mockAxios.history.post[0].auth).toExist();
+            expect(mockAxios.history.post[0].auth.username).toBe('user');
+            expect(mockAxios.history.post[0].auth.password).toBe("password");
+            done();
+        });
     });
 });

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -11,7 +11,7 @@ const API = require('../GeoStoreDAO');
 const axios = require("../../libs/ajax");
 const MockAdapter = require("axios-mock-adapter");
 
-const mockAxios = new MockAdapter(axios);
+let mockAxios;
 
 const SAMPLE_RULES = {
    "SecurityRuleList": {
@@ -73,11 +73,12 @@ const SAMPLE_XML_RULES = "<SecurityRuleList>"
 describe('Test correctness of the GeoStore APIs', () => {
 
     beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
         setTimeout(done);
     });
 
     afterEach(done => {
-        mockAxios.reset();
+        mockAxios.restore();
         setTimeout(done);
     });
 


### PR DESCRIPTION
## Description
This quick change allows calling the session login service without basic auth credentials, so that other authentication system can be enabled in geostore (e.g. cookie based authentication).

## Issues
 - Fix #3501

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Basic authentication header is always sent with session login call, even if they are empty. 

**What is the new behavior?**
To enable different form of authentications, we need to send the basic auth credentials only if they are passed in, so that a different authentication (based for example on cookies) can be enabled on the backend.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
