### PR TITLE
Fix #3138. Avoid purgeMapInfoResults to refresh layout (2019.01.xx)

### DIFF
--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -10,23 +10,23 @@ const expect = require('expect');
 
 const configureMockStore = require('redux-mock-store').default;
 const { createEpicMiddleware, combineEpics } = require('redux-observable');
-const {ADD_LAYER, UPDATE_NODE, CHANGE_LAYER_PROPERTIES} = require('../../actions/layers');
-const {CHANGE_DRAWING_STATUS, geometryChanged} = require('../../actions/draw');
-const {HIDE_MAPINFO_MARKER, PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
-const {configureMap} = require('../../actions/config');
-const {editAnnotation, confirmRemoveAnnotation, saveAnnotation, cancelEditAnnotation, setStyle, highlight, cleanHighlight,
-    toggleAdd, UPDATE_ANNOTATION_GEOMETRY} = require('../../actions/annotations');
+const { ADD_LAYER, UPDATE_NODE, CHANGE_LAYER_PROPERTIES } = require('../../actions/layers');
+const { CHANGE_DRAWING_STATUS, geometryChanged } = require('../../actions/draw');
+const { HIDE_MAPINFO_MARKER, PURGE_MAPINFO_RESULTS, CLOSE_IDENTIFY } = require('../../actions/mapInfo');
+const { configureMap } = require('../../actions/config');
+const { editAnnotation, confirmRemoveAnnotation, saveAnnotation, cancelEditAnnotation, setStyle, highlight, cleanHighlight,
+    toggleAdd, UPDATE_ANNOTATION_GEOMETRY } = require('../../actions/annotations');
 
-const {addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic,
+const { addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic,
     cancelEditAnnotationEpic, startDrawMarkerEpic, endDrawMarkerEpic, setStyleEpic, restoreStyleEpic, highlighAnnotationEpic,
-    cleanHighlightAnnotationEpic} = require('../annotations')({});
+    cleanHighlightAnnotationEpic } = require('../annotations')({});
 const rootEpic = combineEpics(addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic,
     setStyleEpic, cancelEditAnnotationEpic, startDrawMarkerEpic, endDrawMarkerEpic, restoreStyleEpic, highlighAnnotationEpic,
     cleanHighlightAnnotationEpic);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
 
-const {testEpic, addTimeoutEpic, TEST_TIMEOUT} = require('./epicTestUtils');
+const { testEpic, addTimeoutEpic, TEST_TIMEOUT } = require('./epicTestUtils');
 
 describe('annotations Epics', () => {
     let store;
@@ -111,10 +111,12 @@ describe('annotations Epics', () => {
     it('remove annotation', (done) => {
         store.subscribe(() => {
             const actions = store.getActions();
-            if (actions.length >= 8) {
+            if (actions.length > 10) {
                 expect(actions[5].type).toBe(UPDATE_NODE);
                 expect(actions[6].type).toBe(HIDE_MAPINFO_MARKER);
                 expect(actions[7].type).toBe(PURGE_MAPINFO_RESULTS);
+                // ensure it triggers identify
+                expect(actions.filter(({type}) => type === CLOSE_IDENTIFY).length).toBe(1);
                 done();
             }
         });

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -48,7 +48,7 @@ const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 const {RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl} = require('../../actions/controls');
 const {ZOOM_TO_EXTENT} = require('../../actions/map');
-const {PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
+const { CLOSE_IDENTIFY } = require('../../actions/mapInfo');
 const {toggleSyncWms, QUERY, querySearchResponse} = require('../../actions/wfsquery');
 const {CHANGE_LAYER_PROPERTIES} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
@@ -71,7 +71,7 @@ const {
     onCloseFeatureGridConfirmed,
     onFeatureGridZoomAll,
     resetControlsOnEnterInEditMode,
-    closeIdentifyEpic,
+    closeIdentifyWhenOpenFeatureGrid,
     startSyncWmsFilter,
     stopSyncWmsFilter,
     handleDrawFeature,
@@ -1035,13 +1035,13 @@ describe('featuregrid Epics', () => {
         }, {});
     });
 
-    it('test closeIdentifyEpic', (done) => {
-        testEpic(closeIdentifyEpic, 1, openFeatureGrid(), actions => {
+    it('test closeIdentifyWhenOpenFeatureGrid', (done) => {
+        testEpic(closeIdentifyWhenOpenFeatureGrid, 1, openFeatureGrid(), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
-                    case PURGE_MAPINFO_RESULTS:
-                        expect(action.type).toBe(PURGE_MAPINFO_RESULTS);
+                    case CLOSE_IDENTIFY:
+                        expect(action.type).toBe(CLOSE_IDENTIFY);
                         break;
                     default:
                         expect(true).toBe(false);

--- a/web/client/epics/__tests__/maplayout-test.js
+++ b/web/client/epics/__tests__/maplayout-test.js
@@ -10,10 +10,10 @@ const expect = require('expect');
 
 const {toggleControl} = require('../../actions/controls');
 const {UPDATE_MAP_LAYOUT} = require('../../actions/maplayout');
-const {closeIdentify} = require('../../actions/mapInfo');
+const {closeIdentify, purgeMapInfoResults} = require('../../actions/mapInfo');
 
 const {updateMapLayoutEpic} = require('../maplayout');
-const {testEpic} = require('./epicTestUtils');
+const {testEpic, addTimeoutEpic, TEST_TIMEOUT} = require('./epicTestUtils');
 
 describe('map layout epics', () => {
     it('tests layout', (done) => {
@@ -70,5 +70,22 @@ describe('map layout epics', () => {
         };
         const state = {};
         testEpic(updateMapLayoutEpic, 1, closeIdentify(), epicResult, state);
+    });
+    // avoid glitches with mouse click and widgets. See #3138
+    it('purge map info should not trigger layout update', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(1);
+                actions.map((action) => {
+                    expect(action.type).toBe(TEST_TIMEOUT);
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+        const state = {};
+        testEpic(addTimeoutEpic(updateMapLayoutEpic, 10), 1, purgeMapInfoResults(), epicResult, state);
+
     });
 });

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -10,7 +10,7 @@ const Rx = require('rxjs');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
 const {TOGGLE_CONTROL, toggleControl} = require('../actions/controls');
 const {addLayer, updateNode, changeLayerProperties, removeLayer} = require('../actions/layers');
-const {hideMapinfoMarker, purgeMapInfoResults} = require('../actions/mapInfo');
+const { hideMapinfoMarker, purgeMapInfoResults, closeIdentify} = require('../actions/mapInfo');
 
 const {updateAnnotationGeometry, setStyle, toggleStyle, cleanHighlight, toggleAdd,
     CONFIRM_REMOVE_ANNOTATION, SAVE_ANNOTATION, EDIT_ANNOTATION, CANCEL_EDIT_ANNOTATION,
@@ -118,7 +118,9 @@ module.exports = (viewer) => ({
                     features: newFeatures
                 }),
                 hideMapinfoMarker(),
-                purgeMapInfoResults()
+                // TODO: not sure if necessary to purge also results. closeIdentify may purge automatically if annotations are disabled
+                purgeMapInfoResults(),
+                closeIdentify()
             ].concat(newFeatures.length === 0 ? [removeLayer('annotations')] : []));
         }),
     saveAnnotationEpic: (action$, store) =>

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -28,7 +28,7 @@ const {reset, QUERY_FORM_SEARCH, loadFilter} = require('../actions/queryform');
 const {zoomToExtent} = require('../actions/map');
 
 const {BROWSE_DATA, changeLayerProperties, refreshLayerVersion} = require('../actions/layers');
-const {purgeMapInfoResults} = require('../actions/mapInfo');
+const { closeIdentify } = require('../actions/mapInfo');
 const {getCapabilities, parseLayerCapabilities} = require('../api/WMS');
 
 const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURES, featureSaving, changePage,
@@ -642,10 +642,10 @@ module.exports = {
     resetControlsOnEnterInEditMode: (action$) =>
         action$.ofType(TOGGLE_MODE)
         .filter(a => a.mode === MODES.EDIT).map(() => resetControls(["query"])),
-    closeIdentifyEpic: (action$) =>
+    closeIdentifyWhenOpenFeatureGrid: (action$) =>
         action$.ofType(OPEN_FEATURE_GRID)
         .switchMap(() => {
-            return Rx.Observable.of(purgeMapInfoResults());
+            return Rx.Observable.of(closeIdentify());
         }),
     /**
      * start sync filter with wms layer

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -12,7 +12,6 @@ const {MAP_CONFIG_LOADED} = require('../actions/config');
 const {SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID} = require('../actions/featuregrid');
 const {CLOSE_IDENTIFY, ERROR_FEATURE_INFO, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO} = require('../actions/mapInfo');
 const {SHOW_SETTINGS, HIDE_SETTINGS} = require('../actions/layers');
-const {PURGE_MAPINFO_RESULTS} = require('../actions/mapInfo');
 const {mapInfoRequestsSelector} = require('../selectors/mapinfo');
 
 /**
@@ -25,15 +24,15 @@ const {head, get} = require('lodash');
 const {isFeatureGridOpen, getDockSize} = require('../selectors/featuregrid');
 
 /**
- * Gets `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `PURGE_MAPINFO_RESULTS`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `CLOSE_IDENTIFY`, `LOAD_FEATURE_INFO`, `TOGGLE_MAPINFO_STATE`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY` events.
+ * Capture that cause layout change to update the proper object.
  * Configures a map layout based on state of panels.
- * @param {external:Observable} action$ manages `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `PURGE_MAPINFO_RESULTS`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `CLOSE_IDENTIFY`, `LOAD_FEATURE_INFO`, `TOGGLE_MAPINFO_STATE`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY`.
+ * @param {external:Observable} action$ manages `MAP_CONFIG_LOADED`, `SIZE_CHANGE`, `CLOSE_FEATURE_GRID`, `OPEN_FEATURE_GRID`, `CLOSE_IDENTIFY`, `LOAD_FEATURE_INFO`, `TOGGLE_MAPINFO_STATE`, `TOGGLE_CONTROL`, `SET_CONTROL_PROPERTY`.
  * @memberof epics.mapLayout
  * @return {external:Observable} emitting {@link #actions.map.updateMapLayout} action
  */
 
 const updateMapLayoutEpic = (action$, store) =>
-    action$.ofType(MAP_CONFIG_LOADED, SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID, CLOSE_IDENTIFY, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SHOW_SETTINGS, HIDE_SETTINGS, ERROR_FEATURE_INFO, PURGE_MAPINFO_RESULTS)
+    action$.ofType(MAP_CONFIG_LOADED, SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID, CLOSE_IDENTIFY, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SHOW_SETTINGS, HIDE_SETTINGS, ERROR_FEATURE_INFO)
         .switchMap(() => {
 
             const state = store.getState();


### PR DESCRIPTION
## Description
This pull request solves issue #3138. Probably the issue was solved, that found some error and reverted, but the issue, for some reason, remained closed.

The problem is that, when the action PURGE_MAPINFO_RESULT is performed, the mapLayout is updated, triggering the resize. Instead of this, this should happen only on FEATUREINFO_CLOSE.

PURGE_MAPINFO_RESULT is triggered also by feature grid and annotation tools to colose the feature info tool. So I fixed them to trigger also closeIdentify action.

So 

**Please test annotations and feature grid open/close events to identify possible problems that this refactor caused** 

## Issues
 - Fix #3138

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
See #3138. 

**What is the new behavior?**
Glitch do not happen anymore. The application triggers also closeIdentify also on featuregrid open or annotation remove..

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

