### PR TITLE
3523 manage exponential number coord editor

### DIFF
--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -261,6 +261,85 @@ describe("test the SearchBar", () => {
         expect(cog.length).toBe(2);
         expect(inputs.length).toBe(6);
     });
+
+    it('test calling zoomToPoint with onKeyDown event', (done) => {
+        const tb = ReactDOM.render(
+            <SearchBar
+                format="decimal"
+                activeSearchTool="coordinatesSearch"
+                showOptions
+                onZoomToPoint={(point, zoom, crs) => {
+                    expect(point).toEqual({x: 15, y: 15});
+                    expect(zoom).toEqual(12);
+                    expect(crs).toEqual("EPSG:4326");
+                    done();
+                }}
+                coordinate={{lat: 15, lon: 15}}
+                typeAhead={false} />, document.getElementById("container")
+        );
+        expect(tb).toExist();
+        const container = document.getElementById('container');
+        const elements = container.querySelectorAll('input');
+        TestUtils.Simulate.keyDown(elements[0], {
+            keyCode: 13
+        });
+        /* setTimeout(() => {
+            expect(spyOnZoomToPoint).toHaveBeenCalled();
+        }, 50);*/
+
+    });
+    it('Test SearchBar with not allowed e char for keyDown event', (done) => {
+        const tb = ReactDOM.render(
+            <SearchBar
+                format="decimal"
+                activeSearchTool="coordinatesSearch"
+                showOptions
+                onZoomToPoint={() => {
+                    expect(true).toBe(false);
+                }}
+                coordinate={{lat: 15, lon: 15}}
+                typeAhead={false} />, document.getElementById("container")
+        );
+        expect(tb).toExist();
+        const container = document.getElementById('container');
+        const elements = container.querySelectorAll('input');
+        expect(elements.length).toBe(2);
+        expect(elements[0].value).toBe('15');
+
+        TestUtils.Simulate.keyDown(elements[0], {
+            keyCode: 69, // char e
+            preventDefault: () => {
+                expect(true).toBe(true);
+                done();
+            }
+        });
+    });
+    it('Test SearchBar with valid onKeyDown event by pressing number 8', () => {
+        const tb = ReactDOM.render(
+            <SearchBar
+                format="decimal"
+                activeSearchTool="coordinatesSearch"
+                showOptions
+                onZoomToPoint={() => {
+                    expect(true).toBe(false);
+                }}
+                coordinate={{lat: 1, lon: 1}}
+                typeAhead={false} />, document.getElementById("container")
+        );
+        expect(tb).toExist();
+        const container = document.getElementById('container');
+        const elements = container.querySelectorAll('input');
+        expect(elements.length).toBe(2);
+        expect(elements[0].value).toBe('1');
+
+        TestUtils.Simulate.keyDown(elements[0], {
+            keyCode: 56,
+            preventDefault: () => {
+                expect(true).toBe(false);
+            }
+        });
+    });
+
     it('test showOptions false, only address tool visible', () => {
         const tb = ReactDOM.render(<SearchBar showOptions={false} searchText={""} delay={0} typeAhead={false} />, document.getElementById("container"));
         let reset = TestUtils.findRenderedDOMComponentWithClass(tb, "glyphicon-search");

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -283,10 +283,6 @@ describe("test the SearchBar", () => {
         TestUtils.Simulate.keyDown(elements[0], {
             keyCode: 13
         });
-        /* setTimeout(() => {
-            expect(spyOnZoomToPoint).toHaveBeenCalled();
-        }, 50);*/
-
     });
     it('Test SearchBar with not allowed e char for keyDown event', (done) => {
         const tb = ReactDOM.render(

--- a/web/client/components/misc/coordinateeditors/CoordinateEntry.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinateEntry.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
 const React = require('react');
 const PropTypes = require('prop-types');
 const DecimalCoordinateEditor = require('./editors/DecimalCoordinateEditor');

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
 const React = require('react');
 const PropTypes = require('prop-types');
 const {Row, Col, Glyphicon, Button} = require('react-bootstrap');

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -32,7 +32,8 @@ class AeronauticalCoordinateEditor extends React.Component {
         direction: PropTypes.string,
         aeronauticalOptions: PropTypes.object,
         coordinate: PropTypes.string,
-        onChange: PropTypes.func
+        onChange: PropTypes.func,
+        onKeyDown: PropTypes.func
     };
     static defaultProps = {
         coordinate: "lat",
@@ -43,7 +44,8 @@ class AeronauticalCoordinateEditor extends React.Component {
                 decimals: 4,
                 step: 0.0001
             }
-        }
+        },
+        onKeyDown: () => {}
     }
 
     onChange = (part, newValue) => {
@@ -135,7 +137,10 @@ class AeronauticalCoordinateEditor extends React.Component {
                         step={1}
                         max={this.props.maxDegrees}
                         min={-1}
-                        onKeyDown={this.verifyOnKeyDownEvent}
+                        onKeyDown={(event) => {
+                            this.verifyOnKeyDownEvent(event);
+                            this.props.onKeyDown(event);
+                        }}
                         style={{ width: '100%', ...inputStyle, ...degreesInvalidStyle }}
                         type="number"
                     />
@@ -149,7 +154,10 @@ class AeronauticalCoordinateEditor extends React.Component {
                         onChange={e => this.onChange("minutes", parseInt(e.target.value, 10))}
                         max={60}
                         min={-1}
-                        onKeyDown={this.verifyOnKeyDownEvent}
+                        onKeyDown={(event) => {
+                            this.verifyOnKeyDownEvent(event);
+                            this.props.onKeyDown(event);
+                        }}
                         style={{ width: '100%', ...inputStyle, ...minutesInvalidStyle}}
                         step={1}
                         type="number"
@@ -164,7 +172,10 @@ class AeronauticalCoordinateEditor extends React.Component {
                         onChange={e => this.onChange("seconds", parseFloat(e.target.value))}
                         step={stepSeconds}
                         max={60}
-                        onKeyDown={this.verifyOnKeyDownEvent}
+                        onKeyDown={(event) => {
+                            this.verifyOnKeyDownEvent(event);
+                            this.props.onKeyDown(event);
+                        }}
                         min={-1}
                         style={{ width: '100%', ...inputStyle, ...secondsInvalidStyle}}
                         type="number"

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
 const React = require('react');
 const PropTypes = require('prop-types');
 const {compose} = require('recompose');
@@ -24,14 +32,12 @@ class AeronauticalCoordinateEditor extends React.Component {
         direction: PropTypes.string,
         aeronauticalOptions: PropTypes.object,
         coordinate: PropTypes.string,
-        onChange: PropTypes.func,
-        onKeyDown: PropTypes.func
+        onChange: PropTypes.func
     };
     static defaultProps = {
         coordinate: "lat",
         maxDegrees: 90,
         directions: ["N", "S"],
-        onKeyDown: () => {},
         aeronauticalOptions: {
             seconds: {
                 decimals: 4,
@@ -129,26 +135,26 @@ class AeronauticalCoordinateEditor extends React.Component {
                         step={1}
                         max={this.props.maxDegrees}
                         min={-1}
-                        onKeyDown={this.props.onKeyDown}
+                        onKeyDown={this.verifyOnKeyDownEvent}
                         style={{ width: '100%', ...inputStyle, ...degreesInvalidStyle }}
                         type="number"
                     />
                     <span style={labelStyle}>&deg;</span>
                 </div>
                 <div style={{width: 50, display: 'flex' }}>
-                <FormControl
-                    key={this.props.coordinate + "minutes"}
-                    placeholder={"m"}
-                    value={this.props.minutes}
-                    onChange={e => this.onChange("minutes", parseInt(e.target.value, 10))}
-                    max={60}
-                    min={-1}
-                    onKeyDown={this.props.onKeyDown}
-                    style={{ width: '100%', ...inputStyle, ...minutesInvalidStyle}}
-                    step={1}
-                    type="number"
-                />
-                <span style={labelStyle}>&prime;</span>
+                    <FormControl
+                        key={this.props.coordinate + "minutes"}
+                        placeholder={"m"}
+                        value={this.props.minutes}
+                        onChange={e => this.onChange("minutes", parseInt(e.target.value, 10))}
+                        max={60}
+                        min={-1}
+                        onKeyDown={this.verifyOnKeyDownEvent}
+                        style={{ width: '100%', ...inputStyle, ...minutesInvalidStyle}}
+                        step={1}
+                        type="number"
+                    />
+                    <span style={labelStyle}>&prime;</span>
                 </div>
                 <div style={{flex: 1, display: 'flex'}}>
                     <FormControl
@@ -158,7 +164,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                         onChange={e => this.onChange("seconds", parseFloat(e.target.value))}
                         step={stepSeconds}
                         max={60}
-                        onKeyDown={this.props.onKeyDown}
+                        onKeyDown={this.verifyOnKeyDownEvent}
                         min={-1}
                         style={{ width: '100%', ...inputStyle, ...secondsInvalidStyle}}
                         type="number"
@@ -177,6 +183,17 @@ class AeronauticalCoordinateEditor extends React.Component {
                 </div>
             </FormGroup>
         );
+    }
+    /**
+    * checking and blocking the keydown event to avoid
+    * the only letters matched by input type number 'e' or 'E'
+    * see https://github.com/geosolutions-it/MapStore2/issues/3523#issuecomment-502660391
+    * @param event keydown event
+    */
+    verifyOnKeyDownEvent = (event) => {
+        if (event.keyCode === 69) {
+            event.preventDefault();
+        }
     }
 
     roundToNextSexagesimalStep = val => {

--- a/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
 const React = require('react');
 const PropTypes = require('prop-types');
 const {FormGroup, FormControl} = require('react-bootstrap');
@@ -14,13 +22,11 @@ class DecimalCoordinateEditor extends React.Component {
         constraints: PropTypes.object,
         format: PropTypes.string,
         coordinate: PropTypes.string,
-        onChange: PropTypes.func,
-        onKeyDown: PropTypes.func
+        onChange: PropTypes.func
     };
-    defaultProps = {
+    static defaultProps = {
         format: "decimal",
         coordinate: "lat",
-        onKeyDown: () => {},
         constraints: {
             decimal: {
                 lat: {
@@ -47,6 +53,7 @@ class DecimalCoordinateEditor extends React.Component {
                     value={value}
                     placeholder={coordinate}
                     onChange={e => {
+                        // when inserting 4eee5 as number here it comes "" that makes the re-render fail
                         if (e.target.value === "") {
                             onChange("");
                         }
@@ -54,11 +61,24 @@ class DecimalCoordinateEditor extends React.Component {
                             onChange(e.target.value);
                         }
                     }}
-                    onKeyDown={this.props.onKeyDown}
+                    onKeyDown={this.verifyOnKeyDownEvent}
                     step={1}
                     type="number"/>
             </FormGroup>
         );
+    }
+    /**
+    * checking and blocking the keydown event to avoid
+    * the only letters matched by input type number 'e' or 'E'
+    * see https://github.com/geosolutions-it/MapStore2/issues/3523#issuecomment-502660391
+    * @param event keydown event
+    */
+    verifyOnKeyDownEvent = (event) => {
+        // avoid the 'e' and 'E' chars used for exponential numbers
+        // see https://github.com/geosolutions-it/MapStore2/issues/3523#issuecomment-502660391
+        if (event.keyCode === 69) {
+            event.preventDefault();
+        }
     }
 
     validateDecimalLon = (longitude) => {

--- a/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
@@ -74,8 +74,6 @@ class DecimalCoordinateEditor extends React.Component {
     * @param event keydown event
     */
     verifyOnKeyDownEvent = (event) => {
-        // avoid the 'e' and 'E' chars used for exponential numbers
-        // see https://github.com/geosolutions-it/MapStore2/issues/3523#issuecomment-502660391
         if (event.keyCode === 69) {
             event.preventDefault();
         }

--- a/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
@@ -22,7 +22,8 @@ class DecimalCoordinateEditor extends React.Component {
         constraints: PropTypes.object,
         format: PropTypes.string,
         coordinate: PropTypes.string,
-        onChange: PropTypes.func
+        onChange: PropTypes.func,
+        onKeyDown: PropTypes.func
     };
     static defaultProps = {
         format: "decimal",
@@ -38,7 +39,8 @@ class DecimalCoordinateEditor extends React.Component {
                     max: 180
                 }
             }
-        }
+        },
+        onKeyDown: () => {}
     }
 
 
@@ -61,7 +63,10 @@ class DecimalCoordinateEditor extends React.Component {
                             onChange(e.target.value);
                         }
                     }}
-                    onKeyDown={this.verifyOnKeyDownEvent}
+                    onKeyDown={(event) => {
+                        this.verifyOnKeyDownEvent(event);
+                        this.props.onKeyDown(event);
+                    }}
                     step={1}
                     type="number"/>
             </FormGroup>

--- a/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
 const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-dom/test-utils');

--- a/web/client/components/misc/coordinateeditors/editors/__tests__/DecimalCoordinateEditor-test.js
+++ b/web/client/components/misc/coordinateeditors/editors/__tests__/DecimalCoordinateEditor-test.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactTestUtils = require('react-dom/test-utils');
+const expect = require('expect');
+const DecimalCoordinateEditor = require('../DecimalCoordinateEditor');
+
+describe('DecimalCoordinateEditor enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('DecimalCoordinateEditor rendering with defaults', () => {
+        ReactDOM.render(<DecimalCoordinateEditor />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const elements = container.querySelectorAll('input');
+        expect(elements.length).toBe(1);
+    });
+    it('Test DecimalCoordinateEditor onKeyDown with keyCode 69 "e" ', () => {
+        ReactDOM.render( <DecimalCoordinateEditor value={19} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const elements = container.querySelectorAll('input');
+        expect(elements.length).toBe(1);
+        expect(elements[0].value).toBe('19');
+
+        ReactTestUtils.Simulate.keyDown(elements[0], {
+            keyCode: 69,
+            preventDefault: () => {
+                expect(true).toBe(true);
+            }
+        });
+    });
+    it('Test DecimalCoordinateEditor onKeyDown with a number ', () => {
+        ReactDOM.render( <DecimalCoordinateEditor value={1} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const elements = container.querySelectorAll('input');
+        expect(elements.length).toBe(1);
+        expect(elements[0].value).toBe('1');
+
+        ReactTestUtils.Simulate.keyDown(elements[0], {
+            keyCode: 19,
+            preventDefault: () => {
+                // this is expected to not be called
+                expect(true).toBe(false);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Description
This pr add a validity check on the number insterted in the coordinate input field.

it blocks the 'e' 'E' chars avoiding a lot of problems

## Issues
 - #3523

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
you can insert exponential numbers in coordiante editor causing some problems in Search when we want to reset the entries

**What is the new behavior?**
it avoids to insert the 'e' char

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

- the key point is the [preventDefault ](https://github.com/geosolutions-it/MapStore2/pull/3907/files#diff-cd36e9c89ebc2e0ec31b36736854e042R193) of the onKeyDown method of the two editor components
- i also provided a use case for test that needs to fail if the 'e' char is pressed
- i tested also copy paste the value  4e5 but it does not allow me to do that