### PR TITLE
Fix #3713 Pop up Validation error doesn't show up for SLD

### DIFF
--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -130,4 +130,20 @@ describe('Test styleeditor reducer', () => {
             }
         });
     });
+
+    it('test errorStyle sld error', () => {
+        const state = styleeditor({ }, errorStyle('edit', { status: 400, statusText: 'Error on lineNumber: 10; columnNumber: 2;' }));
+        expect(state).toEqual({
+            loading: false,
+            canEdit: true,
+            error: {
+                edit: {
+                    status: 400,
+                    message: 'Error on lineNumber: 10; columnNumber: 2;',
+                    line: 10,
+                    column: 2
+                }
+            }
+        });
+    });
 });

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -86,10 +86,10 @@ function styleeditor(state = {}, action) {
         }
         case ERROR_STYLE: {
             const message = action.error && action.error.statusText || '';
-            const position = message.match(/line\s([\d]+)|column\s([\d]+)/g);
+            const position = message.match(/line\s([\d]+)|column\s([\d]+)|lineNumber:\s([\d]+)|columnNumber:\s([\d]+)/g);
             const errorInfo = position && position.length === 2 && position.reduce((info, pos) => {
                 const splittedValues = pos.split(' ');
-                const param = splittedValues[0];
+                const param = splittedValues[0].replace(/Number:/g, '');
                 const value = parseFloat(splittedValues[1]);
                 return param && !isNaN(value) && {
                     ...info,


### PR DESCRIPTION
## Description
This PR improves the regex that parses the error message of Style Editor.

## Issues
 - Fix #3713

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
If SLD returns a validation error it does not show as pop up

**What is the new behavior?**
If SLD returns a validation error and it has lineNumber and columnNumber in the error message, it does show as pop up

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
