### PR TITLE
Fix #3525 add possibility to save and load mapInfo configuration

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -20,6 +20,7 @@ var {
     GET_VECTOR_INFO,
     TOGGLE_MAPINFO_STATE,
     UPDATE_CENTER_TO_MARKER,
+    TOGGLE_EMPTY_MESSAGE_GFI, toggleEmptyMessageGFI,
     getFeatureInfo,
     changeMapInfoState,
     newMapInfoRequest,
@@ -205,5 +206,9 @@ describe('Test correctness of the map actions', () => {
         const retval = updateCenterToMarker('enabled');
         expect(retval.type).toBe(UPDATE_CENTER_TO_MARKER);
         expect(retval.status).toBe('enabled');
+    });
+    it('toggleEmptyMessageGFI', () => {
+        const retval = toggleEmptyMessageGFI();
+        expect(retval.type).toBe(TOGGLE_EMPTY_MESSAGE_GFI);
     });
 });

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -30,6 +30,9 @@ const TOGGLE_MAPINFO_STATE = 'TOGGLE_MAPINFO_STATE';
 const UPDATE_CENTER_TO_MARKER = 'UPDATE_CENTER_TO_MARKER';
 const CLOSE_IDENTIFY = 'IDENTIFY:CLOSE_IDENTIFY';
 
+const TOGGLE_EMPTY_MESSAGE_GFI = "IDENTIFY:TOGGLE_EMPTY_MESSAGE_GFI";
+const toggleEmptyMessageGFI = () => ({type: TOGGLE_EMPTY_MESSAGE_GFI});
+
 /**
  * Private
  * @return a LOAD_FEATURE_INFO action with the response data to a wms GetFeatureInfo
@@ -240,6 +243,7 @@ module.exports = {
     TOGGLE_MAPINFO_STATE,
     UPDATE_CENTER_TO_MARKER,
     CLOSE_IDENTIFY,
+    TOGGLE_EMPTY_MESSAGE_GFI, toggleEmptyMessageGFI,
     closeIdentify,
     getFeatureInfo,
     changeMapInfoState,

--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -34,7 +34,8 @@ class DefaultViewer extends React.Component {
         onNext: PropTypes.func,
         onPrevious: PropTypes.func,
         onUpdateIndex: PropTypes.func,
-        setIndex: PropTypes.func
+        setIndex: PropTypes.func,
+        showEmptyMessageGFI: PropTypes.bool
     };
 
     static defaultProps = {
@@ -52,6 +53,7 @@ class DefaultViewer extends React.Component {
         },
         containerProps: {},
         index: 0,
+        showEmptyMessageGFI: true,
         onNext: () => {},
         onPrevious: () => {},
         setIndex: () => {}
@@ -79,12 +81,12 @@ class DefaultViewer extends React.Component {
                 const {layerMetadata} = res;
                 return layerMetadata.title;
             });
-            return (
+            return this.props.showEmptyMessageGFI ? (
                 <Alert bsStyle={"info"}>
                     <Message msgId={"noInfoForLayers"} />
                     <b>{titles.join(', ')}</b>
                 </Alert>
-            );
+            ) : null;
         }
         return null;
     };

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -51,7 +51,8 @@ module.exports = props => {
         setIndex,
         warning,
         clearWarning,
-        zIndex
+        zIndex,
+        showEmptyMessageGFI
     } = props;
 
     const latlng = point && point.latlng || null;
@@ -105,6 +106,7 @@ module.exports = props => {
                     format={format}
                     missingResponses={missingResponses}
                     responses={responses}
+                    showEmptyMessageGFI={showEmptyMessageGFI}
                     {...viewerOptions}/>
             </DockablePanel>
             <Portal>

--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -12,15 +12,12 @@ const PropTypes = require('prop-types');
     to the clipboard
 */
 
-// components required
 const React = require('react');
 const CopyToClipboard = require('react-copy-to-clipboard');
 const Message = require('../../components/I18N/Message');
 const {Glyphicon, Col, Grid, Row, Tooltip, Button, Checkbox} = require('react-bootstrap');
 const OverlayTrigger = require('../misc/OverlayTrigger');
-
 const url = require('url');
-// css required
 require('./share.css');
 
 class ShareEmbed extends React.Component {

--- a/web/client/epics/mapexport.js
+++ b/web/client/epics/mapexport.js
@@ -12,12 +12,13 @@ const {EXPORT_MAP} = require('../actions/mapexport');
 const { setControlProperty } = require('../actions/controls');
 
 const { mapSelector } = require('../selectors/map');
+const { mapInfoConfigurationSelector } = require('../selectors/mapInfo');
 const { layersSelector, groupsSelector } = require('../selectors/layers');
 const { mapOptionsToSaveSelector } = require('../selectors/mapsave');
 const textSearchConfigSelector = state => state.searchconfig && state.searchconfig.textSearchConfig;
 
 const PersistMap = {
-    mapstore2: (state) => JSON.stringify(MapUtils.saveMapConfiguration(mapSelector(state), layersSelector(state), groupsSelector(state), textSearchConfigSelector(state), mapOptionsToSaveSelector(state)))
+    mapstore2: (state) => JSON.stringify(MapUtils.saveMapConfiguration(mapSelector(state), layersSelector(state), groupsSelector(state), textSearchConfigSelector(state), mapOptionsToSaveSelector(state), mapInfoConfigurationSelector(state)))
 };
 
 

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -15,9 +15,9 @@ const {createSelector} = require('reselect');
 const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
 
-const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState} = require('../actions/mapInfo');
+const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults} = require('../actions/mapInfo');
 const {changeMousePointer} = require('../actions/map');
-const {changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults} = require('../actions/mapInfo');
+const {showEmptyMessageGFISelector} = require('../selectors/mapInfo');
 const {currentLocaleSelector} = require('../selectors/locale');
 
 const {compose, defaultProps} = require('recompose');
@@ -46,9 +46,10 @@ const selector = createSelector([
     (state) => state.mapInfo && state.mapInfo.reverseGeocodeData,
     (state) => state.mapInfo && state.mapInfo.warning,
     currentLocaleSelector,
-    state => mapLayoutValuesSelector(state, {height: true})
-], (enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle) => ({
-    enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle
+    state => mapLayoutValuesSelector(state, {height: true}),
+    state => showEmptyMessageGFISelector(state)
+], (enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle, showEmptyMessageGFI) => ({
+    enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle, showEmptyMessageGFI
 }));
 // result panel
 

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -17,7 +17,7 @@ const {layersSelector} = require('../selectors/layers');
 
 const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults} = require('../actions/mapInfo');
 const {changeMousePointer} = require('../actions/map');
-const {showEmptyMessageGFISelector} = require('../selectors/mapInfo');
+const {showEmptyMessageGFISelector, generalInfoFormatSelector} = require('../selectors/mapInfo');
 const {currentLocaleSelector} = require('../selectors/locale');
 
 const {compose, defaultProps} = require('recompose');
@@ -37,7 +37,7 @@ const selector = createSelector([
     (state) => state.mapInfo && state.mapInfo.enabled || state.controls && state.controls.info && state.controls.info.enabled || false,
     (state) => state.mapInfo && state.mapInfo.responses || [],
     (state) => state.mapInfo && state.mapInfo.requests || [],
-    (state) => state.mapInfo && state.mapInfo.infoFormat,
+    (state) => generalInfoFormatSelector(state),
     mapSelector,
     layersSelector,
     (state) => state.mapInfo && state.mapInfo.clickPoint,
@@ -160,6 +160,18 @@ const identifyDefaultProps = defaultProps({
  *       }
  *    }
  * }
+ *
+ * If you want ot configure the showEmptyMessageGFI you need to update the "initialState.defaultState"
+ * @example
+ * ```
+ * "mapInfo": {
+ *   "enabled": true,
+ *   "configuration": {
+ *     "showEmptyMessageGFI": false
+ *   }
+ * }
+ * ```
+
  */
 
 const IdentifyPlugin = compose(
@@ -185,7 +197,7 @@ const IdentifyPlugin = compose(
 
 // configuration UI
 const FeatureInfoFormatSelector = connect((state) => ({
-    infoFormat: state.mapInfo && state.mapInfo.infoFormat
+    infoFormat: generalInfoFormatSelector(state)
 }), {
     onInfoFormatChange: changeMapInfoFormat
 })(require("../components/misc/FeatureInfoFormatSelector"));

--- a/web/client/plugins/Save.jsx
+++ b/web/client/plugins/Save.jsx
@@ -23,11 +23,14 @@ const ConfigUtils = require('../utils/ConfigUtils');
 const {mapSelector} = require('../selectors/map');
 const {layersSelector, groupsSelector} = require('../selectors/layers');
 const {mapOptionsToSaveSelector} = require('../selectors/mapsave');
-
+const {mapInfoConfigurationSelector} = require('../selectors/mapinfo');
 const MapUtils = require('../utils/MapUtils');
 const showSelector = state => state.controls && state.controls.save && state.controls.save.enabled;
 const textSearchConfigSelector = state => state.searchconfig && state.searchconfig.textSearchConfig;
-const selector = createSelector(mapSelector, mapOptionsToSaveSelector, layersSelector, groupsSelector, showSelector, textSearchConfigSelector, (map, additionalOptions, layers, groups, show, textSearchConfig) => ({
+
+const selector = createSelector(
+    mapSelector, mapOptionsToSaveSelector, layersSelector, groupsSelector, showSelector, textSearchConfigSelector, mapInfoConfigurationSelector,
+    (map, additionalOptions, layers, groups, show, textSearchConfig, mapInfoConfiguration) => ({
     currentZoomLvl: map && map.zoom,
     show,
     map,
@@ -35,7 +38,8 @@ const selector = createSelector(mapSelector, mapOptionsToSaveSelector, layersSel
     mapId: map && map.mapId,
     layers,
     textSearchConfig,
-    groups
+    groups,
+    mapInfoConfiguration
 }));
 
 class Save extends React.Component {
@@ -49,6 +53,7 @@ class Save extends React.Component {
         map: PropTypes.object,
         layers: PropTypes.array,
         groups: PropTypes.array,
+        mapInfoConfiguration: PropTypes.object,
         params: PropTypes.object,
         textSearchConfig: PropTypes.object
     };
@@ -90,7 +95,7 @@ class Save extends React.Component {
     goForTheUpdate = () => {
         if (this.props.mapId) {
             if (this.props.map && this.props.layers) {
-                const resultingmap = MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions);
+                const resultingmap = MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions, this.props.mapInfoConfiguration);
                 const {name, description} = this.props.map.info;
                 this.props.onMapSave({id: this.props.mapId, data: resultingmap, metadata: {name, description}, category: "MAP"});
                 this.props.onClose();

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -20,6 +20,7 @@ const {editMap, updateCurrentMap, errorCurrentMap, resetCurrentMap} = require('.
 const {mapSelector} = require('../selectors/map');
 const {layersSelector, groupsSelector} = require('../selectors/layers');
 const {mapOptionsToSaveSelector} = require('../selectors/mapsave');
+const {mapInfoConfigurationSelector} = require('../selectors/mapInfo');
 const {mapTypeSelector} = require('../selectors/maptype');
 const {indexOf} = require('lodash');
 const uuid = require('uuid/v1');
@@ -41,13 +42,15 @@ const selector = createSelector(
         groupsSelector,
         mapOptionsToSaveSelector,
         saveAsStateSelector,
-        (map, layers, groups, additionalOptions, saveAsState) => ({
+        mapInfoConfigurationSelector,
+        (map, layers, groups, additionalOptions, saveAsState, mapInfoConfiguration) => ({
     currentZoomLvl: map && map.zoom,
     map,
     layers,
     groups,
     additionalOptions,
-    ...saveAsState
+    ...saveAsState,
+    mapInfoConfiguration
 }));
 
 class SaveAs extends React.Component {
@@ -75,7 +78,8 @@ class SaveAs extends React.Component {
         metadataChanged: PropTypes.func,
         onMapSave: PropTypes.func,
         loadMapInfo: PropTypes.func,
-        textSearchConfig: PropTypes.object
+        textSearchConfig: PropTypes.object,
+        mapInfoConfiguration: PropTypes.object
     };
 
     static contextTypes = {
@@ -140,7 +144,7 @@ class SaveAs extends React.Component {
 
     // this method creates the content for the Map Resource
     createV2Map = () => {
-        return MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions);
+        return MapUtils.saveMapConfiguration(this.props.map, this.props.layers, this.props.groups, this.props.textSearchConfig, this.props.additionalOptions, this.props.mapInfoConfiguration);
     };
 
     saveMap = (id, name, description) => {

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -218,11 +218,11 @@ describe('Test the mapInfo reducer', () => {
     it('change mapinfo format', () => {
         let state = mapInfo({}, {type: 'CHANGE_MAPINFO_FORMAT', infoFormat: "testFormat"});
         expect(state).toExist();
-        expect(state.infoFormat).toBe("testFormat");
+        expect(state.configuration.infoFormat).toBe("testFormat");
 
-        state = mapInfo({infoFormat: 'oldFormat'}, {type: 'CHANGE_MAPINFO_FORMAT', infoFormat: "newFormat"});
+        state = mapInfo({configuration: {infoFormat: 'oldFormat'}}, {type: 'CHANGE_MAPINFO_FORMAT', infoFormat: "newFormat"});
         expect(state).toExist();
-        expect(state.infoFormat).toBe('newFormat');
+        expect(state.configuration.infoFormat).toBe('newFormat');
     });
 
     it('show reverese geocode', () => {

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -8,7 +8,8 @@
 
 const expect = require('expect');
 const mapInfo = require('../mapInfo');
-const { featureInfoClick } = require('../../actions/mapInfo');
+const { featureInfoClick, toggleEmptyMessageGFI } = require('../../actions/mapInfo');
+const { MAP_CONFIG_LOADED } = require('../../actions/config');
 const assign = require('object-assign');
 
 require('babel-polyfill');
@@ -1424,6 +1425,34 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[0].layerMetadata.fields.length).toBe(2);
         expect(state.responses[0].layerMetadata.title).toBe("Annotations");
         expect(state.responses[0].layerMetadata.buffer).toBe(2);
+    });
+
+    it('TOGGLE_EMPTY_MESSAGE_GFI', () => {
+        let state = mapInfo({
+            infoFormat: "text/html",
+            configuration: {}
+        }, toggleEmptyMessageGFI());
+        expect(state.configuration.showEmptyMessageGFI).toBe(true);
+        state = mapInfo(state, toggleEmptyMessageGFI());
+        expect(state.configuration.showEmptyMessageGFI).toBe(false);
+    });
+    it('MAP_CONFIG_LOADED', () => {
+        const oldInfoFormat = "text/html";
+        const newInfoFormat = "application/json";
+        let state = mapInfo({
+            infoFormat: oldInfoFormat,
+            configuration: {}
+        }, {
+            type: MAP_CONFIG_LOADED,
+            config: {
+                mapInfoConfiguration: {
+                    infoFormat: newInfoFormat,
+                    showEmptyMessageGFI: true
+                }
+            }
+        });
+        expect(state.configuration.showEmptyMessageGFI).toBe(true);
+        expect(state.configuration.infoFormat).toBe(newInfoFormat);
     });
 
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -23,8 +23,12 @@ const {
     CLEAR_WARNING,
     FEATURE_INFO_CLICK,
     TOGGLE_MAPINFO_STATE,
-    UPDATE_CENTER_TO_MARKER
+    UPDATE_CENTER_TO_MARKER,
+    TOGGLE_EMPTY_MESSAGE_GFI
 } = require('../actions/mapInfo');
+const {
+    MAP_CONFIG_LOADED
+} = require('../actions/config');
 const {RESET_CONTROLS} = require('../actions/controls');
 
 const assign = require('object-assign');
@@ -44,7 +48,10 @@ function receiveResponse(state, action, type) {
     }
     return state;
 }
-const initState = {enabled: true};
+const initState = {
+    enabled: true,
+    configuration: {}
+};
 
 function mapInfo(state = initState, action) {
     switch (action.type) {
@@ -92,9 +99,13 @@ function mapInfo(state = initState, action) {
         });
     }
     case CHANGE_MAPINFO_FORMAT: {
-        return assign({}, state, {
-            infoFormat: action.infoFormat
-        });
+        return {...state,
+            infoFormat: action.infoFormat,
+            configuration: {
+                ...state.configuration,
+                infoFormat: action.infoFormat
+            }
+        };
     }
     case SHOW_MAPINFO_MARKER: {
         return assign({}, state, {
@@ -190,6 +201,18 @@ function mapInfo(state = initState, action) {
         return assign({}, state, {
             centerToMarker: action.status
         });
+    }
+    case TOGGLE_EMPTY_MESSAGE_GFI: {
+        return {...state, configuration: {
+            ...state.configuration, showEmptyMessageGFI: !state.configuration.showEmptyMessageGFI
+            }
+        };
+    }
+    case MAP_CONFIG_LOADED: {
+        return {...state,
+            configuration: action.config.mapInfoConfiguration,
+            infoFormat: action.config.mapInfoConfiguration.infoFormat
+        };
     }
     default:
         return state;

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -100,7 +100,6 @@ function mapInfo(state = initState, action) {
     }
     case CHANGE_MAPINFO_FORMAT: {
         return {...state,
-            infoFormat: action.infoFormat,
             configuration: {
                 ...state.configuration,
                 infoFormat: action.infoFormat
@@ -211,8 +210,7 @@ function mapInfo(state = initState, action) {
     case MAP_CONFIG_LOADED: {
         return {
             ...state,
-            configuration: action.config.mapInfoConfiguration || {},
-            infoFormat: action.config.mapInfoConfiguration.infoFormat || "text/plain"
+            configuration: action.config.mapInfoConfiguration || state.configuration || {}
         };
     }
     default:

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -209,9 +209,10 @@ function mapInfo(state = initState, action) {
         };
     }
     case MAP_CONFIG_LOADED: {
-        return {...state,
-            configuration: action.config.mapInfoConfiguration,
-            infoFormat: action.config.mapInfoConfiguration.infoFormat
+        return {
+            ...state,
+            configuration: action.config.mapInfoConfiguration || {},
+            infoFormat: action.config.mapInfoConfiguration.infoFormat || "text/plain"
         };
     }
     default:

--- a/web/client/selectors/__tests__/mapinfo-test.js
+++ b/web/client/selectors/__tests__/mapinfo-test.js
@@ -23,12 +23,11 @@ describe('Test mapinfo selectors', () => {
         expect(mapinfo).toBe("text/plain");
     });
     it('test generalInfoFormatSelector infoFormat: undefined', () => {
-        const mapinfo = generalInfoFormatSelector({mapInfo: {infoFormat: undefined}});
+        const mapinfo = generalInfoFormatSelector({mapInfo: {configuration: {infoFormat: undefined}}});
         expect(mapinfo).toBe("text/plain");
     });
     it('test generalInfoFormatSelector ', () => {
-        const mapinfo = generalInfoFormatSelector({mapInfo: {infoFormat: "text/html"}});
-
+        const mapinfo = generalInfoFormatSelector({mapInfo: {configuration: {infoFormat: "text/html"}}});
         expect(mapinfo).toExist();
         expect(mapinfo).toBe("text/html");
     });
@@ -130,9 +129,9 @@ describe('Test mapinfo selectors', () => {
         expect(props.infoFormat).toEqual(infoFormat);
         expect(props.showEmptyMessageGFI).toEqual(showEmptyMessageGFI);
     });
-    it('test showEmptyMessageGFISelector', () => {
-        const showEmptyMessageGFI = true;
-        const props = showEmptyMessageGFISelector({
+    it('test showEmptyMessageGFISelector true', () => {
+        const showEmptyMessageGFI = false;
+        let props = showEmptyMessageGFISelector({
             mapInfo: {
                 configuration: {
                     showEmptyMessageGFI
@@ -140,6 +139,10 @@ describe('Test mapinfo selectors', () => {
             }
         });
         expect(props).toEqual(showEmptyMessageGFI);
+        props = showEmptyMessageGFISelector({
+            mapInfo: {}
+        });
+        expect(props).toEqual(true);
     });
 
 });

--- a/web/client/selectors/__tests__/mapinfo-test.js
+++ b/web/client/selectors/__tests__/mapinfo-test.js
@@ -8,7 +8,14 @@
 
 
 const expect = require('expect');
-const {mapInfoRequestsSelector, generalInfoFormatSelector, stopGetFeatureInfoSelector, isMapInfoOpen} = require('../mapinfo');
+const {
+    mapInfoRequestsSelector,
+    generalInfoFormatSelector,
+    stopGetFeatureInfoSelector,
+    isMapInfoOpen,
+    mapInfoConfigurationSelector,
+    showEmptyMessageGFISelector
+} = require('../mapinfo');
 
 describe('Test mapinfo selectors', () => {
     it('test generalInfoFormatSelector default value', () => {
@@ -108,6 +115,31 @@ describe('Test mapinfo selectors', () => {
             }
         });
         expect(props).toEqual(true);
+    });
+    it('test mapInfoConfigurationSelector', () => {
+        const infoFormat = "text/html";
+        const showEmptyMessageGFI = true;
+        const props = mapInfoConfigurationSelector({
+            mapInfo: {
+                configuration: {
+                    infoFormat,
+                    showEmptyMessageGFI
+                }
+            }
+        });
+        expect(props.infoFormat).toEqual(infoFormat);
+        expect(props.showEmptyMessageGFI).toEqual(showEmptyMessageGFI);
+    });
+    it('test showEmptyMessageGFISelector', () => {
+        const showEmptyMessageGFI = true;
+        const props = showEmptyMessageGFISelector({
+            mapInfo: {
+                configuration: {
+                    showEmptyMessageGFI
+                }
+            }
+        });
+        expect(props).toEqual(showEmptyMessageGFI);
     });
 
 });

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -37,6 +37,9 @@ const isMapInfoOpen = state => !!mapInfoRequestsSelector(state) && mapInfoReques
  */
 const generalInfoFormatSelector = (state) => get(state, "mapInfo.infoFormat", "text/plain");
 
+const showEmptyMessageGFISelector = (state) => get(state, "mapInfo.configuration.showEmptyMessageGFI", true); // verify if we need to remove this default in austrocontrol
+const mapInfoConfigurationSelector = (state) => get(state, "mapInfo.configuration", {});
+
 const measureActiveSelector = (state) => get(state, "measurement.lineMeasureEnabled") || get(state, "measurement.areaMeasureEnabled") || get(state, "measurement.bearingMeasureEnabled");
 const drawSupportActiveSelector = (state) => {
     const drawStatus = get(state, "draw.drawStatus", false);
@@ -73,5 +76,7 @@ module.exports = {
     isMapInfoOpen,
     generalInfoFormatSelector,
     mapInfoRequestsSelector,
-    stopGetFeatureInfoSelector
+    stopGetFeatureInfoSelector,
+    showEmptyMessageGFISelector,
+    mapInfoConfigurationSelector
 };

--- a/web/client/selectors/mapinfo.js
+++ b/web/client/selectors/mapinfo.js
@@ -35,9 +35,8 @@ const isMapInfoOpen = state => !!mapInfoRequestsSelector(state) && mapInfoReques
  * @param  {object} state the state
  * @return {string}       the maptype in the state
  */
-const generalInfoFormatSelector = (state) => get(state, "mapInfo.infoFormat", "text/plain");
-
-const showEmptyMessageGFISelector = (state) => get(state, "mapInfo.configuration.showEmptyMessageGFI", true); // verify if we need to remove this default in austrocontrol
+const generalInfoFormatSelector = (state) => get(state, "mapInfo.configuration.infoFormat", "text/plain");
+const showEmptyMessageGFISelector = (state) => get(state, "mapInfo.configuration.showEmptyMessageGFI", true);
 const mapInfoConfigurationSelector = (state) => get(state, "mapInfo.configuration", {});
 
 const measureActiveSelector = (state) => get(state, "measurement.lineMeasureEnabled") || get(state, "measurement.areaMeasureEnabled") || get(state, "measurement.bearingMeasureEnabled");

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -328,7 +328,7 @@ const extractTileMatrixSetFromLayers = (sourcesFromLayers, sources = {}) => {
     }, assign({}, sources)) || sources;
 };
 
-function saveMapConfiguration(currentMap, currentLayers, currentGroups, textSearchConfig, additionalOptions) {
+function saveMapConfiguration(currentMap, currentLayers, currentGroups, textSearchConfig, additionalOptions, mapInfoConfiguration) {
 
     const map = {
         center: currentMap.center,
@@ -371,7 +371,7 @@ function saveMapConfiguration(currentMap, currentLayers, currentGroups, textSear
         version: 2,
         // layers are defined inside the map object
         map: assign({}, map, {layers: formattedLayers, groups, text_serch_config: textSearchConfig}, !isEmpty(sources) && {sources} || {}),
-        ...additionalOptions
+        ...additionalOptions, mapInfoConfiguration
     };
 }
 

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -428,6 +428,7 @@ describe('Test the MapUtils', () => {
                 units: 'm',
                 zoom: 10
             },
+            mapInfoConfiguration: undefined,
             version: 2
         });
     });
@@ -702,6 +703,7 @@ describe('Test the MapUtils', () => {
                 units: 'm',
                 zoom: 10
             },
+            mapInfoConfiguration: undefined,
             version: 2
         });
     });
@@ -955,10 +957,143 @@ describe('Test the MapUtils', () => {
                     }
                 }
             },
+            mapInfoConfiguration: undefined,
             version: 2
         });
     });
-
+    it('save map configuration with tile matrix and map info configuration', () => {
+        const flat = [
+            {
+                allowedSRS: {},
+                bbox: {},
+                description: undefined,
+                dimensions: [],
+                id: "layer001",
+                loading: true,
+                name: "layer001",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer001",
+                type: "wms",
+                url: "http:url001",
+                visibility: true,
+                catalogURL: "url",
+                matrixIds: {
+                    'EPSG:4326': [{
+                        identifier: 'EPSG:4326:0'
+                    }]
+                },
+                tileMatrixSet: [{
+                    TileMatrix: [{
+                        'ows:Identifier': 'EPSG:4326:0'
+                    }],
+                    'ows:Identifier': "EPSG:4326",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                }, {
+                    TileMatrix: [{
+                        'ows:Identifier': 'custom:0'
+                    }],
+                    'ows:Identifier': "custom",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                }]
+            }
+        ];
+        const groups = [
+            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+            ]}
+        ];
+        const mapConfig = {
+            center: {x: 0, y: 0, crs: 'EPSG:4326'},
+            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+            projection: 'EPSG:900913',
+            units: 'm',
+            zoom: 10
+        };
+        const saved = saveMapConfiguration(mapConfig, flat, groups, '', {}, {infoFormat: "text/html", showEmptyMessageGFI: false});
+        expect(saved).toEqual({
+            map: {
+                center: {crs: 'EPSG:4326', x: 0, y: 0},
+                groups: [{
+                    id: 'Default',
+                    expanded: true
+                }, {
+                    id: 'custom',
+                    expanded: false
+                }, {
+                    id: 'custom.nested001',
+                    expanded: true
+                }],
+                layers: [{
+                    allowedSRS: {},
+                    thumbURL: undefined,
+                    availableStyles: undefined,
+                    bbox: {},
+                    capabilitiesURL: undefined,
+                    description: undefined,
+                    dimensions: [],
+                    nativeCrs: undefined,
+                    features: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer001",
+                    matrixIds: ['EPSG:4326'],
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer001",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: true,
+                    tiled: undefined,
+                    title: "layer001",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "http:url001",
+                    visibility: true,
+                    catalogURL: "url",
+                    hidden: false,
+                    useForElevation: false,
+                    origin: undefined,
+                    thematic: undefined
+                }],
+                mapOptions: {},
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                text_serch_config: '',
+                units: 'm',
+                zoom: 10,
+                sources: {
+                    'http:url001': {
+                        tileMatrixSet: {
+                            'EPSG:4326': {
+                                TileMatrix: [{
+                                    'ows:Identifier': 'EPSG:4326:0'
+                                }],
+                                'ows:Identifier': "EPSG:4326",
+                                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                            }
+                        }
+                    }
+                }
+            }, mapInfoConfiguration: {
+                infoFormat: "text/html",
+                showEmptyMessageGFI: false
+            },
+            version: 2
+        });
+    });
     it('extract TileMatrixSet from layers without sources and grouped layers', () => {
         expect(extractTileMatrixSetFromLayers()).toEqual({});
     });


### PR DESCRIPTION
## Description
This PR add the possibility to save a piece of mapinfo state into map configuration and use it when loading a map. 
it saves:
- the flag to show or hide empty results for other layers when GFI hits a feature.
- the global infoFormat property

## Issues
 - Fix #3525 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature
 - [x] Refactoring (no functional changes, no api changes) infoFormat moved into configuration object

**What is the current behavior?** (You can also link to an open issue here)
- you cannot decide to show or hide the empty message on gfi results panel.
- you cannot save/load this information and infoFormat in the map config.

**What is the new behavior?**
- you can

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

**this pr is going on c125_annotations branch and in a close future also on master**