### PR TITLE
Fix #3913 GFI window does not close when opening the catalog (#3913)

### DIFF
--- a/web/client/epics/__tests__/controls-test.js
+++ b/web/client/epics/__tests__/controls-test.js
@@ -10,11 +10,7 @@ const expect = require('expect');
 
 const configureMockStore = require('redux-mock-store').default;
 const { createEpicMiddleware, combineEpics } = require('redux-observable');
-const { testEpic, addTimeoutEpic } = require('./epicTestUtils');
-const { setControlProperties } = require('../../actions/controls');
-const { HIDE_MAPINFO_MARKER, PURGE_MAPINFO_RESULTS } = require('../../actions/mapInfo');
-
-const {onEpic, setControlPropertiesEpic} = require('../controls');
+const {onEpic} = require('../controls');
 const rootEpic = combineEpics(onEpic);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
@@ -70,37 +66,5 @@ describe('controls Epics', () => {
         });
 
         store.dispatch(action);
-    });
-
-    it('enable metadataexplorer control is enabled', (done) => {
-        const state = {controls: {}};
-        const NUMBER_OF_ACTIONS = 2;
-        const callback = actions => {
-            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
-            expect(actions[0].type).toEqual(PURGE_MAPINFO_RESULTS);
-            expect(actions[1].type).toEqual(HIDE_MAPINFO_MARKER);
-            done();
-        };
-        testEpic(
-            setControlPropertiesEpic,
-            NUMBER_OF_ACTIONS,
-            setControlProperties('metadataexplorer', "enabled", true),
-            callback,
-            state);
-    });
-
-    it('disable metadataexplorer should not affect mapinfo', (done) => {
-        const state = {controls: {}};
-        const NUMBER_OF_ACTIONS = 1;
-        const callback = actions => {
-            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
-            done();
-        };
-        testEpic(
-            addTimeoutEpic(setControlPropertiesEpic),
-            NUMBER_OF_ACTIONS,
-            setControlProperties('metadataexplorer', "enabled", false),
-            callback,
-            state);
     });
 });

--- a/web/client/epics/__tests__/controls-test.js
+++ b/web/client/epics/__tests__/controls-test.js
@@ -10,8 +10,11 @@ const expect = require('expect');
 
 const configureMockStore = require('redux-mock-store').default;
 const { createEpicMiddleware, combineEpics } = require('redux-observable');
+const { testEpic, addTimeoutEpic } = require('./epicTestUtils');
+const { setControlProperties } = require('../../actions/controls');
+const { HIDE_MAPINFO_MARKER, PURGE_MAPINFO_RESULTS } = require('../../actions/mapInfo');
 
-const {onEpic} = require('../controls');
+const {onEpic, setControlPropertiesEpic} = require('../controls');
 const rootEpic = combineEpics(onEpic);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
@@ -67,5 +70,37 @@ describe('controls Epics', () => {
         });
 
         store.dispatch(action);
+    });
+
+    it('enable metadataexplorer control is enabled', (done) => {
+        const state = {controls: {}};
+        const NUMBER_OF_ACTIONS = 2;
+        const callback = actions => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            expect(actions[0].type).toEqual(PURGE_MAPINFO_RESULTS);
+            expect(actions[1].type).toEqual(HIDE_MAPINFO_MARKER);
+            done();
+        };
+        testEpic(
+            setControlPropertiesEpic,
+            NUMBER_OF_ACTIONS,
+            setControlProperties('metadataexplorer', "enabled", true),
+            callback,
+            state);
+    });
+
+    it('disable metadataexplorer should not affect mapinfo', (done) => {
+        const state = {controls: {}};
+        const NUMBER_OF_ACTIONS = 1;
+        const callback = actions => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            done();
+        };
+        testEpic(
+            addTimeoutEpic(setControlPropertiesEpic),
+            NUMBER_OF_ACTIONS,
+            setControlProperties('metadataexplorer', "enabled", false),
+            callback,
+            state);
     });
 });

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -10,10 +10,11 @@ const expect = require('expect');
 
 const { ZOOM_TO_POINT, clickOnMap } = require('../../actions/map');
 const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature } = require('../../actions/mapInfo');
-const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh } = require('../identify');
+const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh, closeFeatureInfoOnCatalogOpenEpic } = require('../identify');
 const { CLOSE_ANNOTATIONS } = require('../../actions/annotations');
 const { testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
 const { registerHook } = require('../../utils/MapUtils');
+const { setControlProperties } = require('../../actions/controls');
 
 const TEST_MAP_STATE = {
     present: {
@@ -493,5 +494,37 @@ describe('identify Epics', () => {
                 }
             }
         });
+    });
+
+    it('enable metadataexplorer control is enabled', (done) => {
+        const state = {controls: {}};
+        const NUMBER_OF_ACTIONS = 2;
+        const callback = actions => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            expect(actions[0].type).toEqual(PURGE_MAPINFO_RESULTS);
+            expect(actions[1].type).toEqual(HIDE_MAPINFO_MARKER);
+            done();
+        };
+        testEpic(
+            closeFeatureInfoOnCatalogOpenEpic,
+            NUMBER_OF_ACTIONS,
+            setControlProperties('metadataexplorer', "enabled", true),
+            callback,
+            state);
+    });
+
+    it('disable metadataexplorer should not affect mapinfo', (done) => {
+        const state = {controls: {}};
+        const NUMBER_OF_ACTIONS = 1;
+        const callback = actions => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            done();
+        };
+        testEpic(
+            addTimeoutEpic(closeFeatureInfoOnCatalogOpenEpic),
+            NUMBER_OF_ACTIONS,
+            setControlProperties('metadataexplorer', "enabled", false),
+            callback,
+            state);
     });
 });

--- a/web/client/epics/controls.js
+++ b/web/client/epics/controls.js
@@ -7,6 +7,8 @@
  */
 
 const Rx = require('rxjs');
+const { SET_CONTROL_PROPERTIES } = require('../actions/controls');
+const { purgeMapInfoResults, hideMapinfoMarker } = require('../actions/mapInfo');
 
 module.exports = {
     onEpic: (action$, store) =>
@@ -16,5 +18,13 @@ module.exports = {
                 return Rx.Observable.of(action.action);
             }
             return Rx.Observable.of(action.elseAction.call());
-        })
+        }),
+
+    setControlPropertiesEpic: (action$) =>
+        action$
+            .ofType(SET_CONTROL_PROPERTIES)
+            .filter((action) => action.control === "metadataexplorer" && action.properties && action.properties.enabled)
+            .switchMap(() => {
+                return Rx.Observable.of(purgeMapInfoResults(), hideMapinfoMarker());
+            })
 };

--- a/web/client/epics/controls.js
+++ b/web/client/epics/controls.js
@@ -7,8 +7,6 @@
  */
 
 const Rx = require('rxjs');
-const { SET_CONTROL_PROPERTIES } = require('../actions/controls');
-const { purgeMapInfoResults, hideMapinfoMarker } = require('../actions/mapInfo');
 
 module.exports = {
     onEpic: (action$, store) =>
@@ -18,13 +16,5 @@ module.exports = {
                 return Rx.Observable.of(action.action);
             }
             return Rx.Observable.of(action.elseAction.call());
-        }),
-
-    setControlPropertiesEpic: (action$) =>
-        action$
-            .ofType(SET_CONTROL_PROPERTIES)
-            .filter((action) => action.control === "metadataexplorer" && action.properties && action.properties.enabled)
-            .switchMap(() => {
-                return Rx.Observable.of(purgeMapInfoResults(), hideMapinfoMarker());
-            })
+        })
 };

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -16,6 +16,8 @@ const { LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLI
 
     exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo, noQueryableLayers, newMapInfoRequest, getVectorInfo, showMapinfoMarker, hideMapinfoMarker } = require('../actions/mapInfo');
 
+const { SET_CONTROL_PROPERTIES } = require('../actions/controls');
+
 const { closeFeatureGrid } = require('../actions/featuregrid');
 const { CHANGE_MOUSE_POINTER, CLICK_ON_MAP, zoomToPoint } = require('../actions/map');
 const { closeAnnotations } = require('../actions/annotations');
@@ -202,5 +204,15 @@ module.exports = {
                 const center = centerToVisibleArea(coords, map, layoutBounds, resolution);
                 return Rx.Observable.of(updateCenterToMarker('enabled'), zoomToPoint(center.pos, center.zoom, center.crs));
             })
-        )
+        ),
+    /**
+     * Close Feature Info when catalog is enabled
+     */
+    closeFeatureInfoOnCatalogOpenEpic: (action$) =>
+        action$
+            .ofType(SET_CONTROL_PROPERTIES)
+            .filter((action) => action.control === "metadataexplorer" && action.properties && action.properties.enabled)
+            .switchMap(() => {
+                return Rx.Observable.of(purgeMapInfoResults(), hideMapinfoMarker());
+            })
 };


### PR DESCRIPTION
fix #3913

## Description
Fix GFI window fails to close when opening the catalog from TOC, see #3913

## Issues
 - #3913
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3913 

**What is the new behavior?**
GIF close on opening catalog from TOC

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
