### PR TITLE
#3784 Activate Sync Map by default

### DIFF
--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -296,12 +296,7 @@ class AnnotationsEditor extends React.Component {
                             visible: true,
                             onClick: () => {
                                 if (this.props.unsavedChanges) {
-                                    const errors = this.validate();
-                                    if (Object.keys(errors).length === 0) {
-                                        this.props.onToggleUnsavedChangesModal();
-                                    } else {
-                                        this.props.onError(errors);
-                                    }
+                                    this.props.onToggleUnsavedChangesModal();
                                 } else {
                                     this.cancelEdit();
                                 }

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -279,6 +279,36 @@ describe("test the AnnotationsEditor Panel", () => {
         expect(spyCancel.calls.length).toEqual(1);
     });
 
+    it('test click cancel trigger UnsavedChangesModal', () => {
+        const feature = {
+            id: "1",
+            title: 'mytitle',
+            description: '<span><i>desc</i></span>'
+        };
+
+        const testHandlers = {
+            onToggleUnsavedChangesModal: (id) => { return id; }
+        };
+
+        const spyUnsavedModal = expect.spyOn(testHandlers, 'onToggleUnsavedChangesModal');
+
+        const viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions} editing={{
+            properties: feature,
+            geometry: {}
+        }}
+        onToggleUnsavedChangesModal={testHandlers.onToggleUnsavedChangesModal}
+        unsavedChanges
+        />, document.getElementById("container"));
+        expect(viewer).toExist();
+
+        let cancelButton = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithTag(viewer, "button")[0]);
+
+        expect(cancelButton).toExist();
+        TestUtils.Simulate.click(cancelButton);
+
+        expect(spyUnsavedModal.calls.length).toEqual(1);
+    });
+
     it('test click save validate title error', () => {
         const feature = {
             id: "1",

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -586,13 +586,7 @@ describe('featuregrid Epics', () => {
     describe('featureGridBrowseData', () => {
         it('browseData action triggers featuregrid setup', done => {
             const LAYER = state.layers.flat[0];
-            testEpic(featureGridBrowseData, 5, browseData(LAYER), ([
-                a1,
-                a2,
-                a3,
-                a4,
-                a5
-            ]) => {
+            testEpic(featureGridBrowseData, 5, browseData(LAYER), ([ a1, a2, a3, a4, a5 ]) => {
                 // disable draw
                 expect(a1.type).toBe(SET_CONTROL_PROPERTY);
                 expect(a1.control).toBe('drawer');

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -198,7 +198,7 @@ module.exports = {
                 ).merge(
                     Rx.Observable.of(isActive)
                         // if sync is active on startup
-                        // but nativeCRS is missing, it should be
+                        // but nativeCRS is missing, it should be get from the server
                         .switchMap( active => {
                             if (!active || (objLayer && objLayer.nativeCrs)) {
                                 return Rx.Observable.empty();


### PR DESCRIPTION
## Description
This pull request activates sync map by default in feature grid. 

## Issues
 - #3784 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Sync map is not active

**What is the new behavior?**
Sync map is active

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No


**Other information**:
Usage of CQL_FILTER need to retrieve nativeCRS (e.g. spatial filters need to be sent in native CRS), therefore a pre-fetch of the crs is needed (previously it was fetched on syncmap activation only).
You can test nativeCRS fetch by using layers with native CRS different from 4326 and 3857. 
One of them is spearfish_bugsites on gs-stable.