### PR TITLE
Fix color ramp translations, added gray and jet

### DIFF
--- a/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
+++ b/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
@@ -13,7 +13,7 @@ class ColorRampItem extends React.Component {
                 {ramp.map(cell => <div className="color-cell" key={this.props.item && this.props.item.name + "-" + cell} style={{backgroundColor: cell}}/>)}
                 <div className="colorname-cell">
                     {this.props.item && this.props.item.name
-                        ? <Message msgId={this.props.item.name} msgParams={{number: ramp.length}} />
+                        ? <Message msgId={`global.colors.${this.props.item.name}`} msgParams={{number: ramp.length}} />
                     : this.props.item && this.props.item.name}
                 </div>
                 </div>);

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -170,6 +170,8 @@
                 "red": "{number, plural, =0 {Rot} =1 {Rot} other {Rottöne}}",
                 "blue": "{number, plural, =0 {Blau} =1 {Blau} other {Blau}}",
                 "green": "{number, plural, =0 {Grün} =1 {Grün} other {Grüns}}",
+                "gray": "{number, plural, =0 {Grau} =1 {Grau} other {Grau}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Braun} =1 {Braun} other {Braun}}",
                 "purple": "{number, plural, =0 {Lila} =1 {Lila} other {Purpur}}",
                 "random": "{number, plural, =0 {Zufällig} =1 {Zufällig} other {Zufällig}}"

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -169,7 +169,9 @@
             "colors": {
                 "red": "{number, plural, =0 {Red} =1 {Red} other {Reds}}",
                 "blue": "{number, plural, =0 {Blue} =1 {Blue} other {Blues}}",
-                "green": "{number, plural, =0 {green} =1 {Green} other {Greens}}",
+                "green": "{number, plural, =0 {Green} =1 {Green} other {Greens}}",
+                "gray": "{number, plural, =0 {Gray} =1 {Gray} other {Grays}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Brown} =1 {Brown} other {Browns}}",
                 "purple": "{number, plural, =0 {Purple} =1 {Purple} other {Purples}}",
                 "random": "{number, plural, =0 {Random} =1 {Random} other {Random}}"

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -170,6 +170,8 @@
                 "red": "{number, plural, =0 {Rojo} =1 {Rojo} other {rojos}}",
                 "blue": "{number, plural, =0 {Azul} =1 {Azul} other {Azul}}",
                 "green": "{number, plural, =0 {Verde} =1 {Verde} other {Verdes}}",
+                "gray": "{number, plural, =0 {Gris} =1 {Gris} other {Gris}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Marrón} =1 {Marrón} other {Marrónes}}",
                 "purple": "{number, plural, =0 {Púrpura} =1 {Púrpura} other {Púrpura}}",
                 "random": "{number, plural, =0 {Aleatorio} =1 {Aleatorio} other {Aleatorio}}"

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -170,6 +170,8 @@
                 "red": "{number, plural, =0 {Rouge} =1 {Rouge} other {Rouges}}",
                 "blue": "{number, plural, =0 {Bleu} =1 {Bleu} other {Bleus}}",
                 "green": "{number, plural, =0 {Vert} =1 {Vert} other {Verts}}",
+                "gray": "{number, plural, =0 {Gris} =1 {Gris} other {Gris}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Brun} =1 {Brun} other {Bruns}}",
                 "purple": "{number, plural, =0 {Pourpre} =1 {Pourpre} other {Pourpre}}",
                 "random": "{number, plural, =0 {Random} =1 {Random} other {Random}}"

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -170,6 +170,8 @@
                 "red": "{number, plural, =0 {Crveno} =1 {Crveno} other {Crvene}}",
                 "blue": "{number, plural, =0 {Plavo} =1 {Plavo} other {Plave}}",
                 "green": "{number, plural, =0 {Zeleno} =1 {Zeleno} other {Zelene}}",
+                "gray": "{number, plural, =0 {Gray} =1 {Gray} other {Grays}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Smeđe} =1 {Smeđe} other {Smeđe}}",
                 "purple": "{number, plural, =0 {Ljubičasto} =1 {Ljubičasto} other {Ljubičaste}}",
                 "random": "{number, plural, =0 {Nasumično} =1 {Nasumično} other {Nasumične}}"

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -170,6 +170,8 @@
                 "red": "{number, plural, =0 {Rosso} =1 {Rosso} other {Rossi}}",
                 "blue": "{number, plural, =0 {Blu} =1 {Blu} other {Blu}}",
                 "green": "{number, plural, =0 {Verde} =1 {Verde} other {Verdi}}",
+                "gray": "{number, plural, =0 {Grigio} =1 {Grigio} other {Grigi}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Marrone} =1 {Marrone} other {Marroni}}",
                 "purple": "{number, plural, =0 {Porpora} =1 {Porpora} other {Porpora}}",
                 "random": "{number, plural, =0 {Casuale} =1 {Casuale} other {Casuale}}"

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -168,7 +168,9 @@
             "colors": {
                 "red": "{number, plural, =0 {Rouge} =1 {Rouge} other {rouges}}",
                 "blue": "{number, plural, =0 {Bleu} =1 {Bleu} other {Bleus}}",
-                "green": "{number, plural, =0 {vert} =1 {vert} other {verts}}",
+                "green": "{number, plural, =0 {Vert} =1 {Vert} other {Verts}}",
+                "gray": "{number, plural, =0 {Gray} =1 {Gray} other {Grays}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Brun} =1 {Brun} other {Bruns}}",
                 "purple": "{number, plural, =0 {Pourpre} =1 {Pourpre} other {Pourpre}}",
                 "random": "{number, plural, =0 {Random} =1 {Random} other {Random}}"

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -171,6 +171,8 @@
                 "red": "{number, plural, =0 {Red} =1 {Red} other {Reds}}",
                 "blue": "{number, plural, =0 {Blue} =1 {Blue} other {Blues}}",
                 "green": "{number, plural, =0 {green} =1 {Green} other {Greens}}",
+                "gray": "{number, plural, =0 {Gray} =1 {Gray} other {Grays}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Brown} =1 {Brown} other {Browns}}",
                 "purple": "{number, plural, =0 {Purple} =1 {Purple} other {Purples}}",
                 "random": "{number, plural, =0 {Random} =1 {Random} other {Random}}"

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -170,6 +170,8 @@
                 "red": "{number, plural, =0 {Red} =1 {Red} other {Reds}}",
                 "blue": "{number, plural, =0 {Blue} =1 {Blue} other {Blues}}",
                 "green": "{number, plural, =0 {green} =1 {Green} other {Greens}}",
+                "gray": "{number, plural, =0 {Gray} =1 {Gray} other {Grays}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
                 "brown": "{number, plural, =0 {Brown} =1 {Brown} other {Browns}}",
                 "purple": "{number, plural, =0 {Purple} =1 {Purple} other {Purples}}",
                 "random": "{number, plural, =0 {Random} =1 {Random} other {Random}}"


### PR DESCRIPTION
## Description
some Color ramp for text are not localized and generates noisy warnings in the console.

## Issues
 - #

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
you have some errors is console when selecting the color in the Thematic Layer settings


**What is the new behavior?**
no errors and missing colors are now present

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
