### PR TITLE
3548 fix ui drag menu for coordinate editor (c125_annotations)

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -27,7 +27,7 @@ const Portal = require('../../misc/Portal');
  * @prop {function} getNavigationButtons must return an array of navigation buttons, eg (props) => [{ glyph: 'info-sign', tooltip: 'hello!'}]
  */
 
-const CoordinatesEditor = require('../../../plugins/identify/CoordinatesEditor');
+const IdentifyEditor = require('../../../plugins/identify/IdentifyEditor');
 
 module.exports = props => {
     const {
@@ -99,9 +99,8 @@ module.exports = props => {
                 showFullscreen={showFullscreen}
                 zIndex={zIndex}
                 header={[enabledCoordEditorButton && showCoordinateEditor &&
-                    <CoordinatesEditor
+                    <IdentifyEditor
                         key="coordinate-editor"
-                        isDraggable={false}
                         removeVisible={false}
                         formatCoord={formatCoord}
                         coordinate={point.latlng ? {lat: point.latlng.lat, lon: lngCorrected } : {lat: "", lon: ""}}

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -35,7 +35,7 @@ const MeasureEditor = require('./MeasureEditor');
  * @prop {string} isDraggable tells if the coordinate row is draggable
  *
 */
-class CoordinateEditor extends React.Component {
+class CoordinatesEditor extends React.Component {
     static propTypes = {
         components: PropTypes.array,
         measureOptions: PropTypes.object,
@@ -238,6 +238,7 @@ class CoordinateEditor extends React.Component {
                         sortId={idx}
                         key={idx + " key"}
                         isDraggable={this.props.isDraggable && componentsValidation[type].remove && this[componentsValidation[type].validation]()}
+                        showDraggable={this.props.isDraggable && !(this.props.type === "Point" || this.props.type === "Text" || this.props.type === "Circle")}
                         formatVisible={false}
                         removeVisible={componentsValidation[type].remove}
                         removeEnabled={this[componentsValidation[type].validation](this.props.components, componentsValidation[type].remove, idx)}
@@ -352,4 +353,4 @@ class CoordinateEditor extends React.Component {
     }
 }
 
-module.exports = draggableContainer(CoordinateEditor);
+module.exports = draggableContainer(CoordinatesEditor);

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -237,7 +237,8 @@ class CoordinatesEditor extends React.Component {
                         aeronauticalOptions={this.props.aeronauticalOptions}
                         sortId={idx}
                         key={idx + " key"}
-                        isDraggable={this.props.isDraggable && componentsValidation[type].remove && this[componentsValidation[type].validation]()}
+                        isDraggable={this.props.isDraggable}
+                        isDraggableEnabled={this.props.isDraggable && this[componentsValidation[type].validation]()}
                         showDraggable={this.props.isDraggable && !(this.props.type === "Point" || this.props.type === "Text" || this.props.type === "Circle")}
                         formatVisible={false}
                         removeVisible={componentsValidation[type].remove}

--- a/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
@@ -568,7 +568,7 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(editor).toExist();
 
         let buttons = TestUtils.scryRenderedDOMComponentsWithTag(editor, "button");
-        let firstDelButton = buttons[3];
+        let firstDelButton = buttons[4];
         TestUtils.Simulate.click(firstDelButton);
         expect(spyOnHighlightPoint).toHaveBeenCalled();
         expect(spyOnHighlightPoint).toHaveBeenCalledWith({ lat: 8, lon: 8 });
@@ -598,7 +598,7 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(editor).toExist();
 
         let buttons = TestUtils.scryRenderedDOMComponentsWithTag(editor, "button");
-        let firstDelButton = buttons[3];
+        let firstDelButton = buttons[4];
         TestUtils.Simulate.click(firstDelButton);
         expect(spyOnHighlightPoint).toNotHaveBeenCalled();
         expect(firstDelButton.disabled).toBe(true);
@@ -636,7 +636,7 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(editor).toExist();
 
         let buttons = TestUtils.scryRenderedDOMComponentsWithTag(editor, "button");
-        let firstDelButton = buttons[3];
+        let firstDelButton = buttons[4];
         TestUtils.Simulate.click(firstDelButton);
         expect(spyOnSetInvalidSelected).toNotHaveBeenCalled();
         expect(spyOnChange).toHaveBeenCalled();
@@ -674,11 +674,11 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(editor).toExist();
 
         const buttons = TestUtils.scryRenderedDOMComponentsWithTag(editor, "button");
-        expect(buttons.length).toBe(7);
-        expect(buttons[3].disabled).toBe(false);
-        expect(buttons[4].disabled).toBe(true);
-        expect(buttons[5].disabled).toBe(true);
-        expect(buttons[6].disabled).toBe(false);
+        expect(buttons.length).toBe(11);
+        expect(buttons[4].disabled).toBe(false);
+        expect(buttons[6].disabled).toBe(true);
+        expect(buttons[8].disabled).toBe(true);
+        expect(buttons[10].disabled).toBe(false);
     });
     it('CoordinatesEditor as Polygon, 5 rows, only invalid rows are not disabled', () => {
         const components = [{
@@ -715,12 +715,12 @@ describe("test the CoordinatesEditor Panel", () => {
         const hamburgerMenus = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-menu-hamburger");
         expect(hamburgerMenus.length).toBe(5);
         const buttons = TestUtils.scryRenderedDOMComponentsWithTag(editor, "button");
-        expect(buttons.length).toBe(8);
-        expect(buttons[3].disabled).toBe(false);
-        expect(buttons[4].disabled).toBe(true);
-        expect(buttons[5].disabled).toBe(true);
+        expect(buttons.length).toBe(13);
+        expect(buttons[4].disabled).toBe(false);
         expect(buttons[6].disabled).toBe(true);
-        expect(buttons[7].disabled).toBe(false);
+        expect(buttons[8].disabled).toBe(true);
+        expect(buttons[10].disabled).toBe(true);
+        expect(buttons[12].disabled).toBe(false);
     });
 
 });

--- a/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
@@ -52,6 +52,8 @@ describe("test the CoordinatesEditor Panel", () => {
             />, document.getElementById("container")
         );
         expect(editor).toExist();
+        const hamburgerMenus = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-menu-hamburger");
+        expect(hamburgerMenus.length).toBe(0);
 
         const spans = TestUtils.scryRenderedDOMComponentsWithTag(editor, "span");
         expect(spans).toExist();
@@ -92,7 +94,8 @@ describe("test the CoordinatesEditor Panel", () => {
             />, document.getElementById("container")
         );
         expect(editor).toExist();
-
+        const hamburgerMenus = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-menu-hamburger");
+        expect(hamburgerMenus.length).toBe(3);
         const inputs = TestUtils.scryRenderedDOMComponentsWithTag(editor, "input");
         expect(inputs).toExist();
         const input = inputs[0];
@@ -331,6 +334,8 @@ describe("test the CoordinatesEditor Panel", () => {
         );
         expect(editor).toExist();
 
+        const hamburgerMenus = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-menu-hamburger");
+        expect(hamburgerMenus.length).toBe(0);
         const inputs = TestUtils.scryRenderedDOMComponentsWithTag(editor, "input");
         expect(inputs).toExist();
         const inputRadius = inputs[0];
@@ -491,6 +496,9 @@ describe("test the CoordinatesEditor Panel", () => {
         const inputText = inputs[0];
         inputText.value = "";
         TestUtils.Simulate.change(inputText);
+
+        const hamburgerMenus = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-menu-hamburger");
+        expect(hamburgerMenus.length).toBe(0);
 
         expect(spyOnHighlightPoint).toNotHaveBeenCalled();
         expect(spyOnChange).toNotHaveBeenCalled();
@@ -704,6 +712,8 @@ describe("test the CoordinatesEditor Panel", () => {
         );
         expect(editor).toExist();
 
+        const hamburgerMenus = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-menu-hamburger");
+        expect(hamburgerMenus.length).toBe(5);
         const buttons = TestUtils.scryRenderedDOMComponentsWithTag(editor, "button");
         expect(buttons.length).toBe(8);
         expect(buttons[3].disabled).toBe(false);

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -319,6 +319,7 @@ class MeasureComponent extends React.Component {
                 {(this.props.bearingMeasureEnabled || this.props.areaMeasureEnabled || this.props.lineMeasureEnabled)
                         ? <Row style={ this.props.isCoordinateEditorEnabled ? {} : {pointerEvents: "none", opacity: 0.5}}>
                         <CoordinatesEditor
+                            key="measureEditor"
                             isMouseEnterEnabled
                             isMouseLeaveEnabled
                             format={this.props.format}

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -42,7 +42,7 @@ class CoordinatesRow extends React.Component {
     render() {
         const {idx} = this.props;
         const rowStyle = {marginLeft: -5, marginRight: -5};
-        // drag button must be a button in order to shwo the disabled state
+        // drag button must be a button in order to show the disabled state
         const dragButton = (
             <div><Button
                 disabled={!this.props.isDraggableEnabled}

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -26,13 +26,16 @@ class CoordinatesRow extends React.Component {
         customClassName: PropTypes.string,
         isDraggable: PropTypes.bool,
         showLabels: PropTypes.bool,
+        showDraggable: PropTypes.bool,
         removeVisible: PropTypes.bool,
         formatVisible: PropTypes.bool,
         removeEnabled: PropTypes.bool
     };
     defaultProps = {
         showLabels: false,
-        formatVisible: false
+        formatVisible: false,
+        onMouseEnter: () => {},
+        onMouseLeave: () => {}
     }
 
     render() {
@@ -59,7 +62,7 @@ class CoordinatesRow extends React.Component {
                 }
             }}>
                 <Col xs={1}>
-                    {this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton}
+                    {this.props.showDraggable ? this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton : null}
                 </Col>
                 <Col xs={5}>
                     {this.props.showLabels && <span><Message msgId="latitude"/></span>}

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const {Row, Col, Glyphicon} = require('react-bootstrap');
+const {Row, Col, Glyphicon, Button} = require('react-bootstrap');
 const Toolbar = require('../toolbar/Toolbar');
 const draggableComponent = require('../enhancers/draggableComponent');
 const CoordinateEntry = require('./CoordinateEntry');
@@ -25,6 +25,7 @@ class CoordinatesRow extends React.Component {
         aeronauticalOptions: PropTypes.object,
         customClassName: PropTypes.string,
         isDraggable: PropTypes.bool,
+        isDraggableEnabled: PropTypes.bool,
         showLabels: PropTypes.bool,
         showDraggable: PropTypes.bool,
         removeVisible: PropTypes.bool,
@@ -41,15 +42,17 @@ class CoordinatesRow extends React.Component {
     render() {
         const {idx} = this.props;
         const rowStyle = {marginLeft: -5, marginRight: -5};
-        const dragButton = (<div
-            className="square-button-md no-border btn btn-default"
-            style={{display: "flex" /*workaround for firefox*/}}
-            >
-            <Glyphicon
-            glyph="menu-hamburger"
-            disabled={!this.props.isDraggable}
-            style={{pointerEvents: !this.props.isDraggable ? "none" : "auto"}}
-        /></div>);
+        // drag button must be a button in order to shwo the disabled state
+        const dragButton = (
+            <div><Button
+                disabled={!this.props.isDraggableEnabled}
+                className="square-button-md no-border btn btn-default"
+                style={{display: "flex"/*workaround for firefox*/}}>
+                <Glyphicon
+                    glyph="menu-hamburger"
+                    style={{pointerEvents: !this.props.isDraggableEnabled ? "none" : "auto"}}
+                />
+            </Button></div>);
 
         return (
             <Row className={`coordinateRow ${this.props.customClassName || ""}`} style={!this.props.customClassName ? rowStyle : {}} onMouseEnter={() => {

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -47,7 +47,7 @@ class CoordinatesRow extends React.Component {
             <div><Button
                 disabled={!this.props.isDraggableEnabled}
                 className="square-button-md no-border btn btn-default"
-                style={{display: "flex"/*workaround for firefox*/}}>
+                style={{display: "flex", cursor: this.props.isDraggableEnabled && 'grab'}}>
                 <Glyphicon
                     glyph="menu-hamburger"
                     style={{pointerEvents: !this.props.isDraggableEnabled ? "none" : "auto"}}

--- a/web/client/plugins/identify/IdentifyEditor.jsx
+++ b/web/client/plugins/identify/IdentifyEditor.jsx
@@ -9,8 +9,9 @@
 const React = require('react');
 const CoordinatesRow = require('../../components/misc/coordinateeditors/CoordinatesRow');
 
-const CoordinatesEditor = (props) => (
+const IdentifyEditor = (props) => (
     <CoordinatesRow
+        key="IdentifyEditor"
         format={props.formatCoord || "decimal"}
         aeronauticalOptions={{
             seconds: {
@@ -29,9 +30,10 @@ const CoordinatesEditor = (props) => (
         component={props.coordinate || {}}
         customClassName="GFI-coord-editor"
         isDraggable={false}
+        showDraggable={false}
         formatVisible
         showLabels
         removeVisible={false}
     />);
 
-module.exports = CoordinatesEditor;
+module.exports = IdentifyEditor;


### PR DESCRIPTION
## Description
This pr updates the drag button visibility in the various coordinate editor in the 

It also fixes the problem with focus when form goes invalid.

## Issues
 - Fix #3548

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
the drag menu appears in GFI panel even if there is only on row present

**What is the new behavior?**
now in the GFI the drag button does not option

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
