### PR TITLE
Fix 3985 add catalog autosearch

### DIFF
--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -20,7 +20,7 @@ const {getRecords, addLayerError, addLayer, ADD_LAYER_ERROR, changeCatalogFormat
     changeUrl, CHANGE_URL, changeType, CHANGE_TYPE, addService, ADD_SERVICE, addCatalogService, ADD_CATALOG_SERVICE, resetCatalog, RESET_CATALOG,
     changeAutoload, CHANGE_AUTOLOAD, deleteCatalogService, DELETE_CATALOG_SERVICE, deleteService, DELETE_SERVICE, savingService,
     SAVING_SERVICE, DESCRIBE_ERROR, initCatalog, CATALOG_INITED, changeText, CHANGE_TEXT,
-    TOGGLE_ADVANCED_SETTINGS, toggleAdvancedSettings, TOGGLE_THUMBNAIL, toggleThumbnail, TOGGLE_TEMPLATE, toggleTemplate, CHANGE_METADATA_TEMPLATE, changeMetadataTemplate
+    TOGGLE_ADVANCED_SETTINGS, toggleAdvancedSettings, TOGGLE_THUMBNAIL, toggleThumbnail, TOGGLE_TEMPLATE, toggleTemplate, CHANGE_METADATA_TEMPLATE, changeMetadataTemplate, SET_LOADING
 } = require('../catalog');
 const {CHANGE_LAYER_PROPERTIES, ADD_LAYER} = require('../layers');
 describe('Test correctness of the catalog actions', () => {
@@ -146,10 +146,14 @@ describe('Test correctness of the catalog actions', () => {
     it('getRecords ISO Metadata Profile', (done) => {
         getRecords('csw', 'base/web/client/test-resources/csw/getRecordsResponseISO.xml', 1, 1)((actionResult) => {
             try {
-                let result = actionResult && actionResult.result;
-                expect(result).toExist();
-                expect(result.records).toExist();
-                expect(result.records.length).toBe(1);
+                if (actionResult.type === SET_LOADING) {
+                    expect(actionResult.loading).toBe(true);
+                } else {
+                    let result = actionResult && actionResult.result;
+                    expect(result).toExist();
+                    expect(result.records).toExist();
+                    expect(result.records.length).toBe(1);
+                }
                 done();
             } catch (ex) {
                 done(ex);
@@ -159,8 +163,12 @@ describe('Test correctness of the catalog actions', () => {
     it('getRecords Error', (done) => {
         getRecords('csw', 'base/web/client/test-resources/csw/getRecordsResponseException.xml', 1, 1)((result) => {
             try {
-                expect(result).toExist();
-                expect(result.error).toExist();
+                if (result.type === SET_LOADING) {
+                    expect(result.loading).toBe(true);
+                } else {
+                    expect(result).toExist();
+                    expect(result.error).toExist();
+                }
                 done();
             } catch (ex) {
                 done(ex);
@@ -171,17 +179,21 @@ describe('Test correctness of the catalog actions', () => {
         getRecords('csw', 'base/web/client/test-resources/csw/getRecordsResponseDC.xml', 1, 2)((actionResult) => {
             try {
                 let result = actionResult && actionResult.result;
-                expect(result).toExist();
-                expect(result.records).toExist();
-                expect(result.records.length).toBe(2);
-                let rec0 = result.records[0];
-                expect(rec0.dc).toExist();
-                expect(rec0.dc.URI).toExist();
-                expect(rec0.dc.URI[0]);
-                let uri = rec0.dc.URI[0];
-                expect(uri.name).toExist();
-                expect(uri.value).toExist();
-                expect(uri.description).toExist();
+                if (actionResult.type === SET_LOADING) {
+                    expect(actionResult.loading).toBe(true);
+                } else {
+                    expect(result).toExist();
+                    expect(result.records).toExist();
+                    expect(result.records.length).toBe(2);
+                    let rec0 = result.records[0];
+                    expect(rec0.dc).toExist();
+                    expect(rec0.dc.URI).toExist();
+                    expect(rec0.dc.URI[0]);
+                    let uri = rec0.dc.URI[0];
+                    expect(uri.name).toExist();
+                    expect(uri.value).toExist();
+                    expect(uri.description).toExist();
+                }
                 done();
             } catch (ex) {
                 done(ex);

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -41,6 +41,7 @@ export const DELETE_SERVICE = 'CATALOG:DELETE_SERVICE';
 export const SAVING_SERVICE = 'CATALOG:SAVING_SERVICE';
 export const CATALOG_INITED = 'CATALOG:INIT';
 export const GET_METADATA_RECORD_BY_ID = 'CATALOG:GET_METADATA_RECORD_BY_ID';
+export const SET_LOADING = 'CATALOG:SET_LOADING';
 export const TOGGLE_TEMPLATE = 'CATALOG:TOGGLE_TEMPLATE';
 export const TOGGLE_THUMBNAIL = 'CATALOG:TOGGLE_THUMBNAIL';
 export const TOGGLE_ADVANCED_SETTINGS = 'CATALOG:TOGGLE_ADVANCED_SETTINGS';
@@ -62,6 +63,12 @@ export function savingService(status) {
     return {
         type: SAVING_SERVICE,
         status
+    };
+}
+export function setLoading(loading = false) {
+    return {
+        type: SET_LOADING,
+        loading
     };
 }
 export function changeSelectedService(service) {
@@ -167,6 +174,7 @@ export function initCatalog(apis = API) {
 export function getRecords(format, url, startPosition = 1, maxRecords, filter, options) {
     return (dispatch /* , getState */) => {
         // TODO auth (like) let opts = GeoStoreApi.getAuthOptionsFromState(getState(), {params: {start: 0, limit: 20}, baseURL: geoStoreUrl });
+        dispatch(setLoading(true));
         API[format].getRecords(url, startPosition, maxRecords, filter, options).then((result) => {
             if (result.error) {
                 dispatch(recordsLoadError(result));
@@ -186,6 +194,7 @@ export function getRecords(format, url, startPosition = 1, maxRecords, filter, o
 export function textSearch(format, url, startPosition, maxRecords, text, options) {
     return (dispatch /* , getState */) => {
         // TODO auth (like) let opts = GeoStoreApi.getAuthOptionsFromState(getState(), {params: {start: 0, limit: 20}, baseURL: geoStoreUrl });
+        dispatch(setLoading(true));
         API[format].textSearch(url, startPosition, maxRecords, text, options).then((result) => {
             if (result.error) {
                 dispatch(recordsLoadError(result));

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -119,6 +119,7 @@ class Catalog extends React.Component {
         pageSize: 4,
         records: [],
         saving: false,
+        loading: false,
         services: {},
         wrapOptions: false,
         zoomToLayer: true,
@@ -126,7 +127,6 @@ class Catalog extends React.Component {
     };
 
     state = {
-        loading: false,
         catalogURL: null
     };
 
@@ -140,9 +140,6 @@ class Catalog extends React.Component {
 
     componentWillReceiveProps(nextProps) {
         if (nextProps !== this.props) {
-            this.setState({
-                loading: false
-            });
             if (((nextProps.mode === "view" && this.props.mode === "edit") || nextProps.services !== this.props.services || nextProps.selectedService !== this.props.selectedService) &&
                 nextProps.active && this.props.active &&
                 nextProps.selectedService &&
@@ -189,7 +186,7 @@ class Catalog extends React.Component {
     };
 
     renderLoading = () => {
-        return this.state.loading ? <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/> : null;
+        return this.props.loading ? <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/> : null;
     };
     renderSaving = () => {
         return this.props.saving ? <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/> : null;
@@ -502,9 +499,6 @@ class Catalog extends React.Component {
         const url = services[selectedService].url;
         const type = services[selectedService].type;
         this.props.onSearch(type, url, start, this.props.pageSize, searchText || "");
-        this.setState({
-            loading: true
-        });
     };
 
     isViewMode = (mode) => {
@@ -525,9 +519,6 @@ class Catalog extends React.Component {
         if (eventKey) {
             let start = (eventKey - 1) * this.props.pageSize + 1;
             this.search({services: this.props.services, selectedService: this.props.selectedService, start, searchText: this.props.searchText});
-            this.setState({
-                loading: true
-            });
         }
     };
 }

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -12,10 +12,10 @@ const API = {
     csw
 };
 import catalog from '../catalog';
-const {getMetadataRecordById, autoSearchEpic} = catalog(API);
+const {getMetadataRecordById} = catalog(API);
 import {SHOW_NOTIFICATION} from '../../actions/notifications';
-import {testEpic, TEST_TIMEOUT, addTimeoutEpic} from './epicTestUtils';
-import {getMetadataRecordById as initAction, changeText, SET_LOADING} from '../../actions/catalog';
+import {testEpic} from './epicTestUtils';
+import {getMetadataRecordById as initAction} from '../../actions/catalog';
 
 describe('catalog Epics', () => {
     it('getMetadataRecordById', (done) => {
@@ -36,38 +36,5 @@ describe('catalog Epics', () => {
         });
 
     });
-    it('autoSearchEpic', (done) => {
-        const NUM_ACTIONS = 3;
-        testEpic(addTimeoutEpic(autoSearchEpic, 100), NUM_ACTIONS, changeText("value"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((action) => {
-                switch (action.type) {
-                    case SET_LOADING: {
-                        expect(action.loading).toBe(true);
-                        break;
-                    }
-                    // here actions[2] is a thunk
-                    case TEST_TIMEOUT:
-                        done();
-                        break;
-                    default:
-                        done(new Error("Action not recognized"));
-                }
-            });
-            done();
-        }, {
-            catalog: {
-                selectedService: 'gs_stable_csw',
-                services: {
-                    gs_stable_csw: {
-                        url: 'https://gs-stable.geo-solutions.it/geoserver/csw',
-                        type: 'csw',
-                        title: 'GeoSolutions GeoServer CSW',
-                        autoload: true
-                    }
-                }
-            }
-        });
 
-    });
 });

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -6,15 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-
+import expect from 'expect';
+import csw from '../../api/CSW';
 const API = {
-    csw: require('../../api/CSW')
+    csw
 };
-const {getMetadataRecordById} = require('../catalog')(API);
-const {SHOW_NOTIFICATION} = require('../../actions/notifications');
-const {testEpic} = require('./epicTestUtils');
-const {getMetadataRecordById: initAction} = require('../../actions/catalog');
+import catalog from '../catalog';
+const {getMetadataRecordById, autoSearchEpic} = catalog(API);
+import {SHOW_NOTIFICATION} from '../../actions/notifications';
+import {testEpic, TEST_TIMEOUT, addTimeoutEpic} from './epicTestUtils';
+import {getMetadataRecordById as initAction, changeText, SET_LOADING} from '../../actions/catalog';
 
 describe('catalog Epics', () => {
     it('getMetadataRecordById', (done) => {
@@ -31,6 +32,40 @@ describe('catalog Epics', () => {
                     id: "TEST",
                     catalogURL: "base/web/client/test-resources/csw/getRecordsResponseException.xml"
                 }]
+            }
+        });
+
+    });
+    it('autoSearchEpic', (done) => {
+        const NUM_ACTIONS = 3;
+        testEpic(addTimeoutEpic(autoSearchEpic, 100), NUM_ACTIONS, changeText("value"), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                    case SET_LOADING: {
+                        expect(action.loading).toBe(true);
+                        break;
+                    }
+                    // here actions[2] is a thunk
+                    case TEST_TIMEOUT:
+                        done();
+                        break;
+                    default:
+                        done(new Error("Action not recognized"));
+                }
+            });
+            done();
+        }, {
+            catalog: {
+                selectedService: 'gs_stable_csw',
+                services: {
+                    gs_stable_csw: {
+                        url: 'https://gs-stable.geo-solutions.it/geoserver/csw',
+                        type: 'csw',
+                        title: 'GeoSolutions GeoServer CSW',
+                        autoload: true
+                    }
+                }
             }
         });
 

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -9,7 +9,7 @@
 const Rx = require('rxjs');
 const {
     ADD_SERVICE, GET_METADATA_RECORD_BY_ID, DELETE_SERVICE, deleteCatalogService, addCatalogService, savingService,
-    CHANGE_TEXT, textSearch, setLoading
+    CHANGE_TEXT, textSearch
 } = require('../actions/catalog');
 const {showLayerMetadata} = require('../actions/layers');
 const {error, success} = require('../actions/notifications');
@@ -184,7 +184,6 @@ module.exports = (API) => ({
                 const state = getState();
                 const pageSize = pageSizeSelector(state);
                 const {type, url} = selectedCatalogSelector(state);
-                return Rx.Observable.of(textSearch(type, url, 1, pageSize, text))
-                    .startWith(setLoading(true));
+                return Rx.Observable.of(textSearch(type, url, 1, pageSize, text));
             })
 });

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -7,13 +7,23 @@
 */
 
 const Rx = require('rxjs');
-const {ADD_SERVICE, GET_METADATA_RECORD_BY_ID, DELETE_SERVICE, deleteCatalogService, addCatalogService, savingService} = require('../actions/catalog');
+const {
+    ADD_SERVICE, GET_METADATA_RECORD_BY_ID, DELETE_SERVICE, deleteCatalogService, addCatalogService, savingService,
+    CHANGE_TEXT, textSearch, setLoading
+} = require('../actions/catalog');
 const {showLayerMetadata} = require('../actions/layers');
 const {error, success} = require('../actions/notifications');
 const {SET_CONTROL_PROPERTY} = require('../actions/controls');
 const {closeFeatureGrid} = require('../actions/featuregrid');
 const {purgeMapInfoResults, hideMapinfoMarker} = require('../actions/mapInfo');
-const {newServiceSelector, selectedServiceSelector, servicesSelector} = require('../selectors/catalog');
+const {
+    delayAutoSearchSelector,
+    newServiceSelector,
+    pageSizeSelector,
+    selectedServiceSelector,
+    servicesSelector,
+    selectedCatalogSelector
+} = require('../selectors/catalog');
 const {getSelectedLayer} = require('../selectors/layers');
 const axios = require('../libs/ajax');
 
@@ -162,5 +172,19 @@ module.exports = (API) => ({
                             position: "tc"
                         }), showLayerMetadata({}, false));
                 });
+            }),
+        autoSearchEpic: (action$, {getState = () => {}} = {}) =>
+            action$.ofType(CHANGE_TEXT)
+            .debounce(() => {
+                const state = getState();
+                const delay = delayAutoSearchSelector(state);
+                return Rx.Observable.timer(delay);
+            })
+            .switchMap(({text}) => {
+                const state = getState();
+                const pageSize = pageSizeSelector(state);
+                const {type, url} = selectedCatalogSelector(state);
+                return Rx.Observable.of(textSearch(type, url, 1, pageSize, text))
+                    .startWith(setLoading(true));
             })
 });

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -25,7 +25,7 @@ const {resultSelector, serviceListOpenSelector, newServiceSelector,
     newServiceTypeSelector, selectedServiceTypeSelector, searchOptionsSelector,
     servicesSelector, formatsSelector, loadingErrorSelector, selectedServiceSelector,
     modeSelector, layerErrorSelector, activeSelector, savingSelector, authkeyParamNameSelector,
-    searchTextSelector, groupSelector
+    searchTextSelector, groupSelector, pageSizeSelector, loadingSelector
 } = require("../selectors/catalog");
 
 const {mapLayoutValuesSelector} = require('../selectors/maplayout');
@@ -44,14 +44,18 @@ const catalogSelector = createSelector([
     (state) => selectedServiceTypeSelector(state),
     (state) => searchOptionsSelector(state),
     (state) => currentLocaleSelector(state),
-    (state) => currentMessagesSelector(state)
-], (authkeyParamNames, result, saving, openCatalogServiceList, newService, newformat, selectedFormat, options, currentLocale, locales) =>({
+    (state) => currentMessagesSelector(state),
+    (state) => pageSizeSelector(state),
+    (state) => loadingSelector(state)
+], (authkeyParamNames, result, saving, openCatalogServiceList, newService, newformat, selectedFormat, options, currentLocale, locales, pageSize, loading) =>({
     authkeyParamNames,
     saving,
     openCatalogServiceList,
     format: newformat,
     newService,
     currentLocale,
+    pageSize,
+    loading,
     records: result && CatalogUtils.getCatalogRecords(selectedFormat, result, options, locales) || []
 }));
 
@@ -217,6 +221,7 @@ const API = {
  * @prop {object} cfg.hideIdentifier shows/hides identifier
  * @prop {boolean} cfg.hideExpand shows/hides full description button
  * @prop {number} cfg.zoomToLayer enable/disable zoom to layer when added
+ * @prop {number} [delayAutoSearch] time in ms passed after a search is triggered by filter changes, default 1000
  */
 module.exports = {
     MetadataExplorerPlugin: assign(MetadataExplorerPlugin, {

--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -32,7 +32,7 @@ const catalog = require('../catalog');
 const {RECORD_LIST_LOADED, ADD_LAYER_ERROR, RESET_CATALOG, RECORD_LIST_LOAD_ERROR, CHANGE_CATALOG_FORMAT, CHANGE_CATALOG_MODE,
     FOCUS_SERVICES_LIST, CHANGE_TITLE, CHANGE_URL, CHANGE_TYPE, CHANGE_SELECTED_SERVICE, ADD_CATALOG_SERVICE,
     CHANGE_AUTOLOAD, DELETE_CATALOG_SERVICE, SAVING_SERVICE, CHANGE_METADATA_TEMPLATE, TOGGLE_THUMBNAIL, TOGGLE_TEMPLATE, TOGGLE_ADVANCED_SETTINGS,
-    changeText} = require('../../actions/catalog');
+    changeText, setLoading} = require('../../actions/catalog');
 const {MAP_CONFIG_LOADED} = require('../../actions/config');
 const sampleRecord = {
     boundingBox: {
@@ -67,8 +67,17 @@ describe('Test the catalog reducer', () => {
         const state = catalog({}, {type: RECORD_LIST_LOADED, result: {records: [sampleRecord], searchOptions: {catalogURL: "test"}}});
         expect(state.hasOwnProperty('result')).toBe(true);
         expect(state.hasOwnProperty('searchOptions')).toBe(true);
+        expect(state.loading).toBe(false);
     });
-
+    it('changes the loading status of catalog', () => {
+        let state = catalog({}, setLoading(true));
+        expect(state.loading).toBe(true);
+        state = catalog({}, setLoading(false));
+        expect(state.loading).toBe(false);
+        // default
+        state = catalog({}, setLoading());
+        expect(state.loading).toBe(false);
+    });
     it('handles layers error', () => {
         const state = catalog({}, {type: ADD_LAYER_ERROR, error: 'myerror'});
         expect(state.layerError).toBe('myerror');
@@ -114,6 +123,7 @@ describe('Test the catalog reducer', () => {
         const state = catalog({}, {type: RECORD_LIST_LOAD_ERROR, error});
         expect(state.result).toBe(null);
         expect(state.loadingError).toBe(error);
+        expect(state.loading).toBe(false);
         expect(state.searchOptions).toBe(null);
     });
     it('FOCUS_SERVICES_LIST', () => {

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -54,6 +54,8 @@ function catalog(state = {
         selectedService: "",
         newService: {}
     },
+    delayAutoSearch: 1000,
+    pageSize: 4,
     services: {},
     selectedService: "",
     newService: {}

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -55,6 +55,7 @@ function catalog(state = {
         newService: {}
     },
     delayAutoSearch: 1000,
+    loading: false,
     pageSize: 4,
     services: {},
     selectedService: "",

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -23,8 +23,9 @@ const {
     ADD_CATALOG_SERVICE,
     DELETE_CATALOG_SERVICE,
     SAVING_SERVICE,
-    TOGGLE_THUMBNAIL,
     CHANGE_METADATA_TEMPLATE,
+    SET_LOADING,
+    TOGGLE_THUMBNAIL,
     TOGGLE_TEMPLATE,
     TOGGLE_ADVANCED_SETTINGS
 } = require('../actions/catalog');
@@ -59,15 +60,17 @@ function catalog(state = {
 }, action) {
     switch (action.type) {
     case SAVING_SERVICE:
-        return assign({}, state, {
+        return {
+            ...state,
             saving: action.status
-        });
+        };
     case RECORD_LIST_LOADED:
         return assign({}, state, {
             result: action.result,
             searchOptions: action.searchOptions,
             loadingError: null,
-            layerError: null
+            layerError: null,
+            loading: false
         });
     case RESET_CATALOG:
         return assign({}, state, {
@@ -85,6 +88,7 @@ function catalog(state = {
             result: null,
             searchOptions: null,
             loadingError: action.error,
+            loading: false,
             layerError: null
         });
     case CHANGE_CATALOG_FORMAT:
@@ -185,6 +189,9 @@ function catalog(state = {
     }
     case TOGGLE_THUMBNAIL: {
         return set("newService.hideThumbnail", !state.newService.hideThumbnail, state);
+    }
+    case SET_LOADING: {
+        return set("loading", action.loading, state);
     }
     case CHANGE_METADATA_TEMPLATE: {
         return set("newService.metadataTemplate", action.metadataTemplate, state);

--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -8,22 +8,25 @@
 
 const expect = require('expect');
 const {
-    resultSelector,
-    serviceListOpenSelector,
-    newServiceSelector,
-    servicesSelector,
-    newServiceTypeSelector,
-    selectedServiceTypeSelector,
-    searchOptionsSelector,
-    formatsSelector,
-    loadingErrorSelector,
-    selectedServiceSelector,
-    modeSelector,
-    layerErrorSelector,
     activeSelector,
     authkeyParamNameSelector,
+    delayAutoSearchSelector,
+    formatsSelector,
+    groupSelector,
+    layerErrorSelector,
+    loadingErrorSelector,
+    loadingSelector,
+    modeSelector,
+    newServiceSelector,
+    newServiceTypeSelector,
+    pageSizeSelector,
+    resultSelector,
     searchTextSelector,
-    groupSelector
+    searchOptionsSelector,
+    selectedServiceTypeSelector,
+    selectedServiceSelector,
+    servicesSelector,
+    serviceListOpenSelector
 } = require("../catalog");
 
 const {set} = require('../../utils/ImmutableUtils');
@@ -203,6 +206,32 @@ describe('Test catalog selectors', () => {
         const authkeyParamNames = authkeyParamNameSelector({});
         expect(authkeyParamNames).toExist();
         expect(authkeyParamNames.length).toBe(0);
+    });
+    it('test loadingSelector', () => {
+        let loading = loadingSelector({});
+        expect(loading).toBe(false);
+
+        loading = loadingSelector({catalog: {loading: true}});
+        expect(loading).toExist();
+        expect(loading).toBe(true);
+    });
+    it('test pageSizeSelector', () => {
+        let pageSize = pageSizeSelector({});
+        expect(pageSize).toExist();
+        expect(pageSize).toBe(4);
+
+        pageSize = pageSizeSelector({catalog: {pageSize: 5}});
+        expect(pageSize).toExist();
+        expect(pageSize).toBe(5);
+    });
+    it('test delayAutoSearchSelector', () => {
+        let delay = delayAutoSearchSelector({});
+        expect(delay).toExist();
+        expect(delay).toBe(1000);
+
+        delay = delayAutoSearchSelector({catalog: {delayAutoSearch: 1234}});
+        expect(delay).toExist();
+        expect(delay).toBe(1234);
     });
 
 });

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -13,6 +13,7 @@ module.exports = {
     searchOptionsSelector: (state) => get(state, "catalog.searchOptions"),
     formatsSelector: (state) => get(state, "catalog.supportedFormats") || [{name: "csw", label: "CSW"}, {name: "wms", label: "WMS"}, {name: "wmts", label: "WMTS"}],
     loadingErrorSelector: (state) => get(state, "catalog.loadingError"),
+    loadingSelector: (state) => get(state, "catalog.loading", false),
     selectedServiceSelector: (state) => get(state, "catalog.selectedService"),
     modeSelector: (state) => get(state, "catalog.mode", "view"),
     layerErrorSelector: (state) => get(state, "catalog.layerError"),
@@ -20,5 +21,7 @@ module.exports = {
     activeSelector: (state) => get(state, "controls.toolbar.active") === "metadataexplorer" || get(state, "controls.metadataexplorer.enabled"),
     authkeyParamNameSelector: (state) => {
         return (get(state, "localConfig.authenticationRules") || []).filter(a => a.method === "authkey").map(r => r.authkeyParamName) || [];
-    }
+    },
+    pageSizeSelector: (state) => get(state, "catalog.pageSize", 4),
+    delayAutoSearchSelector: (state) => get(state, "catalog.delayAutoSearch", 1000)
 };


### PR DESCRIPTION
## Description
This pr adds AutoSearch to the filter of catalog form
Also loading state has been moved from local to the global state
The delay can be configured in the initialState of localConfig, for example: 
```
"initialState": {
  "defaultState": {
    "catalog": {
      "delayAutoSearch" : 1000
    }
  }
}
```

## Issues
 - #3985

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
When you type in the filter you have to click on "search button" in order to trigger the search

**What is the new behavior?**
after 1 second it triggers automatically the search when idle for 1s

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No 

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
notes this could be harmful for projects that are customizing the catalog plugin (components and plugin changes needs to be ported too)
