### PR TITLE
#3950: the whole group containing the annotations layer disappears in…

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -145,7 +145,7 @@ class DefaultLayer extends React.Component {
     renderNode = (grab, hide, selected, error, warning, other) => {
         const isEmpty = this.props.node.type === 'wms' && !this.props.activateLegendTool && !this.props.showFullTitleOnExpand
         || this.props.node.type !== 'wms' && !this.props.showFullTitleOnExpand;
-        return (
+        return this.props.node.showComponent !== false ? (
             <Node className={'toc-default-layer' + hide + selected + error + warning} sortableStyle={this.props.sortableStyle} style={this.props.style} type="layer" {...other}>
                 <div className="toc-default-layer-head">
                     {grab}
@@ -167,7 +167,7 @@ class DefaultLayer extends React.Component {
                 {!this.props.activateOpacityTool || this.props.node.expanded || !this.props.node.visibility || this.props.node.loadingError === 'Error' ? null : this.renderOpacitySlider(this.props.hideOpacityTooltip)}
                 {isEmpty ? null : this.renderCollapsible()}
             </Node>
-        );
+        ) : null;
     }
 
     render() {

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -339,4 +339,35 @@ describe('test DefaultLayer module component', () => {
         expect(tooltips.length).toBe(0);
     });
 
+    it('showComponent false hides item', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            opacity: 0.5,
+            showComponent: false
+        };
+        const comp = ReactDOM.render(<Layer hideOpacityTooltip node={l} />,
+            document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toNotExist();
+    });
+
+    it('showComponent true shows item', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            opacity: 0.5,
+            showComponent: true
+        };
+        const comp = ReactDOM.render(<Layer hideOpacityTooltip node={l} />,
+            document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+    });
 });

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -50,9 +50,9 @@ const addFilteredAttributesGroups = (nodes, filters) => {
             node = assign({}, node, {nodes: addFilteredAttributesGroups(node.nodes, filters)});
         }
         filters.forEach(filter => {
-            if (node.nodes && filter.func(node)) {
+            if (filter.func(node)) {
                 node = assign({}, node, filter.options);
-            } else if (node.nodes) {
+            } else {
                 node = assign({}, node);
             }
         });
@@ -110,15 +110,19 @@ const tocSelector = createSelector(
             },
             {
                 options: {loadingError: true},
-                func: (node) => head(node.nodes.filter(n => n.loadingError && n.loadingError !== 'Warning'))
+                func: (node) => head((node.nodes || []).filter(n => n.loadingError && n.loadingError !== 'Warning'))
             },
             {
                 options: {expanded: true, showComponent: true},
-                func: (node) => filterText && head(node.nodes.filter(l => filterLayersByTitle(l, filterText, currentLocale) || l.nodes && head(node.nodes.filter(g => g.showComponent))))
+                func: (node) => filterText && head((node.nodes || []).filter(l => filterLayersByTitle(l, filterText, currentLocale) || l.nodes && head(node.nodes.filter(g => g.showComponent))))
             },
             {
                 options: { showComponent: false },
-                func: (node) => head(node.nodes.filter(l => l.hidden || l.id === "annotations" && isCesiumActive))
+                func: (node) => head((node.nodes || []).filter(l => l.hidden || l.id === "annotations" && isCesiumActive)) && node.nodes.length === 1
+            },
+            {
+                options: { showComponent: false },
+                func: (node) => node.id === "annotations" && isCesiumActive
             }
         ]),
         catalogActive,

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TOCPlugin from '../TOC';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('TOCPlugin Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('Shows TOCPlugin plugin', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            controls: {
+                addgroup: {
+                    enabled: true
+                }
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.getElementsByClassName('mapstore-toc').length).toBe(1);
+    });
+
+    it('TOCPlugin shows annotations layer in openlayers mapType', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [{id: 'default', title: 'Default', nodes: ['annotations']}],
+                flat: [{id: 'annotations', title: 'Annotations'}]
+            },
+            mapType: {
+                mapType: 'openlayers'
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelector('.toc-title').textContent).toBe('Annotations');
+        expect(document.querySelector('.toc-group-title').textContent).toBe('Default');
+    });
+
+    it('TOCPlugin hides annotations layer and empty group in cesium mapType', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [{ id: 'default', title: 'Default', nodes: ['annotations'] }],
+                flat: [{ id: 'annotations', title: 'Annotations' }]
+            },
+            maptype: {
+                mapType: 'cesium'
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelectorAll('.toc-title').length).toBe(0);
+        expect(document.querySelectorAll('.toc-group-title').length).toBe(0);
+    });
+
+    it('TOCPlugin hides annotations layer but not its group if not empty in cesium mapType', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [{ id: 'default', title: 'Default', nodes: ['annotations', 'other'] }],
+                flat: [{ id: 'annotations', title: 'Annotations' }, { id: 'other', title: 'Other'}]
+            },
+            maptype: {
+                mapType: 'cesium'
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelectorAll('.toc-title').length).toBe(1);
+        expect(document.querySelectorAll('.toc-group-title').length).toBe(1);
+    });
+});

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -13,6 +13,7 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { combineEpics, createEpicMiddleware } from 'redux-observable';
 
 import map from '../../reducers/map';
+import maptype from '../../reducers/maptype';
 import layers from '../../reducers/layers';
 import controls from '../../reducers/controls';
 
@@ -20,7 +21,8 @@ import controls from '../../reducers/controls';
 const rootReducers = {
     map,
     layers,
-    controls
+    controls,
+    maptype
 };
 
 const createRegisterActionsMiddleware = (actions) => {


### PR DESCRIPTION
… 3d mode, also if it contains other layers

## Description
the whole group containing the annotations layer disappears in 3d mode, also if it contains other layers

## Issues
 - #3950

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
The group containing the annotations layer disappears from the TOC in 3D mode, also if contains other layers in addition to the annotations one.

**What is the new behavior?**
The group containing the annotations layer disappears from the TOC in 3D mode only if it doesn't contain other layers in addition to the annotations one.
If the group contains more layers, only the annotations layer is hidden from the group, not the whole group.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
