### PR TITLE
Backporting: Fix #3144 Different ajax requests for empty params using proxy (#4100)

### DIFF
--- a/web/client/libs/__tests__/ajax-test.js
+++ b/web/client/libs/__tests__/ajax-test.js
@@ -141,6 +141,35 @@ describe('Tests ajax library', () => {
             });
     });
 
+    it('ignore undefined and null query params with custom proxy', (done) => {
+        axios.get('http://fakeexternaldomain.mapstore2', {
+            proxyUrl: '/proxy/?url=',
+            params: {
+                param1: 'param1',
+                param2: '',
+                param3: undefined,
+                param4: null,
+                param5: [],
+                param6: [1, 2, "3", ''],
+                param7: {},
+                param8: {
+                    a: 'a'
+                },
+                param9: new Date(),
+                param10: false,
+                param11: NaN,
+                param12: 0
+            }})
+            .then(() => {
+                done();
+            })
+            .catch((ex) => {
+                const decodedUrl = urlUtil.parse(decodeURIComponent(ex.config.url), true);
+                expect(decodedUrl.query).toNotContainKeys(['param3', 'param4', 'param11']);
+                done();
+            });
+    });
+
     it('uses a custom proxy for requests on the same origin with string query param', (done) => {
         axios.get('http://fakeexternaldomain.mapstore2', {
             proxyUrl: '/proxy/?url=',

--- a/web/client/libs/ajax.js
+++ b/web/client/libs/ajax.js
@@ -13,7 +13,7 @@ const ConfigUtils = require('../utils/ConfigUtils');
 
 const SecurityUtils = require('../utils/SecurityUtils');
 const assign = require('object-assign');
-const {isObject} = require('lodash');
+const {isObject, omitBy, isNil} = require('lodash');
 const urlUtil = require('url');
 
 /**
@@ -122,11 +122,12 @@ axios.interceptors.request.use(config => {
             const cannotUseCORS = corsDisabled.reduce((found, current) => found || uri.indexOf(current) === 0, false);
             if (!isCORS && (!autoDetectCORS || cannotUseCORS)) {
                 const parsedUri = urlUtil.parse(uri, true, true);
+                const params = omitBy(config.params, isNil);
                 config.url = proxyUrl + encodeURIComponent(
                     urlUtil.format(
                         assign({}, parsedUri, {
                             search: null,
-                            query: assign({}, parsedUri.query, config.params )
+                            query: assign({}, parsedUri.query, params)
                         })
                     )
                 );


### PR DESCRIPTION
## Description
Fix proxied ajax request with undefined and null params

## Issues
 - #3144 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3144 

**What is the new behavior?**
undefined and null params will not be part of the proxy url as the result it default to axios default behaviour on undefined and null params

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
