### PR TITLE
Fix 3894 Cannot add Catalog service

### DIFF
--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -592,7 +592,9 @@ const TOCPlugin = connect(tocSelector, {
 })(LayerTree);
 
 const API = {
-    csw: require('../api/CSW')
+    csw: require('../api/CSW'),
+    wms: require('../api/WMS'),
+    wmts: require('../api/WMTS')
 };
 
 module.exports = {


### PR DESCRIPTION
## Description
TOC and MetadataExplorer (Catalog ) plugins use the same `/epics/catalog` with different API argument, this behavior causes an override when MetadataExplorer is imported in plugin.js before TOC plugin.
The overridden epics work for TOC but not for MetadataExplorer because some services are missing (`wms`, `wmts`).
This PR add wms and wmts service to catalog epics of TOC plugin

## Issues
 - #3894

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
#3893

**What is the new behavior?**
WMS and WMTS services can be saved again

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
