### PR TITLE
Align OL measure number format of tooltip to measure panel's one

### DIFF
--- a/web/client/components/I18N/enhancers/__tests__/addI18NProps-test.js
+++ b/web/client/components/I18N/enhancers/__tests__/addI18NProps-test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {createSink} = require('recompose');
+const expect = require('expect');
+const addI18NProps = require('../addI18NProps');
+var Localized = require('../../Localized');
+
+
+describe('addI18NProps enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('addI18NProps format numbers', () => {
+        const Sink = addI18NProps(['formatNumber'])(createSink( props => {
+            expect(props).toExist();
+            expect(props.formatNumber).toExist();
+            expect(typeof props.formatNumber(1)).toBe('string');
+            expect(props.formatNumber(1.1)).toBe("1.1");
+        }));
+        ReactDOM.render(<Localized locale="en-EN" messages={{}}>
+            <Sink />
+        </Localized>, document.getElementById("container"));
+    });
+});

--- a/web/client/components/I18N/enhancers/__tests__/addI18NProps-test.js
+++ b/web/client/components/I18N/enhancers/__tests__/addI18NProps-test.js
@@ -23,12 +23,23 @@ describe('addI18NProps enhancer', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
+    it('addI18NProps format with no context', () => {
+        const Sink = addI18NProps(['formatNumber'])(createSink(props => {
+            expect(props).toExist();
+            expect(props.formatNumber).toExist();
+            // this is the default implementation.
+            expect(props.formatNumber(1.1)).toBe(1.1);
+            expect(props.formatNumber(1000)).toBe(1000);
+        }));
+        ReactDOM.render(<Sink />, document.getElementById("container"));
+    });
     it('addI18NProps format numbers', () => {
         const Sink = addI18NProps(['formatNumber'])(createSink( props => {
             expect(props).toExist();
             expect(props.formatNumber).toExist();
             expect(typeof props.formatNumber(1)).toBe('string');
             expect(props.formatNumber(1.1)).toBe("1.1");
+            expect(props.formatNumber(1000)).toBe("1,000");
         }));
         ReactDOM.render(<Localized locale="en-EN" messages={{}}>
             <Sink />

--- a/web/client/components/I18N/enhancers/addI18NProps.js
+++ b/web/client/components/I18N/enhancers/addI18NProps.js
@@ -8,7 +8,7 @@
 const {injectIntl} = require('react-intl');
 const PropTypes = require('prop-types');
 const {omit} = require('lodash');
-const { compose, branch, getContext, withProps, mapProps } = require('recompose');
+const { compose, branch, getContext, withProps, withPropsOnChange, mapProps } = require('recompose');
 
 const omitProps = keys => mapProps(props => omit(props, keys));
 
@@ -30,19 +30,25 @@ const defaults = {
 };
 
 /**
+ * Add i18n functionalities and properties as props. Useful to get format functions when the react-intl components can not be used (i.e. with wrapped libs)
  * @name addI18NFormat
- * @param {string[]} props add the props to format as props. One of these https://github.com/yahoo/react-intl/wiki/API#intlshape
+ * @param {string[]} props add the props to format as props. Should be keys of of this interface https://github.com/yahoo/react-intl/wiki/API#intlshape
+ * @example
+ * addI18NProps(['formatNumber'])(MyCmp); // MyCmp will receive `formatNumber` from current locale Intl object as a property
  */
 module.exports = (propsToAdd = []) => compose(
+    // check intl and inject (or add default dummy object)
     getContext({intl: PropTypes.object}),
     branch(
         ({intl}) => !!intl,
         injectIntl,
         withProps({intl: defaults})
     ),
-    withProps(({ intl = {} }) => propsToAdd.reduce((acc = {}, k) => ({
+    // add propsToAdd properties from intl object
+    withPropsOnChange(['intl'], ({ intl = {} }) => propsToAdd.reduce((acc = {}, k) => ({
         ...acc,
         [k]: intl[k]
     }), {})),
+    // clean up intl property
     omitProps(['intl'])
 );

--- a/web/client/components/I18N/enhancers/addI18NProps.js
+++ b/web/client/components/I18N/enhancers/addI18NProps.js
@@ -6,20 +6,43 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {injectIntl} = require('react-intl');
+const PropTypes = require('prop-types');
 const {omit} = require('lodash');
-const { compose, toClass, mapProps, withProps } = require('recompose');
+const { compose, branch, getContext, withProps, mapProps } = require('recompose');
 
 const omitProps = keys => mapProps(props => omit(props, keys));
 
+// TODO: provide better defaults
+const defaults = {
+    locale: navigator && navigator.language,
+    formats: { },
+    messages: { },
+    defaultLocale: 'en',
+    defaultFormats: {},
+    formatDate: v => v,
+    formatTime: v => v,
+    formatRelative: v => v,
+    formatNumber: v => v,
+    formatPlural: v => v,
+    formatMessage: v => v,
+    formatHTMLMessage: v => v,
+    now: () => new Date()
+};
+
 /**
  * @name addI18NFormat
- * @param {string[]} propsToAdd add the props to format as props. Choose in theese of these https://github.com/yahoo/react-intl/wiki/API#intlshape
+ * @param {string[]} props add the props to format as props. One of these https://github.com/yahoo/react-intl/wiki/API#intlshape
  */
 module.exports = (propsToAdd = []) => compose(
-    C => injectIntl(C, { intlPropName: '__intl__'} ),
-    withProps(({__intl__ = {}}) => propsToAdd.reduce((acc = {}, k) => ({
+    getContext({intl: PropTypes.object}),
+    branch(
+        ({intl}) => !!intl,
+        injectIntl,
+        withProps({intl: defaults})
+    ),
+    withProps(({ intl = {} }) => propsToAdd.reduce((acc = {}, k) => ({
         ...acc,
-        [k]: __intl__[k]
+        [k]: intl[k]
     }), {})),
-    omitProps(['__intl__'])
+    omitProps(['intl'])
 );

--- a/web/client/components/I18N/enhancers/addI18NProps.js
+++ b/web/client/components/I18N/enhancers/addI18NProps.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {injectIntl} = require('react-intl');
+const {omit} = require('lodash');
+const { compose, toClass, mapProps, withProps } = require('recompose');
+
+const omitProps = keys => mapProps(props => omit(props, keys));
+
+/**
+ * @name addI18NFormat
+ * @param {string[]} propsToAdd add the props to format as props. Choose in theese of these https://github.com/yahoo/react-intl/wiki/API#intlshape
+ */
+module.exports = (propsToAdd = []) => compose(
+    C => injectIntl(C, { intlPropName: '__intl__'} ),
+    withProps(({__intl__ = {}}) => propsToAdd.reduce((acc = {}, k) => ({
+        ...acc,
+        [k]: __intl__[k]
+    }), {})),
+    omitProps(['__intl__'])
+);

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -11,6 +11,8 @@ const PropTypes = require('prop-types');
 const {round, isEqual, dropRight, pick} = require('lodash');
 const assign = require('object-assign');
 const ol = require('openlayers');
+const addI18NProps = require('../../I18N/enhancers/addI18NProps');
+
 const wgs84Sphere = new ol.Sphere(6378137);
 const {reprojectGeoJson, reproject, calculateAzimuth, calculateDistance, transformLineToArcs} = require('../../../utils/CoordinatesUtils');
 const {convertUom, getFormattedBearingValue} = require('../../../utils/MeasureUtils');
@@ -30,6 +32,7 @@ class MeasurementSupport extends React.Component {
         measurement: PropTypes.object,
         enabled: PropTypes.bool,
         uom: PropTypes.object,
+        formatNumber: PropTypes.func,
         changeMeasurementState: PropTypes.func,
         updateMeasures: PropTypes.func,
         resetGeometry: PropTypes.func,
@@ -46,6 +49,7 @@ class MeasurementSupport extends React.Component {
         resetGeometry: () => {},
         updateMeasures: () => {},
         changeGeometry: () => {},
+        formatNumber: () => {},
         startEndPoint: {
             startPointOptions: {
                 radius: 3,
@@ -451,7 +455,7 @@ class MeasurementSupport extends React.Component {
         const length = calculateDistance(reprojectedCoords, props.measurement.lengthFormula);
         const {label, unit} = props.uom && props.uom.length;
         const output = round(convertUom(length, "m", unit), 2);
-        return output + " " + (label);
+        return this.props.formatNumber(output) + " " + (label);
     };
 
     /**
@@ -464,7 +468,7 @@ class MeasurementSupport extends React.Component {
         const {label, unit} = props.uom && props.uom.area;
         const output = round(convertUom(area, "sqm", unit), 2);
 
-        return output + " " + label;
+        return this.props.formatNumber(output) + " " + label;
     };
 
     removeHelpTooltip = () => {
@@ -486,4 +490,6 @@ class MeasurementSupport extends React.Component {
     }
 }
 
-module.exports = MeasurementSupport;
+module.exports = addI18NProps(
+    ['formatNumber']
+)(MeasurementSupport);

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -11,7 +11,6 @@ const PropTypes = require('prop-types');
 const {round, isEqual, dropRight, pick} = require('lodash');
 const assign = require('object-assign');
 const ol = require('openlayers');
-const addI18NProps = require('../../I18N/enhancers/addI18NProps');
 
 const wgs84Sphere = new ol.Sphere(6378137);
 const {reprojectGeoJson, reproject, calculateAzimuth, calculateDistance, transformLineToArcs} = require('../../../utils/CoordinatesUtils');
@@ -49,7 +48,7 @@ class MeasurementSupport extends React.Component {
         resetGeometry: () => {},
         updateMeasures: () => {},
         changeGeometry: () => {},
-        formatNumber: () => {},
+        formatNumber: n => n,
         startEndPoint: {
             startPointOptions: {
                 radius: 3,
@@ -490,6 +489,4 @@ class MeasurementSupport extends React.Component {
     }
 }
 
-module.exports = addI18NProps(
-    ['formatNumber']
-)(MeasurementSupport);
+module.exports = MeasurementSupport;

--- a/web/client/plugins/map/openlayers/index.js
+++ b/web/client/plugins/map/openlayers/index.js
@@ -5,13 +5,17 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
+const addI18NProps = require('../../../components/I18N/enhancers/addI18NProps');
+
+// number format localization for measurements
+const addFormatNumber = addI18NProps(['formatNumber']);
 
 module.exports = {
     LMap: require('../../../components/map/openlayers/Map'),
     Layer: require('../../../components/map/openlayers/Layer'),
     Feature: require('../../../components/map/openlayers/Feature'),
     Locate: require('../../../components/map/openlayers/Locate'),
-    MeasurementSupport: require('../../../components/map/openlayers/MeasurementSupport'),
+    MeasurementSupport: addFormatNumber(require('../../../components/map/openlayers/MeasurementSupport')),
     Overview: require('../../../components/map/openlayers/Overview'),
     ScaleBar: require('../../../components/map/openlayers/ScaleBar'),
     DrawSupport: require('../../../components/map/openlayers/DrawSupport'),


### PR DESCRIPTION
## Description
This PR align the tooltip (openlayers only) of measure tool to the number format used in the current locale (selected from MapStore settings)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Note that the decimal grouping (thousands separator) is missing in the tooltip. 
![image](https://user-images.githubusercontent.com/1279510/55548208-43608d00-56d3-11e9-9fd4-3a4d9af69e4b.png)


**What is the new behavior?**
Now they have the same format (please ignore that the style of the panel is different from the previous screenshot)
![image](https://user-images.githubusercontent.com/1279510/55548143-2461fb00-56d3-11e9-9be9-8fa6894e298f.png)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
I added an enhancer that adds localized format props to a react component on demand. 