### PR TITLE
Replace InchCI badge with ReadTheDocs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/geosolutions-it/MapStore2.svg?branch=master)](https://travis-ci.org/geosolutions-it/MapStore2)
 [![Coverage Status](https://coveralls.io/repos/geosolutions-it/MapStore2/badge.svg?branch=master&service=github)](https://coveralls.io/github/geosolutions-it/MapStore2?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1648d484427346e2877006dc287379b6)](https://app.codacy.com/app/geosolutions/MapStore2?utm_source=github.com&utm_medium=referral&utm_content=geosolutions-it/MapStore2&utm_campaign=badger)
-[![Inline docs](http://inch-ci.org/github/geosolutions-it/MapStore2.svg?branch=master)](http://inch-ci.org/github/geosolutions-it/MapStore2)
+[![Documentation Status](https://readthedocs.org/projects/mapstore2/badge/?version=latest)](https://mapstore2.readthedocs.io/en/latest/?badge=latest)
 [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/fold_left.svg?style=social&label=Follow%20%40mapstore2)](https://twitter.com/mapstore2)
 
 MapStore


### PR DESCRIPTION
## Description
Inch CI is well to measure the quantity of the documentation. Anyway is not too much indicative of the quantity of the documentation, because is generic for JavaScript. This means it doesn't take into account: 
 - implicit methods documentation for react methods
 - Some default values like default empty arrow functions are conuted as missing

The official documentation is linked by the badge and it indicates the passing of the failing of the doc build. 


We can use some other continuous integration tool to monitor and maybe check documentation quantity and quality (Codacy or other CI tools)

### Issues
 - Fix #3658