### PR TITLE
Fix #3578. Fix issues with layernames containing points

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -54,7 +54,7 @@ const {CHANGE_LAYER_PROPERTIES} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
 
 const {layerSelectedForSearch, UPDATE_QUERY} = require('../../actions/wfsquery');
-
+const {LOAD_FILTER} = require('../../actions/queryform');
 
 const {
     setHighlightFeaturesPath,
@@ -1479,18 +1479,24 @@ describe('featuregrid Epics', () => {
         }, newState);
     });
 
-    it('test onOpenAdvancedSearch to throw drawstatechange if drawStatus is not clean on queryPanel close', (done) => {
+    it('test onOpenAdvancedSearch', (done) => {
         const stateFeaturegrid = {
             featuregrid: {
                 open: true,
-                selectedLayer: "TEST__6",
+                // layer id with `.` and `:`
+                selectedLayer: "TEST:A.LAYER__6",
                 mode: 'EDIT',
                 select: [{id: 'polygons.1', _new: 'polygons._new'}],
-                changes: []
+                changes: [],
+                advancedFilters: {
+                    "TEST:A.LAYER__6": {
+                        "someFilter": "something"
+                    }
+                }
             },
             layers: {
                 flat: [{
-                    id: "TEST__6",
+                    id: "TEST:A.LAYER__6",
                     name: "V_TEST",
                     title: "V_TEST",
                     filterObj,
@@ -1508,7 +1514,12 @@ describe('featuregrid Epics', () => {
             expect(actions.length).toBe(4);
             actions.map((action) => {
                 switch (action.type) {
+                    case LOAD_FILTER:
+                        // load filter, if present
+                        expect(action.filter).toExist();
+                        break;
                     case CHANGE_DRAWING_STATUS:
+                        //  throw drawstatechange if drawStatus is not clean on queryPanel close
                         expect(action.status).toBe('clean');
                         break;
                     default:

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -171,7 +171,7 @@ const createLoadPageFlow = (store) => ({page, size} = {}) => {
 };
 
 const createInitialQueryFlow = (action$, store, {url, name, id} = {}) => {
-    const filterObj = get(store.getState(), `featuregrid.advancedFilters.${id}`);
+    const filterObj = get(store.getState(), `featuregrid.advancedFilters["${id}"]`);
     const createInitialQuery = () => createQuery(url, filterObj || {
         featureTypeName: name,
         filterType: 'OGC',
@@ -606,7 +606,7 @@ module.exports = {
     onOpenAdvancedSearch: (action$, store) =>
         action$.ofType(OPEN_ADVANCED_SEARCH).switchMap(() => {
             return Rx.Observable.of(
-                loadFilter(get(store.getState(), `featuregrid.advancedFilters.${selectedLayerIdSelector(store.getState())}`)),
+                loadFilter(get(store.getState(), `featuregrid.advancedFilters["${selectedLayerIdSelector(store.getState())}"]`)),
                 closeFeatureGrid(),
                 setControlProperty('queryPanel', "enabled", true)
             )

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -64,7 +64,8 @@ let feature2 = {
 let initialState = {
         query: {
         featureTypes: {
-          'editing:polygons': {
+            // use name with chars ":" and "."
+          'editing:polygons.test': {
             geometry: [
               {
                 label: 'geometry',
@@ -259,7 +260,7 @@ let initialState = {
         resultError: null,
         isNew: false,
         filterObj: {
-          featureTypeName: 'editing:polygons',
+          featureTypeName: 'editing:polygons.test',
           groupFields: [
             {
               id: 1,
@@ -284,7 +285,7 @@ let initialState = {
           hits: false
         },
         searchUrl: 'http://localhost:8081/geoserver/wfs?',
-        typeName: 'editing:polygons',
+        typeName: 'editing:polygons.test',
         url: 'http://localhost:8081/geoserver/wfs?',
         featureLoading: false
       },
@@ -458,14 +459,14 @@ describe('Test featuregrid selectors', () => {
     it('test hasSupportedGeometry', () => {
         expect(hasSupportedGeometry(initialState)).toBe(true);
         let initialStateWithGmlGeometry = assign({}, initialState);
-        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:Geometry';
-        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'Geometry';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].type = 'gml:Geometry';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].localType = 'Geometry';
         expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);
-        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:GeometryCollection';
-        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'GeometryCollection';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].type = 'gml:GeometryCollection';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].localType = 'GeometryCollection';
         expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(false);
-        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].type = 'gml:Polygon';
-        initialStateWithGmlGeometry.query.featureTypes['editing:polygons'].original.featureTypes[0].properties[1].localType = 'Polygon';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].type = 'gml:Polygon';
+        initialStateWithGmlGeometry.query.featureTypes['editing:polygons.test'].original.featureTypes[0].properties[1].localType = 'Polygon';
         expect(hasSupportedGeometry(initialStateWithGmlGeometry)).toBe(true);
 
     });
@@ -480,7 +481,7 @@ describe('Test featuregrid selectors', () => {
             flat: [{
                 id: "TEST_LAYER",
                 title: "Test Layer",
-                name: 'editing:polygons'
+                name: 'editing:polygons.test'
             }]
         }, featuregrid: {
             open: true,
@@ -489,7 +490,7 @@ describe('Test featuregrid selectors', () => {
             select: [feature1, feature2],
             changes: [{id: feature2.id, updated: {geometry: null}}]
         }};
-        expect(selectedLayerNameSelector(state)).toBe('editing:polygons');
+        expect(selectedLayerNameSelector(state)).toBe('editing:polygons.test');
         expect(selectedLayerNameSelector({})).toBe('');
     });
     it('queryOptionsSelector gets viewParams', () => {
@@ -498,7 +499,7 @@ describe('Test featuregrid selectors', () => {
                 flat: [{
                     id: "TEST_LAYER",
                     title: "Test Layer",
-                    name: 'editing:polygons',
+                    name: 'editing:polygons.test',
                     params: {
                         viewParams: "a:b"
                     }
@@ -519,7 +520,7 @@ describe('Test featuregrid selectors', () => {
                 flat: [{
                     id: "TEST_LAYER",
                     title: "Test Layer",
-                    name: 'editing:polygons',
+                    name: 'editing:polygons.test',
                     params: {
                         CQL_FILTER: "a:b"
                     }

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -18,14 +18,14 @@ const getTitle = (layer = {}) => layer.title || layer.name;
 const selectedLayerIdSelector = state => get(state, "featuregrid.selectedLayer");
 const chartDisabledSelector = state => get(state, "featuregrid.chartDisabled", false);
 const getCustomAttributeSettings = (state, att) => get(state, `featuregrid.attributes[${att.name || att.attribute}]`);
-const {attributesSelector} = require('./query');
+const { attributesSelector, describeSelector } = require('./query');
 const selectedFeaturesSelector = state => state && state.featuregrid && state.featuregrid.select;
 const changesSelector = state => state && state.featuregrid && state.featuregrid.changes;
 const newFeaturesSelector = state => state && state.featuregrid && state.featuregrid.newFeatures;
 const selectedFeatureSelector = state => head(selectedFeaturesSelector(state));
 
 const geomTypeSelectedFeatureSelector = state => {
-    let desc = get(state, `query.featureTypes.${get(state, "query.filterObj.featureTypeName")}.original`);
+    let desc = describeSelector(state);
     if (desc) {
         const geomDesc = findGeometryProperty(desc);
         return geomDesc && geomDesc.localType;


### PR DESCRIPTION
## Description
This solves various issues with featureType names cotaining points. 
 - FeatureGrid attribute columns didn't show 
 - QueryForm filter was not correctly reloaded when close and re-open
 - Attributes was not correctly loaded by the query form
 - Editing geometry (geometry type was always not compatible with editing)
 - Initial load of featureType any time open the feature grid ( no errors, it's only it didn't use the describeFeatureType cache)

note: I put in common some duplicated state access code here and there that had the same issue.

## Issues
 - Fix #3578

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
FeatureGrid and QueryForm didn't work with layers with points in the name

**What is the new behavior?**
FeatureGrid and QueryForm work correctly for layers that has a point in the name.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

