### PR TITLE
Fixes #3554: external init of StandardApp

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -101,6 +101,7 @@
           "framework": [
             "web/client/api/SLDService.js",
             "web/client/components/index.jsdoc",
+            "web/client/components/app/StandardApp.jsx",
             "web/client/components/buttons/FullScreenButton.jsx",
             "web/client/components/buttons/GlobeViewSwitcherButton.jsx",
             "web/client/components/buttons/GoFullButton.jsx",

--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -27,6 +27,22 @@ const urlQuery = url.parse(window.location.href, true).query;
 
 require('./appPolyfill');
 
+/**
+ * Standard MapStore2 application component
+ *
+ * @name  StandardApp
+ * @memberof components.app
+ * @prop {function} appStore store creator function
+ * @prop {object} pluginsDef plugins definition object (e.g. as loaded from plugins.js)
+ * @prop {object} storeOpts options for the store
+ * @prop {array} initialActions list of actions to be dispatched on startup
+ * @prop {function/object} appComponent root component for the application
+ * @prop {bool} printingEnabled initializes printing environment based on mapfish-print
+ * @prop {function} onStoreInit optional callback called just after store creation
+ * @prop {function} onInit optional callback called before first rendering, can delay first rendering
+ * to do custom initialization (e.g. force SSO login)
+ * @prop {string} mode current application mode (e.g. desktop/mobile) drives plugins loaded from localConfig
+ */
 class StandardApp extends React.Component {
     static propTypes = {
         appStore: PropTypes.func,
@@ -36,6 +52,7 @@ class StandardApp extends React.Component {
         appComponent: PropTypes.func,
         printingEnabled: PropTypes.bool,
         onStoreInit: PropTypes.func,
+        onInit: PropTypes.func,
         mode: PropTypes.string
     };
 
@@ -49,7 +66,7 @@ class StandardApp extends React.Component {
     };
 
     state = {
-        store: null
+        initialized: false
     };
 
     addProjDefinitions(config) {
@@ -88,9 +105,6 @@ class StandardApp extends React.Component {
             });
             this.store = this.props.appStore(this.props.pluginsDef.plugins, opts);
             this.props.onStoreInit(this.store);
-            this.setState({
-                store: this.store
-            });
 
             if (!opts.persist) {
                 onInit(config);
@@ -103,24 +117,35 @@ class StandardApp extends React.Component {
         const {plugins, requires} = this.props.pluginsDef;
         const {pluginsDef, appStore, initialActions, appComponent, mode, ...other} = this.props;
         const App = this.props.appComponent;
-        return this.state.store ?
-            <Provider store={this.state.store}>
+        return this.state.initialized ?
+            <Provider store={this.store}>
                 <App {...other} plugins={assign(PluginsUtils.getPlugins(plugins), {requires})}/>
             </Provider>
-         : null;
+            : (<span><div className="_ms2_init_spinner _ms2_init_center"><div></div></div>
+                <div className="_ms2_init_text _ms2_init_center">Loading MapStore</div></span>);
     }
-    init = (config) => {
-        this.store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
-        this.store.dispatch(localConfigLoaded(config));
-        this.addProjDefinitions(config);
-        const locale = LocaleUtils.getUserLocale();
-        this.store.dispatch(loadLocale(null, locale));
+    afterInit = () => {
         if (this.props.printingEnabled) {
             this.store.dispatch(loadPrintCapabilities(ConfigUtils.getConfigProp('printUrl')));
         }
         this.props.initialActions.forEach((action) => {
             this.store.dispatch(action());
         });
+        this.setState({
+            initialized: true
+        });
+    };
+    init = (config) => {
+        this.store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
+        this.store.dispatch(localConfigLoaded(config));
+        this.addProjDefinitions(config);
+        const locale = LocaleUtils.getUserLocale();
+        this.store.dispatch(loadLocale(null, locale));
+        if (this.props.onInit) {
+            this.props.onInit(this.store, this.afterInit.bind(this, [config]), config);
+        } else {
+            this.afterInit(config);
+        }
     };
     /**
      * It returns an object of the same structure of the initialState but replacing strings like "{someExpression}" with the result of the expression between brackets.

--- a/web/client/components/app/__tests__/StandardApp-test.jsx
+++ b/web/client/components/app/__tests__/StandardApp-test.jsx
@@ -53,6 +53,18 @@ describe('StandardApp', () => {
         expect(app).toExist();
     });
 
+    it('creates a default app with onInit', (done) => {
+        const init = {
+            onInit: () => { }
+        };
+        const spy = expect.spyOn(init, 'onInit');
+        ReactDOM.render(<StandardApp onInit={init.onInit}/>, document.getElementById("container"));
+        setTimeout(() => {
+            expect(spy).toHaveBeenCalled();
+            done();
+        }, 100);
+    });
+
     it('creates a default app with the given store creator', (done) => {
         let dispatched = 0;
         const store = () => ({


### PR DESCRIPTION
## Description
We want to be able to delegate app initialization so that custom applications can drive the initialization phase (e.g. force a login before application startup).

## Issues
 - Fix #3554

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: new configuration option


**What is the current behavior?** (You can also link to an open issue here)
We cannot delegate app initialization so that custom applications can drive the initialization phase (e.g. force a login before application startup).

**What is the new behavior?**
We can delegate app initialization so that custom applications can drive the initialization phase (e.g. force a login before application startup).

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
