### PR TITLE
Fixes #3516: more override functionalities for plugins

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -159,7 +159,12 @@ class PluginsContainer extends React.Component {
     filterLoaded = (plugin) => plugin && !plugin.impl.loadPlugin;
 
     filterRoot = (plugin) => {
-        const container = PluginsUtils.getMorePrioritizedContainer(plugin.impl, this.props.pluginsConfig[this.props.mode], 0);
+        const container = PluginsUtils.getMorePrioritizedContainer(
+            plugin.impl,
+            PluginsUtils.getPluginConfiguration(this.props.pluginsConfig[this.props.mode], plugin.name).override,
+            this.props.pluginsConfig[this.props.mode],
+            0
+        );
         // render on root if container is root (plugin === null || plugin.impl === null) or plugin explicitly wants to render on root (doNotHide = true)
         // in addition to the container
         return !container.plugin || !container.plugin.impl || container.plugin.impl.doNotHide;

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -400,6 +400,8 @@ module.exports = {
         onFontError: errorLoadingFont
     })(MapPlugin),
     reducers: {
+        map: require('../reducers/map'),
+        layers: require('../reducers/layers'),
         draw: require('../reducers/draw'),
         highlight: require('../reducers/highlight'),
         maptype: require('../reducers/maptype'),

--- a/web/client/plugins/__tests__/Map-test.jsx
+++ b/web/client/plugins/__tests__/Map-test.jsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Plugin from '../Map';
+import { getPluginForTest } from './pluginsTestUtils';
+
+import { INIT_MAP } from '../../actions/map';
+import { RESET_CONTROLS } from '../../actions/controls';
+
+const map = {
+    center: {
+        x: 13.0,
+        y: 43.0
+    },
+    zoom: 10
+};
+
+describe('Map Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates a Map plugin with default configuration (leaflet)', () => {
+        const MapPlugin = getPluginForTest(Plugin, {map});
+        ReactDOM.render(<MapPlugin.plugin />, document.getElementById("container"));
+        expect(document.getElementById('map')).toExist();
+        expect(document.getElementsByClassName('leaflet-container').length).toBe(1);
+    });
+
+    it('creates a Map plugin with specified mapType configuration (openlayers)', () => {
+        const MapPlugin = getPluginForTest(Plugin, { map, maptype: {
+            mapType: 'openlayers'
+        } });
+        ReactDOM.render(<MapPlugin.plugin pluginCfg={{ shouldLoadFont: false }} />, document.getElementById("container"));
+        expect(document.getElementById('map')).toExist();
+        expect(document.getElementsByClassName('ol-viewport').length).toBe(1);
+    });
+
+    it('resetOnMapInit epic is activated by INIT_MAP action', () => {
+        const MapPlugin = getPluginForTest(Plugin, { map });
+        ReactDOM.render(<MapPlugin.plugin/>, document.getElementById("container"));
+        MapPlugin.store.dispatch({
+            type: INIT_MAP
+        });
+        expect(MapPlugin.actions.filter(action => action.type === RESET_CONTROLS).length).toBe(1);
+    });
+});

--- a/web/client/plugins/__tests__/Map-test.jsx
+++ b/web/client/plugins/__tests__/Map-test.jsx
@@ -9,7 +9,7 @@ import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Plugin from '../Map';
+import MapPlugin from '../Map';
 import { getPluginForTest } from './pluginsTestUtils';
 
 import { INIT_MAP } from '../../actions/map';
@@ -36,27 +36,27 @@ describe('Map Plugin', () => {
     });
 
     it('creates a Map plugin with default configuration (leaflet)', () => {
-        const MapPlugin = getPluginForTest(Plugin, {map});
-        ReactDOM.render(<MapPlugin.plugin />, document.getElementById("container"));
+        const { Plugin } = getPluginForTest(MapPlugin, {map});
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
         expect(document.getElementById('map')).toExist();
         expect(document.getElementsByClassName('leaflet-container').length).toBe(1);
     });
 
     it('creates a Map plugin with specified mapType configuration (openlayers)', () => {
-        const MapPlugin = getPluginForTest(Plugin, { map, maptype: {
+        const { Plugin } = getPluginForTest(MapPlugin, { map, maptype: {
             mapType: 'openlayers'
         } });
-        ReactDOM.render(<MapPlugin.plugin pluginCfg={{ shouldLoadFont: false }} />, document.getElementById("container"));
+        ReactDOM.render(<Plugin pluginCfg={{ shouldLoadFont: false }} />, document.getElementById("container"));
         expect(document.getElementById('map')).toExist();
         expect(document.getElementsByClassName('ol-viewport').length).toBe(1);
     });
 
     it('resetOnMapInit epic is activated by INIT_MAP action', () => {
-        const MapPlugin = getPluginForTest(Plugin, { map });
-        ReactDOM.render(<MapPlugin.plugin/>, document.getElementById("container"));
-        MapPlugin.store.dispatch({
+        const { Plugin, store, actions } = getPluginForTest(MapPlugin, { map });
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        store.dispatch({
             type: INIT_MAP
         });
-        expect(MapPlugin.actions.filter(action => action.type === RESET_CONTROLS).length).toBe(1);
+        expect(actions.filter(action => action.type === RESET_CONTROLS).length).toBe(1);
     });
 });

--- a/web/client/plugins/__tests__/ZoomIn-test.jsx
+++ b/web/client/plugins/__tests__/ZoomIn-test.jsx
@@ -9,7 +9,7 @@ import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Plugin from '../ZoomIn';
+import ZoomInPlugin from '../ZoomIn';
 import { getPluginForTest } from './pluginsTestUtils';
 
 const map = {
@@ -33,15 +33,15 @@ describe('ZoomIn Plugin', () => {
     });
 
     it('creates a ZoomIn plugin with default configuration', () => {
-        const ZoomInPlugin = getPluginForTest(Plugin, { map });
-        ReactDOM.render(<ZoomInPlugin.plugin />, document.getElementById("container"));
+        const { Plugin } = getPluginForTest(ZoomInPlugin, { map });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
         expect(document.getElementById('zoomin-btn')).toExist();
     });
 
     it('Checks ZoomIn supported containers', () => {
-        const ZoomInPlugin = getPluginForTest(Plugin, { map }, {
+        const { containers } = getPluginForTest(ZoomInPlugin, { map }, {
             ToolbarPlugin: {}
         });
-        expect(Object.keys(ZoomInPlugin.containers)).toContain('Toolbar');
+        expect(Object.keys(containers)).toContain('Toolbar');
     });
 });

--- a/web/client/plugins/__tests__/ZoomIn-test.jsx
+++ b/web/client/plugins/__tests__/ZoomIn-test.jsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Plugin from '../ZoomIn';
+import { getPluginForTest } from './pluginsTestUtils';
+
+const map = {
+    center: {
+        x: 13.0,
+        y: 43.0
+    },
+    zoom: 10
+};
+
+describe('ZoomIn Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates a ZoomIn plugin with default configuration', () => {
+        const ZoomInPlugin = getPluginForTest(Plugin, { map });
+        ReactDOM.render(<ZoomInPlugin.plugin />, document.getElementById("container"));
+        expect(document.getElementById('zoomin-btn')).toExist();
+    });
+
+    it('Checks ZoomIn supported containers', () => {
+        const ZoomInPlugin = getPluginForTest(Plugin, { map }, {
+            ToolbarPlugin: {}
+        });
+        expect(Object.keys(ZoomInPlugin.containers)).toContain('Toolbar');
+    });
+});

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import endsWith from 'lodash/endsWith';
+import {Provider} from 'react-redux';
+
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import { combineEpics, createEpicMiddleware } from 'redux-observable';
+
+const createRegisterActionsMiddleware = (actions) => {
+    return () => next => action => {
+        actions.push(action);
+        return next(action);
+    };
+};
+
+export const getPluginForTest = (pluginDef, storeState, plugins) => {
+    const PluginImpl = Object.keys(pluginDef).reduce((previous, key) => {
+        if (endsWith(key, 'Plugin')) {
+            return pluginDef[key];
+        }
+        return previous;
+    }, null);
+    const containers = Object.keys(PluginImpl)
+        .filter(prop => !plugins || Object.keys(plugins).indexOf(prop + 'Plugin') !== -1)
+        .reduce((previous, key) => {
+            return { ...previous, [key]: PluginImpl[key]};
+        }, {});
+    const reducer = combineReducers(pluginDef.reducers || {});
+
+    const rootEpic = combineEpics.apply(null, Object.keys(pluginDef.epics || {}).map(key => pluginDef.epics[key]) || []);
+    const epicMiddleware = createEpicMiddleware(rootEpic);
+    const actions = [];
+    const store = applyMiddleware(epicMiddleware, createRegisterActionsMiddleware(actions))(createStore)(reducer, storeState);
+    return {
+        plugin: (props) => <Provider store={store}><PluginImpl {...props} /></Provider>,
+        store,
+        actions,
+        containers
+    };
+};
+

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -19,6 +19,22 @@ const createRegisterActionsMiddleware = (actions) => {
     };
 };
 
+/**
+ * Helper to get a plugin configured for testing.
+ *
+ * @param  {object}   pluginDef plugin definition as loaded from require / import
+ * @param  {object}   storeState      optional initial state for redux store (overrides default store built using plugin's reducers)
+ * @param  {object}   plugins     optional plugins definition list ({MyPlugin: <definition>, ...}), used to filter available containers
+ * @returns {object} an object with the following properties:
+ *   - Plugin: plugin propertly connected to a mocked store
+ *   - store: the mocked store
+ *   - actions: list of dispatched actions (can be read at any time to test actions launched)
+ *   - containers: list of plugins supported containers
+ *
+ * @example
+ * import MyPlugin from './MyPlugin';
+ * const { Plugin, store, actions, containers } = getPluginForTest(MyPlugin, {}, {ContainerPlugin: {}});
+ */
 export const getPluginForTest = (pluginDef, storeState, plugins) => {
     const PluginImpl = Object.keys(pluginDef).reduce((previous, key) => {
         if (endsWith(key, 'Plugin')) {
@@ -38,7 +54,7 @@ export const getPluginForTest = (pluginDef, storeState, plugins) => {
     const actions = [];
     const store = applyMiddleware(epicMiddleware, createRegisterActionsMiddleware(actions))(createStore)(reducer, storeState);
     return {
-        plugin: (props) => <Provider store={store}><PluginImpl {...props} /></Provider>,
+        Plugin: (props) => <Provider store={store}><PluginImpl {...props} /></Provider>,
         store,
         actions,
         containers

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -104,7 +104,6 @@ const FeatureInfo = defaultProps({
     defaultInfoFormat: MapInfoUtils.getAvailableInfoFormat()
 })(require('../../components/TOC/fragments/settings/FeatureInfo'));
 
-let settingsPlugins = null;
 const configuredPlugins = {};
 
 const getConfiguredPlugin = (plugin, loaded, loadingComp) => {
@@ -121,10 +120,12 @@ const getConfiguredPlugin = (plugin, loaded, loadingComp) => {
     return plugin;
 };
 
+let settingsPlugins;
+
 module.exports = ({showFeatureInfoTab = true, ...props}, {plugins, pluginsConfig, loadedPlugins}) => {
     if (!settingsPlugins) {
         settingsPlugins = assign({}, (PluginsUtils.getPluginItems({}, plugins, pluginsConfig, "TOC", props.id, true, loadedPlugins, (p) => p.container === 'TOCItemSettings') || [])
-            .reduce((previoius, p) => ({[p.name]: p}), {}));
+            .reduce((previous, p) => ({...previous, [p.name]: p}), {}));
     }
 
     return [
@@ -152,14 +153,14 @@ module.exports = ({showFeatureInfoTab = true, ...props}, {plugins, pluginsConfig
             onClose: () => settingsPlugins && settingsPlugins.StyleEditor && props.onToggleStyleEditor && props.onToggleStyleEditor(null, false),
             onClick: () => settingsPlugins && settingsPlugins.StyleEditor && props.onToggleStyleEditor && props.onToggleStyleEditor(null, true),
             visible: props.settings.nodeType === 'layers' && props.element.type === "wms",
-            Component: props.activeTab === 'style' && props.element.thematic && settingsPlugins.ThematicLayer && getConfiguredPlugin(settingsPlugins.ThematicLayer, loadedPlugins, <LoadingView width={100} height={100} />)
+            Component: props.activeTab === 'style' && props.settings.options.thematic && settingsPlugins.ThematicLayer && getConfiguredPlugin(settingsPlugins.ThematicLayer, loadedPlugins, <LoadingView width={100} height={100} />)
             || settingsPlugins.StyleEditor && getConfiguredPlugin({...settingsPlugins.StyleEditor, cfg: {...settingsPlugins.StyleEditor.cfg, active: true }}, loadedPlugins, <LoadingView width={100} height={100} />)
             || StyleList,
             toolbar: [
                 {
                     glyph: 'list',
                     tooltipId: 'toc.thematic.classify',
-                    visible: settingsPlugins.ThematicLayer && props.isAdmin && !props.element.thematic && props.element.search || false,
+                    visible: settingsPlugins.ThematicLayer && props.isAdmin && !props.settings.options.thematic && props.element.search || false,
                     onClick: () => props.onUpdateParams && props.onUpdateParams({
                         thematic: {
                             unconfigured: true
@@ -169,7 +170,7 @@ module.exports = ({showFeatureInfoTab = true, ...props}, {plugins, pluginsConfig
                 {
                     glyph: 'trash',
                     tooltipId: 'toc.thematic.remove_thematic',
-                    visible: settingsPlugins.ThematicLayer && props.isAdmin && props.element.thematic || false,
+                    visible: settingsPlugins.ThematicLayer && props.isAdmin && props.settings.options.thematic || false,
                     onClick: () => props.onUpdateParams && props.onUpdateParams({
                         thematic: null
                     })

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -43,7 +43,9 @@ const getPluginSimpleName = plugin => endsWith(plugin, 'Plugin') && plugin.subst
 
 const getPluginConfiguration = (cfg, plugin) => {
     const pluginName = getPluginSimpleName(plugin);
-    return head(cfg.filter((cfgObj) => cfgObj.name === pluginName || cfgObj === pluginName)) || {};
+    return head(cfg.filter((cfgObj) => cfgObj.name === pluginName || cfgObj === pluginName).map(cfgObj => isString(cfgObj) ? {
+        name: cfgObj
+    } : cfgObj)) || {};
 };
 
 /*eslint-disable */
@@ -206,7 +208,7 @@ const getPluginItems = (state, plugins, pluginsConfig, containerName, containerI
                         cfg: assign(
                             {},
                             pluginImpl.cfg || {},
-                            parsePluginConfig(state, plugins.requires, plugin.config || {}) || undefined
+                            parsePluginConfig(state, plugins.requires, plugin.config.cfg || {}) || undefined
                         )
                     },
                     {

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -168,7 +168,7 @@ const isMorePrioritizedContainer = (pluginImpl, override, plugins, priority) => 
 
 const isValidConfiguration = (cfg) => {
     return cfg && isString(cfg) || (isObject(cfg) && cfg.name);
-}
+};
 
 const getPluginItems = (state, plugins, pluginsConfig, containerName, containerId, isDefault, loadedPlugins, filter) => {
     return Object.keys(plugins)

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -8,7 +8,7 @@
 
 const React = require('react');
 const assign = require('object-assign');
-const {omit, isObject, head, isArray, isString, memoize, get} = require('lodash');
+const { omit, isObject, head, isArray, isString, memoize, get, endsWith } = require('lodash');
 const {combineReducers} = require('redux');
 const {connect} = require('react-redux');
 const url = require('url');
@@ -39,10 +39,11 @@ const filterState = memoize((state, monitor) => {
     }, '');
 });
 
-const isPluginConfigured = (pluginsConfig, plugin) => {
-    const cfg = pluginsConfig;
-    const pluginName = plugin.substring(0, plugin.length - 6);
-    return head(cfg.filter((cfgObj) => cfgObj.name === pluginName || cfgObj === pluginName));
+const getPluginSimpleName = plugin => endsWith(plugin, 'Plugin') && plugin.substring(0, plugin.length - 6) || plugin;
+
+const getPluginConfiguration = (cfg, plugin) => {
+    const pluginName = getPluginSimpleName(plugin);
+    return head(cfg.filter((cfgObj) => cfgObj.name === pluginName || cfgObj === pluginName)) || {};
 };
 
 /*eslint-disable */
@@ -84,19 +85,33 @@ const handleExpression = (state, context, expression) => {
  * @param  {Object} [plugins={}] the plugins object to get requires
  * @return {Boolean}             the result of the expression evaluation in the given context.
  */
-const filterDisabledPlugins = (item, state = {}, plugins = {}) => {
+const filterDisabledPlugins = (item = {}, state = {}, plugins = {}) => {
     // checks for disablePluginIf first in cfg then in plugin definition (cfg overrides plugin default)
-    const disablePluginIf = item && item.cfg && item.cfg.disablePluginIf || item && item.plugin && item.plugin.disablePluginIf;
-    if (disablePluginIf && !(item && item.cfg && item.cfg.skipAutoDisable)) {
+    const disablePluginIf = get(item, 'cfg.disablePluginIf') || get(item, 'plugin.disablePluginIf');
+    if (disablePluginIf && !get(item, 'cfg.skipAutoDisable')) {
         return !handleExpression(state, plugins.requires, disablePluginIf);
     }
     return true;
 };
-const showIn = (state, requires, cfg, name, id, isDefault) => {
-    return (id && cfg.showIn && handleExpression(state, requires, cfg.showIn).indexOf(id) !== -1 ||
-            cfg.showIn && handleExpression(state, requires, cfg.showIn).indexOf(name) !== -1 ||
-            !cfg.showIn && isDefault) &&
-            !(cfg.hideFrom && handleExpression(state, requires, cfg.hideFrom).indexOf(name) !== -1 || id && cfg.hideFrom && handleExpression(state, requires, cfg.hideFrom).indexOf(id) !== -1);
+
+const isContainedInList = (prop, list, state, requires) => {
+    return prop && list && handleExpression(state, requires, list).indexOf(prop) !== -1;
+};
+
+const showIn = (state, requires, cfg = {}, name, id, isDefault) => {
+    return (
+            // showIn contains plugin id
+            isContainedInList(id, cfg.showIn, state, requires) ||
+            // showIn contains plugin name
+            isContainedInList(name, cfg.showIn, state, requires) ||
+            // always show in default container
+            !cfg.showIn && isDefault
+        ) && !(
+            // dot not show if hideFrom contains id
+            isContainedInList(id, cfg.hideFrom, state, requires) ||
+            // dot not show if hideFrom contains name
+            isContainedInList(name, cfg.hideFrom, state, requires)
+        );
 };
 
 const includeLoaded = (name, loadedPlugins, plugin) => {
@@ -106,17 +121,24 @@ const includeLoaded = (name, loadedPlugins, plugin) => {
     return plugin;
 };
 
-const includeLoadedItem = (name, loadedPlugins, plugin) => {
-    if (loadedPlugins[name]) {
-        return assign(loadedPlugins[name], plugin, {loadPlugin: undefined});
-    }
-    return plugin;
+const getPriority = (plugin, override = {}, container) => {
+    return (
+        get(override, container + ".priority") ||
+        get(plugin, container + ".priority") ||
+        0
+    );
 };
 
-const getMorePrioritizedContainer = (pluginImpl, plugins, priority) => {
+const getMorePrioritizedContainer = (pluginImpl, override = {}, plugins, priority) => {
     return plugins.reduce((previous, current) => {
-        const pluginName = current.name || current;
-        return pluginImpl[pluginName] && pluginImpl[pluginName].priority > previous.priority ? {plugin: {name: pluginName, impl: pluginImpl[pluginName]}, priority: pluginImpl[pluginName].priority} : previous;
+        const containerName = current.name || current;
+        const pluginPriority = getPriority(pluginImpl, override, containerName);
+        return pluginPriority > previous.priority ? {
+            plugin: {
+                name: containerName,
+                impl: assign({}, pluginImpl[containerName], override[containerName])
+            },
+            priority: pluginPriority} : previous;
     }, {plugin: null, priority: priority});
 };
 
@@ -133,32 +155,69 @@ const parsePluginConfig = (state, requires, cfg) => {
     return parseExpression(state, requires, cfg);
 };
 
-const getPluginItems = (state, plugins, pluginsConfig, name, id, isDefault, loadedPlugins, filter) => {
+const canContain = (container, plugin, override = {}) => {
+    return plugin[container] || override[container] || false;
+};
+
+const isMorePrioritizedContainer = (pluginImpl, override, plugins, priority) => {
+    return getMorePrioritizedContainer(pluginImpl,
+        override,
+        plugins,
+        priority).plugin === null;
+};
+
+const isValidConfiguration = (cfg) => {
+    return cfg && isString(cfg) || (isObject(cfg) && cfg.name);
+}
+
+const getPluginItems = (state, plugins, pluginsConfig, containerName, containerId, isDefault, loadedPlugins, filter) => {
     return Object.keys(plugins)
-            .filter((plugin) => plugins[plugin][name])
+            // extract basic info for each plugins (name, implementation and config)
+            .map(pluginName => ({
+                name: pluginName,
+                impl: plugins[pluginName],
+                config: getPluginConfiguration(pluginsConfig, pluginName)
+            }))
+            // include only plugins that are configured for the current mode
+            .filter((plugin) => isValidConfiguration(plugin.config))
+            // include only plugins that support container as a parent
+            .filter((plugin) => canContain(containerName, plugin.impl, plugin.config.override))
+            // include only plugins that are configured to be shown in container (use showIn and hideFrom to customize the behaviour)
             .filter((plugin) => {
-                const cfgObj = isPluginConfigured(pluginsConfig, plugin);
-                return cfgObj && showIn(state, plugins.requires, cfgObj, name, id, isDefault);
+                return showIn(state, plugins.requires, plugin.config, containerName, containerId, isDefault);
             })
-            .filter((plugin) => getMorePrioritizedContainer(plugins[plugin], pluginsConfig, plugins[plugin][name].priority || 0).plugin === null)
+            // include only plugins for which container is the preferred container
+            .filter((plugin) => isMorePrioritizedContainer(plugin.impl, plugin.config.override, pluginsConfig,
+                getPriority(plugin.impl, plugin.config.override, containerName)))
             .map((plugin) => {
-                const pluginName = plugin.substring(0, plugin.length - 6);
-                const pluginImpl = includeLoadedItem(pluginName, loadedPlugins, plugins[plugin]);
-                const pluginCfg = isPluginConfigured(pluginsConfig, plugin);
-                const item = pluginImpl[name].impl || pluginImpl[name];
-                return assign({
+                const pluginName = getPluginSimpleName(plugin.name);
+                const pluginImpl = includeLoaded(pluginName, loadedPlugins, plugin.impl);
+                const containerProperties = assign(
+                    {},
+                    get(pluginImpl, containerName + '.impl') || get(pluginImpl, containerName),
+                    get(plugin.config, 'override.' + containerName)
+                );
+                return assign(
+                    {
                         name: pluginName
                     },
-                    item,
-                    pluginCfg.override && pluginCfg.override[name] || {},
+                    containerProperties,
                     {
-                        cfg: assign({ }, pluginImpl.cfg || {}, pluginCfg && parsePluginConfig(state, plugins.requires, pluginCfg.cfg || {}) || undefined)
+                        cfg: assign(
+                            {},
+                            pluginImpl.cfg || {},
+                            parsePluginConfig(state, plugins.requires, plugin.config || {}) || undefined
+                        )
                     },
                     {
                         plugin: pluginImpl,
                         items: getPluginItems(state, plugins, pluginsConfig, pluginName, null, true, loadedPlugins)
                     });
-            }).filter((item) => filterDisabledPlugins(item, state, plugins) && (!filter || filter(item)));
+            })
+            // filter disabled plugins
+            .filter((item) => filterDisabledPlugins(item, state, plugins))
+            // apply optional user filter
+            .filter((item) => (!filter || filter(item)));
 };
 
 const getReducers = (plugins) => Object.keys(plugins).map((name) => plugins[name].reducers)
@@ -181,6 +240,11 @@ const defaultEpicWrapper = epic => (...args) =>
       setTimeout(() => { throw error; }, 0);
       return source;
   });
+
+
+const getPluginImplementation = (impl, stateSelector) => {
+    return impl.loadPlugin || impl.displayName || impl.prototype.isReactComponent ? impl : impl(stateSelector);
+};
 /**
  * Utilities to manage plugins
  * @memberof utils
@@ -273,20 +337,24 @@ const PluginsUtils = {
         return {
             id: id || name,
             name,
-            impl: includeLoaded(name, loadedPlugins, impl.loadPlugin || impl.displayName || impl.prototype.isReactComponent ? impl : impl(stateSelector)),
+            impl: includeLoaded(name, loadedPlugins, getPluginImplementation(impl, stateSelector)),
             cfg: assign({}, impl.cfg || {}, isObject(pluginDef) ? parsePluginConfig(state, plugins.requires, pluginDef.cfg) : {}),
             items: getPluginItems(state, plugins, pluginsConfig, name, id, isDefault, loadedPlugins)
         };
     },
     getPluginItems,
-    getConfiguredPlugin: (pluginDef, loadedPlugins, loaderComponent) => {
+    getConfiguredPlugin: (pluginDef, loadedPlugins = {}, loaderComponent) => {
         if (pluginDef) {
-            const Plugin = loadedPlugins && loadedPlugins[pluginDef.name] || (pluginDef.plugin && !pluginDef.plugin.loadPlugin && pluginDef.plugin);
+            const impl = loadedPlugins[pluginDef.name] ||
+                !pluginDef.plugin.loadPlugin && pluginDef.plugin;
+            const id = isObject(pluginDef) ? pluginDef.id : null;
+            const stateSelector = isObject(pluginDef) ? pluginDef.stateSelector : id || undefined;
+            const Plugin = getPluginImplementation(impl, stateSelector);
             const result = (props) => {
                 return Plugin ? (<Plugin key={pluginDef.id}
-                    {...props} {...pluginDef.cfg} pluginCfg={pluginDef.cfg} />) : loaderComponent;
+                    {...props} {...pluginDef.cfg} pluginCfg={pluginDef.cfg} items={pluginDef.items || []}/>) : loaderComponent;
             };
-            result.loaded = !!Plugin;
+            result.loaded = !!impl;
             return result;
         }
         return pluginDef;
@@ -312,6 +380,7 @@ const PluginsUtils = {
         return connect(mapStateToProps, mapDispatchToProps, mergeProps || pluginsMergeProps, options);
     },
     handleExpression,
-    getMorePrioritizedContainer
+    getMorePrioritizedContainer,
+    getPluginConfiguration
 };
 module.exports = PluginsUtils;

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -29,6 +29,11 @@ const epicTest = (epic, count, action, callback, state = {}) => {
         actions.next(action);
     }
 };
+
+const defaultState = () => {
+    return {};
+};
+
 describe('PluginsUtils', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -169,6 +174,177 @@ describe('PluginsUtils', () => {
     it('handleExpression', () => {
         expect(PluginsUtils.handleExpression({state1: "test1"}, {context1: "test2"}, "{state.state1 + ' ' + context.context1}")).toBe("test1 test2");
     });
+
+    it('getPluginItems', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 1
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1"
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(1);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(1);
+    });
+
+    it('getPluginItems with showIn', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 1
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1",
+            showIn: ['Container1']
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(1);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(0);
+    });
+
+    it('getPluginItems with hideFrom', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 1
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1",
+            hideFrom: ['Container1']
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(0);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(1);
+    });
+
+    it('getPluginItems with priority', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 2
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1"
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(0);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(1);
+    });
+
+    it('getPluginItems with overridden priority', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 2
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1",
+            override: {
+                Container1: {
+                    priority: 3
+                }
+            }
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(1);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(0);
+    });
+
+    it('getPluginItems with disabled plugin', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 2
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1",
+            disablePluginIf: "{true}"
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
+        expect(items1.length).toBe(0);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, []);
+        expect(items2.length).toBe(0);
+    });
+
+    it('getPluginItems with filtered plugin', () => {
+        const plugins = {
+            Test1Plugin: {
+                Container1: {
+                    priority: 1
+                },
+                Container2: {
+                    priority: 2
+                }
+            },
+            Container1Plugin: {},
+            Container2Plugin: {}
+        };
+
+        const pluginsConfig = [{
+            name: "Test1",
+            disablePluginIf: "{true}"
+        }, "Container1", "Container2"];
+        const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, [], () => false);
+        expect(items1.length).toBe(0);
+        const items2 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container2", "Container2", true, [], () => false);
+        expect(items2.length).toBe(0);
+    });
+
     it('dispatch', () => {
         const expr = PluginsUtils.handleExpression(() => ({
             dispatch: (action) => action

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -313,7 +313,9 @@ describe('PluginsUtils', () => {
 
         const pluginsConfig = [{
             name: "Test1",
-            disablePluginIf: "{true}"
+            "cfg": {
+                disablePluginIf: "{true}"
+            }
         }, "Container1", "Container2"];
         const items1 = PluginsUtils.getPluginItems(defaultState, plugins, pluginsConfig, "Container1", "Container1", true, []);
         expect(items1.length).toBe(0);


### PR DESCRIPTION
## Description
Allow more override to work on plugins:
 * override of containers priority
 * adding a new override block for a custom container, so that plugins can be included in every container, by configuration

Some cleanup as a bonus.

## Issues
 - Fix #3516

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
You cannot override plugin container priorities, neither configure a new container for a plugin.

**What is the new behavior?**
You can override plugin container priorities, and configure a new container for a plugin.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
