### PR TITLE
Fix #3805 User edit password field retain value across users

### DIFF
--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -114,6 +114,7 @@ class UserDialog extends React.Component {
                     helpText="Password must contain at least 6 characters"/>
                   </ControlLabel>
                   <FormControl ref="newPassword"
+                   inputRef={node => this.newPasswordField = node}
                    key="newPassword"
                    type="password"
                    name="newPassword"
@@ -124,6 +125,7 @@ class UserDialog extends React.Component {
               <FormGroup validationState={ (this.isValidPassword() ? "success" : "error") }>
                   <ControlLabel><Message msgId="user.retypePwd"/>{' '}<span style={{ fontWeight: 'bold' }}>*</span></ControlLabel>
                   <FormControl ref="confirmPassword"
+                      inputRef={node => this.confirmPasswordField = node}
                       key="confirmPassword"
                       name="confirmPassword"
                       type="password"
@@ -204,7 +206,7 @@ class UserDialog extends React.Component {
               onClick={() => this.props.onSave(this.props.user)}
               disabled={!this.isValid() || this.isSaving()}>
               {this.renderSaveButtonContent()}</Button>,
-          <Button key="close" bsSize={this.props.buttonSize} bsSize="small" onClick={this.props.onClose}><Message msgId="close"/></Button>
+          <Button key="close" bsSize={this.props.buttonSize} bsSize="small" onClick={this.close}><Message msgId="close"/></Button>
         ];
     };
 
@@ -247,6 +249,12 @@ class UserDialog extends React.Component {
               {this.renderButtons()}
           </div>
       </Dialog>);
+    }
+
+    close = () => {
+        this.props.onClose();
+        this.newPasswordField.value = '';
+        this.confirmPasswordField.value = '';
     }
 
     isMainPasswordValid = (password) => {

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -254,4 +254,16 @@ describe("Test UserDialog Component", () => {
         expect(retypePassword.children[0].innerHTML).toBe('user.retypePwd');
         expect(retypePassword.children[1].innerHTML).toBe('*');
     });
+
+    it('Test on close dialog, reset password field', () => {
+        let comp = ReactDOM.render(
+            <UserDialog user={newUser} />, document.getElementById("container"));
+        expect(comp).toExist();
+        const passwordField = document.querySelector("input[name='newPassword']");
+        const closeBtn = document.querySelector(".btn-default");
+        passwordField.value = 'password';
+        ReactTestUtils.Simulate.click(closeBtn);
+        expect(passwordField.value).toEqual('');
+
+    });
 });


### PR DESCRIPTION

## Description
On editing user, the form use to retain password field across editing
session. This commit fix and enable password field reset on close edit
dialog

## Issues
 - #3805 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3805 

**What is the new behavior?**
see description above

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
