### PR TITLE
Fix link on quickstart page

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -16,7 +16,7 @@ Windows: `mapstore2_startup.bat`
 
 Linux: `./mapstore2_startup.sh`
 
-Point your browser to: [http://localhost:8800/mapstore](http://localhost:8800/mapstore)
+Point your browser to: [http://localhost:8082/mapstore](http://localhost:8082/mapstore)
 
 To stop MapStore simply do:
 


### PR DESCRIPTION
## Description
Fix quickstart documentation page

**What kind of change does this PR introduce?** 
 - [x] Other... Please describe: Documentation

**What is the current behavior?** (You can also link to an open issue here)
The link is wrong

**What is the new behavior?**
The link is correct

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
