### PR TITLE
Fix #3712 SLD styles version 1.1.0 are not saved correctly from Style Editor

### DIFF
--- a/web/client/actions/__tests__/styleeditor-test.js
+++ b/web/client/actions/__tests__/styleeditor-test.js
@@ -51,12 +51,14 @@ describe('Test the styleeditor actions', () => {
         const code = '* { stroke: #333333; }';
         const format = 'css';
         const init = true;
+        const languageVersion = { version: '1.0.0' };
         const retval = updateTemporaryStyle({
             temporaryId,
             templateId,
             code,
             format,
-            init
+            init,
+            languageVersion
         });
         expect(retval).toExist();
         expect(retval.type).toBe(UPDATE_TEMPORARY_STYLE);
@@ -65,6 +67,7 @@ describe('Test the styleeditor actions', () => {
         expect(retval.code).toBe(code);
         expect(retval.format).toBe(format);
         expect(retval.init).toBe(init);
+        expect(retval.languageVersion).toEqual(languageVersion);
     });
     it('updateStatus', () => {
         const status = 'edit';
@@ -92,13 +95,15 @@ describe('Test the styleeditor actions', () => {
         const code = '* { stroke: #333333; }';
         const format = 'css';
         const init = true;
-        const retval = selectStyleTemplate({ code, templateId, format, init });
+        const languageVersion = { version: '1.0.0' };
+        const retval = selectStyleTemplate({ code, templateId, format, init, languageVersion });
         expect(retval).toExist();
         expect(retval.type).toBe(SELECT_STYLE_TEMPLATE);
         expect(retval.templateId).toBe(templateId);
         expect(retval.code).toBe(code);
         expect(retval.format).toBe(format);
         expect(retval.init).toBe(init);
+        expect(retval.languageVersion).toEqual(languageVersion);
     });
     it('createStyle', () => {
         const settings = { title: 'Title', _abstract: ''};

--- a/web/client/actions/styleeditor.js
+++ b/web/client/actions/styleeditor.js
@@ -55,13 +55,14 @@ function updateStatus(status) {
 * @param {object} styleProps { code, templateId, format, init } init set initialCode
 * @return {object} of type `SELECT_STYLE_TEMPLATE` styleProps
 */
-function selectStyleTemplate({ code, templateId, format, init } = {}) {
+function selectStyleTemplate({ code, templateId, format, languageVersion, init } = {}) {
     return {
         type: SELECT_STYLE_TEMPLATE,
         code,
         templateId,
         format,
-        init
+        init,
+        languageVersion
     };
 }
 /**
@@ -70,14 +71,15 @@ function selectStyleTemplate({ code, templateId, format, init } = {}) {
 * @param {object} styleProps { temporaryId, templateId, code, format, init } init set initialCode
 * @return {object} of type `UPDATE_TEMPORARY_STYLE` styleProps
 */
-function updateTemporaryStyle({ temporaryId, templateId, code, format, init } = {}) {
+function updateTemporaryStyle({ temporaryId, templateId, code, format, languageVersion, init } = {}) {
     return {
         type: UPDATE_TEMPORARY_STYLE,
         temporaryId,
         templateId,
         code,
         format,
-        init
+        init,
+        languageVersion
     };
 }
 /**

--- a/web/client/api/geoserver/__tests__/Styles-test.js
+++ b/web/client/api/geoserver/__tests__/Styles-test.js
@@ -6,8 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var expect = require('expect');
-var API = require('../Styles');
+import expect from 'expect';
+import API from '../Styles';
+import MockAdapter from 'axios-mock-adapter';
+import axios from '../../../libs/ajax';
+
+let mockAxios;
 
 describe('Test styles rest API', () => {
     it('save style', (done) => {
@@ -84,6 +88,89 @@ describe('Test styles rest API', () => {
                 name: 'test_style'
             });
             done();
+        });
+    });
+});
+
+describe('Test styles rest API, Content Type of SLD', () => {
+
+    beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+
+    it('test createStyle with sld version 1.1.0', (done) => {
+
+        mockAxios.onPost(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.se+xml');
+            expect(config.url).toBe('/geoserver/rest/styles.json');
+            done();
+            return [ 200, {}];
+        });
+
+        API.createStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.1.0' }
+        });
+    });
+
+    it('test createStyle with sld version 1.0.0', (done) => {
+
+        mockAxios.onPost(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.sld+xml');
+            expect(config.url).toBe('/geoserver/rest/styles.json');
+            done();
+            return [ 200, {}];
+        });
+
+        API.createStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.0.0' }
+        });
+    });
+
+    it('test updateStyle with sld version 1.1.0', (done) => {
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.se+xml');
+            expect(config.url).toBe('/geoserver/rest/styles/style_name');
+            done();
+            return [ 200, {}];
+        });
+
+        API.updateStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.1.0' }
+        });
+    });
+
+    it('test updateStyle with sld version 1.0.0', (done) => {
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.sld+xml');
+            expect(config.url).toBe('/geoserver/rest/styles/style_name');
+            done();
+            return [ 200, {}];
+        });
+
+        API.updateStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.0.0' }
         });
     });
 });

--- a/web/client/components/styleeditor/StyleList.jsx
+++ b/web/client/components/styleeditor/StyleList.jsx
@@ -9,7 +9,6 @@
 const React = require('react');
 
 const { Glyphicon: GlyphiconRB } = require('react-bootstrap');
-
 const BorderLayout = require('../layout/BorderLayout');
 const emptyState = require('../misc/enhancers/emptyState');
 const withLocal = require("../misc/enhancers/localizedProps");
@@ -26,6 +25,16 @@ const SideGrid = emptyState(
         glyph: '1-stilo'
     }
 )(require('../misc/cardgrids/SideGrid'));
+
+// get the text to use in the icon
+const getFormatText = (format) => {
+    const text = {
+        sld: 'SLD',
+        css: 'CSS',
+        mbstyle: 'MBS'
+    };
+    return text[format] || format || '';
+};
 
 /**
  * Component for rendering a grid of style templates.
@@ -83,7 +92,7 @@ const StyleList = ({
                                 backgroundColor="#333333"
                                 texts={[
                                     {
-                                        text: style.format.toUpperCase(),
+                                        text: getFormatText(style.format).toUpperCase(),
                                         fill: formatColors[style.format] || '#f2f2f2',
                                         style: {
                                             fontSize: 70,

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -51,7 +51,8 @@ const StyleToolbar = ({
     onSelectStyle = () => {},
     onEditStyle = () => {},
     onUpdate = () => {},
-    onSetDefault = () => {}
+    onSetDefault = () => {},
+    disableCodeEditing
 }) => (
     <div>
         <Toolbar
@@ -101,7 +102,7 @@ const StyleToolbar = ({
                     glyph: 'code',
                     tooltipId: 'styleeditor.editSelectedStyle',
                     visible: !status && editEnabled ? true : false,
-                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1,
+                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1 || disableCodeEditing,
                     onClick: () => onEditStyle()
                 },
                 {

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -1250,64 +1250,6 @@ describe('Test styleeditor epics, with mock axios', () => {
             selectStyleTemplate({ }),
             results,
         state);
-
-        /*const TEMPORARY_ID = 'id';
-
-        mockAxios.onDelete(/\/styles/).reply((config) => {
-            try {
-                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
-            } catch(e) {
-                done(e);
-            }
-            return [ 404, {}];
-        });
-
-        mockAxios.onPut(/\/styles/).reply((config) => {
-            try {
-                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
-            } catch(e) {
-                done(e);
-            }
-            return [ 200, {}];
-        });
-
-        const state = {
-            styleeditor: {
-                temporaryId: TEMPORARY_ID,
-                format: 'css',
-                service: {
-                    baseUrl: '/geoserver/'
-                }
-            }
-        };
-
-        const NUMBER_OF_ACTIONS = 4;
-
-        const results = (actions) => {
-            try {
-                const [
-                    putLoadingStyleAction,
-                    loadedStyleAction,
-                    updateOptionsByOwnerAction,
-                    updateTemporaryStyleAction
-                ] = actions;
-                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
-                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
-                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
-                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
-                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMPORARY_ID);
-            } catch(e) {
-                done(e);
-            }
-            done();
-        };
-
-        testEpic(
-            updateTemporaryStyleEpic,
-            NUMBER_OF_ACTIONS,
-            selectStyleTemplate({ format: 'sld' }),
-            results,
-        state);*/
     });
 
 });

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -1213,4 +1213,101 @@ describe('Test styleeditor epics, with mock axios', () => {
         state);
     });
 
+
+    it('test updateTemporaryStyleEpic fails on create should reset temporary properties', (done) => {
+
+        mockAxios.onPost(/\/styles/).reply(() => [ 404, {}]);
+
+        const state = {};
+
+        const results = (actions) => {
+            try {
+                const [
+                    loadingStyleAction,
+                    errorStyleAction,
+                    loadedStyleAction,
+                    showNotifiactionAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(loadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(errorStyleAction.type).toBe(ERROR_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(showNotifiactionAction.type).toBe(SHOW_NOTIFICATION);
+                expect(showNotifiactionAction.level).toBe('error');
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(null);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        const NUMBER_OF_ACTIONS = 5;
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({ }),
+            results,
+        state);
+
+        /*const TEMPORARY_ID = 'id';
+
+        mockAxios.onDelete(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 404, {}];
+        });
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        const state = {
+            styleeditor: {
+                temporaryId: TEMPORARY_ID,
+                format: 'css',
+                service: {
+                    baseUrl: '/geoserver/'
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 4;
+
+        const results = (actions) => {
+            try {
+                const [
+                    putLoadingStyleAction,
+                    loadedStyleAction,
+                    updateOptionsByOwnerAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMPORARY_ID);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({ format: 'sld' }),
+            results,
+        state);*/
+    });
+
 });

--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -6,27 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {
+import {
     UPDATE_NODE,
     UPDATE_SETTINGS_PARAMS
-} = require('../../actions/layers');
+} from '../../actions/layers';
 
-const {
+import {
     SET_CONTROL_PROPERTY
-} = require('../../actions/controls');
+} from '../../actions/controls';
 
-const {
+import {
     SHOW_NOTIFICATION
-} = require('../../actions/notifications');
+} from '../../actions/notifications';
 
-const {
+import {
     REMOVE_ADDITIONAL_LAYER,
     UPDATE_OPTIONS_BY_OWNER
-} = require('../../actions/additionallayers');
+} from '../../actions/additionallayers';
 
-const {
+import {
     RESET_STYLE_EDITOR,
     LOADING_STYLE,
     SELECT_STYLE_TEMPLATE,
@@ -41,9 +41,9 @@ const {
     deleteStyle,
     UPDATE_STATUS,
     setDefaultStyle
-} = require('../../actions/styleeditor');
+} from '../../actions/styleeditor';
 
-const {
+import {
     toggleStyleEditorEpic,
     updateLayerOnStatusChangeEpic,
     updateTemporaryStyleEpic,
@@ -51,11 +51,16 @@ const {
     updateStyleCodeEpic,
     deleteStyleEpic,
     setDefaultStyleEpic
-} = require('../styleeditor');
+} from '../styleeditor';
 
-const { testEpic } = require('./epicTestUtils');
+import { testEpic } from './epicTestUtils';
 
-describe('styleeditor Epics', () => {
+import MockAdapter from 'axios-mock-adapter';
+import axios from '../../libs/ajax';
+
+let mockAxios;
+
+describe('Test styleeditor epics', () => {
 
     it('test toggleStyleEditorEpic enabled to true', (done) => {
 
@@ -755,4 +760,457 @@ describe('styleeditor Epics', () => {
             done(e);
         }
     });
+});
+
+describe('Test styleeditor epics, with mock axios', () => {
+    beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+
+    it('test updateStyleCodeEpic with 200 response', (done) => {
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            expect(config.url).toBe('/geoserver/rest/styles/test_style');
+            expect(config.params.raw).toBe(true);
+            return [ 200, {}];
+        });
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        url: '/geoserver/',
+                        describeFeatureType: {},
+                        style: 'test_style'
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ]
+            },
+            styleeditor: {
+                service: {
+                    baseUrl: '/geoserver/'
+                },
+                code: '* { stroke: #ff0000; }'
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 5;
+
+        const results = (actions) => {
+            const [
+                loadingStyleAction,
+                loadedStyleAction,
+                updateNodeAction,
+                updateTemporaryStyleAction,
+                showNotificationAction
+            ] = actions;
+
+            try {
+                expect(loadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateNodeAction.type).toBe(UPDATE_NODE);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(showNotificationAction.type).toBe(SHOW_NOTIFICATION);
+                expect(showNotificationAction.level).toBe('success');
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateStyleCodeEpic,
+            NUMBER_OF_ACTIONS,
+            updateStyleCode(),
+            results,
+        state);
+    });
+
+
+    it('test updateStyleCodeEpic with 404 response', (done) => {
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            expect(config.url).toBe('/geoserver/rest/styles/test_style');
+            expect(config.params.raw).toBe(true);
+            return [ 404, {}];
+        });
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        url: '/geoserver/',
+                        describeFeatureType: {},
+                        style: 'test_style'
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ]
+            },
+            styleeditor: {
+                service: {
+                    baseUrl: '/geoserver/'
+                },
+                code: '* { stroke: #ff0000; }'
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 4;
+
+        const results = (actions) => {
+            const [
+                loadingStyleAction,
+                errorStyleAction,
+                loadedStyleAction,
+                showNotificationAction
+            ] = actions;
+
+            try {
+                expect(loadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(errorStyleAction.type).toBe(ERROR_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(showNotificationAction.type).toBe(SHOW_NOTIFICATION);
+                expect(showNotificationAction.level).toBe('error');
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateStyleCodeEpic,
+            NUMBER_OF_ACTIONS,
+            updateStyleCode(),
+            results,
+        state);
+    });
+
+    it('test updateTemporaryStyleEpic, temporary style does not exist, response 200', (done) => {
+
+        let TEMP_STYLE_ID;
+
+        mockAxios.onPost(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe('/geoserver/rest/styles.json');
+                TEMP_STYLE_ID = config.params.name;
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMP_STYLE_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        const state = {
+            styleeditor: {
+                service: {
+                    baseUrl: '/geoserver/'
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 5;
+
+        const results = (actions) => {
+            try {
+                const [
+                    postLoadingStyleAction,
+                    putLoadingStyleAction,
+                    loadedStyleAction,
+                    updateOptionsByOwnerAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(postLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMP_STYLE_ID);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({}),
+            results,
+        state);
+    });
+
+
+    it('test updateTemporaryStyleEpic, temporary style exist and change format, response 200', (done) => {
+
+        let TEMP_STYLE_ID;
+        const TEMPORARY_ID = 'id';
+
+        mockAxios.onDelete(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        mockAxios.onPost(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe('/geoserver/rest/styles.json');
+                TEMP_STYLE_ID = config.params.name;
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMP_STYLE_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        const state = {
+            styleeditor: {
+                temporaryId: TEMPORARY_ID,
+                format: 'css',
+                service: {
+                    baseUrl: '/geoserver/'
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 5;
+
+        const results = (actions) => {
+            try {
+                const [
+                    postLoadingStyleAction,
+                    putLoadingStyleAction,
+                    loadedStyleAction,
+                    updateOptionsByOwnerAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(postLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMP_STYLE_ID);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({ format: 'sld' }),
+            results,
+        state);
+    });
+
+
+    it('test updateTemporaryStyleEpic, temporary style exist and same format and version, response 200', (done) => {
+
+        const TEMPORARY_ID = 'id';
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+                expect(config.params.raw).toBe(undefined);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        const state = {
+            styleeditor: {
+                temporaryId: TEMPORARY_ID,
+                format: 'sld',
+                languageVersion: {
+                    version: '1.0.0'
+                },
+                service: {
+                    baseUrl: '/geoserver/'
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 4;
+
+        const results = (actions) => {
+            try {
+                const [
+                    putLoadingStyleAction,
+                    loadedStyleAction,
+                    updateOptionsByOwnerAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMPORARY_ID);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({ format: 'sld' }),
+            results,
+        state);
+    });
+
+    it('test updateTemporaryStyleEpic, temporary style exist and same format and different version (style body version 1.1.0), response 200', (done) => {
+
+        const TEMPORARY_ID = 'id';
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+                expect(config.params.raw).toBe(true);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        const state = {
+            styleeditor: {
+                temporaryId: TEMPORARY_ID,
+                format: 'sld',
+                languageVersion: {
+                    version: '1.0.0'
+                },
+                service: {
+                    baseUrl: '/geoserver/'
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 4;
+
+        const results = (actions) => {
+            try {
+                const [
+                    putLoadingStyleAction,
+                    loadedStyleAction,
+                    updateOptionsByOwnerAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMPORARY_ID);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({
+                format: 'sld',
+                code: '<StyledLayerDescriptor version="1.1.0" ></StyledLayerDescriptor>'
+            }),
+            results,
+        state);
+    });
+
+
+    it('test updateTemporaryStyleEpic, temporary style exist and cahnge format, delete response 404', (done) => {
+
+        const TEMPORARY_ID = 'id';
+
+        mockAxios.onDelete(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 404, {}];
+        });
+
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            try {
+                expect(config.url).toBe(`/geoserver/rest/styles/${TEMPORARY_ID}`);
+            } catch(e) {
+                done(e);
+            }
+            return [ 200, {}];
+        });
+
+        const state = {
+            styleeditor: {
+                temporaryId: TEMPORARY_ID,
+                format: 'css',
+                service: {
+                    baseUrl: '/geoserver/'
+                }
+            }
+        };
+
+        const NUMBER_OF_ACTIONS = 4;
+
+        const results = (actions) => {
+            try {
+                const [
+                    putLoadingStyleAction,
+                    loadedStyleAction,
+                    updateOptionsByOwnerAction,
+                    updateTemporaryStyleAction
+                ] = actions;
+                expect(putLoadingStyleAction.type).toBe(LOADING_STYLE);
+                expect(loadedStyleAction.type).toBe(LOADED_STYLE);
+                expect(updateOptionsByOwnerAction.type).toBe(UPDATE_OPTIONS_BY_OWNER);
+                expect(updateTemporaryStyleAction.type).toBe(UPDATE_TEMPORARY_STYLE);
+                expect(updateTemporaryStyleAction.temporaryId).toBe(TEMPORARY_ID);
+            } catch(e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            updateTemporaryStyleEpic,
+            NUMBER_OF_ACTIONS,
+            selectStyleTemplate({ format: 'sld' }),
+            results,
+        state);
+    });
+
 });

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -42,6 +42,7 @@ const {
     temporaryIdSelector,
     codeStyleSelector,
     formatStyleSelector,
+    languageVersionStyleSelector,
     statusStyleSelector,
     selectedStyleSelector,
     enabledStyleEditorSelector,
@@ -67,6 +68,7 @@ const getStyleCodeObservable = ({status, styleName, baseUrl}) =>
         )
         .switchMap(style => Rx.Observable.of(
             selectStyleTemplate({
+                languageVersion: style.languageVersion,
                 code: style.code,
                 templateId: '',
                 format: style.format,
@@ -79,14 +81,14 @@ const getStyleCodeObservable = ({status, styleName, baseUrl}) =>
  * Observable delete styles.
  * silent to false hide notifications
  */
-const deleteStyleObservable = ({styleName, baseUrl}, silent) =>
+const deleteStyleObservable = ({styleName, baseUrl, observableResponse, observableReject}, silent) =>
     Rx.Observable.defer(() =>
         StylesAPI.deleteStyle({
             baseUrl,
             styleName
         })
     )
-    .switchMap(() => silent ? Rx.Observable.empty() : Rx.Observable.of(
+    .switchMap(() => silent ? observableResponse || Rx.Observable.empty() : Rx.Observable.of(
             success({
                 title: "styleeditor.deletedStyleSuccessTitle",
                 message: "styleeditor.deletedStyleSuccessMessage",
@@ -95,7 +97,7 @@ const deleteStyleObservable = ({styleName, baseUrl}, silent) =>
             })
         )
     )
-    .catch(() => silent ? Rx.Observable.empty() : Rx.Observable.of(
+    .catch(() => silent ? observableReject || Rx.Observable.empty() : Rx.Observable.of(
         error({
             title: "styleeditor.deletedStyleErrorTitle",
             message: "styleeditor.deletedStyleErrorMessage",
@@ -148,13 +150,15 @@ const updateAvailableStylesObservable = ({baseUrl, layer, styleName, format, tit
 /*
  * Observable to create/update style
  */
-const createUpdateStyleObservable = ({baseUrl, update, code, format, styleName, status}, successActions = [], errorActions = []) =>
+const createUpdateStyleObservable = ({baseUrl, update, code, format, styleName, status, languageVersion, options}, successActions = [], errorActions = []) =>
     Rx.Observable.defer(() =>
         StylesAPI[update ? 'updateStyle' : 'createStyle']({
             baseUrl,
             code,
             format,
-            styleName
+            styleName,
+            languageVersion,
+            options
         })
     )
     .switchMap(() => isArray(successActions) && Rx.Observable.of(loadedStyle(), ...successActions) || successActions)
@@ -302,29 +306,45 @@ module.exports = {
 
                 const layer = getUpdatedLayer(state);
                 const { workspace } = getNameParts(layer.name);
+                const isChangedFormat = action.format && action.format !== formatStyleSelector(state);
 
                 const styleName = temporaryId || `${workspace ? `${workspace}:` : ''}${generateTemporaryStyleId()}`;
                 const format = action.format || formatStyleSelector(state);
                 const status = statusStyleSelector(state);
-                const { baseUrl = '', formats } = styleServiceSelector(state);
+                const { baseUrl = '' } = styleServiceSelector(state);
 
-                const updateTmpCode = createUpdateStyleObservable(
+                // check if previous version of temporary style is changed
+                // if so it add 'raw=true' param to the request to eansure SLD is updated correctly
+                const previousLanguageVersion = languageVersionStyleSelector(state);
+                const currentLanguageVersion = format === 'sld'
+                    && (action.code || '').match(/version=\"1\.1\.0\"/) && { version: '1.1.0' }
+                    || action.format && !action.languageVersion && { version: '1.0.0' }
+                    || action.languageVersion
+                    || { version: '1.0.0' };
+                const options = previousLanguageVersion.version !== currentLanguageVersion.version
+                    ? { params: { raw: true } }
+                    : { };
+                const languageVersion = currentLanguageVersion;
+                const updateTmpCode = (name) => createUpdateStyleObservable(
                     {
                         update: true,
                         code: action.code,
                         format,
-                        styleName,
+                        styleName: name,
                         status,
-                        baseUrl
+                        baseUrl,
+                        languageVersion,
+                        options
                     },
                     [
-                        updateOptionsByOwner(STYLE_OWNER_NAME, [{ style: styleName, _v_: Date.now(), singleTile: true }]),
+                        updateOptionsByOwner(STYLE_OWNER_NAME, [{ style: name, _v_: Date.now(), singleTile: true }]),
                         updateTemporaryStyle({
-                            temporaryId: styleName,
+                            temporaryId: name,
                             templateId: action.templateId || '',
                             code: action.code,
                             format,
-                            init: action.init
+                            init: action.init,
+                            languageVersion
                         })
                     ],
                     status === 'edit' ? [] : [
@@ -337,30 +357,39 @@ module.exports = {
                     ]
                 );
 
-                const availableFormat = isArray(formats) && formats.indexOf('css') !== -1 && 'css' || 'sld';
                 // valid code needed to initialize and create temp style
-                const baseCode = availableFormat === 'css' && '* { stroke: #888888; }' ||
-                availableFormat === 'sld' && '<?xml version="1.0" encoding="ISO-8859-1"?>\n<StyledLayerDescriptor version="1.0.0"\n\t\txsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"\n\t\txmlns="http://www.opengis.net/sld"\n\t\txmlns:ogc="http://www.opengis.net/ogc"\n\t\txmlns:xlink="http://www.w3.org/1999/xlink"\n\t\txmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n\n\t<NamedLayer>\n\t\t<Name>Default Style</Name>\n\t\t<UserStyle>\n\t\t\t<Title>${styleTitle}</Title>\n\t\t\t<Abstract>${styleAbstract}</Abstract>\n\t\t\t<FeatureTypeStyle>\n\t\t\t\t<Rule>\n\t\t\t\t\t<Name>Rule Name</Name>\n\t\t\t\t\t<Title>Rule Title</Title>\n\t\t\t\t\t<Abstract>Rule Abstract</Abstract>\n\t\t\t\t\t<LineSymbolizer>\n\t\t\t\t\t\t<Stroke>\n\t\t\t\t\t\t\t<CssParameter name="stroke">#0000FF</CssParameter>\n\t\t\t\t\t\t</Stroke>\n\t\t\t\t\t\t</LineSymbolizer>\n\t\t\t\t\t<PointSymbolizer>\n\t\t\t\t\t\t<Graphic>\n\t\t\t\t\t\t\t<Mark>\n\t\t\t\t\t\t\t\t<WellKnownName>square</WellKnownName>\n\t\t\t\t\t\t\t\t<Fill>\n\t\t\t\t\t\t\t\t\t<CssParameter name="fill">#FF0000</CssParameter>\n\t\t\t\t\t\t\t\t</Fill>\n\t\t\t\t\t\t\t</Mark>\n\t\t\t\t\t\t</Graphic>\n\t\t\t\t\t</PointSymbolizer>\n\t\t\t\t\t</Rule>\n\t\t\t\t</FeatureTypeStyle>\n\t\t\t</UserStyle>\n\t\t</NamedLayer>\n\t</StyledLayerDescriptor>\n'
+                const baseCode = format === 'css' && '* { stroke: #888888; }' ||
+                format === 'sld' && '<?xml version="1.0" encoding="ISO-8859-1"?>\n<StyledLayerDescriptor version="1.0.0"\n\t\txsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"\n\t\txmlns="http://www.opengis.net/sld"\n\t\txmlns:ogc="http://www.opengis.net/ogc"\n\t\txmlns:xlink="http://www.w3.org/1999/xlink"\n\t\txmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n\n\t<NamedLayer>\n\t\t<Name>Default Style</Name>\n\t\t<UserStyle>\n\t\t\t<Title>${styleTitle}</Title>\n\t\t\t<Abstract>${styleAbstract}</Abstract>\n\t\t\t<FeatureTypeStyle>\n\t\t\t\t<Rule>\n\t\t\t\t\t<Name>Rule Name</Name>\n\t\t\t\t\t<Title>Rule Title</Title>\n\t\t\t\t\t<Abstract>Rule Abstract</Abstract>\n\t\t\t\t\t<LineSymbolizer>\n\t\t\t\t\t\t<Stroke>\n\t\t\t\t\t\t\t<CssParameter name="stroke">#0000FF</CssParameter>\n\t\t\t\t\t\t</Stroke>\n\t\t\t\t\t\t</LineSymbolizer>\n\t\t\t\t\t<PointSymbolizer>\n\t\t\t\t\t\t<Graphic>\n\t\t\t\t\t\t\t<Mark>\n\t\t\t\t\t\t\t\t<WellKnownName>square</WellKnownName>\n\t\t\t\t\t\t\t\t<Fill>\n\t\t\t\t\t\t\t\t\t<CssParameter name="fill">#FF0000</CssParameter>\n\t\t\t\t\t\t\t\t</Fill>\n\t\t\t\t\t\t\t</Mark>\n\t\t\t\t\t\t</Graphic>\n\t\t\t\t\t</PointSymbolizer>\n\t\t\t\t\t</Rule>\n\t\t\t\t</FeatureTypeStyle>\n\t\t\t</UserStyle>\n\t\t</NamedLayer>\n\t</StyledLayerDescriptor>\n'
                 || '';
 
-                return temporaryId && updateTmpCode ||
+                const createTmpCode = (name) =>
                     createUpdateStyleObservable({
-                        code: baseCode,
-                        format: availableFormat,
-                        styleName,
-                        status,
-                        baseUrl
-                    },
-                    updateTmpCode,
-                    [
-                        error({
-                            title: "styleeditor.createTmpErrorTitle",
-                            message: "styleeditor.createTmpStyleErrorMessage",
-                            uid: "createTmpStyleError",
-                            autoDismiss: 5
-                        })
-                    ]
-                );
+                            code: baseCode,
+                            format,
+                            styleName: name,
+                            status,
+                            baseUrl
+                        },
+                        updateTmpCode(name),
+                        [
+                            error({
+                                title: "styleeditor.createTmpErrorTitle",
+                                message: "styleeditor.createTmpStyleErrorMessage",
+                                uid: "createTmpStyleError",
+                                autoDismiss: 5
+                            })
+                        ]
+                    );
+
+                // delete and replace current temporary style if format is changed
+                return (isChangedFormat && temporaryId) && deleteStyleObservable({
+                    styleName: temporaryId,
+                    baseUrl,
+                    observableResponse: createTmpCode(`${workspace ? `${workspace}:` : ''}${generateTemporaryStyleId()}`),
+                    observableReject: updateTmpCode(styleName)
+                }, true)
+                || temporaryId && updateTmpCode(styleName)
+                || createTmpCode(styleName);
             }),
     /**
      * Gets every `CREATE_STYLE` event.
@@ -423,6 +452,7 @@ module.exports = {
                 const state = store.getState();
 
                 const format = formatStyleSelector(state);
+                const languageVersion = languageVersionStyleSelector(state);
                 const code = codeStyleSelector(state);
                 const styleName = selectedStyleSelector(state);
                 const temporaryId = temporaryIdSelector(state);
@@ -436,7 +466,10 @@ module.exports = {
                         format,
                         styleName,
                         status: 'global',
-                        baseUrl
+                        baseUrl,
+                        // add 'raw=true' param to ensure correct update of SLD style
+                        // in case of update of version (SLD/SLDSE)
+                        options: { params: { raw: true } }
                     },
                     [
                         updateNode(layer.id, 'layer', { _v_: Date.now() }),
@@ -445,7 +478,8 @@ module.exports = {
                             templateId: '',
                             code,
                             format,
-                            init: true
+                            init: true,
+                            languageVersion
                         }),
                         success({
                             title: "styleeditor.savedStyleTitle",

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -51,7 +51,8 @@ const {
     canEditStyleSelector,
     getAllStyles,
     styleServiceSelector,
-    getUpdatedLayer
+    getUpdatedLayer,
+    selectedStyleFormatSelector
 } = require('../../selectors/styleeditor');
 
 const { getEditorMode, STYLE_OWNER_NAME, getStyleTemplates } = require('../../utils/StyleEditorUtils');
@@ -189,16 +190,20 @@ const StyleToolbar = compose(
                 loadingStyleSelector,
                 selectedStyleSelector,
                 canEditStyleSelector,
-                getAllStyles
+                getAllStyles,
+                styleServiceSelector,
+                selectedStyleFormatSelector
             ],
-            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }) => ({
+            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format) => ({
                 status,
                 templateId,
                 error,
                 isCodeChanged: initialCode !== code,
                 loading,
                 selectedStyle: defaultStyle === selectedStyle ? '' : selectedStyle,
-                editEnabled: canEdit
+                editEnabled: canEdit,
+                // enable edit only if service support current format
+                disableCodeEditing: formats.indexOf(format) === -1
             })
         ),
         {

--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -47,14 +47,16 @@ describe('Test styleeditor reducer', () => {
         const code = '* { stroke: #ff0000; }';
         const format = 'css';
         const init = true;
-        const state = styleeditor({}, updateTemporaryStyle({ temporaryId, templateId, code, format, init }));
+        const languageVersion = { version: '1.0.0' };
+        const state = styleeditor({}, updateTemporaryStyle({ temporaryId, templateId, code, format, init, languageVersion }));
         expect(state).toEqual({
             temporaryId,
             templateId,
             code,
             format,
             error: null,
-            initialCode: code
+            initialCode: code,
+            languageVersion
         });
     });
     it('test updateStatus', () => {

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -41,6 +41,7 @@ function styleeditor(state = {}, action) {
                 code: action.code,
                 format: action.format,
                 error: null,
+                languageVersion: action.languageVersion,
                 initialCode: action.init ? action.code : state.initialCode
             };
         }

--- a/web/client/selectors/__tests__/styleeditor-test.js
+++ b/web/client/selectors/__tests__/styleeditor-test.js
@@ -14,6 +14,7 @@ const {
     errorStyleSelector,
     loadingStyleSelector,
     formatStyleSelector,
+    languageVersionStyleSelector,
     codeStyleSelector,
     initialCodeStyleSelector,
     selectedStyleSelector,
@@ -24,7 +25,8 @@ const {
     styleServiceSelector,
     canEditStyleSelector,
     getUpdatedLayer,
-    getAllStyles
+    getAllStyles,
+    selectedStyleFormatSelector
 } = require('../styleeditor');
 
 describe('Test styleeditor selector', () => {
@@ -103,6 +105,17 @@ describe('Test styleeditor selector', () => {
 
         expect(retval).toExist();
         expect(retval).toBe('css');
+    });
+    it('test languageVersionStyleSelector', () => {
+        const state = {
+            styleeditor: {
+                languageVersion: { version: '1.0.0' }
+            }
+        };
+        const retval = languageVersionStyleSelector(state);
+
+        expect(retval).toExist();
+        expect(retval).toEqual({ version: '1.0.0' });
     });
     it('test codeStyleSelector', () => {
         const state = {
@@ -431,5 +444,45 @@ describe('Test styleeditor selector', () => {
             defaultStyle: 'point',
             enabledStyle: 'square'
         });
+    });
+    it('test temporaryIdSelector', () => {
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        style: 'point',
+                        availableStyles: [
+                            {
+                                name: 'point',
+                                format: 'sld'
+                            },
+                            {
+                                name: 'generic',
+                                format: 'css'
+                            }
+                        ]
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ],
+                settings: {
+                    expanded: true,
+                    node: 'layerId',
+                    nodeType: 'layers',
+                    options: {
+                        opacity: 1,
+                        style: 'generic'
+                    }
+                }
+            }
+        };
+        const retval = selectedStyleFormatSelector(state);
+        expect(retval).toExist();
+        expect(retval).toBe('css');
+
     });
 });

--- a/web/client/selectors/styleeditor.js
+++ b/web/client/selectors/styleeditor.js
@@ -53,12 +53,19 @@ const errorStyleSelector = state => get(state, 'styleeditor.error') || {};
  */
 const loadingStyleSelector = state => get(state, 'styleeditor.loading');
 /**
- * selects current format of selected style from state
+ * selects current format of temporary style from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string}
  */
 const formatStyleSelector = state => get(state, 'styleeditor.format') || 'css';
+/**
+ * selects current langage version of temporary style from state
+ * @memberof selectors.styleeditor
+ * @param  {object} state the state
+ * @return {object}
+ */
+const languageVersionStyleSelector = state => get(state, 'styleeditor.languageVersion') || {};
 /**
  * selects code of style in editing from state
  * @memberof selectors.styleeditor
@@ -146,6 +153,17 @@ const selectedStyleSelector = state => {
     || updatedLayer.availableStyles && updatedLayer.availableStyles[0] && updatedLayer.availableStyles[0].name;
 };
 /**
+ * selects format of selected style from state
+ * @memberof selectors.styleeditor
+ * @param  {object} state the state
+ * @return {string}
+ */
+const selectedStyleFormatSelector = state => {
+    const { availableStyles = []} = getUpdatedLayer(state) || {};
+    const styleName = selectedStyleSelector(state);
+    return head(availableStyles.filter(({ name }) => name === styleName).map(({ format }) => format));
+};
+/**
  * selects all style values of selected layer (availableStyles, defaultStyle, enabledStyle) from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
@@ -177,6 +195,7 @@ module.exports = {
     errorStyleSelector,
     loadingStyleSelector,
     formatStyleSelector,
+    languageVersionStyleSelector,
     codeStyleSelector,
     initialCodeStyleSelector,
     selectedStyleSelector,
@@ -187,5 +206,6 @@ module.exports = {
     styleServiceSelector,
     canEditStyleSelector,
     getUpdatedLayer,
+    selectedStyleFormatSelector,
     getAllStyles
 };


### PR DESCRIPTION
## Description
This PR introduces following changes to verify version of SLD style is correctly updated in the editing phase.
changes:
- temporary style will be replaced when style editor switches format
- Style Editor sends every save POST request with param raw equal true to ensure correct  update of the version
- If SLD changes version, Style Editor sends POST/PUT requests for temporary style with raw equal to true
- disabled editing for unsupported format (currently it is not possible to edit style such as mbstyle or ysld)

ui with editing disabled
![2019-05-06 09_40_44-Window](https://user-images.githubusercontent.com/19175505/57212736-f3802900-6fe4-11e9-95b7-0cabef2db515.png)

## Issues
 - Fix #3712

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3712

**What is the new behavior?**
- temporary style will be replaced when style editor switches format
- Style Editor sends every save POST request with param raw equal true to ensure correct  update of the version
- If SLD changes version, Style Editor sends POST/PUT requests for temporary style with raw equal to true
- disabled editing for unsupported format

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
