### PR TITLE
Revert "Fix #3754 Add default configuration for testing in Style Editor (2019.01.xx)"

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -346,21 +346,7 @@
             "Timeline",
             "Playback",
             "FeedbackMask",
-            {
-              "name": "StyleEditor",
-              "cfg": {
-                "styleService": {
-                  "baseUrl": "https://gs-stable.geo-solutions.it/geoserver/",
-                  "formats": [
-                    "css",
-                    "sld"
-                  ],
-                  "availableUrls": [
-                    "http://gs-stable.geo-solutions.it/geoserver/"
-                  ]
-                }
-              }
-            }
+            "StyleEditor"
         ],
         "embedded": [{
                 "name": "Map",


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#3760 
To avoid to use the configured server until it's stable. 