### PR TITLE
Fix #3918 Autocomplete does't filter result accordingly to layer filter

### DIFF
--- a/web/client/epics/autocomplete.js
+++ b/web/client/epics/autocomplete.js
@@ -14,7 +14,7 @@ const {getWpsPayload} = require('../utils/ogc/WPS/autocomplete');
 const {isArray, startsWith} = require('lodash');
 const {error} = require('../actions/notifications');
 const {typeNameSelector} = require('../selectors/query');
-const {maxFeaturesWPSSelector} = require('../selectors/queryform');
+const {maxFeaturesWPSSelector, appliedFilterSelector, storedFilterSelector} = require('../selectors/queryform');
 const {getParsedUrl} = require('../utils/ConfigUtils');
 const {authkeyParamNameSelector} = require('../selectors/catalog');
 
@@ -67,6 +67,7 @@ module.exports = {
                 const data = getWpsPayload({
                         attribute: filterField.attribute,
                         layerName: typeNameSelector(state),
+                        layerFilter: appliedFilterSelector(state) || storedFilterSelector(state),
                         maxFeatures: maxFeaturesWPS,
                         startIndex: (action.fieldOptions.currentPage - 1) * maxFeaturesWPS,
                         value: action.fieldValue

--- a/web/client/utils/ogc/WPS/autocomplete.js
+++ b/web/client/utils/ogc/WPS/autocomplete.js
@@ -1,7 +1,26 @@
 // const wfsRequestBuilder = require('../WFS/RequestBuilder');
 // const {getFeature, property, query} = wfsRequestBuilder({wfsVersion: "1.1.0"});
+const FilterUtils = require('../../FilterUtils');
+const filterBuilder = require('../Filter/FilterBuilder');
+const {and} = filterBuilder({});
 
-const getRequestBody = ({layerName, attribute, maxFeatures, startIndex}) => {
+const getWpsPayload = ({layerName, layerFilter, attribute, maxFeatures, startIndex, value}) => {
+    const attributeFilterObj = value
+    ? '<ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">'
+    + '   <ogc:PropertyName>' + attribute + '</ogc:PropertyName>'
+    + '   <ogc:Literal>*' + value + '*</ogc:Literal>'
+    + '</ogc:PropertyIsLike>'
+    : '';
+
+    const layerFilterObj = layerFilter && !layerFilter.disabled && FilterUtils.isFilterValid(layerFilter)
+                         ? FilterUtils.toOGCFilterParts(layerFilter, "1.1.0", "ogc")
+                         : [];
+
+    const filter = attributeFilterObj.length > 0 || layerFilterObj.length > 0
+    ? '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml">'
+    + and(...layerFilterObj, attributeFilterObj)
+    + '</ogc:Filter>'
+    : '';
 
     let requestBody =
       '<wps:Execute xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WPS" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd"> '
@@ -15,65 +34,7 @@ const getRequestBody = ({layerName, attribute, maxFeatures, startIndex}) => {
     + '       <wps:Body>'
     + '         <wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" service="WFS" version="1.0.0">'
     + '           <wfs:Query typeName="' + layerName + '">'
-    + '             <ogc:SortBy xmlns:ogc="http://www.opengis.net/ogc">'
-    + '               <ogc:SortProperty>'
-    + '                 <ogc:PropertyName>' + attribute + '</ogc:PropertyName>'
-    + '               </ogc:SortProperty>'
-    + '             </ogc:SortBy>'
-    + '           </wfs:Query>'
-    + '         </wfs:GetFeature>'
-    + '       </wps:Body>'
-    + '     </wps:Reference>'
-    + '   </wps:Input>'
-    + '   <wps:Input>'
-    + '     <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">fieldName</ows:Identifier>'
-    + '     <ows:Title xmlns:ows="http://www.opengis.net/ows/1.1">fieldName</ows:Title>'
-    + '     <wps:Data>'
-    + '       <wps:LiteralData>' + attribute + '</wps:LiteralData>'
-    + '     </wps:Data>'
-    + '   </wps:Input>'
-    + '   <wps:Input>'
-    + '     <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">maxFeatures</ows:Identifier>'
-    + '     <ows:Title xmlns:ows="http://www.opengis.net/ows/1.1">maxFeatures</ows:Title>'
-    + '     <wps:Data>'
-    + '       <wps:LiteralData>' + maxFeatures + '</wps:LiteralData>'
-    + '     </wps:Data>'
-    + '   </wps:Input>'
-    + '   <wps:Input>'
-    + '     <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">startIndex</ows:Identifier>'
-    + '     <ows:Title xmlns:ows="http://www.opengis.net/ows/1.1">startIndex</ows:Title>'
-    + '     <wps:Data>'
-    + '       <wps:LiteralData>' + startIndex + '</wps:LiteralData>'
-    + '     </wps:Data>'
-    + '   </wps:Input>'
-    + ' </wps:DataInputs>'
-    + ' <wps:ResponseForm>'
-    + '   <wps:RawDataOutput mimeType="application/json">'
-    + '     <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">result</ows:Identifier>'
-    + '   </wps:RawDataOutput>'
-    + ' </wps:ResponseForm>'
-    + '</wps:Execute>';
-    return requestBody;
-};
-const getRequestBodyWithFilter = ({layerName, attribute, maxFeatures, startIndex, value}) => {
-    let requestBody =
-      '<wps:Execute xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WPS" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd"> '
-    + ' <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">gs:PagedUnique</ows:Identifier> '
-    + ' <wps:DataInputs> '
-    + '   <wps:Input> '
-    + '     <ows:Identifier xmlns:ows="http://www.opengis.net/ows/1.1">features</ows:Identifier> '
-    + '     <ows:Title xmlns:ows="http://www.opengis.net/ows/1.1">features</ows:Title> '
-    + '     <wps:Data /> '
-    + '     <wps:Reference xmlns:xlink="http://www.w3.org/1999/xlink" mimeType="text/xml" xlink:href="http://geoserver/wfs" method="POST"> '
-    + '       <wps:Body>'
-    + '         <wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" service="WFS" version="1.0.0">'
-    + '           <wfs:Query typeName="' + layerName + '">'
-    + '             <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">'
-    + '               <ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!">'
-    + '                 <ogc:PropertyName>' + attribute + '</ogc:PropertyName>'
-    + '                 <ogc:Literal>*' + value + '*</ogc:Literal>'
-    + '               </ogc:PropertyIsLike>'
-    + '             </ogc:Filter>'
+    + filter
     + '             <ogc:SortBy xmlns:ogc="http://www.opengis.net/ogc">'
     + '               <ogc:SortProperty>'
     + '                 <ogc:PropertyName>' + attribute + '</ogc:PropertyName>'
@@ -116,7 +77,5 @@ const getRequestBodyWithFilter = ({layerName, attribute, maxFeatures, startIndex
 };
 
 module.exports = {
-    getWpsPayload: (options) => options.value ? getRequestBodyWithFilter(options) : getRequestBody(options),
-    getRequestBodyWithFilter,
-    getRequestBody
+    getWpsPayload
 };


### PR DESCRIPTION
## Description
Modified autocomplete to include current applied(if exists) or persisted layerFilter into the request body

## Issues
 - #3918 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement


**What is the current behavior?** (You can also link to an open issue here)
Autocomplete doesn't filter results in accordance with layer filter

**What is the new behavior?**
Autocomplete filters results using current layer filter

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
