### PR TITLE
Fix 3945 zoom to feature for point now zooms correctly

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -527,13 +527,12 @@ class OpenlayersMap extends React.Component {
             // if EPSG:4326 with max extent (-180, -90, 180, 90) bounds are 0,0,0,0. In this case zoom to max extent
             // TODO: improve this to manage all degenerated bounding boxes.
             if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3] &&
-                // the following is needed to avoid to use projection extent when extent is generated from a point
                 crs === "EPSG:4326" && isArray(extent) && extent[0] === -180 && extent[1] === -90) {
                 bounds = this.map.getView().getProjection().getExtent();
             }
             let maxZoom = zoomLevel;
             if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3] && isNil(maxZoom)) {
-                maxZoom = 20; // is enough for points
+                maxZoom = 21; // TODO: allow to this maxZoom to be customizable
             }
             this.map.getView().fit(bounds, {
                 padding: padding && [padding.top || 0, padding.right || 0, padding.bottom || 0, padding.left || 0],

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -16,7 +16,7 @@ const ConfigUtils = require('../../../utils/ConfigUtils');
 const mapUtils = require('../../../utils/MapUtils');
 const projUtils = require('../../../utils/openlayers/projUtils');
 
-const { isEqual, throttle } = require('lodash');
+const { isEqual, throttle, isArray, isNil } = require('lodash');
 
 class OpenlayersMap extends React.Component {
     static propTypes = {
@@ -522,12 +522,18 @@ class OpenlayersMap extends React.Component {
         mapUtils.registerHook(mapUtils.GET_COORDINATES_FROM_PIXEL_HOOK, (pixel) => {
             return this.map.getCoordinateFromPixel(pixel);
         });
-        mapUtils.registerHook(mapUtils.ZOOM_TO_EXTENT_HOOK, (extent, { padding, crs, maxZoom, duration } = {}) => {
+        mapUtils.registerHook(mapUtils.ZOOM_TO_EXTENT_HOOK, (extent, { padding, crs, maxZoom: zoomLevel, duration } = {}) => {
             let bounds = CoordinatesUtils.reprojectBbox(extent, crs, this.props.projection);
-            // if EPSG:4326 with max extent (-90. 180, 180, 90) bounds are 0,0,0,0. In this case zoom to max extent
+            // if EPSG:4326 with max extent (-180, -90, 180, 90) bounds are 0,0,0,0. In this case zoom to max extent
             // TODO: improve this to manage all degenerated bounding boxes.
-            if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3]) {
+            if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3] &&
+                // the following is needed to avoid to use projection extent when extent is generated from a point
+                crs === "EPSG:4326" && isArray(extent) && extent[0] === -180 && extent[1] === -90) {
                 bounds = this.map.getView().getProjection().getExtent();
+            }
+            let maxZoom = zoomLevel;
+            if (bounds && bounds[0] === bounds[2] && bounds[1] === bounds[3] && isNil(maxZoom)) {
+                maxZoom = 20; // is enough for points
             }
             this.map.getView().fit(bounds, {
                 padding: padding && [padding.top || 0, padding.right || 0, padding.bottom || 0, padding.left || 0],

--- a/web/client/components/map/openlayers/__tests__/Map-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Map-test.jsx
@@ -880,7 +880,7 @@ describe('OpenlayersMap', () => {
             expect(spy.calls[1].arguments[0].x).toBeLessThan(2);
             expect(spy.calls[1].arguments[0].y).toBeLessThan(2);
             // Bbox should not be max.
-            expect(spy.calls[1].arguments[1]).toBe(20);
+            expect(spy.calls[1].arguments[1]).toBe(21);
             expect(spy.calls[1].arguments[2].bounds.maxx).toBeGreaterThan(111319);
             expect(spy.calls[1].arguments[2].bounds.maxy).toBeGreaterThan(111325);
             expect(spy.calls[1].arguments[2].bounds.minx).toBeLessThan(111320);


### PR DESCRIPTION
## Description
Fix zoom to feature for points in feature grid

it was a regression as indicated in the issue.

## Issues
 - #3945 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
zooms do not work for points in feature grid, see issue

**What is the new behavior?**
now it zooms correctly setting a max  zoom level to 20 if not specified

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
