### PR TITLE
Fix #3367 removing layers from timeline during animation

### DIFF
--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -7,7 +7,7 @@
  */
 const React = require('react');
 const { connect } = require('react-redux');
-const { isString, differenceBy } = require('lodash');
+const { isString, differenceBy, isNil } = require('lodash');
 const { currentTimeSelector, layersWithTimeDataSelector } = require('../../selectors/dimension');
 
 
@@ -34,8 +34,9 @@ const moment = require('moment');
  * Typically `loading` attribute
  */
 const timeLayersSelector = createShallowSelectorCreator(
-    (a = {}, b = {}) => {
-        return a.id === b.id && a.title === b.title && a.name === b.name;
+    (a, b) => {
+        return a === b
+            || !isNil(a) && !isNil(b) && a.id === b.id && a.title === b.title && a.name === b.name;
     }
 )(layersWithTimeDataSelector, layers => layers);
 

--- a/web/client/utils/ReselectUtils.js
+++ b/web/client/utils/ReselectUtils.js
@@ -5,10 +5,14 @@ const defaultCompare = (a, b) => a === b;
 
 const isShallowEqualBy = (compare = defaultCompare) => (el1, el2) => {
     if (Array.isArray(el1) && Array.isArray(el2)) {
-        return el1 === el2 || el1.reduce((acc, curr, i) => acc && compare(curr, el2[i]), true);
+        return el1 === el2
+            || el1.length === el2.length
+                && el1.reduce((acc, curr, i) => acc && compare(curr, el2[i]), true);
     }
     if (isObject(el1) && isObject(el2)) {
-        return el1 === el2 || Object.keys(el1).reduce((acc, k) => acc && compare(el1[k], el2[k]), true);
+        return el1 === el2
+            || Object.keys(el1).length === Object.keys(el2).length
+                && Object.keys(el1).reduce((acc, k) => acc && compare(el1[k], el2[k]), true);
     }
     return el1 === el2;
 };
@@ -17,11 +21,18 @@ const isShallowEqualBy = (compare = defaultCompare) => (el1, el2) => {
  * Custom version of createSelector with custom compare function.
  * The previous compare function checks if values are arrays, then compares each element of the array.
  * This allows to avoid re-render when dependencies if the dependency keys do not change
+ * @returns {function} selector that does shallow compare
  */
 const createShallowSelector = createSelectorCreator(
     defaultMemoize,
     (a, b) => isEqualWith(a, b, isShallowEqualBy())
 );
+
+/**
+ * Similar to createShallowSelector, but allow to customize compare function with a custom one.
+ * You can use isEqual from lodash (to do a deep compare) or compare only certain properties you're interested to.
+ * @param {function} compare a function for compare elements
+ */
 const createShallowSelectorCreator = (compare) => createSelectorCreator(
     defaultMemoize,
     (a, b) => isEqualWith(a, b, isShallowEqualBy(compare))

--- a/web/client/utils/__tests__/ReselectUtils-test.js
+++ b/web/client/utils/__tests__/ReselectUtils-test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+const {
+    createShallowSelector,
+    createShallowSelectorCreator
+} = require('../ReselectUtils');
+const { isEqual } = require('lodash');
+
+const TEST_STRING_1 = "TEST_1";
+const TEST_STRING_2 = "TEST_2";
+const ST_ARR1 = [TEST_STRING_1, TEST_STRING_2];
+const ST_ARR2 = [TEST_STRING_1];
+const OBJ_1 = {
+    a: "a",
+    b: "b",
+    c: "c"
+};
+const OBJ_2 = {
+    a: "a",
+    b: "b"
+};
+
+const OBJ_ARR_1 = [OBJ_1, OBJ_2];
+const OBJ_ARR_2 = [OBJ_1];
+
+const createMockState = value => ({
+    test: value
+});
+
+const mockStateSelector = state => state.test;
+
+describe('ReselectUtils', () => {
+
+    it('createShallowSelector with array', () => {
+
+        const selector = createShallowSelector(
+            mockStateSelector,
+            v => v
+        );
+        // TEST ARRAYS OF STRING
+        expect(selector(createMockState(ST_ARR1))).toBe(ST_ARR1);
+        // check cache
+        expect(selector(createMockState([...ST_ARR1]))).toBe(ST_ARR1);
+        // check update on element remove
+        expect(selector(createMockState(ST_ARR2))).toBe(ST_ARR2);
+        expect(selector(createMockState(ST_ARR1))).toBe(ST_ARR1);
+
+        // TEST ARRAYS OF OBJECTS
+        expect(selector(createMockState(OBJ_ARR_1))).toBe(OBJ_ARR_1);
+        // check cache
+        expect(selector(createMockState([...OBJ_ARR_1]))).toBe(OBJ_ARR_1);
+        // check update on element remove
+        expect(selector(createMockState(OBJ_ARR_2))).toBe(OBJ_ARR_2);
+        expect(selector(createMockState(OBJ_ARR_1))).toBe(OBJ_ARR_1);
+        // check cache on object copy
+        expect(selector(createMockState([
+            { ...OBJ_1 },
+            { ...OBJ_2 }
+        ]))).toNotBe(OBJ_ARR_1);
+    });
+    it('createShallowSelector with object', () => {
+
+        const selector = createShallowSelector(
+            mockStateSelector,
+            v => v
+        );
+        expect(selector(createMockState(OBJ_1))).toBe(OBJ_1);
+        // check Cache
+        expect(selector(createMockState({ ...OBJ_1 }))).toBe(OBJ_1);
+        expect(selector(createMockState(OBJ_2))).toBe(OBJ_2);
+        // check change on array size changes
+        expect(selector(createMockState(OBJ_1))).toBe(OBJ_1);
+    });
+    it('createShallowSelectorCreator', () => {
+        const selector = createShallowSelectorCreator(isEqual)(
+            mockStateSelector,
+            v => v
+        );
+        expect(selector(createMockState(OBJ_ARR_1))).toBe(OBJ_ARR_1);
+
+        // cashes with deep equal
+        expect(selector(createMockState([
+            { ...OBJ_1 },
+            { ...OBJ_2 }
+        ]))).toBe(OBJ_ARR_1);
+    });
+    it('createShallowSelectorCreator with custom props', () => {
+        const selector = createShallowSelectorCreator(
+            (O1, O2) => {
+                return O1 && O2 && O1.a === O2.a && O1.b === O2.b;
+            }
+        )(
+            mockStateSelector,
+            v => v
+        );
+        expect(selector(createMockState(OBJ_ARR_2))).toBe(OBJ_ARR_2);
+
+        // cashes ignoring the "c" property
+        expect(selector(createMockState([
+            OBJ_2
+        ]))).toBe(OBJ_ARR_2);
+    });
+});


### PR DESCRIPTION
## Description
When the layers are removed during the animation, they are correctly removed also from the timeline.

The issue is that, even if the state is normalized, the selector continued caching it because of a bug in the utility to create the optimized selector. 

## Issues
 - Fix #3367 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
- Delete a 2nd layer (not guide layer) from the TOC when animated didn't remove the layer from the timeline

**What is the new behavior?**
- Now the layer is removed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No