### PR TITLE
Updated starter/core components for a thinner customization

### DIFF
--- a/web/client/product/appConfigEmbedded.js
+++ b/web/client/product/appConfigEmbedded.js
@@ -4,9 +4,13 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
+*/
+
+const {updateMapLayoutEpic} = require('../epics/maplayout');
+const {readQueryParamsOnMapEpic} = require('../epics/share');
 
 module.exports = {
+    mode: "embedded",
     pages: [{
         name: "mapviewer",
         path: "/:mapId",
@@ -37,6 +41,16 @@ module.exports = {
         },
         mobile: {
         }
+    },
+    baseReducers: {
+        mode: (state = 'embedded') => state,
+        version: require('../reducers/version'),
+        maplayout: require('../reducers/maplayout'),
+        searchconfig: require('../reducers/searchconfig')
+    },
+    baseEpics: {
+        updateMapLayoutEpic,
+        readQueryParamsOnMapEpic
     },
     storeOpts: {
         persist: {

--- a/web/client/product/embedded.jsx
+++ b/web/client/product/embedded.jsx
@@ -4,55 +4,15 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
-const React = require('react');
-const ReactDOM = require('react-dom');
-const {connect} = require('react-redux');
-const LocaleUtils = require('../utils/LocaleUtils');
+*/
 
-const startApp = () => {
-    const StandardApp = require('../components/app/StandardApp');
-    const {loadVersion} = require('../actions/version');
-    const {versionSelector} = require('../selectors/version');
-    const {loadAfterThemeSelector} = require('../selectors/config');
-    const {pages, pluginsDef, initialState, storeOpts} = require('./appConfigEmbedded');
+const {loadVersion} = require('../actions/version');
 
-    const StandardRouter = connect((state) => ({
-        locale: state.locale || {},
-        pages,
-        version: versionSelector(state),
-        loadAfterTheme: loadAfterThemeSelector(state)
-    }))(require('../components/app/StandardRouter'));
-
-    const {updateMapLayoutEpic} = require('../epics/maplayout');
-    const {readQueryParamsOnMapEpic} = require('../epics/share');
-
-    const appStore = require('../stores/StandardStore').bind(null, initialState, {
-        mode: (state = 'embedded') => state,
-        version: require('../reducers/version'),
-        maplayout: require('../reducers/maplayout'),
-        searchconfig: require('../reducers/searchconfig')
-    }, {updateMapLayoutEpic, readQueryParamsOnMapEpic});
-
-    const appConfig = {
-        mode: 'embedded',
-        storeOpts,
-        appStore,
-        pluginsDef,
-        initialActions: [loadVersion],
-        appComponent: StandardRouter,
-        printingEnabled: true
-    };
-
-    ReactDOM.render(
-        <StandardApp {...appConfig} mode="embedded"/>,
-        document.getElementById('container')
-    );
-};
-
-if (!global.Intl ) {
-    // Ensure Intl is loaded, then call the given callback
-    LocaleUtils.ensureIntl(startApp);
-} else {
-    startApp();
-}
+require('./main')(
+    require('./appConfigEmbedded'),
+    require('./apiPlugins.js'),
+    (cfg) => ({
+        ...cfg,
+        initialActions: [loadVersion]
+    })
+);

--- a/web/client/product/main.jsx
+++ b/web/client/product/main.jsx
@@ -20,11 +20,23 @@ module.exports = (config, pluginsDef, overrideConfig = cfg => cfg) => {
         const {loadAfterThemeSelector} = require('../selectors/config');
         const StandardApp = require('../components/app/StandardApp');
 
-        const {pages, initialState, storeOpts, appEpics = {}, themeCfg, printingEnabled = true} = config;
+        const {
+            appEpics = {},
+            baseEpics = {},
+            appReducers = {},
+            baseReducers = {},
+            initialState,
+            pages,
+            printingEnabled = true,
+            storeOpts,
+            themeCfg = {},
+            mode
+        } = config;
 
         const StandardRouter = connect((state) => ({
             locale: state.locale || {},
             pages,
+            themeCfg,
             version: versionSelector(state),
             loadAfterTheme: loadAfterThemeSelector(state)
         }))(require('../components/app/StandardRouter'));
@@ -33,15 +45,36 @@ module.exports = (config, pluginsDef, overrideConfig = cfg => cfg) => {
         const {setSupportedLocales} = require('../epics/localconfig');
         const {readQueryParamsOnMapEpic} = require('../epics/share');
 
-        const appStore = require('../stores/StandardStore').bind(null, initialState, {
-            maptype: require('../reducers/maptype'),
-            maps: require('../reducers/maps'),
-            maplayout: require('../reducers/maplayout'),
-            version: require('../reducers/version')
-        }, {...appEpics, updateMapLayoutEpic, setSupportedLocales, readQueryParamsOnMapEpic});
+        /**
+         * appStore data needed to create the store
+         * @param {object} baseReducers is used to override all the appReducers
+         * @param {object} appReducers is used to extend the appReducers
+         * @param {object} baseEpics is used to override all the appEpics
+         * @param {object} appEpics is used to extend the appEpics
+         * @param {object} initialState is used to initialize the state of the application
+        */
+        const appStore = require('../stores/StandardStore').bind(null,
+            initialState,
+            baseReducers || {
+                maptype: require('../reducers/maptype'),
+                maps: require('../reducers/maps'),
+                maplayout: require('../reducers/maplayout'),
+                version: require('../reducers/version'),
+                ...appReducers
+            },
+            baseEpics || {
+                readQueryParamsOnMapEpic,
+                setSupportedLocales,
+                updateMapLayoutEpic,
+                ...appEpics
+            }
+        );
 
         const initialActions = [
-            () => loadMaps(ConfigUtils.getDefaults().geoStoreUrl, ConfigUtils.getDefaults().initialMapFilter || "*"),
+            () => loadMaps(
+                ConfigUtils.getDefaults().geoStoreUrl,
+                ConfigUtils.getDefaults().initialMapFilter || "*"
+            ),
             loadVersion
         ];
 
@@ -53,7 +86,8 @@ module.exports = (config, pluginsDef, overrideConfig = cfg => cfg) => {
             initialActions,
             appComponent: StandardRouter,
             printingEnabled,
-            themeCfg
+            themeCfg,
+            mode
         });
 
         ReactDOM.render(


### PR DESCRIPTION
## Description
this pr add the possibility to extend actual appReducers and appEpics 
or to override them completely using baseReducers and baseEpics

although you can use the overrideCfg function to override the config this pr adds a possibility to avoid it if you just need to customize the appReducers or appEpics

it also aligns the embedded.jsx using the function main [here](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/product/main.jsx#L9) and updating the relative appEmbededdConfig.

## Issues
 - #

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
you are force to use overrideCfg to override something

**What is the new behavior?**
You can use AppConfig with properties described above

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
