### PR TITLE
Fix #3738 Add the possibility to customize default regex for GeoServer

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -11,7 +11,7 @@ const toBbox = require('turf-bbox');
 const uuidv1 = require('uuid/v1');
 const { isString, isObject, isArray, head, castArray, isEmpty, findIndex, pick, isNil} = require('lodash');
 
-let REG_GEOSERVER_RULE = /\/[\w- ]*geoserver[\w- ]*\//;
+let regGeoServerRule = /\/[\w- ]*geoserver[\w- ]*\//;
 
 const getGroup = (groupId, groups) => {
     return head(groups.filter((subGroup) => isObject(subGroup) && subGroup.id === groupId));
@@ -485,20 +485,21 @@ const LayersUtils = {
         layer.credits ? { credits: layer.credits } : {});
     },
     /**
-    * default constant regex rule for searching for a /geoserver/ string in a url
+    * default initial constant regex rule for searching for a /geoserver/ string in a url
+    * useful for a reset to an initial state of the rule
     */
-    REG_GEOSERVER_RULE,
+    REG_GEOSERVER_RULE: regGeoServerRule,
     /**
      * Override default REG_GEOSERVER_RULE variable
      * @param {regex} regex custom regex to override
      */
     setRegGeoserverRule: (regex) => {
-        REG_GEOSERVER_RULE = regex;
+        regGeoServerRule = regex;
     },
     /**
      * Get REG_GEOSERVER_RULE regex variable
      */
-    getRegGeoserverRule: () => REG_GEOSERVER_RULE,
+    getRegGeoserverRule: () => regGeoServerRule,
     /**
     * it tests if a url is matched by a regex,
     * if so it returns the matched string

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -966,4 +966,19 @@ describe('LayersUtils', () => {
         layers.map(([layer, test]) => test(LayersUtils.saveLayer(layer)) );
     });
 
+    it('findGeoServerName with a positive match and using custom regex (setRegGeoserverRule)', () => {
+        const customRegex = /\/[\w- ]*gs[\w- ]*\//;
+        LayersUtils.setRegGeoserverRule(customRegex);
+
+        const matchedGeoServerName = LayersUtils.findGeoServerName({url: "http:/hostname/gs/ows"});
+        expect(matchedGeoServerName).toBe("/gs/");
+
+        // reset regex
+        LayersUtils.setRegGeoserverRule(LayersUtils.REG_GEOSERVER_RULE);
+    });
+
+    it('getRegGeoserverRule test default value', () => {
+        expect(LayersUtils.getRegGeoserverRule()).toBe(LayersUtils.REG_GEOSERVER_RULE);
+    });
+
 });


### PR DESCRIPTION
## Description
This PR introduces the possibility to override the REG_GEOSERVER_RULE in LayersUtils.

## Issues
 - Fix #3738

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
#3738

**What is the new behavior?**
It's possible to override the variable REG_GEOSERVER_RULE in LayersUtils via setRegGeoserverRule function

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
