### PR TITLE
Fix #4055 ZoomToMaxExtentButton switching CRS

### DIFF
--- a/web/client/components/buttons/ZoomToMaxExtentButton.jsx
+++ b/web/client/components/buttons/ZoomToMaxExtentButton.jsx
@@ -120,7 +120,7 @@ class ZoomToMaxExtentButton extends React.Component {
         // zooming to the initial extent based on initial map configuration
         var mapConfig = this.props.mapInitialConfig;
         let bbox = mapUtils.getBbox(mapConfig.center, mapConfig.zoom, this.props.mapConfig.size);
-        this.props.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, mapConfig.projection);
+        this.props.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, this.props.mapConfig.projection);
     };
 }
 

--- a/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
@@ -194,7 +194,8 @@ describe('This test for ZoomToMaxExtentButton', () => {
             expect(actionsSpy.calls[0].arguments[2]).toNotExist();
             expect(actionsSpy.calls[0].arguments[3]).toExist();
             expect(actionsSpy.calls[0].arguments[4]).toNotExist();
-            expect(actionsSpy.calls[0].arguments[5]).toExist();
+            // the projection is null since no hook was registered
+            expect(actionsSpy.calls[0].arguments[5]).toNotExist();
         };
 
         genericTest("normal");


### PR DESCRIPTION
## Description
Fix to issue #4055 where the ZoomToMaxExtent Button would switch the CRS back to the mapInitialConfig's CRS.

## Issues
 - #4055 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (#4055 )
Changing the CRS using the CRSSelector and then zooming to max extent using the ZoomToMaxExtent Button returns the user to the original CRS.

**What is the new behavior?**
After changing the CRS using the CRSSelector and then zooming to max extent using the ZoomToMaxExtent Button, the user stays in the latter CRS.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
The issue was that in the zoomToInitialExtent function, the call to the changeMapView function was using the mapInitialConfig's projection instead of using the current mapConfig's projection.

