### PR TITLE
#3767 resizable flag for DrawerMenu plugin

### DIFF
--- a/web/client/epics/__tests__/maplayout-test.js
+++ b/web/client/epics/__tests__/maplayout-test.js
@@ -8,7 +8,7 @@
 
 const expect = require('expect');
 
-const {toggleControl} = require('../../actions/controls');
+const { toggleControl, setControlProperty } = require('../../actions/controls');
 const {UPDATE_MAP_LAYOUT} = require('../../actions/maplayout');
 const {closeIdentify, purgeMapInfoResults} = require('../../actions/mapInfo');
 
@@ -87,5 +87,28 @@ describe('map layout epics', () => {
         const state = {};
         testEpic(addTimeoutEpic(updateMapLayoutEpic, 10), 1, purgeMapInfoResults(), epicResult, state);
 
+    });
+
+    it('tests resizable drawer', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(1);
+                actions.map((action) => {
+                    expect(action.type).toBe(UPDATE_MAP_LAYOUT);
+                    expect(action.layout).toEqual({
+                        left: 512, right: 0, bottom: 30, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
+                            left: 512,
+                            right: 0,
+                            bottom: 30
+                        }
+                    });
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+        const state = { controls: { drawer: { enabled: true, resizedWidth: 512} } };
+        testEpic(updateMapLayoutEpic, 1, setControlProperty("drawer", "resizedWidth", 512), epicResult, state);
     });
 });

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -61,11 +61,13 @@ const updateMapLayoutEpic = (action$, store) =>
                 }));
             }
 
+            const resizedDrawer = get(state, "controls.drawer.resizedWidth");
+
             const leftPanels = head([
                 get(state, "controls.queryPanel.enabled") && {left: mapLayout.left.lg} || null,
                 get(state, "controls.widgetBuilder.enabled") && {left: mapLayout.left.md} || null,
                 get(state, "layers.settings.expanded") && {left: mapLayout.left.md} || null,
-                get(state, "controls.drawer.enabled") && {left: mapLayout.left.sm} || null
+                get(state, "controls.drawer.enabled") && { left: resizedDrawer || mapLayout.left.sm} || null
             ].filter(panel => panel)) || {left: 0};
 
             const rightPanels = head([

--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -32,7 +32,7 @@ const Button = tooltip(ButtonB);
 const menuSelector = createSelector([
     state => state.controls.drawer && state.controls.drawer.enabled,
     state => state.controls.drawer && state.controls.drawer.menu || "1",
-    state => state.controls.queryPanel && state.controls.queryPanel.enabled && state.controls.drawer && state.controls.drawer.width || undefined,
+    state => state.controls.queryPanel && state.controls.queryPanel.enabled && state.controls.drawer && state.controls.drawer.width || state.controls.drawer.resizedWidth || undefined,
     state => mapLayoutValuesSelector(state, {height: true})
 ], (show, activeKey, dynamicWidth, layout) => ({
     show,
@@ -43,6 +43,7 @@ const menuSelector = createSelector([
 
 const Menu = connect(menuSelector, {
     onToggle: toggleControl.bind(null, 'drawer', null),
+    onResize: setControlProperty.bind(null, 'drawer', 'resizedWidth'),
     onChoose: partialRight(setControlProperty.bind(null, 'drawer', 'menu'), true),
     changeMapStyle: changeMapStyle
 })(require('./drawer/Menu'));
@@ -83,7 +84,10 @@ const DrawerButton = connect(state => ({
  * @prop {string} cfg.glyph glyph icon to use for the button
  * @prop {object} cfg.menuButtonStyle Css inline style for the button. Display property will be overridden by the hideButton/forceDrawer options.
  * @prop {string} cfg.buttonClassName class for the toggle button
- * @prop {object} cfg.menuOptions options for the drawer menu. They can be `docked`, `width.
+ * @prop {object} cfg.menuOptions options for the drawer menu
+ * @prop {boolean} cfg.menuOptions.docked
+ * @prop {number} cfg.menuOptions.width
+ * @prop {boolean} cfg.menuOptions.resizable enables horizontal resizing
  * @memberof plugins
  * @class
  * @example

--- a/web/client/plugins/FloatingLegend.jsx
+++ b/web/client/plugins/FloatingLegend.jsx
@@ -61,12 +61,12 @@ class FloatingLegendComponent extends React.Component {
 
     renderPanel() {
         const Plugin = this.props.items && head(this.props.items.filter(item => item && item.name === this.props.pluginName));
-        return Plugin && Plugin.plugin && <Plugin.plugin {...(Plugin.cgf || {})} items={Plugin.items || []} menuButtonStyle={{display: 'none'}}/>;
+        return Plugin && Plugin.plugin && <Plugin.plugin {...(Plugin.cfg || {})} items={Plugin.items || []} menuButtonStyle={{display: 'none'}}/>;
     }
 
     renderToggleButton() {
         const Plugin = this.props.items && head(this.props.items.filter(item => item && item.name === this.props.pluginName));
-        return Plugin && Plugin.button && <Plugin.button {...(Plugin.cgf || {})} tooltipId={this.props.tooltipId}/>;
+        return Plugin && Plugin.button && <Plugin.button {...(Plugin.cfg || {})} tooltipId={this.props.tooltipId}/>;
     }
 
     render() {

--- a/web/client/plugins/__tests__/DrawerMenu-test.jsx
+++ b/web/client/plugins/__tests__/DrawerMenu-test.jsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import DrawerMenuPlugin from '../DrawerMenu';
+import { getPluginForTest, } from './pluginsTestUtils';
+
+const mouseMove = (x, y, node) => {
+    const doc = node ? node.ownerDocument : document;
+    const evt = doc.createEvent('MouseEvents');
+    evt.initMouseEvent('mousemove', true, true, window,
+        0, 0, 0, x, y, false, false, false, false, 0, null);
+    doc.dispatchEvent(evt);
+    return evt;
+};
+
+const simulateMovementFromTo = (drag, fromX, fromY, toX, toY) => {
+    const node = ReactDOM.findDOMNode(drag);
+
+    ReactTestUtils.Simulate.mouseDown(node, { clientX: fromX, clientY: fromX });
+    mouseMove(toX, toY, node);
+    ReactTestUtils.Simulate.mouseUp(node);
+};
+
+describe('DrawerMenu Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates a resizable DrawerMenu plugin', () => {
+        const { Plugin, store } = getPluginForTest(DrawerMenuPlugin, { controls: {
+            drawer: {}
+        } });
+        ReactDOM.render(<Plugin menuOptions={{resizable: true}} />, document.getElementById("container"));
+        expect(document.getElementById('mapstore-drawermenu')).toExist();
+
+        const drag = document.getElementsByClassName('react-resizable-handle')[0];
+        simulateMovementFromTo(drag, 300, 100, 400, 100);
+        expect(store.getState().controls.drawer.resizedWidth).toBe(400);
+    });
+});

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -14,11 +14,13 @@ import { combineEpics, createEpicMiddleware } from 'redux-observable';
 
 import map from '../../reducers/layers';
 import layers from '../../reducers/layers';
+import controls from '../../reducers/controls';
 
 // StandardStore add by default current reducers
 const rootReducers = {
     map,
-    layers
+    layers,
+    controls
 };
 
 const createRegisterActionsMiddleware = (actions) => {

--- a/web/client/plugins/drawer/Menu.jsx
+++ b/web/client/plugins/drawer/Menu.jsx
@@ -10,6 +10,7 @@ const PropTypes = require('prop-types');
 const {Glyphicon, Button, Tooltip} = require('react-bootstrap');
 const OverlayTrigger = require('../../components/misc/OverlayTrigger');
 const Sidebar = require('react-sidebar').default;
+const { Resizable } = require('react-resizable');
 const Message = require('../../components/I18N/Message');
 
 class Menu extends React.Component {
@@ -26,7 +27,9 @@ class Menu extends React.Component {
         dynamicWidth: PropTypes.number,
         overlapMap: PropTypes.bool,
         changeMapStyle: PropTypes.func,
-        layout: PropTypes.object
+        layout: PropTypes.object,
+        resizable: PropTypes.bool,
+        onResize: PropTypes.func
     };
 
     static defaultProps = {
@@ -34,7 +37,9 @@ class Menu extends React.Component {
         single: false,
         width: 300,
         overlapMap: true,
-        layout: {}
+        layout: {},
+        resizable: false,
+        onResize: () => {}
     };
 
     componentDidMount() {
@@ -50,6 +55,10 @@ class Menu extends React.Component {
             this.props.changeMapStyle(style, "drawerMenu");
         }
     }
+
+    getWidth = () => {
+        return this.props.dynamicWidth || this.props.width;
+    };
 
     renderChildren = (child, index) => {
         const props = {
@@ -91,12 +100,13 @@ class Menu extends React.Component {
             <span className="title">{this.props.title}</span>
             <Glyphicon glyph="1-close" className="no-border btn-default" onClick={this.props.onToggle} style={{cursor: "pointer"}}/>
         </div>);
-        return (<div className={"nav-content"}>
+        const content = (<div className={"nav-content"}>
             {header}
             <div className={"nav-body"}>
             {this.props.children.filter((child) => !this.props.single || this.props.activeKey === child.props.eventKey).map(this.renderChildren)}
             </div>
         </div>);
+        return this.props.resizable ? <Resizable axis="x" resizeHandles={['e']} width={this.getWidth()} onResize={this.resize}>{content}</Resizable> : content;
     };
 
     render() {
@@ -105,7 +115,7 @@ class Menu extends React.Component {
                 sidebar: {
                     ...this.props.layout,
                     zIndex: 1022,
-                    width: this.props.dynamicWidth || this.props.width
+                    width: this.getWidth()
                 },
                 overlay: {
                     zIndex: 1021
@@ -125,6 +135,12 @@ class Menu extends React.Component {
             </Sidebar>
         );
     }
+
+
+    resize = (event, { size }) => {
+        this.props.onResize(size.width);
+    };
+
 }
 
 module.exports = Menu;

--- a/web/client/themes/default/less/drawer-menu.less
+++ b/web/client/themes/default/less/drawer-menu.less
@@ -35,6 +35,21 @@
             }
         }
     }
+
+    .react-resizable-handle {
+        position: absolute;
+        width: 10px;
+        height: 100%;
+        bottom: 0;
+        right: 0;
+        background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iNnB4Ij48ZyBvcGFjaXR5PSIwLjMwMiI+PHBhdGggZD0iTSA2IDYgTCAwIDYgTCAwIDQuMiBMIDQgNC4yIEwgNC4yIDQuMiBMIDQuMiAwIEwgNiAwIEwgNiA2IEwgNiA2IFoiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+');
+        background-position: bottom right;
+        padding: 0 3px 3px 0;
+        background-repeat: no-repeat;
+        background-origin: content-box;
+        box-sizing: border-box;
+        cursor: e-resize;
+    }
 }
 
 .toolbar-panel #background-switcher {


### PR DESCRIPTION
## Description
Optional flag to add horizontal resize behaviour to DrawerMenu.

## Issues
 - Fix #3767

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
DrawerMenu is not resizable

**What is the new behavior?**
When cfg.menuOptions.resizable is true in the DrawerMenu plugin cfg, the DrawerMenu becomes resizable horizontally.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
