### PR TITLE
Add configuration to Footer plugin

### DIFF
--- a/web/client/product/plugins/Footer.jsx
+++ b/web/client/product/plugins/Footer.jsx
@@ -6,26 +6,64 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
-const {Grid, Row, Col} = require('react-bootstrap');
-const src = require("./attribution/geosolutions-brand.png");
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid, Row, Col } from 'react-bootstrap';
+import src from "./attribution/geosolutions-brand.png";
+import HTML from '../../components/I18N/HTML';
+
+/**
+ * Footer plugin, section of the homepage.
+ * descripition of footer can be overrided by
+ * `home.footerDescription` message id in the translations
+ * @prop {object} cfg.logo logo data to change image and href, set to null to hide the logo
+ * @prop {object} cfg.logo.src source of the logo
+ * @prop {object} cfg.logo.width width of the logo image
+ * @prop {object} cfg.logo.height height of the logo image
+ * @prop {object} cfg.logo.title title of the logo image
+ * @prop {object} cfg.logo.alt alternative text of the logo image
+ * @memberof plugins
+ * @class
+ */
 
 class Footer extends React.Component {
+
+    static propTypes = {
+        logo: PropTypes.object
+    };
+
+    static defaultProps = {
+        logo: {
+            src,
+            width: 140,
+            height: 'auto',
+            href: 'http://www.geo-solutions.it/',
+            title: 'GeoSolutions',
+            alt: 'GeoSolutions'
+        }
+    };
+
     render() {
+        const { href, ...logo } = this.props.logo || {};
         return (
             <Grid>
-                <Row>
+                {logo && logo.src && <Row>
                     <Col xs={12} className="text-center">
                         <div>
-                            <a target="_blank" href="http://www.geo-solutions.it/">
-                                <img src={src} width="140" title="GeoSolutions" alt="GeoSolutions" />
+                            <a target="_blank" href={href || ''}>
+                                <img
+                                    src={logo.src}
+                                    width={logo.width || 'auto'}
+                                    height={logo.height || 'auto'}
+                                    title={logo.title || ''}
+                                    alt={logo.alt || ''} />
                             </a>
                         </div>
                     </Col>
-                </Row>
+                </Row>}
                 <Row>
                     <Col xs={12} className="text-center">
-                        <small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>
+                        <HTML msgId="home.footerDescription"/>
                     </Col>
                 </Row>
             </Grid>
@@ -33,6 +71,4 @@ class Footer extends React.Component {
     }
 }
 
-module.exports = {
-    FooterPlugin: Footer
-};
+export const FooterPlugin = Footer;

--- a/web/client/product/plugins/Footer.jsx
+++ b/web/client/product/plugins/Footer.jsx
@@ -45,19 +45,22 @@ class Footer extends React.Component {
 
     render() {
         const { href, ...logo } = this.props.logo || {};
+        const image = (
+            <img
+                src={logo.src}
+                width={logo.width || 'auto'}
+                height={logo.height || 'auto'}
+                title={logo.title || ''}
+                alt={logo.alt || ''} />
+        );
         return (
             <Grid>
                 {logo && logo.src && <Row>
                     <Col xs={12} className="text-center">
                         <div>
-                            <a target="_blank" href={href || ''}>
-                                <img
-                                    src={logo.src}
-                                    width={logo.width || 'auto'}
-                                    height={logo.height || 'auto'}
-                                    title={logo.title || ''}
-                                    alt={logo.alt || ''} />
-                            </a>
+                            {href ? <a target="_blank" href={href}>
+                                {image}
+                            </a> : image}
                         </div>
                     </Col>
                 </Row>}

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -167,6 +167,7 @@
             "Examples": "Beispiele",
             "LinkedinGroup": "Mapstore Linkedin Gruppe",
             "scrollTop": "An den Anfang der Seite scrollen",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Bleibe in Verbindung und auf dem Laufenden mit der Mailing Liste",
                 "subscribe_users": "Abonniere die Benutzer Mailing Liste",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -167,6 +167,7 @@
             "Examples": "Examples",
             "LinkedinGroup": "Mapstore Linkedin Group",
             "scrollTop": "Scroll to the top of the page",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Keep in touch and stay up-to-date with the mailing lists",
                 "subscribe_users": "Subscribe Users Mailing List",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -167,6 +167,7 @@
             "Examples": "Ejemplos",
             "LinkedinGroup": "Grupo Linkedin de Mapstore",
             "scrollTop": "Volver al principio de la página",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Esté informado a la última sobre los cambios en el desrrollo via listas de correo",
                 "subscribe_users": "Suscribirse a las listas de correo de usuarios",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -168,6 +168,7 @@
             "Examples": "Exemples",
             "LinkedinGroup": "Groupe Linkedin Mapstore",
             "scrollTop": "Retour en haut de la page",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Restez au fait des derniers développements via les mailing lists",
                 "subscribe_users": "Souscrire à la Mailing List utilisateurs",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -167,6 +167,7 @@
             "Examples": "Primjeri",
             "LinkedinGroup": "Mapstore Linkedin grupa",
             "scrollTop": "Pomakni gore na vrh stranice",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Ostanite u kontaktu i informirani putem E-mail lista",
                 "subscribe_users": "Pretplati se na korisničku E-mail listu",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -167,6 +167,7 @@
             "Examples": "Esempi",
             "LinkedinGroup": "Gruppo Linkedin Mapstore",
             "scrollTop": "Torna all'inizio della pagina",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Resta in contatto e tieniti aggiornato con le mailing list",
                 "subscribe_users": "Sottoscrivi la mailing list degli utenti",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -141,6 +141,7 @@
             "Examples": "Voorbeelden",
             "LinkedinGroup": "Mapstore Linkedin groep",
             "scrollTop": "Terug naar boven",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Blijf op de hoogte van de laatste ontwikkelingen via mailinglijsten",
                 "subscribe_users": "Abonneer u op de gebruikers mailinglijsten",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -167,6 +167,7 @@
             "Examples": "Exemplos",
             "LinkedinGroup": "Grupo Mapstore no Linkedin",
             "scrollTop": "Navegar para o topo da página",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Mantenha-se em contacto e actualizado com as mailing lists",
                 "subscribe_users": "Subscrever a Mailing List de Utilizadores",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -140,6 +140,7 @@
             "Examples": "例子",
             "LinkedinGroup": "Mapstore Linkedin Group",
             "scrollTop": "滚动到页面顶部",
+            "footerDescription": "<small>GeoSolutions S.a.s. | Via di Montramito 3/A, 55054 Massarosa (Lucca) - Italy info@geo-solutions.it | Tel: +39 0584 962313 | Fax: +39 0584 1660272</small>",
             "ml": {
                 "title": "Keep in touch and stay up-to-date with the mailing lists",
                 "subscribe_users": "Subscribe Users Mailing List",


### PR DESCRIPTION
## Description
This PR add some configuration and translation for Footer plugin.
Logo is cofigurable by adding following configuration
```
{
  "name": "Footer",
  "cfg": {
    "logo": {
      "src": "path/to/logo",
      "width": "140",
      "href": "go/to/external/link",
      "title": "TITLE",
      "alt": "ALTERNATIVE TITLE"
    }
  }
}
```
`logo` equal `null` hides the logo in the footer.

Description can be changed by overriding 'home.footerDescription' message id in traslations.

## Issues
 - 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
Footer is not configurable for standard project.

**What is the new behavior?**
Information of Footer plugin are configurable

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
