### PR TITLE
Fix 3859 Change map view action does not work in openlayer

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -412,9 +412,14 @@ class OpenlayersMap extends React.Component {
         let view = this.map.getView();
         let tempCenter = view.getCenter();
         let projectionExtent = view.getProjection().getExtent();
+        const crs = view.getProjection().getCode();
+        // some projections are reapeated on the y axis
+        // and they need to be updated also if the center is outside of the projection extent
+        const wrappedProjections = [ 'EPSG:3857', 'EPSG:900913', 'EPSG:4326' ];
         // prevent user from dragging outside the projection extent
-        if (tempCenter && tempCenter[0] >= projectionExtent[0] && tempCenter[0] <= projectionExtent[2] &&
-            tempCenter[1] >= projectionExtent[1] && tempCenter[1] <= projectionExtent[3]) {
+        if (wrappedProjections.indexOf(crs) !== -1
+        || (tempCenter && tempCenter[0] >= projectionExtent[0] && tempCenter[0] <= projectionExtent[2] &&
+            tempCenter[1] >= projectionExtent[1] && tempCenter[1] <= projectionExtent[3])) {
             let c = this.normalizeCenter(view.getCenter());
             let bbox = view.calculateExtent(this.map.getSize());
             let size = {
@@ -428,7 +433,7 @@ class OpenlayersMap extends React.Component {
                     maxx: bbox[2],
                     maxy: bbox[3]
                 },
-                crs: view.getProjection().getCode(),
+                crs,
                 rotation: view.getRotation()
             }, size, this.props.id, this.props.projection);
         }

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -413,7 +413,7 @@ class OpenlayersMap extends React.Component {
         let tempCenter = view.getCenter();
         let projectionExtent = view.getProjection().getExtent();
         const crs = view.getProjection().getCode();
-        // some projections are reapeated on the y axis
+        // some projections are repeated on the y axis
         // and they need to be updated also if the center is outside of the projection extent
         const wrappedProjections = [ 'EPSG:3857', 'EPSG:900913', 'EPSG:4326' ];
         // prevent user from dragging outside the projection extent

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -413,7 +413,7 @@ class OpenlayersMap extends React.Component {
         let tempCenter = view.getCenter();
         let projectionExtent = view.getProjection().getExtent();
         const crs = view.getProjection().getCode();
-        // some projections are repeated on the y axis
+        // some projections are repeated on the x axis
         // and they need to be updated also if the center is outside of the projection extent
         const wrappedProjections = [ 'EPSG:3857', 'EPSG:900913', 'EPSG:4326' ];
         // prevent user from dragging outside the projection extent

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -900,9 +900,9 @@ describe('OpenlayersMap', () => {
             crs: 'EPSG:4326'
         };
         const testHandlers = {
-            handler: () => { }
+            onMapViewChanges: () => { }
         };
-        const spy = expect.spyOn(testHandlers, 'handler');
+        const spyOnMapViewChanges = expect.spyOn(testHandlers, 'onMapViewChanges');
         const projectionDefs = [
             {
                 "code": "EPSG:3003",
@@ -926,13 +926,13 @@ describe('OpenlayersMap', () => {
             id="ol-map"
             center={CENTER_OUTSIDE_OF_MAX_EXTENT}
             projectionDefs={projectionDefs}
-            onMapViewChanges={testHandlers.handler}
+            onMapViewChanges={testHandlers.onMapViewChanges}
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={projectionDefs[0].code}
             />, document.getElementById("map"));
 
-        expect(spy.calls.length).toBe(0);
+        expect(spyOnMapViewChanges.calls.length).toBe(0);
     });
 
     it('test updateMapInfoState projection 3857', () => {
@@ -943,20 +943,20 @@ describe('OpenlayersMap', () => {
             crs: 'EPSG:4326'
         };
         const testHandlers = {
-            handler: () => { }
+            onMapViewChanges: () => { }
         };
-        const spy = expect.spyOn(testHandlers, 'handler');
+        const spyOnMapViewChanges = expect.spyOn(testHandlers, 'onMapViewChanges');
 
         ReactDOM.render(<OpenlayersMap
             id="ol-map"
             center={CENTER_OUTSIDE_OF_MAX_EXTENT}
-            onMapViewChanges={testHandlers.handler}
+            onMapViewChanges={testHandlers.onMapViewChanges}
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={'EPSG:3857'}
             />, document.getElementById("map"));
 
-        expect(spy.calls.length).toBe(1);
+        expect(spyOnMapViewChanges.calls.length).toBe(1);
     });
 
     it('test updateMapInfoState projection 4326', () => {
@@ -967,20 +967,20 @@ describe('OpenlayersMap', () => {
             crs: 'EPSG:4326'
         };
         const testHandlers = {
-            handler: () => { }
+            onMapViewChanges: () => { }
         };
-        const spy = expect.spyOn(testHandlers, 'handler');
+        const spyOnMapViewChanges = expect.spyOn(testHandlers, 'onMapViewChanges');
 
         ReactDOM.render(<OpenlayersMap
             id="ol-map"
             center={CENTER_OUTSIDE_OF_MAX_EXTENT}
-            onMapViewChanges={testHandlers.handler}
+            onMapViewChanges={testHandlers.onMapViewChanges}
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={'EPSG:4326'}
             />, document.getElementById("map"));
 
-        expect(spy.calls.length).toBe(1);
+        expect(spyOnMapViewChanges.calls.length).toBe(1);
     });
 
     it('test updateMapInfoState projection 900913', () => {
@@ -991,20 +991,20 @@ describe('OpenlayersMap', () => {
             crs: 'EPSG:4326'
         };
         const testHandlers = {
-            handler: () => { }
+            onMapViewChanges: () => { }
         };
-        const spy = expect.spyOn(testHandlers, 'handler');
+        const spyOnMapViewChanges = expect.spyOn(testHandlers, 'onMapViewChanges');
 
         ReactDOM.render(<OpenlayersMap
             id="ol-map"
             center={CENTER_OUTSIDE_OF_MAX_EXTENT}
-            onMapViewChanges={testHandlers.handler}
+            onMapViewChanges={testHandlers.onMapViewChanges}
             zoom={11}
             mapOptions={{ attribution: { container: 'body' } }}
             projection={'EPSG:900913'}
             />, document.getElementById("map"));
 
-        expect(spy.calls.length).toBe(1);
+        expect(spyOnMapViewChanges.calls.length).toBe(1);
     });
 
 });

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -891,4 +891,120 @@ describe('OpenlayersMap', () => {
         attributions = document.getElementsByClassName('ol-attribution');
         expect(attributions.length).toBe(2);
     });
+
+    it('test updateMapInfoState with custom projection 3003 (not listed in wrappedProjections)', () => {
+
+        const CENTER_OUTSIDE_OF_MAX_EXTENT = {
+            x: 50,
+            y: 70,
+            crs: 'EPSG:4326'
+        };
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+        const projectionDefs = [
+            {
+                "code": "EPSG:3003",
+                "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+                "extent": [
+                    1241482.0019432348,
+                    972767.2605398067,
+                    1847542.2626266503,
+                    5215189.085323715
+                ],
+                "worldExtent": [
+                    6.6500,
+                    8.8000,
+                    12.0000,
+                    47.0500
+                ]
+            }
+        ];
+        proj.defs(projectionDefs[0].code, projectionDefs[0].def);
+        ReactDOM.render(<OpenlayersMap
+            id="ol-map"
+            center={CENTER_OUTSIDE_OF_MAX_EXTENT}
+            projectionDefs={projectionDefs}
+            onMapViewChanges={testHandlers.handler}
+            zoom={11}
+            mapOptions={{ attribution: { container: 'body' } }}
+            projection={projectionDefs[0].code}
+            />, document.getElementById("map"));
+
+        expect(spy.calls.length).toBe(0);
+    });
+
+    it('test updateMapInfoState projection 3857', () => {
+
+        const CENTER_OUTSIDE_OF_MAX_EXTENT = {
+            x: -200,
+            y: -100,
+            crs: 'EPSG:4326'
+        };
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+
+        ReactDOM.render(<OpenlayersMap
+            id="ol-map"
+            center={CENTER_OUTSIDE_OF_MAX_EXTENT}
+            onMapViewChanges={testHandlers.handler}
+            zoom={11}
+            mapOptions={{ attribution: { container: 'body' } }}
+            projection={'EPSG:3857'}
+            />, document.getElementById("map"));
+
+        expect(spy.calls.length).toBe(1);
+    });
+
+    it('test updateMapInfoState projection 4326', () => {
+
+        const CENTER_OUTSIDE_OF_MAX_EXTENT = {
+            x: 200,
+            y: 100,
+            crs: 'EPSG:4326'
+        };
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+
+        ReactDOM.render(<OpenlayersMap
+            id="ol-map"
+            center={CENTER_OUTSIDE_OF_MAX_EXTENT}
+            onMapViewChanges={testHandlers.handler}
+            zoom={11}
+            mapOptions={{ attribution: { container: 'body' } }}
+            projection={'EPSG:4326'}
+            />, document.getElementById("map"));
+
+        expect(spy.calls.length).toBe(1);
+    });
+
+    it('test updateMapInfoState projection 900913', () => {
+
+        const CENTER_OUTSIDE_OF_MAX_EXTENT = {
+            x: 200,
+            y: -100,
+            crs: 'EPSG:4326'
+        };
+        const testHandlers = {
+            handler: () => { }
+        };
+        const spy = expect.spyOn(testHandlers, 'handler');
+
+        ReactDOM.render(<OpenlayersMap
+            id="ol-map"
+            center={CENTER_OUTSIDE_OF_MAX_EXTENT}
+            onMapViewChanges={testHandlers.handler}
+            zoom={11}
+            mapOptions={{ attribution: { container: 'body' } }}
+            projection={'EPSG:900913'}
+            />, document.getElementById("map"));
+
+        expect(spy.calls.length).toBe(1);
+    });
+
 });


### PR DESCRIPTION
## Description
This PR allows default projections to trigger CHANGE_MAP_VIEW even if the center is outside the max extension of the projections. (EPSG:3857, EPSG:900913 and EPSG:4326) 

## Issues
 - #3859

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
#3859

**What is the new behavior?**
This PR allows default projections to trigger CHANGE_MAP_VIEW even if the center is outside the max extension of the projections. (EPSG:3857, EPSG:900913 and EPSG:4326) 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
