### PR TITLE
Fixes #3732: createPlugin helper function

### DIFF
--- a/web/client/plugins/BurgerMenu.jsx
+++ b/web/client/plugins/BurgerMenu.jsx
@@ -23,6 +23,8 @@ const Container = connect(() => ({
 const ToolsContainer = require('./containers/ToolsContainer');
 const Message = require('./locale/Message');
 
+const { createPlugin } = require('../utils/PluginsUtils');
+
 require('./burgermenu/burgermenu.css');
 
 class BurgerMenu extends React.Component {
@@ -97,16 +99,19 @@ class BurgerMenu extends React.Component {
     }
 }
 
-module.exports = {
-    BurgerMenuPlugin: assign(connect((state) => ({
-        controls: state.controls
-    }))(BurgerMenu), {
-        OmniBar: {
-            name: "burgermenu",
-            position: 2,
-            tool: true,
-            priority: 1
+module.exports = createPlugin(
+    'BurgerMenu',
+    {
+        component: connect((state) =>({
+            controls: state.controls
+        }))(BurgerMenu),
+        containers: {
+            OmniBar: {
+                name: "burgermenu",
+                position: 2,
+                tool: true,
+                priority: 1
+            }
         }
-    }),
-    reducers: {}
-};
+    }
+);

--- a/web/client/plugins/ShapeFile.jsx
+++ b/web/client/plugins/ShapeFile.jsx
@@ -16,25 +16,26 @@ const {zoomToExtent} = require('../actions/map');
 const {addLayer} = require('../actions/layers');
 const {toggleControl} = require('../actions/controls');
 
-const assign = require('object-assign');
 const {Glyphicon} = require('react-bootstrap');
 
-module.exports = {
-    ShapeFilePlugin: assign({loadPlugin: (resolve) => {
-        require.ensure(['./shapefile/ShapeFile'], () => {
-            const ShapeFile = require('./shapefile/ShapeFile');
+const {createPlugin} = require('../utils/PluginsUtils');
+const {Promise} = require('es6-promise');
 
-            const ShapeFilePlugin = connect((state) => (
-                {
-                    visible: state.controls && state.controls.shapefile && state.controls.shapefile.enabled,
-                    layers: state.shapefile && state.shapefile.layers || null,
-                    selected: state.shapefile && state.shapefile.selected || null,
-                    bbox: state.shapefile && state.shapefile.bbox || null,
-                    success: state.shapefile && state.shapefile.success || null,
-                    error: state.shapefile && state.shapefile.error || null,
-                    shapeStyle: state.style || {}
-                }
-            ), {
+const loader = () => new Promise((resolve) => {
+    require.ensure(['./shapefile/ShapeFile'], () => {
+        const ShapeFile = require('./shapefile/ShapeFile');
+
+        const ShapeFilePlugin = connect((state) => (
+            {
+                visible: state.controls && state.controls.shapefile && state.controls.shapefile.enabled,
+                layers: state.shapefile && state.shapefile.layers || null,
+                selected: state.shapefile && state.shapefile.selected || null,
+                bbox: state.shapefile && state.shapefile.bbox || null,
+                success: state.shapefile && state.shapefile.success || null,
+                error: state.shapefile && state.shapefile.error || null,
+                shapeStyle: state.style || {}
+            }
+        ), {
                 onShapeChoosen: onShapeChoosen,
                 onLayerAdded: onLayerAdded,
                 onSelectLayer: onSelectLayer,
@@ -47,34 +48,45 @@ module.exports = {
                 toggleControl: toggleControl.bind(null, 'shapefile', null)
             })(ShapeFile);
 
-            resolve(ShapeFilePlugin);
-        });
-    }, enabler: (state) => state.shapefile && state.shapefile.enabled || state.toolbar && state.toolbar.active === 'shapefile'}, {
-        disablePluginIf: "{state('mapType') === 'cesium'}",
-        Toolbar: {
-            name: 'shapefile',
-            position: 9,
-            panel: true,
-            help: <Message msgId="helptexts.shapefile"/>,
-            title: "shapefile.title",
-            tooltip: "shapefile.tooltip",
-            wrap: false,
-            icon: <Glyphicon glyph="open-file"/>,
-            exclusive: true,
-            priority: 1
+        resolve(ShapeFilePlugin);
+    });
+});
+
+module.exports = createPlugin(
+    'ShapeFile',
+    {
+        lazy: true,
+        enabler: (state) => state.shapefile && state.shapefile.enabled || state.toolbar && state.toolbar.active === 'shapefile',
+        loader,
+        options: {
+            disablePluginIf: "{state('mapType') === 'cesium'}"
         },
-        BurgerMenu: {
-            name: 'shapefile',
-            position: 4,
-            text: <Message msgId="shapefile.title"/>,
-            icon: <Glyphicon glyph="upload"/>,
-            action: toggleControl.bind(null, 'shapefile', null),
-            priority: 2,
-            doNotHide: true
+        containers: {
+            Toolbar: {
+                name: 'shapefile',
+                position: 9,
+                panel: true,
+                help: <Message msgId="helptexts.shapefile" />,
+                title: "shapefile.title",
+                tooltip: "shapefile.tooltip",
+                wrap: false,
+                icon: <Glyphicon glyph="open-file" />,
+                exclusive: true,
+                priority: 1
+            },
+            BurgerMenu: {
+                name: 'shapefile',
+                position: 4,
+                text: <Message msgId="shapefile.title" />,
+                icon: <Glyphicon glyph="upload" />,
+                action: toggleControl.bind(null, 'shapefile', null),
+                priority: 2,
+                doNotHide: true
+            }
+        },
+        reducers: {
+            shapefile: require('../reducers/shapefile'),
+            style: require('../reducers/style')
         }
-    }),
-    reducers: {
-        shapefile: require('../reducers/shapefile'),
-        style: require('../reducers/style')
     }
-};
+);

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -251,8 +251,6 @@ const getPluginImplementation = (impl, stateSelector) => {
     return impl.loadPlugin || impl.displayName || impl.prototype.isReactComponent ? impl : impl(stateSelector);
 };
 
-
-
 /**
  * Utilities to manage plugins
  * @memberof utils

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -14,6 +14,7 @@ const {connect} = require('react-redux');
 const url = require('url');
 const defaultMonitoredState = [{name: "mapType", path: 'maptype.mapType'}, {name: "user", path: 'security.user'}];
 const {combineEpics} = require('redux-observable');
+
 /**
  * Gives a reduced version of the status to check.
  * It cached the last state to prevent re-evaluations if the input didn't change.
@@ -40,6 +41,8 @@ const filterState = memoize((state, monitor) => {
 });
 
 const getPluginSimpleName = plugin => endsWith(plugin, 'Plugin') && plugin.substring(0, plugin.length - 6) || plugin;
+
+const normalizeName = name => endsWith(name, 'Plugin') && name || (name + "Plugin");
 
 const getPluginConfiguration = (cfg, plugin) => {
     const pluginName = getPluginSimpleName(plugin);
@@ -247,6 +250,9 @@ const defaultEpicWrapper = epic => (...args) =>
 const getPluginImplementation = (impl, stateSelector) => {
     return impl.loadPlugin || impl.displayName || impl.prototype.isReactComponent ? impl : impl(stateSelector);
 };
+
+
+
 /**
  * Utilities to manage plugins
  * @memberof utils
@@ -380,6 +386,36 @@ const PluginsUtils = {
      */
     connect: (mapStateToProps, mapDispatchToProps, mergeProps, options) => {
         return connect(mapStateToProps, mapDispatchToProps, mergeProps || pluginsMergeProps, options);
+    },
+    /**
+     * Use this function to export a plugin from a module.
+     *
+     * @param {string} name name of the plugin (without the Plugin postfix)
+     * @param {object} config configuration object, with the following (optional) properties:
+     *  * component: ReactJS component that implements the plugin functionalities, can be null if the plugin supports lazy loading
+     *  * options: generic plugins configuration options (e.g. disablePluginIf)
+     *  * containers: object with supported containers (key=container name, value=container config)
+     *  * reducers: reducers the plugin will need
+     *  * epics: epics the plugin will need to work
+     *  * lazy: true if the plugin implements on-demand loading,
+     *  * enabler: function used in lazy mode to decide when plugin needs to be loaded (receives redux state as the only param)
+     *  * loader: promise that will return the loaded implementation
+     */
+    createPlugin: (name, { component, options = {}, containers = {}, reducers = {}, epics = {}, lazy = false, enabler = () => true, loader}) => {
+        const pluginName = normalizeName(name);
+        const pluginImpl = lazy ? {
+            loadPlugin: (resolve) => {
+                loader().then(loadedImpl => {
+                    resolve(loadedImpl);
+                });
+            },
+            enabler
+        } : component;
+        return {
+            [pluginName]: assign(pluginImpl, containers, options),
+            reducers,
+            epics
+        };
     },
     handleExpression,
     getMorePrioritizedContainer,

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -391,14 +391,52 @@ const PluginsUtils = {
      *
      * @param {string} name name of the plugin (without the Plugin postfix)
      * @param {object} config configuration object, with the following (optional) properties:
-     *  * component: ReactJS component that implements the plugin functionalities, can be null if the plugin supports lazy loading
-     *  * options: generic plugins configuration options (e.g. disablePluginIf)
-     *  * containers: object with supported containers (key=container name, value=container config)
-     *  * reducers: reducers the plugin will need
-     *  * epics: epics the plugin will need to work
-     *  * lazy: true if the plugin implements on-demand loading,
-     *  * enabler: function used in lazy mode to decide when plugin needs to be loaded (receives redux state as the only param)
-     *  * loader: promise that will return the loaded implementation
+     * @param {object|function} config.component: ReactJS component that implements the plugin functionalities, can be null if the plugin supports lazy loading
+     * @param {object} config.options: generic plugins configuration options (e.g. disablePluginIf)
+     * @param {object} config.containers: object with supported containers (key=container name, value=container config)
+     * @param {object} config.reducers: reducers the plugin will need
+     * @param {object} config.epics: epics the plugin will need to work
+     * @param {boolean} config.lazy: true if the plugin implements on-demand loading,
+     * @param {function} config.enabler: function used in lazy mode to decide when plugin needs to be loaded (receives redux state as the only param)
+     * @param {promise} config.loader: promise that will return the loaded implementation
+     * 
+     * @example statically loaded plugin
+     * createPlugin('My', {
+     *  component: MyPluginComponent,
+     *  options: {...},
+     *  containers: {
+     *      Toolbar: {
+     *          priority: 1,
+     *          tool: true,
+     *          ...
+     *      }
+     *  },
+     *  reducers: {my: require('...')},
+     *  epics: {myEpic: require('...')}
+     * });
+     * 
+     * @example lazy loaded plugin
+     * createPlugin('My', {
+     *  enabler: (state) => state.my.enabled || false,
+     *  loader: () => new Promise((resolve) => {
+     *    require.ensure(['...'], () => {
+     *        const MyComponent = require('...');
+     *        ...
+     *        const MyPlugin = connect(...)(MyComponent);
+     *        resolve(MyPlugin);
+     *    });
+     *  },
+     *  options: {...},
+     *  containers: {
+     *      Toolbar: {
+     *          priority: 1,
+     *          tool: true,
+     *          ...
+     *      }
+     *  },
+     *  reducers: {my: require('...')},
+     *  epics: {myEpic: require('...')}
+     * });
      */
     createPlugin: (name, { component, options = {}, containers = {}, reducers = {}, epics = {}, lazy = false, enabler = () => true, loader}) => {
         const pluginName = normalizeName(name);

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -246,9 +246,10 @@ const defaultEpicWrapper = epic => (...args) =>
       return source;
   });
 
+const isMapStorePlugin = (impl) => impl.loadPlugin || impl.displayName || impl.prototype.isReactComponent || impl.isMapStorePlugin;
 
 const getPluginImplementation = (impl, stateSelector) => {
-    return impl.loadPlugin || impl.displayName || impl.prototype.isReactComponent ? impl : impl(stateSelector);
+    return isMapStorePlugin(impl) ? impl : impl(stateSelector);
 };
 
 /**
@@ -404,11 +405,11 @@ const PluginsUtils = {
         const pluginImpl = lazy ? {
             loadPlugin: (resolve) => {
                 loader().then(loadedImpl => {
-                    resolve(loadedImpl);
+                    resolve(assign(loadedImpl, { isMapStorePlugin: true }));
                 });
             },
             enabler
-        } : component;
+        } : assign(component, {isMapStorePlugin: true});
         return {
             [pluginName]: assign(pluginImpl, containers, options),
             reducers,
@@ -417,6 +418,7 @@ const PluginsUtils = {
     },
     handleExpression,
     getMorePrioritizedContainer,
-    getPluginConfiguration
+    getPluginConfiguration,
+    isMapStorePlugin
 };
 module.exports = PluginsUtils;

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -399,7 +399,7 @@ const PluginsUtils = {
      * @param {boolean} config.lazy: true if the plugin implements on-demand loading,
      * @param {function} config.enabler: function used in lazy mode to decide when plugin needs to be loaded (receives redux state as the only param)
      * @param {promise} config.loader: promise that will return the loaded implementation
-     * 
+     *
      * @example statically loaded plugin
      * createPlugin('My', {
      *  component: MyPluginComponent,
@@ -414,7 +414,7 @@ const PluginsUtils = {
      *  reducers: {my: require('...')},
      *  epics: {myEpic: require('...')}
      * });
-     * 
+     *
      * @example lazy loaded plugin
      * createPlugin('My', {
      *  enabler: (state) => state.my.enabled || false,

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -97,7 +97,19 @@ describe('PluginsUtils', () => {
         expect(desc1.items.length).toBe(1);
         expect(desc1.items[0].test).toBe(item.test);
         expect(desc1.items[0].cfg).toExist();
-
+    });
+    it('getPluginDescriptor functional component', () => {
+        const Component = () => {
+            return <div>hello</div>;
+        };
+        const P1 = PluginsUtils.createPlugin('P1', {
+            component: Component
+        });
+        const desc1 = PluginsUtils.getPluginDescriptor({}, P1, ["P1"], "P1");
+        expect(desc1).toExist();
+        expect(desc1.id).toBe("P1");
+        expect(desc1.name).toBe("P1");
+        expect(desc1.impl).toBe(Component);
     });
     it('combineEpics', () => {
         const plugins = {MapSearchPlugin: MapSearchPlugin};
@@ -369,6 +381,7 @@ describe('PluginsUtils', () => {
             options: {myoption: {}}
         });
         expect(plugin.MyPlugin).toExist();
+        expect(plugin.MyPlugin.isMapStorePlugin).toBe(true);
         expect(plugin.MyPlugin.myprop).toExist();
         expect(plugin.MyPlugin.Container).toExist();
         expect(plugin.MyPlugin.myoption).toExist();
@@ -381,7 +394,9 @@ describe('PluginsUtils', () => {
             lazy: true,
             enabler: (state) => state.my.enabled,
             loader: () => new Promise((resolve) => {
-                resolve(true);
+                resolve({
+                    myproperty: true
+                });
             }),
             containers: {
                 Container: {}
@@ -403,7 +418,9 @@ describe('PluginsUtils', () => {
             }
         })).toBe(true);
         plugin.MyPlugin.loadPlugin(resp => {
-            expect(resp).toBe(true);
+            expect(resp).toExist();
+            expect(resp.myproperty).toBe(true);
+            expect(resp.isMapStorePlugin).toBe(true);
             done();
         });
     });

--- a/web/client/utils/__tests__/PluginUtils-test.js
+++ b/web/client/utils/__tests__/PluginUtils-test.js
@@ -355,4 +355,56 @@ describe('PluginsUtils', () => {
         expect(expr).toExist();
         expect(expr()).toBe("test");
     });
+
+    it('createPlugin', () => {
+        const plugin = PluginsUtils.createPlugin('My', {
+            component: {
+                myprop: {}
+            },
+            containers: {
+                Container: {}
+            },
+            reducers: {myreducer: {}},
+            epics: {myepic: {}},
+            options: {myoption: {}}
+        });
+        expect(plugin.MyPlugin).toExist();
+        expect(plugin.MyPlugin.myprop).toExist();
+        expect(plugin.MyPlugin.Container).toExist();
+        expect(plugin.MyPlugin.myoption).toExist();
+        expect(plugin.reducers).toExist();
+        expect(plugin.epics).toExist();
+    });
+
+    it('createPlugin lazy', (done) => {
+        const plugin = PluginsUtils.createPlugin('My', {
+            lazy: true,
+            enabler: (state) => state.my.enabled,
+            loader: () => new Promise((resolve) => {
+                resolve(true);
+            }),
+            containers: {
+                Container: {}
+            },
+            reducers: { myreducer: {} },
+            epics: { myepic: {} },
+            options: { myoption: {} }
+        });
+        expect(plugin.MyPlugin).toExist();
+        expect(plugin.MyPlugin.Container).toExist();
+        expect(plugin.MyPlugin.myoption).toExist();
+        expect(plugin.MyPlugin.enabler).toExist();
+        expect(plugin.MyPlugin.loadPlugin).toExist();
+        expect(plugin.reducers).toExist();
+        expect(plugin.epics).toExist();
+        expect(plugin.MyPlugin.enabler({
+            my: {
+                enabled: true
+            }
+        })).toBe(true);
+        plugin.MyPlugin.loadPlugin(resp => {
+            expect(resp).toBe(true);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
## Description
Helper function to ease creating new plugins.

## Issues
 - Fix #3732

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
To create a plugin you need to export a JS object, a descriptor of the plugin

**What is the new behavior?**
The old way of exporting plugins still works, the new helper makes the process more easy and readable.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
