### PR TITLE
Fix 2749 search urls for cross layer filter are compared ignoring "dirty" chars

### DIFF
--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -46,7 +46,7 @@ export const isSameUrl = (originalUrl, otherUrl) => {
     const isSamePort = originalUrlParts.port === otherUrlParts.port;
 
     const isSamePathname = urlParsed.pathname === otherUrlParsed.pathname;
-    const ignoreSearchPath = ((urlParsed.search || "").length <= 4 ) === (otherUrlParsed.search || "").length <= 4;
+    const ignoreSearchPath = ((urlParsed.search || "").length < 4 ) === (otherUrlParsed.search || "").length < 4;
     /* ignoreSearchPath is needed to ignore url where path are dirty like /wfs? and /wfs?&
     * the minimum valid search path is 4 char length => ?p=v
     */

--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -6,7 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const urlParts = (url) => {
+import Url from "url";
+
+export const urlParts = (url) => {
     if (!url) return {};
     let isRelativeUrl = !(url.indexOf("http") === 0);
     let urlPartsArray = isRelativeUrl ? [] : url.match(/([^:]*:)\/\/([^:]*:?[^@]*@)?([^:\/\?]*):?([^\/\?]*)/);
@@ -32,19 +34,21 @@ const urlParts = (url) => {
  * @param  {string} otherUrl url to compare to
  * @return {boolean} true when urls are the same else false
  */
-const isSameUrl = (originalUrl, otherUrl) => {
+export const isSameUrl = (originalUrl, otherUrl) => {
     if (originalUrl === otherUrl) return true;
+    const urlParsed = Url.parse(originalUrl);
+    const otherUrlParsed = Url.parse(otherUrl);
     const originalUrlParts = urlParts(originalUrl);
     const otherUrlParts = urlParts(otherUrl);
     const isSameProtocol = originalUrlParts.protocol === otherUrlParts.protocol;
     const isSameDomain = originalUrlParts.domain === otherUrlParts.domain;
     const isSameRootPath = originalUrlParts.rootPath === otherUrlParts.rootPath;
     const isSamePort = originalUrlParts.port === otherUrlParts.port;
-    return isSameProtocol && isSamePort && isSameDomain && isSameRootPath;
-};
 
-
-module.exports = {
-    isSameUrl,
-    urlParts
+    const isSamePathname = urlParsed.pathname === otherUrlParsed.pathname;
+    const ignoreSearchPath = ((urlParsed.search || "").length <= 4 ) === (otherUrlParsed.search || "").length <= 4;
+    /* ignoreSearchPath is needed to ignore url where path are dirty like /wfs? and /wfs?&
+    * the minimum valid search path is 4 char length => ?p=v
+    */
+    return isSameProtocol && isSamePort && isSameDomain && (ignoreSearchPath && isSamePathname ? true : isSameRootPath);
 };

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -19,7 +19,7 @@ const urlPartsResult1 = {
     rootPath: "/geoserver/wfs",
     applicationRootPath: 'geoserver'
 };
-describe.only('URLUtils', () => {
+describe('URLUtils', () => {
     it('test urlParts', () => {
         const data = urlParts(url1);
         expect(data).toEqual(urlPartsResult1);

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -19,7 +19,7 @@ const urlPartsResult1 = {
     rootPath: "/geoserver/wfs",
     applicationRootPath: 'geoserver'
 };
-describe('URLUtils', () => {
+describe.only('URLUtils', () => {
     it('test urlParts', () => {
         const data = urlParts(url1);
         expect(data).toEqual(urlPartsResult1);
@@ -35,6 +35,34 @@ describe('URLUtils', () => {
     it('test isSameUrl with relative url', () => {
         const data = isSameUrl(url3, url4);
         expect(data).toBeTruthy();
+    });
+    it('test isSameUrl with clean and dirty relative url', () => {
+        expect(isSameUrl(
+            "/geoserver/wfs",
+            "/geoserver/wfs?&")).toBe(true);
+        expect(isSameUrl(
+            "/geoserver/wfs",
+            "/geoserver/wfs?")).toBe(true);
+        expect(isSameUrl(
+            "/geoserver/wfs?&",
+            "/geoserver/wfs?param1=true&param2=false")).toBe(false);
+        expect(isSameUrl(
+            "/path/geoserver/wfs?",
+            "/geoserver/wfs?")).toBe(false);
+    });
+    it('test isSameUrl with clean and dirty absolute url', () => {
+        expect(isSameUrl(
+            "https://demo.geo-solutions.it:443/geoserver/wfs",
+            "https://demo.geo-solutions.it/geoserver/wfs?")).toBe(true);
+        expect(isSameUrl(
+            "https://demo.geo-solutions.it:443/geoserver/wfs",
+            "https://demo.geo-solutions.it/geoserver/wfs?")).toBe(true);
+        expect(isSameUrl(
+            "https://demo.geo-solutions.it/geoserver/wfs?",
+            "https://demo.geo-solutions.it/geoserver/wfs?param1=true&param2=false")).toBe(false);
+        expect(isSameUrl(
+            "https://demo.geo-solutions.it/path/geoserver/wfs?",
+            "https://demo.geo-solutions.it/geoserver/wfs?")).toBe(false);
     });
 
 });


### PR DESCRIPTION
## Description
There was a problem when comparing search url for cross layer filter functionality. With this pr it allows to ignore some small differences like ? or ?&

## Issues
 - #2749 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
some layers are filtered out from the select menu in the cross layer filter form

**What is the new behavior?**
Layers that have similar search url besides a ? or a ?& are not filtered out from the list

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
If you think there are other urls to test just drop some examples, thanks.