### PR TITLE
Fix Glich of query panels roi styles

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -144,6 +144,7 @@ const FeatureDock = (props = {
             {getDialogs(props.tools)}
             <Grid
                 onMount={props.onMount}
+                showFilteredObject={props.showFilteredObject}
                 editingAllowedRoles={props.editingAllowedRoles}
                 initPlugin={props.initPlugin}
                 customEditorsOptions={props.customEditorsOptions}

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -143,8 +143,6 @@ const FeatureDock = (props = {
             footer={getFooter(props)}>
             {getDialogs(props.tools)}
             <Grid
-                onMount={props.onMount}
-                showFilteredObject={props.showFilteredObject}
                 editingAllowedRoles={props.editingAllowedRoles}
                 initPlugin={props.initPlugin}
                 customEditorsOptions={props.customEditorsOptions}

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -59,7 +59,7 @@ const emptyResultsState = {
     filters: {},
     editingAllowedRoles: ["ADMIN"],
     enableColumnFilters: true,
-    showFilteredObject: true,
+    showFilteredObject: false,
     timeSync: false,
     showTimeSync: false,
     open: false,

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -45,7 +45,8 @@ let feature3 = [{
         coordinates: [ [ 0.000008983152841195214, 0.000017966305681987637 ] ]
     },
     style: {
-        fillColor: 'rgba(255, 255, 255, 0.2)',
+        fillColor: '#FFFFFF',
+        fillOpacity: '0.2',
         color: '#ffcc33'
     },
     id: 'spatial_object'

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -27,7 +27,8 @@ const filteredFeatures = createSelector(
                         coordinates: geometryCoordinates
                     },
                     style: {
-                        fillColor: 'rgba(255, 255, 255, 0.2)',
+                        fillColor: '#FFFFFF',
+                        fillOpacity: '0.2',
                         color: '#ffcc33'
                     },
                     id: geometryId


### PR DESCRIPTION
## Description
this pr fixes the behaviour of query panel rois.

if showFilteredObject is configured to be true it keeps the filter when pressing search
and the the style has a white fill with 0.2 opacity

## Issues
 - #3924 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
filter stays in map with a wrong style

**What is the new behavior?**
style is correct if filter remains in map.
by default filter wil lnot remain (reducer change)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
TODO  we should handle a fill configured as RGBA(R, G, B, A)