### PR TITLE
Close #3695 Wrong west south coordinates

### DIFF
--- a/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMS.jsx
+++ b/web/client/components/mapcontrols/mouseposition/MousePositionLabelDMS.jsx
@@ -36,19 +36,22 @@ class MousePositionLabelDMS extends React.Component {
     };
 
     render() {
+        const {lng, lat} = this.props.position || {};
         let pos = this.getPositionValues(this.props.position);
+        let lgnSign = lng < 0 ? "-" : "";
+        let latSign = lat < 0 ? "-" : "";
         let integerFormat = {style: "decimal", minimumIntegerDigits: 2, maximumFractionDigits: 0};
         let decimalFormat = {style: "decimal", minimumIntegerDigits: 2, maximumFractionDigits: 2, minimumFractionDigits: 2};
         let lngDFormat = {style: "decimal", minimumIntegerDigits: 3, maximumFractionDigits: 0};
         return (
                 <h5>
                 <Label bsSize="lg" bsStyle="info">
-                    <span>Lat: </span><NumberFormat key="latD" numberParams={integerFormat} value={roundCoord({roundingBehaviour: "floor", value: pos.lat, maximumFractionDigits: integerFormat.maximumFractionDigits})} />
+                    <span>Lat: {latSign}</span><NumberFormat key="latD" numberParams={integerFormat} value={Math.abs(pos.lat)} />
                     <span>° </span><NumberFormat key="latM" numberParams={integerFormat} value={roundCoord({roundingBehaviour: "floor", value: pos.latM, maximumFractionDigits: integerFormat.maximumFractionDigits})} />
                     <span>&apos; </span><NumberFormat key="latS" numberParams={decimalFormat} value={pos.latS}/>
                     <span>&apos;&apos;</span>
                     <span className="mouseposition-separator"/>
-                    <span> Lng: </span><NumberFormat key="lngD" numberParams={lngDFormat} value={roundCoord({roundingBehaviour: "floor", value: pos.lng, maximumFractionDigits: lngDFormat.maximumFractionDigits})} />
+                    <span> Lng: {lgnSign}</span><NumberFormat key="lngD" numberParams={lngDFormat} value={Math.abs(pos.lng)} />
                     <span>° </span><NumberFormat key="lngM" numberParams={integerFormat} value={roundCoord({roundingBehaviour: "floor", value: pos.lngM, maximumFractionDigits: integerFormat.maximumFractionDigits})} />
                     <span>&apos; </span><NumberFormat key="lngS" numberParams={decimalFormat} value={pos.lngS}/><span>''</span>
                 </Label>

--- a/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
+++ b/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
@@ -25,7 +25,6 @@ describe('MousePositionLabelDMS', () => {
     });
 
     it('checks default', () => {
-
         const cmp = ReactDOM.render(
                 <MousePositionLabelDMS/>
             , document.getElementById("container"));
@@ -70,7 +69,6 @@ describe('MousePositionLabelDMS', () => {
 
         const cmpDom = ReactDOM.findDOMNode(cmp);
         expect(cmpDom).toExist();
-
         expect(cmpDom.textContent).toBe("Lat: 13° 31' 60.00'' Lng: 028° 18' 00.00''");
     });
 
@@ -104,8 +102,7 @@ describe('MousePositionLabelDMS', () => {
         expect(cmp).toExist();
         const cmpDom = ReactDOM.findDOMNode(cmp);
         expect(cmpDom).toExist();
-
-        // it should be 010° 28' 30.05'' instead of 010° 29' 00''
+        // it should be Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''
         expect(cmpDom.textContent).toBe("Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''");
     });
 });

--- a/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
+++ b/web/client/components/mapcontrols/mouseposition/__tests__/MousePositionLabelDMS-test.js
@@ -102,7 +102,36 @@ describe('MousePositionLabelDMS', () => {
         expect(cmp).toExist();
         const cmpDom = ReactDOM.findDOMNode(cmp);
         expect(cmpDom).toExist();
-        // it should be Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''
+        // it should be Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60'' instead of Lat: -01° 00' 21.60'' Lng: -001° 00' 21.60''
         expect(cmpDom.textContent).toBe("Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''");
+    });
+    it('test sign changes when crossing greenwich meridian and equator parallel and latD lngD are 0', () => {
+        const cmp = ReactDOM.render(
+                <IntlProvider>
+                    <MousePositionLabelDMS
+                        position={{lng: -0.006, lat: -0.006}}
+                    />
+                </IntlProvider>
+            , document.getElementById("container"));
+        expect(cmp).toExist();
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+       // it should be Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''
+        expect(cmpDom.textContent).toBe("Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''");
+
+        const cmpPositive = ReactDOM.render(
+            <IntlProvider>
+                <MousePositionLabelDMS
+                    position={{lng: 0.006, lat: 0.006}}
+                />
+            </IntlProvider>
+        , document.getElementById("container"));
+        expect(cmpPositive).toExist();
+        const cmpDomPositive = ReactDOM.findDOMNode(cmpPositive);
+        expect(cmpDomPositive).toExist();
+
+        // it should be Lat: 00° 00' 21.60'' Lng: 000° 00' 21.60'' instead of Lat: -00° 00' 21.60'' Lng: -000° 00' 21.60''
+        expect(cmpDomPositive.textContent).toBe("Lat: 00° 00' 21.60'' Lng: 000° 00' 21.60''");
     });
 });


### PR DESCRIPTION
## Description
Intl number formatter has problem with -0 and 0, when passing from positive to negative or reverse it keeps the sign until the rounded value reaches 1 or -1.
The sign is now managed outside the number formatter.
## Issues
 - Fix #3695
 - ...

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
See description

**What is the new behavior?**
Fixed the problem described above

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
