### PR TITLE
Fix #3564. Annotation panel closes when annotation layer removed

### DIFF
--- a/web/client/selectors/__tests__/annotations-test.js
+++ b/web/client/selectors/__tests__/annotations-test.js
@@ -1,0 +1,79 @@
+/*
+* Copyright 2019, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+const expect = require('expect');
+const {
+    modeSelector,
+    annotationsListSelector
+} = require('../annotations');
+
+
+describe('Test annotations selectors', () => {
+    it('modeSelector', () => {
+        // list mode
+        expect(modeSelector({
+            annotations: { editing: false }
+        })).toBe('list');
+        // editing mode
+        expect(modeSelector({
+            annotations: {editing: true}
+        })).toBe('editing');
+
+        // detail mode
+        expect(modeSelector({
+            layers: {
+                flat: [{id: 'annotations'}]
+            },
+            annotations: {
+                current: true
+            }
+        })).toBe('detail');
+
+        // list mode if annotations layer is not present and editing deactivated
+        expect(modeSelector({
+            layers: {
+                flat: [{ id: 'OTHER_LAYER' }]
+            },
+            annotations: {
+                current: true
+            }
+        })).toBe('list');
+    });
+
+    it('annotationsListSelector', () => {
+        // list mode
+        expect(annotationsListSelector({
+            annotations: { editing: false }
+        }).mode).toBe('list');
+        // editing mode
+        expect(annotationsListSelector({
+            annotations: { editing: true }
+        }).mode).toBe('editing');
+
+        // detail mode
+        expect(annotationsListSelector({
+            layers: {
+                flat: [{ id: 'annotations' }]
+            },
+            annotations: {
+                current: true
+            }
+        }).mode).toBe('detail');
+
+        // list mode if annotations layer is not present and editing deactivated
+        expect(annotationsListSelector({
+            layers: {
+                flat: [{ id: 'OTHER_LAYER' }]
+            },
+            annotations: {
+                current: true
+            }
+        }).mode).toBe('list');
+    });
+});

--- a/web/client/selectors/annotations.js
+++ b/web/client/selectors/annotations.js
@@ -19,7 +19,7 @@ const removingSelector = (state) => get(state, "annotations.removing");
 const closingSelector = (state) => !!get(state, "annotations.closing");
 const editingSelector = (state) => get(state, "annotations.editing");
 const currentSelector = (state) => get(state, "annotations.current");
-const modeSelector = (state) => editingSelector(state) && 'editing' || currentSelector(state) && 'detail' || 'list';
+const modeSelector = (state) => editingSelector(state) && 'editing' || annotationsLayerSelector(state) && currentSelector(state) && 'detail' || 'list';
 
 const annotationsInfoSelector = (state) => (assign({}, {
     editing: editingSelector(state),
@@ -40,11 +40,12 @@ const annotationsSelector = (state) => ({
 const annotationsListSelector = createSelector([
     annotationsInfoSelector,
     annotationsSelector,
-    annotationsLayerSelector
-], (info, annotations, layer) => (assign({}, {
+    annotationsLayerSelector,
+    modeSelector
+], (info, annotations, layer, mode) => (assign({}, {
     removing: annotations.removing,
     closing: !!annotations.closing,
-    mode: annotations.editing && 'editing' || annotations.current && 'detail' || 'list',
+    mode,
     annotations: layer && layer.features || [],
     current: annotations.current || null,
     editing: info.editing,
@@ -61,6 +62,7 @@ const annotationSelector = createSelector([annotationsListSelector], (annotation
 });
 
 module.exports = {
+    modeSelector,
     annotationsLayerSelector,
     annotationsInfoSelector,
     annotationsSelector,


### PR DESCRIPTION
## Description
This fix exit detail mode of annotation when annotations layer is not present. This fixes red-box error when delete layer in detail mode.

## Issues
 - Fix #3564


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
See #3564 

**What is the new behavior?**
The panel closes

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

