### PR TITLE
Fix #3910 Text annotations - wrong text align in preview

### DIFF
--- a/web/client/components/style/StyleCanvas.jsx
+++ b/web/client/components/style/StyleCanvas.jsx
@@ -133,10 +133,22 @@ class StyleCanvas extends React.Component {
 
     }
     paintText = (ctx) => {
-        ctx.font = this.props.shapeStyle.font || '14px Arial';
-        ctx.textAlign = this.props.shapeStyle.textAlign || 'center';
-        ctx.strokeText(this.props.shapeStyle.label || "New", this.props.width / 2, this.props.height / 2);
-        ctx.fillText(this.props.shapeStyle.label || "New", this.props.width / 2, this.props.height / 2);
+        const {width, height} = this.props;
+        const {textAlign = 'center', label, font = '14px Arial'} = this.props.shapeStyle;
+        ctx.textAlign = textAlign;
+        ctx.font = font;
+        if (textAlign === 'start') {
+            ctx.strokeText(label || "New", width / 2.5, height / 2);
+            ctx.fillText(label || "New", width / 2.5, height / 2);
+            return;
+        }
+        if (textAlign === 'end') {
+            ctx.strokeText(label || "New", width / 1.5, height / 2);
+            ctx.fillText(label || "New", width / 1.5, height / 2);
+            return;
+        }
+        ctx.strokeText(label || "New", width / 2, height / 2);
+        ctx.fillText(label || "New", width / 2, height / 2);
     };
     paintPolygon = (ctx) => {
         ctx.transform(1, 0, 0, 1, -27.5, 0);

--- a/web/client/components/style/__tests__/StyleCanvas-test.jsx
+++ b/web/client/components/style/__tests__/StyleCanvas-test.jsx
@@ -69,4 +69,11 @@ describe("Test the StyleCanvas style component", () => {
         const cmp = ReactDOM.render(<StyleCanvas shapeStyle={style} geomType="Point"/>, document.getElementById("container"));
         expect(cmp).toExist();
     });
+    it('test component drawing text', () => {
+        let style = {...{width: 100, height: 100}};
+        ReactDOM.render(<StyleCanvas shapeStyle={style} geomType="Text"/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const canvas = container.querySelector('canvas');
+        expect(canvas).toExist();
+    });
 });


### PR DESCRIPTION
fix #3910

## Description
Text annotation label wring text align see #3910 

## Issues
 - #3910 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3910 

**What is the new behavior?**
The text annotations align works as expected

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
