### PR TITLE
Updated style of active toggled buttons

### DIFF
--- a/web/client/components/buttons/FullScreenButton.jsx
+++ b/web/client/components/buttons/FullScreenButton.jsx
@@ -61,7 +61,7 @@ class FullScreenButton extends React.Component {
         notActiveTooltip: 'fullscreen.tooltipActivate',
         tooltipPlace: 'left',
         defaultStyle: 'primary',
-        pressedStyle: 'success',
+        pressedStyle: 'success active',
         glyphicon: '1-full-screen',
         btnConfig: {
             className: "square-button"

--- a/web/client/components/buttons/GlobeViewSwitcherButton.jsx
+++ b/web/client/components/buttons/GlobeViewSwitcherButton.jsx
@@ -61,7 +61,7 @@ class GlobeViewSwitcherButton extends React.Component {
         notActiveTooltip: 'globeswitcher.tooltipActivate',
         tooltipPlace: 'left',
         defaultStyle: 'primary',
-        pressedStyle: 'success',
+        pressedStyle: 'success active',
         glyphicon: '3d',
         btnConfig: {
             className: "square-button"

--- a/web/client/components/mapcontrols/locate/LocateBtn.jsx
+++ b/web/client/components/mapcontrols/locate/LocateBtn.jsx
@@ -133,7 +133,7 @@ class LocateBtn extends React.Component {
     getBtnStyle = () => {
         let style = this.props.bsStyle;
         if (this.props.locate === "FOLLOWING") {
-            style = "success";
+            style = "success active";
         } else if (this.props.locate === "ENABLED") {
             style = "info";
         }

--- a/web/client/plugins/playback/Playback.jsx
+++ b/web/client/plugins/playback/Playback.jsx
@@ -96,6 +96,7 @@ module.exports = playbackEnhancer(({
                     tooltip: <Message msgId={"playback.backwardStep"} />
                 }, {
                     glyph: status === statusMap.PLAY ? "pause" : "play",
+                    active: status === statusMap.PLAY || status === statusMap.PAUSE,
                     bsStyle: status === statusMap.PLAY || status === statusMap.PAUSE ? "success" : "primary",
                     onClick: () => status === statusMap.PLAY ? pause() : play(),
                     tooltipId: status === statusMap.PLAY


### PR DESCRIPTION
## Description
This PR updates these buttons styles when they are active (green + inset shadow):

- Fullscreen
- 3D
- Locate
- Play Button in timeline

## Issues
 - 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Update theme style


**What is the current behavior?** (You can also link to an open issue here)
Toggle Buttons have different style when active

**What is the new behavior?**
Toggle Buttons have same style when active

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
