### PR TITLE
Fix #3906  the 'back' button does not undo the annotation creation

### DIFF
--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -296,12 +296,7 @@ class AnnotationsEditor extends React.Component {
                             visible: true,
                             onClick: () => {
                                 if (this.props.unsavedChanges) {
-                                    const errors = this.validate();
-                                    if (Object.keys(errors).length === 0) {
-                                        this.props.onToggleUnsavedChangesModal();
-                                    } else {
-                                        this.props.onError(errors);
-                                    }
+                                    this.props.onToggleUnsavedChangesModal();
                                 } else {
                                     this.cancelEdit();
                                 }

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -279,6 +279,36 @@ describe("test the AnnotationsEditor Panel", () => {
         expect(spyCancel.calls.length).toEqual(1);
     });
 
+    it('test click cancel trigger UnsavedChangesModal', () => {
+        const feature = {
+            id: "1",
+            title: 'mytitle',
+            description: '<span><i>desc</i></span>'
+        };
+
+        const testHandlers = {
+            onToggleUnsavedChangesModal: (id) => { return id; }
+        };
+
+        const spyUnsavedModal = expect.spyOn(testHandlers, 'onToggleUnsavedChangesModal');
+
+        const viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions} editing={{
+            properties: feature,
+            geometry: {}
+        }}
+        onToggleUnsavedChangesModal={testHandlers.onToggleUnsavedChangesModal}
+        unsavedChanges
+        />, document.getElementById("container"));
+        expect(viewer).toExist();
+
+        let cancelButton = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithTag(viewer, "button")[0]);
+
+        expect(cancelButton).toExist();
+        TestUtils.Simulate.click(cancelButton);
+
+        expect(spyUnsavedModal.calls.length).toEqual(1);
+    });
+
     it('test click save validate title error', () => {
         const feature = {
             id: "1",


### PR DESCRIPTION
## Description
On annotation create/update, the 'back' button should always allow user to leave annotation creation/edit screen. see #3906 

## Issues
 - #3906

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3906

**What is the new behavior?**
The back button accompanied with confirm dialog allow user to leave annotation edit screen at anytime

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
