### PR TITLE
Fix #3548 add coordinate editor for GFI panel

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -29,7 +29,9 @@ var {
     hideMapinfoRevGeocode,
     getVectorInfo,
     toggleMapInfoState,
-    updateCenterToMarker
+    updateCenterToMarker,
+    TOGGLE_SHOW_COORD_EDITOR, toggleShowCoordinateEditor,
+    CHANGE_FORMAT, changeFormat
 } = require('../mapInfo');
 
 describe('Test correctness of the map actions', () => {
@@ -205,5 +207,17 @@ describe('Test correctness of the map actions', () => {
         const retval = updateCenterToMarker('enabled');
         expect(retval.type).toBe(UPDATE_CENTER_TO_MARKER);
         expect(retval.status).toBe('enabled');
+    });
+    it('toggleShowCoordinateEditor', () => {
+        const showCoordinateEditor = true;
+        const retval = toggleShowCoordinateEditor(showCoordinateEditor);
+        expect(retval.type).toBe(TOGGLE_SHOW_COORD_EDITOR);
+        expect(retval.showCoordinateEditor).toBe(showCoordinateEditor);
+    });
+    it('changeFormat', () => {
+        const format = "decimal";
+        const retval = changeFormat(format);
+        expect(retval.type).toBe(CHANGE_FORMAT);
+        expect(retval.format).toBe(format);
     });
 });

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -29,6 +29,8 @@ const FEATURE_INFO_CLICK = 'FEATURE_INFO_CLICK';
 const TOGGLE_MAPINFO_STATE = 'TOGGLE_MAPINFO_STATE';
 const UPDATE_CENTER_TO_MARKER = 'UPDATE_CENTER_TO_MARKER';
 const CLOSE_IDENTIFY = 'IDENTIFY:CLOSE_IDENTIFY';
+const CHANGE_FORMAT = 'IDENTIFY:CHANGE_FORMAT';
+const TOGGLE_SHOW_COORD_EDITOR = 'IDENTIFY:TOGGLE_SHOW_COORD_EDITOR';
 
 /**
  * Private
@@ -221,6 +223,24 @@ const closeIdentify = () => ({
     type: CLOSE_IDENTIFY
 });
 
+/**
+ * change format of coordinate editor
+ * @prop {string} format
+*/
+const changeFormat = (format) => ({
+    type: CHANGE_FORMAT,
+    format
+});
+
+/**
+ * action for toggling the state of the showCoordinateEditor flag
+ * @prop {boolean} showCoordinateEditor
+*/
+const toggleShowCoordinateEditor = (showCoordinateEditor) => ({
+    type: TOGGLE_SHOW_COORD_EDITOR,
+    showCoordinateEditor
+});
+
 module.exports = {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
@@ -240,6 +260,8 @@ module.exports = {
     TOGGLE_MAPINFO_STATE,
     UPDATE_CENTER_TO_MARKER,
     CLOSE_IDENTIFY,
+    TOGGLE_SHOW_COORD_EDITOR, toggleShowCoordinateEditor,
+    CHANGE_FORMAT, changeFormat,
     closeIdentify,
     getFeatureInfo,
     changeMapInfoState,

--- a/web/client/components/data/identify/GeocodeViewer.jsx
+++ b/web/client/components/data/identify/GeocodeViewer.jsx
@@ -23,7 +23,7 @@ const {Glyphicon, Row, Col} = require('react-bootstrap');
  * @prop {node} revGeocodeDisplayName text/info displayed on modal
  */
 
-module.exports = ({latlng, enableRevGeocode, hideRevGeocode = () => {}, showModalReverse, revGeocodeDisplayName}) => {
+module.exports = ({latlng, enableRevGeocode, hideRevGeocode = () => {}, showModalReverse, revGeocodeDisplayName, showCoordinateEditor = false}) => {
 
     let lngCorrected = null;
     if (latlng) {
@@ -35,10 +35,11 @@ module.exports = ({latlng, enableRevGeocode, hideRevGeocode = () => {}, showModa
     }
 
     return enableRevGeocode && latlng && lngCorrected ? (
-        <Row key="ms-geocode-coords" className="ms-geoscode-viewer text-center">
-            <Col xs={12}>
+        <Row key="ms-geocode-coords" className="ms-geoscode-viewer text-center" style={{display: showCoordinateEditor ? "none" : "block"}}>
+            {!showCoordinateEditor &&
+            (<Col xs={12}>
                 <div className="ms-geocode-coords">{latlng ? 'Lat: ' + (Math.round(latlng.lat * 100000) / 100000) + '- Long: ' + lngCorrected : null}</div>
-            </Col>
+            </Col>)}
             <Portal>
                 <ResizableModal
                     fade

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -17,7 +17,7 @@ const ResizableModal = require('../../misc/ResizableModal');
 const Portal = require('../../misc/Portal');
 
 /**
- * Component for rendering Identify Container inside a Dockable contanier
+ * Component for rendering Identify Container inside a Dockable container
  * @memberof components.data.identify
  * @name IdentifyContainer
  * @class
@@ -26,6 +26,8 @@ const Portal = require('../../misc/Portal');
  * @prop {object} viewerOptions options to use with the viewer, eg { header: MyHeader, container: MyContainer }
  * @prop {function} getButtons must return an array of object representing the toolbar buttons, eg (props) => [{ glyph: 'info-sign', tooltip: 'hello!'}]
  */
+
+const CoordinatesEditor = require('../../../plugins/identify/CoordinatesEditor');
 
 module.exports = props => {
     const {
@@ -51,7 +53,13 @@ module.exports = props => {
         setIndex,
         warning,
         clearWarning,
-        zIndex
+        zIndex,
+        // coord editor props
+        enabledCoordEditorButton,
+        showCoordinateEditor,
+        onChangeClickPoint,
+        onChangeFormat,
+        formatCoord
     } = props;
 
     const latlng = point && point.latlng || null;
@@ -71,7 +79,7 @@ module.exports = props => {
     const buttons = getButtons({...props, lngCorrected, validResponses, latlng});
     const missingResponses = requests.length - responses.length;
     const revGeocodeDisplayName = reverseGeocodeData.error ? <Message msgId="identifyRevGeocodeError"/> : reverseGeocodeData.display_name;
-
+    const CoordEditor = enabledCoordEditorButton && showCoordinateEditor ? CoordinatesEditor : null;
     return (
         <div>
             <DockablePanel
@@ -88,7 +96,15 @@ module.exports = props => {
                 style={dockStyle}
                 showFullscreen={showFullscreen}
                 zIndex={zIndex}
-                header={[
+                header={[ CoordEditor &&
+                    <CoordEditor
+                        isDraggable={false}
+                        removeVisible={false}
+                        formatCoord={formatCoord}
+                        coordinate={point.latlng ? {lat: point.latlng.lat, lon: lngCorrected } : {lat: "", lon: ""}}
+                        onChange={onChangeClickPoint}
+                        onChangeFormat={onChangeFormat}
+                    /> || null,
                     <GeocodeViewer latlng={latlng} revGeocodeDisplayName={revGeocodeDisplayName} {...props}/>,
                     buttons.length > 0 ? (
                     <Row className="text-center">

--- a/web/client/components/data/identify/__tests__/GeocodeViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/GeocodeViewer-test.jsx
@@ -42,10 +42,11 @@ describe('GeocodeViewer', () => {
         expect(geocodeViewer.length).toBe(0);
     });
 
-    it('creates the GeocodeViewer enable', () => {
+    it('creates the GeocodeViewer enable, showCoordinateEditor=false', () => {
         ReactDOM.render(
             <GeocodeViewer
                 enableRevGeocode
+                showCoordinateEditor={false}
                 latlng={{lat: 40, lng: 10}}
                 lngCorrected={10}/>,
             document.getElementById("container")
@@ -55,6 +56,21 @@ describe('GeocodeViewer', () => {
         const coords = document.getElementsByClassName('ms-geocode-coords')[0];
         expect(coords.innerHTML.indexOf('Lat:') !== -1).toBe(true);
         expect(coords.innerHTML.indexOf('Long:') !== -1).toBe(true);
+    });
+
+    it('creates the GeocodeViewer enable, showCoordinateEditor=true', () => {
+        ReactDOM.render(
+            <GeocodeViewer
+                enableRevGeocode
+                showCoordinateEditor
+                latlng={{lat: 40, lng: 10}}
+                lngCorrected={10}/>,
+            document.getElementById("container")
+        );
+        const geocodeViewer = document.getElementsByClassName('ms-geoscode-viewer');
+        expect(geocodeViewer.length).toBe(1);
+        const coords = document.getElementsByClassName('ms-geocode-coords')[0];
+        expect(coords).toNotExist();
     });
 
     it('creates the GeocodeViewer hide', () => {

--- a/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
+++ b/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
@@ -455,4 +455,48 @@ describe("test identify enhancers", () => {
         expect(spyHideMarker).toHaveBeenCalled();
     });
 
+    it("test identifyLifecycle onChangeFormat", () => {
+        const testHandlers = {
+            onChangeFormat: () => {}
+        };
+        const spyChangeFormat = expect.spyOn(testHandlers, 'onChangeFormat');
+        const Component = identifyLifecycle(({onChangeFormat = () => {}}) => <div id="test-component" onClick={() => onChangeFormat("format")}></div>);
+        ReactDOM.render(
+            <Component
+                enabled
+                showCoordinateEditor
+                enabledCoordEditorButton
+                formatCoord="decimal"
+                responses={[{}]}
+                onChangeFormat={testHandlers.onChangeFormat}
+            />,
+            document.getElementById("container")
+        );
+        const testComponent = document.getElementById('test-component');
+        TestUtils.Simulate.click(testComponent);
+        expect(spyChangeFormat).toHaveBeenCalled();
+    });
+    it("test identifyLifecycle onChangeClickPoint", () => {
+        const testHandlers = {
+            onChangeClickPoint: () => {}
+        };
+        const spyOnChangeClickPoint = expect.spyOn(testHandlers, 'onChangeClickPoint');
+        const Component = identifyLifecycle(({onChangeClickPoint = () => {}}) => <div id="test-component" onClick={() => onChangeClickPoint("lat", "4")}></div>);
+        ReactDOM.render(
+            <Component
+                enabled
+                showCoordinateEditor
+                enabledCoordEditorButton
+                formatCoord="decimal"
+                responses={[{}]}
+                onChangeClickPoint={testHandlers.onChangeClickPoint}
+            />,
+            document.getElementById("container")
+        );
+        const testComponent = document.getElementById('test-component');
+        TestUtils.Simulate.click(testComponent);
+        expect(spyOnChangeClickPoint).toHaveBeenCalled();
+    });
+
+
 });

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -8,7 +8,8 @@
 
 const {lifecycle, withHandlers, branch, withState, compose, defaultProps} = require('recompose');
 const MapInfoUtils = require('../../../../utils/MapInfoUtils');
-const {isEqual, isArray} = require('lodash');
+const {set} = require('../../../../utils/ImmutableUtils');
+const {isEqual, isArray, isNil} = require('lodash');
 
 /**
  * Enhancer to enable set index only if Component has not header in viewerOptions props
@@ -26,6 +27,7 @@ const switchControlledIdentify = branch(
  * Enhancer to enable set index only if Component has header
  * - needsRefresh: check if current selected point if different of next point, if so return true
  * - onClose: delete results, close identify panel and hide the marker on map
+ * - onChange: changed the coords OF GFI coord editor from the UI
  * @memberof enhancers.identifyHandlers
  * @class
  */
@@ -34,6 +36,7 @@ const identifyHandlers = withHandlers({
         if (newProps.enabled && newProps.point && newProps.point.pixel) {
             if (!props.point || !props.point.pixel ||
                 props.point.pixel.x !== newProps.point.pixel.x ||
+                props.point.latlng !== newProps.point.latlng ||
                 props.point.pixel.y !== newProps.point.pixel.y ) {
                 return true;
             }
@@ -47,6 +50,19 @@ const identifyHandlers = withHandlers({
         hideMarker();
         purgeResults();
         closeIdentify();
+    },
+    onChangeClickPoint: ({
+        onChangeClickPoint = () => {},
+        point
+    }) => (coord, val) => {
+        let changedCoord = coord === "lat" ? "lat" : "lng";
+        let newPoint = set(`latlng.${changedCoord}`, !isNil(val) ? parseFloat(val) : 0, point);
+        onChangeClickPoint(newPoint);
+    },
+    onChangeFormat: ({
+        onChangeFormat = () => {}
+    }) => (format) => {
+        onChangeFormat(format);
     }
 });
 

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -1,0 +1,159 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const {Row, Col, Glyphicon} = require('react-bootstrap');
+const Toolbar = require('../toolbar/Toolbar');
+const draggableComponent = require('../enhancers/draggableComponent');
+const CoordinateEntry = require('./CoordinateEntry');
+const Message = require('../../I18N/Message');
+const DropdownToolbarOptions = require('../toolbar/DropdownToolbarOptions');
+
+/**
+
+*/
+class CoordinatesRow extends React.Component {
+
+    static propTypes = {
+        idx: PropTypes.number,
+        component: PropTypes.object,
+        onRemove: PropTypes.func,
+        onChange: PropTypes.func,
+        onChangeFormat: PropTypes.func,
+        onMouseEnter: PropTypes.func,
+        format: PropTypes.string,
+        type: PropTypes.string,
+        onMouseLeave: PropTypes.func,
+        connectDragSource: PropTypes.func,
+        enhanced: PropTypes.bool,
+        aeronauticalOptions: PropTypes.object,
+        customClassName: PropTypes.string,
+        isDraggable: PropTypes.bool,
+        showLabels: PropTypes.bool,
+        removeVisible: PropTypes.bool,
+        formatVisible: PropTypes.bool,
+        removeEnabled: PropTypes.bool
+    };
+    defaultProps = {
+        enhanced: true,
+        showLabels: false,
+        formatVisible: false
+    }
+
+    getColsSize = () => {
+        let colsSize = [
+            this.props.isDraggable && !(this.props.removeVisible || this.props.formatVisible) ? 2 : (this.props.removeVisible || this.props.formatVisible ? 0 : 1),
+            this.props.isDraggable || this.props.removeVisible || this.props.formatVisible ? 5 : 6,
+            this.props.isDraggable || this.props.removeVisible || this.props.formatVisible ? 5 : 6,
+            (this.props.removeVisible || this.props.formatVisible) && !this.props.isDraggable ? 2 : (this.props.isDraggable ? 0 : 1)
+        ];
+        return colsSize;
+    }
+
+    render() {
+        const rowStyle = {marginLeft: -5, marginRight: -5};
+        const colsSize = this.getColsSize();
+        return (
+            <Row className={`coordinateRow ${this.props.customClassName}`} style={!this.props.customClassName ? rowStyle : {}} onMouseEnter={() => {
+                if (this.props.onMouseEnter) {
+                    this.props.onMouseEnter(this.props.component);
+                }
+            }} onMouseLeave={this.props.onMouseLeave}>
+                <Col xs={colsSize[0]}>
+                    {this.props.isDraggable && this.props.connectDragSource(<div
+                        className="square-button-md no-border btn btn-default"
+                        style={{display: "flex" /*workaround for firefox*/}}
+                        >
+                        <Glyphicon
+                        glyph="menu-hamburger"
+                        disabled={!this.props.isDraggable}
+                        style={{pointerEvents: !this.props.isDraggable ? "none" : "auto"}}
+                    /></div>)}
+                </Col>
+                <Col xs={colsSize[1]}>
+                    {this.props.showLabels && <span><Message msgId="latitude"/></span>}
+                    <CoordinateEntry
+                        format={this.props.format}
+                        aeronauticalOptions={this.props.aeronauticalOptions}
+                        coordinate="lat"
+                        idx={this.props.idx}
+                        value={this.props.component.lat}
+                        onChange={(dd) => this.props.onChange(this.props.idx, "lat", dd)}
+                        constraints={{
+                            decimal: {
+                                lat: {
+                                    min: -90,
+                                    max: 90
+                                },
+                                lon: {
+                                    min: -180,
+                                    max: 180
+                                }
+                            }
+                        }}
+                    />
+                </Col>
+                <Col xs={colsSize[2]}>
+                    {this.props.showLabels && <span><Message msgId="longitude"/></span>}
+                    <CoordinateEntry
+                        format={this.props.format}
+                        aeronauticalOptions={this.props.aeronauticalOptions}
+                        coordinate="lon"
+                        idx={this.props.idx}
+                        value={this.props.component.lon}
+                        onChange={(dd) => this.props.onChange(this.props.idx, "lon", dd)}
+                        constraints={{
+                            decimal: {
+                                lat: {
+                                    min: -90,
+                                    max: 90
+                                },
+                                lon: {
+                                    min: -180,
+                                    max: 180
+                                }
+                            }
+                        }}
+                    />
+                </Col>
+                <Col xs={colsSize[3]}>
+                    <Toolbar
+                        btnGroupProps={{ className: 'pull-right' }}
+                        btnDefaultProps={{ className: 'square-button-md no-border'}}
+                        buttons={
+                        [
+                            {
+                                visible: this.props.removeVisible,
+                                disabled: !this.props.removeEnabled,
+                                glyph: 'trash',
+                                onClick: () => {
+                                    this.props.onRemove(this.props.idx);
+                                }
+                            },
+                            {
+                                buttonConfig: {
+                                    title: <Glyphicon glyph="cog"/>,
+                                    className: "square-button-md no-border",
+                                    pullRight: true
+                                },
+                                menuOptions: [
+                                    {
+                                        active: this.props.format === "decimal",
+                                        onClick: () => { this.props.onChangeFormat("decimal"); },
+                                        text: <Message msgId="search.decimal"/>
+                                    }, {
+                                        active: this.props.format === "aeronautical",
+                                        onClick: () => { this.props.onChangeFormat("aeronautical"); },
+                                        text: <Message msgId="search.aeronautical"/>
+                                    }
+                                ],
+                                visible: this.props.formatVisible,
+                                Element: DropdownToolbarOptions
+                            }
+                        ]
+                    }/>
+                </Col>
+            </Row>
+        );
+    }
+}
+
+module.exports = draggableComponent(CoordinatesRow);

--- a/web/client/components/misc/enhancers/draggableComponent.jsx
+++ b/web/client/components/misc/enhancers/draggableComponent.jsx
@@ -1,0 +1,48 @@
+
+const React = require('react');
+const {compose, branch} = require('recompose');
+const {DragSource: dragSource} = require('react-dnd');
+const {DropTarget: dropTarget} = require('react-dnd');
+
+
+const itemSource = {
+    beginDrag: props => ({...props})
+};
+
+const itemTarget = {
+    drop: (props, monitor) => {
+        const item = monitor.getItem();
+        if (item.sortId !== props.sortId) {
+            props.onSort(props.sortId, item.sortId);
+        }
+    }
+};
+
+const sourceCollect = (connect, monitor) => ({
+    connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
+    isDragging: monitor.isDragging(),
+    draggingItem: monitor.getItem() || null
+});
+
+const targetCollect = (connect, monitor) => ({
+    connectDropTarget: connect.dropTarget(),
+    isOver: monitor.isOver()
+});
+
+module.exports = branch(
+        ({isDraggable} = {}) => isDraggable,
+        compose(
+            dragSource('row', itemSource, sourceCollect),
+            dropTarget('row', itemTarget, targetCollect),
+            Component => ({connectDragSource, connectDragPreview, connectDropTarget, isDragging, isOver, ...props}) => {
+                const pos = props.draggingItem && props.draggingItem.sortId < props.sortId;
+
+                return connectDragPreview(connectDropTarget(
+                    <div className={`ms-dragg ${isDragging ? 'ms-dragging ' : ''}${isOver ? 'ms-over ' : ''} ${pos ? 'ms-above ' : 'ms-below '}`}>
+                        <div>
+                            <Component {...props} connectDragSource={connectDragSource} isDragging={isDragging} isOver={isOver} />
+                            </div>
+                    </div>));
+            })
+        );

--- a/web/client/components/misc/enhancers/draggableContainer.jsx
+++ b/web/client/components/misc/enhancers/draggableContainer.jsx
@@ -1,0 +1,16 @@
+
+const React = require('react');
+const dragDropContext = require('react-dnd').DragDropContext;
+const html5Backend = require('react-dnd-html5-backend');
+const {compose, branch} = require('recompose');
+
+module.exports = compose(
+    dragDropContext(html5Backend),
+    branch(
+        ({isDraggable = true}) => isDraggable,
+        Component => ({onSort, isDraggable, items, ...props}) => {
+            const draggableItems = items.map((item, sortId) => ({...item, onSort, isDraggable, sortId, key: sortId}));
+            return <Component {...{...props, isDraggable}} items={draggableItems}/>;
+        }
+    )
+);

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -15,9 +15,10 @@ const {createSelector} = require('reselect');
 const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
 
-const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState} = require('../actions/mapInfo');
+const {getFeatureInfo, getVectorInfo, showMapinfoMarker, hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, noQueryableLayers, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults, featureInfoClick, changeFormat,
+    toggleShowCoordinateEditor
+} = require('../actions/mapInfo');
 const {changeMousePointer} = require('../actions/map');
-const {changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults} = require('../actions/mapInfo');
 const {currentLocaleSelector} = require('../selectors/locale');
 
 const {compose, defaultProps} = require('recompose');
@@ -46,9 +47,11 @@ const selector = createSelector([
     (state) => state.mapInfo && state.mapInfo.reverseGeocodeData,
     (state) => state.mapInfo && state.mapInfo.warning,
     currentLocaleSelector,
-    state => mapLayoutValuesSelector(state, {height: true})
-], (enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle) => ({
-    enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle
+    state => mapLayoutValuesSelector(state, {height: true}),
+    (state) => state.mapInfo && state.mapInfo.formatCoord,
+    (state) => state.mapInfo && state.mapInfo.showCoordinateEditor
+], (enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle, formatCoord, showCoordinateEditor) => ({
+    enabled, responses, requests, format, map, layers, point, layer, showModalReverse, reverseGeocodeData, warning, currentLocale, dockStyle, formatCoord, showCoordinateEditor
 }));
 // result panel
 
@@ -61,6 +64,7 @@ const DefaultViewer = compose(
 )(require('../components/data/identify/DefaultViewer'));
 
 const identifyDefaultProps = defaultProps({
+    formatCoord: "decimal",
     enabled: false,
     draggable: true,
     collapsible: false,
@@ -84,6 +88,8 @@ const identifyDefaultProps = defaultProps({
     containerProps: {
         continuous: false
     },
+    enabledCoordEditorButton: true,
+    showCoordinateEditor: false,
     showModalReverse: false,
     reverseGeocodeData: {},
     enableRevGeocode: true,
@@ -167,6 +173,9 @@ const IdentifyPlugin = compose(
         localRequest: getVectorInfo,
         purgeResults: purgeMapInfoResults,
         closeIdentify,
+        onChangeClickPoint: featureInfoClick,
+        onToggleShowCoordinateEditor: toggleShowCoordinateEditor,
+        onChangeFormat: changeFormat,
         changeMousePointer,
         showMarker: showMapinfoMarker,
         noQueryableLayers,

--- a/web/client/plugins/identify/CoordinatesEditor.jsx
+++ b/web/client/plugins/identify/CoordinatesEditor.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const React = require('react');
+const CoordinatesRow = require('../../components/misc/coordinateeditors/CoordinatesRow');
+
+const CoordinatesEditor = (props) => (
+    <CoordinatesRow
+        format={props.formatCoord || "decimal"}
+        aeronauticalOptions={{
+            seconds: {
+                decimals: 4,
+                step: 0.0001
+            }
+        }}
+        idx={1}
+        onChange={(id, key, value) => {
+            props.onChange(key, value === null || value === "" ? undefined : value);
+        }}
+        onChangeFormat={(format) => {
+            props.onChangeFormat(format);
+        }}
+        key={"GFI row coord editor"}
+        component={props.coordinate || {}}
+        customClassName="GFI-coord-editor"
+        isDraggable={false}
+        formatVisible
+        showLabels
+        removeVisible={false}
+    />);
+
+module.exports = CoordinatesEditor;

--- a/web/client/plugins/identify/defaultIdentifyButtons.js
+++ b/web/client/plugins/identify/defaultIdentifyButtons.js
@@ -25,6 +25,15 @@ module.exports = props => [
         }
     },
     {
+        glyph: 'search-coords',
+        tooltipId: props.showCoordinateEditor ? 'identifyHideCoordinateEditor' : 'identifyShowCoordinateEditor',
+        visible: props.enabledCoordEditorButton,
+        bsStyle: (props.showCoordinateEditor) ? "success" : "primary",
+        onClick: () => {
+            props.onToggleShowCoordinateEditor(props.showCoordinateEditor);
+        }
+    },
+    {
         glyph: 'arrow-right',
         tooltipId: 'wizard.next',
         visible: !props.viewerOptions.header && props.validResponses.length > 1 && props.index < props.validResponses.length - 1,

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -8,7 +8,7 @@
 
 const expect = require('expect');
 const mapInfo = require('../mapInfo');
-const { featureInfoClick } = require('../../actions/mapInfo');
+const { featureInfoClick, toggleShowCoordinateEditor, changeFormat } = require('../../actions/mapInfo');
 const assign = require('object-assign');
 
 require('babel-polyfill');
@@ -262,5 +262,17 @@ describe('Test the mapInfo reducer', () => {
         expect(state).toExist();
         expect(state.centerToMarker).toBe('enabled');
 
+    });
+    it('toggleShowCoordinateEditor', () => {
+        let state = mapInfo({}, toggleShowCoordinateEditor(true));
+        expect(state).toExist();
+        expect(state.showCoordinateEditor).toBe(false);
+    });
+    it('changeFormat', () => {
+        let state = mapInfo({
+            formatCoord: "aeronautical"
+        }, changeFormat("decimal"));
+        expect(state).toExist();
+        expect(state.formatCoord).toBe("decimal");
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -23,7 +23,9 @@ const {
     CLEAR_WARNING,
     FEATURE_INFO_CLICK,
     TOGGLE_MAPINFO_STATE,
-    UPDATE_CENTER_TO_MARKER
+    UPDATE_CENTER_TO_MARKER,
+    CHANGE_FORMAT,
+    TOGGLE_SHOW_COORD_EDITOR
 } = require('../actions/mapInfo');
 
 const {RESET_CONTROLS} = require('../actions/controls');
@@ -184,6 +186,18 @@ function mapInfo(state = initState, action) {
         return assign({}, state, {
             centerToMarker: action.status
         });
+    }
+    case CHANGE_FORMAT: {
+        return {
+            ...state,
+            formatCoord: action.format
+        };
+    }
+    case TOGGLE_SHOW_COORD_EDITOR: {
+        return {
+            ...state,
+            showCoordinateEditor: !action.showCoordinateEditor
+        };
     }
     default:
         return state;

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -1,91 +1,32 @@
-#mapstore-getfeatureinfo .panel-body {
-	padding: 0;
-}
 
-#mapstore-getfeatureinfo .panel-heading {
-	background-color: @ms2-color-background;
-	color: @ms2-color-text;
-    background-image: none;
-}
-
-.mapstore-mobile-identify {
-    -webkit-overflow-scrolling: touch;
-    background-color: @ms2-color-background;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    max-width: none !important;
-    height: 55%;
-    transition: 0.3s;
-    &.fullscreen {
-        height: 100%;
+.coordinateRow {
+    margin: 8px 0px;
+    border: 1px solid #dddddd;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    input {
+        font-size: 12px;
+        font-family: Menlo, Monaco, Consolas, Courier New, monospace;
     }
-
-    .info-wrap {
-        position: absolute;
-        height: ~"calc(100% - @{square-btn-size})";
-        width: 100%;
+    .col-xs-5, .col-xs-1, .col-xs-2 {
         padding: 0;
-
-        .swipe-header-left-button,
-        .swipe-header-right-button {
-            height: @square-btn-medium-size;
-            width: @square-btn-medium-size;
-            padding: floor((@padding-left-square-md)/1.230769231) (@padding-left-square-md);
-            outline: 0 !important;
-
-            .glyphicon {
-                font-size: @icon-size-md;
-            }
-        }
-
-        .swipe-header-left-button {
-            right: @square-btn-medium-size !important;
-        }
-
-        .swipe-header-right-button {
-            right: 0 !important;
-        }
-
-        .react-swipeable-view-container {
-            .panel-heading {
-                height: @square-btn-medium-size + 10px !important;
-                .panel-title {
-                    & > span {
-                        & > span {
-                            width: ~"calc(100% - @{square-btn-medium-size} * 2 - 10px)";
-                            display: inline-block;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                        }
-                    }
-                }
-            }
-        }
-
-
-        & > div {
-            display: flex;
-            flex-direction: column;
-            position: absolute;
-            width: 100%;
-            height: 100%;
-            padding: 10px;
-            padding-bottom: 0;
-            overflow: hidden;
-            #mapstore-identify-revgeocoder {
-                margin-bottom: 10px;
-                overflow: hidden;
-                & > div {
-                    overflow: hidden;
-                }
-            }
-
-            .mapstore-identify-viewer {
-                flex: 1;
-                overflow: auto;
-            }
-        }
+        float: unset;
+        width: auto;
+        margin: 0 4px;
+    }
+    .col-xs-5 {
+        display: grid;
+        flex: 1;
+    }
+    &.GFI-coord-editor .col-xs-2 {
+        min-width: unset !important;
+    }
+    .form-group {
+        margin: 4px 0;
+    }
+    .pull-right.btn-group {
+        margin-top: 20px;
     }
 }

--- a/web/client/themes/default/ms2-theme.less
+++ b/web/client/themes/default/ms2-theme.less
@@ -13,8 +13,7 @@
 @import "./less/dropdown-menu.less";
 @import "./less/dropzone.less";
 @import "./less/embedded.less";
-// remove after test on new style of get feature info
-// @import "./less/get-feature.less";
+@import "./less/get-feature.less";
 @import "./less/help-badge.less";
 @import "./less/home.less";
 @import "./less/leaflet.less";

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -493,6 +493,8 @@
         "identifyTitle": "Feature Info",
         "identifyNoQueryableLayers": "Keine aktive abrufbare Ebene",
         "identifyRevGeocodeHeader": "Koordinaten",
+        "identifyShowCoordinateEditor": "Koordinateneditor anzeigen",
+        "identifyHideCoordinateEditor": "Koordinateneditor ausblenden",
         "identifyRevGeocodeModalTitle": "Addresse",
         "identifyRevGeocodeSubmitText": "Mehr Informationen",
         "identifyRevGeocodeCloseText": "Schliessen",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -493,6 +493,8 @@
         "identifyTitle": "Feature Info",
         "identifyNoQueryableLayers": "No active queryable layer",
         "identifyRevGeocodeHeader": "Coordinates",
+        "identifyShowCoordinateEditor": "Show coordinate editor",
+        "identifyHideCoordinateEditor": "Hide coordinate editor",
         "identifyRevGeocodeModalTitle": "Address",
         "identifyRevGeocodeSubmitText": "More Info",
         "identifyRevGeocodeCloseText": "Close",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -493,6 +493,8 @@
         "identifyTitle": "Informaciones de las features",
         "identifyNoQueryableLayers": "Noy hay capas a las que poder preguntar",
         "identifyRevGeocodeHeader": "Coordenadas",
+        "identifyShowCoordinateEditor": "Mostrar editor de coordenadas",
+        "identifyHideCoordinateEditor": "Ocultar editor de coordenadas",
         "identifyRevGeocodeModalTitle": "Dirección",
         "identifyRevGeocodeSubmitText": "Más información",
         "identifyRevGeocodeCloseText": "Cerrar",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -494,6 +494,8 @@
         "identifyTitle": "Informations de l'objet",
         "identifyNoQueryableLayers": "Aucune couche active rencontrée",
         "identifyRevGeocodeHeader": "Coordonnées",
+        "identifyShowCoordinateEditor": "Afficher l'éditeur de coordonnées",
+        "identifyHideCoordinateEditor": "Masquer l'éditeur de coordonnées",
         "identifyRevGeocodeModalTitle": "Adresse",
         "identifyRevGeocodeSubmitText": "Plus d'Informations",
         "identifyRevGeocodeCloseText": "Fermer",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -493,6 +493,8 @@
         "identifyTitle": "Informacije o objektu",
         "identifyNoQueryableLayers": "Nema aktivnih slojeva za dohvat informacija",
         "identifyRevGeocodeHeader": "Koordinate",
+        "identifyShowCoordinateEditor": "Show coordinate editor",
+        "identifyHideCoordinateEditor": "Hide coordinate editor",
         "identifyRevGeocodeModalTitle": "Adresa",
         "identifyRevGeocodeSubmitText": "Više informacija",
         "identifyRevGeocodeCloseText": "Zatvori",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -493,6 +493,8 @@
         "identifyTitle": "Informazioni Sulle Feature",
         "identifyNoQueryableLayers": "Nessun livello interrogabile attivo",
         "identifyRevGeocodeHeader": "Coordinate",
+        "identifyShowCoordinateEditor": "Mostra l'editor",
+        "identifyHideCoordinateEditor": "Nascondi l'editor",
         "identifyRevGeocodeModalTitle": "Indirizzo",
         "identifyRevGeocodeSubmitText": "Più informazioni",
         "identifyRevGeocodeCloseText": "Chiudi",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -341,6 +341,8 @@
         "identifyTitle": "Item informatie",
         "identifyNoQueryableLayers": "Geen actieve laag nodig",
         "identifyRevGeocodeHeader": "Coördinaten",
+        "identifyShowCoordinateEditor": "Show coordinate editor",
+        "identifyHideCoordinateEditor": "Hide coordinate editor",
         "identifyRevGeocodeModalTitle": "Adres",
         "identifyRevGeocodeSubmitText": "Meer informatie",
         "identifyRevGeocodeCloseText": "Afsluiten",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -492,6 +492,8 @@
         "identifyTitle": "Informação do elemento",
         "identifyNoQueryableLayers": "No active queryable layer",
         "identifyRevGeocodeHeader": "Coordenadas",
+        "identifyShowCoordinateEditor": "Show coordinate editor",
+        "identifyHideCoordinateEditor": "Hide coordinate editor",
         "identifyRevGeocodeModalTitle": "Endereço",
         "identifyRevGeocodeSubmitText": "Mais informação",
         "identifyRevGeocodeCloseText": "Fechar",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -344,6 +344,8 @@
         "identifyTitle": "特征信息",
         "identifyNoQueryableLayers": "没有有效的可查询层",
         "identifyRevGeocodeHeader": "坐标",
+        "identifyShowCoordinateEditor": "Show coordinate editor",
+        "identifyHideCoordinateEditor": "Hide coordinate editor",
         "identifyRevGeocodeModalTitle": "地址",
         "identifyRevGeocodeSubmitText": "更多信息",
         "identifyRevGeocodeCloseText": "关闭",


### PR DESCRIPTION
## Description
This pr add the coordinate editor in the header of GFI panel.
the flag used to show the button that trigger visibility of coord editor in the toolbar is true by default and is called "enabledCoordEditorButton"
by default the flag used to show the coordinate editor is false by default and is called "showCoordinateEditor"

![image](https://user-images.githubusercontent.com/11991428/53179254-a8fd2c00-35f3-11e9-8dde-134ecef5ab31.png)

## Issues
 - Fix #3548 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
you cannot perform a GetFeatureInfo for exact coordinates

**What is the new behavior?**
you can use a coordinate editor to search custom point

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

If you want to avoid to hidethe button in the toolbar (true by default)
```
{
"name": "Identify",
  "cfg": {
    "enabledCoordEditorButton": false
}
```
or if you do not specify the previous config and you want to show the coordinate editor (by default is false), in the initialState add
```
"mapInfo": {
  "enabled": true,
  "showCoordinateEditor": true
}
```