### PR TITLE
fix formatting of temporal metadata

### DIFF
--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -159,7 +159,7 @@ const converters = {
                     metadata = {...metadata, subject: ["<ul>" + castArray(dc.subject).map(s => `<li>${s}</li>`).join("") + "</ul>"]};
                 }
                 if (references && castArray(references).length ) {
-                    metadata = {...metadata, references: ["<ul>" + castArray(references).map(ref => `<li><a target="_blank" href="${ref.url}">${ref.params && ref.params.name || ref.url}</a></li>`) + "</ul>"]
+                    metadata = {...metadata, references: ["<ul>" + castArray(references).map(ref => `<li><a target="_blank" href="${ref.url}">${ref.params && ref.params.name || ref.url}</a></li>`).join("") + "</ul>"]
                     };
                 } else {
                     // in order to use a default value
@@ -192,7 +192,7 @@ const converters = {
                                 }
                                 return "";
                             });
-                        metadata = {...metadata, temporal: ["<ul>" + temporal.map(date => `<li>${date}</li>`) + "</ul>"]};
+                        metadata = {...metadata, temporal: ["<ul>" + temporal.map(date => `<li>${date}</li>`).join("") + "</ul>"]};
                     }
                 }
                 // setup the final record object

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -302,7 +302,7 @@ describe('Test the CatalogUtils', () => {
         }, {}, {});
         expect(records.length).toEqual(1);
         let temporal = records[0].metadata.temporal;
-        expect(temporal).toEqual(["<ul><li>catalog.start2019-02-03</li>,<li>catalog.end2019-03-03</li></ul>"]);
+        expect(temporal).toEqual(["<ul><li>catalog.start2019-02-03</li><li>catalog.end2019-03-03</li></ul>"]);
     });
     it('csw dct:temporal metadata YYYY-MM', () => {
         let records = CatalogUtils.getCatalogRecords('csw', {
@@ -314,7 +314,7 @@ describe('Test the CatalogUtils', () => {
         }, {}, {});
         expect(records.length).toEqual(1);
         let temporal = records[0].metadata.temporal;
-        expect(temporal).toEqual(["<ul><li>catalog.start2019-02</li>,<li>catalog.end2019-03</li></ul>"]);
+        expect(temporal).toEqual(["<ul><li>catalog.start2019-02</li><li>catalog.end2019-03</li></ul>"]);
     });
     it('csw dct:temporal metadata YYYY', () => {
         let records = CatalogUtils.getCatalogRecords('csw', {
@@ -326,7 +326,7 @@ describe('Test the CatalogUtils', () => {
         }, {}, {});
         expect(records.length).toEqual(1);
         let temporal = records[0].metadata.temporal;
-        expect(temporal).toEqual(["<ul><li>catalog.start2019</li>,<li>catalog.end2019</li></ul>"]);
+        expect(temporal).toEqual(["<ul><li>catalog.start2019</li><li>catalog.end2019</li></ul>"]);
     });
     it('csw dct:temporal metadata YYYY-MM-DDThh:mm:ssZ', () => {
         let records = CatalogUtils.getCatalogRecords('csw', {
@@ -338,7 +338,7 @@ describe('Test the CatalogUtils', () => {
         }, {}, {});
         expect(records.length).toEqual(1);
         let temporal = records[0].metadata.temporal;
-        expect(temporal).toEqual([`<ul><li>catalog.start${new Date("2019-03-05T02:02:00Z").toLocaleString()}</li>,<li>catalog.end${new Date("2019-03-05T02:52:00Z").toLocaleString()}</li></ul>`]);
+        expect(temporal).toEqual([`<ul><li>catalog.start${new Date("2019-03-05T02:02:00Z").toLocaleString()}</li><li>catalog.end${new Date("2019-03-05T02:52:00Z").toLocaleString()}</li></ul>`]);
     });
     it('csw dct:temporal metadata YYYY-MM-DDThh:mm:ssTZD', () => {
         let records = CatalogUtils.getCatalogRecords('csw', {
@@ -350,7 +350,7 @@ describe('Test the CatalogUtils', () => {
         }, {}, {});
         expect(records.length).toEqual(1);
         let temporal = records[0].metadata.temporal;
-        expect(temporal).toEqual([`<ul><li>catalog.start${new Date("2019-03-05T02:02:00+05:00").toLocaleString()}</li>,<li>catalog.end${new Date("2019-03-05T02:52:00+05:00").toLocaleString()}</li></ul>`]);
+        expect(temporal).toEqual([`<ul><li>catalog.start${new Date("2019-03-05T02:02:00+05:00").toLocaleString()}</li><li>catalog.end${new Date("2019-03-05T02:52:00+05:00").toLocaleString()}</li></ul>`]);
     });
     it('csw dct:temporal metadata YYYY-MM-DDThh:mm:ssTZD scheme="W3C-DTF"', () => {
         let records = CatalogUtils.getCatalogRecords('csw', {
@@ -362,7 +362,7 @@ describe('Test the CatalogUtils', () => {
         }, {}, {});
         expect(records.length).toEqual(1);
         let temporal = records[0].metadata.temporal;
-        expect(temporal).toEqual([`<ul><li>catalog.start${new Date("2019-03-05T02:02:00+05:00").toLocaleString()}</li>,<li>catalog.end${new Date("2019-03-05T02:52:00+05:00").toLocaleString()}</li></ul>`]);
+        expect(temporal).toEqual([`<ul><li>catalog.start${new Date("2019-03-05T02:02:00+05:00").toLocaleString()}</li><li>catalog.end${new Date("2019-03-05T02:52:00+05:00").toLocaleString()}</li></ul>`]);
     });
     it('csw dct:temporal metadata YYYY-MM-DDThh:mm:ssTZD scheme="Geological timescale"', () => {
         let records = CatalogUtils.getCatalogRecords('csw', {


### PR DESCRIPTION
## Description
this pr solves a little formatting error with temproal metadata in catalog

## Issues
 - #3867 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Code style update (formatting, local variables)

**What is the current behavior?** (You can also link to an open issue here)
a comma appears between temporal metadata 

![image](https://user-images.githubusercontent.com/11991428/60100830-d6e9ad00-975a-11e9-98fa-a785b25c2931.png)

**What is the new behavior?**
it no longer does it 
![image](https://user-images.githubusercontent.com/11991428/60100841-e0731500-975a-11e9-8e47-b9f1c5cb75de.png)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
