### PR TITLE
Fix #3712 SLD styles version 1.1.0 are not saved correctly from Style Editor (2019.01.xx)

### DIFF
--- a/web/client/actions/__tests__/styleeditor-test.js
+++ b/web/client/actions/__tests__/styleeditor-test.js
@@ -51,12 +51,14 @@ describe('Test the styleeditor actions', () => {
         const code = '* { stroke: #333333; }';
         const format = 'css';
         const init = true;
+        const languageVersion = { version: '1.0.0' };
         const retval = updateTemporaryStyle({
             temporaryId,
             templateId,
             code,
             format,
-            init
+            init,
+            languageVersion
         });
         expect(retval).toExist();
         expect(retval.type).toBe(UPDATE_TEMPORARY_STYLE);
@@ -65,6 +67,7 @@ describe('Test the styleeditor actions', () => {
         expect(retval.code).toBe(code);
         expect(retval.format).toBe(format);
         expect(retval.init).toBe(init);
+        expect(retval.languageVersion).toEqual(languageVersion);
     });
     it('updateStatus', () => {
         const status = 'edit';
@@ -92,13 +95,15 @@ describe('Test the styleeditor actions', () => {
         const code = '* { stroke: #333333; }';
         const format = 'css';
         const init = true;
-        const retval = selectStyleTemplate({ code, templateId, format, init });
+        const languageVersion = { version: '1.0.0' };
+        const retval = selectStyleTemplate({ code, templateId, format, init, languageVersion });
         expect(retval).toExist();
         expect(retval.type).toBe(SELECT_STYLE_TEMPLATE);
         expect(retval.templateId).toBe(templateId);
         expect(retval.code).toBe(code);
         expect(retval.format).toBe(format);
         expect(retval.init).toBe(init);
+        expect(retval.languageVersion).toEqual(languageVersion);
     });
     it('createStyle', () => {
         const settings = { title: 'Title', _abstract: ''};

--- a/web/client/actions/styleeditor.js
+++ b/web/client/actions/styleeditor.js
@@ -55,13 +55,14 @@ function updateStatus(status) {
 * @param {object} styleProps { code, templateId, format, init } init set initialCode
 * @return {object} of type `SELECT_STYLE_TEMPLATE` styleProps
 */
-function selectStyleTemplate({ code, templateId, format, init } = {}) {
+function selectStyleTemplate({ code, templateId, format, languageVersion, init } = {}) {
     return {
         type: SELECT_STYLE_TEMPLATE,
         code,
         templateId,
         format,
-        init
+        init,
+        languageVersion
     };
 }
 /**
@@ -70,14 +71,15 @@ function selectStyleTemplate({ code, templateId, format, init } = {}) {
 * @param {object} styleProps { temporaryId, templateId, code, format, init } init set initialCode
 * @return {object} of type `UPDATE_TEMPORARY_STYLE` styleProps
 */
-function updateTemporaryStyle({ temporaryId, templateId, code, format, init } = {}) {
+function updateTemporaryStyle({ temporaryId, templateId, code, format, languageVersion, init } = {}) {
     return {
         type: UPDATE_TEMPORARY_STYLE,
         temporaryId,
         templateId,
         code,
         format,
-        init
+        init,
+        languageVersion
     };
 }
 /**

--- a/web/client/api/geoserver/__tests__/Styles-test.js
+++ b/web/client/api/geoserver/__tests__/Styles-test.js
@@ -6,8 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var expect = require('expect');
-var API = require('../Styles');
+import expect from 'expect';
+import API from '../Styles';
+import MockAdapter from 'axios-mock-adapter';
+import axios from '../../../libs/ajax';
+
+let mockAxios;
 
 describe('Test styles rest API', () => {
     it('save style', (done) => {
@@ -84,6 +88,89 @@ describe('Test styles rest API', () => {
                 name: 'test_style'
             });
             done();
+        });
+    });
+});
+
+describe('Test styles rest API, Content Type of SLD', () => {
+
+    beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+
+    it('test createStyle with sld version 1.1.0', (done) => {
+
+        mockAxios.onPost(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.se+xml');
+            expect(config.url).toBe('/geoserver/rest/styles.json');
+            done();
+            return [ 200, {}];
+        });
+
+        API.createStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.1.0' }
+        });
+    });
+
+    it('test createStyle with sld version 1.0.0', (done) => {
+
+        mockAxios.onPost(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.sld+xml');
+            expect(config.url).toBe('/geoserver/rest/styles.json');
+            done();
+            return [ 200, {}];
+        });
+
+        API.createStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.0.0' }
+        });
+    });
+
+    it('test updateStyle with sld version 1.1.0', (done) => {
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.se+xml');
+            expect(config.url).toBe('/geoserver/rest/styles/style_name');
+            done();
+            return [ 200, {}];
+        });
+
+        API.updateStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.1.0' }
+        });
+    });
+
+    it('test updateStyle with sld version 1.0.0', (done) => {
+        mockAxios.onPut(/\/styles/).reply((config) => {
+            expect(config.headers['Content-Type']).toBe('application/vnd.ogc.sld+xml');
+            expect(config.url).toBe('/geoserver/rest/styles/style_name');
+            done();
+            return [ 200, {}];
+        });
+
+        API.updateStyle({
+            baseUrl: '/geoserver/',
+            code: '<StyledLayerDescriptor></StyledLayerDescriptor>',
+            format: 'sld',
+            styleName: 'style_name',
+            languageVersion: { version: '1.0.0' }
         });
     });
 });

--- a/web/client/components/styleeditor/StyleList.jsx
+++ b/web/client/components/styleeditor/StyleList.jsx
@@ -9,7 +9,6 @@
 const React = require('react');
 
 const { Glyphicon: GlyphiconRB } = require('react-bootstrap');
-
 const BorderLayout = require('../layout/BorderLayout');
 const emptyState = require('../misc/enhancers/emptyState');
 const withLocal = require("../misc/enhancers/localizedProps");
@@ -26,6 +25,16 @@ const SideGrid = emptyState(
         glyph: '1-stilo'
     }
 )(require('../misc/cardgrids/SideGrid'));
+
+// get the text to use in the icon
+const getFormatText = (format) => {
+    const text = {
+        sld: 'SLD',
+        css: 'CSS',
+        mbstyle: 'MBS'
+    };
+    return text[format] || format || '';
+};
 
 /**
  * Component for rendering a grid of style templates.
@@ -83,7 +92,7 @@ const StyleList = ({
                                 backgroundColor="#333333"
                                 texts={[
                                     {
-                                        text: style.format.toUpperCase(),
+                                        text: getFormatText(style.format).toUpperCase(),
                                         fill: formatColors[style.format] || '#f2f2f2',
                                         style: {
                                             fontSize: 70,

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -51,7 +51,8 @@ const StyleToolbar = ({
     onSelectStyle = () => {},
     onEditStyle = () => {},
     onUpdate = () => {},
-    onSetDefault = () => {}
+    onSetDefault = () => {},
+    disableCodeEditing
 }) => (
     <div>
         <Toolbar
@@ -101,7 +102,7 @@ const StyleToolbar = ({
                     glyph: 'code',
                     tooltipId: 'styleeditor.editSelectedStyle',
                     visible: !status && editEnabled ? true : false,
-                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1,
+                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1 || disableCodeEditing,
                     onClick: () => onEditStyle()
                 },
                 {

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -51,7 +51,8 @@ const {
     canEditStyleSelector,
     getAllStyles,
     styleServiceSelector,
-    getUpdatedLayer
+    getUpdatedLayer,
+    selectedStyleFormatSelector
 } = require('../../selectors/styleeditor');
 
 const { getEditorMode, STYLE_OWNER_NAME, getStyleTemplates } = require('../../utils/StyleEditorUtils');
@@ -189,16 +190,20 @@ const StyleToolbar = compose(
                 loadingStyleSelector,
                 selectedStyleSelector,
                 canEditStyleSelector,
-                getAllStyles
+                getAllStyles,
+                styleServiceSelector,
+                selectedStyleFormatSelector
             ],
-            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }) => ({
+            (status, templateId, error, initialCode, code, loading, selectedStyle, canEdit, { defaultStyle }, { formats = [ 'sld' ] } = {}, format) => ({
                 status,
                 templateId,
                 error,
                 isCodeChanged: initialCode !== code,
                 loading,
                 selectedStyle: defaultStyle === selectedStyle ? '' : selectedStyle,
-                editEnabled: canEdit
+                editEnabled: canEdit,
+                // enable edit only if service support current format
+                disableCodeEditing: formats.indexOf(format) === -1
             })
         ),
         {

--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -47,14 +47,16 @@ describe('Test styleeditor reducer', () => {
         const code = '* { stroke: #ff0000; }';
         const format = 'css';
         const init = true;
-        const state = styleeditor({}, updateTemporaryStyle({ temporaryId, templateId, code, format, init }));
+        const languageVersion = { version: '1.0.0' };
+        const state = styleeditor({}, updateTemporaryStyle({ temporaryId, templateId, code, format, init, languageVersion }));
         expect(state).toEqual({
             temporaryId,
             templateId,
             code,
             format,
             error: null,
-            initialCode: code
+            initialCode: code,
+            languageVersion
         });
     });
     it('test updateStatus', () => {

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -41,6 +41,7 @@ function styleeditor(state = {}, action) {
                 code: action.code,
                 format: action.format,
                 error: null,
+                languageVersion: action.languageVersion,
                 initialCode: action.init ? action.code : state.initialCode
             };
         }

--- a/web/client/selectors/__tests__/styleeditor-test.js
+++ b/web/client/selectors/__tests__/styleeditor-test.js
@@ -14,6 +14,7 @@ const {
     errorStyleSelector,
     loadingStyleSelector,
     formatStyleSelector,
+    languageVersionStyleSelector,
     codeStyleSelector,
     initialCodeStyleSelector,
     selectedStyleSelector,
@@ -24,7 +25,8 @@ const {
     styleServiceSelector,
     canEditStyleSelector,
     getUpdatedLayer,
-    getAllStyles
+    getAllStyles,
+    selectedStyleFormatSelector
 } = require('../styleeditor');
 
 describe('Test styleeditor selector', () => {
@@ -103,6 +105,17 @@ describe('Test styleeditor selector', () => {
 
         expect(retval).toExist();
         expect(retval).toBe('css');
+    });
+    it('test languageVersionStyleSelector', () => {
+        const state = {
+            styleeditor: {
+                languageVersion: { version: '1.0.0' }
+            }
+        };
+        const retval = languageVersionStyleSelector(state);
+
+        expect(retval).toExist();
+        expect(retval).toEqual({ version: '1.0.0' });
     });
     it('test codeStyleSelector', () => {
         const state = {
@@ -431,5 +444,45 @@ describe('Test styleeditor selector', () => {
             defaultStyle: 'point',
             enabledStyle: 'square'
         });
+    });
+    it('test temporaryIdSelector', () => {
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        style: 'point',
+                        availableStyles: [
+                            {
+                                name: 'point',
+                                format: 'sld'
+                            },
+                            {
+                                name: 'generic',
+                                format: 'css'
+                            }
+                        ]
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ],
+                settings: {
+                    expanded: true,
+                    node: 'layerId',
+                    nodeType: 'layers',
+                    options: {
+                        opacity: 1,
+                        style: 'generic'
+                    }
+                }
+            }
+        };
+        const retval = selectedStyleFormatSelector(state);
+        expect(retval).toExist();
+        expect(retval).toBe('css');
+
     });
 });

--- a/web/client/selectors/styleeditor.js
+++ b/web/client/selectors/styleeditor.js
@@ -53,12 +53,19 @@ const errorStyleSelector = state => get(state, 'styleeditor.error') || {};
  */
 const loadingStyleSelector = state => get(state, 'styleeditor.loading');
 /**
- * selects current format of selected style from state
+ * selects current format of temporary style from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string}
  */
 const formatStyleSelector = state => get(state, 'styleeditor.format') || 'css';
+/**
+ * selects current langage version of temporary style from state
+ * @memberof selectors.styleeditor
+ * @param  {object} state the state
+ * @return {object}
+ */
+const languageVersionStyleSelector = state => get(state, 'styleeditor.languageVersion') || {};
 /**
  * selects code of style in editing from state
  * @memberof selectors.styleeditor
@@ -146,6 +153,17 @@ const selectedStyleSelector = state => {
     || updatedLayer.availableStyles && updatedLayer.availableStyles[0] && updatedLayer.availableStyles[0].name;
 };
 /**
+ * selects format of selected style from state
+ * @memberof selectors.styleeditor
+ * @param  {object} state the state
+ * @return {string}
+ */
+const selectedStyleFormatSelector = state => {
+    const { availableStyles = []} = getUpdatedLayer(state) || {};
+    const styleName = selectedStyleSelector(state);
+    return head(availableStyles.filter(({ name }) => name === styleName).map(({ format }) => format));
+};
+/**
  * selects all style values of selected layer (availableStyles, defaultStyle, enabledStyle) from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
@@ -177,6 +195,7 @@ module.exports = {
     errorStyleSelector,
     loadingStyleSelector,
     formatStyleSelector,
+    languageVersionStyleSelector,
     codeStyleSelector,
     initialCodeStyleSelector,
     selectedStyleSelector,
@@ -187,5 +206,6 @@ module.exports = {
     styleServiceSelector,
     canEditStyleSelector,
     getUpdatedLayer,
+    selectedStyleFormatSelector,
     getAllStyles
 };


### PR DESCRIPTION
## Description
This PR introduces following changes to verify version of SLD style is correctly updated in the editing phase.
changes:
- temporary style will be replaced when style editor switches format
- Style Editor sends every save POST request with param raw equal true to ensure correct  update of the version
- If SLD changes version, Style Editor sends POST/PUT requests for temporary style with raw equal to true
- disabled editing for unsupported format (currently it is not possible to edit style such as mbstyle or ysld)

ui with editing disabled
![2019-05-06 09_40_44-Window](https://user-images.githubusercontent.com/19175505/57212736-f3802900-6fe4-11e9-95b7-0cabef2db515.png)

## Issues
 - Fix #3712

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3712

**What is the new behavior?**
- temporary style will be replaced when style editor switches format
- Style Editor sends every save POST request with param raw equal true to ensure correct  update of the version
- If SLD changes version, Style Editor sends POST/PUT requests for temporary style with raw equal to true
- disabled editing for unsupported format

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
