### PR TITLE
Fix 3814 single_layer option for launchInfoPanel and highlight features

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -94,15 +94,17 @@ describe('Test correctness of the map actions', () => {
         const point = {latlng: {lat: 1, lng: 3}};
         const layer = {id: "layer.1"};
         const filterNameList = [];
+        const itemId = "itemId";
         const overrideParams = {cql_filter: "ID_ORIG=1234"};
 
-        const action = featureInfoClick(point, layer, filterNameList, overrideParams);
+        const action = featureInfoClick(point, layer, filterNameList, overrideParams, itemId);
         expect(action).toExist();
         expect(action.type).toBe(FEATURE_INFO_CLICK);
         expect(action.point).toBe(point);
         expect(action.layer).toBe(layer);
         expect(action.filterNameList).toBe(filterNameList);
         expect(action.overrideParams).toBe(overrideParams);
+        expect(action.itemId).toBe(itemId);
     });
     it('reset reverse geocode data', () => {
         const e = hideMapinfoRevGeocode();

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -192,14 +192,16 @@ function updateCenterToMarker(status) {
  * @param {string} layer the name of the layer without workspace
  * @param {object[]} [filterNameList=[]] list of layers to perform the GFI request
  * @param {object} [overrideParams={}] a map based on name as key and objec as value for overriding request params
+ * @param {string} [itemId=null] id of the item needed for filtering results
  */
-function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}) {
+function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}, itemId = null) {
     return {
         type: FEATURE_INFO_CLICK,
         point,
         layer,
         filterNameList,
-        overrideParams
+        overrideParams,
+        itemId
     };
 }
 

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -113,17 +113,25 @@ module.exports = props => {
                             <Col key="tools" xs={12}>
                                 <Toolbar
                                     btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
-                                    buttons={toolButtons}/>
+                                    buttons={toolButtons}
+                                    transitionProps={null
+                                        /* transitions was causing a bad rendering of toolbar present in the identify panel
+                                         * for this reason they ahve been disabled
+                                        */
+                                      }/>
                             </Col>
                         <div key="navigation" style={{
                                 zIndex: 1,
                                 position: "absolute",
                                 right: 0,
+                                top: 0,
                                 margin: "0 10px"
                             }}>
                                 <Toolbar
                                     btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
-                                    buttons={getNavigationButtons(props)} />
+                                    buttons={getNavigationButtons(props)}
+                                    transitionProps={null /* same here */}
+                                     />
                         </div>
                     </Row>
                 ].filter(headRow => headRow)}>

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -139,7 +139,7 @@ describe('identify Epics', () => {
                 }]
             }
         };
-        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }, "TEST", ["TEST"], {"TEST": {cql_filter: "id>1"}})];
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }, "TEST", ["TEST"], {"TEST": {cql_filter: "id>1"}}, "province_view.5")];
         testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
             try {
                 expect(a0).toExist();
@@ -153,6 +153,8 @@ describe('identify Epics', () => {
                 expect(a2).toExist();
                 expect(a2.type).toBe(LOAD_FEATURE_INFO);
                 expect(a2.data).toExist();
+                expect(a2.data.features).toExist();
+                expect(a2.data.features.length).toBe(1);
                 expect(a2.requestParams).toExist();
                 expect(a2.reqId).toExist();
                 expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
@@ -160,7 +162,10 @@ describe('identify Epics', () => {
             } catch (ex) {
                 done(ex);
             }
-        }, state);
+        }, {...state, mapInfo: {
+            ...state.mapInfo,
+            itemId: "province_view.5"
+        }});
     });
     it('getFeatureInfoOnFeatureInfoClick with multiSelection', (done) => {
         // remove previous hook

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -170,6 +170,7 @@ describe('search Epics', () => {
 
     it('produces the selectSearchItem epic and GFI for for single layer', () => {
         let action = selectSearchItem({
+            "id": "Feature_1",
             "type": "Feature",
             "bbox": [125, 10, 126, 11],
             "geometry": {
@@ -199,7 +200,9 @@ describe('search Epics', () => {
         expect(actions.length).toBe(4);
         expect(actions[1].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
         expect(actions[2].type).toBe(FEATURE_INFO_CLICK);
+        expect(actions[2].itemId).toEqual("Feature_1");
         expect(actions[2].filterNameList).toEqual(["gs:layername"]);
+        expect(actions[2].overrideParams).toEqual({"gs:layername": {info_format: "application/json"}});
         expect(actions[3].type).toBe(SHOW_MAPINFO_MARKER);
     });
 

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -7,14 +7,19 @@
 */
 const Rx = require('rxjs');
 
-const {get, find, isString} = require('lodash');
+const {get, find, isString, isNil} = require('lodash');
 const axios = require('../libs/ajax');
 
 const uuid = require('uuid');
 
-const { LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO, FEATURE_INFO_CLICK, CLOSE_IDENTIFY, TOGGLE_HIGHLIGHT_FEATURE, featureInfoClick, updateCenterToMarker, purgeMapInfoResults,
-
-    exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo, noQueryableLayers, newMapInfoRequest, getVectorInfo, showMapinfoMarker, hideMapinfoMarker } = require('../actions/mapInfo');
+const {
+    LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO,
+    FEATURE_INFO_CLICK, CLOSE_IDENTIFY, TOGGLE_HIGHLIGHT_FEATURE,
+    featureInfoClick, updateCenterToMarker, purgeMapInfoResults,
+    exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo,
+    noQueryableLayers, newMapInfoRequest, getVectorInfo,
+    showMapinfoMarker, hideMapinfoMarker
+} = require('../actions/mapInfo');
 
 const { SET_CONTROL_PROPERTIES } = require('../actions/controls');
 
@@ -60,7 +65,7 @@ const getFeatureInfo = (basePath, requestParams, lMetaData, appParams = {}, atta
                         .catch(() => Rx.Observable.of({})) // errors on geometry retrieval are ignored
                 ).map(([response, data ]) => ({
                     ...response,
-                    features: data && data.features && data.features.filter(f => itemId ? f.id === itemId : true),
+                    features: data && data.features && data.features.filter(f => !isNil(itemId) ? f.id === itemId : true),
                     featuresCrs: data && data.crs && parseURN(data.crs)
                 }))
             // simply get the feature info, geometry is already there

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -7,7 +7,7 @@
 */
 const Rx = require('rxjs');
 
-const {get, find} = require('lodash');
+const {get, find, isString} = require('lodash');
 const axios = require('../libs/ajax');
 
 const uuid = require('uuid');
@@ -30,7 +30,7 @@ const { mapSelector, projectionDefsSelector, projectionSelector } = require('../
 const { boundingMapRectSelector } = require('../selectors/maplayout');
 const { centerToVisibleArea, isInsideVisibleArea, isPointInsideExtent, reprojectBbox } = require('../utils/CoordinatesUtils');
 
-const { isHighlightEnabledSelector } = require('../selectors/mapInfo');
+const { isHighlightEnabledSelector, itemIdSelector, overrideParamsSelector, filterNameListSelector } = require('../selectors/mapInfo');
 
 const { getCurrentResolution, parseLayoutValue } = require('../utils/MapUtils');
 const MapInfoUtils = require('../utils/MapInfoUtils');
@@ -46,7 +46,7 @@ const stopFeatureInfo = state => stopGetFeatureInfoSelector(state) || gridEditin
  * @param basePath {string} base path to the service
  * @param requestParams {object} map of params for a getfeatureinfo request.
  */
-const getFeatureInfo = (basePath, requestParams, lMetaData, appParams = {}, attachJSON) => {
+const getFeatureInfo = (basePath, requestParams, lMetaData, appParams = {}, attachJSON, itemId = null) => {
     const param = { ...appParams, ...requestParams };
     const reqId = uuid.v1();
     const retrieveFlow = (params) => Rx.Observable.defer(() => axios.get(basePath, { params }));
@@ -60,15 +60,18 @@ const getFeatureInfo = (basePath, requestParams, lMetaData, appParams = {}, atta
                         .catch(() => Rx.Observable.of({})) // errors on geometry retrieval are ignored
                 ).map(([response, data ]) => ({
                     ...response,
-                    features: data && data.features,
+                    features: data && data.features && data.features.filter(f => itemId ? f.id === itemId : true),
                     featuresCrs: data && data.crs && parseURN(data.crs)
                 }))
             // simply get the feature info, geometry is already there
             : retrieveFlow(param)
                 .map(res => res.data)
                 .map( ( data = {} ) => ({
-                    data,
-                    features: data.features,
+                    data: isString(data) ? data : {
+                        ...data,
+                        features: data.features && data.features.filter(f => itemId ? f.id === itemId : true)
+                    },
+                    features: data.features && data.features.filter(f => itemId ? f.id === itemId : true),
                     featuresCrs: data && data.crs && parseURN(data.crs)
                 }))
         )
@@ -97,7 +100,7 @@ module.exports = {
             if (queryableLayers.length === 0) {
                 return Rx.Observable.of(purgeMapInfoResults(), noQueryableLayers());
             }
-            // TODO: make it in the application state
+            // TODO: make it in the application getState()
             const excludeParams = ["SLD_BODY"];
             const includeOptions = [
                 "buffer",
@@ -112,11 +115,14 @@ module.exports = {
                 .mergeMap(layer => {
                     let { url, request, metadata } = MapInfoUtils.buildIdentifyRequest(layer, identifyOptionsSelector(getState()));
                     // request override
+                    if (itemIdSelector(getState()) && overrideParamsSelector(getState())) {
+                        request = {...request, ...overrideParamsSelector(getState())[layer.name]};
+                    }
                     if (overrideParams[layer.name]) {
                         request = {...request, ...overrideParams[layer.name]};
                     }
                     if (url) {
-                        return getFeatureInfo(url, request, metadata, MapInfoUtils.filterRequestParams(layer, includeOptions, excludeParams), isHighlightEnabledSelector(getState()) );
+                        return getFeatureInfo(url, request, metadata, MapInfoUtils.filterRequestParams(layer, includeOptions, excludeParams), isHighlightEnabledSelector(getState()), itemIdSelector(getState()));
                     }
                     return Rx.Observable.of(getVectorInfo(layer, request, metadata));
                 });
@@ -173,7 +179,7 @@ module.exports = {
                 enabled
                 && clickPointSelector(getState())
             )
-            .switchMap( () => Rx.Observable.from([featureInfoClick(clickPointSelector(getState()), clickLayerSelector(getState())), showMapinfoMarker()])),
+            .switchMap( () => Rx.Observable.from([featureInfoClick(clickPointSelector(getState()), clickLayerSelector(getState()), filterNameListSelector(getState()), overrideParamsSelector(getState()), itemIdSelector(getState())), showMapinfoMarker()])),
     /**
      * Centers marker on visible map if it's hidden by layout
      * @param {external:Observable} action$ manages `FEATURE_INFO_CLICK` and `LOAD_FEATURE_INFO`.

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -130,8 +130,19 @@ export const searchItemSelected = action$ =>
                     const latlng = { lng: coord[0], lat: coord[1] };
                     const typeName = item.__SERVICE__.options.typeName;
                     if (coord) {
+                        let itemId = null;
+                        let filterNameList = [];
+                        let overrideParams = {};
+                        if (item.__SERVICE__.launchInfoPanel === "single_layer") {
+                            /* take info from the item selected and restrict feature info to this layer
+                             * and force info_format to application/json for allowing
+                             * filtering results later on (identify epic) */
+                            filterNameList = [typeName];
+                            itemId = item.id;
+                            overrideParams = {[item.__SERVICE__.options.typeName]: {info_format: "application/json"}};
+                        }
                         return [
-                            featureInfoClick({ latlng }, typeName, item.__SERVICE__.launchInfoPanel === "single_layer" ? [typeName] : [], { }),
+                            featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId),
                             showMapinfoMarker()
                         ];
                     }

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -202,7 +202,7 @@ class extends React.Component {
 
     static defaultProps = {
         searchOptions: {
-            services: [{type: "nominatim"}]
+            services: [{type: "nominatim", priority: 5}]
         },
         isSearchClickable: false,
         splitTools: true,

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -203,6 +203,18 @@ describe('Test the mapInfo reducer', () => {
         state = mapInfo({ clickPoint: 'oldP' }, featureInfoClick("p"));
         expect(state.clickPoint).toExist();
         expect(state.clickPoint).toBe('p');
+
+        const overrideParams = {"ws:layername": {info_format: "application/json"}};
+        const filterNameList = ["ws:layername"];
+        const layer = {};
+        const itemId = "ws:layername_1";
+        state = mapInfo({ clickPoint: 'oldP' }, featureInfoClick("p", layer, filterNameList, overrideParams, itemId ));
+        expect(state.clickPoint).toExist();
+        expect(state.clickPoint).toEqual('p');
+        expect(state.clickLayer).toEqual(layer);
+        expect(state.filterNameList).toEqual(filterNameList);
+        expect(state.overrideParams).toEqual(overrideParams);
+        expect(state.itemId).toEqual(itemId);
     });
 
     it('enables map info', () => {

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -220,7 +220,10 @@ function mapInfo(state = initState, action) {
     case FEATURE_INFO_CLICK: {
         return assign({}, state, {
             clickPoint: action.point,
-            clickLayer: action.layer || null
+            clickLayer: action.layer || null,
+            itemId: action.itemId || null,
+            overrideParams: action.overrideParams || null,
+            filterNameList: action.filterNameList || null
         });
     }
     case CHANGE_MAPINFO_FORMAT: {

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -18,7 +18,10 @@ const {
     showEmptyMessageGFISelector,
     clickPointSelector,
     clickedPointWithFeaturesSelector,
-    highlightStyleSelector
+    highlightStyleSelector,
+    itemIdSelector,
+    filterNameListSelector,
+    overrideParamsSelector
 } = require('../mapInfo');
 
 const QUERY_PARAMS = {
@@ -257,6 +260,21 @@ describe('Test mapinfo selectors', () => {
                 highlightStyle: TEST
             }
         })).toBe(TEST);
+    });
+    it('test clickPointSelector', () => {
+        expect(clickPointSelector(RESPONSE_STATE)).toBe(RESPONSE_STATE.mapInfo.clickPoint);
+    });
+    it('test itemIdSelector', () => {
+        const itemId = "itemId";
+        expect(itemIdSelector({mapInfo: {...RESPONSE_STATE, itemId}})).toBe(itemId);
+    });
+    it('test filterNameListSelector', () => {
+        const filterNameList = ["layer"];
+        expect(filterNameListSelector({mapInfo: {...RESPONSE_STATE, filterNameList}})).toEqual(filterNameList);
+    });
+    it('test overrideParamsSelector', () => {
+        const overrideParams = {"ws:layername": {info_format: "application/json"}};
+        expect(overrideParamsSelector({mapInfo: {...RESPONSE_STATE, overrideParams}})).toEqual(overrideParams);
     });
     it('test clickPointSelector', () => {
         expect(clickPointSelector(RESPONSE_STATE)).toBe(RESPONSE_STATE.mapInfo.clickPoint);

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -51,7 +51,9 @@ const measureActiveSelector = (state) => get(state, "controls.measure.enabled") 
 const clickPointSelector = state => state && state.mapInfo && state.mapInfo.clickPoint;
 const clickLayerSelector = state => state && state.mapInfo && state.mapInfo.clickLayer;
 const showMarkerSelector = state => state && state.mapInfo && state.mapInfo.showMarker;
-
+const itemIdSelector = state => get(state, "mapInfo.itemId", null);
+const overrideParamsSelector = state => get(state, "mapInfo.overrideParams", {});
+const filterNameListSelector = state => get(state, "mapInfo.filterNameList", []);
 const drawSupportActiveSelector = (state) => {
     const drawStatus = get(state, "draw.drawStatus", false);
     return drawStatus && drawStatus !== 'clean' && drawStatus !== 'stop';
@@ -190,5 +192,8 @@ module.exports = {
     stopGetFeatureInfoSelector,
     showEmptyMessageGFISelector,
     mapInfoConfigurationSelector,
-    isHighlightEnabledSelector
+    isHighlightEnabledSelector,
+    itemIdSelector,
+    overrideParamsSelector,
+    filterNameListSelector
 };

--- a/web/client/test-resources/featureInfo-response.json
+++ b/web/client/test-resources/featureInfo-response.json
@@ -44446,6 +44446,43 @@
                 "fname": "Balochistan",
                 "capital": "Quetta"
             }
+        },
+        {
+          "type": "Feature",
+          "id": "province_view.2",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    579401.6538179666,
+                    3547217.229597207
+                  ],
+                  [
+                    579441.0566179641,
+                    3547123.3253972046
+                  ],
+                  [
+                    579424.7444179673,
+                    3547039.3331972044
+                  ],
+                  [
+                    579401.6538179666,
+                    3547217.229597207
+                  ]
+                ]
+              ]
+          ]},
+          "geometry_name": "the_geom",
+          "properties": {
+              "province": "BALdOCHISTAN",
+              "pop": 6961556,
+              "area_km2": 347394,
+              "dens_km2": 20.04,
+              "fname": "Balochdistan",
+              "capital": "Quetdta"
+          }
         }
     ],
     "crs": {


### PR DESCRIPTION
## Description
This PR adds some improvements for launchInfoPanel configure in WFS services.

## Issues
 - #3814

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
- try to open [this](https://dev.mapstore2.geo-solutions.it/mapstore/#/viewer/openlayers/10638) map
- search new jersey in the search bar
- click on new jersey result
- two results are returned with text/plain info_format
- click highlight 

**What is the new behavior?**
one result is returned which corresponds to the imte clicked in application/json info_format
highlight returns always one result when the search has been triggered by item fetched by this service with single layer option

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
some info regarding feature info click have been stored in the state since they are used across multiple epics (search, identify) only when single_layer is used as launchInfoPanel property for WFS services

here the visual bug that has been fixed
![issue_3814_issue_toolbar identify](https://user-images.githubusercontent.com/11991428/63863691-ee3d5480-c9ae-11e9-94d8-50395251968e.gif)
