### PR TITLE
Avoid errors due to layerDetails not supported

### DIFF
--- a/web/client/test-resources/geoserver/rest/geofence/full_rule1.json
+++ b/web/client/test-resources/geoserver/rest/geofence/full_rule1.json
@@ -6,30 +6,5 @@
   "request": "DESCRIBEFEATURETYPE",
   "userName": "admin",
   "roleName": "ADMIN",
-  "addressRange": "192.168.1.1/8",
-  "layerDetails": {
-    "layerType": "VECTOR",
-    "defaultStyle": "burg",
-    "cqlFilterRead": "INCLUDE",
-    "cqlFilterWrite": "INCLUDE",
-    "allowedArea": "MULTIPOLYGON (((-74.01196092367172 40.70918709039688, -74.01196092367172 40.708114206790924, -74.00962203741074 40.708114206790924, -74.00962203741074 40.70918709039688, -74.01196092367172 40.70918709039688)))",
-    "allowedStyles": [
-      "point",
-      "poi"
-    ],
-    "attributes": [
-      {
-        "name": "the_geom",
-        "accessType": "READONLY"
-      },
-      {
-        "name": "THUMBNAIL",
-        "accessType": "NONE"
-      },
-      {
-        "name": "MAINPAGE",
-        "accessType": "NONE"
-      }
-    ]
-  }
+  "addressRange": "192.168.1.1/8"
 }

--- a/web/client/utils/RuleServiceUtils.jsx
+++ b/web/client/utils/RuleServiceUtils.jsx
@@ -80,8 +80,8 @@ module.exports = {
         username,
         rolename,
         limits,
-        ipaddress,
-        constraints = {}
+        ipaddress
+        // constraints = {}
 
     }) => ({
         id,
@@ -94,7 +94,8 @@ module.exports = {
         userName: username,
         roleName: rolename,
         limits, // TODO: parse and manage
-        addressRange: ipaddress,
+        addressRange: ipaddress
+        /* LAYER DETAILS NOT SUPPORTED YET
         layerDetails: constraints && layer && {
             layerType: constraints.type,
             defaultStyle: constraints.defaultStyle,
@@ -109,5 +110,6 @@ module.exports = {
                         accessType: access
                     }))
         }
+        */
     })
 };

--- a/web/client/utils/__tests__/RuleServiceUtils-test.js
+++ b/web/client/utils/__tests__/RuleServiceUtils-test.js
@@ -18,14 +18,17 @@ describe('RuleServiceUtils', () => {
         Object.keys(converted).map(k => {
             expect(converted[k]).toEqual(GS_RULE1[k]);
         });
-        // check layerDetails exists only if layer is present
-        expect(convertRuleGF2GS({ ...GF_RULE1 }).layerDetails).toExist();
+        // check layerDetails not supported
+        expect(convertRuleGF2GS({ ...GF_RULE1 }).layerDetails).toNotExist();
         expect(convertRuleGF2GS({ ...GF_RULE1, layer: undefined }).layerDetails).toNotExist();
     });
     it('convertRuleGS2GF', () => {
         const converted = convertRuleGS2GF(GS_RULE1);
         Object.keys(converted).map(k => {
-            expect(converted[k]).toEqual(GF_RULE1[k]);
+            if (k !== "constraints") { // NOT SUPPORTED
+                expect(converted[k]).toEqual(GF_RULE1[k]);
+            }
+
         });
     });
 


### PR DESCRIPTION
GeoFence API integrated in GeoServer do not support layerDetails.
This pull request remove details in certain cases, to avoid error on the back-end due to the presence of layerDetails.
