### PR TITLE
Fix #2996 - OpenLayers WMTS refactor

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -25,6 +25,126 @@ require('../plugins/OverlayLayer');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const ConfigUtils = require('../../../../utils/ConfigUtils');
 
+const sampleTileMatrixConfig900913 = {
+    "matrixIds": {
+        'EPSG:900913': [
+            {
+                identifier: "EPSG:900913:0",
+                ranges: {
+                    cols: { min: "0", max: "0" },
+                    rows: { min: "0", max: "0" }
+                }
+
+            },
+            {
+                identifier: "EPSG:900913:1",
+                ranges: {
+                    cols: { min: "0", max: "1" },
+                    rows: { min: "0", max: "1" }
+                }
+
+            },
+            {
+                identifier: "EPSG:900913:2",
+                ranges: {
+                    cols: { min: "0", max: "3" },
+                    rows: { min: "1", max: "2" }
+                }
+
+            }
+        ]
+
+    },
+
+    "tileMatrixSet": [
+        {
+            "TileMatrix": [
+                {
+                    "MatrixHeight": "1",
+                    "MatrixWidth": "1",
+                    "ScaleDenominator": "5.590822639508929E8",
+                    "TileHeight": "256",
+                    "TileWidth": "256",
+                    "TopLeftCorner": "-2.003750834E7 2.0037508E7",
+                    "ows:Identifier": "EPSG:900913:0"
+                },
+                {
+                    "MatrixHeight": "2",
+                    "MatrixWidth": "2",
+                    "ScaleDenominator": "2.7954113197544646E8",
+                    "TileHeight": "256",
+                    "TileWidth": "256",
+                    "TopLeftCorner": "-2.003750834E7 2.0037508E7",
+                    "ows:Identifier": "EPSG:900913:1"
+                },
+                {
+                    "MatrixHeight": "4",
+                    "MatrixWidth": "4",
+                    "ScaleDenominator": "1.3977056598772323E8",
+                    "TileHeight": "256",
+                    "TileWidth": "256",
+                    "TopLeftCorner": "-2.003750834E7 2.0037508E7",
+                    "ows:Identifier": "EPSG:900913:2"
+                }
+            ],
+            "ows:Identifier": "EPSG:900913",
+            "ows:SupportedCRS": "urn:ogc:def:crs:EPSG:900913"
+        }
+    ]
+};
+
+const lowResGridset = {
+    "matrixIds": {
+        'SPHMERC_900913_CoFi': [
+            {
+                identifier: "SPHMERC_900913_CoFi:0",
+                ranges: {
+                    cols: { min: "0", max: "0" },
+                    rows: { min: "0", max: "0" }
+                }
+
+            },
+            {
+                identifier: "SPHMERC_900913_CoFi:1",
+                ranges: {
+                    cols: { min: "0", max: "1" },
+                    rows: { min: "0", max: "1" }
+                }
+
+            }
+        ]
+
+    },
+    "tileMatrixSet": [
+        {
+            "ows:Identifier": "SPHMERC_900913_CoFi",
+            "ows:SupportedCRS": "urn:ogc:def:crs:EPSG::900913",
+            "TileMatrix": [
+                {
+                    "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+                    "ows:Identifier": "SPHMERC_900913_CoFi:0",
+                    "ScaleDenominator": "272989.38669477194",
+                    "TopLeftCorner": "1232776.0 5459439.0",
+                    "TileWidth": "256",
+                    "TileHeight": "256",
+                    "MatrixWidth": "2",
+                    "MatrixHeight": "2"
+                },
+                {
+                    "ows:Abstract": "The grid was not well-defined, the scale therefore assumes 1m per map unit.",
+                    "ows:Identifier": "SPHMERC_900913_CoFi:1",
+                    "ScaleDenominator": "136494.69334738597",
+                    "TopLeftCorner": "1232776.0 5449655.0",
+                    "TileWidth": "256",
+                    "TileHeight": "256",
+                    "MatrixWidth": "4",
+                    "MatrixHeight": "3"
+                }
+            ]
+        }
+    ]
+};
+
 describe('Openlayers layer', () => {
     document.body.innerHTML = '<div id="map"></div>';
     let map;
@@ -51,7 +171,6 @@ describe('Openlayers layer', () => {
         map.setTarget(null);
         document.body.innerHTML = '';
     });
-
     it('missing layer', () => {
         var source = {
             "P_TYPE": "wrong ptype key"
@@ -260,79 +379,14 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().getLength()).toBe(1);
         expect(map.getLayers().item(0).getSource().urls.length).toBe(1);
     });
-
-    it('test wmts max and min resolutions', () => {
+    it('test wmts resolutions, maxResolutions and minResolutions', () => {
         var options = {
             "type": "wmts",
             "visibility": true,
             "name": "nurc:Arc_Sample",
             "group": "Meteo",
             "format": "image/png",
-            "matrixIds": {
-                'EPSG:900913': [
-                    {
-                        identifier: "EPSG:900913:0",
-                        ranges: {
-                            cols: {min: "0", max: "0"},
-                            rows: {min: "0", max: "0"}
-                        }
-
-                    },
-                    {
-                        identifier: "EPSG:900913:1",
-                        ranges: {
-                            cols: {min: "0", max: "1"},
-                            rows: {min: "0", max: "1"}
-                        }
-
-                    },
-                    {
-                        identifier: "EPSG:900913:2",
-                        ranges: {
-                            cols: {min: "0", max: "3"},
-                            rows: {min: "1", max: "2"}
-                        }
-
-                    }
-                ]
-
-            },
-
-            "tileMatrixSet": [
-                {
-                    "TileMatrix": [
-                        {
-                            "MatrixHeight": "1",
-                            "MatrixWidth": "1",
-                            "ScaleDenominator": "5.590822639508929E8",
-                            "TileHeight": "256",
-                            "TileWidth": "256",
-                            "TopLeftCorner": "-2.003750834E7 2.0037508E7",
-                            "ows:Identifier": "EPSG:900913:0"
-                        },
-                        {
-                            "MatrixHeight": "2",
-                            "MatrixWidth": "2",
-                            "ScaleDenominator": "2.7954113197544646E8",
-                            "TileHeight": "256",
-                            "TileWidth": "256",
-                            "TopLeftCorner": "-2.003750834E7 2.0037508E7",
-                            "ows:Identifier": "EPSG:900913:1"
-                        },
-                        {
-                            "MatrixHeight": "4",
-                            "MatrixWidth": "4",
-                            "ScaleDenominator": "1.3977056598772323E8",
-                            "TileHeight": "256",
-                            "TileWidth": "256",
-                            "TopLeftCorner": "-2.003750834E7 2.0037508E7",
-                            "ows:Identifier": "EPSG:900913:2"
-                        }
-                    ],
-                    "ows:Identifier": "EPSG:900913",
-                    "ows:SupportedCRS": "urn:ogc:def:crs:EPSG:900913"
-                }
-            ],
+            ...sampleTileMatrixConfig900913,
             "url": "http://sample.server/geoserver/gwc/service/wmts"
         };
         // create layers
@@ -346,8 +400,34 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().getLength()).toBe(1);
 
         const wmtsLayer = map.getLayers().item(0);
-        expect(Math.round(wmtsLayer.getMinResolution())).toBe(39136);
-        expect(Math.round(wmtsLayer.getMaxResolution())).toBe(156543);
+        const expectedResolutions = sampleTileMatrixConfig900913.tileMatrixSet[0].TileMatrix.map( e => e.ScaleDenominator * 0.28E-3);
+        wmtsLayer.getSource().getTileGrid().getResolutions().map((v, i) => expect(v).toBe(expectedResolutions[i]));
+    });
+    it('test fix for OL draw image (remove when OL > 5.3.0) ', () => {
+        // see https://github.com/openlayers/openlayers/issues/8700
+        var options = {
+            "type": "wmts",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "url": "http://sample.server/geoserver/gwc/service/wmts",
+            ...lowResGridset
+        };
+        // create layers
+        const layer = ReactDOM.render(
+            <OpenlayersLayer type="wmts"
+                options={options} map={map} />, document.getElementById("container"));
+
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+
+        const wmtsLayer = map.getLayers().item(0);
+        const expectedResolutions = lowResGridset.tileMatrixSet[0].TileMatrix.map(e => e.ScaleDenominator * 0.28E-3);
+        wmtsLayer.getSource().getTileGrid().getResolutions().map((v, i) => expect(v).toBe(expectedResolutions[i]));
+        expect(wmtsLayer.getMaxResolution()).toBeMoreThan(wmtsLayer.getSource().getTileGrid().getResolutions()[0]);
     });
 
     it('creates a wmts layer with multiple urls for openlayers map', () => {

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -8,7 +8,7 @@
 
 var Layers = require('../../../../utils/openlayers/Layers');
 var ol = require('openlayers');
-const {castArray, head, isEmpty} = require('lodash');
+const { castArray, head, last } = require('lodash');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const WMTSUtils = require('../../../../utils/WMTSUtils');
 const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
@@ -16,7 +16,7 @@ const mapUtils = require('../../../../utils/MapUtils');
 const assign = require('object-assign');
 const urlParser = require('url');
 
-function getWMSURLs( urls ) {
+function getWMSURLs(urls) {
     return urls.map((url) => url.split("\?")[0]);
 }
 
@@ -24,80 +24,63 @@ const createLayer = options => {
     // options.urls is an alternative name of URL.
     const urls = getWMSURLs(castArray(options.url));
     const srs = CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS);
+    const projection = ol.proj.get(srs);
+    const metersPerUnit = projection.getMetersPerUnit();
     const tilMatrixSetName = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
     const tileMatrixSet = head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tilMatrixSetName));
     const scales = tileMatrixSet && tileMatrixSet.TileMatrix.map(t => t.ScaleDenominator);
-    const mapResolutions = options.resolutions || mapUtils.getResolutions();
-    const matrixResolutions = options.resolutions || scales && mapUtils.getResolutionsForScales(scales, srs, 96) || [];
-    const resolutions = matrixResolutions && matrixResolutions.map(res => {
-        return head(mapResolutions.map((mRes, i) => {
-            if (i === mapResolutions.length - 1) {
-                return null;
-            }
-            const isBetween = res <= mapResolutions[i] && res > mapResolutions[i + 1];
-            if (isBetween) {
-                const delta = res - mapResolutions[i + 1];
-                return delta > (mapResolutions[i] - mapResolutions[i + 1]) / 2 ? mapResolutions[i] : mapResolutions[i + 1];
-            }
-            return null;
-        }).filter(r => r)) || res;
-    }) || mapResolutions;
+    const mapResolutions = mapUtils.getResolutions();
+    /*
+     * WMTS assumes a DPI 90.7 instead of 96 as documented in the WMTSCapabilities document:
+     * "The tile matrix set that has scale values calculated based on the dpi defined by OGC specification
+     * (dpi assumes 0.28mm as the physical distance of a pixel)."
+     */
+    const scaleToResolution = s => s * 0.28E-3 / metersPerUnit;
+    const matrixResolutions = options.resolutions || scales && scales.map(scaleToResolution);
+    const resolutions = matrixResolutions || mapResolutions;
 
     const matrixIds = WMTSUtils.limitMatrix(options.matrixIds && WMTSUtils.getMatrixIds(options.matrixIds, tilMatrixSetName || srs) || WMTSUtils.getDefaultMatrixId(options), resolutions.length);
 
-    const origin = tileMatrixSet && tileMatrixSet.TileMatrix && tileMatrixSet.TileMatrix[1] && tileMatrixSet.TileMatrix[1].TopLeftCorner && CoordinatesUtils.parseString(tileMatrixSet.TileMatrix[1].TopLeftCorner) || {};
-
-    let bbox = null;
-
-    /* calculate bbox from tile matrix set to avoid tile errors when fit world bounds*/
-    if (!isEmpty(origin) && origin.x && options.bbox && options.bbox.bounds
-            && parseFloat(options.bbox.bounds.minx) === -180 && parseFloat(options.bbox.bounds.miny) === -90
-            && parseFloat(options.bbox.bounds.maxx) === 180 && parseFloat(options.bbox.bounds.maxy) === 90
-            && tileMatrixSet && tileMatrixSet.TileMatrix[1] && tileMatrixSet.TileMatrix[1].ScaleDenominator
-            && tileMatrixSet.TileMatrix[1].MatrixWidth && tileMatrixSet.TileMatrix[1].MatrixHeight
-            && tileMatrixSet.TileMatrix[1].TileWidth && tileMatrixSet.TileMatrix[1].TileHeight
-        ) {
-        const res = mapUtils.getResolutionsForScales([tileMatrixSet.TileMatrix[1].ScaleDenominator], srs, 96);
-        bbox = {
-            bounds: {
-                minx: origin.x,
-                maxx: origin.x + tileMatrixSet.TileMatrix[1].MatrixWidth * tileMatrixSet.TileMatrix[1].TileWidth * res,
-                maxy: origin.y,
-                miny: origin.y - tileMatrixSet.TileMatrix[1].MatrixHeight * tileMatrixSet.TileMatrix[1].TileHeight * res
-            },
-            crs: srs
-        };
-
-    }
-    bbox = bbox || options.bbox || null;
-
-    const extent = bbox ? ol.extent.applyTransform([parseFloat(bbox.bounds.minx), parseFloat(bbox.bounds.miny), parseFloat(bbox.bounds.maxx), parseFloat(bbox.bounds.maxy)], ol.proj.getTransform(bbox.crs, options.srs)) : null;
-
-    /* remove matrix 0, it doesn't happear correctly on map  */
-    const paramResolutions = resolutions.filter((r, i) => i > 0);
-    const paramMatrixIds = matrixIds.filter((r, i) => i > 0);
-    const sizes = tileMatrixSet
+    /* - enu - the default easting, north-ing, elevation
+    * - neu - north-ing, easting, up - useful for "lat/long" geographic coordinates, or south orientated transverse mercator
+    * - wnu - westing, north-ing, up - some planetary coordinate systems have "west positive" coordinate systems
+    */
+    const switchOriginXY = projection.getAxisOrientation().substr(0, 2) === 'ne';
+    let origins = tileMatrixSet
         && tileMatrixSet.TileMatrix
         && tileMatrixSet.TileMatrix
-        .filter(({ "ows:Identifier": id } = {}) => paramMatrixIds.indexOf(id) >= 0 )
-        .map(({ MatrixWidth, MatrixHeight } = {}) => [MatrixWidth, MatrixHeight]);
+            .map(({ TopLeftCorner } = {}) => TopLeftCorner && CoordinatesUtils.parseString(TopLeftCorner))
+            .map(({ x, y } = {}) => switchOriginXY ? [y, x] : [x, y]);
+
+    const bbox = options.bbox;
+
+    const extent = bbox
+        ? ol.extent.applyTransform([
+                parseFloat(bbox.bounds.minx),
+                parseFloat(bbox.bounds.miny),
+                parseFloat(bbox.bounds.maxx),
+                parseFloat(bbox.bounds.maxy)
+            ], ol.proj.getTransform(bbox.crs, options.srs))
+        : null;
+
     let queryParameters = {};
     urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters, options.securityToken));
-    const queryParametersString = urlParser.format({ query: {...queryParameters}});
-
-    const maxResolution = resolutions[0]; // exclusive
-    const minResolution = resolutions[resolutions.length - 1]; // inclusive
+    const queryParametersString = urlParser.format({ query: { ...queryParameters } });
 
     // WMTS Capabilities has "RESTful"/"KVP", OpenLayers uses "REST"/"KVP";
     let requestEncoding = options.requestEncoding === "RESTful" ? "REST" : options.requestEncoding;
+    // TODO: support tileSizes from  matrix
+    const TILE_SIZE = 256;
 
+    // Temporary fix for https://github.com/openlayers/openlayers/issues/8700 . It should be solved in OL 5.3.0
+    // it's exclusive so the map lower resolution that draws the image in less then 0.5 pixels have to be the maxResolution
+    const maxResolution = options.maxResolution || last(mapResolutions.filter((r = []) => resolutions[0] / r * TILE_SIZE < 0.5));
     return new ol.layer.Tile({
         opacity: options.opacity !== undefined ? options.opacity : 1,
         zIndex: options.zIndex,
         extent: extent,
-        visible: options.visibility !== false,
         maxResolution,
-        minResolution,
+        visible: options.visibility !== false,
         source: new ol.source.WMTS(assign({
             requestEncoding,
             urls: urls.map(u => u + queryParametersString),
@@ -107,16 +90,13 @@ const createLayer = options => {
             format: options.format || 'image/png',
             style: options.style,
             tileGrid: new ol.tilegrid.WMTS({
-                origin: [
-                    origin.lng || origin.x || options.originX || -20037508.3428,
-                    origin.lat || origin.y || options.originY || 20037508.3428
-                ],
-                extent: extent,
-                resolutions: paramResolutions,
-                sizes,
+                origins,
+                origin: !origins ? [20037508.3428, -20037508.3428] : undefined, // Either origin or origins must be configured, never both.
+                // extent: extent,
+                resolutions,
+                matrixIds,
                 // TODO: matrixLimits from ranges
-                matrixIds: paramMatrixIds,
-                tileSize: options.tileSize || [256, 256]
+                tileSize: options.tileSize || [TILE_SIZE, TILE_SIZE]
             }),
             wrapX: true
         }))
@@ -124,10 +104,13 @@ const createLayer = options => {
 };
 
 const updateLayer = (layer, newOptions, oldOptions) => {
-    if (oldOptions.securityToken !== newOptions.securityToken) {
+    if (oldOptions.securityToken !== newOptions.securityToken || oldOptions.srs !== newOptions.srs) {
         return createLayer(newOptions);
     }
     return null;
 };
+const compatibleLayer = options =>
+    head(CoordinatesUtils.getEquivalentSRS(options.srs).filter(proj => options.matrixIds && options.matrixIds.hasOwnProperty(proj))) ? true : false;
 
-Layers.registerType('wmts', {create: createLayer, update: updateLayer});
+
+Layers.registerType('wmts', { create: createLayer, update: updateLayer, isCompatible: compatibleLayer });


### PR DESCRIPTION
## Description
This pull request : 
 - Uses the WMTS server resolutions instead of map ones
 - Removes all work-arounds and simplify the needed ones.
 - Correctly calculate resolutions from scale denominators from WMTS
 - Support different origins at different zoom levels for server sides resolutions
 - Support custom resolutions on map different from server resolutions
## Issues
 - Fix #2996

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
WMTS from services like [this](http://tms.comune.fi.it/geowebcache/service/wmts) still doesn't work

**What is the new behavior?**
Works with : 
 - http://tms.comune.fi.it/geowebcache/service/wmts
 - https://basemap.at/wmts/1.0.0/WMTSCapabilities.xml
 - https://demo.geo-solutions.it/geoserver/gwc/service/wmts

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

