### PR TITLE
Fixed default lon to east in aeronautical format

### DIFF
--- a/web/client/components/misc/coordinateeditors/enhancers/__tests__/decimalToAeronautical-test.js
+++ b/web/client/components/misc/coordinateeditors/enhancers/__tests__/decimalToAeronautical-test.js
@@ -25,6 +25,33 @@ describe("test the Annotations enahncers", () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
+    it('rendering default values', () => {
+        const Sink = decimalToAeronautical(createSink(props => {
+            expect(props).toExist();
+            // east is default in aeronautical format
+            if (props.coordinate === "lon") {
+                expect(props.direction).toBe('E');
+            } else {
+                expect(props.direction).toBe('N');
+            }
+
+
+        }));
+        // lat
+        ReactDOM.render((<Sink
+            />), document.getElementById("container"));
+        ReactDOM.render((<Sink
+            value={0}
+            />), document.getElementById("container"));
+        // lon
+        ReactDOM.render((<Sink
+            coordinate="lon"
+            />), document.getElementById("container"));
+        ReactDOM.render((<Sink
+            value={0}
+            coordinate="lon"
+            />), document.getElementById("container"));
+    });
     it('decimalToAeronautical conversion', (done) => {
         const Sink = decimalToAeronautical(createSink( props => {
             expect(props).toExist();

--- a/web/client/components/misc/coordinateeditors/enhancers/decimalToAeronautical.js
+++ b/web/client/components/misc/coordinateeditors/enhancers/decimalToAeronautical.js
@@ -28,7 +28,7 @@ const convertDDToDMS = (D, lng, {seconds} = {seconds: {decimals: 4}}) => {
             degrees: "",
             minutes: "",
             seconds: "",
-            direction: lng ? 'W' : 'N' // let's chose some default direction if coord is 0
+            direction: lng ? 'E' : 'N' // let's chose some default direction if coord is 0
         };
     }
     let values = {


### PR DESCRIPTION
## Description
Fixed default lon to east in aeronautical format, when undefined or 0.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
longitude in coordinate picker is W by default when value is 0 or not defined (empty)

**What is the new behavior?**
longitude in coordinate picker is E by default when value is 0 or not defined (empty)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No