### PR TITLE
Fixes #3584: security token added to printed wms layers and legends

### DIFF
--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -78,6 +78,10 @@ const authenticationRules = [
 ];
 
 describe('Tests ajax library', () => {
+    afterEach(() => {
+        expect.restoreSpies();
+    });
+
     it('uses proxy for requests not on the same origin', (done) => {
         axios.get('http://fakeexternaldomain.mapstore2').then(() => {
             done();

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -7,6 +7,7 @@
  */
 
 const CoordinatesUtils = require('./CoordinatesUtils');
+const SecurityUtils = require('./SecurityUtils');
 const MapUtils = require('./MapUtils');
 const {colorToHexStr} = require("./ColorUtils");
 
@@ -193,12 +194,12 @@ const PrintUtils = {
                 "styles": [
                     layer.style || ''
                 ],
-                "customParams": assign({
+                "customParams": SecurityUtils.addAuthenticationParameter(PrintUtils.normalizeUrl(layer.url), assign({
                     "TRANSPARENT": true,
                     "TILED": true,
                     "EXCEPTIONS": "application/vnd.ogc.se_inimage",
                     "scaleMethod": "accurate"
-                }, layer.baseParams || {}, layer.params || {})
+                }, layer.baseParams || {}, layer.params || {}))
             }),
             legend: (layer, spec) => ({
                 "name": layer.title || layer.name,
@@ -207,7 +208,7 @@ const PrintUtils = {
                       "name": "",
                       "icons": [
                          PrintUtils.normalizeUrl(layer.url) + url.format({
-                             query: {
+                             query: SecurityUtils.addAuthenticationParameter(PrintUtils.normalizeUrl(layer.url), {
                                  TRANSPARENT: true,
                                  EXCEPTIONS: "application/vnd.ogc.se_xml",
                                  VERSION: "1.1.1",
@@ -222,7 +223,7 @@ const PrintUtils = {
                                  LEGEND_OPTIONS: "forceLabels:" + (spec.forceLabels ? "on" : "") + ";fontAntialiasing:" + spec.antiAliasing + ";dpi:" + spec.legendDpi + ";fontStyle:" + (spec.bold && "bold" || (spec.italic && "italic") || '') + ";fontName:" + spec.fontFamily + ";fontSize:" + spec.fontSize,
                                  format: "image/png",
                                  ...assign({}, layer.params)
-                             }
+                             })
                          })
                       ]
                    }

--- a/web/client/utils/__tests__/SecurityUtils-test.js
+++ b/web/client/utils/__tests__/SecurityUtils-test.js
@@ -69,6 +69,9 @@ const authenticationRules = [
 ];
 
 describe('Test security utils methods', () => {
+    afterEach(() => {
+        expect.restoreSpies();
+    });
 
     it('test getting user attributes', () => {
         // test a null user


### PR DESCRIPTION
## Description
Security token (e.g. authkey) is added to wms layers (and related legends) when printing.

## Issues
 - Fix #3584

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Security token (e.g. authkey) is not added to wms layers (and related legends) when printing.

**What is the new behavior?**
Security token (e.g. authkey) is added to wms layers (and related legends) when printing.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
