### PR TITLE
Fix #3574 Remove Google plus link in Share panel

### DIFF
--- a/web/client/components/share/ShareSocials.jsx
+++ b/web/client/components/share/ShareSocials.jsx
@@ -19,7 +19,6 @@ const {
 // components of the socialnetworks grouped in a bigger container aka ShareSocials
 const {
   FacebookShareButton,
-  GooglePlusShareButton,
   LinkedinShareButton,
   TwitterShareButton
 } = ShareButtons;
@@ -27,14 +26,12 @@ const {
 // counter for counting the number of map-sharing on a given social network
 const {
   FacebookShareCount,
-  GooglePlusShareCount,
   LinkedinShareCount
 } = ShareCounts;
 
 // icons of the social network
 const FacebookIcon = generateShareIcon('facebook');
 const TwitterIcon = generateShareIcon('twitter');
-const GooglePlusIcon = generateShareIcon('google');
 const LinkedinIcon = generateShareIcon('linkedin');
 const Message = require('../../components/I18N/Message');
 require('./share.css');
@@ -97,23 +94,6 @@ class ShareSocials extends React.Component {
                 <div className="share-twitter-count">
                   &nbsp;
                 </div>
-              </div>
-
-
-              <div className="social-box google">
-                <GooglePlusShareButton
-                  url={this.props.shareUrl}
-                  className="share-google-count">
-                  <GooglePlusIcon
-                    size={32}
-                    round />
-                </GooglePlusShareButton>
-                <GooglePlusShareCount
-                  url={this.props.shareUrl}
-                  {...countProps}
-                  className="share-google-count">
-                  {count => count}
-                </GooglePlusShareCount>
               </div>
 
               <div className="social-box linkedin">


### PR DESCRIPTION
## Description
Removed Google plus link in Share panel

## Issues
 - Fix #3574

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe: Removed link due to external service

**What is the current behavior?** (You can also link to an open issue here)
Google plus button is in Share panel

**What is the new behavior?**
Google plus button has been removed from Share panel

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
