### PR TITLE
Some other fixes for issue 3829

### DIFF
--- a/web/client/epics/__tests__/map-test.js
+++ b/web/client/epics/__tests__/map-test.js
@@ -195,6 +195,12 @@ describe('map epics', () => {
             a0(dispatch);
         }, STATE_NORMAL);
     });
+    it('checkMapPermissions after login with no mapId', (done) => {
+        testEpic(addTimeoutEpic(checkMapPermissions, 0), 1, {type: LOGIN_SUCCESS}, ([a]) => {
+            expect(a.type).toBe(TEST_TIMEOUT);
+            done();
+        }, {});
+    });
     it('test the re-configuration of the max extent after the initialization of the map', (done) => {
         const state = {
             map: {

--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -204,6 +204,10 @@ const zoomToExtentEpic = (action$, {getState = () => {} }) =>
  */
 const checkMapPermissions = (action$, {getState = () => {} }) =>
         action$.ofType(LOGIN_SUCCESS)
+        .filter(() => {
+            const mapId = mapIdSelector(getState());
+            return mapId; // sometimes mapId is null
+        })
         .map(() => {
             const mapId = mapIdSelector(getState());
             return loadMapInfo(ConfigUtils.getConfigProp("geoStoreUrl") + "extjs/resource/" + mapId, mapId);

--- a/web/client/plugins/import/StyleDialog.jsx
+++ b/web/client/plugins/import/StyleDialog.jsx
@@ -35,6 +35,7 @@ class StyleDialog extends React.Component {
         panelStyle: PropTypes.object,
         panelClassName: PropTypes.string,
         visible: PropTypes.bool,
+        modal: PropTypes.bool,
         onClose: PropTypes.func,
         closeGlyph: PropTypes.string,
         uploadMessage: PropTypes.string,
@@ -45,6 +46,7 @@ class StyleDialog extends React.Component {
         id: "mapstore-shapefile-upload",
         uploadMessage: "shapefile.placeholder",
         wrap: true,
+        modal: true,
         wrapWithPanel: false,
         panelStyle: {
             minWidth: "360px",
@@ -85,7 +87,7 @@ class StyleDialog extends React.Component {
             return (<Dialog
                 id="import-style-dialog"
                 onClose={this.props.onClose}
-                modal show header={<Message msgId="shapefile.title" />}>
+                modal={this.props.modal} show header={<Message msgId="shapefile.title" />}>
                 {panel}
             </Dialog>);
         }


### PR DESCRIPTION
## Description
added some missing fixes for shapefile modal to be optional.
after login a loadmap is called but it should happen if a mapId exists.

## Issues
 - #3829 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
some problems described before

**What is the new behavior?**
you can disable modal for shapefile dropzone
no request are sent to load a map resource if map id is null

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
