### PR TITLE
Fixes #3598: legends size in printing layouts

### DIFF
--- a/resources/geoserver/print/config.yaml
+++ b/resources/geoserver/print/config.yaml
@@ -87,6 +87,7 @@ layouts:
             - !legends
               horizontalAlignment: left
               #iconMaxWidth: 150
+              maxWidth: 150
               iconMaxHeight: 0
               layerSpace: 5
               layerFontSize: 12
@@ -191,6 +192,7 @@ layouts:
             - !legends
               horizontalAlignment: left
               #iconMaxWidth: 150
+              maxWidth: 160
               iconMaxHeight: 0
               layerSpace: 5
               layerFontSize: 12
@@ -478,10 +480,10 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          widths: [800]
+          widths: [500]
           absoluteX: 30
           absoluteY: 800
-          width: 800
+          width: 500
           items:
             - !legends      
               failOnBrokenUrl: false
@@ -490,7 +492,7 @@ layouts:
               iconMaxHeight: 700
               maxHeight: 750
               maxColumns: 1
-              maxWidth: 800
+              maxWidth: 500
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5
@@ -643,6 +645,7 @@ layouts:
             - !legends
               horizontalAlignment: left
               #iconMaxWidth: 150
+              maxWidth: 240
               iconMaxHeight: 0
               layerSpace: 5
               layerFontSize: 12
@@ -747,6 +750,7 @@ layouts:
             - !legends
               horizontalAlignment: left
               #iconMaxWidth: 150
+              maxWidth: 240
               iconMaxHeight: 0
               layerSpace: 5
               layerFontSize: 12
@@ -1149,7 +1153,7 @@ layouts:
               iconMaxHeight: 700
               maxHeight: 700
               maxColumns: 3
-              maxWidth: 1200
+              maxWidth: 1000
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5


### PR DESCRIPTION
## Description
Fixes legends size in printing layouts.

## Issues
 - Fix #3598

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Legends can overflow their container.

**What is the new behavior?**
Legends are constrained inside their containers, and labels are not cut, but flow on new rows.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
