### PR TITLE
Fix #3957 Avoid showing the MapStore version number (2) in translations

### DIFF
--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -17,7 +17,7 @@
         "about_a0": "diese",
         "about_p5-1": "Seite.",
         "about_h21": "Quellen",
-        "about_p6": "MapStore2 ist entwickelt von:",
+        "about_p6": "MapStore ist entwickelt von:",
         "enable": "Aktiviere",
         "layers": "Ebenen",
         "warning": "Warnung",
@@ -227,7 +227,7 @@
                     "html":"<h3>Plugins</h3><p>Erstelle deine eigene Anwendung</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Verwenden Sie APIs, um eine MapStore2-Karte in Ihre Anwendung aufzunehmen</p>"
+                    "html":"<h3>API</h3><p>Verwenden Sie APIs, um eine MapStore-Karte in Ihre Anwendung aufzunehmen</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Raster Styler</h3><p>Style deine Rasterebene</p>"
@@ -1070,7 +1070,7 @@
                 "dropZone": {
                     "heading": "<p> <h4> Legen Sie hier Ihre Konfigurations- oder Vektordateien ab </h4> <small> oder </small> </p>",
                     "selectFiles": "Dateien auswählen...",
-                    "infoSupported": "<p> <small> Unterstützte Konfigurationsdateien: MapStore2 Legacy-Format. Unterstützte Vektor-Layer-Dateien: Shapefiles müssen in Zip-Archiven, KML / KMZ, GPX oder GeoJSON </small> </p> enthalten sein",
+                    "infoSupported": "<p> <small> Unterstützte Konfigurationsdateien: MapStore Legacy-Format. Unterstützte Vektor-Layer-Dateien: Shapefiles müssen in Zip-Archiven, KML / KMZ, GPX oder GeoJSON </small> </p> enthalten sein",
                     "note": "<p> <small> <i> <strong> Hinweis </strong>: Die aktuelle Map wird bei Konfigurationsdateien überschrieben </i> </small> </p>"
                 },
                 "errors": {
@@ -1853,7 +1853,7 @@
             "checkbox": "Zeige diese Nachricht nicht mehr an",
             "error": "Fehler: Ziel wurde nicht gefunden",
             "intro": {
-                "title": "Willkommen bei MapStore2",
+                "title": "Willkommen bei MapStore",
                 "text": "Framework zum Erstellen von Web Mapping-Anwendungen mit Standard-Mapping-Bibliotheken wie OpenLayers 3 und Leaflet."
             },
             "drawerMenu": {
@@ -1898,11 +1898,11 @@
             },
             "mapsGrid": {
                 "title": "Karten",
-                "text": "Hier einige Beispiele von MapStore2. Klicken Sie auf ein Bild, um die Demo zu testen."
+                "text": "Hier einige Beispiele von MapStore. Klicken Sie auf ein Bild, um die Demo zu testen."
             },
             "examples": {
                 "title": "benutzerdefinierte Anwendung",
-                "text": "Sie können Komponenten und Plugins von MapStore2 verwenden, um benutzerdefinierte Anwendungen zu erstellen"
+                "text": "Sie können Komponenten und Plugins von MapStore verwenden, um benutzerdefinierte Anwendungen zu erstellen"
             },
             "introCesium": {
                 "title": "3D Kartenanweisungen",
@@ -1941,7 +1941,7 @@
             },
             "dashboardContainer": {
                 "title": "Instrumententafel",
-                "text": "<p> Ein Dashboard in MapStore2 bietet eine Reihe von Informationen, die passend gesammelt werden, um aggregierte Daten in der One-Shot-Ansicht anzuzeigen. Geodaten, die in einer Karte angezeigt werden, können Seite an Seite mit verwandten Attributtabellen, Diagrammen und anderen platziert werden, mit dem Ziel, verschiedene Arten von Informationen zu verbinden, statistische Details und textuelle Beschreibungen zu einem bestimmten Kontext anzuzeigen. </p> <p> Alle Benutzer können veröffentlichte Dashboards visualisieren und mit ihnen interagieren, aber nur Benutzer, die sie bearbeiten dürfen, können alle Widgets in einem Dashboard hinzufügen, anordnen, ihre Größe ändern oder löschen </ p>"
+                "text": "<p> Ein Dashboard in MapStore bietet eine Reihe von Informationen, die passend gesammelt werden, um aggregierte Daten in der One-Shot-Ansicht anzuzeigen. Geodaten, die in einer Karte angezeigt werden, können Seite an Seite mit verwandten Attributtabellen, Diagrammen und anderen platziert werden, mit dem Ziel, verschiedene Arten von Informationen zu verbinden, statistische Details und textuelle Beschreibungen zu einem bestimmten Kontext anzuzeigen. </p> <p> Alle Benutzer können veröffentlichte Dashboards visualisieren und mit ihnen interagieren, aber nur Benutzer, die sie bearbeiten dürfen, können alle Widgets in einem Dashboard hinzufügen, anordnen, ihre Größe ändern oder löschen </ p>"
             },
             "dashboardAddWidget": {
                 "title": "Widget hinzufügen",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -17,7 +17,7 @@
         "about_a0": "this",
         "about_p5-1": "page.",
         "about_h21": "Credits",
-        "about_p6": "MapStore2 is made by:",
+        "about_p6": "MapStore is made by:",
         "enable": "Enable",
         "layers": "Layers",
         "warning": "Warning",
@@ -227,7 +227,7 @@
                     "html":"<h3>Plugins</h3><p>Build your own application</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Use APIs to include a MapStore2 map in your application</p>"
+                    "html":"<h3>API</h3><p>Use APIs to include a MapStore map in your application</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Raster Styler</h3><p>Style your raster layer</p>"
@@ -1071,7 +1071,7 @@
             "dropZone": {
                 "heading": "<p><h4>Drop your configuration or vector files here</h4><small>or</small></p>",
                 "selectFiles": "Select Files...",
-                "infoSupported": "<p><small>Supported configuration files: MapStore2 legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
+                "infoSupported": "<p><small>Supported configuration files: MapStore legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
                 "note": "<p><small><i><strong>note</strong>: current map will be overridden in case of configuration files</i></small></p>"
             },
             "errors": {
@@ -1854,7 +1854,7 @@
             "checkbox": "don't show this message again",
             "error": "Error: target not found",
             "intro": {
-                "title": "Welcome on MapStore2",
+                "title": "Welcome on MapStore",
                 "text": "framework to build web mapping applications using standard mapping libraries, such as OpenLayers 3 and Leaflet."
             },
             "drawerMenu": {
@@ -1899,11 +1899,11 @@
             },
             "mapsGrid": {
                 "title": "Maps",
-                "text": "Here some examples of MapStore2. Click on an image to try the demo."
+                "text": "Here some examples of MapStore. Click on an image to try the demo."
             },
             "examples": {
                 "title": "Custom Application",
-                "text": "You can use components and plugins of MapStore2 to build custom applications"
+                "text": "You can use components and plugins of MapStore to build custom applications"
             },
             "introCesium": {
                 "title": "3D map instructions",
@@ -1942,7 +1942,7 @@
             },
             "dashboardContainer": {
                 "title": "Dashboard",
-                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
+                "text": "<p>A Dashboard in MapStore provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -17,7 +17,7 @@
         "about_a0": "esta",
         "about_p5-1": "página.",
         "about_h21": "Créditos",
-        "about_p6": "MapStore2 está hecho por:",
+        "about_p6": "MapStore está hecho por:",
         "enable": "Activar",
         "layers": "Capas",
         "warning": "Atención",
@@ -227,7 +227,7 @@
                     "html":"<h3>Plugins</h3><p>Construya su propia aplicación</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Use las API para  incluir un mapa de MapStore2 en su  aplicación</p>"
+                    "html":"<h3>API</h3><p>Use las API para  incluir un mapa de MapStore en su  aplicación</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Estilos ráster</h3><p>Estilo ráster</p>"
@@ -1070,7 +1070,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Elimine aquí sus archivos de configuración o vector </h4> <small> o </small> </p>",
                 "selectFiles": "Selecciona archivos...",
-                "infoSupported": "<p> <small> Archivos de configuración admitidos: formato heredado MapStore2<br /> Archivos de capa vectorial soportados: shapefiles (deben estar en archivos comprimidos), KML / KMZ, GPX o GeoJSON </small> </p>",
+                "infoSupported": "<p> <small> Archivos de configuración admitidos: formato heredado MapStore<br /> Archivos de capa vectorial soportados: shapefiles (deben estar en archivos comprimidos), KML / KMZ, GPX o GeoJSON </small> </p>",
                 "note": "<p> <small> <i> <strong> nota </strong>: el mapa actual se anulará en el caso de los archivos de configuración </i> </small> </p>"
             },
             "errors": {
@@ -1853,7 +1853,7 @@
             "checkbox": "No volver a mostrar este mensaje",
             "error": "Error: destino no encontrado",
             "intro": {
-                "title": "Bienvenido a MapStore2",
+                "title": "Bienvenido a MapStore",
                 "text": "Marco de trabajo para  construir aplicaciones de mapas usando librerías estándar, como OpenLayers3 y Leaflet."
             },
             "drawerMenu": {
@@ -1902,7 +1902,7 @@
             },
             "examples": {
                 "title": "Aplicaciones personalizadas",
-                "text": "Pueden usar los componentes y plugins de Mapstore2 para construir  aplicaciones personalizadas"
+                "text": "Pueden usar los componentes y plugins de MapStore para construir  aplicaciones personalizadas"
             },
             "introCesium": {
                 "title": "Instrucciones mapa 3D",
@@ -1941,7 +1941,7 @@
             },
             "dashboardContainer": {
                 "title": "Panel de control",
-                "text": "<p> Un panel de control en MapStore2 proporciona un conjunto de información recopilada adecuadamente para mostrar datos agregados en una vista de un solo disparo. Los datos geoespaciales mostrados en un mapa se pueden colocar uno al lado del otro en tablas de atributos relacionados, cuadros y otros, con el objetivo de conectar diferentes tipos de información, mostrar detalles estadísticos y descripciones textuales relacionadas con un contexto específico. </p> <p> Todos los usuarios pueden visualizar e interactuar con los paneles publicados, pero solo los usuarios a los que se les permite editar pueden agregar, organizar, cambiar el tamaño o eliminar todos los widgets dentro de un panel </p>"
+                "text": "<p> Un panel de control en MapStore proporciona un conjunto de información recopilada adecuadamente para mostrar datos agregados en una vista de un solo disparo. Los datos geoespaciales mostrados en un mapa se pueden colocar uno al lado del otro en tablas de atributos relacionados, cuadros y otros, con el objetivo de conectar diferentes tipos de información, mostrar detalles estadísticos y descripciones textuales relacionadas con un contexto específico. </p> <p> Todos los usuarios pueden visualizar e interactuar con los paneles publicados, pero solo los usuarios a los que se les permite editar pueden agregar, organizar, cambiar el tamaño o eliminar todos los widgets dentro de un panel </p>"
             },
             "dashboardAddWidget": {
                 "title": "Agregar Widget",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -17,7 +17,7 @@
         "about_a0": "ceci",
         "about_p5-1": "page.",
         "about_h21": "Crédits",
-        "about_p6": "MapStore2 est développé par:",
+        "about_p6": "MapStore est développé par:",
         "enable": "Activer",
         "layers": "Couches",
         "warning": "Attention",
@@ -227,7 +227,7 @@
                     "html":"<h3>Plugins</h3><p>Contruire sa propre application</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Utilisez les API pour inclure une carte MapStore2 dans votre application</p>"
+                    "html":"<h3>API</h3><p>Utilisez les API pour inclure une carte MapStore dans votre application</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Représentation d'image</h3><p>Représenter votre couche image</p>"
@@ -1070,7 +1070,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Déposez votre configuration ou vos fichiers vectoriels ici </h4> <small> ou </small> </p>",
                 "selectFiles": "Sélectionnez les fichiers...",
-                "infoSupported": "<p> <small> Fichiers de configuration pris en charge: format hérité MapStore2<br /> Fichiers vectoriels pris en charge: shapefile (doivent être contenus dans des archives zip), KML / KMZ, GPX ou GeoJSON </small> </p>",
+                "infoSupported": "<p> <small> Fichiers de configuration pris en charge: format hérité MapStore<br /> Fichiers vectoriels pris en charge: shapefile (doivent être contenus dans des archives zip), KML / KMZ, GPX ou GeoJSON </small> </p>",
                 "note": "<p> <small> <i> <strong> note </strong>: la carte actuelle sera remplacée dans le cas des fichiers de configuration </i> </small> </p>"
             },
             "errors": {
@@ -1853,7 +1853,7 @@
             "checkbox": "Ne plus me montrer ce message",
             "error": "Erreur: ressource non trouvée",
             "intro": {
-                "title": "Bienvenue dans MapStore2",
+                "title": "Bienvenue dans MapStore",
                 "text": "Environnement de développement d'applications cartographiques en ligne utilisant des librairies cartographiques standards, telles qu'OpenLayers 3 et Leaflet."
             },
             "drawerMenu": {
@@ -1898,11 +1898,11 @@
             },
             "mapsGrid": {
                 "title": "Cartes",
-                "text": "Quelques exemples de MapStore2. Cliquez sur une image pour lancer la démo."
+                "text": "Quelques exemples de MapStore. Cliquez sur une image pour lancer la démo."
             },
             "examples": {
                 "title": "Application sur mesure",
-                "text": "Utilisez les composants et outils de MapStore2 pour construire votre application personnalisée"
+                "text": "Utilisez les composants et outils de MapStore pour construire votre application personnalisée"
             },
             "introCesium": {
                 "title": "Instructions carte 3D",
@@ -1941,7 +1941,7 @@
             },
             "dashboardContainer": {
                 "title": "Tableau de bord",
-                "text": "<p> Un tableau de bord dans MapStore2 fournit un ensemble d'informations collectées de manière appropriée pour afficher des données agrégées en une vue. Les données géospatiales affichées dans une carte peuvent être placées côte à côte avec des tableaux d'attributs, des graphiques et autres, dans le but de connecter différents types d'informations, de montrer des détails statistiques et des descriptions textuelles relatives à un contexte spécifique. </p> <p> Tous les utilisateurs peuvent visualiser et interagir avec les tableaux de bord publiés, mais seuls les utilisateurs autorisés à modifier peuvent ajouter, organiser, redimensionner ou supprimer tous les widgets dans un tableau de bord. </p>"
+                "text": "<p> Un tableau de bord dans MapStore fournit un ensemble d'informations collectées de manière appropriée pour afficher des données agrégées en une vue. Les données géospatiales affichées dans une carte peuvent être placées côte à côte avec des tableaux d'attributs, des graphiques et autres, dans le but de connecter différents types d'informations, de montrer des détails statistiques et des descriptions textuelles relatives à un contexte spécifique. </p> <p> Tous les utilisateurs peuvent visualiser et interagir avec les tableaux de bord publiés, mais seuls les utilisateurs autorisés à modifier peuvent ajouter, organiser, redimensionner ou supprimer tous les widgets dans un tableau de bord. </p>"
             },
             "dashboardAddWidget": {
                 "title": "Ajouter un widget",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -17,7 +17,7 @@
         "about_a0": "ovu",
         "about_p5-1": "stranicu.",
         "about_h21": "Zasluge",
-        "about_p6": "MapStore2 je razvijan od:",
+        "about_p6": "MapStore je razvijan od:",
         "enable": "Omogući",
         "layers": "Slojevi",
         "warning": "Upozorenje",
@@ -227,7 +227,7 @@
                     "html":"<h3>Pluginovi</h3><p>Izgradi vlastitu aplikaciju</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Korist API kako bi uključio MapStore2 kartu u svojoj aplikaciji</p>"
+                    "html":"<h3>API</h3><p>Korist API kako bi uključio MapStore kartu u svojoj aplikaciji</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Uređivač stila rastera</h3><p>Stiliziraj svoje rastere</p>"
@@ -1071,7 +1071,7 @@
             "dropZone": {
                 "heading": "<p><h4>Dovucite vašu konfiguraciju ili vektorske datoteke ovdje</h4><small>or</small></p>",
                 "selectFiles": "Odaberi datoteke...",
-                "infoSupported": "<p><small>Podržane konfiguracijske datoteke: MapStore2 format<br />Podržane datoteke vektorskih slojeva: shapefile (mora biti komprimiran u zip arhiv), KML/KMZ, GeoJSON ili GPX</small></p>",
+                "infoSupported": "<p><small>Podržane konfiguracijske datoteke: MapStore format<br />Podržane datoteke vektorskih slojeva: shapefile (mora biti komprimiran u zip arhiv), KML/KMZ, GeoJSON ili GPX</small></p>",
                 "note": "<p><small><i><strong>note</strong>: trenutna karta će biti zamijenjena u slučaju učitavanja konfiguracijskih datoteka</i></small></p>"
             },
             "errors": {
@@ -1854,7 +1854,7 @@
             "checkbox": "nemoj više prikazivati ovu poruku",
             "error": "Greška: cilj nije pronađen",
             "intro": {
-                "title": "Dobrodošli u MapStore2",
+                "title": "Dobrodošli u MapStore",
                 "text": "framework za izradu web mapping aplikacija koristeći standardne biblioteke kao što su OpenLayers 3 i Leaflet."
             },
             "drawerMenu": {
@@ -1903,7 +1903,7 @@
             },
             "examples": {
                 "title": "Prilagođena aplikacija",
-                "text": "Možete koristiti Mapstore2 komponente i pluginove kako bi izgradili vlastite aplikacije"
+                "text": "Možete koristiti MapStore komponente i pluginove kako bi izgradili vlastite aplikacije"
             },
             "introCesium": {
                 "title": "Upute za 3D prikaz",
@@ -1942,7 +1942,7 @@
             },
             "dashboardContainer": {
                 "title": "Kontrolna ploča",
-                "text": "<p>Kontrolna ploča u Mapstore2 daje skup podataka prikladno prikupljenih za prikaz zbirnih podataka u jedinstvenom prikazu. Geografski podaci prikazani na karti mogu se postaviti paralelno s povezanim atributnim tabelama, grafikonima i drugim, s ciljem povezivanja različitih vrsta informacija, s ciljem prikaza statističkih pojedinosti i tekstualnih opisa povezanih s određenim kontekstom.</p><p> Svi korisnici mogu vizualizirati i interaktivno raditi s objavljenim kontrolnim pločama, ali samo korisnici koji imaju dopuštenje za uređivanje mogu dodavati, organizirati, promijeniti veličinu ili brisati widgete unutar nadzorne ploče</p>"
+                "text": "<p>Kontrolna ploča u MapStore daje skup podataka prikladno prikupljenih za prikaz zbirnih podataka u jedinstvenom prikazu. Geografski podaci prikazani na karti mogu se postaviti paralelno s povezanim atributnim tabelama, grafikonima i drugim, s ciljem povezivanja različitih vrsta informacija, s ciljem prikaza statističkih pojedinosti i tekstualnih opisa povezanih s određenim kontekstom.</p><p> Svi korisnici mogu vizualizirati i interaktivno raditi s objavljenim kontrolnim pločama, ali samo korisnici koji imaju dopuštenje za uređivanje mogu dodavati, organizirati, promijeniti veličinu ili brisati widgete unutar nadzorne ploče</p>"
             },
             "dashboardAddWidget": {
                 "title": "Dodaj widget",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -17,7 +17,7 @@
         "about_a0": "questa",
         "about_p5-1": "pagina.",
         "about_h21": "Crediti",
-        "about_p6": "MapStore2 è sviluppato da:",
+        "about_p6": "MapStore è sviluppato da:",
         "enable": "Abilita",
         "layers": "Livelli",
         "warning": "Attenzione",
@@ -227,7 +227,7 @@
                     "html":"<h3>Plugins</h3><p>Costruisci la tua applicazione</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Usa le API per includere una mappa MapStore2 nella tua applicazione</p>"
+                    "html":"<h3>API</h3><p>Usa le API per includere una mappa MapStore nella tua applicazione</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Raster Styler</h3><p>Crea stile per dati raster</p>"
@@ -1070,7 +1070,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Rilascia qui la configurazione o i file vettoriali </h4> <small> o </small> </p>",
                 "selectFiles": "Seleziona i file...",
-                "infoSupported": "<p> <small> File di configurazione supportati: formato legacy di MapStore2<br /> File di livello vettoriale supportati: shapefile (devono essere contenuti in archivi zip), KML / KMZ, GPX o GeoJSON </small> </p>",
+                "infoSupported": "<p> <small> File di configurazione supportati: formato legacy di MapStore<br /> File di livello vettoriale supportati: shapefile (devono essere contenuti in archivi zip), KML / KMZ, GPX o GeoJSON </small> </p>",
                 "note": "<p> <small> <i> <strong> nota </strong>: la mappa corrente verrà sovrascritta in caso di file di configurazione </i> </small> </p>"
             },
             "errors": {
@@ -1853,7 +1853,7 @@
                 "checkbox": "non mostrare più questo messaggio",
                 "error": "Errore: oggetto non trovato",
                 "intro": {
-                    "title": "Benvenuto su MapStore2",
+                    "title": "Benvenuto su MapStore",
                     "text": "framework per costruire applicazioni di web mapping usando librerie standard di mappatura, come OpenLayers 3 e Leaflet."
                 },
                 "drawerMenu": {
@@ -1898,11 +1898,11 @@
                 },
                 "mapsGrid": {
                     "title": "Mappe",
-                    "text": "Qui alcuni esempi di MapStore2. Fai click su un'immagine per provare la demo"
+                    "text": "Qui alcuni esempi di MapStore. Fai click su un'immagine per provare la demo"
                 },
                 "examples": {
                     "title": "Applicazioni personalizzate",
-                    "text": "Puoi utilizzare componenti e plugins di MapStore2 per costruire applicazioni personalizzate"
+                    "text": "Puoi utilizzare componenti e plugins di MapStore per costruire applicazioni personalizzate"
                 },
                 "introCesium": {
                     "title": "Istruzioni della mappa 3D",
@@ -1941,7 +1941,7 @@
                 },
                 "dashboardContainer": {
                     "title": "Cruscotto",
-                    "text": "<p> Una Dashboard in MapStore2 fornisce un insieme di informazioni raccolte in modo appropriato per mostrare i dati aggregati in un'unica visualizzazione. I dati geospaziali visualizzati in una mappa possono essere affiancati alle relative tabelle degli attributi, grafici ed altro, allo scopo di connettere diversi tipi di informazioni, mostrare dettagli statistici e descrizioni testuali relative ad un contesto specifico. </p> <p> Tutti gli utenti possono visualizzare e interagire con le dashboard pubblicate, ma solo gli utenti autorizzati a modificare possono aggiungere, organizzare, ridimensionare o eliminare tutti i widget all'interno di una dashboard </p>"
+                    "text": "<p> Una Dashboard in MapStore fornisce un insieme di informazioni raccolte in modo appropriato per mostrare i dati aggregati in un'unica visualizzazione. I dati geospaziali visualizzati in una mappa possono essere affiancati alle relative tabelle degli attributi, grafici ed altro, allo scopo di connettere diversi tipi di informazioni, mostrare dettagli statistici e descrizioni testuali relative ad un contesto specifico. </p> <p> Tutti gli utenti possono visualizzare e interagire con le dashboard pubblicate, ma solo gli utenti autorizzati a modificare possono aggiungere, organizzare, ridimensionare o eliminare tutti i widget all'interno di una dashboard </p>"
                 },
                 "dashboardAddWidget": {
                     "title": "Aggiungi widget",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -17,7 +17,7 @@
         "about_a0": "deze",
         "about_p5-1": "bladzijde.",
         "about_h21": "Credits",
-        "about_p6": "MapStore2 ontwikkeld door:",
+        "about_p6": "MapStore ontwikkeld door:",
         "enable": "Activeren",
         "layers": "Lagen",
         "warning": "Opgepast",
@@ -226,7 +226,7 @@
                     "html":"<h3>Plugins</h3><p>Uw eigen applicatie opbouwen</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Gebruik API's om een MapStore2-kaart in uw applicatie op te nemen</p>"
+                    "html":"<h3>API</h3><p>Gebruik API's om een MapStore-kaart in uw applicatie op te nemen</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Beeldweergave</h3><p>Uw beeldlaag weergeven</p>"
@@ -1007,7 +1007,7 @@
             "dropZone": {
                 "heading": "<p><h4>Drop your configuration or vector files here</h4><small>or</small></p>",
                 "selectFiles": "Select Files...",
-                "infoSupported": "<p><small>Supported configuration files: MapStore2 legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
+                "infoSupported": "<p><small>Supported configuration files: MapStore legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
                 "note": "<p><small><i><strong>note</strong>: current map will be overridden in case of configuration files</i></small></p>"
             },
             "errors": {
@@ -1603,7 +1603,7 @@
             "checkbox": "laat dit bericht niet meer zien",
             "error": "Fout: doel niet gevonden",
             "intro": {
-                "title": "Welkom bij MapStore2",
+                "title": "Welkom bij MapStore",
                 "text": "framework om web mapping-applicaties te bouwen met behulp van standaard mapping-bibliotheken, zoals OpenLayers 3 en Leaflet."
             },
             "drawerMenu": {
@@ -1648,11 +1648,11 @@
             },
             "mapsGrid": {
                 "title": "Kaarten",
-                "text": "Hier enkele voorbeelden van MapStore2. Klik op een afbeelding om de demo te proberen."
+                "text": "Hier enkele voorbeelden van MapStore. Klik op een afbeelding om de demo te proberen."
             },
             "examples": {
                 "title": "Aangepaste applicatie",
-                "text": "U kunt componenten en plug-ins van MapStore2 gebruiken om aangepaste applicaties te bouwen"
+                "text": "U kunt componenten en plug-ins van MapStore gebruiken om aangepaste applicaties te bouwen"
             },
             "introCesium": {
                 "title": "3D-kaartinstructies",
@@ -1691,7 +1691,7 @@
             },
             "dashboardContainer": {
                 "title": "Dashboard",
-                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
+                "text": "<p>A Dashboard in MapStore provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -4,7 +4,7 @@
         "Language": "Idioma",
         "msgId0": "{name} tirou {numPhotos, plural, =0 {sem fotos} =1 {one photo} other {# fotos}} em {takenDate, date, long}.",
         "htmlTest": "{name} {surname}",
-        "about_title": "Sobre o MapStore2...",
+        "about_title": "Sobre o MapStore...",
         "aboutLbl": "Sobre",
         "about_p0-0": "MapStore 2 é uma plataforma para construir aplicações web mapping que utiliza livrarias de mapping standard, tais como",
         "about_p0-1": "e",
@@ -17,7 +17,7 @@
         "about_a0": "isto",
         "about_p5-1": "página.",
         "about_h21": "Créditos",
-        "about_p6": "MapStore2 é desenvolvido por:",
+        "about_p6": "MapStore é desenvolvido por:",
         "enable": "Activar",
         "layers": "Temas",
         "warning": "Aviso",
@@ -182,7 +182,7 @@
             "open": "Abrir",
             "shortDescription": "Modern webmapping com OpenLayers, Leaflet e React<br/><small>visite a página de <a href=\"https://mapstore.readthedocs.io/en/latest/\">documentação</a></small>",
             "forkMeOnGitHub": "Fork me on GitHub",
-            "description": "MapStore 2 foi desenvolvido para criar, guardar e partilhar de uma maneira simples e intuitiva mapas e mashups criados seleccionando conteudos de fontes populares como o Google Maps e OpenStreetMap ou de serviços fornecidos por organisações utilizando protocolos livre como OGC WMS, WFS, WMTS ou TMS, etc.<br/>Visite <a href=\"http://geosolutions-it.github.io/MapStore2/\">home page</a> para mais detalhes.",
+            "description": "MapStore 2 foi desenvolvido para criar, guardar e partilhar de uma maneira simples e intuitiva mapas e mashups criados seleccionando conteudos de fontes populares como o Google Maps e OpenStreetMap ou de serviços fornecidos por organisações utilizando protocolos livre como OGC WMS, WFS, WMTS ou TMS, etc.<br/>Visite <a href=\"http://geosolutions-it.github.io/MapStore/\">home page</a> para mais detalhes.",
             "Applications": "Aplicações",
             "Examples": "Exemplos",
             "LinkedinGroup": "Grupo Mapstore no Linkedin",
@@ -228,7 +228,7 @@
                     "html":"<h3>Plugins</h3><p>Construa a sua aplicação</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Utilize APIs para incluir um mapa do MapStore2 na sua aplicação</p>"
+                    "html":"<h3>API</h3><p>Utilize APIs para incluir um mapa do MapStore na sua aplicação</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Raster Styler</h3><p>Estilize um tema Raster</p>"
@@ -1045,7 +1045,7 @@
             "dropZone": {
                 "heading": "<p><h4>Drop your configuration or vector files here</h4><small>or</small></p>",
                 "selectFiles": "Select Files...",
-                "infoSupported": "<p><small>Supported configuration files: MapStore2 legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
+                "infoSupported": "<p><small>Supported configuration files: MapStore legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
                 "note": "<p><small><i><strong>note</strong>: current map will be overridden in case of configuration files</i></small></p>"
             },
             "errors": {
@@ -1809,7 +1809,7 @@
             "checkbox": "don't show this message again",
             "error": "Error: target not found",
             "intro": {
-                "title": "Welcome on MapStore2",
+                "title": "Welcome on MapStore",
                 "text": "framework to build web mapping applications using standard mapping libraries, such as OpenLayers 3 and Leaflet."
             },
             "drawerMenu": {
@@ -1854,11 +1854,11 @@
             },
             "mapsGrid": {
                 "title": "Maps",
-                "text": "Here some examples of MapStore2. Click on an image to try the demo."
+                "text": "Here some examples of MapStore. Click on an image to try the demo."
             },
             "examples": {
                 "title": "Custom Application",
-                "text": "You can use components and plugins of MapStore2 to build custom applications"
+                "text": "You can use components and plugins of MapStore to build custom applications"
             },
             "introCesium": {
                 "title": "3D map instructions",
@@ -1897,7 +1897,7 @@
             },
             "dashboardContainer": {
                 "title": "Dashboard",
-                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
+                "text": "<p>A Dashboard in MapStore provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -6,9 +6,9 @@
         "htmlTest": "{name} {surname}",
         "about_title": "关于这个程序...",
         "aboutLbl": "关于",
-        "about_p0-0": "MapStore2是一个使用标准映射库构建Web地图应用程序的框架，比如",
+        "about_p0-0": "MapStore是一个使用标准映射库构建Web地图应用程序的框架，比如",
         "about_p0-1": "和",
-        "about_p1": "MapStore2有几个应用实例：",
+        "about_p1": "MapStore有几个应用实例：",
         "about_ul0_li0": "MapViewer简单展现预先配置好的地图 (optionally stored in a database using GeoStore)",
         "about_ul0_li1": "MapPublisher开发的目的是以简单直观的方式创建，保存和共享地图和混搭，从Google Maps和OpenStreetMap等着名资源中选择内容，或者使用OGC WMS，WFS，WMTS等开放协议提供的服务。 TMS等。 有关更多信息，请查看",
         "about_h20": "许可",
@@ -17,7 +17,7 @@
         "about_a0": "this",
         "about_p5-1": "页.",
         "about_h21": "Credits",
-        "about_p6": "MapStore2是由:",
+        "about_p6": "MapStore是由:",
         "enable": "启用",
         "layers": "图层",
         "warning": "警告",
@@ -227,7 +227,7 @@
                     "html":"<h3>Plugins</h3><p>Build your own application</p>"
                 },
                 "api":{
-                    "html":"<h3>API</h3><p>Use APIs to include a MapStore2 map in your application</p>"
+                    "html":"<h3>API</h3><p>Use APIs to include a MapStore map in your application</p>"
                 },
                 "rasterstyler":{
                     "html":"<h3>Raster Styler</h3><p>Style your raster layer</p>"
@@ -1023,7 +1023,7 @@
             "dropZone": {
                 "heading": "<p><h4>Drop your configuration or vector files here</h4><small>or</small></p>",
                 "selectFiles": "Select Files...",
-                "infoSupported": "<p><small>Supported configuration files: MapStore2 legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
+                "infoSupported": "<p><small>Supported configuration files: MapStore legacy format<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
                 "note": "<p><small><i><strong>note</strong>: current map will be overridden in case of configuration files</i></small></p>"
             },
             "errors": {
@@ -1784,7 +1784,7 @@
             "checkbox": "不要再显示此消息",
             "error": "错误：未找到目标",
             "intro": {
-                "title": "欢迎使用MapStore2",
+                "title": "欢迎使用MapStore",
                 "text": "框架使用标准映射库（如OpenLayers 3和Leaflet）构建Web映射应用程序。"
             },
             "drawerMenu": {
@@ -1829,11 +1829,11 @@
             },
             "mapsGrid": {
                 "title": "Maps",
-                "text": "这里有一些MapStore2的例子。 点击图片试试演示。"
+                "text": "这里有一些MapStore的例子。 点击图片试试演示。"
             },
             "examples": {
                 "title": "Custom Application",
-                "text": "You can use components and plugins of MapStore2 to build custom applications"
+                "text": "You can use components and plugins of MapStore to build custom applications"
             },
             "introCesium": {
                 "title": "3D map instructions",
@@ -1872,7 +1872,7 @@
             },
             "dashboardContainer": {
                 "title": "Dashboard",
-                "text": "<p>A Dashboard in MapStore2 provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
+                "text": "<p>A Dashboard in MapStore provides a set of information suitably collected to show aggregated data in one shot view. Geospatial data displayed in a map can be placed side by side to related attribute tables, charts and other, with the aim to connect different kind of information, show statistical details and textual descriptions relating to a specific context.</p><p> All users can visualize and interact with published dashboards but only users allowed to edit can add, arrange, resize or delete all the widgets inside a dashboard</p>"
             },
             "dashboardAddWidget": {
                 "title": "Add Widget",


### PR DESCRIPTION
## Description
Avoid showing the MapStore version number (2) in translations

## Issues
 - #3957
 
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3957 

**What is the new behavior?**
No MapStore version number (2) in translations

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
