### PR TITLE
Fix #3608 Toc tooltips options saved in map configuration

### DIFF
--- a/web/client/components/TOC/fragments/GroupTitle.jsx
+++ b/web/client/components/TOC/fragments/GroupTitle.jsx
@@ -11,7 +11,7 @@ const PropTypes = require('prop-types');
 const StatusIcon = require('./StatusIcon');
 const {Tooltip} = require('react-bootstrap');
 const OverlayTrigger = require('../../misc/OverlayTrigger');
-const {getTitleAndtooltip} = require('../../../utils/TOCUtils');
+const {getTitleAndTooltip} = require('../../../utils/TOCUtils');
 
 class GroupTitle extends React.Component {
     static propTypes = {
@@ -40,7 +40,7 @@ class GroupTitle extends React.Component {
 
     render() {
         let expanded = this.props.node.expanded !== undefined ? this.props.node.expanded : true;
-        const {title: groupTitle, tooltipText} = getTitleAndtooltip(this.props);
+        const {title: groupTitle, tooltipText} = getTitleAndTooltip(this.props);
 
         return this.props.tooltip && tooltipText ? (
             <OverlayTrigger placement={this.props.node.tooltipPlacement || "top"} overlay={(<Tooltip id={"tooltip-layer-group"}>{tooltipText}</Tooltip>)}>

--- a/web/client/components/TOC/fragments/Title.jsx
+++ b/web/client/components/TOC/fragments/Title.jsx
@@ -10,7 +10,8 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const {Tooltip} = require('react-bootstrap');
 const OverlayTrigger = require('../../misc/OverlayTrigger');
-const {getTitleAndtooltip} = require('../../../utils/TOCUtils');
+const {getTitleAndTooltip} = require('../../../utils/TOCUtils');
+
 require("./css/toctitle.css");
 
 class Title extends React.Component {
@@ -48,7 +49,7 @@ class Title extends React.Component {
     }
 
     render() {
-        const {title, tooltipText} = getTitleAndtooltip(this.props);
+        const {title, tooltipText} = getTitleAndTooltip(this.props);
         return this.props.tooltip && tooltipText ? (
             <OverlayTrigger placement={this.props.node.tooltipPlacement || "top"} overlay={(<Tooltip id={"tooltip-layer-title"}>{tooltipText}</Tooltip>)}>
                 <div className="toc-title" onClick={this.props.onClick ? (e) => this.props.onClick(this.props.node.id, 'layer', e.ctrlKey) : () => {}} onContextMenu={(e) => {e.preventDefault(); this.props.onContextMenu(this.props.node); }}>

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -464,7 +464,9 @@ const LayersUtils = {
             useForElevation: layer.useForElevation || false,
             hidden: layer.hidden || false,
             origin: layer.origin,
-            thematic: layer.thematic
+            thematic: layer.thematic,
+            tooltipOptions: layer.tooltipOptions,
+            tooltipPlacement: layer.tooltipPlacement
         },
         layer.params ? { params: layer.params } : {},
         layer.credits ? { credits: layer.credits } : {});

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -69,8 +69,9 @@ const TOCUtils = {
      * @return {string} separator
      * @return {number} maxLength
     */
-    getTitleAndtooltip: ({node, currentLocale, tooltipOptions = {separator: " - ", maxLength: 807}}) => {
-        let tooltipText = TOCUtils.getTooltip(node, currentLocale, tooltipOptions.separator).substring(0, tooltipOptions.maxLength);
+    getTitleAndTooltip: ({node, currentLocale, tooltipOptions = {separator: " - ", maxLength: 807}}) => {
+        let tooltipText = TOCUtils.getTooltip(node, currentLocale, tooltipOptions.separator) || "";
+        tooltipText = tooltipText && tooltipText.substring(0, tooltipOptions.maxLength);
         if (tooltipText.length === tooltipOptions.maxLength) {
             tooltipText += "...";
         }

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -844,6 +844,17 @@ describe('LayersUtils', () => {
                 l => {
                     expect(l.credits).toExist();
                 }
+            ],
+            // save tooltipOptions and tooltipPlacement if present
+            [
+                {
+                    tooltipOptions: "both",
+                    tooltipPlacement: "right"
+                },
+                l => {
+                    expect(l.tooltipOptions).toExist();
+                    expect(l.tooltipPlacement).toExist();
+                }
             ]
         ];
         layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -284,7 +284,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -328,7 +330,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -372,7 +376,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -416,7 +422,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: [100000, 100000],
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 }],
                 mapOptions: {},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -478,7 +486,9 @@ describe('Test the MapUtils', () => {
                 type: "wms",
                 url: "",
                 visibility: true,
-                catalogURL: "url"
+                catalogURL: "url",
+                tooltipOptions: "both",
+                tooltipPlacement: "right"
             }
         ];
 
@@ -582,7 +592,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -626,7 +638,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -670,7 +684,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: "both",
+                    tooltipPlacement: "right"
                 }],
                 mapOptions: {
                     view: {
@@ -854,7 +870,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -898,7 +916,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 },
                 {
                     allowedSRS: {},
@@ -942,7 +962,9 @@ describe('Test the MapUtils', () => {
                     hidden: false,
                     useForElevation: false,
                     origin: undefined,
-                    thematic: undefined
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
                 }],
                 mapOptions: {},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -968,6 +990,145 @@ describe('Test the MapUtils', () => {
         });
     });
 
+
+    it('save map configuration with tile matrix and map info configuration', () => {
+        const flat = [
+            {
+                allowedSRS: {},
+                bbox: {},
+                description: undefined,
+                dimensions: [],
+                id: "layer001",
+                loading: true,
+                name: "layer001",
+                params: {},
+                search: {},
+                singleTile: false,
+                title: "layer001",
+                type: "wms",
+                url: "http:url001",
+                visibility: true,
+                catalogURL: "url",
+                matrixIds: {
+                    'EPSG:4326': [{
+                        identifier: 'EPSG:4326:0'
+                    }]
+                },
+                tileMatrixSet: [{
+                    TileMatrix: [{
+                        'ows:Identifier': 'EPSG:4326:0'
+                    }],
+                    'ows:Identifier': "EPSG:4326",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                }, {
+                    TileMatrix: [{
+                        'ows:Identifier': 'custom:0'
+                    }],
+                    'ows:Identifier': "custom",
+                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                }]
+            }
+        ];
+        const groups = [
+            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+            ]}
+        ];
+        const mapConfig = {
+            center: {x: 0, y: 0, crs: 'EPSG:4326'},
+            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+            projection: 'EPSG:900913',
+            units: 'm',
+            zoom: 10
+        };
+        const saved = saveMapConfiguration(mapConfig, flat, groups, '', { mapInfoConfiguration: {infoFormat: "text/html", showEmptyMessageGFI: false}});
+        expect(saved).toEqual({
+            map: {
+                center: {crs: 'EPSG:4326', x: 0, y: 0},
+                groups: [{
+                    id: 'Default',
+                    expanded: true
+                }, {
+                    id: 'custom',
+                    expanded: false
+                }, {
+                    id: 'custom.nested001',
+                    expanded: true
+                }],
+                layers: [{
+                    allowedSRS: {},
+                    thumbURL: undefined,
+                    availableStyles: undefined,
+                    bbox: {},
+                    requestEncoding: undefined,
+                    capabilitiesURL: undefined,
+                    description: undefined,
+                    dimensions: [],
+                    nativeCrs: undefined,
+                    features: undefined,
+                    queryable: undefined,
+                    featureInfo: undefined,
+                    format: undefined,
+                    group: undefined,
+                    hideLoading: false,
+                    handleClickOnLayer: false,
+                    id: "layer001",
+                    matrixIds: ['EPSG:4326'],
+                    maxZoom: undefined,
+                    maxNativeZoom: undefined,
+                    name: "layer001",
+                    opacity: undefined,
+                    params: {},
+                    provider: undefined,
+                    search: {},
+                    singleTile: false,
+                    source: undefined,
+                    style: undefined,
+                    styleName: undefined,
+                    styles: undefined,
+                    tileMatrixSet: true,
+                    tiled: undefined,
+                    title: "layer001",
+                    transparent: undefined,
+                    type: "wms",
+                    url: "http:url001",
+                    visibility: true,
+                    catalogURL: "url",
+                    hidden: false,
+                    useForElevation: false,
+                    origin: undefined,
+                    thematic: undefined,
+                    tooltipOptions: undefined,
+                    tooltipPlacement: undefined
+                }],
+                mapOptions: {},
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                text_serch_config: '',
+                units: 'm',
+                zoom: 10,
+                sources: {
+                    'http:url001': {
+                        tileMatrixSet: {
+                            'EPSG:4326': {
+                                TileMatrix: [{
+                                    'ows:Identifier': 'EPSG:4326:0'
+                                }],
+                                'ows:Identifier': "EPSG:4326",
+                                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                            }
+                        }
+                    }
+                }
+            },
+            mapInfoConfiguration: {
+                infoFormat: "text/html",
+                showEmptyMessageGFI: false
+            },
+            version: 2
+        });
+    });
 
     it('test getIdFromUri ', () => {
         // /mapstore2/rest/geostore/data/578/raw?decode=datauri

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -11,7 +11,7 @@ const {
     getTooltip,
     getTooltipFragment,
     flattenGroups,
-    getTitleAndtooltip
+    getTitleAndTooltip
 } = require('../TOCUtils');
 let options = [{label: "lab1", value: "val1"}];
 const groups = [{
@@ -157,7 +157,7 @@ describe('TOCUtils', () => {
         expect(allGroups[2].value).toBe("first.second.third");
         expect(allGroups[2].label).toBe("first/second/third");
     });
-    it('test getTitleAndtooltip', () => {
+    it('test getTitleAndTooltip both', () => {
         const node = {
             name: 'layer00',
             title: {
@@ -166,16 +166,28 @@ describe('TOCUtils', () => {
             },
             id: "layer00",
             description: "desc",
-            visibility: true,
-            storeIndex: 9,
-            type: 'wms',
-            url: 'fakeurl',
             tooltipOptions: "both"
         };
         const currentLocale = "it-IT";
-        const {title, tooltipText} = getTitleAndtooltip({node, currentLocale});
+        const {title, tooltipText} = getTitleAndTooltip({node, currentLocale});
         expect(title).toBe("Livello");
         expect(tooltipText).toBe("Livello - desc");
 
+    });
+    it('test getTitleAndTooltip NoTooltip', () => {
+        const node = {
+            name: 'layer00',
+            title: {
+                'default': 'Layer',
+                'it-IT': 'Livello'
+            },
+            id: "layer00",
+            description: "desc",
+            tooltipOptions: "none"
+        };
+        const currentLocale = "it-IT";
+        const {title, tooltipText} = getTitleAndTooltip({node, currentLocale});
+        expect(title).toBe("Livello");
+        expect(tooltipText).toBe("");
     });
 });


### PR DESCRIPTION
## Description
With this pr you tooltip options (composition and placement) are saved when the map is saved

## Issues
 - Fix #3608 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
it is not saving tooltip options and placement

**What is the new behavior?**
it is saving those info

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
