### PR TITLE
Fix #3930 short height of query panel filter when opened in dashboard

### DIFF
--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -26,6 +26,7 @@ const {toggleControl} = require('../actions/controls');
 
 const {groupsSelector, selectedLayerLoadingErrorSelector} = require('../selectors/layers');
 const {mapSelector} = require('../selectors/map');
+const {isDashboardAvailable} = require('../selectors/dashboard');
 const {
     crossLayerFilterSelector,
     availableCrossLayerFilterLayersSelector,
@@ -179,16 +180,17 @@ const tocSelector = createSelector(
         (state) => state.layers && state.layers.settings || {expanded: false, options: {opacity: 1}},
         (state) => state.controls && state.controls.queryPanel && state.controls.queryPanel.enabled || false,
         state => mapLayoutValuesSelector(state, {height: true}),
+        isDashboardAvailable,
         appliedFilterSelector,
         storedFilterSelector,
         (state) => state && state.query && state.query.isLayerFilter,
         selectedLayerLoadingErrorSelector
-    ], (enabled, groups, settings, querypanelEnabled, layout, appliedFilter, storedFilter, advancedToolbar, loadingError) => ({
+    ], (enabled, groups, settings, querypanelEnabled, layoutHeight, dashboardAvailable, appliedFilter, storedFilter, advancedToolbar, loadingError) => ({
         enabled,
         groups,
         settings,
         querypanelEnabled,
-        layout,
+        layout: !dashboardAvailable ? layoutHeight : {},
         appliedFilter,
         storedFilter,
         advancedToolbar,


### PR DESCRIPTION
## Description
Fix the query panel height when opened in dashboard context

## Issues
 - #3930 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3930 

**What is the new behavior?**
<img width="743" alt="Screenshot 2019-08-23 at 15 07 33" src="https://user-images.githubusercontent.com/1956062/63592184-a89d1800-c5b9-11e9-90ed-3616d14213be.png">


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
