### PR TITLE
#4082: avoid initializing router middleware for JS API (backport to 2019.02.xx)

### DIFF
--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -189,7 +189,7 @@ const MapStore2 = {
         });
         const initialActions = [...getInitialActions(options), loadVersion.bind(null, options.versionURL)];
         const appConfig = {
-            storeOpts: assign({}, storeOpts, {notify: true}),
+            storeOpts: assign({}, storeOpts, {notify: true, noRouter: true}),
             appStore,
             pluginsDef,
             initialActions,

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -26,10 +26,7 @@ const ListenerEnhancer = require('@carnesen/redux-add-action-listener-enhancer')
 
 const {routerReducer, routerMiddleware} = require('react-router-redux');
 const routerCreateHistory = require('history/createHashHistory').default;
-const history = routerCreateHistory();
 
-// Build the middleware for intercepting and dispatching navigation actions
-const reduxRouterMiddleware = routerMiddleware(history);
 const layersEpics = require('../epics/layers');
 const controlsEpics = require('../epics/controls');
 const timeManagerEpics = require('../epics/dimension');
@@ -91,7 +88,17 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
             setTimeout(() => {storeOpts.onPersist(); }, 0);
         }
     }
-    store = DebugUtils.createDebugStore(rootReducer, defaultState, [epicMiddleware, reduxRouterMiddleware], enhancer);
+
+    let middlewares = [epicMiddleware];
+    if (!storeOpts.noRouter) {
+        const history = routerCreateHistory();
+
+        // Build the middleware for intercepting and dispatching navigation actions
+        const reduxRouterMiddleware = routerMiddleware(history);
+        middlewares = [...middlewares, reduxRouterMiddleware];
+    }
+
+    store = DebugUtils.createDebugStore(rootReducer, defaultState, middlewares, enhancer);
     if (storeOpts && storeOpts.persist) {
         const persisted = {};
         store.subscribe(() => {


### PR DESCRIPTION
## Description
avoid initializing router middleware for JS API (backport to 2019.02.xx)

## Issues
 - #4082 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
