### PR TITLE
Close #3385 Close missing save button after login

### DIFF
--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -192,7 +192,7 @@ const checkMapPermissions = (action$, {getState = () => {} }) =>
         action$.ofType(LOGIN_SUCCESS)
         .map(() => {
             const mapId = mapIdSelector(getState());
-            return loadMapInfo(ConfigUtils.getConfigProp("geoStoreUrl") + "extjs/resource/" + mapId, `${mapId}`);
+            return loadMapInfo(ConfigUtils.getConfigProp("geoStoreUrl") + "extjs/resource/" + mapId, mapId);
         });
 
 module.exports = {

--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -192,7 +192,7 @@ const checkMapPermissions = (action$, {getState = () => {} }) =>
         action$.ofType(LOGIN_SUCCESS)
         .map(() => {
             const mapId = mapIdSelector(getState());
-            return loadMapInfo(ConfigUtils.getConfigProp("geoStoreUrl") + "extjs/resource/" + mapId, mapId);
+            return loadMapInfo(ConfigUtils.getConfigProp("geoStoreUrl") + "extjs/resource/" + mapId, `${mapId}`);
         });
 
 module.exports = {

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -115,4 +115,17 @@ describe('Test the mapConfig reducer', () => {
         });
         expect(mapConfig({}, {type: MAP_CREATED, resourceId: 2})).toEqual({});
     });
+    it('test MAP_INFO_LOADED accepts string or numeric mapId', () => {
+        var state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', mapId: "1", config: { version: 2, map: {center: {x: 1, y: 1}, zoom: 11, layers: [] }}});
+        state = mapConfig(state, {type: "MAP_INFO_LOADED", mapId: 1, info: {canEdit: true, canDelete: true}});
+        expect(state.map).toExist();
+        expect(state.map.info).toExist();
+        expect(state.map.info.canEdit).toBe(true);
+        state = {};
+        state = mapConfig({}, {type: 'MAP_CONFIG_LOADED', mapId: 1, config: { version: 2, map: {center: {x: 1, y: 1}, zoom: 11, layers: [] }}});
+        state = mapConfig(state, {type: "MAP_INFO_LOADED", mapId: "1", info: {canEdit: true, canDelete: true}});
+        expect(state.map).toExist();
+        expect(state.map.info).toExist();
+        expect(state.map.info.canEdit).toBe(true);
+    });
 });

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -54,7 +54,7 @@ function mapConfig(state = null, action) {
     }
     case MAP_INFO_LOADED:
         map = state && state.map && state.map.present ? state.map.present : state && state.map;
-        if (map && map.mapId === action.mapId) {
+        if (map && `${map.mapId}` === `${action.mapId}`) {
             map = assign({}, map, {info: action.info});
             return assign({}, state, {map: map});
         }


### PR DESCRIPTION


## Description
Fixed mapId type when calling loadMapInfo action, it needed to be a string now accepts number or string
## Issues
 - Fix #3385
 - ...

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Map permissions are requested but on MAP_INFO_LOADED the state isn't updated

**What is the new behavior?**
Map permissions are requested and on MAP_INFO_LOADED the state is updated

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
