### PR TITLE
Fix grid set misalignment in some crs

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -518,7 +518,7 @@ describe('Openlayers layer', () => {
         expect(layer).toExist();
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
-        expect(map.getLayers().item(0).getSource().getTileGrid().getOrigin()).toEqual([-20037508.342789244, 20037508.342789244]);
+        expect(map.getLayers().item(0).getSource().getTileGrid().getOrigin()).toEqual([-20037508.342789244, -20037508.342789244]);
     });
     it('creates a wms layer with custom origin', () => {
         var options = {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -141,10 +141,14 @@ Layers.registerType('wms', {
             urls: urls,
             params: queryParameters,
             tileGrid: new ol.tilegrid.TileGrid({
+                // TODO: custom grid sets with custom extent
                 extent: extent,
+                // TODO: custom grid sets resolutions and tile size (needed to generate resolutions)
                 resolutions: mapUtils.getResolutions(),
                 tileSize: options.tileSize ? options.tileSize : 256,
-                origin: options.origin ? options.origin : [extent[0], extent[3]]
+                // TODO: GWC grid sets with `alignTopLeft=true` may require `extent[0], extent[3]`
+
+                origin: options.origin ? options.origin : [extent[0], extent[1]]
             })
         }, options);
         const layer = new ol.layer.Tile({
@@ -184,10 +188,13 @@ Layers.registerType('wms', {
             if (oldOptions.srs !== newOptions.srs) {
                 const extent = ol.proj.get(CoordinatesUtils.normalizeSRS(newOptions.srs, newOptions.allowedSRS)).getExtent();
                 layer.getSource().tileGrid = new ol.tilegrid.TileGrid({
+                    // TODO: custom grid sets extents
                     extent: extent,
+                    // TODO: custom grid sets resolutions and tile size (needed to generate resolutions)
                     resolutions: mapUtils.getResolutions(),
                     tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
-                    origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
+                    // TODO: GWC grid sets with `alignTopLeft=true` may require `extent[0], extent[3]`
+                    origin: newOptions.origin ? newOptions.origin : [extent[0], extent[1]]
                 });
             }
             if (changed) {
@@ -244,10 +251,13 @@ Layers.registerType('wms', {
                             urls: urls,
                             params: queryParameters,
                             tileGrid: new ol.tilegrid.TileGrid({
+                                // TODO: custom grid sets extents
                                 extent: extent,
+                                // TODO: custom grid sets resolutions and tile size (needed to generate resolutions)
                                 resolutions: mapUtils.getResolutions(),
                                 tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
-                                origin: newOptions.origin ? newOptions.origin : [extent[0], extent[3]]
+                                // TODO: GWC grid sets with `alignTopLeft=true` may require `extent[0], extent[3]`
+                                origin: newOptions.origin ? newOptions.origin : [extent[0], extent[1]]
                             })
                         }, newOptions.forceProxy ? {tileLoadFunction: proxyTileLoadFunction} : {}))
                     });


### PR DESCRIPTION
## Description
This fixes align resolution and extent calculation to GWC default ones, to auto-align WMS tile layer to grid sets generated by default

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
EPSG:3003 and EPSG:32632 didn't HIT the cache because of gridset not alngined

**What is the new behavior?**
EPSG:3003 and EPSG:32632 HIT the cache, when the gridset is : 
 - aligned to the projection extent
 - tile size is 256 pixels 
 - `alignTopLeft=false` in GWC
 - resolutions are generated following the formula (Same of GWC: 

```
resX = extentWidth / tileWidth;
resY = extentHeight / tileHeight;
r[0] = max(resX, resY)
res[k] = r[0] / 2^k
```
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
