### PR TITLE
Fixes to align WMS gridsets

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -63,10 +63,12 @@ class OpenlayersMap extends React.Component {
     };
 
     componentDidMount() {
-        var center = CoordinatesUtils.reproject([this.props.center.x, this.props.center.y], 'EPSG:4326', this.props.projection);
         this.props.projectionDefs.forEach(p => {
             projUtils.addProjections(ol, p.code, p.extent, p.worldExtent);
         });
+        // It may be a good idea to check if CoordinateUtils also registered the projectionDefs
+        // normally it happens ad application level.
+        let center = CoordinatesUtils.reproject([this.props.center.x, this.props.center.y], 'EPSG:4326', this.props.projection);
         let interactionsOptions = assign(this.props.interactive ? {} : {
             doubleClickZoom: false,
             dragPan: false,
@@ -287,10 +289,10 @@ class OpenlayersMap extends React.Component {
         const projection = this.map.getView().getProjection();
         const extent = projection.getExtent();
         const size = !extent ?
-            // use an extent that can fit the whole world if need be
+            // use the max width
             360 * ol.proj.METERS_PER_UNIT[ol.proj.Units.DEGREES] /
                 ol.proj.METERS_PER_UNIT[projection.getUnits()] :
-            Math.max(ol.extent.getWidth(extent), ol.extent.getHeight(extent));
+            ol.extent.getWidth(extent);
 
         const defaultMaxResolution = size / 256 / Math.pow(
             defaultZoomFactor, 0);
@@ -415,7 +417,7 @@ class OpenlayersMap extends React.Component {
         var view = this.map.getView();
         const currentCenter = this.props.center;
         const centerIsUpdated = newProps.center.y === currentCenter.y &&
-                               newProps.center.x === currentCenter.x;
+                                newProps.center.x === currentCenter.x;
 
         if (!centerIsUpdated) {
             // let center = ol.proj.transform([newProps.center.x, newProps.center.y], 'EPSG:4326', newProps.projection);

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -500,7 +500,26 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().getLength()).toBe(1);
         expect(map.getLayers().item(0).getSource().urls.length).toBe(2);
     });
+    it('test correct wms origin', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": ["http://sample.server/geoserver/wms"]
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
 
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(map.getLayers().item(0).getSource().getTileGrid().getOrigin()).toEqual([-20037508.342789244, 20037508.342789244]);
+    });
     it('creates a wms layer with custom origin', () => {
         var options = {
             "type": "wms",

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -655,7 +655,57 @@ describe('OpenlayersMap', () => {
         attributions = document.body.getElementsByClassName('ol-attribution');
         expect(attributions.length).toBe(0);
     });
+    it('test getResolutions default', () => {
+        const maxResolution = 2 * 20037508.34;
+        const tileSize = 256;
+        const expectedResolutions = Array.from(Array(29).keys()).map( k=> maxResolution / tileSize / Math.pow(2, k));
+        let map = ReactDOM.render(<OpenlayersMap id="ol-map" center={{ y: 43.9, x: 10.3 }} zoom={11} mapOptions={{ attribution: { container: 'body' } }} />, document.getElementById("map"));
+        expect(map.getResolutions().length).toBe(expectedResolutions.length);
+        // NOTE: round
+        expect(map.getResolutions().map(a => a.toFixed(4))).toEqual(expectedResolutions.map(a => a.toFixed(4)));
 
+    });
+    it('test getResolutions with custom projection', () => {
+        const projectionDefs = [
+            {
+                "code": "EPSG:3003",
+                "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+                "extent": [
+                    1241482.0019432348,
+                    972767.2605398067,
+                    1847542.2626266503,
+                    5215189.085323715
+                ],
+                "worldExtent": [
+                    6.6500,
+                    8.8000,
+                    12.0000,
+                    47.0500
+                ]
+            }
+        ];
+        proj.defs(projectionDefs[0].code, projectionDefs[0].def);
+        const maxResolution = 1847542.2626266503 - 1241482.0019432348;
+        const tileSize = 256;
+        const expectedResolutions = Array.from(Array(29).keys()).map(k => maxResolution / tileSize / Math.pow(2, k));
+        let map = ReactDOM.render(<OpenlayersMap
+            id="ol-map"
+            center={{
+                x: 10.710054361528954,
+                y: 43.69814562139725,
+                crs: 'EPSG:4326'
+            }}
+            projectionDefs={projectionDefs}
+            zoom={11}
+            mapOptions={{ attribution: { container: 'body' } }}
+            projection={projectionDefs[0].code}
+            />, document.getElementById("map"));
+
+        expect(map.getResolutions()).toExist();
+        expect(map.getResolutions().length).toBe(expectedResolutions.length);
+        // NOTE: round
+        expect(map.getResolutions().map(a => a.toFixed(4))).toEqual(expectedResolutions.map(a => a.toFixed(4)));
+    });
     it('test double attribution on document', () => {
         let map = ReactDOM.render(
             <span>

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -142,7 +142,7 @@ Layers.registerType('wms', {
             params: queryParameters,
             tileGrid: new ol.tilegrid.TileGrid({
                 extent: extent,
-                resolutions: [...mapUtils.getResolutions()],
+                resolutions: mapUtils.getResolutions(),
                 tileSize: options.tileSize ? options.tileSize : 256,
                 origin: options.origin ? options.origin : [extent[0], extent[3]]
             })
@@ -185,7 +185,7 @@ Layers.registerType('wms', {
                 const extent = ol.proj.get(CoordinatesUtils.normalizeSRS(newOptions.srs, newOptions.allowedSRS)).getExtent();
                 layer.getSource().tileGrid = new ol.tilegrid.TileGrid({
                     extent: extent,
-                    resolutions: [...mapUtils.getResolutions()],
+                    resolutions: mapUtils.getResolutions(),
                     tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
                     origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
                 });
@@ -245,7 +245,7 @@ Layers.registerType('wms', {
                             params: queryParameters,
                             tileGrid: new ol.tilegrid.TileGrid({
                                 extent: extent,
-                                resolutions: [...mapUtils.getResolutions()],
+                                resolutions: mapUtils.getResolutions(),
                                 tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
                                 origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
                             })

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -142,7 +142,7 @@ Layers.registerType('wms', {
             params: queryParameters,
             tileGrid: new ol.tilegrid.TileGrid({
                 extent: extent,
-                resolutions: mapUtils.getResolutions(),
+                resolutions: [...mapUtils.getResolutions()],
                 tileSize: options.tileSize ? options.tileSize : 256,
                 origin: options.origin ? options.origin : [extent[0], extent[3]]
             })
@@ -185,7 +185,7 @@ Layers.registerType('wms', {
                 const extent = ol.proj.get(CoordinatesUtils.normalizeSRS(newOptions.srs, newOptions.allowedSRS)).getExtent();
                 layer.getSource().tileGrid = new ol.tilegrid.TileGrid({
                     extent: extent,
-                    resolutions: mapUtils.getResolutions(),
+                    resolutions: [...mapUtils.getResolutions()],
                     tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
                     origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
                 });
@@ -204,7 +204,7 @@ Layers.registerType('wms', {
             if (oldOptions.singleTile !== newOptions.singleTile
                 || oldOptions.securityToken !== newOptions.securityToken
                 || oldOptions.ratio !== newOptions.ratio
-                // no way to remove attribution when credits are removed, so have re-create the layer is needed. Seems to be solved in OL v5.3.0, due to the ol commit 9b8232f65b391d5d381d7a99a7cd070fc36696e9 (https://github.com/openlayers/openlayers/pull/7329)
+                 // no way to remove attribution when credits are removed, so have re-create the layer is needed. Seems to be solved in OL v5.3.0, due to the ol commit 9b8232f65b391d5d381d7a99a7cd070fc36696e9 (https://github.com/openlayers/openlayers/pull/7329)
                 || oldOptions.credits !== newOptions.credits && !newOptions.credits
                 ) {
                 // this forces cache empty, required when auth permission changed to avoid caching when unauthorized
@@ -245,7 +245,7 @@ Layers.registerType('wms', {
                             params: queryParameters,
                             tileGrid: new ol.tilegrid.TileGrid({
                                 extent: extent,
-                                resolutions: mapUtils.getResolutions(),
+                                resolutions: [...mapUtils.getResolutions()],
                                 tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
                                 origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
                             })

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -144,7 +144,7 @@ Layers.registerType('wms', {
                 extent: extent,
                 resolutions: mapUtils.getResolutions(),
                 tileSize: options.tileSize ? options.tileSize : 256,
-                origin: options.origin ? options.origin : [extent[0], extent[1]]
+                origin: options.origin ? options.origin : [extent[0], extent[3]]
             })
         }, options);
         const layer = new ol.layer.Tile({
@@ -187,7 +187,7 @@ Layers.registerType('wms', {
                     extent: extent,
                     resolutions: mapUtils.getResolutions(),
                     tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
-                    origin: newOptions.origin ? newOptions.origin : [extent[0], extent[1]]
+                    origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
                 });
             }
             if (changed) {
@@ -204,7 +204,7 @@ Layers.registerType('wms', {
             if (oldOptions.singleTile !== newOptions.singleTile
                 || oldOptions.securityToken !== newOptions.securityToken
                 || oldOptions.ratio !== newOptions.ratio
-                 // no way to remove attribution when credits are removed, so have re-create the layer is needed. Seems to be solved in OL v5.3.0, due to the ol commit 9b8232f65b391d5d381d7a99a7cd070fc36696e9 (https://github.com/openlayers/openlayers/pull/7329)
+                // no way to remove attribution when credits are removed, so have re-create the layer is needed. Seems to be solved in OL v5.3.0, due to the ol commit 9b8232f65b391d5d381d7a99a7cd070fc36696e9 (https://github.com/openlayers/openlayers/pull/7329)
                 || oldOptions.credits !== newOptions.credits && !newOptions.credits
                 ) {
                 // this forces cache empty, required when auth permission changed to avoid caching when unauthorized
@@ -247,7 +247,7 @@ Layers.registerType('wms', {
                                 extent: extent,
                                 resolutions: mapUtils.getResolutions(),
                                 tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
-                                origin: newOptions.origin ? newOptions.origin : [extent[0], extent[1]]
+                                origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
                             })
                         }, newOptions.forceProxy ? {tileLoadFunction: proxyTileLoadFunction} : {}))
                     });


### PR DESCRIPTION
## Description
This pull request fixes some issues that didn't allow GWC caching HIT on WMS using projections different from EPSG:4326 and EPSG:3857. (Issue found on EPSG:3003) 

## Issues
 - Fix #3410 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
Tiles in some srs (like EPSG:3003) do not hit cache. 

**What is the new behavior?**
Tiles in srs EPSG:3003 hit cache. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
There were 2 problems: 
1. Origin was set to minX,minY, instead to use minX,maxY. This problem was hidden using EPSG:3857 and EPSG:4326. These 2 projection have `minX= k * maxX, k Integer`, and so setting the this wrong origin make it aligned anyway to the grid
2. The second problem was that the resolutions was calculated with `maxResolution=max(extentWidth, extentHeight)`. Instead, to have the correct resolution aligned to the grid, you must use extent width. This again didn't caused any issue in EPSG:4326 and EPSG:3857 because in these cases `extentWidth >= extentHeight`