### PR TITLE
Closes #3393 Featured maps are not updated on user log(in/out)

### DIFF
--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -80,6 +80,7 @@ const featuredMapsPluginSelector = createSelector([
     resourceSelector
 ], (mapType, role, isMobile, searchText, resource) => ({
     mapType,
+    role,
     permission: role === 'ADMIN',
     pagination: isMobile ? 'virtual-scroll-horizontal' : 'show-more',
     searchText,
@@ -95,6 +96,7 @@ const updateFeaturedMapsStream = mapPropsStream(props$ =>
                 isEqual(previous.resource, next.resource)
                 && previous.searchText === next.searchText
                 && previous.permission === next.permission
+                && previous.role === next.role
             )
             .do(({permission: newPermission, viewSize: newViewSize, searchText: newSearchText, pageSize: newPageSize} = {}) =>
                 loadFirst({permission: newPermission, viewSize: newViewSize, searchText: newSearchText, pageSize: newPageSize})


### PR DESCRIPTION
## Description
Featured maps are not updated on user log(in/out)
## Issues
 - Fix #3393 
 - ...

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
In home featured maps aren't updated on normal user (not admin) log(in/out)

**What is the new behavior?**
In home featured maps are updated on user  log(in/out)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
