### PR TITLE
Fix 3824 catalog issues in Firefox and template example

### DIFF
--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -328,6 +328,7 @@ class Catalog extends React.Component {
             this.isViewMode(this.props.mode) ? (
                 <BorderLayout
                     key="catalog-BorderLayout"
+                    bodyClassName="ms2-border-layout-body catalog"
                     header={(<Form>
                                 <FormGroup controlId="labelService" key="labelService">
                                     <ControlLabel><Message msgId="catalog.service"/></ControlLabel>
@@ -367,6 +368,7 @@ class Catalog extends React.Component {
                         </BorderLayout>
             ) : (
                 <BorderLayout
+                   bodyClassName="ms2-border-layout-body catalog"
                    header={<Form horizontal >
                        <FormGroup>
                            <Col xs={12}>
@@ -455,7 +457,7 @@ class Catalog extends React.Component {
                                                     </OverlayTrigger>
                                                 </p>
                                                 <pre>
-                                                    <Message msgId="catalog.templateFormatDescriptionExample"/>
+                                                    <Message msgId="catalog.templateFormatDescriptionExample"/>{ " ${ description }"}
                                                 </pre>
                                             </span>
                                        </Col>)}

--- a/web/client/themes/default/less/catalog.less
+++ b/web/client/themes/default/less/catalog.less
@@ -52,4 +52,7 @@
             text-align: justify;
         }
     }
+    .ms2-border-layout-body.catalog {
+        display: block !important;
+    }
 }

--- a/web/client/themes/default/less/catalog.less
+++ b/web/client/themes/default/less/catalog.less
@@ -52,6 +52,7 @@
             text-align: justify;
         }
     }
+    /* needed to avoid an error with Firefox where the width was not properly calculated #3824 */
     .ms2-border-layout-body.catalog {
         display: block !important;
     }

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1103,7 +1103,7 @@
             "missingReference": "Fehlende OGC-Referenzmetadaten",
             "showDescription": "Vollständige Beschreibung anzeigen",
             "hideDescription": "Vollständige Beschreibung ausblenden",
-            "templateFormatDescriptionExample": "Die Beschreibung der Schicht lautet $\\{ description \\}",
+            "templateFormatDescriptionExample": "Die Beschreibung der Schicht lautet",
             "showTemplate": "Metadatenvorlage anzeigen",
             "showPreview": "Vorschau zeigen",
             "advancedSettings": "Erweiterte Einstellungen",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1103,7 +1103,7 @@
             "missingReference": "Missing OGC reference metadata",
             "showDescription": "Show full description",
             "hideDescription": "Hide full description",
-            "templateFormatDescriptionExample": "The description of layer is $\\{ description \\}",
+            "templateFormatDescriptionExample": "The description of layer is",
             "showTemplate": "Show metadata template",
             "showPreview": "Show preview",
             "advancedSettings": "Advanced settings",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1103,7 +1103,7 @@
             "missingReference": "Faltan metadatos de referencia OGC",
             "showDescription": "Mostrar descripción completa",
             "hideDescription": "Ocultar descripción completa",
-            "templateFormatDescriptionExample": "La descripción de la capa es $\\{ description \\}",
+            "templateFormatDescriptionExample": "La descripción de la capa es",
             "showTemplate": "Mostrar plantilla de metadatos",
             "showPreview": "Mostrar vista previa",
             "advancedSettings": "Ajustes avanzados",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1103,7 +1103,7 @@
             "missingReference": "Les métadonnées des références OGC manquent",
             "showDescription": "Afficher la description complète",
             "hideDescription": "Masquer la description complète",
-            "templateFormatDescriptionExample": "La description de la couche est $\\{ description \\}",
+            "templateFormatDescriptionExample": "La description de la couche est",
             "showTemplate": "Afficher le modèle de métadonnées",
             "showPreview": "Afficher l'aperçu",
             "advancedSettings": "Réglages avancés",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1089,7 +1089,7 @@
             "missingReference": "Nedostaju referentni OGC metapodaci",
             "showDescription": "Prikaži puni opis",
             "hideDescription": "Sakrij puni opis",
-            "templateFormatDescriptionExample": "The description of layer is $\\{ description \\}",
+            "templateFormatDescriptionExample": "The description of layer is",
             "showTemplate": "Show metadata template",
             "showPreview": "Show preview",
             "advancedSettings": "Advanced Settings",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1103,7 +1103,7 @@
             "missingReference": "Metadati di riferimento OGC mancanti",
             "showDescription": "Mostra descrizione completa",
             "hideDescription": "Nascondi descrizione completa",
-            "templateFormatDescriptionExample": "La descrizione del layer è: $\\{ description \\}",
+            "templateFormatDescriptionExample": "La descrizione del layer è",
             "showTemplate": "Mostra il modello dei metadati",
             "showPreview": "Mostra la preview",
             "advancedSettings": "Impostazioni avanzante",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1023,7 +1023,7 @@
             "missingReference": "Missing OGC reference metadata",
             "showDescription": "Show full description",
             "hideDescription": "Hide full description",
-            "templateFormatDescriptionExample": "The description of layer is $\\{ description \\}",
+            "templateFormatDescriptionExample": "The description of layer is",
             "showTemplate": "Show metadata template",
             "showPreview": "Show preview",
             "advancedSettings": "Advanced Settings",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -1090,7 +1090,7 @@
             "missingReference": "Missing OGC reference metadata",
             "showDescription": "Show full description",
             "hideDescription": "Hide full description",
-            "templateFormatDescriptionExample": "The description of layer is $\\{ description \\}",
+            "templateFormatDescriptionExample": "The description of layer is",
             "showTemplate": "Show metadata template",
             "showPreview": "Show preview",
             "advancedSettings": "Advanced Settings",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1050,7 +1050,7 @@
             "missingReference": "Missing OGC reference metadata",
             "showDescription": "Show full description",
             "hideDescription": "Hide full description",
-            "templateFormatDescriptionExample": "The description of layer is $\\{ description \\}",
+            "templateFormatDescriptionExample": "The description of layer is",
             "showTemplate": "Show metadata template",
             "showPreview": "Show preview",
             "advancedSettings": "Advanced Settings",


### PR DESCRIPTION
## Description
this pr fixes a layouyt problem with firefox
and tthe template example by removing the escapes strings "\"

## Issues
 - #3824

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
with firefox the layout is not messed up

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
