### PR TITLE
Backporting: Fix #3439 Layer properties Fails if the Layer's has domain sharding

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -510,7 +510,8 @@ const LayersUtils = {
     */
     findGeoServerName: ({url, regexRule}) => {
         const regex = regexRule || LayersUtils.getRegGeoserverRule();
-        return regex.test(url) && url.match(regex)[0] || null;
+        const location = isArray(url) ? url[0] : url;
+        return regex.test(location) && location.match(regex)[0] || null;
     },
     /**
      * This method search for a /geoserver/  string inside the url
@@ -519,7 +520,7 @@ const LayersUtils = {
     */
     getCapabilitiesUrl: (layer) => {
         const matchedGeoServerName = LayersUtils.findGeoServerName({url: layer.url});
-        let reqUrl = layer.url;
+        let reqUrl = isArray(layer.url) ? layer.url[0] : layer.url;
         if (!!matchedGeoServerName) {
             let urlParts = reqUrl.split(matchedGeoServerName);
             if (urlParts.length === 2) {

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -741,6 +741,23 @@ describe('LayersUtils', () => {
         const matchedGeoServerNameCustomReg = LayersUtils.findGeoServerName({url: "http:/hostname/geosssearavering/ows", regex: /\/geoserver\//});
         expect(matchedGeoServerNameCustomReg).toBe(null);
     });
+    it('test findGeoServerName with array url', () => {
+        const matched = LayersUtils
+        .findGeoServerName({url: ['https://1maps.geo-solutions.it/geoserver/wms'], regexRule: /\/[\w- ]*geoserver[\w- ]*\//});
+        expect(matched).toExist();
+    });
+
+    it('test findGeoServerName with string url', () => {
+        const matched = LayersUtils
+        .findGeoServerName({url: 'https://1maps.geo-solutions.it/geoserver/wms', regexRule: /\/[\w- ]*geoserver[\w- ]*\//});
+        expect(matched).toExist();
+    });
+
+    it('test getCapabilitiesUrl', () => {
+        const capabilities = LayersUtils
+        .getCapabilitiesUrl({url: ['https://1maps.geo-solutions.it/geoserver/wms'], name: 'states'});
+        expect(capabilities).toExist();
+    });
     it('getAuthenticationParam', () => {
         expect(LayersUtils.getAuthenticationParam({
             url: ['http://url/'],


### PR DESCRIPTION
## Description
Fix layer properties fails if the Layer's has domain sharding

## Issues
 - #3439 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3439 

**What is the new behavior?**
No layer property failure

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

