### PR TITLE
Fix #3640 Start animation from the current time

### DIFF
--- a/web/client/epics/__tests__/playback-test.js
+++ b/web/client/epics/__tests__/playback-test.js
@@ -10,12 +10,49 @@ const expect = require('expect');
 const { testEpic } = require('./epicTestUtils');
 const { UPDATE_METADATA } = require('../../actions/playback');
 const { retrieveFramesForPlayback, playbackStopWhenDeleteLayer, playbackCacheNextPreviousTimes } = require('../playback');
+const DOMAIN_VALUES_RESPONSE = require('raw-loader!../../test-resources/wmts/DomainValues.xml');
 const { removeNode, CHANGE_LAYER_PROPERTIES } = require('../../actions/layers');
 const { STOP, play, stop, FRAMES_LOADING, SET_FRAMES } = require('../../actions/playback');
 const { setCurrentTime, moveTime } = require('../../actions/dimension');
 const { selectLayer, LOADING } = require('../../actions/timeline');
+const axios = require("../../libs/ajax");
+const MockAdapter = require("axios-mock-adapter");
+const ANIMATION_MOCK_STATE = {
+    dimension: {
+        currentTime: '2016-09-05T00:00:00.000Z'
+    },
+    layers: {
+        flat: [
+            {
+                id: 'playback:selected_layer',
+                name: 'playback_layer',
+                dimensions: [
+                    {
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'MOCK_DOMAIN_VALUES'
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    timeline: {
+        selectedLayer: 'playback:selected_layer'
+    }
+};
+
 describe('playback Epics', () => {
+    let mock;
+    beforeEach(() => {
+        mock = new MockAdapter(axios);
+    });
+    afterEach(() => {
+        mock.restore();
+    });
     it('retrieveFramesForPlayback', done => {
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_VALUES_RESPONSE);
         testEpic(retrieveFramesForPlayback, 6, play(), ([a0, a1, a2, a3, a4, a5]) => {
             // set single tile
             expect(a0.type).toBe(CHANGE_LAYER_PROPERTIES);
@@ -26,35 +63,55 @@ describe('playback Epics', () => {
             expect(a3.type).toBe(SET_FRAMES);
             expect(a4.type).toBe(FRAMES_LOADING);
             expect(a5.type).toBe(LOADING);
+
+            // check request parameters
+            expect(mock.history.get.length).toBe(1);
+            expect(mock.history.get[0].params.domain).toBe("time");
+            // if animation range is not active, animation should start from current time
+            expect(mock.history.get[0].params.fromValue).toBe(ANIMATION_MOCK_STATE.dimension.currentTime);
+            expect(mock.history.get[0].params.layer).toBe(ANIMATION_MOCK_STATE.layers.flat[0].name);
+            expect(mock.history.get[0].params.limit).toBe(20);
+            expect(mock.history.get[0].params.request).toBe("GetDomainValues");
+            expect(mock.history.get[0].params.service).toBe("WMTS");
+            expect(mock.history.get[0].params.sort).toBe("asc");
+            expect(mock.history.get[0].params.version).toBe("1.0.0");
+            expect(mock.history.get.length).toBe(1);
+
+            done();
+        }, ANIMATION_MOCK_STATE);
+    });
+    it('retrieveFramesForPlayback with animation range', done => {
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_VALUES_RESPONSE);
+        testEpic(retrieveFramesForPlayback, 6, play(), ([a0, a1, a2, a3, a4, a5]) => {
+            // set single tile
+            expect(a0.type).toBe(CHANGE_LAYER_PROPERTIES);
+            expect(a0.newProperties.singleTile).toBe(true);
+            // loading events
+            expect(a1.type).toBe(LOADING);
+            expect(a2.type).toBe(FRAMES_LOADING);
+            expect(a3.type).toBe(SET_FRAMES);
+            expect(a4.type).toBe(FRAMES_LOADING);
+            expect(a5.type).toBe(LOADING);
+
+            // check request parameters
+            expect(mock.history.get.length).toBe(1);
+            expect(mock.history.get[0].params.domain).toBe("time");
+            // if animation range active, animation fromValue at the beginning should not be set
+            expect(mock.history.get[0].params.fromValue).toNotExist();
             done();
         }, {
-                dimension: {
-                    currentTime: '2016-09-05T00:00:00.000Z'
-                },
-                layers: {
-                    flat: [
-                        {
-                            id: 'playback:selected_layer',
-                            name: 'playback_layer',
-                            dimensions: [
-                                {
-                                    name: 'time',
-                                    source: {
-                                        type: 'multidim-extension',
-                                        url: 'base/web/client/test-resources/wmts/DomainValues.xml'
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                timeline: {
-                    selectedLayer: 'playback:selected_layer'
+            ...ANIMATION_MOCK_STATE,
+            playback: {
+                playbackRange: {
+                    startPlaybackTime: '2016-09-04T00:00:00.000Z',
+                    endPlaybackTime: '2016-09-04T00:00:00.000Z'
                 }
-            });
+            }
+        });
     });
     it('playbackCacheNextPreviousTimes with time arg setCurrentTime() action', done => {
         const time = '2016-09-04T00:00:00.000Z';
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_VALUES_RESPONSE);
         testEpic(playbackCacheNextPreviousTimes, 1, setCurrentTime(time), ([ action ]) => {
             try {
                 expect(action.type).toBe(UPDATE_METADATA);
@@ -63,34 +120,11 @@ describe('playback Epics', () => {
                 done(e);
             }
             done();
-        }, {
-            dimension: {
-                currentTime: '2016-09-05T00:00:00.000Z'
-            },
-            layers: {
-                flat: [
-                    {
-                        id: 'playback:selected_layer',
-                        name: 'playback_layer',
-                        dimensions: [
-                            {
-                                name: 'time',
-                                source: {
-                                    type: 'multidim-extension',
-                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
-                                }
-                            }
-                        ]
-                    }
-                ]
-            },
-            timeline: {
-                selectedLayer: 'playback:selected_layer'
-            }
-        });
+        }, ANIMATION_MOCK_STATE);
     });
     it('playbackCacheNextPreviousTimes with time arg moveTime() action', done => {
         const time = '2016-09-04T00:00:00.000Z';
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_VALUES_RESPONSE);
         testEpic(playbackCacheNextPreviousTimes, 1, moveTime(time), ([ action ]) => {
             try {
                 expect(action.type).toBe(UPDATE_METADATA);
@@ -99,34 +133,11 @@ describe('playback Epics', () => {
                 done(e);
             }
             done();
-        }, {
-            dimension: {
-                currentTime: '2016-09-05T00:00:00.000Z'
-            },
-            layers: {
-                flat: [
-                    {
-                        id: 'playback:selected_layer',
-                        name: 'playback_layer',
-                        dimensions: [
-                            {
-                                name: 'time',
-                                source: {
-                                    type: 'multidim-extension',
-                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
-                                }
-                            }
-                        ]
-                    }
-                ]
-            },
-            timeline: {
-                selectedLayer: 'playback:selected_layer'
-            }
-        });
+        }, ANIMATION_MOCK_STATE);
     });
     it('playbackCacheNextPreviousTimes without time arg selectLayer() action', done => {
         const currentTime = '2016-09-04T00:00:00.000Z';
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_VALUES_RESPONSE);
         testEpic(playbackCacheNextPreviousTimes, 1, selectLayer(), ([ action ]) => {
             try {
                 expect(action.type).toBe(UPDATE_METADATA);
@@ -136,33 +147,15 @@ describe('playback Epics', () => {
             }
             done();
         }, {
+            ...ANIMATION_MOCK_STATE,
             dimension: {
                 currentTime
-            },
-            layers: {
-                flat: [
-                    {
-                        id: 'playback:selected_layer',
-                        name: 'playback_layer',
-                        dimensions: [
-                            {
-                                name: 'time',
-                                source: {
-                                    type: 'multidim-extension',
-                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
-                                }
-                            }
-                        ]
-                    }
-                ]
-            },
-            timeline: {
-                selectedLayer: 'playback:selected_layer'
             }
         });
     });
     it('playbackCacheNextPreviousTimes without time arg stop() action', done => {
         const currentTime = '2016-09-04T00:00:00.000Z';
+        mock.onGet('MOCK_DOMAIN_VALUES').reply(200, DOMAIN_VALUES_RESPONSE);
         testEpic(playbackCacheNextPreviousTimes, 1, stop(), ([ action ]) => {
             try {
                 expect(action.type).toBe(UPDATE_METADATA);
@@ -172,30 +165,11 @@ describe('playback Epics', () => {
             }
             done();
         }, {
-            dimension: {
-                currentTime
-            },
-            layers: {
-                flat: [
-                    {
-                        id: 'playback:selected_layer',
-                        name: 'playback_layer',
-                        dimensions: [
-                            {
-                                name: 'time',
-                                source: {
-                                    type: 'multidim-extension',
-                                    url: 'base/web/client/test-resources/wmts/DomainValues.xml'
-                                }
-                            }
-                        ]
-                    }
-                ]
-            },
-            timeline: {
-                selectedLayer: 'playback:selected_layer'
-            }
-        });
+                ...ANIMATION_MOCK_STATE,
+                dimension: {
+                    currentTime
+                }
+            });
     });
     it('playbackStopWhenDeleteLayer', done => {
         testEpic(playbackStopWhenDeleteLayer, 1, removeNode(), ([action]) => {

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -168,11 +168,12 @@ module.exports = {
         action$.ofType(PLAY).exhaustMap(() =>
             getAnimationFrames(getState, {
                 fromValue:
-                    // if animation range is not enabled, use the current time to start
+                    // if animation range is set, don't set from value on startup...
                     (playbackRangeSelector(getState())
                         && playbackRangeSelector(getState()).startPlaybackTime
                         && playbackRangeSelector(getState()).endPlaybackTime)
                     ? undefined
+                    // ...otherwise, start from the current time (start animation from cursor position)
                     : currentTimeSelector(getState())
                 })
                 .map((frames) => setFrames(frames))

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -186,16 +186,18 @@ module.exports = {
      * Initializes the time line
      */
     setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, UPDATE_LAYER_DIMENSION_DATA)
-        .exhaustMap(() => isAutoSelectEnabled(getState()) && get(layersWithTimeDataSelector(getState()), "[0].id")
-        && !selectedLayerSelector(getState())
-            ? Rx.Observable.of(selectLayer(get(layersWithTimeDataSelector(getState()), "[0].id")))
-                .concat(
-                    Rx.Observable.of(1).switchMap( () =>
-                        snapTime(getState(), get(layersWithTimeDataSelector(getState()), "[0].id"), currentTimeSelector(getState) || new Date().toISOString())
-                            .filter( v => v)
-                            .map(time => setCurrentTime(time)))
-                )
-            : Rx.Observable.empty()
+        .exhaustMap(() =>
+            isAutoSelectEnabled(getState())
+            && get(layersWithTimeDataSelector(getState()), "[0].id")
+            && !selectedLayerSelector(getState())
+                ? Rx.Observable.of(selectLayer(get(layersWithTimeDataSelector(getState()), "[0].id")))
+                    .concat(
+                        Rx.Observable.of(1).switchMap( () =>
+                            snapTime(getState(), get(layersWithTimeDataSelector(getState()), "[0].id"), currentTimeSelector(getState) || new Date().toISOString())
+                                .filter( v => v)
+                                .map(time => setCurrentTime(time)))
+                    )
+                : Rx.Observable.empty()
     ),
      /**
      * When offset is initiated this epic sets both initial current time and offset if any does not exist

--- a/web/client/plugins/playback/Playback.jsx
+++ b/web/client/plugins/playback/Playback.jsx
@@ -97,6 +97,7 @@ module.exports = playbackEnhancer(({
                 }, {
                     glyph: status === statusMap.PLAY ? "pause" : "play",
                     active: status === statusMap.PLAY || status === statusMap.PAUSE,
+                    disabled: !hasNext,
                     bsStyle: status === statusMap.PLAY || status === statusMap.PAUSE ? "success" : "primary",
                     onClick: () => status === statusMap.PLAY ? pause() : play(),
                     tooltipId: status === statusMap.PLAY


### PR DESCRIPTION
## Description
Animation start from current time

## Issues
 - Fix #3640

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
Animation starts from the beginning

**What is the new behavior?**
- If no animation range is set, start from the current cursor
- If the cursor is at the end (of the guide layer available domain values), the play button is disabled

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

