### PR TITLE
Fix #3530. Fixed layer properties in dashboard

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/nodeEditor-test.jsx
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/nodeEditor-test.jsx
@@ -51,5 +51,22 @@ describe('nodeEditor enhancer', () => {
             map={{ groups: [{ id: 'GGG' }], layers: [{ id: "LAYER", group: "GGG", options: {} }] }}/>, document.getElementById("container"));
         expect(spyonChange).toHaveBeenCalled();
     });
+    it('nodeEditor onUpdateParams callback', () => {
+        const Sink = nodeEditor(createSink(props => {
+            expect(props.onUpdateParams).toExist();
+            props.onUpdateParams({something: "newValue"}, true);
+
+        }));
+        const actions = {
+            onChange: () => { }
+        };
+        const spyonChange = expect.spyOn(actions, 'onChange');
+        ReactDOM.render(<Sink
+            settings={{nodeType: "layer", props: {oldKey: "oldValue"}}}
+            onChange={actions.onChange}
+            editNode={"LAYER"}
+            map={{ groups: [{ id: 'GROUP' }], layers: [{ id: "LAYER", group: "GROUP", options: {} }] }} />, document.getElementById("container"));
+        expect(spyonChange).toHaveBeenCalledWith("map.layers[0].something", "newValue");
+    });
 
 });

--- a/web/client/components/widgets/builder/wizard/map/enhancers/nodeEditor.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/nodeEditor.js
@@ -80,17 +80,30 @@ module.exports = compose(
         groups: get(splitMapAndLayers(map), 'layers.groups')
     })),
     // adapter for handlers
-    handleNodePropertyChanges,
-    withHandlers({
-        onUpdateNode: ({changeLayerProperty = () => {}, changeGroupProperty = () => {}, editNode}) => (node, type, newProps) => {
-            if (type === "layers") {
-                Object.keys(newProps).map(k => changeLayerProperty(editNode, k, newProps[k]));
+    compose(
+        handleNodePropertyChanges,
+        withHandlers({
+            onUpdateNode: ({changeLayerProperty = () => {}, changeGroupProperty = () => {}, editNode}) => (node, type, newProps) => {
+                if (type === "layers") {
+                    Object.keys(newProps).map(k => changeLayerProperty(editNode, k, newProps[k]));
+                }
+                if (type === "groups") {
+                    Object.keys(newProps).map(k => changeGroupProperty(editNode, k, newProps[k]));
+                }
             }
-            if (type === "groups") {
-                Object.keys(newProps).map(k => changeGroupProperty(editNode, k, newProps[k]));
+        }),
+        withHandlers({
+            onUpdateParams: ({ settings = {}, onUpdateNode = () => { } }) => (newParams, doUpdate = true) => {
+                if (doUpdate) {
+                    onUpdateNode(
+                        settings.node,
+                        settings.nodeType,
+                        { ...settings.props, ...newParams }
+                    );
+                }
             }
-        }
-    }),
+        })
+    ),
     // manage local changes
     settingsLifecycle,
     // manage tabs of node editor


### PR DESCRIPTION
## Description
This PR add a proper adapter for node editing, needed due to changes applied for StyleEditor.

## Issues
 - Fix #3530

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
See #3530 

**What is the new behavior?**
The layer properties now are working also in dashboard.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
`onUpdateParams` was calling `onUpdateNode` on each tab of `TOCItemSettings` in the original implementatiom. This method call chain has been moved to the `layers` epic. 

Anyway the `NodeEditor` component uses the same tabs and now `onUpdateNode` was not triggered anymore because of the missing implementation of `onUpdateParams` 
This fix adds to the `nodeEditor` enhancer the `onUpdateParams` implementation to call `onUpdateNode`.
