### PR TITLE
Fix #3507 Improve url parsing of GeoServer layers in style editor

### DIFF
--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -58,14 +58,59 @@ const { testEpic } = require('./epicTestUtils');
 describe('styleeditor Epics', () => {
 
     it('test toggleStyleEditorEpic enabled to true', (done) => {
-
+        const LAYER_URL = '/geoserver/';
         const state = {
             layers: {
                 flat: [
                     {
                         id: 'layerId',
                         name: 'layerName',
-                        url: '/geoserver/'
+                        url: LAYER_URL
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ]
+            }
+        };
+        const NUMBER_OF_ACTIONS = 1;
+
+        const results = (actions) => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            try {
+                actions.map((action) => {
+                    switch (action.type) {
+                        case LOADING_STYLE:
+                            expect(action.status).toBe('global');
+                            break;
+                        default:
+                            expect(true).toBe(false);
+                    }
+                });
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            toggleStyleEditorEpic,
+            NUMBER_OF_ACTIONS,
+            toggleStyleEditor(undefined, true),
+            results,
+        state);
+
+    });
+
+    it('test toggleStyleEditorEpic enabled to true with relative url of layer', (done) => {
+        const LAYER_URL = 'geoserver/';
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        url: LAYER_URL
                     }
                 ],
                 selected: [

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -7,7 +7,7 @@
  */
 
 const Rx = require('rxjs');
-const { get, head, isArray, template } = require('lodash');
+const { get, head, isArray, template, startsWith } = require('lodash');
 const { success, error } = require('../actions/notifications');
 const { UPDATE_NODE, updateNode, updateSettingsParams } = require('../actions/layers');
 const { updateAdditionalLayer, removeAdditionalLayer, updateOptionsByOwner } = require('../actions/additionallayers');
@@ -210,7 +210,13 @@ module.exports = {
                 const layer = action.layer || getSelectedLayer(state);
                 if (!layer || layer && !layer.url) return Rx.Observable.empty();
 
-                const normalizedUrl = normalizeUrl(layer.url);
+                // check url without / or protocol and add /
+                // eg: geoserver/wms
+                const layerUrl = startsWith(layer.url, 'http') || startsWith(layer.url, '/')
+                    ? layer.url
+                    : `/${layer.url}`;
+
+                const normalizedUrl = normalizeUrl(layerUrl) || layer.url;
                 const parsedUrl = url.parse(normalizedUrl);
 
                 return updateLayerSettingsObservable(action$, store,


### PR DESCRIPTION
## Description
Improve url parsing of GeoServer layers in style editor by adding / if missing on layer url

## Issues
 - Fix #3507

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
 #3507

**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
