### PR TITLE
Fix #3917 Widgets builder - layer filter

### DIFF
--- a/web/client/actions/__tests__/widgets-test.js
+++ b/web/client/actions/__tests__/widgets-test.js
@@ -12,6 +12,7 @@ const {
     INSERT,
     UPDATE,
     UPDATE_PROPERTY,
+    UPDATE_LAYER,
     DELETE,
     CHANGE_LAYOUT,
     EDIT,
@@ -32,6 +33,7 @@ const {
     insertWidget,
     updateWidget,
     updateWidgetProperty,
+    updateWidgetLayer,
     deleteWidget,
     changeLayout,
     editWidget,
@@ -100,6 +102,13 @@ describe('Test correctness of the widgets actions', () => {
         expect(retval.key).toBe("key");
         expect(retval.value).toBe("value");
         expect(retval.target).toBe(DEFAULT_TARGET);
+    });
+    it('updateWidgetLayer', () => {
+        const layer = {id: "1", name: "layer1"};
+        const retval = updateWidgetLayer(layer);
+        expect(retval).toExist();
+        expect(retval.type).toBe(UPDATE_LAYER);
+        expect(retval.layer).toBe(layer);
     });
     it('deleteWidget', () => {
         const widget = {};

--- a/web/client/actions/widgets.js
+++ b/web/client/actions/widgets.js
@@ -14,6 +14,7 @@ const EDITOR_CHANGE = "WIDGETS:EDITOR_CHANGE";
 const EDITOR_SETTING_CHANGE = "WIDGETS:EDITOR_SETTING_CHANGE";
 const UPDATE = "WIDGETS:UPDATE";
 const UPDATE_PROPERTY = "WIDGETS:UPDATE_PROPERTY";
+const UPDATE_LAYER = "WIDGETS:UPDATE_LAYER";
 const CHANGE_LAYOUT = "WIDGETS:CHANGE_LAYOUT";
 const DELETE = "WIDGETS:DELETE";
 const CLEAR_WIDGETS = "WIDGETS:CLEAR_WIDGETS";
@@ -91,6 +92,15 @@ const updateWidgetProperty = (id, key, value, target = DEFAULT_TARGET) => ({
     target,
     key,
     value
+});
+/**
+ * Update a layer property of all widgets with that layer
+ * @param {object} layer New layer object
+ * @return {object} action with type `WIDGETS:UPDATE_LAYER`
+ */
+const updateWidgetLayer = (layer) => ({
+    type: UPDATE_LAYER,
+    layer
 });
 /**
  * Deletes a widget from the passed target
@@ -280,6 +290,7 @@ module.exports = {
     INSERT,
     UPDATE,
     UPDATE_PROPERTY,
+    UPDATE_LAYER,
     DELETE,
     CLEAR_WIDGETS,
     CHANGE_LAYOUT,
@@ -304,6 +315,7 @@ module.exports = {
     insertWidget,
     updateWidget,
     updateWidgetProperty,
+    updateWidgetLayer,
     deleteWidget,
     clearWidgets,
     changeLayout,

--- a/web/client/epics/layers.js
+++ b/web/client/epics/layers.js
@@ -8,9 +8,8 @@
 
 const Rx = require('rxjs');
 const Api = require('../api/WMS');
-const { REFRESH_LAYERS, UPDATE_LAYERS_DIMENSION, UPDATE_SETTINGS_PARAMS, CHANGE_LAYER_PROPERTIES, layersRefreshed, updateNode, updateSettings, layersRefreshError, changeLayerParams } = require('../actions/layers');
-const { updateWidgetLayer } = require('../actions/widgets');
-const {getLayerFromId, getLayersWithDimension, layerSettingSelector} = require('../selectors/layers');
+const { REFRESH_LAYERS, UPDATE_LAYERS_DIMENSION, UPDATE_SETTINGS_PARAMS, layersRefreshed, updateNode, updateSettings, layersRefreshError, changeLayerParams } = require('../actions/layers');
+const {getLayersWithDimension, layerSettingSelector} = require('../selectors/layers');
 
 const { setControlProperty } = require('../actions/controls');
 const { initialSettingsSelector, originalSettingsSelector } = require('../selectors/controls');
@@ -19,7 +18,7 @@ const LayersUtils = require('../utils/LayersUtils');
 
 
 const assign = require('object-assign');
-const {has, isArray, head} = require('lodash');
+const {isArray, head} = require('lodash');
 
 const getUpdates = (updates, options) => {
     return Object.keys(options).filter((opt) => options[opt]).reduce((previous, current) => {
@@ -149,25 +148,8 @@ const updateSettingsParamsEpic = (action$, store) =>
             );
         });
 
-/**
- * Triggers updates of the layer property of widgets on layerFilter change
- * @memberof epics.layers
- * @param {external:Observable} action$ manages `CHANGE_LAYER_PROPERTIES`
- * @return {external:Observable}
- */
-const changeLayerPropertiesEpic = (action$, store) =>
-    action$.ofType(CHANGE_LAYER_PROPERTIES)
-        .switchMap(({layer, newProperties}) => {
-            const state = store.getState();
-            const flatLayer = getLayerFromId(state, layer);
-            return Rx.Observable.of(
-                ...(has(newProperties, "layerFilter") && flatLayer ? [updateWidgetLayer(flatLayer)] : [])
-            );
-        });
-
 module.exports = {
     refresh,
     updateDimension,
-    updateSettingsParamsEpic,
-    changeLayerPropertiesEpic
+    updateSettingsParamsEpic
 };

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -11,6 +11,7 @@ const {
     changeEditorSetting,
     onEditorChange,
     insertWidget,
+    updateWidgetLayer,
     deleteWidget,
     changeLayout,
     clearWidgets,
@@ -70,6 +71,50 @@ describe('Test the widgets reducer', () => {
     it('insertWidget', () => {
         const state = widgets(undefined, insertWidget({id: "1"}));
         expect(state.containers[DEFAULT_TARGET].widgets.length).toBe(1);
+    });
+    it('updateWidgetLayers', () => {
+        const targetLayer = {
+            name: "layer2",
+            id: "2",
+            visibility: true
+        };
+        const state = {
+            containers: {
+                [DEFAULT_TARGET]: {
+                    widgets: [{
+                        id: "widget1",
+                        layer: {
+                            visibility: false,
+                            name: "layer",
+                            id: "1"
+                        }
+                    }, {
+                        id: "widget2",
+                        layer: Object.assign({}, targetLayer)
+                    }, {
+                        id: "widget3",
+                        layer: {
+                            visibility: false,
+                            name: "layer3",
+                            id: "3"
+                        }
+                    }, {
+                        id: "widget4",
+                        layer: Object.assign({}, targetLayer)
+                    }]
+                }
+            }
+        };
+
+        const newTargetLayer = Object.assign({}, targetLayer, {visibility: false});
+        const newState = widgets(state, updateWidgetLayer(newTargetLayer));
+
+        const widgetObjects = newState.containers[DEFAULT_TARGET].widgets;
+        expect(widgetObjects.length).toBe(4);
+        expect(widgetObjects[0].layer).toEqual(state.containers[DEFAULT_TARGET].widgets[0].layer);
+        expect(widgetObjects[1].layer).toEqual(newTargetLayer);
+        expect(widgetObjects[2].layer).toEqual(state.containers[DEFAULT_TARGET].widgets[2].layer);
+        expect(widgetObjects[3].layer).toEqual(newTargetLayer);
     });
     it('deleteWidget', () => {
         const state = {

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { EDIT_NEW, INSERT, EDIT, UPDATE_PROPERTY, DELETE, EDITOR_CHANGE, EDITOR_SETTING_CHANGE, CHANGE_LAYOUT, CLEAR_WIDGETS, DEFAULT_TARGET,
+const { EDIT_NEW, INSERT, EDIT, UPDATE_PROPERTY, UPDATE_LAYER, DELETE, EDITOR_CHANGE, EDITOR_SETTING_CHANGE, CHANGE_LAYOUT, CLEAR_WIDGETS, DEFAULT_TARGET,
     ADD_DEPENDENCY, REMOVE_DEPENDENCY, LOAD_DEPENDENCIES, RESET_DEPENDENCIES, TOGGLE_COLLAPSE, TOGGLE_COLLAPSE_ALL, TOGGLE_TRAY, toggleCollapse} = require('../actions/widgets');
 const {
     MAP_CONFIG_LOADED
@@ -102,6 +102,16 @@ function widgetsReducer(state = emptyState, action) {
                 ), {
                     id: action.id
                 }, state);
+        case UPDATE_LAYER: {
+            if (action.layer) {
+                const widgets = get(state, `containers[${DEFAULT_TARGET}].widgets`);
+                if (widgets) {
+                    return set(`containers[${DEFAULT_TARGET}].widgets`,
+                        widgets.map(w => get(w, "layer.id") === action.layer.id ? set("layer", action.layer, w) : w), state);
+                }
+            }
+            return state;
+        }
         case DELETE:
             return arrayDelete(`containers[${action.target}].widgets`, {
                 id: action.widget.id


### PR DESCRIPTION
## Description
Widget objects have their own copy of properties of the layer that they belong to. It looks like when
layerFilter gets updated it only alters the main layer object in state.layers, but not any of the widgets.
I introduced an action that takes a layer object, goes through all widgets in DEFAULT_TARGET target,
finds those that have the same layer.id and updates their layer property with a new one, and an epic
that manages CHANGE_LAYER_PROPERTIES action and produces updateWidgetLayer action whenever
needed. For now it does that only on layerFilter updates.

## Issues
 - #3917 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Widgets don't update on filter changes of the layer that they belong to

**What is the new behavior?**
Widgets update their output on filter changes

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
