### PR TITLE
Fix #3963 Some further improvements to Y axis in charts

### DIFF
--- a/web/client/components/charts/Line.jsx
+++ b/web/client/components/charts/Line.jsx
@@ -67,7 +67,7 @@ class LineChartWrapper extends React.Component {
                 margin={props.xAxisAngle ? {
                     top: 20,
                     right: 30,
-                    left: marginLeft,
+                    left: marginLeft + 5,
                     bottom: marginBottom + 20
                 } : margin }
             >

--- a/web/client/components/charts/__tests__/YAxisLabel-test.js
+++ b/web/client/components/charts/__tests__/YAxisLabel-test.js
@@ -42,7 +42,7 @@ describe('YAxisLabel component', () => {
         const container = document.getElementById('container');
         const text = container.querySelector('text');
         expect(text).toExist();
-        expect(text.innerText).toBe("1234");
+        expect(text.innerText).toBe("1.2 K");
     });
 
     it('YAxisLabel rendering with a string as label', () => {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -19,6 +19,7 @@
     "ignoreMobileCss": false,
     "useAuthenticationRules": true,
     "loadAfterTheme": true,
+    "shortenLabelThreshold": 1000,
     "defaultMapOptions": {
       "cesium": {
           "flyTo": true,

--- a/web/client/utils/WidgetsUtils.js
+++ b/web/client/utils/WidgetsUtils.js
@@ -10,6 +10,7 @@ const { get, find, isNumber, round} = require('lodash');
 const {WIDGETS_REGEX} = require('../actions/widgets');
 const { findGroups } = require('./GraphUtils');
 const { sameToneRangeColors } = require('./ColorUtils');
+const ConfigUtils = require('./ConfigUtils');
 
 const getDependentWidget = (k, widgets) => {
     const [match, id] = WIDGETS_REGEX.exec(k);
@@ -47,14 +48,14 @@ const getConnectionList = (widgets = []) => {
 };
 
 /**
- * it checks if a number is higher of 10k and it returns a shortened version of it
+ * it checks if a number is higher than threshold and returns a shortened version of it
  * @param {number} label to parse
  * @param {number} threshold threshold to check if it needs to be rounded
  * @param {number} decimals number of decimal to use when rounding
  * @return the shortened number plus a suffix or the label is a string is passed
 */
-const shortenLabel = (label, threshold = 10000, decimals = 1)=> {
-    if (!isNumber(label) || isNumber(label) && label.toString().length < 7) {
+const shortenLabel = (label, threshold = (ConfigUtils.getConfigProp('shortenLabelThreshold') || 1000), decimals = 1) => {
+    if (!isNumber(label)) {
         return label;
     }
     let unit;

--- a/web/client/utils/__tests__/WidgetsUtils-test.js
+++ b/web/client/utils/__tests__/WidgetsUtils-test.js
@@ -9,6 +9,7 @@
 const expect = require('expect');
 
 const { getConnectionList, getWidgetsGroups, shortenLabel } = require('../WidgetsUtils');
+const ConfigUtils = require('../ConfigUtils');
 
 const {widgets} = require('json-loader!../../test-resources/widgets/widgets1.json');
 const { widgets: complexGraphWidgets } = require('json-loader!../../test-resources/widgets/complex_graph.json');
@@ -47,18 +48,27 @@ describe('Test WidgetsUtils', () => {
         expect(complexChartGroups[1].widgets.length).toBe(2);
     });
 
-    it('shortenLabel with 2500000000', () => {
+    it('shortenLabel with 2500000000 and threshold=1000', () => {
         const num = 2500000000;
+        ConfigUtils.setConfigProp('shortenLabelThreshold', 1000);
         const label = shortenLabel(num);
         expect(label).toEqual("2.5 B");
     });
-    it('shortenLabel with 123456789', () => {
+    it('shortenLabel with 123456789 and threshold=1000', () => {
         const num = 123456789;
+        ConfigUtils.setConfigProp('shortenLabelThreshold', 1000);
         const label = shortenLabel(num);
         expect(label).toEqual("123.5 M");
     });
-    it('shortenLabel with 2500', () => {
+    it('shortenLabel with 2500 and threshold=1000', () => {
         const num = 2500;
+        ConfigUtils.setConfigProp('shortenLabelThreshold', 1000);
+        const label = shortenLabel(num);
+        expect(label).toEqual("2.5 K");
+    });
+    it('shortenLabel with 2500 and threshold=10000', () => {
+        const num = 2500;
+        ConfigUtils.setConfigProp('shortenLabelThreshold', 10000);
         const label = shortenLabel(num);
         expect(label).toEqual(2500);
     });


### PR DESCRIPTION
## Description

* added 'shortenLabelThreshold' option to the localConfig
* shortenLabel will now get its threshold value from 'shortenLabelThreshold'
* updated tests
* added 5px margin to the left of LineChart

## Issues
 - #3963 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Improvement

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
