### PR TITLE
Release 2019.01.00 - porting changelog and docs changes to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Change Log
 
+## [2019.01.00](https://github.com/geosolutions-it/MapStore2/tree/v2019.01.00) (2019-02-26)
+
+ - **[Full Changelog](https://github.com/geosolutions-it/MapStore2/compare/v2018.02.01...v2019.01.00)**
+
+ - **[Implemented enhancements](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222019.01.00%22+is%3Aclosed+label%3Aenhancement)**
+
+ - **[Fixed bugs](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222019.01.00%22+is%3Aclosed+label%3Abug)**
+
+ - **[Closed issues](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222019.01.00%22+is%3Aclosed)**
+
 ## [2018.02.01](https://github.com/geosolutions-it/MapStore2/tree/2018.02.01) (2018-11-16)
- 
+
  - **[Full Changelog](https://github.com/geosolutions-it/MapStore2/compare/tv2018.02.00...v2018.02.01)**
 
  - **[Implemented enhancements](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222018.02.01%22+is%3Aclosed+label%3Aenhancement)**
@@ -9,9 +19,9 @@
  - **[Fixed bugs](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222018.02.01%22+is%3Aclosed+label%3Abug)**
 
  - **[Closed issues](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222018.02.01%22+is%3Aclosed)**
- 
+
 ## [2018.02.00](https://github.com/geosolutions-it/MapStore2/tree/2018.02.00) (2018-09-11)
- 
+
  - **[Full Changelog](https://github.com/geosolutions-it/MapStore2/compare/tv2018.01.00...v2018.02.00)**
 
  - **[Implemented enhancements](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222018.02.00%22+is%3Aclosed+label%3Aenhancement)**

--- a/docs/developer-guide/release.md
+++ b/docs/developer-guide/release.md
@@ -6,7 +6,7 @@ Then you can check each entry on the GitHub issue when done until the release is
 Add an entry in the changelog like this:
 ```
 ## [2018.02.00](https://github.com/geosolutions-it/MapStore2/tree/2018.02.00) (2018-09-11)
- 
+
  - **[Full Changelog](https://github.com/geosolutions-it/MapStore2/compare/tv2018.01.00...v2018.02.00)**
 
  - **[Implemented enhancements](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222018.02.00%22+is%3Aclosed+label%3Aenhancement)**
@@ -16,9 +16,9 @@ Add an entry in the changelog like this:
  - **[Closed issues](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222018.02.00%22+is%3Aclosed)**
 
 ```
-Replacing: 
+Replacing:
  -  replacing `2018.02.00` with branch name
- - with current release tag name `v2018.02.00` 
+ - with current release tag name `v2018.02.00`
  - `%222018.02.00%22` with the name of the milestone (`%22` are `"` in the URL to generate a filter like `milestone:"2018.02.00"`)
 
 NOTE: we don't use  github_changelog_generator anymore because it has some issues that may address issues to wrong milestone, accordingly to our current workflow.
@@ -28,19 +28,21 @@ NOTE: we don't use  github_changelog_generator anymore because it has some issue
 - [ ] Create an issue with this checklist in the release milestone.
 - [ ] If major release (YYYY.XX.00), create a branch (**YYYY.XX.xx**)  (`xx` is really `xx`, example: 2018.01.xx)
 - [ ]  If major release,Change [QA Jenkins job](http://build.geo-solutions.it/jenkins/view/MapStore2/job/MapStore2-QA-Build/) to build the new branch, enable the job continuous deploy
+- [ ] create on [ReadTheDocs](https://readthedocs.org/projects/mapstore/) project the version build for `YYYY.XX.xx` (click on "Versions" and activate the version of the branch)
 - [ ] Test on QA [http://qa.mapstore2.geo-solutions.it/mapstore/](http://qa.mapstore2.geo-solutions.it/mapstore/)  
     * Any fix must be done on **YYYY.XX.mm**. The fixes will be manually merged on master
     * Test **everything**, not only the new features
 - [ ] Test Binary
-- [ ] Update `CHANGELOG.md`. [Instructions](https://dev.mapstore2.geo-solutions.it/mapstore/docs/release)
+- [ ] Update `CHANGELOG.md`. [Instructions](https://mapstore.readthedocs.io/en/latest/developer-guide/release/#changelog-generation)
 - [ ] Commit the changelog to the release branch
 - [ ] Create a [github draft release](https://github.com/geosolutions-it/MapStore2/releases) pointing to the branch **YYYY.XX.mm**.  
   > The Release name should follow be named YYYY.XX.mm where YYYY is the year, XX is the incremental number of the release for the current year (starting from 01) and the second number mm is an incremental value (starting from 00) to increment for minor releases. Insert the tag vYYYY.XX.mm (**notice the initial 'v' for the tag**) to create when the release is published. In the release description describe the major changes and link the Changelog paragraph.
-- [ ] Launch [MapStore-Releaser](http://build.geo-solutions.it/jenkins/job/MapStore2-Releaser/) Jenkins job setting up the correct name of the version and the branch to build (**and wait the end**). **Note:** Using the MapStore Releaser allows to write the correct version number into the binary packages.
+- [ ] Launch [MapStore2-Releaser](http://build.geo-solutions.it/jenkins/job/MapStore2-Releaser/) Jenkins job setting up the correct name of the version and the branch to build (**and wait the end**). **Note:** Using the MapStore2 Releaser allows to write the correct version number into the binary packages.
 - [ ] Get the [latest mapstore.war](http://build.geo-solutions.it/jenkins/view/MapStore2/job/MapStore2-Releaser/ws/web/target/mapstore.war) from the Releaser Jenkins build and upload it to github  
 - [ ] Get the [latest mapstore2-YYYY.XX.mm-bin.zip](http://build.geo-solutions.it/jenkins/view/MapStore2/job/MapStore2-Releaser/ws/release/target/) from the Releaser Jenkins build and upload it to github
   > from the job [configuration page](http://build.geo-solutions.it/jenkins/view/MapStore2/job/MapStore2-Releaser/ws/) there is a link to access the job workspace to easily download the built WAR and binary package
 - [ ] Publish the release
+- [ ] create on [ReadTheDocs](https://readthedocs.org/projects/mapstore/) project the version build for `vYYYY.XX.mm` (click on "Versions" and activate the version of the tag, created when release was published)
 - [ ] Port needed commits to master branch (Changelog changes, docs changes...)
 - [ ] Create a blog post
 - [ ] Write to the mailing list about the current release news and the next release major changes
@@ -48,4 +50,3 @@ NOTE: we don't use  github_changelog_generator anymore because it has some issue
 - [ ] Close this issue
 - [ ] Close the related milestone
 ```
-


### PR DESCRIPTION
## Description
In this PR all the needed commits for the new release has been ported to master branch.
In particular:
- changelog
- 'how to release' docs

## Issues
 - related to #3522 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Changes for the new release


**What is the current behavior?** (You can also link to an open issue here)
The changelog and the docs on the master branch are not updated

**What is the new behavior?**
The changelog and the docs  on the master branch are updated

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No
