### PR TITLE
Updated default settings for timeline and measure

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -296,7 +296,12 @@
             "AddGroup",
             "TOCItemsSettings",
             "Tutorial", "MapFooter", {
-                "name": "Measure"
+                "name": "Measure",
+                "cfg": {
+                  "defaultOptions": {
+                    "showAddAsAnnotation": true
+                  }
+                }
             }, "Print", "MapImport", "MapExport", {
                 "name": "Settings",
                 "cfg": {

--- a/web/client/reducers/playback.js
+++ b/web/client/reducers/playback.js
@@ -2,12 +2,14 @@ const { PLAY, PAUSE, STOP, STATUS, SET_FRAMES, APPEND_FRAMES, FRAMES_LOADING, SE
 const { RESET_CONTROLS } = require('../actions/controls');
 const { set } = require('../utils/ImmutableUtils');
 
-module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: {
+const DEFAULT_SETTINGS = {
     timeStep: 1,
     stepUnit: "days",
     frameDuration: 2,
     following: true
-}}, action) => {
+};
+
+module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: DEFAULT_SETTINGS}, action) => {
     switch (action.type) {
         case PLAY: {
             return set(`status`, STATUS.PLAY, state);
@@ -48,12 +50,7 @@ module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: {
         }
         case RESET_CONTROLS: {
             return set('metadata', undefined, set('framesLoading', undefined, set('playbackRange', undefined, set('frames', undefined,
-                       set('currentFrame', -1, set('status', "STOP", set('settings', {
-                        timeStep: 1,
-                        stepUnit: "days",
-                        frameDuration: 5,
-                        following: true
-                       }, state)
+                set('currentFrame', -1, set('status', "STOP", set('settings', DEFAULT_SETTINGS, state)
             ))))));
         }
         default:


### PR DESCRIPTION
## Description
 - Update timeline frame duration to 2s
 - enabled measure to annotation feature in configuration

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe: Config/Setup


**What is the current behavior?** (You can also link to an open issue here)
Measure to annotation was disabled
Timeline animation frame duration was set to 5s

**What is the new behavior?**
Measure to annotation feature is available
Timeline animation frame duration is set to 2s

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
