### PR TITLE
Allow service specific users for GeoFence RuleManager

### DIFF
--- a/web/client/api/geoserver/GeoFence.js
+++ b/web/client/api/geoserver/GeoFence.js
@@ -139,7 +139,7 @@ var Api = {
     /**
      * Get the API to use as user service (to retrieve users and roles)
      */
-    getUserService: () => USER_SERVICES[Api.getUserServiceType()]({ addBaseUrl: Api.addBaseUrl, addBaseUrlGS: Api.addBaseUrlGS }),
+    getUserService: () => USER_SERVICES[Api.getUserServiceType()]({ addBaseUrl: Api.addBaseUrl, addBaseUrlGS: Api.addBaseUrlGS, getUserService: Api.getUserServiceName }),
     getRuleService: () => RULE_SERVICES[Api.getRuleServiceType()]({ addBaseUrl: Api.addBaseUrl, addBaseUrlGS: Api.addBaseUrlGS, getGeoServerInstance: Api.getGeoServerInstance}),
     getLayerService: () => LAYER_SERVICES[Api.getLayerServiceType()]({ addBaseUrl: Api.addBaseUrl, addBaseUrlGS: Api.addBaseUrlGS, getGeoServerInstance: Api.getGeoServerInstance }),
     /**
@@ -152,7 +152,10 @@ var Api = {
     * @returns {string} one of `geofence`. TODO: add other service types (geostore, geoserver)
     */
     getRuleServiceType: () => ConfigUtils.getDefaults().geoFenceServiceType || 'geofence',
+    // autocomplete service type for layers. Can be "rest" or "csw"
     getLayerServiceType: () => ConfigUtils.getDefaults().geoFenceLayerServiceType || 'csw',
+    // returns the user service name (for GeoServer user name autocomplete that points to specific servic (i.e. geostore))
+    getUserServiceName: () => ConfigUtils.getDefaults().geoserverUserServiceName,
 
     addBaseUrl: function(options = {}) {
         return assign(options, {

--- a/web/client/api/geoserver/geofence/__tests__/UserService-test.js
+++ b/web/client/api/geoserver/geofence/__tests__/UserService-test.js
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const BASE_URL = "TEST";
+const UserService = require('../UserService')({
+    addBaseUrlGS: (options ) => ({ baseURL: BASE_URL, ...options }),
+    getUserService: () => {}
+});
+// geoserver provides it's default group by default
+// service specific. to test path like /security/usergroup/service/geostore/users.json
+const ServiceSpecificUserService = require('../UserService')({
+    addBaseUrlGS: (options) => ({ baseURL: BASE_URL, ...options }),
+    getUserService: () => "geostore"
+});
+const USERS = require('../../../../test-resources/geoserver/rest/users.json');
+const ROLES = require('../../../../test-resources/geoserver/rest/roles.json');
+const expect = require('expect');
+
+const axios = require('../../../../libs/ajax');
+const MockAdapter = require('axios-mock-adapter');
+
+let mockAxios;
+
+
+describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
+    beforeEach(done => {
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        mockAxios.restore();
+        setTimeout(done);
+    });
+    it('getUsersCount', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+        UserService.getUsersCount()
+            .then(v => {
+                expect(v).toBe(11);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getUsers', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+        UserService.getUsers("", 0, 10)
+            .then(({users}) => {
+                expect(users.length).toBe(10);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getUsers pagination', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+        UserService.getUsers("", 1, 10)
+            .then(({ users }) => {
+                expect(users.length).toBe(1);
+                expect(users[0].userName).toBe("test_user11");
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getUsers from service', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/service/geostore/users.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+
+        ServiceSpecificUserService.getUsers("", 1, 10)
+            .then(({ users }) => {
+                expect(users.length).toBe(1);
+                expect(users[0].userName).toBe("test_user11");
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getUsersCount from service', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/service/geostore/users.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+        ServiceSpecificUserService.getUsersCount()
+            .then(v => {
+                expect(v).toBe(11);
+                done();
+            })
+            .catch(e => done(e));
+    });
+
+    it('getUsersCount with filter', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+        UserService.getUsersCount("USER1") // test_user1, test_user10, test_user11
+            .then(v => {
+                expect(v).toBe(3);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getUsers with filter, case insensitive', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`); // test_user1, test_user10, test_user11
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, USERS];
+        });
+        UserService.getUsers("USER1", 0, 10)
+            .then(({ users }) => {
+                expect(users.length).toBe(3);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getRolesCount, case insensitive', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, ROLES];
+        });
+        UserService.getRolesCount()
+            .then(v => {
+                expect(v).toBe(14);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getRoles', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, ROLES];
+        });
+        UserService.getRoles("", 0, 10)
+            .then(({ roles }) => {
+                expect(roles.length).toBe(10);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getRoles pagination', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, ROLES];
+        });
+        UserService.getRoles("", 1, 10)
+            .then(({ roles }) => {
+                expect(roles.length).toBe(4);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getRolesCount with filter, case insensitive', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, ROLES];
+        });
+        UserService.getRolesCount("GROUP1") // test also case insensitive search
+            .then(v => {
+                expect(v).toBe(2);
+                done();
+            })
+            .catch(e => done(e));
+    });
+    it('getRoles with filter, case insensitive', (done) => {
+        mockAxios.onGet().reply(config => {
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
+            expect(config.baseURL).toBe(`${BASE_URL}`);
+            return [200, ROLES];
+        });
+        UserService.getRoles("GROUP1", 0, 10) // test also case insensitive search
+            .then(({ roles }) => {
+                expect(roles.length).toBe(2);
+                done();
+            })
+            .catch(e => done(e));
+    });
+});

--- a/web/client/product/pages/RulesManager.jsx
+++ b/web/client/product/pages/RulesManager.jsx
@@ -87,6 +87,7 @@ const BorderLayout = require('../../components/layout/BorderLayout');
   * "geoFencePath": "rest/geofence",
   * "geoFenceServiceType": "geoserver",
   * "geoFenceLayerServiceType": "rest",
+  * "geoserverUserServiceName": "geostore" // optional, if you want to use a specific user service for autocomplete, instead of GeoServer's default one
   * "geoFenceGeoServerInstance": {
   *   "url": "/geoserver/",
   *   "id": 1

--- a/web/client/test-resources/geoserver/rest/roles.json
+++ b/web/client/test-resources/geoserver/rest/roles.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    "ADMIN",
+    "GEOSTORE",
+    "GUEST",
+    "USER",
+    "group1",
+    "group2",
+    "group3",
+    "group4",
+    "group5",
+    "group6",
+    "group7",
+    "group8",
+    "group9",
+    "group10"
+  ]
+}

--- a/web/client/test-resources/geoserver/rest/users.json
+++ b/web/client/test-resources/geoserver/rest/users.json
@@ -1,0 +1,59 @@
+{
+  "users": [
+    {
+      "userName": "test_user1",
+      "password": null,
+      "enabled": true
+    },
+    {
+      "userName": "test_user2",
+      "password": null,
+      "enabled": true
+    },
+    {
+      "userName": "test_user3",
+      "password": null,
+      "enabled": false
+    },
+    {
+      "userName": "test_user4",
+      "password": null,
+      "enabled": true
+    },
+    {
+      "userName": "test_user5",
+      "password": null,
+      "enabled": true
+    },
+    {
+      "userName": "test_user6",
+      "password": null,
+      "enabled": true
+    },
+    {
+      "userName": "test_user7",
+      "password": null,
+      "enabled": false
+    },
+    {
+      "userName": "test_user8",
+      "password": null,
+      "enabled": false
+    },
+    {
+      "userName": "test_user9",
+      "password": null,
+      "enabled": false
+    },
+    {
+      "userName": "test_user10",
+      "password": null,
+      "enabled": false
+    },
+    {
+      "userName": "test_user11",
+      "password": null,
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Description
This pull request add the possibility to configure a specific usergroup service to get users from GeoServer rest interface.
By default GeoServer provides it's own usergroup service (most of the times containing only admin user) via rest interface. To get the user for a set-up with MapStore integration, this is not enough.
Adding the optional configuration `geoserverUserServiceName` the Rule Manager can autocomplete by querying the specific usergroup service usually `geostore`).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
User autocomplete combo can list only geoserver's users

**What is the new behavior?**
User autocomplete combo can list all users

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

