### PR TITLE
Fix 3812 Invalid char in Style Editor templates

### DIFF
--- a/web/client/utils/styleeditor/stylesTemplates.js
+++ b/web/client/utils/styleeditor/stylesTemplates.js
@@ -846,7 +846,7 @@ const customTemplates = [
 }
 `,
         types: ['polygon', 'vector'],
-        title: 'Label & Fill',
+        title: 'Label and Fill',
         format: 'css',
         preview: <SVGPreview
             type="polygon"
@@ -1059,7 +1059,7 @@ const customTemplates = [
 }
 `,
         types: ['polygon', 'point', 'vector'],
-        title: 'Label & Marker',
+        title: 'Label and Marker',
         format: 'css',
         preview: <SVGPreview
             type="polygon"


### PR DESCRIPTION
## Description
Replaced `&` with `and` in style templates

## Issues
 - #3812

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3812

**What is the new behavior?**
Replaced `&` with `and` in style templates

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
