### PR TITLE
Fixes #3591: implements automatic compression of deployed HTML, JS and CSS files

### DIFF
--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -53,6 +53,12 @@
           <artifactId>servlet-api</artifactId>
           <version>2.5</version>
     </dependency>
+    <!-- gzip compression filter -->
+    <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-web</artifactId>
+        <version>2.0.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/project/custom/templates/web/src/main/webapp/WEB-INF/web.xml
+++ b/project/custom/templates/web/src/main/webapp/WEB-INF/web.xml
@@ -45,6 +45,24 @@
 		<url-pattern>/rest/*</url-pattern>
 	</filter-mapping>
 
+	<!-- GZip compression -->
+	<filter>
+		<filter-name>CompressionFilter</filter-name>
+		<filter-class>net.sf.ehcache.constructs.web.filter.GzipFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.css</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.html</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.js</url-pattern>
+	</filter-mapping>
+
     <!-- CXF Servlet -->
 	<servlet>
 		<servlet-name>CXFServlet</servlet-name>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -120,6 +120,12 @@
           <artifactId>servlet-api</artifactId>
           <version>2.5</version>
     </dependency>
+    <!-- gzip compression filter -->
+    <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-web</artifactId>
+        <version>2.0.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/project/standard/templates/web/src/main/webapp/WEB-INF/web.xml
+++ b/project/standard/templates/web/src/main/webapp/WEB-INF/web.xml
@@ -45,6 +45,24 @@
 		<url-pattern>/rest/*</url-pattern>
 	</filter-mapping>
 
+  <!-- GZip compression -->
+	<filter>
+		<filter-name>CompressionFilter</filter-name>
+		<filter-class>net.sf.ehcache.constructs.web.filter.GzipFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.css</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.html</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.js</url-pattern>
+	</filter-mapping>
+
     <!-- CXF Servlet -->
 	<servlet>
 		<servlet-name>CXFServlet</servlet-name>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -117,7 +117,13 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
           <version>2.5</version>
-      </dependency>
+    </dependency>
+    <!-- gzip compression filter -->
+    <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-web</artifactId>
+        <version>2.0.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -48,6 +48,24 @@
 		<url-pattern>/rest/*</url-pattern>
 	</filter-mapping>
 
+	<!-- GZip compression -->
+	<filter>
+		<filter-name>CompressionFilter</filter-name>
+		<filter-class>net.sf.ehcache.constructs.web.filter.GzipFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.css</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.html</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>CompressionFilter</filter-name>
+		<url-pattern>*.js</url-pattern>
+	</filter-mapping>
+
 	<!-- CXF Servlet -->
 	<servlet>
 		<servlet-name>CXFServlet</servlet-name>


### PR DESCRIPTION
## Description
Automatic compression of static files (JS, css, HTML, etc.) in deployed war/binary

## Issues
 - Fix #3591

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
(gzip) compression of static files need additional configuration on the java web container or frontend (apache http, etc.). We could implement compression using a standard java filter to avoid additional configuration needs.

**What is the new behavior?**
Automatic compression of static files (JS, css, HTML, etc.) in deployed war/binary


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
