### PR TITLE
Fix #3708 The "Create new style" popup does not appear in Safari (2019.01.xx)

### DIFF
--- a/web/client/components/styleeditor/StyleTemplates.jsx
+++ b/web/client/components/styleeditor/StyleTemplates.jsx
@@ -21,6 +21,7 @@ const Filter = withLocal('filterPlaceholder')(require('../misc/Filter'));
 const FormControl = withLocal('placeholder')(FormControlRB);
 
 const ResizableModal = require('../misc/ResizableModal');
+const Portal = require('../misc/Portal');
 const Message = require('../I18N/Message');
 const HTML = require('../I18N/HTML');
 
@@ -120,35 +121,37 @@ const StyleTemplates = ({
                         selected: styleTemplate.styleId === selectedStyle,
                         disabled: loading
                         }))}/>
-            <ResizableModal
-                show={!!add}
-                fitContent
-                title={<Message msgId="styleeditor.createStyleModalTitle"/>}
-                onClose={() => onClose()}
-                buttons={[
-                    {
-                        text: <Message msgId="save"/>,
-                        bsStyle: 'primary',
-                        disabled: !validateAlphaNumeric(styleSettings),
-                        onClick: () => onSave(styleSettings)
-                    }
-                ]}>
-                <Form>
-                    <FormGroup controlId="styleTitle" validationState={!validateAlphaNumeric(styleSettings) && 'error'}>
-                        {formFields.map(({title, placeholder, key}) => (<span key={key}>
-                            <ControlLabel>{title}</ControlLabel>
-                            <FormControl
-                                type="text"
-                                defaultValue={styleSettings[key]}
-                                placeholder={placeholder}
-                                onChange={event => onUpdate({...styleSettings, [key]: event.target.value})}/>
-                        </span>))}
-                    </FormGroup>
-                    {!validateAlphaNumeric(styleSettings) && <Alert style={{margin: 0}} bsStyle="danger">
-                        <HTML msgId="styleeditor.titleRequired"/>
-                    </Alert>}
-                </Form>
-            </ResizableModal>
+            <Portal>
+                <ResizableModal
+                    show={!!add}
+                    fitContent
+                    title={<Message msgId="styleeditor.createStyleModalTitle"/>}
+                    onClose={() => onClose()}
+                    buttons={[
+                        {
+                            text: <Message msgId="save"/>,
+                            bsStyle: 'primary',
+                            disabled: !validateAlphaNumeric(styleSettings),
+                            onClick: () => onSave(styleSettings)
+                        }
+                    ]}>
+                    <Form>
+                        <FormGroup controlId="styleTitle" validationState={!validateAlphaNumeric(styleSettings) && 'error'}>
+                            {formFields.map(({title, placeholder, key}) => (<span key={key}>
+                                <ControlLabel>{title}</ControlLabel>
+                                <FormControl
+                                    type="text"
+                                    defaultValue={styleSettings[key]}
+                                    placeholder={placeholder}
+                                    onChange={event => onUpdate({...styleSettings, [key]: event.target.value})}/>
+                            </span>))}
+                        </FormGroup>
+                        {!validateAlphaNumeric(styleSettings) && <Alert style={{margin: 0}} bsStyle="danger">
+                            <HTML msgId="styleeditor.titleRequired"/>
+                        </Alert>}
+                    </Form>
+                </ResizableModal>
+            </Portal>
         </BorderLayout>
     );
 

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -9,6 +9,7 @@
 const React = require('react');
 const Toolbar = require('../misc/toolbar/Toolbar');
 const ResizableModal = require('../misc/ResizableModal');
+const Portal = require('../misc/Portal');
 const Message = require('../I18N/Message');
 const { Alert } = require('react-bootstrap');
 
@@ -151,14 +152,16 @@ const StyleToolbar = ({
                 },
                 ...(!!status ? [] : buttons)
             ]} />
-        <ResizableModal
-            show={showModal}
-            fitContent
-            title={showModal && showModal.title}
-            onClose={() => onShowModal(null)}
-            buttons={showModal && showModal.buttons}>
-            {showModal && showModal.message}
-        </ResizableModal>
+        <Portal>
+            <ResizableModal
+                show={showModal}
+                fitContent
+                title={showModal && showModal.title}
+                onClose={() => onShowModal(null)}
+                buttons={showModal && showModal.buttons}>
+                {showModal && showModal.message}
+            </ResizableModal>
+        </Portal>
     </div>
 );
 

--- a/web/client/components/styleeditor/__tests__/StyleTemplates-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleTemplates-test.jsx
@@ -108,4 +108,10 @@ describe('test StyleTemplates module component', () => {
         expect(cards.length).toBe(3);
         TestUtils.Simulate.click(cards[0]);
     });
+
+    it('test StyleTemplates modal uses portal', () => {
+        ReactDOM.render(<StyleTemplates add />, document.getElementById("container"));
+        const modalContainer = document.body.children[1].querySelector('.ms-resizable-modal');
+        expect(modalContainer).toExist();
+    });
 });

--- a/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
@@ -59,4 +59,9 @@ describe('test StyleToolbar module component', () => {
         expect(buttons.length).toBe(4);
     });
 
+    it('test StyleToolbar modal uses portal', () => {
+        ReactDOM.render(<StyleToolbar showModal />, document.getElementById("container"));
+        const modalContainer = document.body.children[1].querySelector('.ms-resizable-modal');
+        expect(modalContainer).toExist();
+    });
 });

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -170,7 +170,8 @@ const StyleList = compose(
                 position: 'relative'
             },
             maskStyle: {
-                overflowY: 'auto'
+                overflowY: 'auto',
+                left: 0
             }
         }
     )


### PR DESCRIPTION
## Description
Added a Portal to Modals of Style Editor to make them visible.

## Issues
 - Fix #3708

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Issue #3708

**What is the new behavior?**
with portal component the models are rendered as overlay on the whole page and they are visible

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
