### PR TITLE
exclude spring dependencies from print plugin

### DIFF
--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -389,7 +389,8 @@
                 <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
-                WEB-INF/lib/commons-pool-1.3.jar
+		WEB-INF/lib/commons-pool-1.3.jar,
+		WEB-INF/lib/spring-*-3.1.0*.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -367,7 +367,8 @@
                 <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
-                WEB-INF/lib/commons-pool-1.3.jar
+		WEB-INF/lib/commons-pool-1.3.jar,
+		WEB-INF/lib/spring-*-3.1.0*.jar
                 </packagingExcludes>
                 <overlays>
                     <overlay>


### PR DESCRIPTION
## Description
Print plugin update caused a Spring dependencies clash between GeoStore and Print plugin. This will exclude print plugin conflicting jars form the final WAR.

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Final MapStore WAR not working

**What is the new behavior?**
Final MapStore WAR is working

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
