### PR TITLE
Fix update symbol style in annotation styler panel

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -283,27 +283,23 @@ class DrawSupport extends React.Component {
         if (!this.drawLayer) {
             feature = this.addLayer(newProps, newProps.options && newProps.options.drawEnabled || false);
         } else {
-            if (newProps.drawOwner === "annotations") {
-                this.updateOnlyFeatureStyles(newProps);
-            } else {
-                this.drawSource.clear();
-                feature = this.addFeatures(newProps);
-                if (newProps.style) {
-                    this.drawLayer.setStyle((ftOl) => {
-                        let originalFeature = find(head(newProps.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
-                        // let originalFeatureOLD = find(head(this.props.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
-                        if (originalFeature) {
-                            let promises = createStylesAsync(castArray(originalFeature.style));
-                            axios.all(promises).then((styles) => {
-                                ftOl.setStyle(() => parseStyles({...originalFeature, style: styles}));
-                            });
-                        } else {
-                            const styleType = this.convertGeometryTypeToStyleType(newProps.drawMethod);
-                            // if the styles is not present in the feature it uses a default one based on the drawMethod basically
-                            return parseStyles({style: VectorStyle.defaultStyles[styleType]});
-                        }
-                    });
-                }
+            this.drawSource.clear();
+            feature = this.addFeatures(newProps);
+            if (newProps.style) {
+                this.drawLayer.setStyle((ftOl) => {
+                    let originalFeature = find(head(newProps.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
+                    // let originalFeatureOLD = find(head(this.props.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
+                    if (originalFeature) {
+                        let promises = createStylesAsync(castArray(originalFeature.style));
+                        axios.all(promises).then((styles) => {
+                            ftOl.setStyle(() => parseStyles({...originalFeature, style: styles}));
+                        });
+                    } else {
+                        const styleType = this.convertGeometryTypeToStyleType(newProps.drawMethod);
+                        // if the styles is not present in the feature it uses a default one based on the drawMethod basically
+                        return parseStyles({style: VectorStyle.defaultStyles[styleType]});
+                    }
+                });
             }
         }
         return feature;

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -288,7 +288,6 @@ class DrawSupport extends React.Component {
             if (newProps.style) {
                 this.drawLayer.setStyle((ftOl) => {
                     let originalFeature = find(head(newProps.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
-                    // let originalFeatureOLD = find(head(this.props.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
                     if (originalFeature) {
                         let promises = createStylesAsync(castArray(originalFeature.style));
                         axios.all(promises).then((styles) => {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -140,16 +140,16 @@ class DrawSupport extends React.Component {
     updateOnlyFeatureStyles = (newProps) => {
         if (this.drawLayer) {
             this.drawLayer.getSource().getFeatures().forEach(ftOl => {
-                let originalGeoJsonFeature = find(head(newProps.features).features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
+
+                let features = head(newProps.features).features || newProps.features; // checking FeatureCollection or an array of simple features
+
+                let originalGeoJsonFeature = find(features, ftTemp => ftTemp.properties.id === ftOl.getProperties().id);
                 if (originalGeoJsonFeature) {
+                    // only if it finds a feature drawn then update its style
                     let promises = createStylesAsync(castArray(originalGeoJsonFeature.style));
                     axios.all(promises).then((styles) => {
                         ftOl.setStyle(() => parseStyles({...originalGeoJsonFeature, style: styles}));
                     });
-                } else {
-                    const styleType = this.convertGeometryTypeToStyleType(newProps.drawMethod);
-                    // if the styles is not present in the feature it uses a default one based on the drawMethod basically
-                    return parseStyles({style: VectorStyle.defaultStyles[styleType]});
                 }
             });
         }

--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -41,11 +41,11 @@ class Feature extends React.Component {
         return !isEqual(nextProps.properties, this.props.properties) || !isEqual(nextProps.geometry, this.props.geometry) || (nextProps.features !== this.props.features) || (nextProps.style !== this.props.style);
     }
 
-    componentWillUpdate(newProps) {
+    componentWillUpdate(nextProps) {
         // TODO check if shallow comparison is enough properties and geometry
-        if (!isEqual(newProps.properties, this.props.properties) || !isEqual(newProps.geometry, this.props.geometry) || (newProps.features !== this.props.features) || (newProps.style !== this.props.style)) {
+        if (!isEqual(nextProps.properties, this.props.properties) || !isEqual(nextProps.geometry, this.props.geometry) || (nextProps.features !== this.props.features) || (nextProps.style !== this.props.style)) {
             this.removeFromContainer();
-            this.addFeatures(newProps);
+            this.addFeatures(nextProps);
         }
     }
 
@@ -89,7 +89,7 @@ class Feature extends React.Component {
             }).forEach(
                 (f) => f.getGeometry().transform(props.featuresCrs, props.crs || 'EPSG:3857'));
 
-            if (props.style && (props.style !== props.layerStyle)) { // TODO test this logic with other functionalities
+            if (props.style && props.style !== props.layerStyles) { // TODO test this logic with other functionalities
                 this._feature.forEach((f) => {
                     let promises = [];
                     let geoJSONFeature = {};

--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -89,7 +89,7 @@ class Feature extends React.Component {
             }).forEach(
                 (f) => f.getGeometry().transform(props.featuresCrs, props.crs || 'EPSG:3857'));
 
-            if (props.style && props.style !== props.layerStyles) { // TODO test this logic with other functionalities
+            if (props.style && (props.style !== props.layerStyle)) {
                 this._feature.forEach((f) => {
                     let promises = [];
                     let geoJSONFeature = {};

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -1842,4 +1842,93 @@ describe('Test DrawSupport', () => {
 
         expect(spyonEndDrawing).toNotHaveBeenCalled();
     });
+    it('edit a feature, then update its style', (done) => {
+        const fakeMap = {
+            addLayer: () => {},
+            removeLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            updateOnlyFeatureStyles: () => {},
+            on: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[
+                  [13, 43],
+                  [15, 43],
+                  [15, 44],
+                  [13, 44]
+                ]]
+            },
+            properties: {
+                name: "some name",
+                id: "a-unique-id"
+            },
+            style: [{
+                id: "style-id",
+                color: "#FF0000",
+                opacity: 1,
+                fillColor: "#0000FF",
+                fillOpacity: 1
+            }]
+        };
+
+        const support = ReactDOM.render(
+            <DrawSupport features={[]} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        ReactDOM.render(
+            <DrawSupport
+                features={[feature]}
+                map={fakeMap}
+                drawStatus="drawOrEdit"
+                drawMethod="Polygon"
+                options={{
+                    drawEnabled: false,
+                    editEnabled: true
+                }}
+            />, document.getElementById("container"));
+
+        ReactDOM.render(
+            <DrawSupport
+                features={[{
+                    ...feature,
+                style: [{
+                    id: "style-id",
+                    color: "#FFFFFF",
+                    opacity: 0.5,
+                    fillColor: "#FFFFFF",
+                    fillOpacity: 0.5
+                }]}]}
+                map={fakeMap}
+                drawStatus="updateStyle"
+                drawMethod="Polygon"
+                options={{
+                    drawEnabled: false,
+                    editEnabled: true
+                }}
+        />, document.getElementById("container"));
+
+        setTimeout( () => {
+            const drawnFt = support.drawLayer.getSource().getFeatures()[0];
+            expect(drawnFt.getStyle()).toExist();
+            expect(drawnFt.getStyle()()).toExist();
+            expect(drawnFt.getStyle()()[0].getStroke().getColor()).toEqual("rgba(255, 255, 255, 0.5)");
+            expect(drawnFt.getStyle()()[0].getFill().getColor()).toEqual("rgba(255, 255, 255, 0.5)");
+            done();
+        }, 100);
+    });
+
 });

--- a/web/client/components/style/StyleCanvas.jsx
+++ b/web/client/components/style/StyleCanvas.jsx
@@ -47,11 +47,6 @@ class StyleCanvas extends React.Component {
         return <canvas ref="styleCanvas" style={this.props.style} width={this.props.width} height={this.props.height} />;
     }
 
-    componentShouldUpdate(props, nexProps) {
-        // not sure why this is wrongly called.
-        // fixing the name rises some problems.
-        return props.shapeStyle !== nexProps.shapeStyle || props.width !== nexProps.width || props.height !== nexProps.height || props.geomType !== nexProps.geomType;
-    }
     paint = (ctx) => {
         ctx.save();
         ctx.beginPath();

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -94,6 +94,7 @@ describe('annotations Epics', () => {
             if (actions.length >= 2) {
                 expect(actions[0].type).toBe(SET_STYLE);
                 expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[1].status).toBe("updateStyle");
                 done();
             }
         });

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -23,13 +23,13 @@ const {editAnnotation, confirmRemoveAnnotation, saveAnnotation, cancelEditAnnota
 const {TOGGLE_CONTROL, toggleControl, SET_CONTROL_PROPERTY} = require('../../actions/controls');
 const {addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic, newAnnotationEpic, addAnnotationEpic,
     disableInteractionsEpic, cancelEditAnnotationEpic, startDrawingMultiGeomEpic, endDrawGeomEpic, endDrawTextEpic, cancelTextAnnotationsEpic,
-    setStyleEpic, restoreStyleEpic, highlighAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
+    setAnnotationStyleEpic, restoreStyleEpic, highlighAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
     downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusEpic, redrawOnChangeTextEpic,
     editSelectedFeatureEpic, editCircleFeatureEpic, purgeMapInfoEpic, closeMeasureToolEpic, openEditorEpic
 } = require('../annotations')({});
 const rootEpic = combineEpics(addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, saveAnnotationEpic, newAnnotationEpic, addAnnotationEpic,
     disableInteractionsEpic, cancelEditAnnotationEpic, startDrawingMultiGeomEpic, endDrawGeomEpic, endDrawTextEpic, cancelTextAnnotationsEpic,
-    setStyleEpic, restoreStyleEpic, highlighAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
+    setAnnotationStyleEpic, restoreStyleEpic, highlighAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
     downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusEpic, redrawOnChangeTextEpic,
     editSelectedFeatureEpic, editCircleFeatureEpic, purgeMapInfoEpic, closeMeasureToolEpic, openEditorEpic
 );

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -31,7 +31,7 @@ const uuidv1 = require('uuid/v1');
 const {FEATURES_SELECTED, GEOMETRY_CHANGED, DRAWING_FEATURE} = require('../actions/draw');
 const {PURGE_MAPINFO_RESULTS} = require('../actions/mapInfo');
 
-const {head, findIndex, castArray, isArray} = require('lodash');
+const {head, findIndex, castArray, isArray, find} = require('lodash');
 const assign = require('object-assign');
 
 const {annotationsLayerSelector} = require('../selectors/annotations');
@@ -346,10 +346,12 @@ module.exports = (viewer) => ({
     setStyleEpic: (action$, store) => action$.ofType(SET_STYLE)
         .switchMap( () => {
             // TODO verify if we need to override the style here or in the store
-            let feature = store.getState().annotations.editing;
-            let projectedFeature = reprojectGeoJson(feature, "EPSG:4326", "EPSG:3857");
+            const features = store.getState().annotations.editing.features;
+            const selected = store.getState().annotations.selected;
+            let ftChanged = find(features, f => f.properties.id === selected.properties.id); // can use also selected.style
+            let projectedFeature = reprojectGeoJson(ftChanged, "EPSG:4326", "EPSG:3857");
             return Rx.Observable.from([
-                changeDrawingStatus("replace", store.getState().annotations.featureType, "annotations", [projectedFeature], {}, assign({}, store.getState().annotations.selected.style, {highlight: false}))
+                changeDrawingStatus("updateStyle", store.getState().annotations.featureType, "annotations", [projectedFeature], {}, assign({}, selected.style, {highlight: false}))
             ]
             );
         }),

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -343,7 +343,7 @@ module.exports = (viewer) => ({
                 }, assign({}, style, {highlight: false}))
             ]);
         }),
-    setStyleEpic: (action$, store) => action$.ofType(SET_STYLE)
+    setAnnotationStyleEpic: (action$, store) => action$.ofType(SET_STYLE)
         .switchMap( () => {
             // TODO verify if we need to override the style here or in the store
             const features = store.getState().annotations.editing.features;

--- a/web/client/utils/VectorStyleUtils.js
+++ b/web/client/utils/VectorStyleUtils.js
@@ -311,13 +311,13 @@ const createSvgUrl = (style = {}, url) => {
 
 const createStylesAsync = (styles = []) => {
     return styles.map(style => {
-        return isSymbolStyle(style) ? createSvgUrl(style, style.symbolUrl || style.symbolUrlCustomized)
+        return isSymbolStyle(style) && !fetchStyle(hashAndStringify(style)) ? createSvgUrl(style, style.symbolUrl || style.symbolUrlCustomized)
             .then(symbolUrlCustomized => {
                 return symbolUrlCustomized ? {...style, symbolUrlCustomized} : fetchStyle(hashAndStringify(style));
             }).catch(() => {
                 return {...style, symbolUrlCustomized: require('../product/assets/symbols/symbolMissing.svg')};
             }) : new Promise((resolve) => {
-                resolve(style);
+                resolve(isSymbolStyle(style) ? fetchStyle(hashAndStringify(style)) : style);
             });
     });
 };


### PR DESCRIPTION
## Description
This pr enhance the way features styles are updated when annotations styler is opened

## Issues
 - 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
There is an excessive re-render for features that are not being edited (style) this cause some blinks especially with symbols.

**What is the new behavior?**
this no longer happens, only the feature being changed update its style

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
