### PR TITLE
Some improvements for #3523 address and coordinate search

### DIFF
--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -240,6 +240,10 @@ class SearchBar extends React.Component {
         onClick={onClick}
         className={className}/>);
 
+
+/**
+ * if one tool is disabled the other one is enabled
+*/
     getActiveTool = () => {
         let activeTool = this.props.activeSearchTool;
         if (this.props.showAddressSearchOption && !this.props.showCoordinatesSearchOption) {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -432,6 +432,7 @@
             }, {
                 "name": "Search",
                 "cfg": {
+                  "showOptions": false,
                   "withToggle": ["max-width: 768px", "min-width: 768px"]
                 }
             }, {


### PR DESCRIPTION
## Description
Removed burger menu from the toolbar in the searchBar in embedded mode
added two new options for configuring the burger menu options list
by default they are true
- "showCoordinatesSearchOption": true
- "showAddressSearchOption": true

## Issues
 - Fix #3523

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
you cannot disable the address search tool or the coordinate search tool

**What is the new behavior?**
you can disable one search tool, and the other is by default enabled

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
for showing only the addresses search
```
{
"name": "Search",
"cfg": {
  "showCoordinatesSearchOption": false,
  "withToggle": ["max-width: 768px", "min-width: 768px"]
  }
}
```

for showing only the coordiantes search
```
{
"name": "Search",
"cfg": {
  "showAddressSearchOption": false,
  "withToggle": ["max-width: 768px", "min-width: 768px"]
  }
}
```

for removing the burger menu option:
```
{
"name": "Search",
"cfg": {
  "showOptions": false,
  "withToggle": ["max-width: 768px", "min-width: 768px"]
  }
}
```
