### PR TITLE
Fix #3763. Fixed cql filter for date filter operator between (><)

### DIFF
--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -726,7 +726,7 @@ const FilterUtils = {
         if (operator === "><") {
             if (value.startDate && value.endDate) {
                 const startIso = value.startDate.toISOString ? value.startDate.toISOString() : value.startDate; // for Compatibility reasons. We should use ISO string to store data.
-                const endIso = value.startDate.toISOString ? value.startDate.toISOString() : value.startDate; // for Compatibility reasons. We should use ISO string to store data.
+                const endIso = value.endDate.toISOString ? value.endDate.toISOString() : value.endDate; // for Compatibility reasons. We should use ISO string to store data.
                 fieldFilter = "(" + attribute + ">='" + startIso +
                     "' AND " + attribute + "<='" + endIso + "')";
             }

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -310,6 +310,8 @@ describe('FilterUtils', () => {
                 + '<ogc:LowerBoundary><ogc:Literal>' + startDate + '</ogc:Literal></ogc:LowerBoundary>'
                 + '<ogc:UpperBoundary><ogc:Literal>' + endDate + '</ogc:Literal></ogc:UpperBoundary>'
             + '</ogc:PropertyIsBetween></ogc:Or>');
+        let cqlFilter = FilterUtils.toCQLFilter(objFilter);
+        expect(cqlFilter).toBe("((attributeEmpty>='2000-01-01T00:00:00.000Z' AND attributeEmpty<='3000-01-01T00:00:00.000Z'))");
     });
     it('Check  for options.cqlFilter are merged with existing fields', () => {
         const versionOGC = "1.1.0";


### PR DESCRIPTION
## Description
Fixed cql Filter generator for filter "><" (Between) for dates

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
See #3763 

**What is the new behavior?**
The map filter is the same of the feature grid filter also for date between 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

