### PR TITLE
Fix #3642 Switch between widgets and timeline

### DIFF
--- a/web/client/actions/__tests__/timeline-test.js
+++ b/web/client/actions/__tests__/timeline-test.js
@@ -17,7 +17,9 @@ const {
     LOADING,
     timeDataLoading,
     ENABLE_OFFSET,
-    enableOffset
+    enableOffset,
+    SET_COLLAPSED,
+    setCollapsed
 } = require('../timeline');
 
 describe('timeline actions', () => {
@@ -46,5 +48,11 @@ describe('timeline actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(ENABLE_OFFSET);
         expect(retval.enabled).toBe(true);
+    });
+    it('setCollapsed', () => {
+        const retval = setCollapsed(true);
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_COLLAPSED);
+        expect(retval.collapsed).toBe(true);
     });
 });

--- a/web/client/actions/timeline.js
+++ b/web/client/actions/timeline.js
@@ -63,6 +63,8 @@ const ENABLE_OFFSET = "TIMELINE:ENABLE_OFFSET";
  */
 const enableOffset = enabled => ({ type: ENABLE_OFFSET, enabled});
 
+const SET_COLLAPSED = "TIMELINE:SET_COLLAPSED";
+const setCollapsed = collapsed => ({ type: SET_COLLAPSED, collapsed});
 /**
  * Actions for timeline
  * @module actions.timeline
@@ -79,5 +81,7 @@ module.exports = {
     SELECT_LAYER,
     selectLayer,
     ENABLE_OFFSET,
-    enableOffset
+    enableOffset,
+    SET_COLLAPSED,
+    setCollapsed
 };

--- a/web/client/epics/__tests__/widgetsTray-test.js
+++ b/web/client/epics/__tests__/widgetsTray-test.js
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+const { testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
+const { configureMap } = require('../../actions/config');
+
+const { updateLayerDimensionData } = require('../../actions/dimension');
+const { changeLayerProperties } = require('../../actions/layers');
+const { SHOW_NOTIFICATION } = require('../../actions/notifications');
+const { rangeDataLoaded, setCollapsed, SET_COLLAPSED } = require('../../actions/timeline');
+const { deleteWidget, insertWidget, toggleCollapseAll, updateWidgetProperty, TOGGLE_COLLAPSE_ALL } = require('../../actions/widgets');
+
+const timeline = require('../../reducers/timeline');
+const dimension = require('../../reducers/dimension');
+const widgets = require('../../reducers/widgets');
+// TEST DATA
+const T1 = '2016-01-01T00:00:00.000Z';
+const T2 = '2016-02-01T00:00:00.000Z';
+const TEST_LAYER_ID = "TEST_LAYER";
+const SAMPLE_RANGE = {
+    start: T1,
+    end: T2
+};
+
+const TIME_DIMENSION_DATA = {
+    source: {
+        type: "multidim-extension",
+        url: "FAKE"
+    },
+    name: "time",
+    dimension: `${T1}--${T2}`
+};
+
+// sample timeline state with histogram
+const TIMELINE_STATE_VALUES = timeline(undefined, rangeDataLoaded(
+    TEST_LAYER_ID,
+    SAMPLE_RANGE,
+    // sample with daily histogram of values 1,2,3,..., 31
+    {
+        values: Array(31).fill().map((x, i) => i),
+        domain: `${T1}/${T2}/1D`
+    },
+    { values: [T1] }
+));
+
+// sample dimension state for TEST_LAYER
+const DIMENSION_STATE = dimension(undefined, updateLayerDimensionData(TEST_LAYER_ID, "time", TIME_DIMENSION_DATA));
+
+const LAYERS_NO_TIME_STATE = {
+    flat: [{
+        id: TEST_LAYER_ID
+    }]
+};
+
+const LAYERS_WITH_TIME = {
+    flat: [{
+        id: TEST_LAYER_ID,
+        dimensions: [TIME_DIMENSION_DATA]
+    }]
+};
+
+// SAMPLE STATE WITH TIMELINE SHOWING
+const SAMPLE_TIMELINE_STATE = {
+    layers: LAYERS_WITH_TIME,
+    dimension: DIMENSION_STATE,
+    timeline: TIMELINE_STATE_VALUES
+};
+// SAMPLE STATE WITH TIMELINE COLLAPSED
+const SAMPLE_COLLAPSED_TIMELINE_STATE = {
+    ...SAMPLE_TIMELINE_STATE,
+    timeline: timeline(SAMPLE_TIMELINE_STATE, setCollapsed(true))
+};
+// SAMPLE STATE WITH NO TIMELINE (NO TIME DATA)
+const NO_TIMELINE_STATE = {
+    layers: LAYERS_NO_TIME_STATE,
+    dimension: DIMENSION_STATE,
+    timeline: TIMELINE_STATE_VALUES
+};
+const WIDGETS_STATE = {
+    widgets: widgets(undefined, insertWidget({id: "TEST"}))
+};
+const NO_WIDGETS_STATE = {
+    widgets: widgets(undefined, { type: "DUMMY" })
+};
+
+// EPICS TO TEST
+const {
+    collapseTimelineOnWidgetsEvents,
+    collapseWidgetsOnTimelineEvents,
+    expandTimelineIfCollapsedOnTrayUnmount
+} = require('../widgetsTray');
+
+
+describe('widgetsTray epics', () => {
+    describe('collapseTimelineOnWidgetsEvents', () => {
+        it('collapse timeline on widget add', done => {
+            testEpic(collapseTimelineOnWidgetsEvents, 2, [insertWidget({ id: "TEST" })], ([a0, a1]) => {
+                expect(a0.type).toBe(SHOW_NOTIFICATION);
+                expect(a1.type).toBe(SET_COLLAPSED);
+                expect(a1.collapsed).toBe(true);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+        it('collapse timeline on expand', done => {
+            testEpic(collapseTimelineOnWidgetsEvents, 2, [toggleCollapseAll()], ([a0, a1]) => {
+                expect(a0.type).toBe(SHOW_NOTIFICATION);
+                expect(a1.type).toBe(SET_COLLAPSED);
+                expect(a1.collapsed).toBe(true);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+        it('notification triggered once', done => {
+            testEpic(addTimeoutEpic(collapseTimelineOnWidgetsEvents, 10), 4, [toggleCollapseAll(), toggleCollapseAll()], ([a0, a1, a2, a3]) => {
+                expect(a0.type).toBe(SHOW_NOTIFICATION);
+                expect(a1.type).toBe(SET_COLLAPSED);
+                expect(a1.collapsed).toBe(true);
+                expect(a2.type).toBe(SET_COLLAPSED);
+                expect(a2.collapsed).toBe(true);
+                expect(a3.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+        it('timeline not collapsed if widgets are not on map', done => {
+            testEpic(addTimeoutEpic(collapseTimelineOnWidgetsEvents, 10), 1, [toggleCollapseAll()], ([a0]) => {
+                expect(a0.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...NO_WIDGETS_STATE
+            });
+        });
+        it('timeline if not collapsed if are all static (pinned)', done => {
+            testEpic(addTimeoutEpic(collapseTimelineOnWidgetsEvents, 10), 1, [updateWidgetProperty("TEST", "dataGrid.static", true)], ([a0]) => {
+                expect(a0.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                widgets: widgets(WIDGETS_STATE.widgets, updateWidgetProperty("TEST", "dataGrid.static", true))
+            });
+        });
+    });
+    describe('collapseWidgetsOnTimelineEvents', () => {
+        it('collapse widgets on timeline expand', done => {
+            testEpic(collapseWidgetsOnTimelineEvents, 2, [setCollapsed(false)], ([a0, a1]) => {
+                expect(a0.type).toBe(SHOW_NOTIFICATION);
+                expect(a1.type).toBe(TOGGLE_COLLAPSE_ALL);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+        it('collapse widgets on timeline layer dimension set', done => { // AKA new layer with time dimension
+            testEpic(collapseWidgetsOnTimelineEvents, 2, [changeLayerProperties("TEST", {dimensions: [{name: "time"}]})], ([a0, a1]) => {
+                expect(a0.type).toBe(SHOW_NOTIFICATION);
+                expect(a1.type).toBe(TOGGLE_COLLAPSE_ALL);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+        it('notification triggered once', done => {
+            testEpic(addTimeoutEpic(collapseWidgetsOnTimelineEvents, 10), 4, [setCollapsed(false), setCollapsed(false)], ([a0, a1, a2, a3]) => {
+                expect(a0.type).toBe(SHOW_NOTIFICATION);
+                expect(a1.type).toBe(TOGGLE_COLLAPSE_ALL);
+                expect(a2.type).toBe(TOGGLE_COLLAPSE_ALL);
+                expect(a3.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+
+        it('check widgets not collapsed if timeline is not present', done => {
+            testEpic(addTimeoutEpic(collapseWidgetsOnTimelineEvents, 10), 1, [setCollapsed(false)], ([a0]) => {
+                expect(a0.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                ...NO_TIMELINE_STATE,
+                ...WIDGETS_STATE
+            });
+        });
+        it('check not trigger collapse if only pinned widgets', done => {
+            testEpic(addTimeoutEpic(collapseWidgetsOnTimelineEvents, 10), 1, [setCollapsed(false)], ([a0]) => {
+                expect(a0.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                ...SAMPLE_TIMELINE_STATE,
+                widgets: widgets(WIDGETS_STATE.widgets, updateWidgetProperty("TEST", "dataGrid.static", true))
+            });
+        });
+    });
+    describe('expandTimelineIfCollapsedOnTrayUnmount', () => {
+        /*
+         * when widgets are not present or all static, the WidgetsTray is not visible anymore.
+         * So the timeline have to be expanded or it will not be visible anymore
+         */
+        it('timeline expanded if are widgets become are static', done => {
+            testEpic(expandTimelineIfCollapsedOnTrayUnmount, 1, [updateWidgetProperty("TEST", "dataGrid.static", true)], ([a0]) => {
+                expect(a0.type).toBe(SET_COLLAPSED);
+                expect(a0.collapsed).toBe(false);
+                done();
+            }, {
+                ...SAMPLE_COLLAPSED_TIMELINE_STATE,
+                widgets: widgets(WIDGETS_STATE.widgets, updateWidgetProperty("TEST", "dataGrid.static", true))
+            });
+        });
+        it('timeline expanded if no widgets anymore', done => {
+            testEpic(expandTimelineIfCollapsedOnTrayUnmount, 1, [deleteWidget("TEST")], ([a0]) => {
+                expect(a0.type).toBe(SET_COLLAPSED);
+                expect(a0.collapsed).toBe(false);
+                done();
+            }, {
+                    ...SAMPLE_COLLAPSED_TIMELINE_STATE,
+                    NO_WIDGETS_STATE
+                });
+        });
+        it('timeline expanded on map config loaded, if collapsed but it should be present and no widgets are on map', done => {
+            testEpic(expandTimelineIfCollapsedOnTrayUnmount, 1, [configureMap("TEST")], ([a0]) => {
+                expect(a0.type).toBe(SET_COLLAPSED);
+                expect(a0.collapsed).toBe(false);
+                done();
+            }, {
+                    ...SAMPLE_COLLAPSED_TIMELINE_STATE,
+                    NO_WIDGETS_STATE
+                });
+        });
+        it('no effect if timeline is not collapsed', done => {
+            testEpic(addTimeoutEpic(expandTimelineIfCollapsedOnTrayUnmount, 10), 1, [configureMap("TEST")], ([a0]) => {
+                expect(a0.type).toBe(TEST_TIMEOUT);
+                done();
+            }, {
+                    ...SAMPLE_TIMELINE_STATE, // collapsed: false
+                    NO_WIDGETS_STATE
+                });
+        });
+
+    });
+});

--- a/web/client/epics/playback.js
+++ b/web/client/epics/playback.js
@@ -32,7 +32,7 @@ const { LOCATION_CHANGE } = require('react-router-redux');
 
 const { currentFrameSelector, currentFrameValueSelector, lastFrameSelector, playbackRangeSelector, playbackSettingsSelector, frameDurationSelector, statusSelector, playbackMetadataSelector } = require('../selectors/playback');
 
-const { selectedLayerName, selectedLayerUrl, selectedLayerData, selectedLayerTimeDimensionConfiguration, rangeSelector, selectedLayerSelector } = require('../selectors/timeline');
+const { selectedLayerName, selectedLayerUrl, selectedLayerData, selectedLayerTimeDimensionConfiguration, rangeSelector, selectedLayerSelector, timelineLayersSelector } = require('../selectors/timeline');
 
 const pausable = require('../observables/pausable');
 const { wrapStartStop } = require('../observables/epics');
@@ -249,7 +249,7 @@ module.exports = {
                     // need to select first
                     : Rx.Observable.of(
                         selectLayer(
-                            get(layersWithTimeDataSelector(getState()), "[0].id")
+                            get(timelineLayersSelector(getState()), "[0].id")
                         )
                     )
             ),

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -10,8 +10,8 @@ const {REMOVE_NODE} = require('../actions/layers');
 const {error} = require('../actions/notifications');
 
 const {getLayerFromId} = require('../selectors/layers');
-const { rangeSelector, selectedLayerName, selectedLayerUrl, isAutoSelectEnabled, selectedLayerSelector } = require('../selectors/timeline');
-const { layerTimeSequenceSelectorCreator, timeDataSelector, offsetTimeSelector, currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
+const { rangeSelector, selectedLayerName, selectedLayerUrl, isAutoSelectEnabled, selectedLayerSelector, timelineLayersSelector } = require('../selectors/timeline');
+const { layerTimeSequenceSelectorCreator, timeDataSelector, offsetTimeSelector, currentTimeSelector } = require('../selectors/dimension');
 
 const { getNearestDate, roundRangeResolution, isTimeDomainInterval } = require('../utils/TimeUtils');
 const { getHistogram, describeDomains, getDomainValues } = require('../api/MultiDim');
@@ -192,12 +192,12 @@ module.exports = {
     setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, UPDATE_LAYER_DIMENSION_DATA)
         .exhaustMap(() =>
             isAutoSelectEnabled(getState())
-            && get(layersWithTimeDataSelector(getState()), "[0].id")
+            && get(timelineLayersSelector(getState()), "[0].id")
             && !selectedLayerSelector(getState())
-                ? Rx.Observable.of(selectLayer(get(layersWithTimeDataSelector(getState()), "[0].id")))
+                ? Rx.Observable.of(selectLayer(get(timelineLayersSelector(getState()), "[0].id")))
                     .concat(
                         Rx.Observable.of(1).switchMap( () =>
-                            snapTime(getState(), get(layersWithTimeDataSelector(getState()), "[0].id"), currentTimeSelector(getState) || new Date().toISOString())
+                            snapTime(getState(), get(timelineLayersSelector(getState()), "[0].id"), currentTimeSelector(getState) || new Date().toISOString())
                                 .filter( v => v)
                                 .map(time => setCurrentTime(time)))
                     )

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -128,8 +128,12 @@ const loadRangeData = (id, timeData, getState) => {
         }
 
         const domainValues = domain && domain.indexOf('--') < 0 && domain.split(',');
-        // const total = values.reduce((a, b) => a + b, 0);
 
+        /*
+         * shape of range: {start: "T_START", end: "T_END"}
+         * shape of histogram {values: [1, 2, 3], domain: "T_START/T_END/RESOLUTION" }
+         * shape of domain: {values: ["T1", "T2", ....]}, present only if not in the form "T1--T2"
+         */
         return Rx.Observable.of({
             range,
             histogram: histogram && histogram.Domain
@@ -199,7 +203,7 @@ module.exports = {
                     )
                 : Rx.Observable.empty()
     ),
-     /**
+    /**
      * When offset is initiated this epic sets both initial current time and offset if any does not exist
      * The policy is:
      *  - if current time is not defined, it will be placed to the center of the current timeline's viewport. If the viewport is undefined it is set to "now"

--- a/web/client/epics/widgetsTray.js
+++ b/web/client/epics/widgetsTray.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const Rx = require('rxjs');
+const { get } = require('lodash');
+const { setCollapsed: setTimelineCollapsed, SET_COLLAPSED } = require('../actions/timeline');
+const { TOGGLE_COLLAPSE, INSERT, TOGGLE_COLLAPSE_ALL, UPDATE_PROPERTY, toggleCollapseAll, DELETE } = require('../actions/widgets');
+
+const { MAP_CONFIG_LOADED } = require('../actions/config');
+const { info } = require('../actions/notifications');
+
+
+const { getVisibleFloatingWidgets } = require('../selectors/widgets');
+const { CHANGE_LAYER_PROPERTIES } = require('../actions/layers');
+
+const { isVisible: isTimelineVisible, hasLayers: hasTimelineLayers } = require('../selectors/timeline');
+
+
+const areWidgetsExpanded = state =>
+    // NOTE: pinned widgets can stay together with the timeline
+    (getVisibleFloatingWidgets(state) || []).filter(w => !(get(w, 'dataGrid.static'))).length > 0;
+
+const notifyCollapsedTimeline = (messageProps) => stream$ =>
+    stream$
+        .take(1)
+        .switchMap(() => Rx.Observable.of(info({
+            ...messageProps,
+            autoDismiss: 8,
+            position: "tr",
+            uid: "timeline-collapsed" // a unique identifier (if not present, current time is used),
+        }))
+        ).merge(stream$);
+/**
+ * Epics for widgets tray. Manage automatic tray actions (like timeline/widgets mutual exclusion)
+ * @name widgetsTray
+ * @memberof epics
+ */
+module.exports = {
+    /**
+     * Manages mutual exclusion of visibility between timeline and widgets.
+     * This collapse timeline when one widget is expanded or added to the map
+     */
+    collapseTimelineOnWidgetsEvents: (action$, { getState = () => { } } = {}) =>
+        Rx.Observable.merge(
+            // if there are some (not pinned) widgets
+            action$.ofType(TOGGLE_COLLAPSE, TOGGLE_COLLAPSE_ALL, MAP_CONFIG_LOADED, UPDATE_PROPERTY, INSERT)
+                .filter(() =>
+                    areWidgetsExpanded(getState()) && isTimelineVisible(getState())
+                )
+        )
+        .switchMap(() => Rx.Observable.of(setTimelineCollapsed(true)))
+        .let(notifyCollapsedTimeline({
+            title: "widgets.tray.notifications.collapsed.timelineTitle",
+            message: "widgets.tray.notifications.collapsed.message"
+        })),
+    /**
+     * Manages mutual exclusion of visibility between timeline and widgets.
+     * This collapse widgets when timeline is expanded or added to the map
+     */
+    collapseWidgetsOnTimelineEvents: (action$, { getState = () => { } } = {}) =>
+        Rx.Observable.merge(
+            // when expand timeline...
+            action$.ofType(SET_COLLAPSED).filter(({ collapsed }) => !collapsed),
+            // ... or add some dimensions ...
+            action$.ofType(CHANGE_LAYER_PROPERTIES).filter(({ newProperties = {} } = {}) => newProperties.dimensions)
+        )// ...if there are widgets not collapsed
+        .filter(() =>
+            areWidgetsExpanded(getState())
+            && hasTimelineLayers(getState())
+            && isTimelineVisible(getState())
+        )
+        .switchMap(() => Rx.Observable.of(toggleCollapseAll())).let(notifyCollapsedTimeline({
+            title: "widgets.tray.notifications.collapsed.widgetsTitle",
+            message: "widgets.tray.notifications.collapsed.message"
+        })),
+    /**
+     * When widgets tray disappears, the timeline have to be expanded anyway.
+     * Otherwise it stays in collapsed state without any possibility to expand (tray is hidden)
+     */
+    expandTimelineIfCollapsedOnTrayUnmount: (action$, { getState = () => { } } = {}) =>
+        // on map load or when widgets has been removed (or pinned/unpinned)...
+        action$.ofType(DELETE, UPDATE_PROPERTY, MAP_CONFIG_LOADED)
+            // ... if timeline is present (hasLayers) and it is collapsed...
+            .filter(() => !isTimelineVisible(getState()) && hasTimelineLayers(getState()))
+            // ... and the widget tray is not visible (so when there are no widget expanded anymore, pinned excluded) ...
+            .filter(() => !areWidgetsExpanded(getState()))
+            // ... then force expand timeline
+            .switchMap(() => Rx.Observable.of(setTimelineCollapsed(false)))
+};

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -278,7 +278,7 @@
             "TOCItemsSettings",
             "Tutorial", "MapFooter", {
                 "name": "Measure"
-            }, "Print", "ShapeFile", "Timeline", "Playback", {
+            }, "Print", "ShapeFile", {
                 "name": "Settings",
                 "cfg": {
                     "wrap": true
@@ -348,6 +348,8 @@
                 }
             },
             "OmniBar", "Login", "Save", "SaveAs", "BurgerMenu", "Expander", "Undo", "Redo", "FullScreen", "GlobeViewSwitcher", "SearchServicesConfig", "WidgetsBuilder", "Widgets", "WidgetsTray",
+            "Timeline",
+            "Playback",
             "FeedbackMask",
             "StyleEditor"
         ],

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -13,7 +13,7 @@ const Timeline = require('./timeline/Timeline');
 const InlineDateTimeSelector = require('../components/time/InlineDateTimeSelector');
 const Toolbar = require('../components/misc/toolbar/Toolbar');
 const { offsetEnabledSelector, currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
-const { currentTimeRangeSelector, rangeSelector } = require('../selectors/timeline');
+const { currentTimeRangeSelector, isVisible, rangeSelector } = require('../selectors/timeline');
 const { mapLayoutValuesSelector } = require('../selectors/maplayout');
 
 const { withState, compose, branch, renderNothing, withStateHandlers, withProps, defaultProps } = require('recompose');
@@ -44,6 +44,7 @@ const isValidOffset = (start, end) => moment(end).diff(start) > 0;
 const TimelinePlugin = compose(
     connect(
         createSelector(
+            isVisible,
             layersWithTimeDataSelector,
             currentTimeSelector,
             currentTimeRangeSelector,
@@ -51,7 +52,8 @@ const TimelinePlugin = compose(
             playbackRangeSelector,
             statusSelector,
             rangeSelector,
-            (layers, currentTime, currentTimeRange, offsetEnabled, playbackRange, status, viewRange) => ({
+            (visible, layers, currentTime, currentTimeRange, offsetEnabled, playbackRange, status, viewRange) => ({
+                visible,
                 layers,
                 currentTime,
                 currentTimeRange,
@@ -67,7 +69,7 @@ const TimelinePlugin = compose(
             setPlaybackRange: selectPlaybackRange,
             moveRangeTo: onRangeChanged
         }),
-    branch(({ layers = [] }) => Object.keys(layers).length === 0, renderNothing),
+    branch(({ visible = true, layers = [] }) => !visible || Object.keys(layers).length === 0, renderNothing),
     withState('options', 'setOptions', {collapsed: true}),
     //
     // ** Responsiveness to container.
@@ -271,10 +273,14 @@ const TimelinePlugin = compose(
 );
 
 const assign = require('object-assign');
-
+const TimelineToggle = require('./timeline/TimelineToggle');
 module.exports = {
     TimelinePlugin: assign(TimelinePlugin, {
-        disablePluginIf: "{state('mapType') === 'cesium'}"
+        disablePluginIf: "{state('mapType') === 'cesium'}",
+        WidgetsTray: {
+            tool: <TimelineToggle />,
+            position: 0
+        }
     }),
     reducers: {
         dimension: require('../reducers/dimension'),

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -12,8 +12,8 @@ const { createSelector } = require('reselect');
 const Timeline = require('./timeline/Timeline');
 const InlineDateTimeSelector = require('../components/time/InlineDateTimeSelector');
 const Toolbar = require('../components/misc/toolbar/Toolbar');
-const { offsetEnabledSelector, currentTimeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
-const { currentTimeRangeSelector, isVisible, rangeSelector } = require('../selectors/timeline');
+const { offsetEnabledSelector, currentTimeSelector } = require('../selectors/dimension');
+const { currentTimeRangeSelector, isVisible, rangeSelector, timelineLayersSelector } = require('../selectors/timeline');
 const { mapLayoutValuesSelector } = require('../selectors/maplayout');
 
 const { withState, compose, branch, renderNothing, withStateHandlers, withProps, defaultProps } = require('recompose');
@@ -45,7 +45,7 @@ const TimelinePlugin = compose(
     connect(
         createSelector(
             isVisible,
-            layersWithTimeDataSelector,
+            timelineLayersSelector,
             currentTimeSelector,
             currentTimeRangeSelector,
             offsetEnabledSelector,

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -16,7 +16,7 @@ const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV,
 const editOptions = require('./widgets/editOptions');
 const autoDisableWidgets = require('./widgets/autoDisableWidgets');
 
-
+const RIGHT_MARGIN = 70;
 const {heightProvider} = require('../components/layout/enhancers/gridLayout');
 const ContainerDimensions = require('react-container-dimensions').default;
 
@@ -61,9 +61,9 @@ compose(
             style: {
                 left: (width && width > 800) ? "500px" : "0",
                 marginTop: 52,
-                bottom: 67,
+                bottom: 65,
                 height: Math.floor((height - 100) / (rowHeight + 10)) * (rowHeight + 10),
-                width: `${width && width > 800 ? 'calc(100% - 550px)' : 'calc(100% - 50px)'}`,
+                width: width && width > 800 ? `calc(100% - ${500 + RIGHT_MARGIN}px)` : `calc(100% - ${RIGHT_MARGIN}px)`,
                 position: 'absolute',
                 zIndex: 50
             }

--- a/web/client/plugins/WidgetsTray.jsx
+++ b/web/client/plugins/WidgetsTray.jsx
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 
 const WidgetsTray = require('./widgets/WidgetsTray');

--- a/web/client/plugins/WidgetsTray.jsx
+++ b/web/client/plugins/WidgetsTray.jsx
@@ -18,5 +18,6 @@ const autoDisableWidgets = require('./widgets/autoDisableWidgets');
  * @class
  */
 module.exports = {
-    WidgetsTrayPlugin: autoDisableWidgets(WidgetsTray)
+    WidgetsTrayPlugin: autoDisableWidgets(WidgetsTray),
+    epics: require('../epics/widgetsTray')
 };

--- a/web/client/plugins/timeline/Timeline.jsx
+++ b/web/client/plugins/timeline/Timeline.jsx
@@ -8,11 +8,11 @@
 const React = require('react');
 const { connect } = require('react-redux');
 const { isString, differenceBy, isNil } = require('lodash');
-const { currentTimeSelector, layersWithTimeDataSelector } = require('../../selectors/dimension');
+const { currentTimeSelector } = require('../../selectors/dimension');
 
 
 const { selectTime, selectLayer, onRangeChanged } = require('../../actions/timeline');
-const { itemsSelector, loadingSelector, selectedLayerSelector, currentTimeRangeSelector, rangeSelector } = require('../../selectors/timeline');
+const { itemsSelector, loadingSelector, selectedLayerSelector, currentTimeRangeSelector, rangeSelector, timelineLayersSelector } = require('../../selectors/timeline');
 const { moveTime, setCurrentOffset } = require('../../actions/dimension');
 const { selectPlaybackRange } = require('../../actions/playback');
 const { playbackRangeSelector, statusSelector } = require('../../selectors/playback');
@@ -38,7 +38,7 @@ const timeLayersSelector = createShallowSelectorCreator(
         return a === b
             || !isNil(a) && !isNil(b) && a.id === b.id && a.title === b.title && a.name === b.name;
     }
-)(layersWithTimeDataSelector, layers => layers);
+)(timelineLayersSelector, layers => layers);
 
 /**
  * Provides time dimension data for layers

--- a/web/client/plugins/timeline/TimelineToggle.jsx
+++ b/web/client/plugins/timeline/TimelineToggle.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const { Button: RButton, Glyphicon } = require('react-bootstrap');
+const { setCollapsed } = require('../../actions/timeline');
+const { isCollapsed } = require('../../selectors/timeline');
+
+
+const { compose, withHandlers, withProps } = require('recompose');
+const tooltip = require('../../components/misc/enhancers/tooltip');
+
+
+const {createSelector} = require('reselect');
+const { connect } = require('react-redux');
+const Button = tooltip(RButton);
+
+const ToggleButton = (props) => (<Button
+    {...props}
+    bsSize="xsmall"
+><Glyphicon glyph="time" /></Button>);
+
+module.exports = compose(
+    connect(
+        createSelector(
+            isCollapsed,
+            collapsed => ({
+                collapsed
+            })
+        ),
+        {
+            setCollapsed
+        }
+    ),
+    withHandlers({
+        onClick: ({ collapsed, setCollapsed: handler }) => () => handler(!collapsed)
+    }),
+    withProps(({collapsed}) => ({
+        bsStyle: collapsed ? "primary" : "success active",
+        tooltipId: collapsed ? "timeline.show" : "timeline.hide"
+        })
+    )
+)(ToggleButton);

--- a/web/client/plugins/timeline/TimelineToggle.jsx
+++ b/web/client/plugins/timeline/TimelineToggle.jsx
@@ -6,19 +6,66 @@
  * LICENSE file in the root directory of this source tree.
  */
 const React = require('react');
+const Rx = require('rxjs');
+const Message = require('../../components/I18N/Message');
+
 const { Button: RButton, Glyphicon } = require('react-bootstrap');
 const { setCollapsed } = require('../../actions/timeline');
 const { isCollapsed, hasLayers } = require('../../selectors/timeline');
 
 
-const { compose, withHandlers, withProps, renderNothing, branch } = require('recompose');
+const { compose, withHandlers, withProps, renderNothing, branch, mapPropsStream } = require('recompose');
 const tooltip = require('../../components/misc/enhancers/tooltip');
 
 
 const {createSelector} = require('reselect');
 const { connect } = require('react-redux');
-const Button = tooltip(RButton);
 
+const withPopover = require('../../components/data/featuregrid/enhancers/withPopover');
+
+/**
+ * Creates the properties to toggle the hint popover.
+ * @param {Rx.Observable} props$ stream of props
+ */
+const togglePopover = props$ =>
+    props$
+        .distinctUntilKeyChanged('collapsed')
+        .take(1)
+        .switchMap(({ collapseHintPopoverOptions }) =>
+            Rx.Observable.timer(5000)
+            .startWith({
+                popoverOptions: collapseHintPopoverOptions
+            })
+            .concat(Rx.Observable.of({
+            }))
+        ).startWith({});
+
+/**
+ * Combine render props with ones coming from the stream
+ */
+const withTempHintPopover = () =>
+        compose(
+            withProps({
+                collapseHintPopoverOptions: {
+                    placement: 'top',
+                    props: {
+                        title: <span><Glyphicon glyph="time" /> <strong><Message msgId="timeline.collapsed.title" /></strong></span>
+                    },
+                    content: <Message msgId="timeline.collapsed.tooltip" />
+                }
+            }),
+            mapPropsStream(props$ =>
+                props$.combineLatest(
+                    togglePopover(props$),
+                    (p1, p2) => ({
+                        ...p1, ...p2
+                    })
+                )
+        ),
+        branch(({ popoverOptions }) => popoverOptions, withPopover, tooltip)
+);
+
+const Button = withTempHintPopover()(RButton);
 const ToggleButton = (props) => (<Button
     {...props}
     bsSize="xsmall"

--- a/web/client/plugins/timeline/TimelineToggle.jsx
+++ b/web/client/plugins/timeline/TimelineToggle.jsx
@@ -8,10 +8,10 @@
 const React = require('react');
 const { Button: RButton, Glyphicon } = require('react-bootstrap');
 const { setCollapsed } = require('../../actions/timeline');
-const { isCollapsed } = require('../../selectors/timeline');
+const { isCollapsed, hasLayers } = require('../../selectors/timeline');
 
 
-const { compose, withHandlers, withProps } = require('recompose');
+const { compose, withHandlers, withProps, renderNothing, branch } = require('recompose');
 const tooltip = require('../../components/misc/enhancers/tooltip');
 
 
@@ -24,18 +24,25 @@ const ToggleButton = (props) => (<Button
     bsSize="xsmall"
 ><Glyphicon glyph="time" /></Button>);
 
+/**
+ * Toggle button for timeline hide (collapse)/show functionality for timeline.
+ * Visible in the WidgetsTray, when present
+ */
 module.exports = compose(
     connect(
         createSelector(
             isCollapsed,
-            collapsed => ({
-                collapsed
+            hasLayers,
+            (collapsed, visible) => ({
+                collapsed,
+                visible
             })
         ),
         {
             setCollapsed
         }
     ),
+    branch(({ visible }) => !visible, renderNothing),
     withHandlers({
         onClick: ({ collapsed, setCollapsed: handler }) => () => handler(!collapsed)
     }),

--- a/web/client/plugins/timeline/TimelineToggle.jsx
+++ b/web/client/plugins/timeline/TimelineToggle.jsx
@@ -29,8 +29,11 @@ const withPopover = require('../../components/data/featuregrid/enhancers/withPop
  */
 const togglePopover = props$ =>
     props$
+        // only the first time collapsed property is set to true
         .distinctUntilKeyChanged('collapsed')
+        .filter(({ collapsed }) => collapsed)
         .take(1)
+        // show popover for 5 seconds
         .switchMap(({ collapseHintPopoverOptions }) =>
             Rx.Observable.timer(5000)
             .startWith({
@@ -94,7 +97,7 @@ module.exports = compose(
         onClick: ({ collapsed, setCollapsed: handler }) => () => handler(!collapsed)
     }),
     withProps(({collapsed}) => ({
-        bsStyle: collapsed ? "primary" : "success active",
+        bsStyle: collapsed ? "primary" : "success",
         tooltipId: collapsed ? "timeline.show" : "timeline.hide"
         })
     )

--- a/web/client/plugins/widgets/WidgetsBar.jsx
+++ b/web/client/plugins/widgets/WidgetsBar.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { compose, defaultProps, withProps} = require('recompose');
+const {createSelector} = require('reselect');
+const {connect} = require('react-redux');
+const {filterHiddenWidgets} = require('./widgetsPermission');
+const { toggleCollapse } = require('../../actions/widgets');
+const {trayWidgets} = require('../../selectors/widgetsTray');
+
+
+/**
+ * Button bar with the list of all the widgets to minimize/expand.
+ * note: hides some widgets to user that do not have access too, using `filterHiddenWidgets` enhancer.
+ */
+module.exports = compose(
+    connect(
+        createSelector(
+            trayWidgets,
+            widgets => ({ widgets })
+        ),
+        {
+            onClick: toggleCollapse
+        }
+    ),
+    defaultProps({
+        btnGroupProps: {
+            className: "widgets-toolbar",
+            style: { marginLeft: 2, marginRight: 2 }
+        }
+    }),
+    filterHiddenWidgets,
+    withProps(({ btnGroupProps = {}, btnDefaultProps = {} }) => ({
+        btnGroupProps: {
+            bsSize: "xsmall",
+            ...btnGroupProps
+        },
+        btnDefaultProps: {
+            bsSize: "xsmall",
+            ...(btnDefaultProps || {})
+        }
+    }))
+)(require('../../components/widgets/view/WidgetsBar'));

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -8,102 +8,19 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const { connect } = require('react-redux');
-const { compose, defaultProps, withProps, withState, lifecycle, mapPropsStream } = require('recompose');
+const { compose, withProps, withState, lifecycle, mapPropsStream } = require('recompose');
 const { createSelector } = require('reselect');
-const { find, findIndex, sortBy } = require('lodash');
 const tooltip = require('../../components/misc/enhancers/tooltip');
-const editOptions = require('./editOptions');
 
 const { Glyphicon, Button: BButton } = require('react-bootstrap');
 const Button = tooltip(BButton);
-const { getFloatingWidgets, getVisibleFloatingWidgets, getFloatingWidgetsCurrentLayout, getCollapsedIds, getCollapsedState } = require('../../selectors/widgets');
-const { toggleCollapse, toggleCollapseAll, toggleTray } = require('../../actions/widgets');
+const { getVisibleFloatingWidgets} = require('../../selectors/widgets');
+const { toggleCollapseAll, toggleTray } = require('../../actions/widgets');
+const { trayWidgets } = require('../../selectors/widgetsTray');
+const { filterHiddenWidgets } = require('./widgetsPermission');
 
 const BorderLayout = require('../../components/layout/BorderLayout');
-
-/**
- * Only widgets that are not hidden (to some users) or pinned (static) can be in tray
- * @param {object} widget the widget configuration
- */
-const noHiddenOrStaticWidgets = w => !w.dataGrid || !w.dataGrid.static;
-
-// hide hidden widgets in tray for users has not access to them
-const filterHiddenWidgets = compose(
-    defaultProps({
-        "toolsOptions": {
-            "seeHidden": "user.role===ADMIN"
-        }
-    }),
-    // allow to customize toolsOptions object, with rules. see accessRuleParser
-    editOptions("toolsOptions", { asObject: true }),
-    withProps(({ widgets, toolsOptions = { seeHidden: false } }) => ({
-        widgets: toolsOptions.seeHidden ? widgets : widgets.filter(w => !w.hide)
-    }))
-);
-
-/**
- * A selector that retrieves widgets to display in the tray area
- * @return the widgets to display in the tray area
- */
-const trayWidgets = createSelector(
-    getFloatingWidgets,
-    getCollapsedIds,
-    getFloatingWidgetsCurrentLayout,
-    getCollapsedState,
-    (widgets = [], collapsedIds, layout, collapsed = {}) =>
-        // sort, filter and add collapsed state to the widgets
-        sortBy(
-            // only non-static non-hidden widgets should be visible in tray
-            widgets
-            .filter(noHiddenOrStaticWidgets)
-            // collapsed widgets should have the flag - Collapsed
-            .map(w => findIndex(collapsedIds, id => id === w.id) >= 0
-                ? {
-                    ...w,
-                    collapsed: true
-                }
-                : w),
-            // sort by layout position (row, column)
-            w => {
-                const collapsedLayout = collapsed[w.id] && collapsed[w.id].layout;
-                const position = find(layout, { i: w.id }) || collapsedLayout || {};
-                const { x = 0, y = 0 } = position;
-                return y * 100 + x;
-            })
-);
-
-/**
- * Button bar with the list of widgets to
- * minimize/expand
- */
-const WidgetsBar = compose(
-    connect(
-        createSelector(
-            trayWidgets,
-            widgets => ({ widgets })
-        ),
-        {
-            onClick: toggleCollapse
-        }
-    ),
-    defaultProps({
-        btnGroupProps: {
-            className: "widgets-toolbar",
-            style: { marginLeft: 2, marginRight: 2 }
-        }
-    }),
-    filterHiddenWidgets,
-    withProps(({ btnGroupProps = {}, btnDefaultProps = {} }) => ({
-        btnGroupProps: {
-            bsSize: "xsmall",
-            ...btnGroupProps
-        },
-        btnDefaultProps: {
-            bsSize: "xsmall",
-            ...(btnDefaultProps || {})
-        }
-    }))
-)(require('../../components/widgets/view/WidgetsBar'));
+const WidgetsBar = require('./WidgetsBar');
 
 /**
  * Button that allows collapse/Expand functionality of the tray.
@@ -145,7 +62,6 @@ const CollapseAllButton = compose(
         onClick={onClick}>
         <Glyphicon glyph={"list"} />
     </Button>));
-
 
 /**
  * Main component of the widgets tray.

--- a/web/client/plugins/widgets/WidgetsTray.jsx
+++ b/web/client/plugins/widgets/WidgetsTray.jsx
@@ -14,14 +14,12 @@ const tooltip = require('../../components/misc/enhancers/tooltip');
 
 const { Glyphicon, Button: BButton } = require('react-bootstrap');
 const Button = tooltip(BButton);
-const { getVisibleFloatingWidgets} = require('../../selectors/widgets');
+const { getVisibleFloatingWidgets } = require('../../selectors/widgets');
 const { toggleCollapseAll, toggleTray } = require('../../actions/widgets');
 const { trayWidgets } = require('../../selectors/widgetsTray');
 const { filterHiddenWidgets } = require('./widgetsPermission');
-
 const BorderLayout = require('../../components/layout/BorderLayout');
 const WidgetsBar = require('./WidgetsBar');
-
 /**
  * Button that allows collapse/Expand functionality of the tray.
  * @param {object} props
@@ -43,14 +41,14 @@ const CollapseAllButton = compose(
     connect(
         createSelector(
             getVisibleFloatingWidgets,
-            (widgets = []) => ({widgets})
+            (widgets = []) => ({ widgets })
         ), // get all visible widgets
         {
             onClick: () => toggleCollapseAll()
         }
     ),
     filterHiddenWidgets,
-    withProps(({widgets = []}) => ({
+    withProps(({ widgets = [] }) => ({
         shouldExpand: widgets.length === 0
     }))
 )(({ onClick = () => { }, shouldExpand = false } = {}) =>
@@ -74,11 +72,13 @@ class WidgetsTray extends React.Component {
     static propTypes = {
         enabled: PropTypes.bool,
         toolsOptions: PropTypes.object,
+        items: PropTypes.array,
         expanded: PropTypes.bool,
         setExpanded: PropTypes.fun
     };
     static defaultProps = {
         enabled: true,
+        items: [],
         expanded: false,
         setExpanded: () => { }
     };
@@ -86,16 +86,17 @@ class WidgetsTray extends React.Component {
         return this.props.enabled
             ? (<div className="widgets-tray"
                 style={{
-                    marginBottom: 34,
-                    marginRight: 60,
+                    marginBottom: 32,
+                    marginRight: 80,
                     bottom: 0,
                     right: 0,
                     position: "absolute"
                 }}>
                 <BorderLayout
                     columns={[
-                        <CollapseTrayButton toolsOptions={this.props.toolsOptions} expanded={this.props.expanded} onClick={() => this.props.setExpanded(!this.props.expanded)} />,
-                        <CollapseAllButton toolsOptions={this.props.toolsOptions} />
+                        <CollapseTrayButton key="collapse-tray" toolsOptions={this.props.toolsOptions} expanded={this.props.expanded} onClick={() => this.props.setExpanded(!this.props.expanded)} />,
+                        <CollapseAllButton key="collapse-all" toolsOptions={this.props.toolsOptions} />,
+                        ...(this.props.items.map( i => i.tool) || [])
                     ]}
                 >{this.props.expanded ? <WidgetsBar toolsOptions={this.props.toolsOptions} /> : null}
                 </BorderLayout>
@@ -107,12 +108,12 @@ module.exports = compose(
     withState("expanded", "setExpanded", false),
     connect(createSelector(
         trayWidgets,
-        (widgets = []) => ({widgets})
+        (widgets = []) => ({ widgets })
     ), {
-        toggleTray
-    }),
+            toggleTray
+        }),
     filterHiddenWidgets,
-    withProps(({widgets = []}) => ({
+    withProps(({ widgets = [] }) => ({
         hasCollapsedWidgets: widgets.filter(({ collapsed } = {}) => collapsed).length > 0,
         hasTrayWidgets: widgets.length > 0
     })),
@@ -130,7 +131,7 @@ module.exports = compose(
         .merge(
             props$
                 .distinctUntilKeyChanged('hasCollapsedWidgets')
-                .do(({ setExpanded = () => { }, hasCollapsedWidgets}) => setExpanded(hasCollapsedWidgets))
+                .do(({ setExpanded = () => { }, hasCollapsedWidgets }) => setExpanded(hasCollapsedWidgets))
                 .ignoreElements()
         )
     ),

--- a/web/client/plugins/widgets/widgetsPermission.js
+++ b/web/client/plugins/widgets/widgetsPermission.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+const {compose, withProps, defaultProps} = require('recompose');
+const editOptions = require('./editOptions');
+
+/**
+ * enhancers to manage widgets permissions.
+ */
+module.exports = {
+    /*
+    * Hide hidden widgets (Widgets with property `hide=true`) in tray for users has not access to them.
+    * Uses `toolsOptions` property. See `editOptions` enhancer
+    */
+    filterHiddenWidgets: compose(
+        defaultProps({
+            "toolsOptions": {
+                "seeHidden": "user.role===ADMIN"
+            }
+        }),
+        // allow to customize toolsOptions object, with rules. see `accessRuleParser`
+        editOptions("toolsOptions", { asObject: true }),
+        withProps(({ widgets, toolsOptions = { seeHidden: false } }) => ({
+            widgets: toolsOptions.seeHidden ? widgets : widgets.filter(w => !w.hide)
+        }))
+    )
+};

--- a/web/client/reducers/__tests__/timeline-test.js
+++ b/web/client/reducers/__tests__/timeline-test.js
@@ -7,7 +7,8 @@
  */
 
 const timeline = require('../timeline');
-const {rangeDataLoaded, selectLayer, timeDataLoading} = require('../../actions/timeline');
+const {rangeDataLoaded, selectLayer, timeDataLoading, setCollapsed} = require('../../actions/timeline');
+const { isCollapsed } = require('../../selectors/timeline');
 const expect = require('expect');
 
 describe('Test the timeline reducer', () => {
@@ -113,5 +114,9 @@ describe('Test the timeline reducer', () => {
         expect(state).toExist();
         expect(state.rangeData).toNotExist();
         expect(state.selectedLayer).toNotExist();
+    });
+    it('setCollapsed action', () => {
+        const action = setCollapsed(true);
+        expect(isCollapsed({timeline: timeline(undefined, action)})).toBe(true);
     });
 });

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -50,8 +50,6 @@ const { assign, pickBy, has } = require('lodash');
 module.exports = (state = {
     settings: {
         autoSelect: true, // selects the first layer available as guide layer. This is a configuration only setting for now
-        // enabled: true, // is enabled
-        // disableOnCollapse: true,
         collapsed: false
     }
 }, action) => {

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -1,7 +1,7 @@
 const { RANGE_CHANGED } = require('../actions/timeline');
 const { REMOVE_NODE } = require('../actions/layers');
 const { RESET_CONTROLS } = require('../actions/controls');
-const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER } = require('../actions/timeline');
+const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, SET_COLLAPSED } = require('../actions/timeline');
 const { set } = require('../utils/ImmutableUtils');
 const { assign, pickBy, has } = require('lodash');
 
@@ -48,9 +48,17 @@ const { assign, pickBy, has } = require('lodash');
 
  */
 module.exports = (state = {
-    settings: {autoSelect: true} // selects the first layer available as guide layer. This is a configuration only setting for now
+    settings: {
+        autoSelect: true, // selects the first layer available as guide layer. This is a configuration only setting for now
+        // enabled: true, // is enabled
+        // disableOnCollapse: true,
+        collapsed: false
+    }
 }, action) => {
     switch (action.type) {
+        case SET_COLLAPSED: {
+            return set(`settings.collapsed`, action.collapsed, state);
+        }
         case RANGE_CHANGED: {
             return set(`range`, {
                 start: action.start,

--- a/web/client/selectors/__tests__/timeline-test.js
+++ b/web/client/selectors/__tests__/timeline-test.js
@@ -1,0 +1,141 @@
+/*
+* Copyright 2019, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+const expect = require('expect');
+const {
+    isCollapsed,
+    isVisible,
+    isAutoSelectEnabled,
+    currentTimeRangeSelector,
+    itemsSelector,
+    rangeDataSelector
+} = require('../timeline');
+
+const timeline = require('../../reducers/timeline');
+const { rangeDataLoaded } = require('../../actions/timeline');
+const dimension = require('../../reducers/dimension');
+const { updateLayerDimensionData } = require('../../actions/dimension');
+
+const T1 = '2016-01-01T00:00:00.000Z';
+const T2 = '2016-02-01T00:00:00.000Z';
+const T3 = '2016-03-01T00:00:00.000Z';
+const TEST_LAYER_ID = "TEST_LAYER";
+
+const DIMENSION_SINGLE = {
+    currentTime: T1
+};
+const DIMENSION_RANGE = {
+    ...DIMENSION_SINGLE,
+    offsetTime: T2
+};
+
+const SAMPLE_RANGE = {
+    start: DIMENSION_SINGLE.currentTime,
+    end: DIMENSION_RANGE.offsetTime
+};
+
+// sample timeline state with histogram
+const TIMELINE_STATE_HISTOGRAM = timeline(undefined, rangeDataLoaded(
+    TEST_LAYER_ID,
+    SAMPLE_RANGE,
+    {
+        values: Array(31).fill().map((x, i) => i),
+        domain: `${DIMENSION_RANGE.offsetTime}/${DIMENSION_RANGE.currentTime}/1D`
+    },
+    undefined
+));
+// sample timeline state with histogram
+const TIMELINE_STATE_VALUES = timeline(undefined, rangeDataLoaded(
+    TEST_LAYER_ID,
+    SAMPLE_RANGE,
+    // sample with daily histogram of values 1,2,3,..., 31
+    {
+        values: Array(31).fill().map((x, i) => i),
+        domain: `${DIMENSION_RANGE.offsetTime}/${DIMENSION_RANGE.currentTime}/1D`
+    },
+    { values: [T1, T2, T3] }
+));
+
+// sample dimension state for TEST_LAYER
+const DIMENSION_STATE = dimension(undefined, updateLayerDimensionData(TEST_LAYER_ID, "time", {
+    source: {
+        type: "multidim-extension",
+        url: "FAKE"
+    },
+    name: "time",
+    dimension: `${T1}--${T2}`
+}));
+
+const LAYERS_STATE = {
+    flat: [{
+        id: TEST_LAYER_ID
+    }]
+};
+const SAMPLE_STATE_HISTOGRAM = {
+    layers: LAYERS_STATE,
+    dimension: DIMENSION_STATE,
+    timeline: TIMELINE_STATE_HISTOGRAM
+};
+
+const SAMPLE_STATE_DOMAIN_VALUES = {
+    layers: LAYERS_STATE,
+    dimension: DIMENSION_STATE,
+    timeline: TIMELINE_STATE_VALUES
+};
+
+describe('timeline selector', () => {
+    it('isCollapsed', () => {
+        expect(isCollapsed({})).toBeFalsy();
+        expect(isCollapsed({ timeline: { settings: {} } })).toBeFalsy();
+        expect(isCollapsed({ timeline: { settings: { collapsed: true } } })).toBe(true);
+    });
+    it('isVisible', () => {
+        expect(isVisible({})).toBe(true);
+        expect(isVisible({ timeline: { settings: {} } })).toBe(true);
+        expect(isVisible({ timeline: { settings: { collapsed: true } } })).toBeFalsy();
+    });
+    it('isCollapsed', () => {
+        expect(isAutoSelectEnabled({})).toBeFalsy();
+        expect(isAutoSelectEnabled({ timeline: { settings: {} } })).toBeFalsy();
+        expect(isAutoSelectEnabled({ timeline: { settings: { autoSelect: true } } })).toBe(true);
+    });
+    it('currentTimeRangeSelector', () => {
+        expect(currentTimeRangeSelector({
+            dimension: DIMENSION_RANGE
+        })).toEqual(SAMPLE_RANGE);
+    });
+    it('rangeSelector', () => {
+        expect(rangeDataSelector(SAMPLE_STATE_HISTOGRAM)[TEST_LAYER_ID]).toExist();
+    });
+    it('itemsSelector', () => {
+        const histogramItems = itemsSelector(SAMPLE_STATE_HISTOGRAM);
+        expect(histogramItems.length).toBe(31);
+        // test histogram items generation
+        histogramItems.map( (item, index) => {
+            expect(item.type).toBe("range");
+            expect(item.count).toBe(index);
+            expect(item.group).toBe(TEST_LAYER_ID);
+            expect(item.className).toBe('histogram-item');
+            // create a div with height as value % of max, with value written inside it.
+            expect(item.content).toEqual(`<div><div class="histogram-box" style="height: ${(100 * item.count / 30)}%"></div> <span class="histogram-count">${item.count}</span></div>`);
+        });
+        const domainValuesItems = itemsSelector(SAMPLE_STATE_DOMAIN_VALUES);
+        expect(domainValuesItems.length).toBe(3);
+        // test domain values items generation
+        domainValuesItems.map((item) => {
+            expect(item.type).toBe("point");
+            expect(item.group).toBe(TEST_LAYER_ID);
+            expect(item.start).toExist();
+            expect(item.end).toEqual(item.start);
+            expect(item.count).toNotExist();
+            expect(item.className).toNotExist();
+            expect(item.content).toBe(" ");
+        });
+        // TODO: test items from static time values inside layer, not fully supported yet.
+    });
+});

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -2,7 +2,7 @@ const { get, head } = require('lodash');
 const {createSelector} = require('reselect');
 const { createShallowSelector } = require('../utils/ReselectUtils');
 const { timeIntervalToSequence, timeIntervalToIntervalSequence, analyzeIntervalInRange, isTimeDomainInterval } = require('../utils/TimeUtils');
-const { timeDataSelector, currentTimeSelector, offsetTimeSelector, layerDimensionRangeSelector } = require('../selectors/dimension');
+const { timeDataSelector, currentTimeSelector, offsetTimeSelector, layerDimensionRangeSelector, layersWithTimeDataSelector } = require('../selectors/dimension');
 const {getLayerFromId} = require('../selectors/layers');
 const rangeSelector = state => get(state, 'timeline.range');
 const rangeDataSelector = state => get(state, 'timeline.rangeData');
@@ -11,7 +11,6 @@ const rangeDataSelector = state => get(state, 'timeline.rangeData');
 const MAX_ITEMS = 50;
 
 const isCollapsed = state => get(state, 'timeline.settings.collapsed');
-const isVisible = state => !isCollapsed(state);
 
 const isAutoSelectEnabled = state => get(state, 'timeline.settings.autoSelect');
 /**
@@ -103,6 +102,12 @@ const getTimeItems = (data = {}, range, rangeData) => {
     return [];
 };
 
+/**
+ * Selector that retrieves the time data from the state (layer configuration, dimension state...) and convert it
+ * into timeline object data.
+ * @param {object} state the state
+ * @return {object[]} items to show in the timeline in the [visjs timeline data object format](http://visjs.org/docs/timeline/#Data_Format)
+ */
 const itemsSelector = createShallowSelector(
     timeDataSelector,
     rangeSelector,
@@ -134,11 +139,21 @@ const currentTimeRangeSelector = createSelector(
 );
 const selectedLayerDataRangeSelector = state => layerDimensionRangeSelector(state, selectedLayerSelector(state));
 
+/**
+ * Select layers visible in the timeline
+ */
+const timelineLayersSelector = layersWithTimeDataSelector; // TODO: allow exclusion.
+
+const hasLayers = createSelector(timelineLayersSelector, (layers = []) => layers.length > 0);
+const isVisible = state => !isCollapsed(state) && hasLayers(state);
+
 
 module.exports = {
     isVisible,
     isCollapsed,
     currentTimeRangeSelector,
+    timelineLayersSelector,
+    hasLayers,
     itemsSelector,
     rangeSelector,
     isAutoSelectEnabled,

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -2,7 +2,6 @@ const { get, head } = require('lodash');
 const {createSelector} = require('reselect');
 const { createShallowSelector } = require('../utils/ReselectUtils');
 const { timeIntervalToSequence, timeIntervalToIntervalSequence, analyzeIntervalInRange, isTimeDomainInterval } = require('../utils/TimeUtils');
-const moment = require('moment');
 const { timeDataSelector, currentTimeSelector, offsetTimeSelector, layerDimensionRangeSelector } = require('../selectors/dimension');
 const {getLayerFromId} = require('../selectors/layers');
 const rangeSelector = state => get(state, 'timeline.range');
@@ -10,6 +9,9 @@ const rangeDataSelector = state => get(state, 'timeline.rangeData');
 
 // items
 const MAX_ITEMS = 50;
+
+const isCollapsed = state => get(state, 'timeline.settings.collapsed');
+const isVisible = state => !isCollapsed(state);
 
 const isAutoSelectEnabled = state => get(state, 'timeline.settings.autoSelect');
 /**
@@ -88,7 +90,7 @@ const rangeDataToItems = (rangeData = {}, range) => {
 };
 /**
  * Transforms time values from layer state or rangeData (histogram,values) into items for timeline.
- * @param {object} data layer timedimension data
+ * @param {object} data layer time dimension data
  * @param {object} range start/end object that represent the view range
  * @param {object} rangeData object that contains domain or histogram
  */
@@ -119,18 +121,11 @@ const itemsSelector = createShallowSelector(
 );
 const loadingSelector = state => get(state, "timeline.loading");
 const selectedLayerSelector = state => get(state, "timeline.selectedLayer");
-const calculateOffsetTimeSelector = (state) => {
-    const offset = get(state, "timeline.offsetTime");
-    const time = currentTimeSelector(state);
-    return time && offset && moment(time).add(offset) || time && moment(time).add(1, 'month');
-};
 
 const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(state));
 const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
 const selectedLayerTimeDimensionConfiguration = state => selectedLayerData(state) && selectedLayerData(state).dimensions && head(selectedLayerData(state).dimensions.filter((x) => x.name === "time"));
 const selectedLayerUrl = state => get(selectedLayerTimeDimensionConfiguration(state), "source.url");
-
-const mouseEventSelector = state => get(state, "timeline.mouseEvent");
 
 const currentTimeRangeSelector = createSelector(
     currentTimeSelector,
@@ -141,14 +136,14 @@ const selectedLayerDataRangeSelector = state => layerDimensionRangeSelector(stat
 
 
 module.exports = {
+    isVisible,
+    isCollapsed,
     currentTimeRangeSelector,
-    mouseEventSelector,
     itemsSelector,
     rangeSelector,
     isAutoSelectEnabled,
     loadingSelector,
     selectedLayerSelector,
-    calculateOffsetTimeSelector,
     selectedLayerData,
     selectedLayerTimeDimensionConfiguration,
     selectedLayerDataRangeSelector,

--- a/web/client/selectors/widgetsTray.js
+++ b/web/client/selectors/widgetsTray.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const { createSelector } = require('reselect');
+const { getFloatingWidgets, getFloatingWidgetsCurrentLayout, getCollapsedIds, getCollapsedState } = require('./widgets');
+const { find, findIndex, sortBy } = require('lodash');
+
+/**
+ * Only widgets that are not pinned (static) can be in tray
+ * @param {object} widget the widget configuration
+ */
+const noStaticWidgets = w => !w.dataGrid || !w.dataGrid.static;
+/**
+ * A selector that retrieves widgets to display in the tray area
+ * @return the widgets to display in the tray area
+ */
+const trayWidgets = createSelector(
+    getFloatingWidgets,
+    getCollapsedIds,
+    getFloatingWidgetsCurrentLayout,
+    getCollapsedState,
+    (widgets = [], collapsedIds, layout, collapsed = {}) =>
+        // sort, filter and add collapsed state to the widgets
+        sortBy(
+            // only non-static non-hidden widgets should be visible in tray
+            widgets
+                .filter(noStaticWidgets)
+                // collapsed widgets should have the flag - Collapsed
+                .map(w => findIndex(collapsedIds, id => id === w.id) >= 0
+                    ? {
+                        ...w,
+                        collapsed: true
+                    }
+                    : w),
+            // sort by layout position (row, column)
+            w => {
+                const collapsedLayout = collapsed[w.id] && collapsed[w.id].layout;
+                const position = find(layout, { i: w.id }) || collapsedLayout || {};
+                const { x = 0, y = 0 } = position;
+                return y * 100 + x;
+            })
+);
+
+module.exports = {
+    trayWidgets
+};

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1575,6 +1575,8 @@
                 "snapToGuideLayer": "Auf Führungsebene ausrichten",
                 "snapToGuideLayerTooltip": "Zwingt den Zeitcursor, sich an den Daten der ausgewählten Ebene zu fangen. Deaktivieren Sie diese Option, um die Zeitcursor zu entsperren und die Anpassung des Animationsschritts zu aktivieren."
             },
+            "hide": "Timeline ausblenden",
+            "show": "Timeline anzeigen",
             "currentTime": "Gehe zur aktuellen Uhrzeit",
             "rangeStart": "Gehe zum aktuellen Zeitbereich",
             "rangeEnd": "Gehe zum aktuellen Zeitbereich",

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1408,7 +1408,14 @@
                 "expandTray": "Widgetsleiste erweitern",
                 "collapseTray": "Widgets-Fach ausblenden",
                 "expandAll": "Erweitern Sie alle Widgets",
-                "collapseAll": "Reduzieren Sie alle Widgets"
+                "collapseAll": "Reduzieren Sie alle Widgets",
+                "notifications": {
+                    "collapsed": {
+                        "message": "Zeitleiste und Widgets können nicht gleichzeitig bleiben. In der Taskleiste des Widgets verwenden, um zwischen Zeitleiste und Widgets zu wechseln",
+                        "timelineTitle": "Zeitleiste wurde reduziert",
+                        "widgetsTitle": "Widgets wurden reduziert"
+                    }
+                }
             }
         },
         "dashboard": {
@@ -1588,6 +1595,10 @@
             "disablePlayBack": "Deaktivieren Sie die Wiedergabesteuerung",
             "expand" : "Erweitern Sie den Zeitschieberegler",
             "collapse" : "Schieberegler für die Zeitspanne reduzieren",
+            "collapsed": {
+                "title": "Zeitleiste wurde reduziert",
+                "tooltip": "Klicken Sie hier, um es erneut zu erweitern"
+            },
             "errors": {
                 "multidim_error_title": "Der Backend-Service reagiert nicht",
                 "multidim_error_message": "Die erforderlichen Dienste für die mehrdimensionale Unterstützung reagieren nicht. Bitte versuchen Sie es später erneut oder wenden Sie sich an den Administrator."

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1409,7 +1409,14 @@
                 "expandTray": "Expand widgets tray",
                 "collapseTray": "Collapse widgets tray",
                 "expandAll": "Expand all widgets",
-                "collapseAll": "Collapse all widgets"
+                "collapseAll": "Collapse all widgets",
+                "notifications" : {
+                    "collapsed": {
+                        "message": "Timeline and widgets can not stay at the same time. Use on the widget's tray to switch between timeline and widgets",
+                        "timelineTitle": "Timeline has been collapsed",
+                        "widgetsTitle": "Widgets has been collapsed"
+                    }
+                }
             }
         },
         "dashboard": {
@@ -1589,6 +1596,10 @@
             "disablePlayBack": "Disable playback controls",
             "expand" : "Expand time slider",
             "collapse" : "Collapse time slider",
+            "collapsed": {
+                "title": "Timeline has been collapsed",
+                "tooltip": "Click here to expand it again"
+            },
             "errors": {
                 "multidim_error_title": "Backend service is not responding",
                 "multidim_error_message": "The required services for multidinensional support are not responding. Please try again later or contact the administrator."

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1576,6 +1576,8 @@
                 "snapToGuideLayer": "Snap to guide layer",
                 "snapToGuideLayerTooltip": "Forces the time cursor to snap to the selected layer's data. Disable this option to unlock the time cursors and enable the customization of animation step"
             },
+            "hide": "Hide timeline",
+            "show": "Show timeline",
             "currentTime": "Go to current time",
             "rangeStart":"Go to the current time range",
             "rangeEnd" : "Go to the current time range",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1408,7 +1408,14 @@
                 "expandTray": "Expandir la bandeja de widgets",
                 "collapseTray": "Contraer la bandeja de widgets",
                 "expandAll": "Expandir todos los widgets",
-                "collapseAll": "Contraer todos los widgets"
+                "collapseAll": "Contraer todos los widgets",
+                "notifications": {
+                    "collapsed": {
+                        "message": "La línea de tiempo y los widgets no pueden permanecer al mismo tiempo. Use en la bandeja del widget para cambiar entre la línea de tiempo y los widgets",
+                        "timelineTitle": "La línea de tiempo ha sido colapsada",
+                        "widgetsTitle": "Widgets ha sido colapsado"
+                    }
+                }
             }
         },
         "dashboard": {
@@ -1588,6 +1595,10 @@
             "disablePlayBack": "Deshabilita los controles de reproducción",
             "expand" : "Expandir el control deslizante de tiempo",
             "collapse" : "colapsar el control deslizante de tiempo",
+             "collapsed": {
+                "title": "La línea de tiempo ha sido colapsada",
+                "tooltip": "Haga clic aquí para ampliarlo de nuevo."
+            },
             "errors": {
                 "multidim_error_title": "El servicio de backend no responde",
                 "multidim_error_message": "Los servicios requeridos para soporte multidinensional no están respondiendo. Inténtelo de nuevo más tarde o póngase en contacto con el administrador."

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1575,6 +1575,8 @@
                 "snapToGuideLayer": "Ajustar a capa de guía",
                 "snapToGuideLayerTooltip": "Hace que el cursor del tiempo se ajuste a los datos de la capa seleccionada. Desactive esta opción para desbloquear los cursores de tiempo y habilitar la personalización del paso de animación"
             },
+            "hide": "Esconder la línea de tiempo",
+            "show": "Mostrar la línea de tiempo",
             "currentTime": "Ir a la hora actual",
             "rangeStart": "Ir al rango de tiempo actual",
             "rangeEnd": "Ir al rango de tiempo actual",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1576,6 +1576,8 @@
                 "snapToGuideLayer": "Aligner sur le calque guide",
                 "snapToGuideLayerTooltip": "Force le curseur temporel à s'aligner sur les données du calque sélectionné. Désactivez cette option pour déverrouiller les curseurs temporels et activer la personnalisation de l'étape d'animation"
             },
+            "hide": "Masquer la timeline",
+            "show": "Afficher la timeline",
             "currentTime": "Aller à l'heure actuelle",
             "rangeStart": "Aller à la plage de temps actuelle",
             "rangeEnd": "Aller à la plage de temps actuelle",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1409,7 +1409,14 @@
                 "expandTray": "Développer le plateau de widgets",
                 "collapseTray": "Réduire le tiroir des widgets",
                 "expandAll": "Développer tous les widgets",
-                "collapseAll": "Réduire tous les widgets"
+                "collapseAll": "Réduire tous les widgets",
+                "notifications": {
+                    "collapsed": {
+                        "message": "La chronologie et les widgets ne peuvent pas rester en même temps. Utilisez-le sur le plateau du widget pour basculer entre la timeline et les widgets",
+                        "timelineTitle": "La chronologie a été réduite",
+                        "widgetsTitle": "Les widgets ont été réduits"
+                    }
+                }
             }
         },
         "dashboard": {
@@ -1589,6 +1596,10 @@
             "disablePlayBack": "Désactiver les contrôles de lecture",
             "expand" : "Augmenter le curseur temporel",
             "collapse" : "Réduire le curseur temporel",
+            "collapsed": {
+                "title": "La chronologie a été réduite",
+                "tooltip": "Cliquez ici pour l'agrandir à nouveau"
+            },
             "errors": {
                 "multidim_error_title": "Le service principal ne répond pas",
                 "multidim_error_message": "Les services requis pour le support multidimensionnel ne répondent pas. Veuillez réessayer plus tard ou contactez l'administrateur."

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1575,6 +1575,8 @@
                 "snapToGuideLayer": "Aggancia al livello guida",
                 "snapToGuideLayerTooltip": "Forza il cursore del tempo in modo che si agganci ai dati del livello selezionato. Disattiva questa opzione per sbloccare i cursori temporali e abilitare la personalizzazione del passo di animazione"
             },
+            "hide": "Nascondi timeline",
+            "show": "Mostra timeline",
             "currentTime": "Istante corrente",
             "rangeStart": "Vai all'intervallo di tempo corrente",
             "rangeEnd": "Vai all'intervallo di tempo corrente",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1408,7 +1408,14 @@
                 "expandTray": "Espandi il vassoio dei widget",
                 "collapseTray": "Minimizza vassoio dei widget",
                 "expandAll": "Espandi tutti i widget",
-                "collapseAll": "Minimizza tutti i widget"
+                "collapseAll": "Minimizza tutti i widget",
+                "notifications": {
+                    "collapsed": {
+                        "message": "La timeline e i widget non possono essere visualizzati allo stesso tempo. Utilizzare il la barra degli widget per visualizzare uno o l'altro",
+                        "timelineTitle": "La timeline è stata minimizzata",
+                        "widgetsTitle": "I widget sono stati minimizzati"
+                    }
+                }
             }
         },
         "dashboard": {
@@ -1588,6 +1595,10 @@
             "disablePlayBack": "Disabilita i controlli di riproduzione",
             "expand" : "Espandi",
             "collapse" : "Riduci",
+            "collapsed": {
+                "title": "La timeline è stata collassata",
+                "tooltip": "Clicca qui per espanderla di nuovo"
+            },
             "errors": {
                 "multidim_error_title": "Il servizio di backend non risponde",
                 "multidim_error_message": "I servizi richiesti per il supporto multidimensionale non rispondono. Si prega di riprovare più tardi o contattare l'amministratore."


### PR DESCRIPTION
## Description
This pull request add the following features :
 - When widgets and timeline are on the same map, only one will be visible at the same time.
 - The user can use the widgets tray to switch between timeline or widgets.
 - When the timeline or the widgets are collapsed automatically (due to a widget add or time layer add) a notification explains what happened and how to use it (notifications are triggered only once). A tooltip highlight the timeline button the timeline button when collapsed.
![image](https://user-images.githubusercontent.com/1279510/56294862-1331d900-612c-11e9-8320-1c49d3fe5607.png)

 - Layout has been a little adjusted to uniform the timeline with widgets margins
## Issues
 - Fix #3642

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Widgets and Timeline overlap

**What is the new behavior?**
Widgets and timeline do not overlap anymore. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
