### PR TITLE
Fix #4009 wms records and improved error handling

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -19,7 +19,7 @@ To dispatch additional actions when the map viewer is started, the **actions** q
   "initialActionsWhiteList": ["ZOOM_TO_EXTENT", "ADD_LAYER", ...]
 ```
 
-The value of this paramater is a JSON string containing an array with an object per action. The structure of the object consist of a property type and a bunch of other properties depending on the action.
+The value of this parameter is a JSON string containing an array with an object per action. The structure of the object consist of a property type and a bunch of other properties depending on the action.
 
 ### Available actions
 Only the following actions can be used in the **actions** json string.
@@ -78,18 +78,18 @@ For more details check out the [searchLayerWithFilter](https://mapstore2.geo-sol
 
 #### Add Layers
 
-This action allows to add layers from catalog present in the map
+This action allows to add layers directly to the map by taking them from the Catalogs
 
 Requirements:
-- the number of values must be even
-- catalog name must be present in the map
 
+- The number of layers should match the number of sources
+- The source name must match a catalog service name present in the map
 
 Example:
 ```
 {
     "type": "CATALOG:ADD_LAYERS_FROM_CATALOGS",
-    "layers": ["layer1", "layer2"],
+    "layers": ["workspace1:layer1", "workspace2:layer2"],
     "sources": ["catalog1", "catalog2"]
 }
 ?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["layer1", "layer2"],"sources":["catalog1", "catalog2"]}]

--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -21,9 +21,11 @@ const {
     changeUrl, CHANGE_URL, changeType, CHANGE_TYPE, addService, ADD_SERVICE, addCatalogService, ADD_CATALOG_SERVICE, resetCatalog, RESET_CATALOG,
     changeAutoload, CHANGE_AUTOLOAD, deleteCatalogService, DELETE_CATALOG_SERVICE, deleteService, DELETE_SERVICE, savingService,
     SAVING_SERVICE, DESCRIBE_ERROR, initCatalog, CATALOG_INITED, changeText, CHANGE_TEXT,
-    TOGGLE_ADVANCED_SETTINGS, toggleAdvancedSettings, TOGGLE_THUMBNAIL, toggleThumbnail, TOGGLE_TEMPLATE, toggleTemplate, CHANGE_METADATA_TEMPLATE, changeMetadataTemplate, SET_LOADING
+    TOGGLE_ADVANCED_SETTINGS, toggleAdvancedSettings, TOGGLE_THUMBNAIL, toggleThumbnail, TOGGLE_TEMPLATE, toggleTemplate, CHANGE_METADATA_TEMPLATE, changeMetadataTemplate, SET_LOADING,
+    recordsNotFound
 } = require('../catalog');
 const {CHANGE_LAYER_PROPERTIES, ADD_LAYER} = require('../layers');
+const {SHOW_NOTIFICATION} = require('../notifications');
 describe('Test correctness of the catalog actions', () => {
 
     it('addLayersMapViewerUrl', () => {
@@ -294,5 +296,11 @@ describe('Test correctness of the catalog actions', () => {
         const action = changeMetadataTemplate("${title}");
         expect(action.type).toBe(CHANGE_METADATA_TEMPLATE);
         expect(action.metadataTemplate).toBe("${title}");
+    });
+    it('test recordsNotFound action', () => {
+        const action = recordsNotFound("topp:states , topp:states-tasmania");
+        expect(action.type).toBe(SHOW_NOTIFICATION);
+        expect(action.message).toBe("catalog.notification.errorSearchingRecords");
+        expect(action.values).toEqual({records: "topp:states , topp:states-tasmania"});
     });
 });

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -22,6 +22,7 @@ import * as ConfigUtils from '../utils/ConfigUtils';
 import {find} from 'lodash';
 import {authkeyParamNameSelector} from '../selectors/catalog';
 
+
 export const ADD_LAYERS_FROM_CATALOGS = 'CATALOG:ADD_LAYERS_FROM_CATALOGS';
 export const TEXT_SEARCH = 'CATALOG:TEXT_SEARCH';
 export const RECORD_LIST_LOADED = 'CATALOG:RECORD_LIST_LOADED';
@@ -281,3 +282,13 @@ export const changeMetadataTemplate = (metadataTemplate) => ({type: CHANGE_METAD
 export const toggleAdvancedSettings = () => ({type: TOGGLE_ADVANCED_SETTINGS});
 export const toggleTemplate = () => ({type: TOGGLE_TEMPLATE});
 export const toggleThumbnail = () => ({type: TOGGLE_THUMBNAIL});
+
+import {error} from './notifications';
+
+export function recordsNotFound(records = "") {
+    return error({
+        title: "catalog.notification.errorTitle",
+        message: "catalog.notification.errorSearchingRecords",
+        values: {records}
+    });
+}

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -107,7 +107,7 @@ module.exports = (API) => ({
                         const {type: format, url} = services[sources[i]];
                         const text = layers[i];
                         return Rx.Observable.defer( () =>
-                            API[format].textSearch(url, startPosition, maxRecords, text, addLayerOptions).catch((e) => ({results: []}))
+                            API[format].textSearch(url, startPosition, maxRecords, text, addLayerOptions).catch(() => ({results: []}))
                         ).map(r => ({...r, format, url, text}));
                     });
                 return Rx.Observable.forkJoin(actions)

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -7,7 +7,7 @@
 */
 
 import * as Rx from 'rxjs';
-import {head, isArray} from 'lodash';
+import {head, isArray, isString, isObject} from 'lodash';
 import {
     ADD_SERVICE,
     ADD_LAYERS_FROM_CATALOGS,
@@ -18,6 +18,7 @@ import {
     addCatalogService,
     setLoading,
     deleteCatalogService,
+    recordsNotFound,
     recordsLoaded,
     recordsLoadError,
     savingService,
@@ -94,7 +95,9 @@ module.exports = (API) => ({
     addLayersFromCatalogsEpic: (action$, store) =>
         action$.ofType(ADD_LAYERS_FROM_CATALOGS)
             .filter(({layers, sources}) => isArray(layers) && isArray(sources) && layers.length && layers.length === sources.length)
-            .switchMap(({layers, sources, options, startPosition = 1, maxRecords = 1 }) => {
+            // maxRecords is 4 (by default), but there can be a possibility that the record desired is not among
+            // the results. In that case a more detailed search with full record name can be helpful
+            .switchMap(({layers, sources, options, startPosition = 1, maxRecords = 4 }) => {
                 const state = store.getState();
                 const addLayerOptions = options || searchOptionsSelector(state);
                 const services = servicesSelector(state);
@@ -104,23 +107,17 @@ module.exports = (API) => ({
                         const {type: format, url} = services[sources[i]];
                         const text = layers[i];
                         return Rx.Observable.defer( () =>
-                            API[format].textSearch(url, startPosition, maxRecords, text, addLayerOptions)
-                        ).map(r => ({...r, format, url}));
+                            API[format].textSearch(url, startPosition, maxRecords, text, addLayerOptions).catch((e) => ({results: []}))
+                        ).map(r => ({...r, format, url, text}));
                     });
                 return Rx.Observable.forkJoin(actions)
                     .switchMap((results) => {
                         if (isArray(results) && results.length) {
-                            return Rx.Observable.from(results.filter(r => {
-                                // filter results with no records
-                                const {format, url, ...result} = r;
+                            return Rx.Observable.of(results.map(r => {
+                                const {format, url, text, ...result} = r;
                                 const locales = currentMessagesSelector(state);
                                 const records = getCatalogRecords(format, result, addLayerOptions, locales) || [];
-                                return records && records.length >= 1;
-                            }).map(r => {
-                                const {format, url, ...result} = r;
-                                const locales = currentMessagesSelector(state);
-                                const records = getCatalogRecords(format, result, addLayerOptions, locales) || [];
-                                const record = head(records);
+                                const record = head(records.filter(rec => rec.identifier === text)); // exact match of text and record identifier
                                 const {wms, wmts} = extractOGCServicesReferences(record);
                                 let layer = {};
                                 const layerBaseConfig = {}; // DO WE NEED TO FETCH IT FROM STATE???
@@ -133,7 +130,7 @@ module.exports = (API) => ({
                                     }
                                     layer = recordToLayer(record, "wms", {
                                         removeParams: authkeyParamName,
-                                        catalogURL: format === 'csw' && url ? url + "?request=GetRecordById&service=CSW&version=2.0.2&elementSetName=full&id=" + record.identifier : null
+                                        catalogURL: format === 'csw' && url ? url + "?request=GetRecordById&service=CSW&version=2.0.2&elementSetName=full&id=" + record.identifier : url
                                     }, layerBaseConfig);
                                 } else if (wmts) {
                                     layer = {};
@@ -151,12 +148,30 @@ module.exports = (API) => ({
                                         layer = esriToLayer(record, layerBaseConfig);
                                     }
                                 }
-                                return addLayer(layer);
+                                if (!record) {
+                                    return text;
+                                }
+                                return layer;
                             }));
                         }
                         return Rx.Observable.empty();
                     });
-            }).catch( () => {
+            })
+            .mergeMap(results => {
+                if (results) {
+                    const allRecordsNotFound = results.filter(r => isString(r)).join(" ");
+                    let actions = [];
+                    if (allRecordsNotFound) {
+                        // return one notification for all records that have not been found
+                        actions = [recordsNotFound(allRecordsNotFound)];
+                    }
+                    // add all layers found to the map
+                    actions = [...actions, ...results.filter(r => isObject(r)).map(r => addLayer(r))];
+                    return Rx.Observable.from(actions);
+                }
+                return Rx.Observable.empty();
+            })
+            .catch( () => {
                 return Rx.Observable.empty();
             }),
     /**

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1138,6 +1138,8 @@
             "advancedSettings": "Erweiterte Einstellungen",
             "templateMetadataAvailable": "Metadaten im Dublin Core-Format verfügbar: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Einige Datensätze wurden nicht gefunden: {records} . Bitte überprüfen Sie die URL des Abfrageparameters",
                 "warningAddCatalogService": "Geben Sie eine gültige URL und einen Titel ein",
                 "addCatalogService": "Service wurde korrekt hinzugefügt",
                 "duplicatedServiceTitle": "Ein Service mit diesem Titel existiert bereits, bitte ändere den Titel",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1139,6 +1139,8 @@
             "advancedSettings": "Advanced settings",
             "templateMetadataAvailable": "Metadata available from Dublin Core format: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Some records have not been found: {records} Please check the query param url",
                 "warningAddCatalogService": "Insert a valid url and title",
                 "addCatalogService": "Service added correctly",
                 "duplicatedServiceTitle": "A service with that title already exists. Please, change title",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1138,6 +1138,8 @@
             "advancedSettings": "Ajustes avanzados",
             "templateMetadataAvailable": "Metadatos disponibles en formato Dublin Core: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "No se han encontrado algunos registros: {records} . Por favor revise la consulta param url",
                 "warningAddCatalogService": "Introduzca una url y un título válidos",
                 "addCatalogService": "Servicio añadido correctamente",
                 "duplicatedServiceTitle": "Ya existe un servicio con ese título, Por favor, cambie el título",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1138,6 +1138,8 @@
             "advancedSettings": "Réglages avancés",
             "templateMetadataAvailable": "Métadonnées disponibles au format Dublin Core: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Erreur",
+                "errorSearchingRecords": "Certains enregistrements n'ont pas été trouvés: {records} . S'il vous plaît vérifier la requête param url",
                 "warningAddCatalogService": "Insérer une URL et un titre valides",
                 "addCatalogService": "Service ajouté correctement",
                 "duplicatedServiceTitle": "Un service avec ce titre existe déjà, veuillez modifier le titre",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1139,6 +1139,8 @@
             "advancedSettings": "Napredne mogućnosti",
             "templateMetadataAvailable": "Metapodaci distupni iz Dublin Core formata: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Some records have not been found: {records} Please check the query param url",
                 "warningAddCatalogService": "Unesi ispravni url i naslov",
                 "addCatalogService": "Servis je dodan ispravno",
                 "duplicatedServiceTitle": "Servis sa tim naslovom već postoji. Molim, promijenite naslov",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1138,6 +1138,8 @@
             "advancedSettings": "Impostazioni avanzante",
             "templateMetadataAvailable": "Metadati disponibili del formato Dublin Core: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Errore",
+                "errorSearchingRecords": "Alcuni record non sono stati trovati: {records} . Controlla la lista dei parametri nella barra degli indirizzi",
                 "warningAddCatalogService": "Inserisci un url e titolo validi.",
                 "addCatalogService": "Servizio aggiunto corretamente.",
                 "duplicatedServiceTitle": "Un servizio con quel titolo esiste già, Per favore cambia titolo",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1062,7 +1062,16 @@
             "showTemplate": "Show metadata template",
             "showPreview": "Show preview",
             "advancedSettings": "Advanced Settings",
-            "templateMetadataAvailable": "Metadata available from Dublin Core format: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri"
+            "templateMetadataAvailable": "Metadata available from Dublin Core format: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Some records have not been found: {records} Please check the query param url",
+                "warningAddCatalogService": "Insert a valid url and title",
+                "addCatalogService": "Service added correctly",
+                "duplicatedServiceTitle": "A service with that title already exists. Please, change title",
+                "serviceDeletedCorrectly": "The service was deleted correctly",
+                "errorServiceUrl": "Service not available. Please, check the provided url"
+            }
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -1115,6 +1115,8 @@
             "advancedSettings": "Advanced Settings",
             "templateMetadataAvailable": "Metadata available from Dublin Core format: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Some records have not been found: {records} Please check the query param url",
                 "warningAddCatalogService": "Insert a valid url and title",
                 "addCatalogService": "Service added correctly",
                 "duplicatedServiceTitle": "A service with that title already exists. Please, change title",

--- a/web/client/translations/data.vi-VN
+++ b/web/client/translations/data.vi-VN
@@ -144,6 +144,8 @@
             "noResultsText": "Không có kết quả",
             "notAvailable": "Không có sẵn",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Some records have not been found: {records} Please check the query param url",
                 "addCatalogService": "Dịch vụ được thêm chính xác",
                 "duplicatedServiceTitle": "Một dịch vụ với tiêu đề đó đã tồn tại. Xin vui lòng đổi tiêu đề",
                 "errorServiceUrl": "Dịch vụ không có sẵn. Vui lòng kiểm tra URL được cung cấp",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1091,6 +1091,8 @@
             "advancedSettings": "Advanced Settings",
             "templateMetadataAvailable": "Metadata available from Dublin Core format: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
             "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Some records have not been found: {records} Please check the query param url",
                 "warningAddCatalogService": "Insert a valid url and title",
                 "addCatalogService": "Service added correctly",
                 "duplicatedServiceTitle": "A service with that title already exists. Please, change title",

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -414,11 +414,11 @@ const CatalogUtils = {
         const urls = ogcServiceReference.url;
 
         // extract additional parameters and alternative URLs.
-        if (isArray(urls)) {
+        if (urls && isArray(urls)) {
             originalUrl = urls.map( u => cleanURL(u)).map( ({url: u}) => u);
             params = urls.map(u => cleanURL(u)).map(({params: p}) => p).reduce( (prev, cur) => ({...prev, ...cur}), {});
         } else {
-            const { url: uu, params: pp } = cleanURL(urls);
+            const { url: uu, params: pp } = cleanURL(urls || catalogURL);
             originalUrl = uu;
             params = pp;
         }

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -98,6 +98,23 @@ describe('Test the CatalogUtils', () => {
         expect(layer.allowedSRS['EPSG:5041']).toNotExist();
     });
 
+    it('wms with no ogcServiceReference.url', () => {
+        const records = CatalogUtils.getCatalogRecords(
+            'wms',
+            {
+                records: [{
+                    SRS: ['EPSG:4326', 'EPSG:3857', 'EPSG:5041']
+                }]
+            }, {
+                url: undefined
+            });
+        expect(records.length).toBe(1);
+        const sampleUrl = "http://sample";
+        const layer = CatalogUtils.recordToLayer(records[0], "wms", {catalogURL: sampleUrl});
+
+        expect(layer.url).toBe(sampleUrl);
+    });
+
     it('wmts', () => {
         const records = CatalogUtils.getCatalogRecords('wmts', {
             records: [{}]


### PR DESCRIPTION
## Description
This pr fixes the wms records and improves error handling for not found layers

## Issues
 - #4009 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
trying this [url](https://dev.mapstore2.geo-solutions.it/mapstore/#/viewer/openlayers/4093?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["topp:states",%20"tiger:poi"],"sources":["Demo%20WMS%20Service",%20"Demo%20CSW%20Service"]}]), it is not adding anything to the map

**What is the new behavior?**
it should add all found layers

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
also rewrote a bit the dev documentation

@allyoucanmap the mergeMap to the end of the epic is needed to catch all records and dispatch 
- add layer action for the ones that have been found 
- one error notification for all the records not found