### PR TITLE
adding string and digits shortcuts to x axis labels

### DIFF
--- a/web/client/components/charts/TrimmedTick.jsx
+++ b/web/client/components/charts/TrimmedTick.jsx
@@ -1,0 +1,72 @@
+ /*
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const React = require('react');
+const{ isString, isNumber, truncate, round} = require('lodash');
+const { Text} = require('recharts');
+
+const shorten = (num)=> {
+    let unit;
+    let number = round(num);
+    let add = number.toString().length % 3;
+
+    if (number >= 10000) {
+
+        let trimmedDigits = number.toString().length - ( add === 0 ? add + 3 : add );
+        let zeroNumber = (trimmedDigits) / 3;
+        let trimmedNumber = number / Math.pow(10, trimmedDigits);
+
+        switch (zeroNumber) {
+            case 1 :
+                unit = ' K';
+                break;
+            case 2 :
+                unit = ' M';
+                break;
+            case 3 :
+                unit = ' B';
+                break;
+            case 4 :
+                unit = ' T';
+                break;
+            default:
+                unit = '';
+        }
+
+        number = round(trimmedNumber) + unit;
+
+    }else {
+
+        number = round(num, Math.abs(4 - number.toString().length));
+    }
+
+    return number;
+};
+
+const customize = (label)=> {
+    try {
+        if (isString(label)) {
+            return truncate(label, {'length': 7});
+        }
+        if (isNumber(label)) {
+            return label.toString().length < 7 || !isFinite(label) ?
+            label : shorten(label);
+        }
+
+    } catch (e) {
+        return label;
+    }
+
+
+};
+
+const TrimmedTick = ({x, y, height, width, payload}) => (
+    <Text style={{fill: '#666'}} x={height === 60 ? x : x - width / 3} y={height === 60 ? y + height / 2 : y} textAnchor="middle" >
+    {customize(payload.value)}
+    </Text> );
+
+module.exports = {TrimmedTick};

--- a/web/client/components/charts/__tests__/SimpleChart-test.jsx
+++ b/web/client/components/charts/__tests__/SimpleChart-test.jsx
@@ -75,8 +75,8 @@ describe('SimpleChart component', () => {
 
     });
     it('test with y axis vlaues over trillion ', () => {
-        let modifiedData = data;
-        modifiedData[6].uv = 10000000000000;
+        const modifiedData = [...data];
+        modifiedData[6] = {...modifiedData[6], uv: 10000000000000};
 
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
@@ -86,8 +86,7 @@ describe('SimpleChart component', () => {
         expect(maxValue).toBe('10 T');
     });
     it('test y axis with short strings ', () => {
-        let modifiedData = data;
-        modifiedData.map(y => y.uv = 'string');
+        const modifiedData = data.map(y => { return {...y, uv: 'string'}; });
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('div');
@@ -96,9 +95,8 @@ describe('SimpleChart component', () => {
         expect(maxValue).toBe('string');
     });
     it('test y axis with long strings ', () => {
-        let modifiedData = data;
         const string = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-        modifiedData.map((y, i) => y.uv = string.substring(0, i * 2));
+        const modifiedData = data.map((y, i) => { return {...y, uv: string.substring(0, i * 2)}; });
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('div');
@@ -119,9 +117,8 @@ describe('SimpleChart component', () => {
 
 
     });
-    it('test y axis with undefined valus ', () => {
-        let modifiedData = data;
-        modifiedData.map(y => y.uv = undefined);
+    it('test y axis with undefined values ', () => {
+        const modifiedData = data.map(y => {return {...y, uv: undefined}; });
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('div');
@@ -129,9 +126,8 @@ describe('SimpleChart component', () => {
         const maxValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis').textContent;
         expect(maxValue).toBe('');
     });
-    it('test y axis with null valus ', () => {
-        let modifiedData = data;
-        modifiedData.map(y => y.uv = null);
+    it('test y axis with null values ', () => {
+        const modifiedData = data.map(y => {return {...y, uv: null}; });
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('div');
@@ -140,8 +136,7 @@ describe('SimpleChart component', () => {
         expect(maxValue).toBe('');
     });
     it('test y axis with long decimal numbers ', () => {
-        let modifiedData = data;
-        modifiedData.map((y, i) => y.uv = 3.1 / (i * 2));
+        const modifiedData = data.map((y, i) => {return {...y, uv: 3.1 / (i * 2)}; });
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('div');
@@ -155,15 +150,14 @@ describe('SimpleChart component', () => {
         const sixthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(6) > text > tspan').textContent;
 
         expect(firstValue).toEqual(Infinity);
-        expect(secondValue.length).toBeLessThan(7);
-        expect(thirdValue.length).toBeLessThan(7);
-        expect(fourthValue.length).toBeLessThan(7);
-        expect(fifthValue.length).toBeLessThan(7);
-        expect(sixthValue.length).toBeLessThan(7);
+        expect(secondValue).toBe('1.55');
+        expect(thirdValue).toBe('0.775');
+        expect(fourthValue).toBe('0.517');
+        expect(fifthValue).toBe('0.3875');
+        expect(sixthValue).toBe('0.31');
     });
     it('test y axis with small values and long decimal numbers ', () => {
-        let modifiedData = data;
-        modifiedData.map((y, i) => y.uv = 0 + i / 100000000);
+        const modifiedData = data.map((y, i) => { return {...y, uv: 0 + (i / 100000000)}; });
         ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('div');

--- a/web/client/components/charts/__tests__/SimpleChart-test.jsx
+++ b/web/client/components/charts/__tests__/SimpleChart-test.jsx
@@ -14,13 +14,13 @@ const expect = require('expect');
 const SimpleChart = require('../SimpleChart');
 
 const data = [
-      {name: 'Page A', uv: 0, pv: 0, amt: 0},
-      {name: 'Page B', uv: 1, pv: 1, amt: 1},
-      {name: 'Page C', uv: 2, pv: 2, amt: 2},
-      {name: 'Page D', uv: 3, pv: 3, amt: 3},
-      {name: 'Page E', uv: 4, pv: 4, amt: 4},
-      {name: 'Page F', uv: 5, pv: 5, amt: 5},
-      {name: 'Page G', uv: 6, pv: 6, amt: 6}
+      {name: 'Page A', uv: 0},
+      {name: 'Page B', uv: 1},
+      {name: 'Page C', uv: 2},
+      {name: 'Page D', uv: 3},
+      {name: 'Page E', uv: 4},
+      {name: 'Page F', uv: 5},
+      {name: 'Page G', uv: 6}
 ];
 const SERIES = [{dataKey: "pv"}, {dataKey: "uv"}];
 describe('SimpleChart component', () => {
@@ -73,5 +73,114 @@ describe('SimpleChart component', () => {
         expect(legend).toExist();
         expect(tooltip).toExist();
 
+    });
+    it('test with y axis vlaues over trillion ', () => {
+        let modifiedData = data;
+        modifiedData[6].uv = 10000000000000;
+
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const maxValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(5) > text > tspan').textContent;
+        expect(maxValue).toBe('10 T');
+    });
+    it('test y axis with short strings ', () => {
+        let modifiedData = data;
+        modifiedData.map(y => y.uv = 'string');
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const maxValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g > text > tspan').textContent;
+        expect(maxValue).toBe('string');
+    });
+    it('test y axis with long strings ', () => {
+        let modifiedData = data;
+        const string = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        modifiedData.map((y, i) => y.uv = string.substring(0, i * 2));
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const firstValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(1) > text > tspan').textContent;
+        const secondValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(2) > text > tspan').textContent;
+        const thirdValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(3) > text > tspan').textContent;
+        const fourthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(4) > text > tspan').textContent;
+        const fifthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(5) > text > tspan').textContent;
+        const sixthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(6) > text > tspan').textContent;
+
+        expect(firstValue).toBe('aa');
+        expect(secondValue).toBe('aaaa');
+        expect(thirdValue).toBe('aaaaaa');
+        expect(fourthValue).toBe('aaaa...');
+        expect(fourthValue).toEqual(fifthValue);
+        expect(fourthValue).toEqual(sixthValue);
+
+
+    });
+    it('test y axis with undefined valus ', () => {
+        let modifiedData = data;
+        modifiedData.map(y => y.uv = undefined);
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const maxValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis').textContent;
+        expect(maxValue).toBe('');
+    });
+    it('test y axis with null valus ', () => {
+        let modifiedData = data;
+        modifiedData.map(y => y.uv = null);
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const maxValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis').textContent;
+        expect(maxValue).toBe('');
+    });
+    it('test y axis with long decimal numbers ', () => {
+        let modifiedData = data;
+        modifiedData.map((y, i) => y.uv = 3.1 / (i * 2));
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        expect(el).toExist();
+        const firstValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(1) > text > tspan').textContent;
+        const secondValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(2) > text > tspan').textContent;
+        const thirdValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(3) > text > tspan').textContent;
+        const fourthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(4) > text > tspan').textContent;
+        const fifthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(5) > text > tspan').textContent;
+        const sixthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(6) > text > tspan').textContent;
+
+        expect(firstValue).toEqual(Infinity);
+        expect(secondValue.length).toBeLessThan(7);
+        expect(thirdValue.length).toBeLessThan(7);
+        expect(fourthValue.length).toBeLessThan(7);
+        expect(fifthValue.length).toBeLessThan(7);
+        expect(sixthValue.length).toBeLessThan(7);
+    });
+    it('test y axis with small values and long decimal numbers ', () => {
+        let modifiedData = data;
+        modifiedData.map((y, i) => y.uv = 0 + i / 100000000);
+        ReactDOM.render(<SimpleChart data={modifiedData} type="line" xAxis={{dataKey: "name"}} yAxis={{dataKey: "uv", type: "category"}} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        expect(el).toExist();
+        const firstValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(1) > text > tspan').textContent;
+        const secondValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(2) > text > tspan').textContent;
+        const thirdValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(3) > text > tspan').textContent;
+        const fourthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(4) > text > tspan').textContent;
+        const fifthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(5) > text > tspan').textContent;
+        const sixthValue = document.querySelector('#container > div > svg > g.recharts-layer.recharts-y-axis > g > g > g:nth-child(6) > text > tspan').textContent;
+
+        expect(firstValue).toEqual(0);
+        expect(secondValue).toEqual(1e-8);
+        expect(thirdValue).toEqual(2e-8);
+        expect(fourthValue).toEqual(3e-8);
+        expect(fifthValue).toEqual(4e-8);
+        expect(sixthValue).toEqual(5e-8);
     });
 });

--- a/web/client/components/charts/__tests__/TrimmedTick-test.jsx
+++ b/web/client/components/charts/__tests__/TrimmedTick-test.jsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const expect = require('expect');
+const {TrimmedTick} = require('../TrimmedTick');
+
+describe('TrimmedTick component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('Tick with a default value', () => {
+        const payload = {value: 50};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('50');
+    });
+
+    it('Tick with a number value of 123456', () => {
+        const payload = {value: 123456};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('123456');
+    });
+    it('Tick with a number value of 123456,789', () => {
+        const payload = {value: 123456.789};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('123 K');
+    });
+    it('Tick with a number value of 0.000001', () => {
+        const payload = {value: 0.000001};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('0');
+    });
+    it('Tick with a small number and long decimal value', () => {
+        const payload = {value: 3e-8};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('3e-8');
+    });
+    it('Tick with a small number and long decimal value', () => {
+        const payload = {value: 0.00000003};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('3e-8');
+    });
+    it('Tick with a long string', () => {
+        const payload = {value: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('aaaa...');
+    });
+    it('Tick with a short string', () => {
+        const payload = {value: 'short'};
+        ReactDOM.render(<TrimmedTick x={60} y={60} height={600} width={600} payload={payload} />, document.getElementById("container"));
+        const el = document.querySelector('#container');
+        expect(el).toExist();
+        const value = document.querySelector('#container > text > tspan').textContent;
+        expect(value).toBe('short');
+    });
+});
+

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -8,10 +8,60 @@
 
 
 const React = require('react');
-const { XAxis, YAxis, CartesianGrid} = require('recharts');
+const{ isString, isNumber, truncate, round} = require('lodash');
+const { XAxis, YAxis, CartesianGrid, Text} = require('recharts');
+
+const shorten = (num)=> {
+    let unit;
+    let number = round(num);
+    let add = number.toString().length % 3;
+
+    if (number >= 10000) {
+
+        let trimedDigits = number.toString().length - ( add === 0 ? add + 3 : add );
+        let zeroNumber = (trimedDigits) / 3;
+        let trimedNumber = number / Math.pow(10, trimedDigits);
+
+        switch (zeroNumber) {
+            case 1 :
+                unit = ' K';
+                break;
+            case 2 :
+                unit = ' M';
+                break;
+            case 3 :
+                unit = ' B';
+                break;
+            case 4 :
+                unit = ' T';
+                break;
+            default:
+                unit = '';
+        }
+
+        number = round(trimedNumber) + unit;
+    }else {
+        number = round(num, Math.abs(4 - number.toString().length));
+    }
+
+    return number;
+};
+
+const customize = (label)=>(
+    isString(label) ? truncate(label, {'length': 7}) :
+    isNumber(label) && label.toString().length < 7 ?
+    label : shorten(label)
+
+
+);
+
+const CustomizedTick = ({x, y, height, width, payload}) => (
+    <Text style={{fill: '#666'}} x={height === 60 ? x : x - width / 3} y={height === 60 ? y + height / 2 : y} angle ={height === 60 ? -45 : 0} textAnchor="middle" >
+    {customize(payload.value)}
+    </Text> );
 
 const renderCartesianTools = ({xAxis, yAxis, cartesian}) => ([
     xAxis && xAxis.show !== false ? <XAxis key="xaxis" {...xAxis}/> : null,
-    yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
+    yAxis ? <YAxis key="yaxis" tick={<CustomizedTick/>} {...yAxis}/> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null]);
 module.exports = {renderCartesianTools};

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -8,60 +8,12 @@
 
 
 const React = require('react');
-const{ isString, isNumber, truncate, round} = require('lodash');
-const { XAxis, YAxis, CartesianGrid, Text} = require('recharts');
+const { XAxis, YAxis, CartesianGrid} = require('recharts');
+const {TrimmedTick} = require('./TrimmedTick');
 
-const shorten = (num)=> {
-    let unit;
-    let number = round(num);
-    let add = number.toString().length % 3;
-
-    if (number >= 10000) {
-
-        let trimedDigits = number.toString().length - ( add === 0 ? add + 3 : add );
-        let zeroNumber = (trimedDigits) / 3;
-        let trimedNumber = number / Math.pow(10, trimedDigits);
-
-        switch (zeroNumber) {
-            case 1 :
-                unit = ' K';
-                break;
-            case 2 :
-                unit = ' M';
-                break;
-            case 3 :
-                unit = ' B';
-                break;
-            case 4 :
-                unit = ' T';
-                break;
-            default:
-                unit = '';
-        }
-
-        number = round(trimedNumber) + unit;
-    }else {
-        number = round(num, Math.abs(4 - number.toString().length));
-    }
-
-    return number;
-};
-
-const customize = (label)=>(
-    isString(label) ? truncate(label, {'length': 7}) :
-    isNumber(label) && label.toString().length < 7 ?
-    label : shorten(label)
-
-
-);
-
-const CustomizedTick = ({x, y, height, width, payload}) => (
-    <Text style={{fill: '#666'}} x={height === 60 ? x : x - width / 3} y={height === 60 ? y + height / 2 : y} angle ={height === 60 ? -45 : 0} textAnchor="middle" >
-    {customize(payload.value)}
-    </Text> );
 
 const renderCartesianTools = ({xAxis, yAxis, cartesian}) => ([
     xAxis && xAxis.show !== false ? <XAxis key="xaxis" {...xAxis}/> : null,
-    yAxis ? <YAxis key="yaxis" tick={<CustomizedTick/>} {...yAxis}/> : null,
+    yAxis ? <YAxis key="yaxis" tick={<TrimmedTick/>} {...yAxis}/> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null]);
 module.exports = {renderCartesianTools};


### PR DESCRIPTION
## Description
adding a function to the y access in charts, that shortens long labels and long numbers. the strings are truncated, while digits are shortened to each ( million, billion, trillion, .....etc)

## Issues
 - Fix #3398
 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
see #3398

**What is the new behavior?**
see the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
