### PR TITLE
Fix 4007 hide filter layer when no layers are present in TOC

### DIFF
--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -343,7 +343,7 @@ class LayerTree extends React.Component {
                 <Header
                     title={this.props.mapName}
                     showTitle={this.props.activateMapTitle}
-                    showFilter={this.props.activateFilterLayer}
+                    showFilter={this.props.activateFilterLayer && (this.props.groups.filter(g => (g.nodes || []).length) || []).length}
                     showTools={this.props.activateToolsContainer}
                     onClear={() => { this.props.onSelectNode(); }}
                     onFilter={this.props.onFilter}

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -12,7 +12,7 @@ import ReactDOM from 'react-dom';
 import TOCPlugin from '../TOC';
 import { getPluginForTest } from './pluginsTestUtils';
 
-describe.only('TOCPlugin Plugin', () => {
+describe('TOCPlugin Plugin', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -12,7 +12,7 @@ import ReactDOM from 'react-dom';
 import TOCPlugin from '../TOC';
 import { getPluginForTest } from './pluginsTestUtils';
 
-describe('TOCPlugin Plugin', () => {
+describe.only('TOCPlugin Plugin', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -49,6 +49,7 @@ describe('TOCPlugin Plugin', () => {
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         expect(document.querySelector('.toc-title').textContent).toBe('Annotations');
         expect(document.querySelector('.toc-group-title').textContent).toBe('Default');
+        expect(document.querySelectorAll('.mapstore-filter.form-group').length).toBe(1);
     });
 
     it('TOCPlugin hides annotations layer and empty group in cesium mapType', () => {
@@ -79,5 +80,31 @@ describe('TOCPlugin Plugin', () => {
         ReactDOM.render(<Plugin />, document.getElementById("container"));
         expect(document.querySelectorAll('.toc-title').length).toBe(1);
         expect(document.querySelectorAll('.toc-group-title').length).toBe(1);
+    });
+    it('TOCPlugin hides filter layer if no groups and no layers are present', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [{ id: 'default', title: 'Default', nodes: [] }],
+                flat: []
+            },
+            maptype: {
+                mapType: 'openlayers'
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelectorAll('.mapstore-filter.form-group').length).toBe(0);
+    });
+    it('TOCPlugin hides filter layer if a group with no layers are present', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [],
+                flat: []
+            },
+            maptype: {
+                mapType: 'openlayers'
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelectorAll('.mapstore-filter.form-group').length).toBe(0);
     });
 });


### PR DESCRIPTION
## Description
Layer Filter in TOC hides if no layers are present or if a group with no layers is present 

## Issues
 - #4007

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
layer filter is always present

**What is the new behavior?**
layer filter is present only if there are at least one layer

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
