### PR TITLE
fix #4079 units dropdown is not fully visible in measure tool

### DIFF
--- a/web/client/components/layout/BorderLayout.jsx
+++ b/web/client/components/layout/BorderLayout.jsx
@@ -19,13 +19,14 @@ const React = require('react');
  *  /></BorderLayout>
  *
  */
-module.exports = ({id, children, header, footer, columns, height, className, bodyClassName = "ms2-border-layout-body"}) =>
+module.exports = ({id, children, header, footer, columns, height, style={}, className, bodyClassName = "ms2-border-layout-body"}) =>
     (<div id={id} className={className} style={{
         display: "flex",
         flexDirection: "column",
         width: "100%",
         height: "100%",
-        overflow: "hidden"
+        overflow: "hidden",
+        ...style
         }}>
         {header}
         <div className={bodyClassName} style={{

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -256,6 +256,7 @@ class MeasureComponent extends React.Component {
         return (
            <BorderLayout
                id={this.props.id}
+               style={{overflow: 'visible'}}
                header={
                    <div>
                        <ButtonToolbar style={{width: '100%', marginBottom: 15, marginTop: 8, display: 'flex', justifyContent: 'center'}}>


### PR DESCRIPTION
## Description
It turned out that the unit dropdown options in measure dialog gets
hidden behind the dialog and prevent user to select. This commit
fix and make the dropdown options visible and selectable.

Note:
This commits also change the border layout by allowing it to accept
style to override the default border inline style.

## Issues
 - #<issue>
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4079 

**What is the new behavior?**
unit dropdown become visible and selectable

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
