### PR TITLE
 autoDetectCORS option for proxy config

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@turf/polygon-to-linestring": "4.1.0",
     "ag-grid": "3.3.3",
     "ag-grid-react": "3.3.1",
-    "axios": "0.11.1",
+    "axios": "0.18.0",
     "b64-to-blob": "1.2.19",
     "babel-polyfill": "6.8.0",
     "babel-standalone": "6.7.7",

--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -76,6 +76,10 @@ const authenticationRules = [
     {
       "urlPattern": ".*useBrowserCredentials.*",
       "method": "browserWithCredentials"
+    },
+    {
+        "urlPattern": ".*sitetocheck.*",
+        "method": "bearer"
     }
 ];
 
@@ -302,6 +306,20 @@ describe('Tests ajax library', () => {
         expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
         expect.spyOn(SecurityUtils, 'getSecurityInfo').andReturn(securityInfoB);
         axios.get('http://non-existent.mapstore2/imtokenized?parameter1=value1&par2=v2').then(() => {
+            done("Axios actually reached the fake url");
+        }).catch((exception) => {
+            expect(exception.config).toExist().toIncludeKey('headers');
+            expect(exception.config.headers.Authorization).toBe('Bearer 263c6917-543f-43e3-8e1a-6a0d29952f72');
+            done();
+        });
+    });
+
+    it('adds Bearer header also when using baseURL', (done) => {
+        // mocking the authentication rules and user info
+        expect.spyOn(SecurityUtils, 'isAuthenticationActivated').andReturn(true);
+        expect.spyOn(SecurityUtils, 'getAuthenticationRules').andReturn(authenticationRules);
+        expect.spyOn(SecurityUtils, 'getSecurityInfo').andReturn(securityInfoB);
+        axios.get('tokenservice?param=token', { baseURL: 'http://sitetocheck', timeout: 1}).then(() => {
             done("Axios actually reached the fake url");
         }).catch((exception) => {
             expect(exception.config).toExist().toIncludeKey('headers');

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -7,6 +7,7 @@
  */
 
 const axios = require('axios');
+const url = require('url');
 const ConfigUtils = require('../utils/ConfigUtils');
 
 const SecurityUtils = require('../utils/SecurityUtils');
@@ -30,6 +31,8 @@ function addParameterToAxiosConfig(axiosConfig, parameterName, parameterValue) {
 function addHeaderToAxiosConfig(axiosConfig, headerName, headerValue) {
     axiosConfig.headers = assign({}, axiosConfig.headers, {[headerName]: headerValue});
 }
+
+const corsDisabled = [];
 
 /**
  * Internal helper that will add to the axios config object the correct
@@ -107,12 +110,15 @@ axios.interceptors.request.use(config => {
         let proxyUrl = ConfigUtils.getProxyUrl(config);
         if (proxyUrl) {
             let useCORS = [];
+            let autoDetectCORS = false;
             if (isObject(proxyUrl)) {
                 useCORS = proxyUrl.useCORS || [];
+                autoDetectCORS = proxyUrl.autoDetectCORS || false;
                 proxyUrl = proxyUrl.url;
             }
             const isCORS = useCORS.reduce((found, current) => found || uri.indexOf(current) === 0, false);
-            if (!isCORS) {
+            const cannotUseCORS = corsDisabled.reduce((found, current) => found || uri.indexOf(current) === 0, false);
+            if (!isCORS && (!autoDetectCORS || cannotUseCORS)) {
                 const parsedUri = urlUtil.parse(uri, true, true);
                 config.url = proxyUrl + encodeURIComponent(
                     urlUtil.format(
@@ -123,10 +129,26 @@ axios.interceptors.request.use(config => {
                     )
                 );
                 config.params = undefined;
+            } else if (autoDetectCORS) {
+                config.autoDetectCORS = true;
             }
         }
     }
     return config;
+});
+
+axios.interceptors.response.use(response => response, (error) => {
+    if (error.config && error.config.autoDetectCORS) {
+        const urlParts = url.parse(error.config.url);
+        const baseUrl = urlParts.protocol + "//" + urlParts.host + urlParts.pathname;
+        if (corsDisabled.indexOf(baseUrl) === -1) {
+            corsDisabled.push(baseUrl);
+            return new Promise((resolve, reject) => {
+                axios({ ...error.config, autoDetectCORS: false}).then(resolve).catch(reject);
+            });
+        }
+    }
+    return Promise.reject(error.response ? {...error.response, originalError: error} : error);
 });
 
 module.exports = axios;

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -7,6 +7,7 @@
  */
 
 const axios = require('axios');
+const combineURLs = require('axios/lib/helpers/combineURLs');
 const url = require('url');
 const ConfigUtils = require('../utils/ConfigUtils');
 
@@ -42,7 +43,8 @@ function addAuthenticationToAxios(axiosConfig) {
     if (!axiosConfig || !axiosConfig.url || !SecurityUtils.isAuthenticationActivated()) {
         return axiosConfig;
     }
-    const rule = SecurityUtils.getAuthenticationRule(axiosConfig.url);
+    const axiosUrl = combineURLs(axiosConfig.baseURL || '', axiosConfig.url);
+    const rule = SecurityUtils.getAuthenticationRule(axiosUrl);
 
     switch (rule && rule.method) {
         case 'browserWithCredentials':

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -51,7 +51,7 @@ const catalogSelector = createSelector([
     format: newformat,
     newService,
     currentLocale,
-    records: CatalogUtils.getCatalogRecords(selectedFormat, result, options)
+    records: result && CatalogUtils.getCatalogRecords(selectedFormat, result, options) || []
 }));
 
 const catalogClose = () => {

--- a/web/client/utils/SecurityUtils.js
+++ b/web/client/utils/SecurityUtils.js
@@ -27,7 +27,7 @@ const SecurityUtils = {
      * Gets security state form the store.
      */
     getSecurityInfo() {
-        return this.store.getState().security;
+        return this.store && this.store.getState().security || {};
     },
 
     /**


### PR DESCRIPTION
## Description
Optional configuration to introduce autodetect of CORS on services used by MapStore2.
If enabled, when contacting any service, MS2 will try to contact it directly, on error will fallback to using the proxy (and continue to use the proxy for following requests)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
CORS is enabled only if an host is listed in useCORS configuration option.

**What is the new behavior?**
CORS is autodetected and proxy is only used as a fallback.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
