### PR TITLE
Fix #3625. Support numeric aggregation for integer data type

### DIFF
--- a/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {createSink} = require('recompose');
+const expect = require('expect');
+const wfsChartOptions = require('../wfsChartOptions');
+const featureTypeProperties = [
+                {
+                    "name": "Integer",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:int",
+                    "localType": "int"
+                },
+                {
+                    "name": "Long",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:int",
+                    "localType": "int"
+                },
+                {
+                    "name": "Float",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:number",
+                    "localType": "number"
+                },
+                {
+                    "name": "Double_Precision",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:number",
+                    "localType": "number"
+                },
+                {
+                    "name": "Date",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:date",
+                    "localType": "date"
+                },
+                {
+                    "name": "Time",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:time",
+                    "localType": "time"
+                },
+                {
+                    "name": "DateTime",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:date-time",
+                    "localType": "date-time"
+                },
+                {
+                    "name": "String",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "xsd:string",
+                    "localType": "string"
+                },
+                {
+                    "name": "Point",
+                    "maxOccurs": 1,
+                    "minOccurs": 0,
+                    "nillable": true,
+                    "type": "gml:Point",
+                    "localType": "Point"
+                }
+            ];
+
+
+describe('wfsChartOptions enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('wfsChartOptions rendering with defaults', (done) => {
+        const Sink = wfsChartOptions(createSink( props => {
+            expect(props).toExist();
+            done();
+        }));
+        ReactDOM.render(<Sink />, document.getElementById("container"));
+    });
+    describe('Check data types', () => {
+        const checkOptions = (options, check = () => {}, done) => {
+            const data = {
+                options
+            };
+
+            const Sink = wfsChartOptions(createSink(props => {
+                check(props);
+                done();
+            }));
+            ReactDOM.render(<Sink data={data} featureTypeProperties={featureTypeProperties} />, document.getElementById("container"));
+        };
+        it('Integer', (done) => {
+            checkOptions({ aggregationAttribute: "Integer" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+        });
+        it('Long', (done) => {
+            checkOptions({ aggregationAttribute: "Long" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+        });
+        it('Float', (done) => {
+            checkOptions({ aggregationAttribute: "Float" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+        });
+        it('Double Precision', (done) => {
+            checkOptions({ aggregationAttribute: "Double_Precision" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+        });
+        it('String', (done) => {
+            checkOptions({ aggregationAttribute: "String" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+        });
+        it('Time', (done) => {
+            checkOptions({ aggregationAttribute: "Time" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+        });
+
+        it('Date', (done) => {
+            checkOptions({ aggregationAttribute: "Date" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+        });
+
+        it('DateTime', (done) => {
+            checkOptions({ aggregationAttribute: "DateTime" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+        });
+    });
+});

--- a/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
+++ b/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
@@ -15,7 +15,7 @@ const propsToOptions = props => props.filter(({type} = {}) => type.indexOf("gml:
 
 const getAllowedAggregationOptions = (propertyName, featureTypeProperties = []) => {
     const prop = find(featureTypeProperties, {name: propertyName});
-    if (prop && prop.localType === 'number') {
+    if (prop && (prop.localType === 'number' || prop.localType === 'int')) {
         return [
           {value: "Count", label: "COUNT"},
           {value: "Sum", label: "SUM"},


### PR DESCRIPTION
## Description
This allow integer value to be used in charts widgets.

## Issues
 - Fix #3625 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
See #3625 
Only float and double precision attributes type can use the numeric aggregation operations  (SUM,MAX,MIN in charts)

**What is the new behavior?**
Also the int and long types have the numeric aggregation operation in the list

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

