### PR TITLE
Fix dashboard autoreload

### DIFF
--- a/web/client/epics/__tests__/dashboards-test.js
+++ b/web/client/epics/__tests__/dashboards-test.js
@@ -12,8 +12,12 @@ const ConfigUtils = require('../../utils/ConfigUtils');
 
 const {
     searchDashboardsOnMapSearch,
-    searchDashboards: searchDashboardsEpic
+    searchDashboards: searchDashboardsEpic,
+    reloadOnDashboards
 } = require('../dashboards');
+
+const { dashboardSaved } = require('../../actions/dashboard');
+
 
 const {
     SEARCH_DASHBOARDS,
@@ -76,6 +80,28 @@ describe('dashboards epics', () => {
             expect(actions[2].value).toBe(false);
             done();
         }, {});
+    });
+    describe('reloadOnDashboards', () => {
+        it('reload on dashboardSaved', (done) => {
+            const startActions = [dashboardSaved("Search Text")];
+            testEpic(reloadOnDashboards, 1, startActions, ([a]) => {
+                expect(a.type).toBe(SEARCH_DASHBOARDS);
+                expect(a.params.start).toBe(0);
+                expect(a.params.limit).toBe(12);
+                expect(a.searchText).toBe("test");
+                done();
+            }, {
+                    dashboards: {
+                        searchText: "test",
+                        options: {
+                            params: {
+                                start: 0,
+                                limit: 12
+                            }
+                        }
+                    }
+                });
+        });
     });
     it('searchDashboards error', (done) => {
         const baseUrl = "base/web/client/test-resources/geostore/extjs/search/NODATA#";

--- a/web/client/epics/dashboards.js
+++ b/web/client/epics/dashboards.js
@@ -7,6 +7,8 @@
  */
 const Rx = require('rxjs');
 const { MAPS_LIST_LOADING, ATTRIBUTE_UPDATED} = require('../actions/maps');
+const { DASHBOARD_SAVED } = require('../actions/dashboard');
+
 const { SEARCH_DASHBOARDS, DELETE_DASHBOARD, DASHBOARD_DELETED, RELOAD, searchDashboards, dashboardListLoaded, dashboardDeleted, dashboardsLoading } = require('../actions/dashboards');
 const { searchParamsSelector, searchTextSelector, totalCountSelector} = require('../selectors/dashboards');
 const GeoStoreApi = require('../api/GeoStoreDAO');
@@ -17,7 +19,7 @@ const {deleteResource} = require('../api/persistence');
 
 const calculateNewParams = state => {
     const totalCount = totalCountSelector(state);
-    const {start, limit, ...params} = searchParamsSelector(state);
+    const {start, limit, ...params} = searchParamsSelector(state) || {};
     if (start === totalCount - 1) {
         return {
             start: Math.max(0, start - limit),
@@ -71,7 +73,7 @@ module.exports = {
             }))
         )),
     reloadOnDashboards: (action$, { getState = () => { } }) =>
-        action$.ofType(DASHBOARD_DELETED, RELOAD, ATTRIBUTE_UPDATED)
+        action$.ofType(DASHBOARD_DELETED, RELOAD, ATTRIBUTE_UPDATED, DASHBOARD_SAVED)
             .delay(1000) // delay as a workaround for geostore issue #178
             .switchMap( () => Rx.Observable.of(searchDashboards(
                 searchTextSelector(getState()),


### PR DESCRIPTION
## Description
This PR triggers again search when a new dashboard is saved, as well as for delete or edit events
## Issues
 - #3914


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
see #3914 

**What is the new behavior?**
When a new dashboard is saved, the search list in home page is updated. 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

