### PR TITLE
Fix #3958 hide layer related buttons when removing a layer from the map

### DIFF
--- a/web/client/plugins/widgetbuilder/MapBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/MapBuilder.jsx
@@ -100,6 +100,7 @@ module.exports = mapBuilder(({
             selectedNodes={selectedNodes}
             selectedLayers={selectedLayers}
             selectedGroups={selectedGroups}
+            onNodeSelect={onNodeSelect}
             toggleLayerSelector={toggleLayerSelector}/></BuilderHeader>)}
         >
         {enabled ? <Builder

--- a/web/client/plugins/widgetbuilder/enhancers/__tests__/handleMapRemoveLayer-test.js
+++ b/web/client/plugins/widgetbuilder/enhancers/__tests__/handleMapRemoveLayer-test.js
@@ -1,0 +1,41 @@
+
+
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+// dependencies
+const React = require('react');
+const ReactDOM = require('react-dom');
+const expect = require('expect');
+const ReactTestUtils = require('react-dom/test-utils');
+const handleMapRemoveLayer = require('../handleMapRemoveLayer');
+const CMP = handleMapRemoveLayer((props) => <button id="CMP" onClick={() => props.onRemoveSelected()} />);
+
+describe('handleMapRemoveLayer enhancer', function() {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should trigger onNodeSelect on remove layer', () => {
+        const lib = {
+            onNodeSelect() { }
+        };
+        const spyReset = expect.spyOn(lib, 'onNodeSelect');
+        ReactDOM.render(<CMP selectedLayers={['layer 1']} onNodeSelect={lib.onNodeSelect} />, document.getElementById("container"));
+        const el = document.querySelector('#CMP');
+        ReactTestUtils.Simulate.click(el);
+        expect(spyReset).toHaveBeenCalled();
+    });
+});

--- a/web/client/plugins/widgetbuilder/enhancers/__tests__/handleMapRemoveLayer-test.js
+++ b/web/client/plugins/widgetbuilder/enhancers/__tests__/handleMapRemoveLayer-test.js
@@ -28,7 +28,7 @@ describe('handleMapRemoveLayer enhancer', function() {
         setTimeout(done);
     });
 
-    it('should trigger onNodeSelect on remove layer', () => {
+    it('layer remove must also unselect the layers by triggering onNodeSelect', () => {
         const lib = {
             onNodeSelect() { }
         };

--- a/web/client/plugins/widgetbuilder/enhancers/handleMapRemoveLayer.js
+++ b/web/client/plugins/widgetbuilder/enhancers/handleMapRemoveLayer.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { withHandlers } = require('recompose');
+
+const enhancer = withHandlers({
+    onRemoveSelected: ({ selectedLayers = [], removeLayersById = () => { }, onNodeSelect = () => { } }) => () => {
+        removeLayersById(selectedLayers);
+        selectedLayers.forEach(layer => onNodeSelect(layer, 'layer', false));
+    }
+});
+
+module.exports = enhancer;

--- a/web/client/plugins/widgetbuilder/enhancers/mapToolbar.js
+++ b/web/client/plugins/widgetbuilder/enhancers/mapToolbar.js
@@ -26,8 +26,9 @@ module.exports = compose(
     manageLayers,
     handleNodeEditing,
     withHandlers({
-        onRemoveSelected: ({selectedLayers = [], removeLayersById = () => { } }) => () => {
+        onRemoveSelected: ({selectedLayers = [], removeLayersById = () => { }, onNodeSelect = () => {} }) => () => {
             removeLayersById(selectedLayers);
+            selectedLayers.forEach(layer => onNodeSelect(layer, 'layer', false));
         }
     }),
     branch(

--- a/web/client/plugins/widgetbuilder/enhancers/mapToolbar.js
+++ b/web/client/plugins/widgetbuilder/enhancers/mapToolbar.js
@@ -5,11 +5,12 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { compose, branch, withProps, withHandlers} = require('recompose');
+const { compose, branch, withProps } = require('recompose');
 const {connect} = require('react-redux');
 const { insertWidget, setPage, onEditorChange} = require('../../../actions/widgets');
 const manageLayers = require('./manageLayers');
 const handleNodeEditing = require('./handleNodeEditing');
+const handleRemoveLayer = require('./handleMapRemoveLayer');
 const { wizardSelector, wizardStateToProps } = require('../commons');
 
 const mapBuilderConnect = require('./connection/mapBuilderConnect');
@@ -25,12 +26,7 @@ module.exports = compose(
     ),
     manageLayers,
     handleNodeEditing,
-    withHandlers({
-        onRemoveSelected: ({selectedLayers = [], removeLayersById = () => { }, onNodeSelect = () => {} }) => () => {
-            removeLayersById(selectedLayers);
-            selectedLayers.forEach(layer => onNodeSelect(layer, 'layer', false));
-        }
-    }),
+    handleRemoveLayer,
     branch(
         ({editNode}) => !!editNode,
         withProps(({ selectedNodes = [], setEditNode = () => { } }) => ({


### PR DESCRIPTION
fix #3958

## Description
Hide layer related buttons when removing a layer from the map widget

## Issues
 - #3958 
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3958 

**What is the new behavior?**
The removed layer related buttons disappear on layer remove 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
