### PR TITLE
Fix #4055 ZoomToMaxExtent button switch CRS

### DIFF
--- a/web/client/components/buttons/ZoomToMaxExtentButton.jsx
+++ b/web/client/components/buttons/ZoomToMaxExtentButton.jsx
@@ -120,7 +120,7 @@ class ZoomToMaxExtentButton extends React.Component {
         // zooming to the initial extent based on initial map configuration
         var mapConfig = this.props.mapInitialConfig;
         let bbox = mapUtils.getBbox(mapConfig.center, mapConfig.zoom, this.props.mapConfig.size);
-        this.props.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, mapConfig.projection);
+        this.props.changeMapView(mapConfig.center, mapConfig.zoom, bbox, this.props.mapConfig.size, null, this.props.mapConfig.projection);
     };
 }
 

--- a/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
+++ b/web/client/components/buttons/__tests__/ZoomToMaxExtentButton-test.jsx
@@ -145,7 +145,7 @@ describe('This test for ZoomToMaxExtentButton', () => {
 
     it('test zoom to initial extent', () => {
 
-        let genericTest = function(btnType) {
+        let genericTest = function(btnType, projection) {
             let actions = {
                 changeMapView: (c, z, mb, ms) => {
                     return {c, z, mb, ms};
@@ -160,7 +160,8 @@ describe('This test for ZoomToMaxExtentButton', () => {
                         size: {
                             height: 100,
                             width: 100
-                        }
+                        },
+                        projection: projection
                     }}
                     mapInitialConfig={{
                         zoom: 10,
@@ -194,10 +195,12 @@ describe('This test for ZoomToMaxExtentButton', () => {
             expect(actionsSpy.calls[0].arguments[2]).toNotExist();
             expect(actionsSpy.calls[0].arguments[3]).toExist();
             expect(actionsSpy.calls[0].arguments[4]).toNotExist();
-            expect(actionsSpy.calls[0].arguments[5]).toExist();
+            expect(actionsSpy.calls[0].arguments[5]).toEqual(projection);
         };
 
-        genericTest("normal");
-        genericTest("image");
+        genericTest("normal", "EPSG:900913");
+        genericTest("normal", "EPSG:4326");
+        genericTest("image", "EPSG:900913");
+        genericTest("image", "EPSG:4326");
     });
 });


### PR DESCRIPTION
## Description
* Changed zoomToInitialExtent to use current CRS
* Updated tests to use different projections


## Issues
 - #4055 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
ZoomToMaxExtent button changes current CRS when useInitialExtent=true

**What is the new behavior?**
ZoomToMaxExtent button doesn't affect current CRS

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
