### PR TITLE
Fix #3531 collapsible hidden widgets

### DIFF
--- a/docma-config.json
+++ b/docma-config.json
@@ -121,6 +121,7 @@
             "web/client/components/misc/cardgrids/SideGrid.jsx",
             "web/client/components/misc/enhancers/emptyState.jsx",
             "web/client/components/misc/enhancers/tooltip.jsx",
+            "web/client/components/misc/enhancers/security/accessRuleParser.jsx",
             "web/client/components/misc/panels/Accordion.jsx",
             "web/client/components/misc/panels/DockablePanel.jsx",
             "web/client/components/misc/panels/DockPanel.jsx",
@@ -226,6 +227,8 @@
                 "web/client/plugins/TOC.jsx",
                 "web/client/plugins/ThematicLayer.jsx",
                 "web/client/plugins/WFSDownload.jsx",
+                "web/client/plugins/Widgets.jsx",
+                "web/client/plugins/WidgetsTray.jsx",
                 "web/client/plugins/ZoomIn.jsx",
                 "web/client/plugins/ZoomOut.jsx"
             ]

--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -36,7 +36,7 @@ require('./appPolyfill');
  * @prop {object} pluginsDef plugins definition object (e.g. as loaded from plugins.js)
  * @prop {object} storeOpts options for the store
  * @prop {array} initialActions list of actions to be dispatched on startup
- * @prop {function/object} appComponent root component for the application
+ * @prop {function|object} appComponent root component for the application
  * @prop {bool} printingEnabled initializes printing environment based on mapfish-print
  * @prop {function} onStoreInit optional callback called just after store creation
  * @prop {function} onInit optional callback called before first rendering, can delay first rendering

--- a/web/client/components/misc/enhancers/security/accessRuleParser.jsx
+++ b/web/client/components/misc/enhancers/security/accessRuleParser.jsx
@@ -74,7 +74,7 @@ const parseRules = ({accessInfo, postProcessValue, reduceFun}) => rawRules => {
  * @param {Object} options - The options to generate the enhancer
  * @param {string} [options.asObject = false] if true, the property is intended to be an object. The rules will be applied on each key of the object.
  *        If not defined, at propToMap have to be defined. Otherwise the rule will be applied only to the property. Useful if you have more than one flag to set.
- * @param {function} [options.postProcessValue = identity] process the value get from a rule to return. The function has the rule as second argument. Example of custom postProcesValue function is: `(v, rule) => rule == "_ALWAYS_FALSE_" ? false : v * 2
+ * @param {function} [options.postProcessValue = identity] process the value get from a rule to return. The function has the rule as second argument. Example of custom postProcessValue function is: `(v, rule) => rule == "_ALWAYS_FALSE_" ? false : v * 2
  * @param {function} [options.reduceFun = AND]. An Array.reduce function to accumulate the rules, useful if you want to transform the variable in a different thing that a flag, or you want to use OR condition.
  * @param {object} [options.accessInfo="accessInfo"]: the property name of the property to use to retrieve data
  */

--- a/web/client/components/widgets/enhancers/tools/__tests__/collapsibleWidget-test.js
+++ b/web/client/components/widgets/enhancers/tools/__tests__/collapsibleWidget-test.js
@@ -58,14 +58,14 @@ describe('collapsibleWidget enhancer', () => {
         }));
         ReactDOM.render(<Sink dataGrid={{"static": true}} />, document.getElementById("container"));
     });
-    it('hide when hidden (hide = true hides the tool for certain types of users )', (done) => {
+    it('show when hidden (hide = true hides the tool for certain types of users )', (done) => {
         const Sink = collapsible(createSink(props => {
             expect(props).toExist();
             expect(props.widgetTools.length).toBe(1);
-            expect(props.widgetTools[0].visible).toBe(false);
+            expect(props.widgetTools[0].visible).toBe(true);
             done();
         }));
-        ReactDOM.render(<Sink hide dataGrid={{ "static": true }} />, document.getElementById("container"));
+        ReactDOM.render(<Sink hide />, document.getElementById("container"));
     });
     it('toggleCollapse callback', () => {
         const actions = {

--- a/web/client/components/widgets/enhancers/tools/collapsibleWidget.js
+++ b/web/client/components/widgets/enhancers/tools/collapsibleWidget.js
@@ -12,7 +12,7 @@ const {compose, withProps} = require('recompose');
  */
 module.exports = () =>
 compose(
-    withProps(({ widgetTools = [], dataGrid = {}, hide, toggleCollapse = () => {}, toolsOptions = {}}) => ({
+    withProps(({ widgetTools = [], dataGrid = {}, toggleCollapse = () => {}, toolsOptions = {}}) => ({
         widgetTools: !!toolsOptions.showCollapse ? [
             ...widgetTools,
             {
@@ -20,7 +20,7 @@ compose(
                 target: "icons",
                 tooltipId: "widgets.widget.menu.collapse",
                 // pinned can not be collapsed, hidden can not be collapsed because they do not appear in the tray
-                visible: !hide && !dataGrid.static,
+                visible: !dataGrid.static,
                 onClick: () => toggleCollapse()
             }
         ] : widgetTools

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -131,7 +131,7 @@ class Widgets extends React.Component {
  *       {showPin: ["__OR__", "user.role===ADMIN", "mapInfo.canEdit"]}
  *       ```
  * @prop {boolean|string|array} [toolsOptions.showPin] show lock tool. By default is visible only to the admin
- * @prop {boolean|string|array} [toolsOptions.showHide] show the "hide tool" for the widget (the tool allows to hide the widget to users that have `seeHidden=false` ). By default is false, in the most common case it should be the same of `seeHidden`. 
+ * @prop {boolean|string|array} [toolsOptions.showHide] show the "hide tool" for the widget (the tool allows to hide the widget to users that have `seeHidden=false` ). By default is false, in the most common case it should be the same of `seeHidden`.
  * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions
  *
  */

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -131,7 +131,7 @@ class Widgets extends React.Component {
  *       {showPin: ["__OR__", "user.role===ADMIN", "mapInfo.canEdit"]}
  *       ```
  * @prop {boolean|string|array} [toolsOptions.showPin] show lock tool. By default is visible only to the admin
- * @prop {boolean|string|array} [toolsOptions.showHide] show hide tool. Allow to hide the tool when hide is false.
+ * @prop {boolean|string|array} [toolsOptions.showHide] show the "hide tool" for the widget (the tool allows to hide the widget to users that have `seeHidden=false` ). By default is false, in the most common case it should be the same of `seeHidden`. 
  * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions
  *
  */

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -124,15 +124,15 @@ class Widgets extends React.Component {
  * @memberof plugins
  * @name Widgets
  * @class
- * @prop object [toolsOptions] options to show and manage widgets tools. Widget tools are buttons available in some widgets. Any entry of this object can be configured using accessRules.
+ * @prop {object} [toolsOptions] options to show and manage widgets tools. Widget tools are buttons available in some widgets. Any entry of this object can be configured using accessRules.
  *       Access rules can be defined using the syntax (@see components.misc.enhancers.security.accessRuleParser).
  *       The accessible parts of the state are `{mapInfo: {canEdit, canDelete...}, user: {role: "USER"}}`. So you can define rules like this:
  *       ```
  *       {showPin: ["__OR__", "user.role===ADMIN", "mapInfo.canEdit"]}
  *       ```
- * @prop {boolean|string|array} [showPin] show lock tool. By default is visible only to the admin
- * @prop {boolean|string|array} [showHide] show hide tool. Allow to hide the tool when hide is false.
- * @prop {boolean|string|array} [seeHidden] hides the widgets under particular conditions
+ * @prop {boolean|string|array} [toolsOptions.showPin] show lock tool. By default is visible only to the admin
+ * @prop {boolean|string|array} [toolsOptions.showHide] show hide tool. Allow to hide the tool when hide is false.
+ * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions
  *
  */
 const WidgetsPlugin = autoDisableWidgets(Widgets);

--- a/web/client/plugins/WidgetsTray.jsx
+++ b/web/client/plugins/WidgetsTray.jsx
@@ -4,9 +4,10 @@ const WidgetsTray = require('./widgets/WidgetsTray');
 const autoDisableWidgets = require('./widgets/autoDisableWidgets');
 
 /**
- * Plugin that shows collapsed widgets
- * @name CollapsedWidgetBar
+ * Plugin that allow to collapse widgets. Shows a small tray where to see the collapsed plugins list.
+ * @name WidgetsTray
  * @memberof plugins
+ * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions. **Must** be the same of rule of the Widget plugin. @see plugins.Widgets.
  * @class
  */
 module.exports = {

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -127,7 +127,7 @@ const CollapseAllButton = compose(
         createSelector(
             getVisibleFloatingWidgets,
             (widgets = []) => ({widgets})
-        ), // TODO: get all collapsed
+        ), // get all visible widgets
         {
             onClick: () => toggleCollapseAll()
         }

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -150,7 +150,7 @@ const CollapseAllButton = compose(
 /**
  * Main component of the widgets tray.
  * @prop {boolean} enabled if true, the component is enabled and visible
- * @prop {object} toolsOptions object that contains `showHidden` property rules to apply. see Widgets plugin configuration
+ * @prop {object} toolsOptions object that contains `seeHidden` property rules to apply. see Widgets plugin configuration
  * @prop {boolean} expanded if true, it shows the list of widgets
  * @prop {function} setExpanded handler to toggle expand/collapse the tray
  */

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -8,10 +8,11 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const { connect } = require('react-redux');
-const { compose, withProps, withState, defaultProps, lifecycle, mapPropsStream } = require('recompose');
+const { compose, defaultProps, withProps, withState, lifecycle, mapPropsStream } = require('recompose');
 const { createSelector } = require('reselect');
 const { find, findIndex, sortBy } = require('lodash');
 const tooltip = require('../../components/misc/enhancers/tooltip');
+const editOptions = require('./editOptions');
 
 const { Glyphicon, Button: BButton } = require('react-bootstrap');
 const Button = tooltip(BButton);
@@ -24,7 +25,21 @@ const BorderLayout = require('../../components/layout/BorderLayout');
  * Only widgets that are not hidden (to some users) or pinned (static) can be in tray
  * @param {object} widget the widget configuration
  */
-const noHiddenOrStaticWidgets = w => !w.hide && (!w.dataGrid || !w.dataGrid.static);
+const noHiddenOrStaticWidgets = w => !w.dataGrid || !w.dataGrid.static;
+
+// hide hidden widgets in tray for users has not access to them
+const filterHiddenWidgets = compose(
+    defaultProps({
+        "toolsOptions": {
+            "seeHidden": "user.role===ADMIN"
+        }
+    }),
+    // allow to customize toolsOptions object, with rules. see accessRuleParser
+    editOptions("toolsOptions", { asObject: true }),
+    withProps(({ widgets, toolsOptions = { seeHidden: false } }) => ({
+        widgets: toolsOptions.seeHidden ? widgets : widgets.filter(w => !w.hide)
+    }))
+);
 
 /**
  * A selector that retrieves widgets to display in the tray area
@@ -77,6 +92,7 @@ const WidgetsBar = compose(
             style: { marginLeft: 2, marginRight: 2 }
         }
     }),
+    filterHiddenWidgets,
     withProps(({ btnGroupProps = {}, btnDefaultProps = {} }) => ({
         btnGroupProps: {
             bsSize: "xsmall",
@@ -106,16 +122,20 @@ const CollapseTrayButton = ({ expanded, onClick = () => { } } = {}) =>
 /**
  * Button to collapse/expand all widgets
  */
-const CollapseAllButton = connect(
-    createSelector(
-        getVisibleFloatingWidgets,
-        (visible = []) => ({
-            shouldExpand: visible.filter(noHiddenOrStaticWidgets).length === 0
-        })
-    ), // TODO: get all collapsed
-    {
-        onClick: () => toggleCollapseAll()
-    }
+const CollapseAllButton = compose(
+    connect(
+        createSelector(
+            getVisibleFloatingWidgets,
+            (widgets = []) => ({widgets})
+        ), // TODO: get all collapsed
+        {
+            onClick: () => toggleCollapseAll()
+        }
+    ),
+    filterHiddenWidgets,
+    withProps(({widgets = []}) => ({
+        shouldExpand: widgets.length === 0
+    }))
 )(({ onClick = () => { }, shouldExpand = false } = {}) =>
     (<Button
         tooltipId={shouldExpand ? "widgets.tray.expandAll" : "widgets.tray.collapseAll"}
@@ -169,13 +189,15 @@ module.exports = compose(
     withState("expanded", "setExpanded", false),
     connect(createSelector(
         trayWidgets,
-        (widgets = []) => ({
-            hasCollapsedWidgets: widgets.filter(({ collapsed } = {}) => collapsed).length > 0,
-            hasTrayWidgets: widgets.length > 0
-        })
+        (widgets = []) => ({widgets})
     ), {
         toggleTray
     }),
+    filterHiddenWidgets,
+    withProps(({widgets = []}) => ({
+        hasCollapsedWidgets: widgets.filter(({ collapsed } = {}) => collapsed).length > 0,
+        hasTrayWidgets: widgets.length > 0
+    })),
     // flag of plugin presence
     lifecycle({
         componentDidMount() {

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -150,12 +150,14 @@ const CollapseAllButton = compose(
 /**
  * Main component of the widgets tray.
  * @prop {boolean} enabled if true, the component is enabled and visible
+ * @prop {object} toolsOptions object that contains `showHidden` property rules to apply. see Widgets plugin configuration
  * @prop {boolean} expanded if true, it shows the list of widgets
  * @prop {function} setExpanded handler to toggle expand/collapse the tray
  */
 class WidgetsTray extends React.Component {
     static propTypes = {
         enabled: PropTypes.bool,
+        toolsOptions: PropTypes.object,
         expanded: PropTypes.bool,
         setExpanded: PropTypes.fun
     };
@@ -176,10 +178,10 @@ class WidgetsTray extends React.Component {
                 }}>
                 <BorderLayout
                     columns={[
-                        <CollapseTrayButton expanded={this.props.expanded} onClick={() => this.props.setExpanded(!this.props.expanded)} />,
-                        <CollapseAllButton />
+                        <CollapseTrayButton toolsOptions={this.props.toolsOptions} expanded={this.props.expanded} onClick={() => this.props.setExpanded(!this.props.expanded)} />,
+                        <CollapseAllButton toolsOptions={this.props.toolsOptions} />
                     ]}
-                >{this.props.expanded ? <WidgetsBar /> : null}
+                >{this.props.expanded ? <WidgetsBar toolsOptions={this.props.toolsOptions} /> : null}
                 </BorderLayout>
             </div>)
             : null;


### PR DESCRIPTION
## Description
This pull request allow to collapse hidden widgets, when the user can see them. 

## Note for testers
There is no way to test this if you don't have the hide tool activated. dev server don't have it activated

### Issues
 - Fix #3531

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
Admin can see hidden widgets but can not collapse them

**What is the new behavior?**
Hidden widgets are as the other widgets for the admin.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

