### PR TITLE
Fix #3083 - When adding a new group/user is not clear which section is opened

### DIFF
--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -75,6 +75,11 @@ class GroupDialog extends React.Component {
         }
     };
 
+    state = {
+        key: 1
+    };
+    // Only to keep the selected button, not for the modal window
+
     getCurrentGroupMembers = () => {
         return this.props.group && (this.props.group.newUsers || this.props.group.users) || [];
     };
@@ -210,13 +215,13 @@ class GroupDialog extends React.Component {
                 <span className="user-panel-title">{(this.props.group && this.props.group.groupName) || <Message msgId="usergroups.newGroup" />}</span>
             </span>
             <div role="body">
-            <Tabs defaultActiveKey={1} key="tab-panel">
-                <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="1-group"/></Button>} >
+            <Tabs defaultActiveKey={1} onSelect={ ( key) => { this.setState({key}); }} key="tab-panel">
+                <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 1 ? "success" : "primary"}><Glyphicon glyph="1-group"/></Button>} >
                     {this.renderGeneral()}
                     {this.checkNameLenght()}
                     {this.checkDescLenght()}
                 </Tab>
-                <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="1-group-add"/></Button>} >
+                <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 2 ? "success" : "primary"}><Glyphicon glyph="1-group-add"/></Button>} >
                     {this.renderMembersTab()}
                 </Tab>
             </Tabs>

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -80,6 +80,11 @@ class UserDialog extends React.Component {
         hidePasswordFields: false
     };
 
+    state = {
+        key: 1
+    };
+    // Only to keep the selected button, not for the modal window
+
     getAttributeValue = (name) => {
         let attrs = this.props.user && this.props.user.attribute;
         if (attrs) {
@@ -217,14 +222,14 @@ class UserDialog extends React.Component {
               </button>
           </span>
           <div role="body">
-          <Tabs defaultActiveKey={1} key="tab-panel" id="userDetails-tabs">
-              <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="user"/></Button>} >
+          <Tabs defaultActiveKey={1} onSelect={ ( key) => { this.setState({key}); }} key="tab-panel" id="userDetails-tabs">
+              <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 1 ? "success" : "primary"}><Glyphicon glyph="user"/></Button>} >
                   {this.renderGeneral()}
               </Tab>
-              <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="info-sign"/></Button>} >
+              <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 2 ? "success" : "primary"}><Glyphicon glyph="info-sign"/></Button>} >
                   {this.renderAttributes()}
               </Tab>
-              <Tab eventKey={3} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle="primary"><Glyphicon glyph="1-group"/></Button>} >
+              <Tab eventKey={3} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 3 ? "success" : "primary"}><Glyphicon glyph="1-group"/></Button>} >
                   {this.renderGroups()}
               </Tab>
           </Tabs>

--- a/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
@@ -82,7 +82,6 @@ describe("Test GroupDialog Component", () => {
             document.getElementById("container"));
 
         expect(comp).toExist();
-        // let domnode = ReactDOM.findDOMNode(comp);
         let buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, "button");
         expect(buttons[1].className).toBe("square-button btn btn-lg btn-success");
         let groupGroupButton = buttons[2];

--- a/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
@@ -9,6 +9,7 @@ const React = require("react");
 const expect = require('expect');
 const ReactDOM = require('react-dom');
 const GroupDialog = require('../GroupDialog');
+const ReactTestUtils = require('react-dom/test-utils');
 const user1 = {
     id: 100,
     name: "USER2",
@@ -37,7 +38,7 @@ const group1 = {
     users: [user1, user2]
 };
 const users = [ user1, user2 ];
-describe("Test UserDialog Component", () => {
+describe("Test GroupDialog Component", () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -74,5 +75,19 @@ describe("Test UserDialog Component", () => {
         let comp = ReactDOM.render(
             <GroupDialog show group={{...group1, newUsers: [user1]}} availableUsers={users}/>, document.getElementById("container"));
         expect(comp).toExist();
+    });
+    it('Testing selected group-dialog-tab is highlighted', () => {
+        let comp = ReactDOM.render(
+            <GroupDialog group={group1} />,
+            document.getElementById("container"));
+
+        expect(comp).toExist();
+        // let domnode = ReactDOM.findDOMNode(comp);
+        let buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, "button");
+        expect(buttons[1].className).toBe("square-button btn btn-lg btn-success");
+        let groupGroupButton = buttons[2];
+        ReactTestUtils.Simulate.click(groupGroupButton);
+        expect(groupGroupButton.className).toBe("square-button btn btn-lg btn-success");
+        expect(buttons[2].className).toBe("square-button btn btn-lg btn-success");
     });
 });

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -183,7 +183,7 @@ describe("Test UserDialog Component", () => {
             }} />, document.getElementById("container"));
         expect(comp).toExist();
         let domnode = ReactDOM.findDOMNode(comp);
-        expect(domnode.getElementsByClassName("btn-primary")[3].disabled).toBe(true);
+        expect(domnode.getElementsByClassName("btn-primary")[2].disabled).toBe(true);
         expect(domnode.getElementsByClassName("spinner").length).toNotBe(0);
     });
     it('displays the success style', () => {
@@ -197,7 +197,7 @@ describe("Test UserDialog Component", () => {
             }} />, document.getElementById("container"));
         expect(comp).toExist();
         let domnode = ReactDOM.findDOMNode(comp);
-        expect(domnode.getElementsByClassName("btn-success").length).toBe(1);
+        expect(domnode.getElementsByClassName("btn-success").length).toBe(2);
     });
     it('Testing selected user-dialog-tab is highlighted', () => {
         let comp = ReactDOM.render(

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -9,6 +9,7 @@ const React = require("react");
 const expect = require('expect');
 const ReactDOM = require('react-dom');
 const UserDialog = require('../UserDialog');
+const ReactTestUtils = require('react-dom/test-utils');
 const enabledUser = {
     id: 1,
     name: "USER1",
@@ -197,5 +198,24 @@ describe("Test UserDialog Component", () => {
         expect(comp).toExist();
         let domnode = ReactDOM.findDOMNode(comp);
         expect(domnode.getElementsByClassName("btn-success").length).toBe(1);
+    });
+    it('Testing selected user-dialog-tab is highlighted', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={{
+                id: 1,
+                name: "USER1",
+                role: "USER",
+                enabled: true,
+                status: "saved"
+            }} />, document.getElementById("container"));
+
+        expect(comp).toExist();
+        // let domnode = ReactDOM.findDOMNode(comp);
+        let buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, "button");
+        expect(buttons[1].className).toBe("square-button btn btn-lg btn-success");
+        let userGroupButton = buttons[3];
+        ReactTestUtils.Simulate.click(userGroupButton);
+        expect(userGroupButton.className).toBe("square-button btn btn-lg btn-success");
+        expect(buttons[3].className).toBe("square-button btn btn-lg btn-success");
     });
 });

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -210,7 +210,6 @@ describe("Test UserDialog Component", () => {
             }} />, document.getElementById("container"));
 
         expect(comp).toExist();
-        // let domnode = ReactDOM.findDOMNode(comp);
         let buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, "button");
         expect(buttons[1].className).toBe("square-button btn btn-lg btn-success");
         let userGroupButton = buttons[3];


### PR DESCRIPTION
## Description
Changing the buttons color when selected in tabs to create a new user or a new group

## Issues
 - #3083

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see https://github.com/geosolutions-it/MapStore2/issues/3083

**What is the new behavior?**
Buttons becomes green when selected

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
