### PR TITLE
Fix #3593 Adjusted catalog position when modals are opened (2019.01.xx)

### DIFF
--- a/web/client/components/mapcontrols/measure/MeasureDialog.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureDialog.jsx
@@ -31,7 +31,7 @@ class MeasureDialog extends React.Component {
     };
 
     render() {
-        return this.props.show ? <Dialog>
+        return this.props.show ? <Dialog id="measure-dialog" style={{zIndex: 1991}}>
             <div key="header" role="header">
                 <Glyphicon glyph="1-ruler"/>&nbsp;<Message key="title" msgId="measureComponent.Measure"/>
                 <button key="close" onClick={this.onClose} className="close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -139,7 +139,7 @@ class SharePanel extends React.Component {
           </Tabs>);
 
         let sharePanel =
-            (<Dialog id="share-panel-dialog" className="modal-dialog modal-content share-win">
+            (<Dialog id="share-panel-dialog" className="modal-dialog modal-content share-win" style={{zIndex: 1993}}>
                 <span role="header">
                     <span className="share-panel-title">
                         <Message msgId="share.title"/>

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -125,7 +125,7 @@ class MetadataExplorerComponent extends React.Component {
     render() {
         const panel = <Catalog zoomToLayer={this.props.zoomToLayer} searchOnStartup={this.props.searchOnStartup} active={this.props.active} {...this.props}/>;
         return (
-            <div style={{width: '100%', height: '100%', pointerEvents: 'none'}}>
+            <div id="catalog-root" style={{width: '100%', height: '100%', pointerEvents: 'none'}}>
                 <ContainerDimensions>
                     {({ width }) => (<DockPanel
                         open={this.props.active}

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -316,7 +316,7 @@ module.exports = {
                                         {this.renderBody()}
                                     </Panel>);
                                 }
-                                return (<Dialog id="mapstore-print-panel" style={this.props.style}>
+                                return (<Dialog id="mapstore-print-panel" style={{ left: "17%", top: "50px", zIndex: 1990, ...this.props.style}}>
                                     <span role="header"><span className="print-panel-title"><Message msgId="print.paneltitle"/></span><button onClick={this.props.toggleControl} className="print-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button></span>
                                     {this.renderBody()}
                                 </Dialog>);

--- a/web/client/plugins/Settings.jsx
+++ b/web/client/plugins/Settings.jsx
@@ -72,10 +72,10 @@ class SettingsButton extends React.Component {
         wrapWithPanel: false,
         panelStyle: {
             minWidth: "300px",
-            zIndex: 100,
+            zIndex: 1996,
             position: "absolute",
             overflow: "auto",
-            top: "100px",
+            top: "90px",
             left: "calc(50% - 150px)",
             backgroundColor: "white"
         },

--- a/web/client/plugins/metadataexplorer/css/style.css
+++ b/web/client/plugins/metadataexplorer/css/style.css
@@ -18,6 +18,9 @@ div.record-grid .record-item .panel-body{
 #mapstore-catalog-panel .record-item {
     min-height: 150px;
 }
+#catalog-root {
+    position: static!important;
+}
 
 /*
 !important is needed because the library we used

--- a/web/client/plugins/shapefile/ShapeFile.jsx
+++ b/web/client/plugins/shapefile/ShapeFile.jsx
@@ -50,10 +50,10 @@ class ShapeFile extends React.Component {
         wrapWithPanel: false,
         panelStyle: {
             minWidth: "360px",
-            zIndex: 100,
+            zIndex: 1995,
             position: "absolute",
             overflow: "visible",
-            top: "100px",
+            top: "30px",
             left: "calc(50% - 150px)"
         },
         panelClassName: "toolbar-panel",

--- a/web/client/product/assets/css/viewer.css
+++ b/web/client/product/assets/css/viewer.css
@@ -67,7 +67,7 @@ html, body, #container, .fill {
 }
 
 .modal-dialog-container {
-    z-index: 2000!important;
+    z-index: 2000;
 }
 
 #mapstore-scalebox-container {

--- a/web/client/product/components/viewer/about/About.jsx
+++ b/web/client/product/components/viewer/about/About.jsx
@@ -49,7 +49,7 @@ class About extends React.Component {
             className="map-logo"
             body={
                 <AboutContent/>
-            }/>) : (<Dialog id="mapstore-about" style={assign({}, {display: this.props.enabled ? "block" : "none"})}>
+            }/>) : (<Dialog id="mapstore-about" style={assign({}, {zIndex: 1992, display: this.props.enabled ? "block" : "none"})}>
                 <span role="header"><span className="about-panel-title"><I18N.Message msgId="about_title"/></span><button onClick={this.props.onClose} className="about-panel-close close">{this.props.modalConfig.closeGlyph ? <Glyphicon glyph={this.props.modalConfig.closeGlyph}/> : <span>×</span>}</button></span>
                 <div role="body"><AboutContent/></div>
             </Dialog>);

--- a/web/client/themes/default/less/panels.less
+++ b/web/client/themes/default/less/panels.less
@@ -49,7 +49,7 @@
                     margin-top: 15px;
                 }
             }
-            
+
             .col-xs-6 {
                 .btn-group {
                     float: right;
@@ -87,7 +87,7 @@
             > li {
                 display: table-cell;
                 width: 1%;
-                
+
                 > a {
                     margin-bottom: 0;
                     border-bottom: 1px solid @nav-tabs-justified-link-border-color;
@@ -200,4 +200,10 @@
             }
         }
     }
+}
+
+#mapstore-print-panel, #measure-dialog, #mapstore-about {
+    position: fixed;
+    top: 0%;
+    left: 20%;
 }

--- a/web/client/themes/default/less/panels.less
+++ b/web/client/themes/default/less/panels.less
@@ -203,7 +203,7 @@
 }
 
 #mapstore-print-panel, #measure-dialog, #mapstore-about {
-    position: fixed;
+    position: absolute;
     top: 0%;
     left: 20%;
 }


### PR DESCRIPTION
## Description
Fixing layout of catalog and modals

## Issues
 - Fix #3593 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: layout update


**What is the current behavior?** (You can also link to an open issue here)
try to open print and catalog
layout messes up (catalog moves below print)

**What is the new behavior?**
if you open print tool or measure and then the catalog, all are visible on the map. (modals have z-index issue tho)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I had to remove the !important line in the viewer.css in order to allow z-index override

![image](https://user-images.githubusercontent.com/11991428/54619582-21290700-4a65-11e9-8096-e2a88be19bf0.png)
