### PR TITLE
Fix #3928 widget builder color selector box shows wrong labels

### DIFF
--- a/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
+++ b/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
@@ -1,8 +1,20 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const React = require('react');
 const PropTypes = require('prop-types');
 const colors = require('./ExtendColorBrewer');
 const Message = require('../../I18N/Message');
 
+/**
+ * @name ColorRampItem
+ * @description Simple component to display color label
+ */
 const ColorRampItem = ({ item }) => {
     let ramp = item && (item.ramp || colors[item.name] && colors[item.name][5]) || [];
     return (

--- a/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
+++ b/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
@@ -22,7 +22,7 @@ const ColorRampItem = ({ item }) => {
             {ramp.map(cell => <div className="color-cell" key={item && item.name + "-" + cell} style={{ backgroundColor: cell }} />)}
             <div className="colorname-cell">
                 {item && item.name
-                    ? <Message msgId={item.name.includes('global.colors') ? item.name : `global.colors.${item.name}`} msgParams={{ number: ramp.length }} />
+                    ? <Message msgId={item.name} msgParams={{ number: ramp.length }} />
                     : item}
             </div>
         </div>

--- a/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
+++ b/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
@@ -1,23 +1,24 @@
-const PropTypes = require('prop-types');
 const React = require('react');
-const colors = require("./ExtendColorBrewer");
+const PropTypes = require('prop-types');
+const colors = require('./ExtendColorBrewer');
 const Message = require('../../I18N/Message');
-class ColorRampItem extends React.Component {
-    static propTypes = {
-        item: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-    };
 
-    render() {
-        let ramp = this.props.item && (this.props.item.ramp || colors[this.props.item.name] && colors[this.props.item.name][5]) || [];
-        return (<div className="color-ramp-item">
-                {ramp.map(cell => <div className="color-cell" key={this.props.item && this.props.item.name + "-" + cell} style={{backgroundColor: cell}}/>)}
-                <div className="colorname-cell">
-                    {this.props.item && this.props.item.name
-                        ? <Message msgId={this.props.item.name.includes('global.colors') ? this.props.item.name : `global.colors.${this.props.item.name}`} msgParams={{number: ramp.length}} />
-                    : this.props.item && this.props.item.name}
-                </div>
-                </div>);
-    }
-}
+const ColorRampItem = ({ item }) => {
+    let ramp = item && (item.ramp || colors[item.name] && colors[item.name][5]) || [];
+    return (
+        <div className="color-ramp-item">
+            {ramp.map(cell => <div className="color-cell" key={item && item.name + "-" + cell} style={{ backgroundColor: cell }} />)}
+            <div className="colorname-cell">
+                {item && item.name
+                    ? <Message msgId={item.name.includes('global.colors') ? item.name : `global.colors.${item.name}`} msgParams={{ number: ramp.length }} />
+                    : item}
+            </div>
+        </div>
+    );
+};
+
+ColorRampItem.propTypes = {
+    item: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+};
 
 module.exports = ColorRampItem;

--- a/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
+++ b/web/client/components/style/EqualIntervalComponents/ColorRampItem.jsx
@@ -13,7 +13,7 @@ class ColorRampItem extends React.Component {
                 {ramp.map(cell => <div className="color-cell" key={this.props.item && this.props.item.name + "-" + cell} style={{backgroundColor: cell}}/>)}
                 <div className="colorname-cell">
                     {this.props.item && this.props.item.name
-                        ? <Message msgId={`global.colors.${this.props.item.name}`} msgParams={{number: ramp.length}} />
+                        ? <Message msgId={this.props.item.name.includes('global.colors') ? this.props.item.name : `global.colors.${this.props.item.name}`} msgParams={{number: ramp.length}} />
                     : this.props.item && this.props.item.name}
                 </div>
                 </div>);

--- a/web/client/components/style/EqualIntervalComponents/__tests__/ColorRampItem-test.jsx
+++ b/web/client/components/style/EqualIntervalComponents/__tests__/ColorRampItem-test.jsx
@@ -35,18 +35,11 @@ describe("Test the ColorRampItem", () => {
         const colorRamp = container.querySelector('.colorname-cell');
         expect(colorRamp.innerHTML).toEqual('blue');
     });
-    it('colorrampitem with object item contain name equal to full INTL path', () => {
+    it('colorrampitem with object item contain name', () => {
         const color = 'global.colors.blue';
         ReactDOM.render(<ColorRampItem item={{name: color}} />, document.getElementById("container"));
         const container = document.getElementById('container');
         const colorRamp = container.querySelector('span');
         expect(colorRamp.innerHTML).toEqual(color);
-    });
-    it('colorrampitem with object item contain name without full INTL path', () => {
-        const color = 'blue';
-        ReactDOM.render(<ColorRampItem item={{name: color}} />, document.getElementById("container"));
-        const container = document.getElementById('container');
-        const colorRamp = container.querySelector('span');
-        expect(colorRamp.innerHTML).toEqual(`global.colors.${color}`);
     });
 });

--- a/web/client/components/style/EqualIntervalComponents/__tests__/ColorRampItem-test.jsx
+++ b/web/client/components/style/EqualIntervalComponents/__tests__/ColorRampItem-test.jsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const React = require('react');
 const ReactDOM = require('react-dom');
 const expect = require('expect');

--- a/web/client/components/style/EqualIntervalComponents/__tests__/ColorRampItem-test.jsx
+++ b/web/client/components/style/EqualIntervalComponents/__tests__/ColorRampItem-test.jsx
@@ -1,0 +1,44 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const expect = require('expect');
+const ColorRampItem = require('../ColorRampItem');
+
+describe("Test the ColorRampItem", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates colorramp with defaults', () => {
+        ReactDOM.render(<ColorRampItem />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const colorRamp = container.querySelector('.color-ramp-item');
+        expect(colorRamp).toExist();
+    });
+    it('colorrampitem with string item equal to blue', () => {
+        ReactDOM.render(<ColorRampItem item="blue" />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const colorRamp = container.querySelector('.colorname-cell');
+        expect(colorRamp.innerHTML).toEqual('blue');
+    });
+    it('colorrampitem with object item contain name equal to full INTL path', () => {
+        const color = 'global.colors.blue';
+        ReactDOM.render(<ColorRampItem item={{name: color}} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const colorRamp = container.querySelector('span');
+        expect(colorRamp.innerHTML).toEqual(color);
+    });
+    it('colorrampitem with object item contain name without full INTL path', () => {
+        const color = 'blue';
+        ReactDOM.render(<ColorRampItem item={{name: color}} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const colorRamp = container.querySelector('span');
+        expect(colorRamp.innerHTML).toEqual(`global.colors.${color}`);
+    });
+});


### PR DESCRIPTION
## Description
This PR correct the widget builder color combobox option labels to proper values so that they have meaning to user. see #3928 

## Issues
 - #3928 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#3928 

**What is the new behavior?**
The widget builder color selector box shows colors properly

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
