### PR TITLE
Fix #3929 Cross layer filter cannot be disabled when filled

### DIFF
--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -52,7 +52,7 @@ module.exports = ({
 
     return (<SwitchPanel
         loading={loadingCapabilities}
-        expanded={operation && queryCollection.typeName ? true : crossLayerExpanded && !loadingCapabilities && !errorObj }
+        expanded={crossLayerExpanded && !loadingCapabilities && !errorObj}
         error={errorObj}
         errorMsgId={"queryPanel"}
         buttons={[

--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -25,7 +25,7 @@ const isSameOGCServiceRoot = (origSearchUrl, {search, url} = {}) => isSameUrl(or
 const getAllowedSpatialOperations = (spatialOperations) => (spatialOperations || []).filter( ({id} = {}) => id !== "BBOX");
 
 module.exports = ({
-    crossLayerExpanded,
+    crossLayerExpanded = true,
     spatialOperations,
     expandCrossLayerFilterPanel = () => {},
     layers = [],

--- a/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
+++ b/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
@@ -111,9 +111,9 @@ describe('CrossLayerFilter component', () => {
                 name: "Within"
             }]}
             />, document.getElementById("container"));
-        expect(container.querySelector('.geometry-operation-selector')).toExist();
-        expect(container.querySelector('.mapstore-conditions-group')).toExist();
-        expect(container.querySelector('.m-slider')).toExist();
+        const collapsablePanel = container.querySelector('.mapstore-switch-panel .panel-collapse');
+        const expected = collapsablePanel.getAttribute('aria-hidden');
+        expect(expected).toEqual('false');
     });
 
 });


### PR DESCRIPTION
## Description
Fix Cross layer filter cannot be disabled, the problem which introduced as the side-effect of the fix for #2953 in PR #3152. I just re-fix #2953 which automatically fix this issue and #2953 all together.

## Issues
 - #3929 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3929 

**What is the new behavior?**
The Cross layer filter can be disabled at any given time

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
