### PR TITLE
Fixed issue with usergroup name

### DIFF
--- a/web/client/components/manager/users/UserCard.jsx
+++ b/web/client/components/manager/users/UserCard.jsx
@@ -50,8 +50,11 @@ class UserCard extends React.Component {
 
     renderGroups = () => {
         return (<div key="groups" className="groups-container" style={this.props.innerItemStyle}><div><strong><Message msgId="users.groupTitle"/></strong></div>
-    <div className="groups-list">{this.props.user && this.props.user.groups ? this.props.user.groups.map((group) => (<div className="group-item" key={"group-" + group.id}>{group.groupName}</div>)) : null}</div>
-
+            <div className="groups-list">
+                {this.props.user && this.props.user.groups ? this.props.user.groups
+                .filter(({ groupName } = {}) => groupName)
+                .map(({ id, groupName } = {}) => (<div className="group-item" key={"group-" + id}>{groupName}</div>)) : null}
+            </div>
      </div>);
     };
 

--- a/web/client/components/manager/users/__tests__/UserCard-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserCard-test.jsx
@@ -49,15 +49,25 @@ describe("Test UserCard Component", () => {
         let comp = ReactDOM.render(
             <UserCard user={enabledUser}/>, document.getElementById("container"));
         expect(comp).toExist();
+        expect(document.querySelector('#container .gridcard')).toExist();
     });
     it('Test disabled user rendering', () => {
         let comp = ReactDOM.render(
             <UserCard user={disabledUser}/>, document.getElementById("container"));
         expect(comp).toExist();
+        expect(document.querySelector('#container .gridcard')).toExist();
     });
     it('Test admin user rendering', () => {
         let comp = ReactDOM.render(
             <UserCard user={adminUser}/>, document.getElementById("container"));
         expect(comp).toExist();
+        expect(document.querySelector('#container .gridcard')).toExist();
+    });
+    it('Test admin user with undefined group do not crash', () => {
+        let comp = ReactDOM.render(
+            <UserCard user={{...enabledUser, groups: [undefined]}} />, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(document.querySelector('#container .gridcard')).toExist();
+
     });
 });


### PR DESCRIPTION
## Description
All the users should have at least the "everyone" group. In some special cases (custom projects) user groups could be missing. In this case the UI should continue working.
Instead you have this error
![image](https://user-images.githubusercontent.com/1279510/57070007-7304b400-6cd6-11e9-928b-76398f414fc0.png)
This pull request fixes the UI

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
In special cases the UI crashes (not reproducible on standard MapStore installation)

**What is the new behavior?**
The UI do not crash, tested using unit tests. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No
