### PR TITLE
Fix warnings and set states for resize observable and  deprecations

### DIFF
--- a/web/client/components/misc/enhancers/withResizeSpy.js
+++ b/web/client/components/misc/enhancers/withResizeSpy.js
@@ -78,6 +78,12 @@ class WithResizeSpy extends React.Component {
             this.ro.observe(div);
         }
     }
+    componentWillUnmount() {
+        const div = this.findDomNode();
+        if (div && this.ro && this.ro.unobserve) {
+            this.ro.unobserve(div);
+        }
+    }
 
 
     render() {

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -34,7 +34,7 @@ module.exports = pure(({
     widgets = [],
     layouts,
     dependencies,
-    verticalCompact = false,
+    compactType,
     useDefaultWidthProvider = true,
     measureBeforeMount,
     width,
@@ -64,7 +64,7 @@ module.exports = pure(({
         className={`widget-container ${className} ${canEdit ? '' : 'no-drag'}`}
         rowHeight={rowHeight}
         autoSize
-        verticalCompact={verticalCompact}
+        compactType={compactType}
         breakpoints={breakpoints}
         cols={cols}>
         {


### PR DESCRIPTION
## Description
Removed these warnings from console during debug
![image](https://user-images.githubusercontent.com/1279510/52415766-3ca90580-2ae8-11e9-949a-181cb79d2b36.png)

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
In debug you had these warnings in console

**What is the new behavior?**
No warnings anymore

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
