### PR TITLE
Fix #3852 Annotation do not work without setting initial state

### DIFF
--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -16,7 +16,7 @@ const {set} = require('../../utils/ImmutableUtils');
 const {HIDE_MAPINFO_MARKER, PURGE_MAPINFO_RESULTS, purgeMapInfoResults} = require('../../actions/mapInfo');
 const {configureMap} = require('../../actions/config');
 const {CLOSE_IDENTIFY} = require('../../actions/mapInfo');
-const {editAnnotation, confirmRemoveAnnotation, saveAnnotation, cancelEditAnnotation,
+const {editAnnotation, confirmRemoveAnnotation, saveAnnotation, startDrawing, cancelEditAnnotation,
     setStyle, highlight, cleanHighlight, download, loadAnnotations, SET_STYLE, toggleStyle,
     resetCoordEditor, changeRadius, changeText, changeSelected, confirmDeleteFeature, openEditor, SHOW_ANNOTATION
 } = require('../../actions/annotations');
@@ -853,6 +853,26 @@ describe('annotations Epics', () => {
             }
         });
 
+        store.dispatch(action);
+    });
+
+    it('should safely start drawing annotation when no annotation config provided', (done) => {
+        store = mockStore({
+            annotations: {
+                editing: {
+                    features: [{}]
+                }
+            }
+        });
+
+        store.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 2) {
+                expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                done();
+            }
+        });
+        const action = startDrawing();
         store.dispatch(action);
     });
 

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -8,6 +8,7 @@
 
 const Rx = require('rxjs');
 const {saveAs} = require('file-saver');
+const {get} = require('lodash');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
 const {TOGGLE_CONTROL, toggleControl, setControlProperty} = require('../actions/controls');
 const {addLayer, updateNode, changeLayerProperties, removeLayer} = require('../actions/layers');
@@ -320,7 +321,7 @@ module.exports = (viewer) => ({
             const feature = state.annotations.editing;
             const type = state.annotations.featureType;
             const defaultTextAnnotation = state.annotations.defaultTextAnnotation;
-            const multiGeom = state.annotations.config.multiGeometry;
+            const multiGeom = get(state, 'annotations.config.multiGeometry');
             const drawOptions = {
                 featureProjection: "EPSG:4326",
                 stopAfterDrawing: !multiGeom,


### PR DESCRIPTION

## Description
It turned out the annotation plugin cannot draw on the map when
the default configuration is not provided. This commit fix and allow
annotation to work well without default config.

## Issues
 - #3852 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3852 

**What is the new behavior?**
see the description section above

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
