### PR TITLE
Close #3025 Add boundary for draggable dialog

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -67,7 +67,7 @@ class DownloadDialog extends React.Component {
     };
 
     render() {
-        return (<Dialog id="mapstore-export" style={{display: this.props.enabled ? "block" : "none"}}>
+        return (<Dialog id="mapstore-export" style={{display: this.props.enabled ? "block" : "none"}} draggable={false} modal>
             <span role="header">
                 <span className="about-panel-title"><Message msgId="wfsdownload.title" /></span>
                 <button onClick={this.props.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>

--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -208,6 +208,7 @@ class GroupDialog extends React.Component {
               id="mapstore-group-dialog"
               className="group-edit-dialog"
               style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}
+              draggable={false}
               >
             <span role="header">
                 <button onClick={this.props.onClose} className="login-panel-close close">

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -223,7 +223,7 @@ class UserDialog extends React.Component {
     };
 
     render() {
-        return (<Dialog onClickOut={this.props.onClose} modal maskLoading={this.props.user && (this.props.user.status === "loading" || this.props.user.status === "saving")} id="mapstore-user-dialog" className="user-edit-dialog" style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
+        return (<Dialog onClickOut={this.props.onClose} modal draggable={false} maskLoading={this.props.user && (this.props.user.status === "loading" || this.props.user.status === "saving")} id="mapstore-user-dialog" className="user-edit-dialog" style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
 
           <span role="header">
               <span className="user-panel-title">{(this.props.user && this.props.user.name) || <Message msgId="users.newUser" />}</span>

--- a/web/client/components/manager/users/style/userdialog.css
+++ b/web/client/components/manager/users/style/userdialog.css
@@ -6,7 +6,6 @@
     width: 300px;
     margin-left: calc(50% - 150px);
     margin-top: 100px;
-    transform: translate(-50%, 0);
 }
 
 .user-edit-dialog .modal-body .nav-tabs li a, .group-edit-dialog .modal-body .nav-tabs li a {

--- a/web/client/components/mapcontrols/Snapshot/SnapshotPanel.jsx
+++ b/web/client/components/mapcontrols/Snapshot/SnapshotPanel.jsx
@@ -21,6 +21,7 @@ const BasicSpinner = require('../../misc/spinners/BasicSpinner/BasicSpinner');
 const Dialog = require('../../misc/Dialog');
 
 const Message = require('../../I18N/Message');
+const Portal = require('../../misc/Portal');
 
 /**
  * SnapshotPanel allow to export a snapshot of the current map, showing a
@@ -88,7 +89,8 @@ class SnapshotPanel extends React.Component {
         },
         panelClassName: "snapshot-panel",
         closeGlyph: "1-close",
-        buttonStyle: "primary"
+        buttonStyle: "primary",
+        bounds: '#container'
     };
 
     componentWillMount() {
@@ -193,10 +195,14 @@ class SnapshotPanel extends React.Component {
                     {panel}
                 </Panel>);
             }
-            return (<Dialog id="mapstore-snapshot-panel" style={this.props.style}>
-                <span role="header"><span className="snapshot-panel-title"><Message msgId="snapshot.title"/></span><button onClick={this.props.toggleControl} className="print-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button></span>
-                {panel}
-            </Dialog>);
+            return (
+                <Portal>
+                  <Dialog id="mapstore-snapshot-panel" style={this.props.panelStyle} bounds={this.props.bounds}>
+                    <span role="header"><span className="snapshot-panel-title"><Message msgId="snapshot.title"/></span><button onClick={this.props.toggleControl} className="print-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button></span>
+                    {panel}
+                  </Dialog>
+                </Portal>
+            );
         }
         return panel;
     };

--- a/web/client/components/mapcontrols/measure/MeasureDialog.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureDialog.jsx
@@ -76,7 +76,7 @@ class MeasureDialog extends React.Component {
             style={this.props.style}>
                 <MeasureComponent id="measure-panel" {...this.props}/>
             </DockablePanel>
-        : (<Dialog id="measure">
+        : (<Dialog id="measure-dialog">
             <div key="header" role="header">
                 <Glyphicon glyph="1-ruler"/>&nbsp;<Message key="title" msgId="measureComponent.Measure"/>
                 <button key="close" onClick={this.onClose} className="close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureDialog-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureDialog-test.jsx
@@ -48,7 +48,7 @@ describe("test the MeasureDialog", () => {
         let measurement = {};
         const mc = ReactDOM.render(<MeasureDialog show measurement={measurement}/>, document.getElementById("container"));
         expect(mc).toExist();
-        const dialog = document.getElementById('measure');
+        const dialog = document.getElementById('measure-dialog');
         expect(dialog).toExist();
 
     });
@@ -79,7 +79,7 @@ describe("test the MeasureDialog", () => {
         const btnGroups = dom.getElementsByClassName('btn-group');
         expect(btnGroups.length).toBe(2);
 
-        const dialog = document.getElementById('measure');
+        const dialog = document.getElementById('measure-dialog');
         expect(dialog).toNotExist();
         expect(spyMount.calls.length).toBe(1);
         expect(spyMount).toHaveBeenCalledWith(showCoordinateEditor);
@@ -119,7 +119,7 @@ describe("test the MeasureDialog", () => {
         const btnGroups = dom.getElementsByClassName('btn-group');
         expect(btnGroups.length).toBe(2);
 
-        const dialog = document.getElementById('measure');
+        const dialog = document.getElementById('measure-dialog');
         expect(dialog).toNotExist();
         expect(spyMount.calls.length).toBe(1);
         expect(spyToggleMeasure.calls.length).toBe(1);

--- a/web/client/components/misc/Dialog.jsx
+++ b/web/client/components/misc/Dialog.jsx
@@ -12,7 +12,6 @@ const Draggable = require('react-draggable');
 const Spinner = require('react-spinkit');
 const assign = require('object-assign');
 const Message = require('../I18N/Message');
-const {withState, withHandlers, compose} = require('recompose');
 
 class Dialog extends React.Component {
     static propTypes = {
@@ -29,9 +28,7 @@ class Dialog extends React.Component {
         modal: PropTypes.bool,
         start: PropTypes.object,
         draggable: PropTypes.bool,
-        bounds: PropTypes.object,
-        noBounds: PropTypes.bool, // if true and dialog is draggable then the there will no no biundary for dragging
-        onDragStart: PropTypes.func
+        bounds: PropTypes.object
     };
 
     static defaultProps = {
@@ -39,7 +36,7 @@ class Dialog extends React.Component {
         backgroundStyle: {
             background: "rgba(0,0,0,.5)"
         },
-        start: {x: 0, y: 0},
+        start: {x: 0, y: 150},
         className: "modal-dialog modal-content",
         maskLoading: false,
         containerClassName: "",
@@ -47,7 +44,8 @@ class Dialog extends React.Component {
         bodyClassName: "modal-body",
         footerClassName: "modal-footer",
         modal: false,
-        draggable: true
+        draggable: true,
+        bounds: 'parent'
     };
 
     renderLoading = () => {
@@ -76,8 +74,7 @@ class Dialog extends React.Component {
     };
 
     render() {
-        const { bounds, noBounds, onDragStart } = this.props;
-        const body = (<div id={this.props.id} style={{zIndex: 3, ...this.props.style}} className={this.props.className + " modal-dialog-container"}>
+        const body = (<div id={this.props.id} style={{zIndex: 3, ...this.props.style}} className={`${this.props.draggable ? 'modal-dialog-draggable' : ''} ${this.props.className} modal-dialog-container`}>
             <div className={this.props.headerClassName + " draggable-header"}>
                 {this.renderRole('header')}
             </div>
@@ -89,7 +86,7 @@ class Dialog extends React.Component {
                 {this.renderRole('footer')}
             </div> : <span/>}
         </div>);
-        const dialog = this.props.draggable ? (<Draggable defaultPosition={this.props.start} bounds={!noBounds ? bounds : null} onStart={onDragStart} onStop={this.handleStop} handle=".draggable-header, .draggable-header *">
+        const dialog = this.props.draggable ? (<Draggable defaultPosition={this.props.start} bounds={this.props.bounds} handle=".draggable-header, .draggable-header *">
             {body}
         </Draggable>) : body;
         let containerStyle = assign({}, this.props.style.display ? {display: this.props.style.display} : {}, this.props.backgroundStyle);
@@ -110,30 +107,5 @@ class Dialog extends React.Component {
     };
 }
 
-const enhance = compose(
-    withState('bounds', 'setBounds', null),
-    withHandlers({
-        onDragStart: props => (event, dragElement) => {
-            const dialog = dragElement.node.getBoundingClientRect();
-            const dialogContainer = dragElement.node.parentElement.getBoundingClientRect();
-            const remainedBottomSpace = dialogContainer.height - dialog.bottom;
-            const bounds = {};
-            bounds.left = -(dialog.left + (dialog.width * 0.7));
-            bounds.top = -(dialog.top);
-            bounds.bottom = dialog.height + (dialogContainer.height - dialog.bottom) * 0.8;
-            if (dialog.height > remainedBottomSpace) {
-                bounds.bottom = dialog.height + remainedBottomSpace * 0.5;
-            } else {
-                bounds.bottom = dialog.height + remainedBottomSpace * 0.8;
-            }
-            bounds.right = dialog.width + (dialogContainer.width - dialog.right) * 0.8;
-            if (!props.bounds) {
-                // This ensure the bounds is set only once
-                props.setBounds(bounds);
-            }
-        }
-    })
-);
 
-
-module.exports = enhance(Dialog);
+module.exports = Dialog;

--- a/web/client/plugins/SearchServicesConfig.jsx
+++ b/web/client/plugins/SearchServicesConfig.jsx
@@ -149,7 +149,7 @@ class SearchServicesConfigPanel extends React.Component {
         const Section = pages && pages[page] || null;
         return enabled ? (
             <Portal>
-                <Dialog id={id} style={panelStyle} className={panelClassName}>
+                <Dialog id={id} style={{...panelStyle, display: enabled ? 'block' : 'none'}} className={panelClassName} draggable={false} modal>
                     <span role="header">
                         <span>{titleText}</span>
                         { this.isDirty() ? (

--- a/web/client/plugins/Settings.jsx
+++ b/web/client/plugins/Settings.jsx
@@ -143,7 +143,7 @@ class SettingsButton extends React.Component {
                         {settings}
                     </Panel>);
                 }
-                return (<Dialog id={this.props.id} style={this.props.panelStyle} className={this.props.panelClassName}>
+                return (<Dialog id={this.props.id} style={{...this.props.panelStyle, display: this.props.visible ? 'block' : 'none'}} className={this.props.panelClassName} draggable={false} modal>
                     <span role="header">
                         <span className="settings-panel-title"><Message msgId="settings"/></span>
                         <button onClick={this.props.toggleControl} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>

--- a/web/client/plugins/print/print.css
+++ b/web/client/plugins/print/print.css
@@ -37,10 +37,6 @@
     right: -155px;
     z-index: 1000;
 }
-
-#mapstore-print-panel{
-    margin-top: 100px !important;
-}
 #mapstore-print-panel.modal-dialog {
     z-index: 2000;
 }

--- a/web/client/product/components/viewer/about/About.jsx
+++ b/web/client/product/components/viewer/about/About.jsx
@@ -49,7 +49,7 @@ class About extends React.Component {
             className="map-logo"
             body={
                 <AboutContent/>
-            }/>) : (<Dialog id="mapstore-about" style={assign({}, {zIndex: 1992, display: this.props.enabled ? "block" : "none"})}>
+            }/>) : (<Dialog id="mapstore-about" style={assign({}, {zIndex: 1992, display: this.props.enabled ? "block" : "none"})} draggable={false} modal>
                 <span role="header"><span className="about-panel-title"><I18N.Message msgId="about_title"/></span><button onClick={this.props.onClose} className="about-panel-close close">{this.props.modalConfig.closeGlyph ? <Glyphicon glyph={this.props.modalConfig.closeGlyph}/> : <span>×</span>}</button></span>
                 <div role="body"><AboutContent/></div>
             </Dialog>);

--- a/web/client/themes/default/bootstrap-theme.less
+++ b/web/client/themes/default/bootstrap-theme.less
@@ -141,6 +141,9 @@ button.close {
         margin: auto;
         margin-top: 150px;
     }
+    .modal-dialog-draggable {
+        margin-top: 0;
+    }
 }
 
 // Dropdown

--- a/web/client/themes/default/less/panels.less
+++ b/web/client/themes/default/less/panels.less
@@ -205,7 +205,7 @@
     }
 }
 
-#mapstore-print-panel, #measure-dialog, #mapstore-about {
+#mapstore-print-panel, #measure-dialog, #mapstore-about, #share-panel-dialog {
     position: absolute;
     top: 0%;
     left: 20%;


### PR DESCRIPTION
## Description
Limit the dialog dragging zone to be within the view port. It also includes changes to the followings dialogs;
- DownloadDialog
- GroupDialog
- UserDialog
- MeasureDialog
- ShareDialog
- Print
- SearchServicesConfig
- Settings
- About

## Issues
 - #3025 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3025 

**What is the new behavior?**
The draggable dialog are by default limited to browser view port

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
