### PR TITLE
Fix 4158 add full screen to images

### DIFF
--- a/web/client/components/geostory/layouts/sections/Background.jsx
+++ b/web/client/components/geostory/layouts/sections/Background.jsx
@@ -85,7 +85,7 @@ class Background extends Component {
                             ? this.props.backgroundPlaceholder
                             : {})
                     }}>
-                    {MediaType && <MediaType { ...this.props } descriptionEnabled={false}/>}
+                    {MediaType && <MediaType { ...this.props } enableFullscreen={false} descriptionEnabled={false}/>}
                     { this.props.mode === Modes.EDIT && (
                     parentNode
                     ? (

--- a/web/client/components/geostory/media/Image.jsx
+++ b/web/client/components/geostory/media/Image.jsx
@@ -57,7 +57,7 @@ class Image extends Component {
             id,
             src,
             fit = 'cover',
-            enableFullscreen,
+            enableFullscreen = true,
             fullscreen,
             onClick,
             description,

--- a/web/client/components/geostory/media/__tests__/Image-test.jsx
+++ b/web/client/components/geostory/media/__tests__/Image-test.jsx
@@ -46,15 +46,27 @@ describe('Image component', () => {
         expect(image).toExist();
         expect(image.style.objectFit).toBe('cover');
     });
-    it('Image rendering with enable fullscreen preview', () => {
+    it('Image rendering with enabled fullscreen preview', () => {
         ReactDOM.render(<Image
             src={SAMPLE_SRC}
-            enableFullscreen/>, document.getElementById("container"));
+            />, document.getElementById("container"));
         const container = document.getElementById('container');
         const image = container.querySelector('.ms-media-image > img');
         expect(image).toExist();
         expect(image.style.objectFit).toBe('cover');
         ReactTestUtils.Simulate.click(image);
         expect(document.querySelector('.ReactModalPortal')).toExist();
+    });
+    it('Image rendering with disabled fullscreen preview', () => {
+        ReactDOM.render(<Image
+            src={SAMPLE_SRC}
+            enableFullscreen={false}
+            />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const image = container.querySelector('.ms-media-image > img');
+        expect(image).toExist();
+        expect(image.style.objectFit).toBe('cover');
+        ReactTestUtils.Simulate.click(image);
+        expect(document.querySelector('.ReactModalPortal')).toNotExist();
     });
 });


### PR DESCRIPTION
## Description
- Image has full screen by default
- background disables it


## Issues
 - #4158 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
no full screen available for images

**What is the new behavior?**
see description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
