### PR TITLE
fix #3608 IE11 combobox problem

### DIFF
--- a/web/client/themes/default/less/dropdown-menu.less
+++ b/web/client/themes/default/less/dropdown-menu.less
@@ -7,7 +7,7 @@
 }
 /* when flipped we need to let the dropdown to display on top */
 .react-selectize.bootstrap3.dropdown-menu.flipped {
-    top: unset;
+    top: auto;
 }
 //
 .react-selectize.bootstrap3.root-node.simple-select{


### PR DESCRIPTION
## Description
Fix a problem on IE11 because it does not supports "unset" css property

## Issues
 - Fix #3608

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
tooltip and placement dropdowns are **not** visible when opened

**What is the new behavior?**
tooltip and placement dropdowns are visible when opened (IE11)
all other browsers are fine

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
> ┻┳|  
> ┳┻| _  
> ┻┳| •.•) 💬 *"look at the screenshot of IE11 below"*  
> ┳┻|⊂ﾉ     
> ┻┳|  

![image](https://user-images.githubusercontent.com/11991428/54598519-f1640a00-4a38-11e9-920b-6e6716aa9f2e.png)
