### PR TITLE
Fix #3842 Switching CRS, circle annotations change size

### DIFF
--- a/build/docma-config.json
+++ b/build/docma-config.json
@@ -192,6 +192,7 @@
             "web/client/utils/LocaleUtils.js",
             "web/client/utils/PluginsUtils.js",
             "web/client/utils/PrintUtils.js",
+            "web/client/utils/openlayers/DrawSupportUtils.js",
             "web/client/utils/ogc/Filter/FilterBuilder.js",
             "web/client/utils/ogc/WFS/RequestBuilder.js",
             "web/client/utils/ogc/WFST/RequestBuilder.js",

--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -88,7 +88,7 @@ export default class Feature extends React.Component {
             this._feature.map(f => {
                 let newF = f;
                 if (f.getProperties().isCircle) {
-                    newF = transformPolygonToCircle(f, props.crs || 'EPSG:3857');
+                    newF = transformPolygonToCircle(f, props.crs || 'EPSG:3857', props.featuresCrs);
                     newF.setGeometry(newF.getGeometry().transform(props.crs || 'EPSG:3857', props.featuresCrs));
                 }
                 return newF;

--- a/web/client/utils/openlayers/DrawSupportUtils.js
+++ b/web/client/utils/openlayers/DrawSupportUtils.js
@@ -12,15 +12,22 @@ import { reproject } from '../CoordinatesUtils';
 import { getCenter } from 'ol/extent';
 import { Circle } from 'ol/geom';
 
-const calculateRadius = (center, coordinates, mapCrs, featureCrs) => {
+const calculateRadius = (center, coordinates, mapCrs, coordinateCrs) => {
     if (isArray(coordinates) && isArray(coordinates[0]) && isArray(coordinates[0][0])) {
-        const point = reproject(coordinates[0][0], featureCrs, mapCrs);
+        const point = reproject(coordinates[0][0], coordinateCrs, mapCrs);
         return Math.sqrt(Math.pow(center[0] - point.x, 2) + Math.pow(center[1] - point.y, 2));
     }
     return 100;
 };
 
-export const transformPolygonToCircle = (feature, mapCrs, featureCrs = mapCrs) => {
+/**
+ * Transform a feature that is a circle with Polygon geometry in coordinateCrs to a feature with Circle geometry in mapCrs
+ * @param {Feature} feature feature to transform
+ * @param {string} mapCrs map's current crs
+ * @param {string} [coordinateCrs=mapCrs] crs that feature's coordinates are in
+ * @returns {Feature} the transformed feature
+ */
+export const transformPolygonToCircle = (feature, mapCrs, coordinateCrs = mapCrs) => {
     if (!feature.getGeometry() || feature.getGeometry().getType() !== "Polygon" || feature.getProperties().center && feature.getProperties().center.length === 0) {
         return feature;
     }
@@ -34,7 +41,7 @@ export const transformPolygonToCircle = (feature, mapCrs, featureCrs = mapCrs) =
         } else {
             center = getCenter(extent);
         }
-        const radius = calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, featureCrs);
+        const radius = calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, coordinateCrs);
         feature.setGeometry(new Circle(center, radius));
         return feature;
     }

--- a/web/client/utils/openlayers/DrawSupportUtils.js
+++ b/web/client/utils/openlayers/DrawSupportUtils.js
@@ -12,12 +12,15 @@ import { reproject } from '../CoordinatesUtils';
 import { getCenter } from 'ol/extent';
 import { Circle } from 'ol/geom';
 
-const calculateRadius = (center, coordinates) => {
-    return isArray(coordinates) && isArray(coordinates[0]) && isArray(coordinates[0][0]) ? Math.sqrt(Math.pow(center[0] - coordinates[0][0][0], 2) + Math.pow(center[1] - coordinates[0][0][1], 2)) : 100;
+const calculateRadius = (center, coordinates, mapCrs, featureCrs) => {
+    if (isArray(coordinates) && isArray(coordinates[0]) && isArray(coordinates[0][0])) {
+        const point = reproject(coordinates[0][0], featureCrs, mapCrs);
+        return Math.sqrt(Math.pow(center[0] - point.x, 2) + Math.pow(center[1] - point.y, 2));
+    }
+    return 100;
 };
 
-export const transformPolygonToCircle = (feature, mapCrs) => {
-
+export const transformPolygonToCircle = (feature, mapCrs, featureCrs = mapCrs) => {
     if (!feature.getGeometry() || feature.getGeometry().getType() !== "Polygon" || feature.getProperties().center && feature.getProperties().center.length === 0) {
         return feature;
     }
@@ -31,7 +34,7 @@ export const transformPolygonToCircle = (feature, mapCrs) => {
         } else {
             center = getCenter(extent);
         }
-        const radius = feature.getProperties().radius || calculateRadius(center, feature.getGeometry().getCoordinates());
+        const radius = calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, featureCrs);
         feature.setGeometry(new Circle(center, radius));
         return feature;
     }

--- a/web/client/utils/openlayers/__tests__/DrawSupportUtils-test.js
+++ b/web/client/utils/openlayers/__tests__/DrawSupportUtils-test.js
@@ -1,0 +1,89 @@
+import expect from 'expect';
+import uuid from 'uuid';
+import { Circle, Polygon } from 'ol/geom';
+import { fromCircle } from 'ol/geom/Polygon';
+import Feature from 'ol/Feature';
+
+import { reproject } from '../../CoordinatesUtils';
+import { transformPolygonToCircle } from '../DrawSupportUtils';
+
+describe('DrawSupportUtils openlayers', () => {
+    const precision = 10;
+    const makePoint = (p) => [p.x, p.y];
+    const numberToPrecision = x => x.toPrecision(precision);
+    const pointToPrecision = ([x, y]) => [x.toPrecision(precision), y.toPrecision(precision)];
+
+    const center = [150.647, -89.43278];
+    const radius = 11.2332;
+    const makeTestFeature = (crs) => {
+        return new Feature({
+            geometry: fromCircle(new Circle(center, radius), 100),
+            isCircle: true,
+            id: uuid.v1(),
+            radius,
+            center: makePoint(reproject(center, crs, "EPSG:4326"))
+        });
+    };
+
+    it('test transformPolygonToCircle with mapCrs=EPSG:4326', () => {
+        const mapCrs = "EPSG:4326";
+        const testFeature = makeTestFeature(mapCrs);
+        const newFeature = transformPolygonToCircle(testFeature, mapCrs);
+        expect(newFeature).toExist();
+        const geometry = newFeature.getGeometry();
+        expect(geometry).toBeA(Circle);
+        expect(pointToPrecision(geometry.getCenter())).toEqual(pointToPrecision(center));
+        expect(numberToPrecision(geometry.getRadius())).toEqual(numberToPrecision(radius));
+    });
+
+    it('test transformPolygonToCircle with mapCrs=EPSG:3857', () => {
+        const mapCrs = "EPSG:3857";
+        const testFeature = makeTestFeature(mapCrs);
+        const newFeature = transformPolygonToCircle(testFeature, mapCrs);
+        expect(newFeature).toExist();
+        const geometry = newFeature.getGeometry();
+        expect(geometry).toBeA(Circle);
+        expect(pointToPrecision(geometry.getCenter())).toEqual(pointToPrecision(center));
+        expect(numberToPrecision(geometry.getRadius())).toEqual(numberToPrecision(radius));
+    });
+
+    it('test transformPolygonToCircle with mapCrs=EPSG:4326 coordinateCrs=EPSG:3857', () => {
+        const mapCrs = "EPSG:4326";
+        const coordinateCrs = "EPSG:3857";
+        const testFeature = makeTestFeature(coordinateCrs);
+        const newFeature = transformPolygonToCircle(testFeature, mapCrs, coordinateCrs);
+        expect(newFeature).toExist();
+        const geometry = newFeature.getGeometry();
+        expect(geometry).toBeA(Circle);
+        const newCenter = makePoint(reproject(center, coordinateCrs, mapCrs));
+        const newRadius = reproject([radius, 0.0], coordinateCrs, mapCrs).x;
+        expect(pointToPrecision(geometry.getCenter())).toEqual(pointToPrecision(newCenter));
+        expect(numberToPrecision(geometry.getRadius())).toEqual(numberToPrecision(newRadius));
+    });
+
+    it('test transformPolygonToCircle with mapCrs=EPSG:3857 coordinateCrs=EPSG:4326', () => {
+        const mapCrs = "EPSG:3857";
+        const coordinateCrs = "EPSG:4326";
+        const testFeature = makeTestFeature(coordinateCrs);
+        const newFeature = transformPolygonToCircle(testFeature, mapCrs, coordinateCrs);
+        expect(newFeature).toExist();
+        const geometry = newFeature.getGeometry();
+        expect(geometry).toBeA(Circle);
+        const newCenter = makePoint(reproject(center, coordinateCrs, mapCrs));
+        const newRadius = reproject([radius, 0.0], coordinateCrs, mapCrs).x;
+        expect(pointToPrecision(geometry.getCenter())).toEqual(pointToPrecision(newCenter));
+        expect(numberToPrecision(geometry.getRadius())).toEqual(numberToPrecision(newRadius));
+    });
+
+    it('test transformPolygonToCircle with Circle', () => {
+        const feature = new Feature({geometry: new Circle([5.0, 7.0], 5.0)});
+        const newFeature = transformPolygonToCircle(feature);
+        expect(newFeature).toEqual(feature);
+    });
+
+    it('test transformPolygonToCircle with Polygon', () => {
+        const feature = new Feature({geometry: new Polygon([[1.0, 2.0], [-1.0, -1.0]])});
+        const newFeature = transformPolygonToCircle(feature);
+        expect(newFeature).toEqual(feature);
+    });
+});


### PR DESCRIPTION
## Description
* Added featureCrs param to transformPolygonToCircle and calculateRadius
for correct radius calculations
* Radius is recalculated on every call to transformPolygonToCircle

## Issues
 - #3842 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#3842

**What is the new behavior?**
In description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
