### PR TITLE
Fix 3398 Added label shortening on y axis for bar and line charts

### DIFF
--- a/web/client/components/charts/Bar.jsx
+++ b/web/client/components/charts/Bar.jsx
@@ -68,7 +68,7 @@ class BarChartWrapper extends React.Component {
                 margin={props.xAxisAngle ? {
                     top: 20,
                     right: 30,
-                    left: marginLeft + 10, // 10 is for balancing the translate left of the oblique label
+                    left: marginLeft,
                     bottom: marginBottom + 20
                 } : margin }>
                 {

--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -67,7 +67,7 @@ class LineChartWrapper extends React.Component {
                 margin={props.xAxisAngle ? {
                     top: 20,
                     right: 30,
-                    left: marginLeft + 10, // 10 is for balancing the translate left of the oblique label
+                    left: marginLeft,
                     bottom: marginBottom + 20
                 } : margin }
             >

--- a/web/client/components/charts/ObliqueLabel.jsx
+++ b/web/client/components/charts/ObliqueLabel.jsx
@@ -37,6 +37,16 @@ class ObliqueLabel extends React.Component {
 
     render() {
         const {x, y, payload, angle } = this.props;
+
+        /* the tranform on g tag is used to place labels on x axis, in particular:
+         * - when angle is over 75° the label needs to be translated left to be
+         * aligned with the tick on the x axis
+         * - it is also moved down a bit to avoid to collide with the tick
+
+         * rotate on the text is needed to create an oblique label in particular,
+         * y = 0 allows all labels to be aligned on the same line
+         * textAnchor
+        */
         return (
             <g transform={`translate(${x - (angle >= 75 ? 10 : 0)},${y + 5})`}>
                 <text

--- a/web/client/components/charts/ObliqueLabel.jsx
+++ b/web/client/components/charts/ObliqueLabel.jsx
@@ -45,7 +45,6 @@ class ObliqueLabel extends React.Component {
 
          * rotate on the text is needed to create an oblique label in particular,
          * y = 0 allows all labels to be aligned on the same line
-         * textAnchor
         */
         return (
             <g transform={`translate(${x - (angle >= 75 ? 10 : 0)},${y + 5})`}>
@@ -57,7 +56,7 @@ class ObliqueLabel extends React.Component {
                     textAnchor="end"
                     fill="#666"
                     transform={`rotate(-${angle})`}
-  >
+                >
                     {payload.value}
                 </text>
             </g>

--- a/web/client/components/charts/YAxisLabel.jsx
+++ b/web/client/components/charts/YAxisLabel.jsx
@@ -10,8 +10,8 @@ import React from 'react';
 
 import {shortenLabel} from '../../utils/WidgetsUtils';
 
-const YAxisLabel = ({x = 0, y, payload = {}}) => (
-    <g>
+const YAxisLabel = ({x = 0, y = 0, payload = {}}) => (
+    <g transform={`translate(0,${y - 1})`}>
         <text
         style={{fill: '#666'}}
         x={x - 5}

--- a/web/client/components/charts/YAxisLabel.jsx
+++ b/web/client/components/charts/YAxisLabel.jsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+import {shortenLabel} from '../../utils/WidgetsUtils';
+
+const YAxisLabel = ({x = 0, y, payload = {}}) => (
+    <g>
+        <text
+        style={{fill: '#666'}}
+        x={x - 5}
+        y={y}
+        textAnchor="end" >
+            {shortenLabel(payload.value)}
+        </text>
+    </g>
+);
+
+export default YAxisLabel;

--- a/web/client/components/charts/YAxisLabel.jsx
+++ b/web/client/components/charts/YAxisLabel.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import {shortenLabel} from '../../utils/WidgetsUtils';
 
 const YAxisLabel = ({x = 0, y = 0, payload = {}}) => (
-    <g transform={`translate(0,${y - 1})`}>
+    <g transform={`translate(0,3)`}>
         <text
         style={{fill: '#666'}}
         x={x - 5}

--- a/web/client/components/charts/__tests__/YAxisLabel-test.js
+++ b/web/client/components/charts/__tests__/YAxisLabel-test.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+
+import YAxisLabel from '../YAxisLabel';
+
+describe('YAxisLabel component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('YAxisLabel rendering with defaults', () => {
+        ReactDOM.render(<YAxisLabel />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const text = container.querySelector('text');
+        expect(text).toExist();
+    });
+
+    it('YAxisLabel rendering with a big number as label', () => {
+        ReactDOM.render(<YAxisLabel payload={{value: 123456789}}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const text = container.querySelector('text');
+        expect(text).toExist();
+        expect(text.innerText).toBe("123.5 M");
+    });
+
+    it('YAxisLabel rendering with a small number as label', () => {
+        ReactDOM.render(<YAxisLabel payload={{value: 1234}}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const text = container.querySelector('text');
+        expect(text).toExist();
+        expect(text.innerText).toBe("1234");
+    });
+
+    it('YAxisLabel rendering with a string as label', () => {
+        ReactDOM.render(<YAxisLabel payload={{value: 123456789}}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const text = container.querySelector('text');
+        expect(text).toExist();
+        expect(text.innerText).toBe("123.5 M");
+    });
+});

--- a/web/client/components/charts/__tests__/YAxisLabel-test.js
+++ b/web/client/components/charts/__tests__/YAxisLabel-test.js
@@ -46,10 +46,10 @@ describe('YAxisLabel component', () => {
     });
 
     it('YAxisLabel rendering with a string as label', () => {
-        ReactDOM.render(<YAxisLabel payload={{value: 123456789}}/>, document.getElementById("container"));
+        ReactDOM.render(<YAxisLabel payload={{value: "123456789"}}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const text = container.querySelector('text');
         expect(text).toExist();
-        expect(text.innerText).toBe("123.5 M");
+        expect(text.innerText).toBe("123456789");
     });
 });

--- a/web/client/components/charts/cartesian.jsx
+++ b/web/client/components/charts/cartesian.jsx
@@ -9,17 +9,27 @@
 
 import React from 'react';
 import { XAxis, YAxis, CartesianGrid} from 'recharts';
-
 import ObliqueLabel from './ObliqueLabel';
+import YAxisLabel from './YAxisLabel';
 
 const renderCartesianTools = ({xAxis, yAxis, cartesian, xAxisAngle = 0, onUpdateLabelLength = () => {}} = {}) => ([
     xAxis && xAxis.show !== false ? <XAxis
         key="xaxis"
         {...xAxis}
         interval={xAxisAngle > 0 ? 0 : undefined}
-        tick={xAxisAngle > 0 ? <ObliqueLabel angle={xAxisAngle} onUpdateLabelLength={onUpdateLabelLength}/> : undefined}
-        /> : null,
-    yAxis ? <YAxis key="yaxis" {...yAxis}/> : null,
+        tick={xAxisAngle > 0 ?
+            <ObliqueLabel
+                angle={xAxisAngle}
+                onUpdateLabelLength={onUpdateLabelLength}/>
+            : undefined
+        }
+    /> : null,
+    yAxis ? <YAxis
+        key="yaxis"
+        tick={<YAxisLabel/>}
+        domain={[0, 'auto']}
+        {...yAxis}
+    /> : null,
     cartesian !== false ? <CartesianGrid key="cartesiangrid" {...cartesian}/> : null] );
 
 export default renderCartesianTools;

--- a/web/client/utils/WidgetsUtils.js
+++ b/web/client/utils/WidgetsUtils.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { get, find } = require('lodash');
+const { get, find, isNumber, round} = require('lodash');
 const {WIDGETS_REGEX} = require('../actions/widgets');
 const { findGroups } = require('./GraphUtils');
 const { sameToneRangeColors } = require('./ColorUtils');
@@ -46,7 +46,49 @@ const getConnectionList = (widgets = []) => {
     }, []);
 };
 
+/**
+ * it checks if a number is higher of 10k and it returns a shortened version of it
+ * @param {number} label to parse
+ * @param {number} threshold threshold to check if it needs to be rounded
+ * @param {number} decimals number of decimal to use when rounding
+ * @return the shortened number plus a suffix or the label is a string is passed
+*/
+const shortenLabel = (label, threshold = 10000, decimals = 1)=> {
+    if (!isNumber(label) || isNumber(label) && label.toString().length < 7) {
+        return label;
+    }
+    let unit;
+    let number = round(label);
+    let add = number.toString().length % 3;
+    if (number >= threshold) {
+        let trimedDigits = number.toString().length - ( add === 0 ? add + 3 : add );
+        let zeroNumber = (trimedDigits) / 3;
+        let trimedNumber = number / Math.pow(10, trimedDigits);
+        switch (zeroNumber) {
+            case 1 :
+                unit = ' K';
+                break;
+            case 2 :
+                unit = ' M';
+                break;
+            case 3 :
+                unit = ' B';
+                break;
+            case 4 :
+                unit = ' T';
+                break;
+            default:
+                unit = '';
+        }
+        number = round(trimedNumber, decimals) + unit;
+    } else {
+        number = round(label, Math.abs(4 - number.toString().length));
+    }
+    return number;
+};
+
 module.exports = {
+    shortenLabel,
     getWidgetDependency,
     getConnectionList,
     getWidgetsGroups: (widgets = []) => {

--- a/web/client/utils/__tests__/WidgetsUtils-test.js
+++ b/web/client/utils/__tests__/WidgetsUtils-test.js
@@ -8,7 +8,7 @@
 
 const expect = require('expect');
 
-const { getConnectionList, getWidgetsGroups } = require('../WidgetsUtils');
+const { getConnectionList, getWidgetsGroups, shortenLabel } = require('../WidgetsUtils');
 
 const {widgets} = require('json-loader!../../test-resources/widgets/widgets1.json');
 const { widgets: complexGraphWidgets } = require('json-loader!../../test-resources/widgets/complex_graph.json');
@@ -46,4 +46,26 @@ describe('Test WidgetsUtils', () => {
         expect(complexChartGroups[0].widgets.length).toBe(3);
         expect(complexChartGroups[1].widgets.length).toBe(2);
     });
+
+    it('shortenLabel with 2500000000', () => {
+        const num = 2500000000;
+        const label = shortenLabel(num);
+        expect(label).toEqual("2.5 B");
+    });
+    it('shortenLabel with 123456789', () => {
+        const num = 123456789;
+        const label = shortenLabel(num);
+        expect(label).toEqual("123.5 M");
+    });
+    it('shortenLabel with 2500', () => {
+        const num = 2500;
+        const label = shortenLabel(num);
+        expect(label).toEqual(2500);
+    });
+    it('shortenLabel with a string', () => {
+        const num = "state names";
+        const label = shortenLabel(num);
+        expect(label).toEqual("state names");
+    });
+
 });


### PR DESCRIPTION
## Description
This pr improves readability of labes on y-axis of bar charts and line charts

## Issues
 - #3398

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
see #3398 sometimes the label on y axis is too big to be fully visible

**What is the new behavior?**
it is shortened but keeping 1 decimal if needed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
