### PR TITLE
Fix #3664 DockPanel do not render content when closed

### DIFF
--- a/web/client/components/TOC/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/components/TOC/__tests__/TOCItemsSettings-test.jsx
@@ -21,6 +21,9 @@ const layers = [
         type: 'wms'
     }
 ];
+const settings = {
+    expanded: true
+};
 
 describe("test TOCItemsSettings", () => {
     beforeEach((done) => {
@@ -35,7 +38,7 @@ describe("test TOCItemsSettings", () => {
     });
 
     it('test with tabs', () => {
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -60,13 +63,13 @@ describe("test TOCItemsSettings", () => {
     });
 
     it('test without tabs', () => {
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => []}/>, document.getElementById("container"));
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => []}/>, document.getElementById("container"));
         const navBar = document.getElementsByClassName('nav-justified')[0];
         expect(navBar).toNotExist();
     });
 
     it('test with tabs length 1', () => {
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [{
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [{
             id: 'general',
             titleId: 'layerProperties.general',
             tooltipId: 'layerProperties.general',
@@ -80,13 +83,13 @@ describe("test TOCItemsSettings", () => {
     });
 
     it('test alert modal', () => {
-        ReactDOM.render(<TOCItemsSettings alertModal/>, document.getElementById("container"));
+        ReactDOM.render(<TOCItemsSettings settings={settings} alertModal/>, document.getElementById("container"));
         const alertModal = document.getElementsByClassName('ms-resizable-modal');
         expect(alertModal.length).toBe(1);
     });
 
     it('test with a title ', () => {
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -115,7 +118,7 @@ describe("test TOCItemsSettings", () => {
 
         const spyOnClick = expect.spyOn(testHandlers, 'onClick');
 
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -147,7 +150,7 @@ describe("test TOCItemsSettings", () => {
 
         const spyOnClose = expect.spyOn(testHandlers, 'onClose');
 
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -173,7 +176,7 @@ describe("test TOCItemsSettings", () => {
 
     it('test ToolbarComponent from tab', () => {
 
-        ReactDOM.render(<TOCItemsSettings activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
             {
                 id: 'general',
                 titleId: 'layerProperties.general',

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -48,7 +48,7 @@ describe("test IdentifyContainer", () => {
     it('test component component uses custom viewer', () => {
         const Viewer = ({responses}) => <div id="test-viewer-gfi">{responses.length}</div>;
         ReactDOM.render(
-            <IdentifyContainer enabled responses={[{}, {}]} viewer={Viewer} />,
+            <IdentifyContainer enabled requests={[{}, {}]} responses={[{}, {}]} viewer={Viewer} />,
             document.getElementById("container")
         );
         const viewer = document.getElementById("test-viewer-gfi");
@@ -58,6 +58,7 @@ describe("test IdentifyContainer", () => {
     it('test component reverse geocode modal', () => {
         ReactDOM.render(
             <IdentifyContainer
+                requests={[{}]} responses={[{}]}
                 enableRevGeocode
                 point={{latlng: {lat: 40, lng: 10}}}
                 enabled

--- a/web/client/components/misc/panels/DockPanel.jsx
+++ b/web/client/components/misc/panels/DockPanel.jsx
@@ -67,7 +67,7 @@ module.exports = withState('fullscreen', 'onFullscreen', false)(
                 zIndex={zIndex}>
                 <BorderLayout
                     header={
-                        !hideHeader && <PanelHeader
+                        !hideHeader && open && <PanelHeader
                             position={position}
                             onClose={onClose}
                             bsStyle={bsStyle}
@@ -78,8 +78,8 @@ module.exports = withState('fullscreen', 'onFullscreen', false)(
                             additionalRows={header}
                             onFullscreen={onFullscreen}/>
                     }
-                    footer={footer}>
-                    {children}
+                    footer={open && footer}>
+                    {open && children}
                 </BorderLayout>
             </Dock>
         </div>

--- a/web/client/components/misc/panels/__tests__/DockPanel-test.jsx
+++ b/web/client/components/misc/panels/__tests__/DockPanel-test.jsx
@@ -58,7 +58,7 @@ describe("test DockPanel", () => {
     });
 
     it('test fullscreen', () => {
-        ReactDOM.render(<DockPanel showFullscreen onClose={() => {}}/>, document.getElementById("container"));
+        ReactDOM.render(<DockPanel open showFullscreen onClose={() => {}}/>, document.getElementById("container"));
         const buttons = document.getElementsByClassName('square-button');
         expect(buttons.length).toBe(2);
         expect(buttons[0].children[0].getAttribute('class')).toBe('glyphicon glyphicon-chevron-left');

--- a/web/client/components/misc/panels/__tests__/DockPanel-test.jsx
+++ b/web/client/components/misc/panels/__tests__/DockPanel-test.jsx
@@ -56,6 +56,22 @@ describe("test DockPanel", () => {
         const body = document.getElementsByClassName('my-custom-body-child')[0];
         expect(body).toExist();
     });
+    it('test header, footer and children with closed panel (render nothing)', () => {
+        // This prevents issues like "Pressing tab cause white space on right #3664"
+        ReactDOM.render(
+            <DockPanel
+                header={<div className="my-custom-head-row" />}
+                footer={<div className="my-custom-footer" />}>
+                <div className="my-custom-body-child" />
+            </DockPanel>, document.getElementById("container"));
+
+        const header = document.getElementsByClassName('my-custom-head-row')[0];
+        expect(header).toNotExist();
+        const footer = document.getElementsByClassName('my-custom-footer')[0];
+        expect(footer).toNotExist();
+        const body = document.getElementsByClassName('my-custom-body-child')[0];
+        expect(body).toNotExist();
+    });
 
     it('test fullscreen', () => {
         ReactDOM.render(<DockPanel open showFullscreen onClose={() => {}}/>, document.getElementById("container"));


### PR DESCRIPTION
## Description
DockPanel was rendering hidden content on the right, in a div shifted out of the browser's viewport. Anyway, if the dockpanel contains focusable elements (like html `input`) when this element focused (pressing tab many times) all the map is shifted to show the hidden tab (see the issue #3664). This is because of the css of mapstore and probably because of the tricks applied to make the dock panel work also in fullscreen. 

This pull request deny rendering inside the `DockPanel` until the panel is open. 
This prevents to render also focusable elements, that are not in the DOM anymore, so can not be focused using TAB button, solving issue #3664 .

## Issues
 - Fix #3664

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see #3664 

**What is the new behavior?**
Pressing tab do not causes this issue anymore

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

