### PR TITLE
Fix 3915 Wrong overflow in feature info settings

### DIFF
--- a/web/client/themes/default/less/panels.less
+++ b/web/client/themes/default/less/panels.less
@@ -190,12 +190,15 @@
             display: flex;
             flex-direction: column;
             position: relative;
+            overflow: hidden;
             .panel-collapse {
                 flex: 1;
                 display: flex;
+                overflow: auto;
                 .panel-body {
                     flex: 1;
                     overflow: auto;
+                    min-height: 100%;
                 }
             }
         }


### PR DESCRIPTION
## Description
This PR fix styles on Accordion panel of feature Info format settings to ensure scrollbar on body of selected panel.

## Issues
 - #3915 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [x] Other... Please describe: LESS/CSS style


**What is the current behavior?** (You can also link to an open issue here)
#3915 

**What is the new behavior?**
see description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
