### PR TITLE
Fix #3934 Cross layer filter: some wfs requests fails

### DIFF
--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -589,7 +589,7 @@ const FilterUtils = {
              `<ogc:Function name="queryCollection">` +
                `<ogc:Literal>${crossLayerFilter.collectGeometries.queryCollection.typeName}</ogc:Literal>` +
                `<ogc:Literal>${crossLayerFilter.collectGeometries.queryCollection.geometryName}</ogc:Literal>` +
-               `<ogc:Literal>${cqlFilter}</ogc:Literal>` +
+               `<ogc:Literal><![CDATA[${cqlFilter}]]></ogc:Literal>` +
              `</ogc:Function>` +
          `</ogc:Function>`;
         }

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -936,7 +936,7 @@ describe('FilterUtils', () => {
          + '<ogc:Function name="queryCollection">'
          + '<ogc:Literal>TEST</ogc:Literal>'
          + '<ogc:Literal>GEOMETRY</ogc:Literal>'
-         + '<ogc:Literal>INCLUDE</ogc:Literal>'
+         + '<ogc:Literal><![CDATA[INCLUDE]]></ogc:Literal>'
          + '</ogc:Function></ogc:Function>'
          + "</ogc:Intersects>";
         let expected =
@@ -1010,7 +1010,7 @@ describe('FilterUtils', () => {
          + '<ogc:Function name="queryCollection">'
          + '<ogc:Literal>regions</ogc:Literal>'
          + '<ogc:Literal>regions_geom</ogc:Literal>'
-         + '<ogc:Literal>area > 10</ogc:Literal>'
+         + '<ogc:Literal><![CDATA[area > 10]]></ogc:Literal>'
          + '</ogc:Function></ogc:Function>'
          + "</ogc:Intersects>";
 


### PR DESCRIPTION
## Description
Fix cross layer filter wfs request fails when filter contain xml characters

## Issues
 - #3934 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3934 

**What is the new behavior?**
The cross layer filter wfs request works even when filter contain xml character

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
