### PR TITLE
Fix 3942 with correct positioning of tutorial for GFI step

### DIFF
--- a/web/client/plugins/tutorial/preset/cesium_tutorial.js
+++ b/web/client/plugins/tutorial/preset/cesium_tutorial.js
@@ -48,7 +48,7 @@ module.exports = [
     },
     {
         translation: 'identifyButton',
-        selector: '#identifyBar-container',
+        selector: '#navigationBar-container > .btn:last-child',
         position: 'top'
     }
 ];

--- a/web/client/plugins/tutorial/preset/cesium_tutorial.js
+++ b/web/client/plugins/tutorial/preset/cesium_tutorial.js
@@ -48,7 +48,7 @@ module.exports = [
     },
     {
         translation: 'identifyButton',
-        selector: '#navigationBar-container > .btn:last-child',
+        selector: '#navigationBar-container .glyphicon.glyphicon-option-horizontal',
         position: 'top'
     }
 ];

--- a/web/client/plugins/tutorial/preset/default_tutorial.js
+++ b/web/client/plugins/tutorial/preset/default_tutorial.js
@@ -40,7 +40,7 @@ module.exports = [
     },
     {
         translation: 'identifyButton',
-        selector: '#navigationBar-container > .btn:last-child',
+        selector: '#navigationBar-container .glyphicon.glyphicon-option-horizontal',
         position: 'top'
     }
 ];

--- a/web/client/plugins/tutorial/preset/default_tutorial.js
+++ b/web/client/plugins/tutorial/preset/default_tutorial.js
@@ -40,7 +40,7 @@ module.exports = [
     },
     {
         translation: 'identifyButton',
-        selector: '#identifyBar-container',
+        selector: '#navigationBar-container > .btn:last-child',
         position: 'top'
     }
 ];


### PR DESCRIPTION
## Description
Fix gfi tutorial step by attaching it on the expander button (last child of toolbar list)

## Issues
 - #3942

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
the gfi step gets attached on the map 

**What is the new behavior?**
the gfi step gets attached on the expander button

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

NOTE: open a new issue for adding id for gfi and expander button in map toolbar because actually this can only be done via config and cannot be used easily with selector for tutorial step


the only problem with this solutions is if you remvoe the expander button from config. then the last step shows forward instead of end.  that's the issue https://github.com/geosolutions-it/MapStore2/issues/3925