### PR TITLE
Fix #3498. Set configurable  minZoom and Extent for mutliple projections

### DIFF
--- a/web/client/actions/__tests__/map-test.js
+++ b/web/client/actions/__tests__/map-test.js
@@ -20,7 +20,7 @@ var {
     INIT_MAP,
     ZOOM_TO_EXTENT,
     RESIZE_MAP,
-    CHANGE_MAP_EXTENTS,
+    CHANGE_MAP_LIMITS,
     errorLoadingFont,
     changeMapView,
     clickOnMap,
@@ -34,7 +34,7 @@ var {
     initMap,
     zoomToExtent,
     resizeMap,
-    changeMapExtents
+    changeMapLimits
 } = require('../map');
 const {
     SHOW_NOTIFICATION
@@ -189,12 +189,15 @@ describe('Test correctness of the map actions', () => {
         expect(retval).toExist();
         expect(retval.type).toEqual(RESIZE_MAP);
     });
-    it('change map max extent', () => {
-        const testVal = [0, 0, 0, 0];
-        const retval = changeMapExtents(testVal);
-
-        expect(retval).toExist();
-        expect(retval.type).toBe(CHANGE_MAP_EXTENTS);
-        expect(retval.restrictedExtent).toBe(testVal);
+    it('change map limits', () => {
+        const restrictedExtent = [0, 0, 1, 1];
+        const crs = "EPSG:4326";
+        const minZoom = 2;
+        const action = changeMapLimits({ restrictedExtent, crs, minZoom});
+        expect(action).toExist();
+        expect(action.type).toBe(CHANGE_MAP_LIMITS);
+        expect(action.restrictedExtent).toBe(restrictedExtent);
+        expect(action.crs).toBe(crs);
+        expect(action.minZoom).toBe(minZoom);
     });
 });

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -22,7 +22,7 @@ const CREATION_ERROR_LAYER = 'CREATION_ERROR_LAYER';
 const UPDATE_VERSION = 'UPDATE_VERSION';
 const INIT_MAP = 'INIT_MAP';
 const RESIZE_MAP = 'RESIZE_MAP';
-const CHANGE_MAP_EXTENTS = 'CHANGE_MAP_EXTENTS';
+const CHANGE_MAP_LIMITS = 'CHANGE_MAP_LIMITS';
 
 
 function errorLoadingFont(err = {family: ""}) {
@@ -142,10 +142,12 @@ function resizeMap() {
         type: RESIZE_MAP
     };
 }
-function changeMapExtents(restrictedExtent) {
+function changeMapLimits({restrictedExtent, crs, minZoom}) {
     return {
-        type: CHANGE_MAP_EXTENTS,
-        restrictedExtent
+        type: CHANGE_MAP_LIMITS,
+        restrictedExtent,
+        crs,
+        minZoom
     };
 }
 
@@ -165,7 +167,7 @@ module.exports = {
     UPDATE_VERSION,
     INIT_MAP,
     RESIZE_MAP,
-    CHANGE_MAP_EXTENTS,
+    CHANGE_MAP_LIMITS,
     changeMapView,
     clickOnMap,
     changeMousePointer,
@@ -181,5 +183,5 @@ module.exports = {
     updateVersion,
     initMap,
     resizeMap,
-    changeMapExtents
+    changeMapLimits
 };

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -30,6 +30,7 @@ class LeafletMap extends React.Component {
         onClick: PropTypes.func,
         onRightClick: PropTypes.func,
         mapOptions: PropTypes.object,
+        limits: PropTypes.limits,
         zoomControl: PropTypes.bool,
         mousePointer: PropTypes.string,
         onMouseMove: PropTypes.func,
@@ -86,6 +87,8 @@ class LeafletMap extends React.Component {
     }
 
     componentDidMount() {
+        const {limits = {}} = this.props;
+        const maxBounds = limits.restrictedExtent && limits.crs && CoordinatesUtils.reprojectBbox(limits.restrictedExtent, limits.crs, "EPSG:4326");
         let mapOptions = assign({}, this.props.interactive ? {} : {
             dragging: false,
             touchZoom: false,
@@ -93,8 +96,15 @@ class LeafletMap extends React.Component {
             doubleClickZoom: false,
             boxZoom: false,
             tap: false,
-            attributionControl: false
-        }, {maxZoom: 23}, this.props.mapOptions, this.crs ? {crs: this.crs} : {});
+            attributionControl: false,
+            maxBounds: maxBounds && L.latLngBounds([
+                [maxBounds[1], maxBounds[0]],
+                [maxBounds[3], maxBounds[2]]
+            ]),
+            maxBoundsViscosity: maxBounds && 1.0,
+            minZoom: limits && limits.minZoom,
+            maxZoom: limits && limits.maxZoom || 23
+        }, this.props.mapOptions, this.crs ? {crs: this.crs} : {});
 
         const map = L.map(this.props.id, assign({zoomControl: this.props.zoomControl}, mapOptions) ).setView([this.props.center.y, this.props.center.x],
           Math.round(this.props.zoom));
@@ -231,6 +241,21 @@ class LeafletMap extends React.Component {
             setTimeout(() => {
                 this.map.invalidateSize(false);
             }, 0);
+        }
+        // update map limits
+        if (this.props.limits !== newProps.limits) {
+            const {limits = {}} = newProps;
+            const {limits: oldLimits} = this.props;
+            if (limits.restrictedExtent !== (oldLimits && oldLimits.restrictedExtent)) {
+                const maxBounds = limits.restrictedExtent && limits.crs && CoordinatesUtils.reprojectBbox(limits.restrictedExtent, limits.crs, "EPSG:4326");
+                this.map.setMaxBounds(limits.restrictedExtent && L.latLngBounds([
+                    [maxBounds[1], maxBounds[0]],
+                    [maxBounds[3], maxBounds[2]]
+                ]));
+            }
+            if (limits.minZoom !== (oldLimits && oldLimits.minZoom)) {
+                this.map.setMinZoom(limits.minZoom);
+            }
         }
         return false;
     }

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -15,7 +15,7 @@ const ConfigUtils = require('../../../utils/ConfigUtils');
 const mapUtils = require('../../../utils/MapUtils');
 const projUtils = require('../../../utils/openlayers/projUtils');
 
-const {isEqual, throttle, head, isArray} = require('lodash');
+const {isEqual, throttle} = require('lodash');
 
 class OpenlayersMap extends React.Component {
     static propTypes = {

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -44,7 +44,7 @@ class OpenlayersMap extends React.Component {
         bbox: PropTypes.object,
         onWarning: PropTypes.func,
         maxExtent: PropTypes.array,
-        restrictedExtent: PropTypes.array
+        limits: PropTypes.object
     };
 
     static defaultProps = {
@@ -109,7 +109,7 @@ class OpenlayersMap extends React.Component {
             controls: controls,
             interactions: interactions,
             target: this.props.id,
-            view: this.createView(center, Math.round(this.props.zoom), this.props.projection, this.props.mapOptions && this.props.mapOptions.view, this.props.restrictedExtent)
+            view: this.createView(center, Math.round(this.props.zoom), this.props.projection, this.props.mapOptions && this.props.mapOptions.view, this.props.limits)
         });
 
         this.map = map;
@@ -212,41 +212,14 @@ class OpenlayersMap extends React.Component {
             }, 0);
         }
 
-        if (this.map && ((this.props.projection !== newProps.projection) || this.haveResolutionsChanged(newProps)) || this.props.restrictedExtent !== newProps.restrictedExtent) {
-            if (this.props.projection !== newProps.projection || this.props.restrictedExtent !== newProps.restrictedExtent) {
+        if (this.map && ((this.props.projection !== newProps.projection) || this.haveResolutionsChanged(newProps)) || this.props.limits !== newProps.limits) {
+            if (this.props.projection !== newProps.projection || this.props.limits !== newProps.limits) {
                 let mapProjection = newProps.projection;
                 const center = CoordinatesUtils.reproject([
                     newProps.center.x,
                     newProps.center.y
                 ], 'EPSG:4326', mapProjection);
-                this.map.setView(this.createView(center, newProps.zoom, newProps.projection, newProps.mapOptions && newProps.mapOptions.view, newProps.restrictedExtent));
-                const mapExtent = mapProjection && newProps.maxExtent && CoordinatesUtils.reprojectBbox(newProps.maxExtent, mapProjection, 'EPSG:4326');
-                // perform a check if the data and the projection are compatible
-                if (newProps.children) {
-                    head(newProps.children).map( layer => {
-                        let boundingBox = layer.props.options.bbox;
-                        if (boundingBox) {
-                            let layerExtent = CoordinatesUtils.getExtentFromNormalized(boundingBox.bounds, boundingBox.crs).extent;
-                            if (layerExtent.length === 2 && isArray(layerExtent[1])) {
-                                layerExtent = layerExtent[1];
-                            }
-
-                            if ( mapProjection !== boundingBox.bounds.crs && (mapExtent && !CoordinatesUtils.isBboxCompatible(CoordinatesUtils.getPolygonFromExtent(mapExtent),
-                            CoordinatesUtils.getPolygonFromExtent(layerExtent))) ||
-                            (layer.props.options.type === "wmts" && !head(CoordinatesUtils.getEquivalentSRS(mapProjection).filter(proj => layer.props.options.matrixIds.hasOwnProperty(proj))))) {
-                                this.props.onWarning({
-                                    title: "warning",
-                                    message: "notification.incompatibleDataAndProjection",
-                                    action: {
-                                        label: "close"
-                                    },
-                                    position: "tc",
-                                    uid: "2"
-                                });
-                            }
-                        }
-                    });
-                }
+                this.map.setView(this.createView(center, newProps.zoom, newProps.projection, newProps.mapOptions && newProps.mapOptions.view, newProps.limits));
             }
             // We have to force ol to drop tile and reload
             this.map.getLayers().forEach((l) => {
@@ -406,9 +379,10 @@ class OpenlayersMap extends React.Component {
         return !isEqual(resolutions, newResolutions);
     };
 
-    createView = (center, zoom, projection, options, newExtent) => {
-
-        const newOptions = !options || (options && !options.view) ? assign({}, options, {extent: newExtent}) : assign({}, options);
+    createView = (center, zoom, projection, options, limits = {}) => {
+        // limit has a crs defined
+        const extent = limits.restrictedExtent && limits.crs && CoordinatesUtils.reprojectBbox(limits.restrictedExtent, limits.crs, CoordinatesUtils.normalizeSRS(projection));
+        const newOptions = !options || (options && !options.view) ? assign({}, options, {extent}) : assign({}, options);
         /*
         * setting the zoom level in the localConfig file is co-related to the projection extent(size)
         * it is recommended to use projections with the same coverage area (extent). If you want to have the same restricted zoom level (minZoom)
@@ -416,7 +390,8 @@ class OpenlayersMap extends React.Component {
         const viewOptions = assign({}, {
             projection: CoordinatesUtils.normalizeSRS(projection),
             center: [center.x, center.y],
-            zoom: zoom
+            zoom: zoom,
+            minZoom: limits.minZoom
         }, newOptions || {});
         return new ol.View(viewOptions);
     };
@@ -461,7 +436,7 @@ class OpenlayersMap extends React.Component {
         });
         mapUtils.registerHook(mapUtils.COMPUTE_BBOX_HOOK, (center, zoom) => {
             var olCenter = CoordinatesUtils.reproject([center.x, center.y], 'EPSG:4326', this.props.projection);
-            let view = this.createView(olCenter, zoom, this.props.projection, this.props.mapOptions && this.props.mapOptions.view, this.props.restrictedExtent);
+            let view = this.createView(olCenter, zoom, this.props.projection, this.props.mapOptions && this.props.mapOptions.view, this.props.limits);
             let size = this.map.getSize();
             let bbox = view.calculateExtent(size);
             return {

--- a/web/client/components/mapcontrols/scale/ScaleBox.jsx
+++ b/web/client/components/mapcontrols/scale/ScaleBox.jsx
@@ -18,6 +18,7 @@ class ScaleBox extends React.Component {
         style: PropTypes.object,
         scales: PropTypes.array,
         currentZoomLvl: PropTypes.number,
+        minZoom: PropTypes.number,
         onChange: PropTypes.func,
         readOnly: PropTypes.bool,
         label: PropTypes.oneOfType([PropTypes.func, PropTypes.string, PropTypes.object]),
@@ -29,9 +30,12 @@ class ScaleBox extends React.Component {
         id: 'mapstore-scalebox',
         scales: mapUtils.getGoogleMercatorScales(0, 28),
         currentZoomLvl: 0,
+        minZoom: 0,
         onChange() {},
         readOnly: false,
-        template: (scale) => "1 : " + Math.round(scale),
+        template: scale => scale < 1
+            ? Math.round(1 / scale) + " : 1"
+            : "1 : " + Math.round(scale),
         useRawInput: false
     };
 
@@ -49,7 +53,7 @@ class ScaleBox extends React.Component {
             return (
                 <option value={index} key={index}>{this.props.template(item, index)}</option>
             );
-        });
+        }).filter((element, index) => index >= this.props.minZoom);
     };
 
     render() {

--- a/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
+++ b/web/client/components/mapcontrols/scale/__tests__/ScaleBox-test.jsx
@@ -40,6 +40,22 @@ describe('ScaleBox', () => {
             const testScale = Math.round(mapUtils.getGoogleMercatorScale(i));
             return pre && scale === testScale;
         }, true)).toBe(true);
+        comboItems.map((option, index) => expect(parseInt(option.value, 10)).toBe(index));
+        expect(comboItems.reduce((pre, cur, i) => {
+            return pre && (i === 0 ? cur.selected : !cur.selected);
+        }), true).toBe(true);
+    });
+    it('minZoom property filters options', () => {
+        const sb = ReactDOM.render(<ScaleBox minZoom={2} />, document.getElementById("container"));
+        expect(sb).toExist();
+        const domNode = ReactDOM.findDOMNode(sb);
+        expect(domNode).toExist();
+        expect(domNode.id).toBe('mapstore-scalebox');
+
+        const comboItems = Array.prototype.slice.call(domNode.getElementsByTagName('option'), 0);
+        expect(comboItems.length).toBe(27);
+        // values 0 and 1 should not be there, because minZoom = 2
+        comboItems.map(option => expect(parseInt(option.value, 10)).toBeGreaterThanOrEqualTo(2));
 
         expect(comboItems.reduce((pre, cur, i) => {
             return pre && (i === 0 ? cur.selected : !cur.selected);

--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -8,8 +8,8 @@
 
 const Rx = require('rxjs');
 const {changeLayerProperties} = require('../actions/layers');
-const {CREATION_ERROR_LAYER, INIT_MAP, changeMapExtents} = require('../actions/map');
-const { configuredExtentCrsSelector, projectionSelector, configuredRestrictedExtentSelector} = require('../selectors/map');
+const { CREATION_ERROR_LAYER, INIT_MAP, CHANGE_MAP_CRS, changeMapLimits} = require('../actions/map');
+const { configuredExtentCrsSelector, configuredRestrictedExtentSelector, configuredMinZoomSelector} = require('../selectors/map');
 const {currentBackgroundLayerSelector, allBackgroundLayerSelector, getLayerFromId} = require('../selectors/layers');
 const {mapTypeSelector} = require('../selectors/maptype');
 const {setControlProperty} = require('../actions/controls');
@@ -19,7 +19,6 @@ const {warning} = require('../actions/notifications');
 const {resetControls} = require('../actions/controls');
 const {clearLayers} = require('../actions/layers');
 const {head} = require('lodash');
-const CoordinatesUtils = require('../utils/CoordinatesUtils');
 
 const handleCreationBackgroundError = (action$, store) =>
     action$.ofType(CREATION_ERROR_LAYER)
@@ -72,16 +71,13 @@ const handleCreationLayerError = (action$, store) =>
 
 const resetMapOnInit = (action$) => action$.ofType(INIT_MAP).switchMap(() => Rx.Observable.of(resetControls(), clearLayers()));
 
-const resetExtentOnInit = (action$, store) =>
-    action$.ofType(MAP_CONFIG_LOADED)
+const resetLimitsOnInit = (action$, store) =>
+    action$.ofType(MAP_CONFIG_LOADED, CHANGE_MAP_CRS)
     .switchMap(() => {
         const confExtentCrs = configuredExtentCrsSelector(store.getState());
-        const projection = projectionSelector(store.getState());
         const restrictedExtent = configuredRestrictedExtentSelector(store.getState());
-        const reprojectionIsValid = restrictedExtent && confExtentCrs && projection && projection !== confExtentCrs;
-        const extent = reprojectionIsValid ? CoordinatesUtils.reprojectBbox(restrictedExtent, confExtentCrs, projection) : restrictedExtent;
-        return Rx.Observable.of(changeMapExtents(extent));
-
+        const minZoom = configuredMinZoomSelector(store.getState());
+        return Rx.Observable.of(changeMapLimits({ restrictedExtent, crs: confExtentCrs, minZoom}));
     });
 
 
@@ -89,5 +85,5 @@ module.exports = {
     handleCreationLayerError,
     handleCreationBackgroundError,
     resetMapOnInit,
-    resetExtentOnInit
+    resetLimitsOnInit
 };

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -23,7 +23,7 @@ const {errorLoadingFont} = require('../actions/map');
 
 const {isString} = require('lodash');
 let plugins;
-const {handleCreationLayerError, handleCreationBackgroundError, resetMapOnInit, resetExtentOnInit} = require('../epics/map');
+const {handleCreationLayerError, handleCreationBackgroundError, resetMapOnInit, resetLimitsOnInit} = require('../epics/map');
 /**
  * The Map plugin allows adding mapping library dependent functionality using support tools.
  * Some are already available for the supported mapping libraries (openlayers, leaflet, cesium), but it's possible to develop new ones.
@@ -131,13 +131,19 @@ const {handleCreationLayerError, handleCreationBackgroundError, resetMapOnInit, 
  *  }
  * ```
  * an additional feature is the ability to set the map restricted extent in the localConfig.json file using "mapConstraints" property e.g
- * "mapConstraints":{
+ * ```
+ * "mapConstraints": {
+ *  "minZoom": 12, // minimal allowed zoom used by default
  *  "crs":"EPSG:3857",
  *  "restrictedExtent":[
  *    1060334.456371965,5228292.734706056,
  *    1392988.403469052,5503466.036532691
- *   ]
+ *   ],
+ *   "projectionsConstraints": {
+ *       "EPSG:1234": { "minZoom": 5 } // customization of minZoom for different projections
+ *   }
  *  }
+ * ```
  * where crs refers to the reference system of the written coordinates, this property is located in the root of localConfig.json.
  *  ```
  * For more info on metadata visit [fontfaceobserver](https://github.com/bramstein/fontfaceobserver)
@@ -415,5 +421,5 @@ module.exports = {
         maptype: require('../reducers/maptype'),
         additionallayers: require('../reducers/additionallayers')
     },
-    epics: assign({}, {handleCreationLayerError, handleCreationBackgroundError, resetMapOnInit, resetExtentOnInit})
+    epics: assign({}, { handleCreationLayerError, handleCreationBackgroundError, resetMapOnInit, resetLimitsOnInit})
 };

--- a/web/client/plugins/ScaleBox.jsx
+++ b/web/client/plugins/ScaleBox.jsx
@@ -10,7 +10,7 @@ const React = require('react');
 const {connect} = require('../utils/PluginsUtils');
 const {createSelector} = require('reselect');
 
-const {mapSelector} = require('../selectors/map');
+const {mapSelector, minZoomSelector} = require('../selectors/map');
 const {changeZoomLevel} = require('../actions/map');
 
 const HelpWrapper = require('./help/HelpWrapper');
@@ -20,12 +20,13 @@ const ScaleBox = require("../components/mapcontrols/scale/ScaleBox");
 const mapUtils = require('../utils/MapUtils');
 const assign = require('object-assign');
 
-const selector = createSelector([mapSelector], (map) => ({
+const selector = createSelector([mapSelector, minZoomSelector], (map, minZoom) => ({
+    minZoom,
     currentZoomLvl: map && map.zoom,
     scales: mapUtils.getScales(
         map && map.projection || 'EPSG:3857',
         map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
-     )
+    )
 }));
 
 require('./scalebox/scalebox.css');

--- a/web/client/plugins/ZoomOut.jsx
+++ b/web/client/plugins/ZoomOut.jsx
@@ -8,9 +8,9 @@
 const React = require('react');
 const {connect} = require('react-redux');
 const {createSelector} = require('reselect');
-const {mapSelector} = require('../selectors/map');
+const {mapSelector, minZoomSelector} = require('../selectors/map');
 // TODO: make step and glyphicon configurable
-const selector = createSelector([mapSelector], (map) => ({currentZoom: map && map.zoom, id: "zoomout-btn", step: -1, glyphicon: "minus"}));
+const selector = createSelector([mapSelector, minZoomSelector], (map, minZoom) => ({ currentZoom: map && map.zoom, id: "zoomout-btn", step: -1, glyphicon: "minus", minZoom}));
 
 const {changeZoomLevel} = require('../actions/map');
 
@@ -26,9 +26,14 @@ const Message = require('../components/I18N/Message');
   * @prop {string} cfg.className the class name for the button
   *
   */
-const ZoomOutButton = connect(selector, {
-    onZoom: changeZoomLevel
-})(require('../components/buttons/ZoomButton'));
+const ZoomOutButton = connect(
+    selector,
+    {onZoom: changeZoomLevel},
+    (stateProps, dispatchProps, ownProps) => ({
+        ...stateProps,
+        ...dispatchProps,
+        ...ownProps
+    }))(require('../components/buttons/ZoomButton'));
 
 require('./zoom/zoom.css');
 

--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -8,6 +8,7 @@
 var expect = require('expect');
 
 var mapConfig = require('../map');
+const { changeMapLimits } = require('../../actions/map');
 
 
 describe('Test the map reducer', () => {
@@ -242,13 +243,20 @@ describe('Test the map reducer', () => {
         let state = mapConfig({}, action);
         expect(state.resize).toEqual(1);
     });
-    it('change the max extent and the restricted extent of a map', () => {
-        const action = {
-            type: 'CHANGE_MAP_EXTENTS',
-            restrictedExtent: [9, 9, 9, 9]
-        };
+    it('change the restricted extent of a map', () => {
+        const action = changeMapLimits({
+            restrictedExtent: [9, 9, 9, 9],
+            crs: "EPSG:4326"
+        });
         let state = mapConfig({}, action);
-        expect(state.restrictedExtent.length).toBe(4);
-        expect(state.restrictedExtent).toEqual([9, 9, 9, 9]);
+        expect(state.limits.restrictedExtent.length).toBe(4);
+        expect(state.limits.restrictedExtent).toEqual([9, 9, 9, 9]);
+    });
+    it('change min zoom a map', () => {
+        const action = changeMapLimits({
+            minZoom: 1
+        });
+        let state = mapConfig({}, action);
+        expect(state.limits.minZoom).toBe(1);
     });
 });

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -8,7 +8,7 @@
 
 var {CHANGE_MAP_VIEW, CHANGE_MOUSE_POINTER,
     CHANGE_ZOOM_LVL, CHANGE_MAP_CRS, CHANGE_MAP_SCALES, ZOOM_TO_EXTENT, PAN_TO,
-    CHANGE_MAP_STYLE, CHANGE_ROTATION, UPDATE_VERSION, ZOOM_TO_POINT, RESIZE_MAP, CHANGE_MAP_EXTENTS} = require('../actions/map');
+    CHANGE_MAP_STYLE, CHANGE_ROTATION, UPDATE_VERSION, ZOOM_TO_POINT, RESIZE_MAP, CHANGE_MAP_LIMITS} = require('../actions/map');
 const {isArray} = require('lodash');
 
 
@@ -30,16 +30,16 @@ function mapConfig(state = null, action) {
             zoom: action.zoom,
             mapStateSource: action.mapStateSource
         });
-    case CHANGE_MAP_EXTENTS:
+    case CHANGE_MAP_LIMITS:
         return assign({}, state, {
-        restrictedExtent: action.restrictedExtent || state.restrictedExtent
+        limits: {
+            restrictedExtent: action.restrictedExtent,
+            crs: action.crs,
+            minZoom: action.minZoom
+        }
     });
     case CHANGE_MAP_CRS:
-    const restrictedExtent = state && state.restrictedExtent;
-    const currentCrs = state && state.projection;
-
         return assign({}, state, {
-            restrictedExtent: restrictedExtent && CoordinatesUtils.reprojectBbox(restrictedExtent, currentCrs, action.crs),
             projection: action.crs
         });
     case CHANGE_MAP_SCALES:

--- a/web/client/selectors/__tests__/map-test.js
+++ b/web/client/selectors/__tests__/map-test.js
@@ -16,7 +16,8 @@ const {
     mapNameSelector,
     mapInfoDetailsUriFromIdSelector,
     configuredRestrictedExtentSelector,
-    configuredExtentCrsSelector
+    configuredExtentCrsSelector,
+    configuredMinZoomSelector
 } = require('../map');
 const center = {x: 1, y: 1};
 let state = {
@@ -110,5 +111,29 @@ describe('Test map selectors', () => {
     it('test configuredExtentSelector', () => {
         const props = configuredRestrictedExtentSelector({localConfig: {mapConstraints: {restrictedExtent: [12, 12, 12, 12]}}});
         expect(props.length).toBe(4);
+    });
+    it('test configuredMinZoomSelector', () => {
+        const minZoom = configuredMinZoomSelector({ localConfig: { mapConstraints: { minZoom: 12 } } });
+        expect(minZoom).toBe(12);
+    });
+    it('test configuredMinZoomSelector with different projection', () => {
+        const minZoom = configuredMinZoomSelector({
+            localConfig: {
+                mapConstraints: {
+                    minZoom: 12,
+                    projectionsConstraints: {
+                        "EPSG:1234": {
+                            minZoom: 14
+                        }
+                    }
+                }
+            },
+            map: {
+                present: {
+                    projection: "EPSG:1234"
+                }
+            }
+        });
+        expect(minZoom).toBe(14);
     });
 });

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -26,14 +26,26 @@ const {get} = require('lodash');
  * @return {object} the map configuration
  */
 const mapSelector = (state) => state.map && state.map.present || state.map || state.config && state.config.map || null;
-const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
 
 const projectionSelector = createSelector([mapSelector], (map) => map && map.projection);
 const stateMapIdSelector = (state) => get(mapSelector(state), "mapId") && parseInt(get(mapSelector(state), "mapId"), 10) || null;
 const mapIdSelector = (state) => get(state, "mapInitialConfig.mapId") && parseInt(get(state, "mapInitialConfig.mapId"), 10) || stateMapIdSelector(state);
 const mapInfoDetailsUriFromIdSelector = (state) => mapSelector(state) && mapSelector(state).info && mapSelector(state).info.details;
-const configuredRestrictedExtentSelector = (state) => state.localConfig && state.localConfig.mapConstraints && state.localConfig.mapConstraints.restrictedExtent;
-const configuredExtentCrsSelector = (state) => state.localConfig && state.localConfig.mapConstraints && state.localConfig.mapConstraints.crs;
+
+// TODO: move these in selectors/localConfig.js or selectors/config.js
+const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
+const mapConstraintsSelector = state => state.localConfig && state.localConfig.mapConstraints || {};
+const configuredRestrictedExtentSelector = (state) => mapConstraintsSelector(state).restrictedExtent;
+const configuredExtentCrsSelector = (state) => mapConstraintsSelector(state).crs;
+const configuredMinZoomSelector = state => {
+    const constraints = mapConstraintsSelector(state);
+    const projection = projectionSelector(state);
+    return projection && get(constraints, `projectionsConstraints["${projection}"].minZoom`) || get(constraints, 'minZoom');
+};
+// END localConfig selectors
+
+const mapLimitsSelector = state => get(mapSelector(state), "limits");
+const minZoomSelector = state => get(mapLimitsSelector(state), "minZoom" );
 
 /**
  * Get the scales of the current map
@@ -76,10 +88,12 @@ module.exports = {
     mapSelector,
     scalesSelector,
     projectionSelector,
+    minZoomSelector,
     mapIdSelector,
     projectionDefsSelector,
     mapVersionSelector,
     mapNameSelector,
+    configuredMinZoomSelector,
     configuredExtentCrsSelector,
     configuredRestrictedExtentSelector
 };


### PR DESCRIPTION
## Description
Centralized configuration for restrictedExtent and minZoom (documented in map plugin).
Here an example: 
```
 "mapConstraints": {
  "minZoom": 12, // minimal allowed zoom used by default
  "crs":"EPSG:3857",
  "restrictedExtent":[
    1060334.456371965,5228292.734706056,
    1392988.403469052,5503466.036532691
   ],
   "projectionsConstraints": {
       "EPSG:1234": { "minZoom": 5 } // customization of minZoom for different projections
   }
  }
 ```
## Issues
 - Fix #3498

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature
 
**What is the current behavior?** (You can also link to an open issue here)
minZoom is not in sync between all the tools

**What is the new behavior?**
minZoom is in sync between all the tools

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
 - This configuration is used to set "map.limits" in the state. When projection or map change, these limits are updated accordingly with it
 - Removed notification on projection change. We may need to do different checks, on the layer bboxes, maybe in an epic,