### PR TITLE
#3826: fixed usage of proj4 from openlayers in related Map, and intro…

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const ol = require('openlayers');
+const proj4 = require('proj4').default;
 const PropTypes = require('prop-types');
 const React = require('react');
 const assign = require('object-assign');
@@ -66,11 +67,12 @@ class OpenlayersMap extends React.Component {
 
     componentDidMount() {
         this.props.projectionDefs.forEach(p => {
-            projUtils.addProjections(ol, p.code, p.extent, p.worldExtent);
+            projUtils.addProjections(ol, p.code, p.extent, p.worldExtent, p.axisOrientation || proj4.defs(p.code).axis || 'enu');
         });
         // It may be a good idea to check if CoordinateUtils also registered the projectionDefs
         // normally it happens ad application level.
         let center = CoordinatesUtils.reproject([this.props.center.x, this.props.center.y], 'EPSG:4326', this.props.projection);
+        ol.proj.setProj4(proj4);
         let interactionsOptions = assign(this.props.interactive ? {} : {
             doubleClickZoom: false,
             dragPan: false,

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -112,6 +112,34 @@ describe('OpenlayersMap', () => {
         expect(ol.proj.get('EPSG:25830')).toExist();
     });
 
+    it('custom projection with axisOrientation', () => {
+        proj.defs("EPSG:31468", "+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=4500000 +y_0=0 +ellps=bessel +towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 +units=m +no_defs");
+        const projectionDefs = [{
+            code: "EPSG:31468",
+            axisOrientation: "neu",
+            "extent": [
+                4036308.74,
+                5255076.75,
+                4617579.38,
+                6108355.90
+            ],
+            "worldExtent": [
+                5.87,
+                47.27,
+                13.84,
+                55.09
+            ]
+        }];
+        const comp = (<OpenlayersMap projection="EPSG:31468" projectionDefs={projectionDefs} center={{ y: 43.9, x: 10.3 }} zoom={11}
+        />);
+
+        const map = ReactDOM.render(comp, document.getElementById("map"));
+        expect(map).toExist();
+        expect(map.map.getView().getProjection().getCode()).toBe('EPSG:31468');
+        expect(ol.proj.get('EPSG:31468')).toExist();
+        expect(ol.proj.get('EPSG:31468').getAxisOrientation()).toBe('neu');
+    });
+
     it('check if the handler for "click" event is called with elevation', () => {
         const testHandlers = {
             handler: () => { }

--- a/web/client/utils/openlayers/projUtils.js
+++ b/web/client/utils/openlayers/projUtils.js
@@ -10,15 +10,14 @@ const projUtils = {
     /**
     * function needed in openlayer for adding new projection
     */
-    addProjections: function(ol, code, extent, worldExtent) {
-        if (!ol.proj.get(code)) {
-            ol.proj.addProjection(new ol.proj.Projection({
-                    code,
-                    extent,
-                    worldExtent
-                })
-            );
-        }
+    addProjections: function(ol, code, extent, worldExtent, axisOrientation) {
+        ol.proj.addProjection(new ol.proj.Projection({
+                code,
+                extent,
+                worldExtent,
+                axisOrientation
+            })
+        );
     }
 };
 


### PR DESCRIPTION
…duced configurable axisOrientation for ol projections

## Description
OpenLayers did not use proj4js projections because proj4j need to be registered with ol to make this happen.
Also, it was not possible to define axisOrientation for custom projections, so ol always works as axis order is enu

## Issues
 - #3826

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
neu projections do not work correctly in openlayers, also proj4 projections are not correctly used and mouse position coordinates can be wrong for some crs.

**What is the new behavior?**
neu projections  work correctly in openlayers, mouse position coordinates are now correct.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
