### PR TITLE
Fix #3713 Pop up Validation error doesn't show up for SLD (add default message 2019.01.xx)

### DIFF
--- a/web/client/components/styleeditor/Editor.jsx
+++ b/web/client/components/styleeditor/Editor.jsx
@@ -183,13 +183,15 @@ class Editor extends React.Component {
                 header={
                     <div className="ms-style-editor-head">
                         {this.props.loading && <Loader className="ms-style-editor-loader" size={20}/>}
-                        {this.props.error && this.props.error.line && <InfoPopover
+                        {this.props.error && <InfoPopover
                             glyph="exclamation-mark"
                             bsStyle="danger"
                             placement="right"
-                            title={'Validation Error'}
-                            text={this.props.error.message}/>
-                        || this.props.error && <Message msgId="styleeditor.genericValidationError"/>}
+                            title={<Message msgId="styleeditor.validationErrorTitle"/>}
+                            text={this.props.error.line
+                                ? this.props.error.message
+                                : <Message msgId="styleeditor.genericValidationError"/>}/>
+                        }
                     </div>
                 }>
                 <Codemirror

--- a/web/client/components/styleeditor/__tests__/Editor-test.jsx
+++ b/web/client/components/styleeditor/__tests__/Editor-test.jsx
@@ -155,4 +155,29 @@ describe('test Editor module component (Style Editor)', () => {
         loadingDOM = document.querySelector('.mapstore-small-size-loader');
         expect(loadingDOM).toNotExist();
     });
+
+    it('test Editor shows default validation pop up', () => {
+        const code = "@styleTitle 'Error';\n@styleAbstract 'Abstract';\n\n {\n\tstroke: #00ff00;\n}";
+
+        ReactDOM.render(<Editor mode="geocss" code={code}/>, document.getElementById("container"));
+
+        let editorError = document.querySelectorAll('.ms-style-editor-error');
+        expect(editorError.length).toBe(0);
+        let infoPopover = document.querySelector('.mapstore-info-popover');
+        expect(infoPopover).toNotExist();
+
+        ReactDOM.render(<Editor
+            mode="geocss"
+            error={{
+                status: 400
+            }}/>, document.getElementById("container"));
+
+        editorError = document.querySelectorAll('.ms-style-editor-error');
+        expect(editorError.length > 0).toBe(true);
+
+        infoPopover = document.querySelector('.mapstore-info-popover');
+        expect(infoPopover).toExist();
+        TestUtils.Simulate.mouseOver(infoPopover.children[0]);
+        expect(document.querySelector('.popover-content > span').innerHTML).toBe('styleeditor.genericValidationError');
+    });
 });

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1515,6 +1515,7 @@
             "createStyleErrorMessage": "Stil konnte nicht im Stildienst gespeichert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
             "updateStyleErrorTitle": "Stil bearbeiten",
             "updateStyleErrorMessage": "Der Stil konnte im Stildienst nicht aktualisiert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
+            "validationErrorTitle": "Validierungsfehler",
             "genericValidationError": "Stil ist nicht gültig und konnte nicht angewendet werden.",
             "setDefaultStyle": "Legen Sie den ausgewählten Stil als Standard für die aktuelle Ebene fest",
             "setDefaultStyleSuccessTitle": "Erfolg beim Setzen des Standardstils",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1516,6 +1516,7 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
+            "validationErrorTitle": "Validation Error",
             "genericValidationError": "Style is not valid and it could not be applied.",
             "setDefaultStyle": "Set selected style as default for the current layer",
             "setDefaultStyleSuccessTitle": "Success on set default style",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1516,6 +1516,7 @@
             "createStyleErrorMessage": "El estilo no se pudo guardar en el servicio de estilo. Esto podría estar en formato de estilo no compatible o problema de conexión.",
             "updateStyleErrorTitle": "Editar estilo",
             "updateStyleErrorMessage": "El estilo no se pudo actualizar en el servicio de estilo. Esto podría estar en formato de estilo no compatible o problema de conexión.",
+            "validationErrorTitle": "Error de validacion",
             "genericValidationError": "El estilo no es válido y no se pudo aplicar.",
             "setDefaultStyle": "Establecer el estilo seleccionado como predeterminado para la capa actual",
             "setDefaultStyleSuccessTitle": "Éxito en el estilo por defecto establecido",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1516,6 +1516,7 @@
             "createStyleErrorMessage": "Le style n'a pas pu être enregistré sur le service de style. Cela pourrait être sur un format de style non pris en charge ou un problème de connexion.",
             "updateStyleErrorTitle": "Modifier le style",
             "updateStyleErrorMessage": "Le style n'a pas pu être mis à jour sur le service de style. Cela pourrait être sur un format de style non pris en charge ou un problème de connexion.",
+            "validationErrorTitle": "Erreur de validation",
             "genericValidationError": "Le style n'est pas valide et il n'a pas pu être appliqué.",
             "setDefaultStyle": "Définir le style sélectionné par défaut pour le calque actuel",
             "setDefaultStyleSuccessTitle": "Succès sur le style par défaut",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1492,6 +1492,7 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
+            "validationErrorTitle": "Validation Error",
             "genericValidationError": "Style is not valid and it could not be applied.",
             "setDefaultStyle": "Set selected style as default for the current layer",
             "setDefaultStyleSuccessTitle": "Success on set default style",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1515,6 +1515,7 @@
             "createStyleErrorMessage": "Lo stile non può essere salvato. Questo potrebbe essere dovuto al formato di stile non supportato o ad un problema di connessione.",
             "updateStyleErrorTitle": "Modifica stile",
             "updateStyleErrorMessage": "Lo stile non può essere aggiornato . Questo potrebbe essere dovuto ad un formato di stile non supportato o ad un problema di connessione.",
+            "validationErrorTitle": "Errore di validazione",
             "genericValidationError": "Lo stile non è valido e non è stato possibile applicarlo.",
             "setDefaultStyle": "Imposta lo stile selezionato come predefinito per il layer corrente",
             "setDefaultStyleSuccessTitle": "Stile predefinito aggiornamento",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1180,6 +1180,7 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
+            "validationErrorTitle": "Validation Error",
             "genericValidationError": "Style is not valid and it could not be applied.",
             "setDefaultStyle": "Set selected style as default for the current layer",
             "setDefaultStyleSuccessTitle": "Success on set default style",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1243,6 +1243,7 @@
             "createStyleErrorMessage": "Style could not be saved on the style service. This could be on unsupported style format or connection issue.",
             "updateStyleErrorTitle": "Edit Style",
             "updateStyleErrorMessage": "Style could not be updated on the style service. This could be on unsupported style format or connection issue.",
+            "validationErrorTitle": "Validation Error",
             "genericValidationError": "Style is not valid and it could not be applied.",
             "setDefaultStyle": "Set selected style as default for the current layer",
             "setDefaultStyleSuccessTitle": "Success on set default style",


### PR DESCRIPTION
## Description
This PR add a default message in validation of Style Editor when the message doesn't contain information about the error.

## Issues
 - Fix #3713 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Some server doesn't return a parsable message of error

**What is the new behavior?**
add a default message in validation

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
