### PR TITLE
Fix #2590. Reload map on URL change

### DIFF
--- a/web/client/product/components/viewer/MapViewerCmp.jsx
+++ b/web/client/product/components/viewer/MapViewerCmp.jsx
@@ -26,12 +26,32 @@ class MapViewerComponent extends React.Component {
     static defaultProps = {
         mode: 'desktop',
         plugins: {},
+        onInit: () => {},
+        loadMapConfig: () => {},
         match: {
             params: {}
         }
     };
     componentWillMount() {
         const id = this.props.match.params.mapId || '0';
+        this.updateMap(id);
+    }
+    componentDidUpdate(oldProps) {
+        const id = this.props.match.params.mapId || '0';
+        const oldId = oldProps.match.params.mapId || '0';
+        if (id !== oldId ) {
+            this.updateMap(id);
+        }
+    }
+    render() {
+        const WrappedContainer = this.props.wrappedContainer;
+        return (<WrappedContainer
+            pluginsConfig={this.props.pluginsConfig}
+            plugins={this.props.plugins}
+            params={this.props.match.params}
+            />);
+    }
+    updateMap = (id) => {
         if (id && oldLocation !== this.props.location) {
             oldLocation = this.props.location;
             if (!ConfigUtils.getDefaults().ignoreMobileCss) {
@@ -46,19 +66,11 @@ class MapViewerComponent extends React.Component {
             // if it is a number it loads the config from geostore
             let mapId = id === '0' ? null : id;
             let config = urlQuery && urlQuery.config || null;
-            const {configUrl} = ConfigUtils.getConfigUrl({mapId, config});
+            const { configUrl } = ConfigUtils.getConfigUrl({ mapId, config });
             mapId = mapId === 'new' ? null : mapId;
             this.props.onInit();
             this.props.loadMapConfig(configUrl, mapId);
         }
-    }
-    render() {
-        const WrappedContainer = this.props.wrappedContainer;
-        return (<WrappedContainer
-            pluginsConfig={this.props.pluginsConfig}
-            plugins={this.props.plugins}
-            params={this.props.match.params}
-            />);
     }
 }
 

--- a/web/client/product/components/viewer/__tests__/MapViewer-test.jsx
+++ b/web/client/product/components/viewer/__tests__/MapViewer-test.jsx
@@ -89,5 +89,27 @@ describe("Test the MapViewerCmp component", () => {
         const component = renderMapViewerComp(mapViewerPros);
         expect(component).toExist();
     });
+    it('testing update of map on mapId change', (done) => {
+        let count = 1;
+        const match = { params: { mapId: 1 } };
+        const match2 = { params: { mapId: 2 } };
+        const mapViewerPros = {
+            match, location, onInit: () => { },
+            wrappedContainer: MapViewerContainer,
+            loadMapConfig: (cfgUrl, mapId) => {
+                expect(cfgUrl).toBe(`/mapstore/rest/geostore/data/${count}`);
+                expect(mapId).toBe(count);
+                count++;
+                if (count === 3) {
+                    done();
+                }
+            }
+        };
+        // override location force re-render. (not sure check location is correct)
+        renderMapViewerComp({ ...mapViewerPros, location: { ...location }});
+        // render second time
+        const component = renderMapViewerComp({ ...mapViewerPros, match: match2, location: {...location}});
+        expect(component).toExist();
+    });
 
 });


### PR DESCRIPTION
## Description
This PR solves the issue about map reload when the URL changes
## Issues
 - Fix #2590
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see #2590 

**What is the new behavior?**
When you change mapId in the URL, the map changes immediately 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

