### PR TITLE
Fixes #3589: problems of the standard template project build

### DIFF
--- a/project/standard/templates/prod-webpack.config.js
+++ b/project/standard/templates/prod-webpack.config.js
@@ -25,20 +25,20 @@ module.exports = require('./MapStore2/buildConfig')(
     '.__PROJECTNAME__',
     [
         new HtmlWebpackPlugin({
-            template: path.join(paths.framework, 'indexTemplate.html'),
+            template: path.join(__dirname, 'indexTemplate.html'),
             chunks: ['__PROJECTNAME__'],
             inject: true,
             hash: true
         }),
         new HtmlWebpackPlugin({
-            template: path.join(paths.framework, 'embeddedTemplate.html'),
+            template: path.join(__dirname, 'embeddedTemplate.html'),
             chunks: ['__PROJECTNAME__-embedded'],
             inject: true,
             hash: true,
             filename: 'embedded.html'
         }),
         new HtmlWebpackPlugin({
-            template: path.join(paths.framework, 'apiTemplate.html'),
+            template: path.join(__dirname, 'apiTemplate.html'),
             chunks: ['__PROJECTNAME__-api'],
             inject: 'head',
             hash: true,

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -150,36 +150,6 @@
                     </configuration>
                 </execution>
                 <execution>
-                    <id>html, configuration files and images</id>
-                    <phase>process-classes</phase>
-                    <goals>
-                        <goal>copy-resources</goal>
-                    </goals>
-                    <configuration>
-                        <outputDirectory>${basedir}/target/__PROJECTNAME__</outputDirectory>
-                        <encoding>UTF-8</encoding>
-                        <resources>
-                            <resource>
-                                <directory>${basedir}/..</directory>
-                                <includes>
-                                    <include>**/*.html</include>
-                                    <include>**/*.json</include>
-                                    <include>**/img/*</include>
-                                    <include>**/*.less</include>
-                                </includes>
-                                <excludes>
-                                    <exclude>node_modules/*</exclude>
-                                    <exclude>node_modules/**/*</exclude>
-                                    <exclude>MapStore2/*</exclude>
-                                    <exclude>MapStore2/**/*</exclude>
-                                    <exclude>**/libs/Cesium/**/*</exclude>
-                                    <exclude>**/test-resources/*</exclude>
-                                </excludes>
-                            </resource>
-                        </resources>
-                    </configuration>
-                </execution>
-                <execution>
                 <id>only index.html</id>
                     <phase>process-classes</phase>
                     <goals>
@@ -243,6 +213,36 @@
                                 <excludes>
                                     <exclude>MapStore2/*</exclude>
                                     <exclude>MapStore2/**/*</exclude>
+                                </excludes>
+                            </resource>
+                        </resources>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>html, configuration files and images</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>copy-resources</goal>
+                    </goals>
+                    <configuration>
+                        <outputDirectory>${basedir}/target/__PROJECTNAME__</outputDirectory>
+                        <encoding>UTF-8</encoding>
+                        <resources>
+                            <resource>
+                                <directory>${basedir}/..</directory>
+                                <includes>
+                                    <include>**/*.html</include>
+                                    <include>**/*.json</include>
+                                    <include>**/img/*</include>
+                                    <include>**/*.less</include>
+                                </includes>
+                                <excludes>
+                                    <exclude>node_modules/*</exclude>
+                                    <exclude>node_modules/**/*</exclude>
+                                    <exclude>MapStore2/*</exclude>
+                                    <exclude>MapStore2/**/*</exclude>
+                                    <exclude>**/libs/Cesium/**/*</exclude>
+                                    <exclude>**/test-resources/*</exclude>
                                 </excludes>
                             </resource>
                         </resources>


### PR DESCRIPTION
## Description
Fixes to the standard project template.

## Issues
 - Fix #3589 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
 * cesium-navigation files are searched from the wrong location
 * main bundle in index.html is included without the version query string

**What is the new behavior?**
 * cesium-navigation files are searched from the rightlocation
 * main bundle in index.html is included with the version query string

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
