### PR TITLE
Fix 3776

### DIFF
--- a/web/client/components/manager/users/GroupCard.jsx
+++ b/web/client/components/manager/users/GroupCard.jsx
@@ -24,6 +24,8 @@ class GroupCard extends React.Component {
         style: PropTypes.object,
         group: PropTypes.object,
         innerItemStyle: PropTypes.object,
+        avatarStyle: PropTypes.object,
+        nameStyle: PropTypes.object,
         actions: PropTypes.array
     };
 
@@ -34,7 +36,22 @@ class GroupCard extends React.Component {
             backgroundPosition: "center",
             backgroundRepeat: "repeat-x"
         },
-        innerItemStyle: {"float": "left", margin: "10px"}
+        innerItemStyle: {
+            marginTop: "35px",
+            marginLeft: "9px"
+        },
+        avatarStyle: {
+            margin: "10px"
+        },
+        nameStyle: {
+            position: "absolute",
+            left: "80px",
+            top: "30px",
+            width: "75%",
+            borderBottom: "1px solid #ddd",
+            fontSize: 18,
+            fontWeight: "bold"
+        }
     };
 
     renderStatus = () => {
@@ -47,16 +64,20 @@ class GroupCard extends React.Component {
     };
 
     renderAvatar = () => {
-        return (<div key="avatar" style={this.props.innerItemStyle} ><Button bsStyle="primary" type="button" className="square-button">
+        return (<div key="avatar" style={this.props.avatarStyle} ><Button bsStyle="primary" type="button" className="square-button">
             <Glyphicon glyph="1-group" />
             </Button></div>);
     };
 
     renderDescription = () => {
-        return (<div className="group-thumb-description">
+        return (<div className="group-thumb-description" style={this.props.innerItemStyle}>
             <div><strong><Message msgId="usergroups.description" /></strong></div>
             <div>{this.props.group.description ? this.props.group.description : <Message msgId="usergroups.noDescriptionAvailable" />}</div>
         </div>);
+    };
+
+    renderName = () => {
+        return (<div key="name" style={this.props.nameStyle}>{this.props.group.groupName}</div>);
     };
 
     render() {
@@ -64,9 +85,12 @@ class GroupCard extends React.Component {
            <GridCard className="group-thumb" style={this.props.style} header={this.props.group.groupName}
                 actions={this.props.actions}
                >
-            {this.renderAvatar()}
+            <div className="user-data-container">
+                {this.renderAvatar()}
+                {this.renderName()}
+                {this.renderDescription()}
+            </div>
             {this.renderStatus()}
-            {this.renderDescription()}
            </GridCard>
         );
     }

--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -85,9 +85,9 @@ class GroupDialog extends React.Component {
     };
 
     renderGeneral = () => {
-        return (<div style={{clear: "both"}}>
+        return (<div style={{clear: "both", marginTop: "10px"}}>
         <FormGroup>
-            <ControlLabel><Message msgId="usergroups.groupName"/></ControlLabel>
+            <ControlLabel><Message msgId="usergroups.groupName"/><b><font color="000000">*</font></b></ControlLabel>
             <FormControl ref="groupName"
                 key="groupName"
                 type="text"
@@ -110,6 +110,7 @@ class GroupDialog extends React.Component {
                 onChange={this.handleChange}
                 value={this.props.group && this.props.group.description || ""}/>
         </FormGroup>
+        <i>Fields marked with asterisk are required</i>
         </div>);
     };
 
@@ -168,7 +169,7 @@ class GroupDialog extends React.Component {
 
     renderMembersTab = () => {
         let availableUsers = this.props.availableUsers.filter((user) => findIndex(this.getCurrentGroupMembers(), member => member.id === user.id) < 0).map(u => ({value: u.id, label: u.name}));
-        return (<div>
+        return (<div style={{marginTop: "10px"}}>
             <label key="member-label" className="control-label"><Message msgId="usergroups.groupMembers" /></label>
             <div key="member-list" style={
             {
@@ -177,7 +178,7 @@ class GroupDialog extends React.Component {
                 overflow: "auto",
                 boxShadow: "inset 0 2px 5px 0 #AAA"
             }} >{this.renderMembers()}</div>
-            <div key="add-member" >
+            <div key="add-member" style={{marginTop: "10px"}}>
                 <label key="add-member-label" className="control-label"><Message msgId="usergroups.addMember" /></label>
                 <Select
                     isLoading={this.props.availableUsersLoading}
@@ -216,12 +217,12 @@ class GroupDialog extends React.Component {
             </span>
             <div role="body">
             <Tabs defaultActiveKey={1} onSelect={ ( key) => { this.setState({key}); }} key="tab-panel">
-                <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 1 ? "success" : "primary"}><Glyphicon glyph="1-group"/></Button>} >
+                <Tab eventKey={1} title={<Button className="square-button" bsStyle={this.state.key === 1 ? "success" : "primary"}><Glyphicon glyph="1-group"/></Button>} >
                     {this.renderGeneral()}
                     {this.checkNameLenght()}
                     {this.checkDescLenght()}
                 </Tab>
-                <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 2 ? "success" : "primary"}><Glyphicon glyph="1-group-add"/></Button>} >
+                <Tab eventKey={2} title={<Button className="square-button" bsStyle={this.state.key === 2 ? "success" : "primary"}><Glyphicon glyph="1-group-add"/></Button>} >
                     {this.renderMembersTab()}
                 </Tab>
             </Tabs>

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -45,6 +45,7 @@ class UserDialog extends React.Component {
         style: PropTypes.object,
         buttonSize: PropTypes.string,
         inputStyle: PropTypes.object,
+        inputPasswordStyle: PropTypes.object,
         attributes: PropTypes.array,
         minPasswordSize: PropTypes.number,
         hidePasswordFields: PropTypes.bool
@@ -71,6 +72,14 @@ class UserDialog extends React.Component {
         inputStyle: {
             height: "32px",
             width: "260px",
+            marginTop: "3px",
+            marginBottom: "20px",
+            padding: "5px",
+            border: "1px solid #078AA3"
+        },
+        inputPasswordStyle: {
+            height: "32px",
+            width: "135px",
             marginTop: "3px",
             marginBottom: "20px",
             padding: "5px",
@@ -105,15 +114,22 @@ class UserDialog extends React.Component {
         return (
           <div>
               <FormGroup validationState={this.getPwStyle()}>
-                  <ControlLabel><Message msgId="user.password"/></ControlLabel>
-                  <FormControl ref="newPassword"
-                      key="newPassword"
-                      type="password"
-                      name="newPassword"
-                      autoComplete="new-password"
-                      style={this.props.inputStyle}
-                      onChange={this.handleChange} />
+                  <ControlLabel><Message msgId="user.password"/>
+                  </ControlLabel>
+                  <Glyphicon glyph="info-sign" style={{position: "absolute", left: "85px", top: "150px"}} title="Password must contain at least 6 characters"/>
+
+                    <FormControl ref="newPassword"
+                        key="newPassword"
+                        type="password"
+                        name="newPassword"
+                        autoComplete="new-password"
+                        style={this.props.inputStyle}
+                        onChange={this.handleChange} />
+
+
               </FormGroup>
+
+
               <FormGroup validationState={ (this.isValidPassword() ? "success" : "error") }>
                   <ControlLabel><Message msgId="user.retypePwd"/></ControlLabel>
                   <FormControl ref="confirmPassword"
@@ -244,7 +260,7 @@ class UserDialog extends React.Component {
     isMainPasswordValid = (password) => {
         let p = password || this.props.user.newPassword || "";
         // Empty password field will signal the GeoStoreDAO not to change the password
-        if (p === "") {
+        if (p === "" && this.props.user && this.props.user.id) {
             return true;
         }
         return (p.length >= this.props.minPasswordSize) && !(/[^a-zA-Z0-9\!\@\#\$\%\&\*]/.test(p));

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -15,9 +15,9 @@ const PropTypes = require('prop-types');
  */
 
 const React = require('react');
-
 const {Alert, Tabs, Tab, Button, Glyphicon, Checkbox, FormControl, FormGroup, ControlLabel} = require('react-bootstrap');
-
+const tooltip = require('../../../components/misc/enhancers/tooltip');
+const GlyphiconTooltip = tooltip(Glyphicon);
 const Dialog = require('../../../components/misc/Dialog');
 const UserGroups = require('./UserGroups');
 const assign = require('object-assign');
@@ -47,7 +47,8 @@ class UserDialog extends React.Component {
         inputStyle: PropTypes.object,
         attributes: PropTypes.array,
         minPasswordSize: PropTypes.number,
-        hidePasswordFields: PropTypes.bool
+        hidePasswordFields: PropTypes.bool,
+        buttonTooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     };
 
     static defaultProps = {
@@ -102,13 +103,16 @@ class UserDialog extends React.Component {
     };
 
     renderPasswordFields = () => {
+
         return (
           <div>
               <FormGroup validationState={this.getPwStyle()}>
                   <ControlLabel><Message msgId="user.password"/>
+                    <b><font color="000000">*</font></b>
+                    <GlyphiconTooltip tooltipId="user.passwordMessage" tooltipPosition="right"
+                    glyph="info-sign" style={{position: "relative", marginLeft: "10px", display: "inline-block", width: 24}}
+                    helpText="Password must contain at least 6 characters"/>
                   </ControlLabel>
-                  <Glyphicon glyph="info-sign" style={{position: "absolute", left: "85px", top: "150px"}}
-                   title="Password must contain at least 6 characters"/>
                   <FormControl ref="newPassword"
                    key="newPassword"
                    type="password"
@@ -118,7 +122,7 @@ class UserDialog extends React.Component {
                    onChange={this.handleChange} />
               </FormGroup>
               <FormGroup validationState={ (this.isValidPassword() ? "success" : "error") }>
-                  <ControlLabel><Message msgId="user.retypePwd"/></ControlLabel>
+                  <ControlLabel><Message msgId="user.retypePwd"/><b><font color="000000">*</font></b></ControlLabel>
                   <FormControl ref="confirmPassword"
                       key="confirmPassword"
                       name="confirmPassword"
@@ -132,9 +136,9 @@ class UserDialog extends React.Component {
     };
 
     renderGeneral = () => {
-        return (<div style={{clear: "both"}}>
+        return (<div style={{clear: "both", marginTop: "10px"}}>
           <FormGroup>
-              <ControlLabel><Message msgId="user.username"/></ControlLabel>
+              <ControlLabel><Message msgId="user.username"/><b><font color="000000">*</font></b></ControlLabel>
               <FormControl ref="name"
                   key="name"
                   type="text"
@@ -150,7 +154,7 @@ class UserDialog extends React.Component {
             <option value="USER">USER</option>
           </select>
           <FormGroup>
-              <ControlLabel><Message msgId="users.enabled"/></ControlLabel>
+              <ControlLabel style={{"float": "left", marginRight: "10px"}}><Message msgId="users.enabled"/></ControlLabel>
               <Checkbox
                   defaultChecked={this.props.user && (this.props.user.enabled === undefined ? false : this.props.user.enabled)}
                   type="checkbox"
@@ -158,12 +162,13 @@ class UserDialog extends React.Component {
                   name="enabled"
                   onClick={(evt) => {this.props.onChange("enabled", evt.target.checked ? true : false); }} />
           </FormGroup>
+          <i>Fields marked with asterisk (<b><font color="000000">*</font></b>) are required</i>
           </div>);
     };
 
     renderAttributes = () => {
         return this.props.attributes.map((attr, index) => {
-            return (<FormGroup key={"form-n-" + index}>
+            return (<FormGroup key={"form-n-" + index} style={{marginTop: "10px"}}>
               <ControlLabel>{attr.name}</ControlLabel>
               <FormControl ref={"attribute." + attr.name}
               key={"attribute." + attr.name}
@@ -226,13 +231,13 @@ class UserDialog extends React.Component {
           </span>
           <div role="body">
           <Tabs defaultActiveKey={1} onSelect={ ( key) => { this.setState({key}); }} key="tab-panel" id="userDetails-tabs">
-              <Tab eventKey={1} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 1 ? "success" : "primary"}><Glyphicon glyph="user"/></Button>} >
+              <Tab eventKey={1} title={<Button className="square-button" bsStyle={this.state.key === 1 ? "success" : "primary"}><Glyphicon glyph="user"/></Button>} >
                   {this.renderGeneral()}
               </Tab>
-              <Tab eventKey={2} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 2 ? "success" : "primary"}><Glyphicon glyph="info-sign"/></Button>} >
+              <Tab eventKey={2} title={<Button className="square-button" bsStyle={this.state.key === 2 ? "success" : "primary"}><Glyphicon glyph="info-sign"/></Button>} >
                   {this.renderAttributes()}
               </Tab>
-              <Tab eventKey={3} title={<Button className="square-button" bsSize={this.props.buttonSize} bsStyle={this.state.key === 3 ? "success" : "primary"}><Glyphicon glyph="1-group"/></Button>} >
+              <Tab eventKey={3} title={<Button className="square-button" bsStyle={this.state.key === 3 ? "success" : "primary"}><Glyphicon glyph="1-group"/></Button>} >
                   {this.renderGroups()}
               </Tab>
           </Tabs>

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -45,7 +45,6 @@ class UserDialog extends React.Component {
         style: PropTypes.object,
         buttonSize: PropTypes.string,
         inputStyle: PropTypes.object,
-        inputPasswordStyle: PropTypes.object,
         attributes: PropTypes.array,
         minPasswordSize: PropTypes.number,
         hidePasswordFields: PropTypes.bool
@@ -72,14 +71,6 @@ class UserDialog extends React.Component {
         inputStyle: {
             height: "32px",
             width: "260px",
-            marginTop: "3px",
-            marginBottom: "20px",
-            padding: "5px",
-            border: "1px solid #078AA3"
-        },
-        inputPasswordStyle: {
-            height: "32px",
-            width: "135px",
             marginTop: "3px",
             marginBottom: "20px",
             padding: "5px",
@@ -116,20 +107,16 @@ class UserDialog extends React.Component {
               <FormGroup validationState={this.getPwStyle()}>
                   <ControlLabel><Message msgId="user.password"/>
                   </ControlLabel>
-                  <Glyphicon glyph="info-sign" style={{position: "absolute", left: "85px", top: "150px"}} title="Password must contain at least 6 characters"/>
-
-                    <FormControl ref="newPassword"
-                        key="newPassword"
-                        type="password"
-                        name="newPassword"
-                        autoComplete="new-password"
-                        style={this.props.inputStyle}
-                        onChange={this.handleChange} />
-
-
+                  <Glyphicon glyph="info-sign" style={{position: "absolute", left: "85px", top: "150px"}}
+                   title="Password must contain at least 6 characters"/>
+                  <FormControl ref="newPassword"
+                   key="newPassword"
+                   type="password"
+                   name="newPassword"
+                   autoComplete="new-password"
+                   style={this.props.inputStyle}
+                   onChange={this.handleChange} />
               </FormGroup>
-
-
               <FormGroup validationState={ (this.isValidPassword() ? "success" : "error") }>
                   <ControlLabel><Message msgId="user.retypePwd"/></ControlLabel>
                   <FormControl ref="confirmPassword"

--- a/web/client/components/manager/users/UserGroups.jsx
+++ b/web/client/components/manager/users/UserGroups.jsx
@@ -63,13 +63,14 @@ class UserCard extends React.Component {
         value={ (this.props.user && this.props.user.groups ? this.props.user.groups : this.getDefaultGroups() ).map(group => group.id) }
         options={this.getOptions()}
         onChange={this.onChange}
+        style={{marginTop: "10px"}}
         />);
     };
 
     render() {
         return this.props.groups ? (
-           <div key="groups-page">
-             <span><Message msgId="users.selectedGroups" /></span>
+           <div style={{marginTop: "10px"}} key="groups-page">
+             <span><Message msgId="users.selectedGroups"/></span>
              {this.renderGroupsSelector()}
          </div>
         ) : null;

--- a/web/client/components/manager/users/__tests__/GroupCard-test.jsx
+++ b/web/client/components/manager/users/__tests__/GroupCard-test.jsx
@@ -47,4 +47,12 @@ describe("Test GroupCard Component", () => {
           "group-thumb-description"
         ).length).toBe(1);
     });
+    it('Test groupname rendering inside the card', () => {
+        let comp = ReactDOM.render(
+            <GroupCard group={group1} />, document.getElementById("container"));
+        expect(comp).toExist();
+        let items = document.querySelectorAll('#container .gridcard .user-data-container > div');
+        let renderName = items[1];
+        expect(renderName.innerHTML).toBe(group1.groupName);
+    });
 });

--- a/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
@@ -83,10 +83,10 @@ describe("Test GroupDialog Component", () => {
 
         expect(comp).toExist();
         let buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, "button");
-        expect(buttons[1].className).toBe("square-button btn btn-lg btn-success");
+        expect(buttons[1].className).toBe("square-button btn btn-success");
         let groupGroupButton = buttons[2];
         ReactTestUtils.Simulate.click(groupGroupButton);
-        expect(groupGroupButton.className).toBe("square-button btn btn-lg btn-success");
-        expect(buttons[2].className).toBe("square-button btn btn-lg btn-success");
+        expect(groupGroupButton.className).toBe("square-button btn btn-success");
+        expect(buttons[2].className).toBe("square-button btn btn-success");
     });
 });

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -106,6 +106,11 @@ describe("Test UserDialog Component", () => {
             <UserDialog user={{...enabledUser, newPassword: "aaabbbà", confirmPassword: "aaabbbà"}}/>, document.getElementById("container"));
         expect(comp).toExist();
         expect(comp.isValidPassword()).toBe(false);
+        // New user, empty password
+        comp = ReactDOM.render(
+            <UserDialog user={{...newUser, newPassword: "", confirmPassword: ""}}/>, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(comp.isValidPassword()).toBe(false);
     });
     it('Test without password fields', () => {
         let comp = ReactDOM.render(

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -216,10 +216,10 @@ describe("Test UserDialog Component", () => {
 
         expect(comp).toExist();
         let buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(comp, "button");
-        expect(buttons[1].className).toBe("square-button btn btn-lg btn-success");
+        expect(buttons[1].className).toBe("square-button btn btn-success");
         let userGroupButton = buttons[3];
         ReactTestUtils.Simulate.click(userGroupButton);
-        expect(userGroupButton.className).toBe("square-button btn btn-lg btn-success");
-        expect(buttons[3].className).toBe("square-button btn btn-lg btn-success");
+        expect(userGroupButton.className).toBe("square-button btn btn-success");
+        expect(buttons[3].className).toBe("square-button btn btn-success");
     });
 });

--- a/web/client/components/manager/users/style/usercard.css
+++ b/web/client/components/manager/users/style/usercard.css
@@ -39,14 +39,11 @@
 }
 .group-thumb .group-thumb-description {
     /* ellipsis for description */
-    margin: 10px;
     display: block; /* Fallback for non-webkit */
     display: -webkit-box;
-    padding: 5px;
     magin: 0 auto;
     height: 75px; /* font-size * webkit-line-clamp + padding */
     font-size: 12px;
-    line-height: 1;
     -webkit-line-clamp: 5;
     -webkit-box-orient: vertical;
     overflow: hidden;

--- a/web/client/components/misc/Dialog.jsx
+++ b/web/client/components/misc/Dialog.jsx
@@ -27,7 +27,6 @@ class Dialog extends React.Component {
         footerClassName: PropTypes.string,
         onClickOut: PropTypes.func,
         modal: PropTypes.bool,
-        start: PropTypes.object,
         draggable: PropTypes.bool
     };
 
@@ -36,7 +35,6 @@ class Dialog extends React.Component {
         backgroundStyle: {
             background: "rgba(0,0,0,.5)"
         },
-        start: {x: 0, y: 0},
         className: "modal-dialog modal-content",
         maskLoading: false,
         containerClassName: "",
@@ -73,7 +71,9 @@ class Dialog extends React.Component {
     };
 
     render() {
-        const body = (<div id={this.props.id} style={{zIndex: 3, ...this.props.style}} className={this.props.className + " modal-dialog-container"}>
+        const body = (<div id={this.props.id}
+                      style={{zIndex: 3, position: "relative", margin: "auto", top: "20%", ...this.props.style}}
+                      className={this.props.className + " modal-dialog-container"}>
             <div className={this.props.headerClassName + " draggable-header"}>
                 {this.renderRole('header')}
             </div>
@@ -85,7 +85,7 @@ class Dialog extends React.Component {
                 {this.renderRole('footer')}
             </div> : <span/>}
         </div>);
-        const dialog = this.props.draggable ? (<Draggable defaultPosition={this.props.start} handle=".draggable-header, .draggable-header *">
+        const dialog = this.props.draggable ? (<Draggable handle= ".draggable-header, .draggable-header *">
             {body}
         </Draggable>) : body;
         let containerStyle = assign({}, this.props.style, this.props.backgroundStyle);

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -816,6 +816,7 @@
             "passwordInvalid": "Ungültiges Passwort",
             "username": "Benutzername",
             "password": "Passwort",
+            "passwordMessage": "Das Passwort muss aus mindestens 6 Zeichen bestehen",
             "passwordChanged": "Passwort geändert",
             "passwordError": "Fehler beim Ändern des Passworts",
             "signIn":"Anmelden",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -816,6 +816,7 @@
             "passwordInvalid": "Invalid password",
             "username": "Username",
             "password": "Password",
+            "passwordMessage": "Password must contain at least 6 characters",
             "passwordChanged": "Password changed",
             "passwordError": "Error changing password",
             "signIn":"Sign-in",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -817,6 +817,7 @@
             "passwordInvalid": "Clave incorrecta",
             "username": "Nombre de usuario",
             "password": "Clave",
+            "passwordMessage": "La contraseña debe contener al menos 6 caracteres",
             "passwordChanged": "Clave cambiada",
             "passwordError": "Error en el cambio de clave",
             "signIn":"Login",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -841,6 +841,7 @@
             "passwordInvalid": "Mot de passe incorrect",
             "username": "Nom d'utilisateur",
             "password": "Mot de passe",
+            "passwordMessage": "Le mot de passe doit contenir au moins 6 caractères",
             "passwordChanged": "Mot de passe changé",
             "passwordError": "Erreur de changement de mot de passe",
             "signIn":"S'authentifier",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -813,6 +813,7 @@
             "passwordInvalid": "Neispravna zaporka",
             "username": "Korisničko ime",
             "password": "Zaporka",
+            "passwordMessage": "Password must contain at least 6 characters",
             "passwordChanged": "Zaporka je promijenjena",
             "passwordError": "Greška prilikom izmjene zaporke",
             "signIn": "Prijava",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -816,6 +816,7 @@
             "passwordInvalid": "Password non valida",
             "username": "Username",
             "password": "Password",
+            "passwordMessage": "La password deve contenere almeno 6 caratteri",
             "passwordChanged": "La password è stata cambiata",
             "passwordError": "Errore nel cambio della password",
             "signIn":"Accedi",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -779,6 +779,7 @@
             "passwordInvalid": "Verkeerd wachtwoord",
             "username": "Gebruikersnaam",
             "password": "Paswoord",
+            "passwordMessage": "Password must contain at least 6 characters",
             "passwordChanged": "Wachtwoord gewijzigd",
             "passwordError": "Fout bij het wijzigen van het wachtwoord",
             "signIn":"Certificeer",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -812,6 +812,7 @@
             "passwordInvalid": "Invalid password",
             "username": "Username",
             "password": "Password",
+            "passwordMessage": "Password must contain at least 6 characters",
             "passwordChanged": "Password changed",
             "passwordError": "Error changing password",
             "signIn":"Sign-in",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -790,6 +790,7 @@
             "passwordInvalid": "无效的密码",
             "username": "用户名",
             "password": "密码",
+            "passwordMessage": "Password must contain at least 6 characters",
             "passwordChanged": "密码已更改",
             "passwordError": "更改密码时出错",
             "signIn":"签到",


### PR DESCRIPTION
## 3776
L&F review for user/group form

## Issues
 - Fix #3776
 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Feature
 
**What is the current behavior?** (You can also link to an open issue here)
see #3776

**What is the new behavior?**
The L&F improvement provided are provided also for Group names.
There is a compilation aid for the PW so the user knows how the PW must be.
The User/Group modal appear at the center of the screen.
Button icons are aligned at the center.
There is more space between the buttons on top and the form.
There is an asterisk in mandatory fields.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Tooltip, asterisks, space between icons and form, glyphicon centering inside buttons and modal centering don't have test.