### PR TITLE
Fix #3537 Zoom to layer does not work

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -400,7 +400,6 @@ module.exports = {
         onFontError: errorLoadingFont
     })(MapPlugin),
     reducers: {
-        map: require('../reducers/map'),
         layers: require('../reducers/layers'),
         draw: require('../reducers/draw'),
         highlight: require('../reducers/highlight'),

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -400,7 +400,6 @@ module.exports = {
         onFontError: errorLoadingFont
     })(MapPlugin),
     reducers: {
-        layers: require('../reducers/layers'),
         draw: require('../reducers/draw'),
         highlight: require('../reducers/highlight'),
         maptype: require('../reducers/maptype'),

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -18,8 +18,7 @@ import layers from '../../reducers/layers';
 // StandardStore add by default current reducers
 const rootReducers = {
     map,
-    layers,
-    mapInitialConfig: map
+    layers
 };
 
 const createRegisterActionsMiddleware = (actions) => {

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -12,6 +12,16 @@ import {Provider} from 'react-redux';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { combineEpics, createEpicMiddleware } from 'redux-observable';
 
+import map from '../../reducers/layers';
+import layers from '../../reducers/layers';
+
+// StandardStore add by default current reducers
+const rootReducers = {
+    map,
+    layers,
+    mapInitialConfig: map
+};
+
 const createRegisterActionsMiddleware = (actions) => {
     return () => next => action => {
         actions.push(action);
@@ -47,7 +57,7 @@ export const getPluginForTest = (pluginDef, storeState, plugins) => {
         .reduce((previous, key) => {
             return { ...previous, [key]: PluginImpl[key]};
         }, {});
-    const reducer = combineReducers(pluginDef.reducers || {});
+    const reducer = combineReducers({ ...pluginDef.reducers, ...rootReducers } || {});
 
     const rootEpic = combineEpics.apply(null, Object.keys(pluginDef.epics || {}).map(key => pluginDef.epics[key]) || []);
     const epicMiddleware = createEpicMiddleware(rootEpic);


### PR DESCRIPTION
## Description
`ZOOM_TO_EXTENT` action doesn't work if map reducer is assigned via Plugin.
This is because of missing `state.size` in the state of map [reducers](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/reducers/map.js#L99).
You will find instead `state.present.size`

## Issues
 -Fix #3537

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3537

**What is the new behavior?**
Zoom to layer works

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
