### PR TITLE
Fix Print tool with vendor param (CQL_FILTER)

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -9,6 +9,7 @@
 const CoordinatesUtils = require('./CoordinatesUtils');
 const SecurityUtils = require('./SecurityUtils');
 const MapUtils = require('./MapUtils');
+const {optionsToVendorParams} = require('./VendorParamsUtils');
 const AnnotationsUtils = require("./AnnotationsUtils");
 const {colorToHexStr} = require("./ColorUtils");
 
@@ -202,8 +203,14 @@ const PrintUtils = {
                     "TILED": true,
                     "EXCEPTIONS": "application/vnd.ogc.se_inimage",
                     "scaleMethod": "accurate"
-                }, layer.baseParams || {}, layer.params || {}))
-            }),
+                }, layer.baseParams || {}, layer.params || {}, {
+                    ...optionsToVendorParams({
+                        nativeCrs: layer.nativeCrs,
+                        layerFilter: layer.layerFilter,
+                        filterObj: layer.filterObj
+                    })
+                }
+            ))}),
             legend: (layer, spec) => ({
                 "name": layer.title || layer.name,
                 "classes": [

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -15,6 +15,71 @@ const layer = {
     type: "wms",
     params: {myparam: "myvalue"}
 };
+
+const layerSottoPasso = {
+    id: 'DBT:SOTTOPASSO__6',
+    type: 'wms',
+    url: 'http://localhost:8081/geoserver-test/wms',
+    nativeCrs: 'EPSG:3003'
+};
+
+const layerFilterSottoPasso = {
+    groupFields: [
+      {
+        id: 1,
+        logic: 'OR',
+        index: 0
+      }
+    ],
+    filterFields: [
+      {
+        rowId: 1563970241851,
+        groupId: 1,
+        attribute: 'TIPO',
+        operator: '=',
+        value: 2,
+        type: 'number',
+        fieldOptions: {
+          valuesCount: 0,
+          currentPage: 1
+        },
+        exception: null
+      }
+    ],
+    spatialField: {
+      method: null,
+      operation: 'INTERSECTS',
+      geometry: null,
+      attribute: 'GEOMETRY'
+    }
+};
+const filterObjSottoPasso = {
+    featureTypeName: 'DBT:SOTTOPASSO',
+    filterType: 'OGC',
+    ogcVersion: '1.1.0',
+    pagination: {
+      startIndex: 0,
+      maxFeatures: 20
+    },
+    groupFields: [
+      {
+        id: 1,
+        logic: 'AND',
+        index: 0
+      }
+    ],
+    filterFields: [
+      {
+        attribute: 'ID_OGGETTO',
+        rowId: 1563970257711,
+        type: 'number',
+        groupId: 1,
+        operator: '<',
+        value: 44
+      }
+    ]
+};
+
 const featurePoint = {
     "type": "Feature",
     "geometry": {
@@ -207,6 +272,37 @@ describe('PrintUtils', () => {
         expect(specs.length).toBe(1);
         expect(specs[0].customParams.authkey).toExist();
         expect(specs[0].customParams.authkey).toBe("mykey");
+    });
+    it('custom params include layerFilter and filterObj', () => {
+        const specs = PrintUtils.getMapfishLayersSpecification([{
+            ...layerSottoPasso,
+            layerFilter: layerFilterSottoPasso,
+            filterObj: filterObjSottoPasso
+        }], {}, 'map');
+        expect(specs).toExist();
+        expect(specs.length).toBe(1);
+        expect(specs[0].customParams.CQL_FILTER).toExist();
+        expect(specs[0].customParams.CQL_FILTER).toBe(`(("TIPO" = '2')) AND (("ID_OGGETTO" < '44'))`);
+    });
+    it('custom params include cql_filter', () => {
+        const specs = PrintUtils.getMapfishLayersSpecification([{
+            ...layerSottoPasso,
+            filterObj: filterObjSottoPasso
+        }], {}, 'map');
+        expect(specs).toExist();
+        expect(specs.length).toBe(1);
+        expect(specs[0].customParams.CQL_FILTER).toExist();
+        expect(specs[0].customParams.CQL_FILTER).toBe(`("ID_OGGETTO" < '44')`);
+    });
+    it('custom params include layerFilter', () => {
+        const specs = PrintUtils.getMapfishLayersSpecification([{
+            ...layerSottoPasso,
+            layerFilter: layerFilterSottoPasso
+        }], {}, 'map');
+        expect(specs).toExist();
+        expect(specs.length).toBe(1);
+        expect(specs[0].customParams.CQL_FILTER).toExist();
+        expect(specs[0].customParams.CQL_FILTER).toBe(`("TIPO" = '2')`);
     });
     it('wms layer generation for legend includes scale', () => {
         const specs = PrintUtils.getMapfishLayersSpecification([layer], testSpec, 'legend');


### PR DESCRIPTION
## Description
Added CQL_FILTER into custom params for mapsfish print functionality.

## Issues
 - #4005 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
- print ignores filters

**What is the new behavior?**
- print uses filters and result is similar

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
@offtherailz i'm "reusing" the optionsToVendorParams