### PR TITLE
#3972: fixed print of vector layers for solid dash stroke

### DIFF
--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -103,7 +103,7 @@ const getDashArrayFromStyle = dashArray => {
 const annStyleToOlStyle = (type, tempStyle, label = "") => {
     let style = tempStyle && tempStyle[type] ? tempStyle[type] : tempStyle;
     const s = style;
-    const dashArray = s.dashArray ? getDashArrayFromStyle(s.dashArray) : "";
+    const dashArray = s.dashArray ? getDashArrayFromStyle(s.dashArray) : "solid";
     switch (type) {
         case "MultiPolygon":
         case "Polygon":

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -763,4 +763,24 @@ describe('Test the AnnotationsUtils', () => {
         expect(getDashArrayFromStyle("3 4 5")).toEqual("3 4 5");
         expect(getDashArrayFromStyle(["3", "4", "5"])).toEqual("3 4 5");
     });
+    it('test annotationsToPrint strokeDashstyle defaults to solid', () => {
+        const f = {
+            type: "FeatureCollection",
+            features: [{
+                type: "Feature",
+                geometry: {
+                    type: "LineString",
+                    coordinates: [[0, 0], [1, 1], [3, 3], [5, 5]]
+                },
+                style: [{
+                    color: "#FF0000"
+                }].concat(getStartEndPointsForLinestring())
+            }]
+        };
+        let fts = annotationsToPrint([f]);
+        expect(fts).toExist();
+        expect(fts.length).toBe(1);
+        expect(fts[0].properties.ms_style).toExist();
+        expect(fts[0].properties.ms_style.strokeDashstyle).toBe('solid');
+    });
 });


### PR DESCRIPTION
## Description
Fixed print of vector layers for solid dash stroke.

## Issues
 - #3972

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Printing of a vector with a solid dash crashes the printing service, because strokeDashstyle is encoded as an empty string.

**What is the new behavior?**
Printing of a vector with a solid dash does not crash the printing service anymore, because strokeDashstyle is encoded as "solid".

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
