### PR TITLE
Set annotation coordinate editor to decimal #4052

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -48,7 +48,7 @@
             "multiGeometry": true,
             "validationErrors": {}
           },
-          "format": "aeronautical",
+          "format": "decimal",
           "defaultTextAnnotation": "New"
         },
         "maptype": {


### PR DESCRIPTION
## Description
Set default coordinate editor to decimal for annotations
## Issues
 -  #4052

Need to be backported on 2019.02.xx