### PR TITLE
fix #3969 annotation description field is not clickable in safari

### DIFF
--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -327,11 +327,6 @@
         }
     }
 }
-.mapstore-annotations-info-viewer-item.mapstore-annotations-info-viewer-description {
-    .quill {
-        overflow: -webkit-paged-y;
-    }
-}
 
 .ms-color-selector {
     overflow: hidden;


### PR DESCRIPTION
## Description
Fix annotation description field is not clickable in safari browser

## Issues
 - #3969 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3969 

**What is the new behavior?**
The annotation description field appear and is clickable

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
