### PR TITLE
add support for oblique labels for line and bar chart in widgets

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/utils', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/utils', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/components/charts/Bar.jsx
+++ b/web/client/components/charts/Bar.jsx
@@ -4,21 +4,84 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
+*/
+const {castArray, isNil, isEqual} = require('lodash');
+const PropTypes = require('prop-types');
 const React = require('react');
 const {BarChart, Bar} = require('recharts');
+
 const {renderCartesianTools} = require('./cartesian');
 
-module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, autoColorOptions, ...props} = {}) => {
-    const seriesArray = (Array.isArray(series) ? series : [series]);
-    const COLORS = colorGenerator(seriesArray.length);
-    // WORKAROUND: rechart do not rerender line and bar charts when change colors, y axis and legend label.
-    const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
-    const yAxisLabel = props.yAxis;
-    const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel).join("");
-    return (<BarChart key={key} autoColorOptions={autoColorOptions} width={width} height={height} data={data}>
-       {seriesArray.map(({color, ...serie} = {}, i) => <Bar key={`bar-${i}`} name={props.yAxisLabel ? props.yAxisLabel : null} fill={COLORS[i]} {...serie}/>)}
-       {renderCartesianTools(props)}
-       {props.children}
-    </BarChart>);
-};
+class BarChartWrapper extends React.Component {
+    static propTypes = {
+        autoColorOptions: PropTypes.object,
+        colorGenerator: PropTypes.func,
+        data: PropTypes.array,
+        isAnimationActive: PropTypes.bool,
+        height: PropTypes.number,
+        margin: PropTypes.object,
+        series: PropTypes.array,
+        xAxisAngle: PropTypes.number,
+        width: PropTypes.number
+    }
+    static defaultProps = {
+        height: 300,
+        series: [],
+        width: 600
+    }
+    state = {
+        marginLeft: 0,
+        marginBottom: 0
+    }
+    componentWillReceiveProps(newProps) {
+        if (!isEqual(newProps.xAxisAngle, this.props.xAxisAngle)) {
+            this.setState({marginLeft: 0, marginBottom: 0});
+        }
+    }
+    render() {
+        const {autoColorOptions, colorGenerator, data, isAnimationActive, height, margin, series, width, ...props} = this.props;
+        const seriesArray = (Array.isArray(series) ? series : [series]);
+        const COLORS = colorGenerator(seriesArray.length);
+        // WORKAROUND: recharts does not re-render line and bar charts when changing colors, y axis, x axis rotation angle and legend label.
+        const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];
+        const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
+        const yAxisLabel = props.yAxis;
+        const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
+
+        const onUpdateLabelLength = ({marginLeft, marginBottom}) => {
+            this.setState((state) => ({
+                marginBottom: (state.marginBottom < marginBottom) ? marginBottom : state.marginBottom,
+                marginLeft: (state.marginLeft < marginLeft) ? marginLeft : state.marginLeft
+            }));
+
+        };
+        const marginLeft = this.state.marginLeft;
+        const marginBottom = this.state.marginBottom;
+
+        return (
+            <BarChart
+                key={key}
+                autoColorOptions={autoColorOptions}
+                width={width}
+                height={height}
+                data={data}
+                margin={props.xAxisAngle ? {
+                    top: 20,
+                    right: 30,
+                    left: marginLeft + 10, // 10 is for balancing the translate left of the oblique label
+                    bottom: marginBottom + 20
+                } : margin }>
+                {
+                    seriesArray.map(({color, ...serie} = {}, i) =>
+                    <Bar
+                        key={`bar-${i}`}
+                        name={props.yAxisLabel ? props.yAxisLabel : null}
+                        fill={COLORS[i]} {...serie}/>)
+                }
+                {renderCartesianTools({...props, onUpdateLabelLength})}
+                {props.children}
+            </BarChart>
+        );
+    }
+}
+module.exports = BarChartWrapper;

--- a/web/client/components/charts/Bar.jsx
+++ b/web/client/components/charts/Bar.jsx
@@ -10,7 +10,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const {BarChart, Bar} = require('recharts');
 
-const {renderCartesianTools} = require('./cartesian');
+const renderCartesianTools = require('./cartesian').default;
 
 class BarChartWrapper extends React.Component {
     static propTypes = {
@@ -40,7 +40,7 @@ class BarChartWrapper extends React.Component {
     }
     render() {
         const {autoColorOptions, colorGenerator, data, isAnimationActive, height, margin, series, width, ...props} = this.props;
-        const seriesArray = (Array.isArray(series) ? series : [series]);
+        const seriesArray = castArray(series);
         const COLORS = colorGenerator(seriesArray.length);
         // WORKAROUND: recharts does not re-render line and bar charts when changing colors, y axis, x axis rotation angle and legend label.
         const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -18,6 +18,7 @@ class LineChartWrapper extends React.Component {
         data: PropTypes.array,
         isAnimationActive: PropTypes.bool,
         height: PropTypes.number,
+        margin: PropTypes.object,
         series: PropTypes.array,
         width: PropTypes.number
     }
@@ -36,7 +37,7 @@ class LineChartWrapper extends React.Component {
         }
     }*/
     render() {
-        const {autoColorOptions, colorGenerator, data, isAnimationActive, height, series, width, ...props} = this.props;
+        const {autoColorOptions, colorGenerator, data, isAnimationActive, height, margin, series, width, ...props} = this.props;
         const seriesArray = castArray(series);
         const COLORS = colorGenerator(seriesArray.length, autoColorOptions);
         const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
@@ -63,7 +64,12 @@ class LineChartWrapper extends React.Component {
                 width={width}
                 height={height}
                 data={data}
-                margin={props.xAxisAngle ? {top: 20, right: 30, left: marginLeft, bottom: marginBottom } : {}}
+                margin={props.xAxisAngle ? {
+                    top: 20,
+                    right: 30,
+                    left: marginLeft + 10, // 10 is for balancing the translate left of the oblique label
+                    bottom: marginBottom
+                } : margin }
             >
                 {seriesArray.map(({color, ...serie}, i) =>
                     <Line

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -4,11 +4,12 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
-const React = require('react');
-const {LineChart, Line} = require('recharts');
+*/
 const {castArray, isNil, isEqual} = require('lodash');
 const PropTypes = require('prop-types');
+const React = require('react');
+const {LineChart, Line} = require('recharts');
+
 const {renderCartesianTools} = require('./cartesian');
 
 class LineChartWrapper extends React.Component {

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -31,11 +31,11 @@ class LineChartWrapper extends React.Component {
         marginLeft: 0,
         marginBottom: 0
     }
-    /*componentWillReceiveProps(newProps) {
+    componentWillReceiveProps(newProps) {
         if (!isEqual(newProps, this.props)) {
             this.setState({marginLeft: 0, marginBottom: 0});
         }
-    }*/
+    }
     render() {
         const {autoColorOptions, colorGenerator, data, isAnimationActive, height, margin, series, width, ...props} = this.props;
         const seriesArray = castArray(series);
@@ -47,8 +47,6 @@ class LineChartWrapper extends React.Component {
         // WORKAROUND: recharts does not re-render line and bar charts when changing colors, y axis, x axis rotation angle and legend label.
         const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
 
-        // const lengthLongestLabels = maxBy(data, (d) => d[props.xAxis.dataKey].length)[props.xAxis.dataKey].length;
-        // const lengthFirstLabel = head(data) && head(data)[props.xAxis.dataKey].length;
         const onUpdateLabelLength = ({marginLeft, marginBottom}) => {
             this.setState((state) => ({
                 marginBottom: (state.marginBottom < marginBottom) ? marginBottom : state.marginBottom,
@@ -68,7 +66,7 @@ class LineChartWrapper extends React.Component {
                     top: 20,
                     right: 30,
                     left: marginLeft + 10, // 10 is for balancing the translate left of the oblique label
-                    bottom: marginBottom
+                    bottom: marginBottom + 20
                 } : margin }
             >
                 {seriesArray.map(({color, ...serie}, i) =>

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -10,7 +10,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const {LineChart, Line} = require('recharts');
 
-const {renderCartesianTools} = require('./cartesian');
+const renderCartesianTools = require('./cartesian').default;
 
 class LineChartWrapper extends React.Component {
     static propTypes = {

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -7,7 +7,7 @@
  */
 const React = require('react');
 const {LineChart, Line} = require('recharts');
-const {castArray, isNil} = require('lodash');
+const {castArray, isNil, maxBy, head} = require('lodash');
 const {renderCartesianTools} = require('./cartesian');
 
 module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, autoColorOptions, isAnimationActive, ...props} = {}) => {
@@ -18,12 +18,17 @@ module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, 
     const yAxisLabel = props.yAxis;
     const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];
     const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
+    // style= {{marginTop: 20, marginLeft: 20, marginBottom: 10, marginRight: 30}}
+    // margin: 20px 20px 10px 30px
+    const lengthLongestLabels = maxBy(data, (d) => d[props.xAxis.dataKey].length)[props.xAxis.dataKey].length;
+    const lengthFirstLabel = head(data) && head(data)[props.xAxis.dataKey].length;
     return (
         <LineChart
             key={key}
             width={width}
             height={height}
             data={data}
+            margin={props.xAxisAngle ? {top: 20, right: 30, left: 30 + lengthFirstLabel, bottom: lengthLongestLabels * 5 } : {}}
         >
             {seriesArray.map(({color, ...serie}, i) =>
                 <Line

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -7,38 +7,76 @@
  */
 const React = require('react');
 const {LineChart, Line} = require('recharts');
-const {castArray, isNil, maxBy, head} = require('lodash');
+const {castArray, isNil, isEqual} = require('lodash');
+const PropTypes = require('prop-types');
 const {renderCartesianTools} = require('./cartesian');
 
-module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, autoColorOptions, isAnimationActive, ...props} = {}) => {
-    const seriesArray = castArray(series);
-    const COLORS = colorGenerator(seriesArray.length, autoColorOptions);
-    const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
-    const yAxisLabel = props.yAxis;
-    const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];
+class LineChartWrapper extends React.Component {
+    static propTypes = {
+        autoColorOptions: PropTypes.object,
+        colorGenerator: PropTypes.func,
+        data: PropTypes.array,
+        isAnimationActive: PropTypes.bool,
+        height: PropTypes.number,
+        series: PropTypes.array,
+        width: PropTypes.number
+    }
+    static defaultProps = {
+        height: 300,
+        series: [],
+        width: 600
+    }
+    state = {
+        marginLeft: 0,
+        marginBottom: 0
+    }
+    /*componentWillReceiveProps(newProps) {
+        if (!isEqual(newProps, this.props)) {
+            this.setState({marginLeft: 0, marginBottom: 0});
+        }
+    }*/
+    render() {
+        const {autoColorOptions, colorGenerator, data, isAnimationActive, height, series, width, ...props} = this.props;
+        const seriesArray = castArray(series);
+        const COLORS = colorGenerator(seriesArray.length, autoColorOptions);
+        const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
+        const yAxisLabel = props.yAxis;
+        const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];
 
-    // WORKAROUND: recharts does not re-render line and bar charts when changing colors, y axis, x axis rotation angle and legend label.
-    const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
+        // WORKAROUND: recharts does not re-render line and bar charts when changing colors, y axis, x axis rotation angle and legend label.
+        const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
 
-    const lengthLongestLabels = maxBy(data, (d) => d[props.xAxis.dataKey].length)[props.xAxis.dataKey].length;
-    const lengthFirstLabel = head(data) && head(data)[props.xAxis.dataKey].length;
-    return (
-        <LineChart
-            key={key}
-            width={width}
-            height={height}
-            data={data}
-            margin={props.xAxisAngle ? {top: 20, right: 30, left: 30 + 10 + lengthFirstLabel, bottom: 5 + (lengthLongestLabels * 5) } : {}}
-        >
-            {seriesArray.map(({color, ...serie}, i) =>
-                <Line
-                    key={`line-${i}`}
-                    name={props.yAxisLabel ? props.yAxisLabel : null}
-                    isAnimationActive={isAnimationActive}
-                    stroke={COLORS[i]} {...serie} />)
-            }
-            {renderCartesianTools(props)}
-            {props.children}
-        </LineChart>
-    );
-};
+        // const lengthLongestLabels = maxBy(data, (d) => d[props.xAxis.dataKey].length)[props.xAxis.dataKey].length;
+        // const lengthFirstLabel = head(data) && head(data)[props.xAxis.dataKey].length;
+        const onUpdateLabelLength = ({marginLeft, marginBottom}) => {
+            this.setState((state) => ({
+                marginBottom: (state.marginBottom < marginBottom) ? marginBottom : state.marginBottom,
+                marginLeft: (state.marginLeft < marginLeft) ? marginLeft : state.marginLeft
+            }));
+
+        };
+        const marginLeft = this.state.marginLeft;
+        const marginBottom = this.state.marginBottom;
+        return (
+            <LineChart
+                key={key}
+                width={width}
+                height={height}
+                data={data}
+                margin={props.xAxisAngle ? {top: 20, right: 30, left: marginLeft, bottom: marginBottom } : {}}
+            >
+                {seriesArray.map(({color, ...serie}, i) =>
+                    <Line
+                        key={`line-${i}`}
+                        name={props.yAxisLabel ? props.yAxisLabel : null}
+                        isAnimationActive={isAnimationActive}
+                        stroke={COLORS[i]} {...serie} />)
+                }
+                {renderCartesianTools({...props, onUpdateLabelLength})}
+                {props.children}
+            </LineChart>
+        );
+    }
+}
+
+module.exports = LineChartWrapper;

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -7,19 +7,33 @@
  */
 const React = require('react');
 const {LineChart, Line} = require('recharts');
+const {castArray, isNil} = require('lodash');
 const {renderCartesianTools} = require('./cartesian');
 
 module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, autoColorOptions, isAnimationActive, ...props} = {}) => {
-    const seriesArray = (Array.isArray(series) ? series : [series]);
+    const seriesArray = castArray(series);
     const COLORS = colorGenerator(seriesArray.length, autoColorOptions);
     // WORKAROUND: rechart do not rerender line and bar charts when change colors, y axis and legend label.
     const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
     const yAxisLabel = props.yAxis;
-    const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel).join("");
-    return (<LineChart key={key} width={width} height={height} data={data}>
-       {seriesArray.map(({color, ...serie}, i) => <Line key={`line-${i}`} name={props.yAxisLabel ? props.yAxisLabel : null} isAnimationActive={isAnimationActive} stroke={COLORS[i]} {...serie} />)}
-       {renderCartesianTools(props)}
-       {props.children}
-
-    </LineChart>);
+    const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];
+    const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
+    return (
+        <LineChart
+            key={key}
+            width={width}
+            height={height}
+            data={data}
+        >
+            {seriesArray.map(({color, ...serie}, i) =>
+                <Line
+                    key={`line-${i}`}
+                    name={props.yAxisLabel ? props.yAxisLabel : null}
+                    isAnimationActive={isAnimationActive}
+                    stroke={COLORS[i]} {...serie} />)
+            }
+            {renderCartesianTools(props)}
+            {props.children}
+        </LineChart>
+    );
 };

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -20,6 +20,7 @@ class LineChartWrapper extends React.Component {
         height: PropTypes.number,
         margin: PropTypes.object,
         series: PropTypes.array,
+        xAxisAngle: PropTypes.number,
         width: PropTypes.number
     }
     static defaultProps = {
@@ -32,7 +33,7 @@ class LineChartWrapper extends React.Component {
         marginBottom: 0
     }
     componentWillReceiveProps(newProps) {
-        if (!isEqual(newProps, this.props)) {
+        if (!isEqual(newProps.xAxisAngle, this.props.xAxisAngle)) {
             this.setState({marginLeft: 0, marginBottom: 0});
         }
     }

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -13,13 +13,13 @@ const {renderCartesianTools} = require('./cartesian');
 module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, autoColorOptions, isAnimationActive, ...props} = {}) => {
     const seriesArray = castArray(series);
     const COLORS = colorGenerator(seriesArray.length, autoColorOptions);
-    // WORKAROUND: rechart do not rerender line and bar charts when change colors, y axis and legend label.
     const legendLabel = props.yAxisLabel ? [props.yAxisLabel] : [];
     const yAxisLabel = props.yAxis;
     const xAxisAngle = !isNil(props.xAxisAngle) ? [`angle${props.xAxisAngle}`] : [];
+
+    // WORKAROUND: recharts does not re-render line and bar charts when changing colors, y axis, x axis rotation angle and legend label.
     const key = (COLORS || ["linechart"]).concat(legendLabel, yAxisLabel, xAxisAngle).join("");
-    // style= {{marginTop: 20, marginLeft: 20, marginBottom: 10, marginRight: 30}}
-    // margin: 20px 20px 10px 30px
+
     const lengthLongestLabels = maxBy(data, (d) => d[props.xAxis.dataKey].length)[props.xAxis.dataKey].length;
     const lengthFirstLabel = head(data) && head(data)[props.xAxis.dataKey].length;
     return (
@@ -28,7 +28,7 @@ module.exports = ({width = 600, height = 300, data, series =[], colorGenerator, 
             width={width}
             height={height}
             data={data}
-            margin={props.xAxisAngle ? {top: 20, right: 30, left: 30 + lengthFirstLabel, bottom: lengthLongestLabels * 5 } : {}}
+            margin={props.xAxisAngle ? {top: 20, right: 30, left: 30 + 10 + lengthFirstLabel, bottom: 5 + (lengthLongestLabels * 5) } : {}}
         >
             {seriesArray.map(({color, ...serie}, i) =>
                 <Line

--- a/web/client/components/charts/ObliqueLabel.jsx
+++ b/web/client/components/charts/ObliqueLabel.jsx
@@ -38,15 +38,15 @@ class ObliqueLabel extends React.Component {
     render() {
         const {x, y, payload, angle } = this.props;
         return (
-            <g transform={`translate(${x},${y + 5})`}>
+            <g transform={`translate(${x - (angle >= 75 ? 10 : 0)},${y + 5})`}>
                 <text
                     ref={(t) => {this.label = t; }}
                     x={0}
                     y={0}
-                    dy={18}
+                    dy={16}
                     textAnchor="end"
                     fill="#666"
-                    transform={`translate(-50%, -50%); rotate(-${angle}); translate(50%, 50%);`}
+                    transform={`rotate(-${angle})`}
   >
                     {payload.value}
                 </text>

--- a/web/client/components/charts/ObliqueLabel.jsx
+++ b/web/client/components/charts/ObliqueLabel.jsx
@@ -38,15 +38,16 @@ class ObliqueLabel extends React.Component {
     render() {
         const {x, y, payload, angle } = this.props;
         return (
-            <g transform={`translate(${x},${y})`}>
+            <g transform={`translate(${x},${y + 5})`}>
                 <text
                     ref={(t) => {this.label = t; }}
                     x={0}
                     y={0}
-                    dy={16}
+                    dy={18}
                     textAnchor="end"
                     fill="#666"
-                    transform={`rotate(-${angle})`}>
+                    transform={`translate(-50%, -50%); rotate(-${angle}); translate(50%, 50%);`}
+  >
                     {payload.value}
                 </text>
             </g>

--- a/web/client/components/charts/ObliqueLabel.jsx
+++ b/web/client/components/charts/ObliqueLabel.jsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class ObliqueLabel extends React.Component {
+    static propTypes = {
+        angle: PropTypes.number,
+        onUpdateLabelLength: PropTypes.func,
+        payload: PropTypes.object,
+        x: PropTypes.number,
+        y: PropTypes.number
+    }
+
+    static defaultProps = {
+        angle: 0,
+        payload: {}
+    }
+
+    componentDidMount() {
+        if (this.label ) {
+            // update margin left
+            const marginLeft = Math.floor(this.label.getClientRects()[0].width * Math.cos(Math.PI / 180 * this.props.angle));
+
+            // update margin bottom
+            const marginBottom = Math.ceil(this.label.getClientRects()[0].height * Math.sin(Math.PI / 180 * this.props.angle));
+            this.props.onUpdateLabelLength({marginLeft, marginBottom});
+        }
+    }
+
+    render() {
+        const {x, y, payload, angle } = this.props;
+        return (
+            <g transform={`translate(${x},${y})`}>
+                <text
+                    ref={(t) => {this.label = t; }}
+                    x={0}
+                    y={0}
+                    dy={16}
+                    textAnchor="end"
+                    fill="#666"
+                    transform={`rotate(-${angle})`}>
+                    {payload.value}
+                </text>
+            </g>
+        );
+    }
+
+
+}
+
+export default ObliqueLabel;

--- a/web/client/components/charts/SimpleChart.jsx
+++ b/web/client/components/charts/SimpleChart.jsx
@@ -55,12 +55,17 @@ const SimpleChart = ({type="line", tooltip = {}, legend = {}, autoColorOptions =
         return null;
     };
 
-    return (<Component margin={{top: 5, right: 30, left: 20, bottom: 5}} colorGenerator={colorGenerator || defaultColorGenerator} autoColorOptions={autoColorOptions} {...props} {...{legend, tooltip}}>
-      {tooltip !== false ? type === "pie" ? <Tooltip content={CustomTooltip}/> : <Tooltip {...tooltip}/> : null}
-      {legend !== false ? <Legend {...legend}/> : null}
-     </Component>
-   );
+    return (<Component
+                margin={{top: 5, right: 30, left: 20, bottom: 5}}
+                colorGenerator={colorGenerator || defaultColorGenerator}
+                autoColorOptions={autoColorOptions}
+                {...props}
+                {...{legend, tooltip}}
+            >
+                {tooltip !== false ? type === "pie" ? <Tooltip content={CustomTooltip}/> : <Tooltip {...tooltip}/> : null}
+                {legend !== false ? <Legend {...legend}/> : null}
+            </Component>
+    );
 };
 
 module.exports = SimpleChart;
-

--- a/web/client/components/charts/SimpleChart.jsx
+++ b/web/client/components/charts/SimpleChart.jsx
@@ -63,7 +63,7 @@ const SimpleChart = ({type="line", tooltip = {}, legend = {}, autoColorOptions =
                 {...{legend, tooltip}}
             >
                 {tooltip !== false ? type === "pie" ? <Tooltip content={CustomTooltip}/> : <Tooltip {...tooltip}/> : null}
-                {legend !== false ? <Legend {...legend}/> : null}
+                {legend !== false ? <Legend {...legend} wrapperStyle={{bottom: 0}} /> : null}
             </Component>
     );
 };

--- a/web/client/components/charts/__tests__/SimpleChart-test.jsx
+++ b/web/client/components/charts/__tests__/SimpleChart-test.jsx
@@ -57,6 +57,10 @@ describe('SimpleChart component', () => {
         const el = container.querySelector('div');
         expect(el).toExist();
     });
+    it('test bar chart with oblique labels', () => {
+        const bar = ReactDOM.render(<SimpleChart data={data} type="bar" xAxis={{dataKey: "name"}} xAxisAngle={45} series={SERIES}/>, document.getElementById("container"));
+        expect(bar).toExist();
+    });
     it('test gauge chart', () => {
         ReactDOM.render(<SimpleChart data={data} type="gauge" xAxis={{dataKey: "name"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');

--- a/web/client/components/charts/__tests__/SimpleChart-test.jsx
+++ b/web/client/components/charts/__tests__/SimpleChart-test.jsx
@@ -45,6 +45,15 @@ describe('SimpleChart component', () => {
         const el = container.querySelector('div');
         expect(el).toExist();
     });
+    it('test line chart with oblique labels', () => {
+        ReactDOM.render(<SimpleChart data={data} type="line" xAxis={{dataKey: "name"}} xAxisAngle={45} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const text = container.querySelector('text');
+        expect(text.attributes.transform.value).toBe("rotate(-45)");
+
+    });
     it('test pie chart', () => {
         ReactDOM.render(<SimpleChart data={data} type="pie" xAxis={{dataKey: "name"}} series={SERIES}/>, document.getElementById("container"));
         const container = document.getElementById('container');
@@ -58,8 +67,13 @@ describe('SimpleChart component', () => {
         expect(el).toExist();
     });
     it('test bar chart with oblique labels', () => {
-        const bar = ReactDOM.render(<SimpleChart data={data} type="bar" xAxis={{dataKey: "name"}} xAxisAngle={45} series={SERIES}/>, document.getElementById("container"));
-        expect(bar).toExist();
+        ReactDOM.render(<SimpleChart data={data} type="bar" xAxis={{dataKey: "name"}} xAxisAngle={45} series={SERIES}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('div');
+        expect(el).toExist();
+        const text = container.querySelector('text');
+        expect(text.attributes.transform.value).toBe("rotate(-45)");
+
     });
     it('test gauge chart', () => {
         ReactDOM.render(<SimpleChart data={data} type="gauge" xAxis={{dataKey: "name"}} series={SERIES}/>, document.getElementById("container"));

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -17,7 +17,7 @@ export const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0, o
         key="xaxis"
         {...xAxis}
         interval={xAxisAngle > 0 ? 0 : undefined}
-        tick={<ObliqueLabel angle={xAxisAngle} onUpdateLabelLength={onUpdateLabelLength}/>}
+        tick={xAxisAngle > 0 ? <ObliqueLabel angle={xAxisAngle} onUpdateLabelLength={onUpdateLabelLength}/> : undefined}
         /> : null,
     yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null] );

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -10,8 +10,21 @@
 const React = require('react');
 const { XAxis, YAxis, CartesianGrid} = require('recharts');
 
-const renderCartesianTools = ({xAxis, yAxis, cartesian}) => ([
-    xAxis && xAxis.show !== false ? <XAxis key="xaxis" {...xAxis}/> : null,
+const CustomizedAxisTick = ({x, y, payload, xAxisAngle = 0}) => {
+    return (
+        <g transform={`translate(${x},${y})`}>
+            <text x={0} y={0} dy={16} textAnchor="end" fill="#666" transform={`rotate(-${xAxisAngle})`}>{payload.value}</text>
+        </g>
+    );
+};
+
+const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0} = {}) => ([
+    xAxis && xAxis.show !== false ? <XAxis
+        key="xaxis"
+        {...xAxis}
+        interval={xAxisAngle > 0 ? 0 : undefined}
+        tick={<CustomizedAxisTick xAxisAngle={xAxisAngle}/>}
+        /> : null,
     yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
-    cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null]);
+    cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null] );
 module.exports = {renderCartesianTools};

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -12,7 +12,7 @@ import { XAxis, YAxis, CartesianGrid} from 'recharts';
 
 import ObliqueLabel from './ObliqueLabel';
 
-export const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0, onUpdateLabelLength = () => {}} = {}) => ([
+const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0, onUpdateLabelLength = () => {}} = {}) => ([
     xAxis && xAxis.show !== false ? <XAxis
         key="xaxis"
         {...xAxis}
@@ -21,3 +21,5 @@ export const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0, o
         /> : null,
     yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null] );
+
+export default renderCartesianTools;

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -7,10 +7,10 @@
   */
 
 
-const React = require('react');
-const { XAxis, YAxis, CartesianGrid} = require('recharts');
+import React from 'react';
+import { XAxis, YAxis, CartesianGrid} from 'recharts';
 
-const CustomizedAxisTick = ({x, y, payload, xAxisAngle = 0}) => {
+export const CustomizedAxisTick = ({x, y, payload, xAxisAngle = 0}) => {
     return (
         <g transform={`translate(${x},${y})`}>
             <text x={0} y={0} dy={16} textAnchor="end" fill="#666" transform={`rotate(-${xAxisAngle})`}>{payload.value}</text>
@@ -18,7 +18,7 @@ const CustomizedAxisTick = ({x, y, payload, xAxisAngle = 0}) => {
     );
 };
 
-const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0} = {}) => ([
+export const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0} = {}) => ([
     xAxis && xAxis.show !== false ? <XAxis
         key="xaxis"
         {...xAxis}
@@ -27,4 +27,3 @@ const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0} = {}) =>
         /> : null,
     yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null] );
-module.exports = {renderCartesianTools};

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -10,20 +10,14 @@
 import React from 'react';
 import { XAxis, YAxis, CartesianGrid} from 'recharts';
 
-export const CustomizedAxisTick = ({x, y, payload, xAxisAngle = 0}) => {
-    return (
-        <g transform={`translate(${x},${y})`}>
-            <text x={0} y={0} dy={16} textAnchor="end" fill="#666" transform={`rotate(-${xAxisAngle})`}>{payload.value}</text>
-        </g>
-    );
-};
+import ObliqueLabel from './ObliqueLabel';
 
-export const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0} = {}) => ([
+export const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0, onUpdateLabelLength = () => {}} = {}) => ([
     xAxis && xAxis.show !== false ? <XAxis
         key="xaxis"
         {...xAxis}
         interval={xAxisAngle > 0 ? 0 : undefined}
-        tick={<CustomizedAxisTick xAxisAngle={xAxisAngle}/>}
+        tick={<ObliqueLabel angle={xAxisAngle} onUpdateLabelLength={onUpdateLabelLength}/>}
         /> : null,
     yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null] );

--- a/web/client/components/widgets/builder/wizard/ChartWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/ChartWizard.jsx
@@ -67,6 +67,7 @@ const renderPreview = ({ data = {}, layer, dependencies = {}, setValid = () => {
         autoColorOptions={data.autoColorOptions}
         options={data.options}
         yAxis={data.yAxis}
+        xAxisAngle={data.xAxisAngle}
         yAxisLabel={data.yAxisLabel}
     />)
     : (<SampleChart

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -6,10 +6,11 @@
   * LICENSE file in the root directory of this source tree.
   */
 const React = require('react');
-const { head, get} = require('lodash');
-const { Row, Col, Form, FormGroup, FormControl, ControlLabel, Panel, Glyphicon} = require('react-bootstrap');
+const { head, get, isNil} = require('lodash');
+const { Row, Col, Form, FormGroup, FormControl, ControlLabel, Glyphicon} = require('react-bootstrap');
 const Message = require('../../../../I18N/Message');
 const Select = require('react-select');
+const Slider = require('react-nouislider');
 const ColorRangeSelector = require('../../../../style/ColorRangeSelector');
 const StepHeader = require('../../../../misc/wizard/StepHeader');
 const SwitchPanel = require('../../../../misc/switch/SwitchPanel');
@@ -125,9 +126,7 @@ module.exports = ({
                                         value={data.options && data.options.aggregateFunction}
                                         options={aggregationOptions}
                                         placeholder={placeHolder}
-                                        onChange={(val) => {
-                                            onChange("options.aggregateFunction", val && val.value);
-                                        }}
+                                        onChange={(val) => { onChange("options.aggregateFunction", val && val.value); }}
                                         />
                                 </Col>
                             </FormGroup>
@@ -150,7 +149,7 @@ module.exports = ({
                                         items={getColorRangeItems(data.type)}
                                         value={head(getColorRangeItems(data.type).filter(c => data.autoColorOptions && c.name === data.autoColorOptions.name ))}
                                         samples={data.type === "pie" ? 5 : 1}
-                                        onChange={v => {onChange("autoColorOptions", {...v.options, name: v.name}); }}/>
+                                        onChange={v => { onChange("autoColorOptions", {...v.options, name: v.name}); }}/>
                                 </Col>
                             </FormGroup> : null}
                         {formOptions.showLegend ?
@@ -161,9 +160,7 @@ module.exports = ({
                                 <Col sm={6}>
                                     <SwitchButton
                                         checked={data.legend}
-                                        onChange={(val) => {
-                                            onChange("legend", val);
-                                        }}
+                                        onChange={(val) => { onChange("legend", val); }}
                                         />
                                 </Col>
                             </FormGroup> : null}
@@ -172,46 +169,58 @@ module.exports = ({
                                         header={renderHeader(data)}
                                         collapsible
                                         expanded={data.panel}
-                                        onSwitch={(val) => {
-                                            onChange("panel", val);
-                                        }}
+                                        onSwitch={(val) => { onChange("panel", val); }}
                                         >
-                                <Panel>
-                                    <FormGroup controlId="AdvancedOptions">
-                                        <Col componentClass={ControlLabel} sm={6}>
-                                            <Message msgId={getLabelMessageId("displayCartesian", data)} />
-                                        </Col>
-                                        <Col sm={6}>
-                                            <SwitchButton
-                                                checked={data.cartesian || data.cartesian === false ? !data.cartesian : false}
-                                                onChange={(val) => {
-                                                    onChange("cartesian", !val);
-                                                }}
-                                                />
-                                        </Col>
-                                        <Col componentClass={ControlLabel} sm={6}>
-                                            <Message msgId={getLabelMessageId("yAxis", data)} />
-                                        </Col>
-                                        <Col sm={6}>
-                                            <SwitchButton
-                                                checked={data.yAxis || data.yAxis === false ? !data.yAxis : true}
-                                                onChange={(val) => {
-                                                    onChange("yAxis", !val);
-                                                }}
-                                                />
-                                        </Col>
+                                <FormGroup controlId="AdvancedOptions">
+                                    <Col componentClass={ControlLabel} sm={6}>
+                                        <Message msgId={getLabelMessageId("displayCartesian", data)} />
+                                    </Col>
+                                    <Col sm={6}>
+                                        <SwitchButton
+                                            checked={data.cartesian || data.cartesian === false ? !data.cartesian : false}
+                                            onChange={(val) => { onChange("cartesian", !val); }}
+                                            />
+                                    </Col>
+                                    <Col componentClass={ControlLabel} sm={6}>
+                                        <Message msgId={getLabelMessageId("yAxis", data)} />
+                                    </Col>
+                                    <Col sm={6}>
+                                        <SwitchButton
+                                            checked={data.yAxis || data.yAxis === false ? !data.yAxis : true}
+                                            onChange={(val) => { onChange("yAxis", !val); }}
+                                            />
+                                    </Col>
+                                    <Col componentClass={ControlLabel} sm={6}>
+                                        <Message msgId={getLabelMessageId("xAxisAngle", data)} />
+                                    </Col>
+                                    <Col sm={6}>
+                                        <div
+                                            className={"mapstore-slider with-tooltip"}
+                                            onClick={(e) => { e.stopPropagation(); }}
+                                        >
+                                            <Slider
+                                            tooltips={[true]}
+                                            key="priority"
+                                            onSlide={(values) => {
+                                                const xAxisAngle = parseInt(values[0], 10);
+                                                onChange("xAxisAngle", xAxisAngle);
+                                            }}
+                                            range={{min: 0, max: 90}}
+                                            start={[!isNil(data.xAxisAngle) ? data.xAxisAngle : 0]}
+                                            step={5}
+                                            />
+                                        </div>
+                                    </Col>
+                                </FormGroup>
 
-                                    </FormGroup>
-
-                                    <FormGroup controlId="yAxisLabel">
-                                        <Col componentClass={ControlLabel} sm={6}>
-                                            <Message msgId={getLabelMessageId("yAxisLabel", data)} />
-                                        </Col>
-                                        <Col sm={6}>
-                                            <FormControl value= {data.yAxisLabel} type="text" onChange={ e => onChange("yAxisLabel", e.target.value)} />
-                                        </Col>
-                                    </FormGroup>
-                                </Panel>
+                                <FormGroup controlId="yAxisLabel">
+                                    <Col componentClass={ControlLabel} sm={6}>
+                                        <Message msgId={getLabelMessageId("yAxisLabel", data)} />
+                                    </Col>
+                                    <Col sm={6}>
+                                        <FormControl value= {data.yAxisLabel} type="text" onChange={ e => onChange("yAxisLabel", e.target.value)} />
+                                    </Col>
+                                </FormGroup>
                             </SwitchPanel> : null}
 
                     </Form>

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -199,15 +199,17 @@ module.exports = ({
                                             onClick={(e) => { e.stopPropagation(); }}
                                         >
                                             <Slider
-                                            tooltips={[true]}
                                             key="priority"
-                                            onSlide={(values) => {
-                                                const xAxisAngle = parseInt(values[0], 10);
-                                                onChange("xAxisAngle", xAxisAngle);
+                                            format= {{
+                                                // this is needed to remove the 2 decimals that this comp adds by default
+                                                to: value => parseInt(value, 10),
+                                                from: value => Number(value)
                                             }}
+                                            onSlide={(values) => { onChange("xAxisAngle", parseInt(values[0], 10)); }}
                                             range={{min: 0, max: 90}}
                                             start={[!isNil(data.xAxisAngle) ? data.xAxisAngle : 0]}
-                                            step={5}
+                                            step={15}
+                                            tooltips={[true]}
                                             />
                                         </div>
                                     </Col>

--- a/web/client/components/widgets/builder/wizard/common/__tests__/WPSWidgetOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/WPSWidgetOptions-test.jsx
@@ -102,4 +102,27 @@ describe('WPSWidgetOptions component', () => {
         expect(spyonChange.calls[2].arguments[0]).toBe("options.seriesOptions.[0].uom");
         expect(spyonChange.calls[2].arguments[1]).toBe("test");
     });
+
+    it('Test WPSWidgetOptions with rotation slider ', () => {
+        const actions = {
+            onChange: () => { }
+        };
+        ReactDOM.render(<WPSWidgetOptions
+            formOptions={{
+                showColorRamp: false,
+                showUom: true,
+                showGroupBy: false,
+                showLegend: false,
+                advancedOptions: true
+            }}
+            featureTypeProperties={get(describeStates, "featureTypes[0].properties")}
+            onChange={actions.onChange}
+            dependencies={{ viewport: {} }}
+            data={{type: "line", xAxisAngle: 45}}/>, document.getElementById("container"));
+        const slider = document.getElementsByClassName('mapstore-slider');
+        expect(slider).toExist();
+        const tooltip = document.getElementsByClassName('noUi-tooltip')[0];
+        expect(tooltip.innerText).toBe("45");
+
+    });
 });

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1508,7 +1508,12 @@
             "displayCartesian": {
                 "line": "Raster ausblenden",
                 "bar": "Raster ausblenden"
-            },"yAxis":{
+            },
+            "xAxisAngle":{
+                "line": "X-Achse: Beschriften Sie den Drehwinkel °",
+                "bar": "X-Achse: Beschriften Sie den Drehwinkel °"
+            },
+            "yAxis":{
                 "line": "Y-Achse ausblenden",
                 "bar": "Y-Achse ausblenden"
             },

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1509,6 +1509,10 @@
                 "line": "Hide Grid",
                 "bar": "Hide Grid"
             },
+            "xAxisAngle":{
+                "line": "X Axis: Label rotation angle °",
+                "bar": "X Axis: Label rotation angle °"
+            },
             "yAxis":{
                 "line": "Hide Y axis",
                 "bar": "Hide Y axis"

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1508,7 +1508,12 @@
             "displayCartesian": {
                 "line": "Ocultar cuadrícula",
                 "bar": "Ocultar cuadrícula"
-            },"yAxis":{
+            },
+            "xAxisAngle":{
+                "line": "Eye X: Ángulo de rotación de la etiqueta °",
+                "bar": "Eye X: Ángulo de rotación de la etiqueta °"
+            },
+            "yAxis":{
                 "line": "Ocultar el eje Y",
                 "bar": "Ocultar el eje Y"
             },

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1509,7 +1509,12 @@
             "displayCartesian": {
                 "line": "Masquer la grille",
                 "bar": "Masquer la grille"
-            },"yAxis":{
+            },
+            "xAxisAngle":{
+                "line": "Axe X: Angle de rotation de l'étiquette °",
+                "bar": "Axe X: Angle de rotation de l'étiquette °"
+            },
+            "yAxis":{
                 "line": "Masquer l'axe Y",
                 "bar": "Masquer l'axe Y"
             },

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1494,6 +1494,10 @@
                 "line": "Sakrij mrežu",
                 "bar": "Sakrij mrežu"
             },
+            "xAxisAngle":{
+                "line": "X Axis: Label rotation angle °",
+                "bar": "X Axis: Label rotation angle °"
+            },
             "yAxis":{
                 "line": "Sakrij Y os",
                 "bar": "Sakrij Y os"

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1508,7 +1508,12 @@
             "displayCartesian": {
                 "line": "Nascondi griglia",
                 "bar": "Nascondi griglia"
-            },"yAxis":{
+            },
+            "xAxisAngle":{
+                "line": "Asse X: Angolo di rotazione °",
+                "bar": "Asse X: Angolo di rotazione °"
+            },
+            "yAxis":{
                 "line": "Nascondi l'asse Y",
                 "bar": "Nascondi l'asse Y"
             },

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1328,7 +1328,12 @@
             "displayCartesian": {
                 "line": "Hide Grid",
                 "bar": "Hide Grid"
-            },"yAxis":{
+            },
+            "xAxisAngle":{
+                "line": "X Axis: Label rotation angle °",
+                "bar": "X Axis: Label rotation angle °"
+            },
+            "yAxis":{
                 "line": "Hide Y axis",
                 "bar": "Hide Y axis"
             },

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -1495,6 +1495,10 @@
                 "line": "Hide Grid",
                 "bar": "Hide Grid"
             },
+            "xAxisAngle":{
+                "line": "X Axis: Label rotation angle °",
+                "bar": "X Axis: Label rotation angle °"
+            },
             "yAxis":{
                 "line": "Hide Y axis",
                 "bar": "Hide Y axis"

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1452,7 +1452,12 @@
             "displayCartesian": {
                 "line": "Hide Grid",
                 "bar": "Hide Grid"
-            },"yAxis":{
+            },
+            "xAxisAngle":{
+                "line": "X Axis: Label rotation angle °",
+                "bar": "X Axis: Label rotation angle °"
+            },
+            "yAxis":{
                 "line": "Hide Y axis",
                 "bar": "Hide Y axis"
             },


### PR DESCRIPTION
## Description
This pr add the possibility to use oblique labels for line and bar chart

## Issues
 - #2655 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
actually you cannot use oblique labels

**What is the new behavior?**
you can set a rotation angle for them with 15° step
![image](https://user-images.githubusercontent.com/11991428/60106612-d1de2b00-9765-11e9-87f0-708bd0243cb2.png)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Note in the preview the space is too limited to see fully the chart, 