### PR TITLE
Disable gs-stable authkey auth on 2019.02.xx

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -31,11 +31,7 @@
     "authenticationRules": [{
         "urlPattern": ".*geostore.*",
         "method": "bearer"
-      }, {
-        "urlPattern": "http(s)?\\:\\/\\/gs-stable\\.geo-solutions\\.it\\/geoserver/.*",
-        "authkeyParamName": "authkey",
-        "method": "authkey"
-    }],
+      }],
     "monitorState": [
       {"name": "routing", "path": "routing.location.pathname"},
       {"name": "browser", "path": "browser"},


### PR DESCRIPTION


## Description
Doing login is not allowed if there the databases are not shared and GeoServer properly configured.

## Issues
 - #4056

