### PR TITLE
#3808: custom sheet is not overridden by capabilities in print

### DIFF
--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -45,6 +45,34 @@ describe('Test the print reducer', () => {
         expect(state.spec.resolution).toBe(96);
     });
 
+    it('load capabilities do not override sheet', () => {
+        const state = print({ capabilities: {}, spec: {sheet: 'A3'} }, {
+            type: PRINT_CAPABILITIES_LOADED,
+            capabilities: {
+                layouts: [{ name: 'A4' }, {name: 'A3'}],
+                dpis: [{ value: 96 }]
+            }
+        });
+        expect(state.capabilities.layouts.length).toBe(2);
+        expect(state.capabilities.dpis.length).toBe(1);
+        expect(state.spec.sheet).toBe('A3');
+        expect(state.spec.resolution).toBe(96);
+    });
+
+    it('load capabilities override sheet if user defined does not exist', () => {
+        const state = print({ capabilities: {}, spec: { sheet: 'A3' } }, {
+            type: PRINT_CAPABILITIES_LOADED,
+            capabilities: {
+                layouts: [{ name: 'A4' }],
+                dpis: [{ value: 96 }]
+            }
+        });
+        expect(state.capabilities.layouts.length).toBe(1);
+        expect(state.capabilities.dpis.length).toBe(1);
+        expect(state.spec.sheet).toBe('A4');
+        expect(state.spec.resolution).toBe(96);
+    });
+
     it('load capabilities error', () => {
         const state = print({capabilities: {}, spec: {}}, {
             type: PRINT_CAPABILITIES_ERROR,

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -19,6 +19,8 @@ const {
     PRINT_CANCEL
 } = require('../actions/print');
 
+const {get} = require('lodash');
+
 const {TOGGLE_CONTROL} = require('../actions/controls');
 const {isObject} = require('lodash');
 
@@ -37,6 +39,10 @@ const initialSpec = {
     description: ''
 };
 
+const getSheetName = (name = '') => {
+    return name.split('_')[0];
+};
+
 function print(state = {spec: initialSpec, capabilities: null, map: null, isLoading: false, pdfUrl: null}, action) {
     switch (action.type) {
     case TOGGLE_CONTROL: {
@@ -46,13 +52,9 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
         return state;
     }
     case PRINT_CAPABILITIES_LOADED: {
-        let sheetName = action.capabilities
-                && action.capabilities.layouts
-                && action.capabilities.layouts.length
-                && action.capabilities.layouts[0].name;
-        if (sheetName && sheetName.indexOf('_') !== -1) {
-            sheetName = sheetName.substring(0, sheetName.indexOf("_"));
-        }
+        const layouts = get(action, 'capabilities.layouts', [{name: 'A4'}]);
+        const sheetName = layouts.filter(l => getSheetName(l.name) === state.spec.sheet).length ?
+            state.spec.sheet : getSheetName(layouts[0].name);
         return assign({}, state, {
             capabilities: action.capabilities,
             spec: assign({}, state.spec || {}, {

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -19,10 +19,8 @@ const {
     PRINT_CANCEL
 } = require('../actions/print');
 
-const {get} = require('lodash');
-
 const {TOGGLE_CONTROL} = require('../actions/controls');
-const {isObject} = require('lodash');
+const {isObject, get} = require('lodash');
 
 const assign = require('object-assign');
 


### PR DESCRIPTION
## Description
If you configure an initial sheet size for printing in localConfig.json this is overridden by the first one found in printing service capabilities document.
We should check if the user-defined sheet size exists in the loaded capabilities, we should use it, and override only if doesn't exist.

## Issues
 - Fix #3808

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Default sheet is always the first one in the capabilities document.

**What is the new behavior?**
Default sheet is user custom defined if it exists in the capabilities document,  the first one in the capabilities document otherwise.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
