### PR TITLE
Closes #3695 Wrong west coordinates in mouse position

### DIFF
--- a/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMS.jsx
+++ b/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMS.jsx
@@ -12,6 +12,7 @@ const Label = BootstrapReact.Label;
 const NumberFormat = require('../../I18N/Number');
 const {roundCoord} = require('../../../utils/CoordinatesUtils');
 
+
 class MousePositionLabelDMS extends React.Component {
     static propTypes = {
         position: PropTypes.shape({
@@ -25,10 +26,10 @@ class MousePositionLabelDMS extends React.Component {
         let [latM, lngM] = [lat % 1 * 60, lng % 1 * 60];
         let [latS, lngS] = [latM % 1 * 60, lngM % 1 * 60];
         return {
-            lat: Math.floor(lat),
+            lat: Math.trunc(lat),
             latM: Math.abs(latM),
             latS: Math.abs(latS),
-            lng: Math.floor(lng),
+            lng: Math.trunc(lng),
             lngM: Math.abs(lngM),
             lngS: Math.abs(lngS)
         };

--- a/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
+++ b/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
@@ -74,7 +74,7 @@ describe('MousePositionLabelDMS', () => {
         expect(cmpDom.textContent).toBe("Lat: 13° 31' 60.00'' Lng: 028° 18' 00.00''");
     });
 
-    it('position with no rounding but flooring of latD and lngD', () => {
+    it('position with no rounding but trunc of latD and lngD', () => {
 
         const cmp = ReactDOM.render(
                 <IntlProvider>
@@ -90,5 +90,22 @@ describe('MousePositionLabelDMS', () => {
 
         // it should be 010° 28' 30.05'' instead of 010° 29' 00''
         expect(cmpDom.textContent).toBe("Lat: 43° 42' 26.16'' Lng: 010° 28' 30.05''");
+    });
+
+    it('position with negative lat and lng correctly truncated ladD e lngD', () => {
+
+        const cmp = ReactDOM.render(
+                <IntlProvider>
+                    <MousePositionLabelDMS
+                        position={{lng: -0.006, lat: -0.006}}
+                    />
+                </IntlProvider>
+            , document.getElementById("container"));
+        expect(cmp).toExist();
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        // it should be 010° 28' 30.05'' instead of 010° 29' 00''
+        expect(cmpDom.textContent).toBe("Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''");
     });
 });


### PR DESCRIPTION
## Description
Fixed wrong coordinates in mouse position plugin

## Issues
 - Fix #3695 


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Mouse positions shows wrong coordinates when close to -0

**What is the new behavior?**
Coordinates are correct

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
