### PR TITLE
Fix #4036 FilterLayer and attribute button are visible in TOC toolbar on Mobile

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -165,7 +165,9 @@
                 "cfg": {
                     "activateMetedataTool": false,
                     "activateMapTitle": false,
-                    "activateSortLayer": false
+                    "activateSortLayer": false,
+                    "activateLayerFilterTool": false,
+                    "activateQueryTool": false
                 }
             }, "AddGroup", {
                 "name": "TOCItemsSettings",


### PR DESCRIPTION
## Description
This PR hides FilterLayer and attribute button from TOC in mobile context

## Issues
#4036 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix


**What is the current behavior?** (You can also link to an open issue here)
[issue](https://github.com/geosolutions-it/MapStore2/issues/4036)

**What is the new behavior?**
FilterLayer and attribute button are hidden from TOC in mobile context

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
