### PR TITLE
Fix #3842 Switching CRS, circle annotations change size

### DIFF
--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -14,7 +14,6 @@ import find from 'lodash/find';
 import castArray from 'lodash/castArray';
 
 import { parseStyles } from './VectorStyle';
-import { transformPolygonToCircle } from '../../../utils/openlayers/DrawSupportUtils';
 import { createStylesAsync } from '../../../utils/VectorStyleUtils';
 import GeoJSON from 'ol/format/GeoJSON';
 

--- a/web/client/components/map/openlayers/Feature.jsx
+++ b/web/client/components/map/openlayers/Feature.jsx
@@ -85,15 +85,7 @@ export default class Feature extends React.Component {
                     // reproject features from featureCrs
                     dataProjection: props.featuresCrs
                 });
-            this._feature.map(f => {
-                let newF = f;
-                if (f.getProperties().isCircle) {
-                    newF = transformPolygonToCircle(f, props.crs || 'EPSG:3857', props.featuresCrs);
-                    newF.setGeometry(newF.getGeometry().transform(props.crs || 'EPSG:3857', props.featuresCrs));
-                }
-                return newF;
-            }).forEach(
-                (f) => f.getGeometry().transform(props.featuresCrs, props.crs || 'EPSG:3857'));
+            this._feature.forEach((f) => f.getGeometry().transform(props.featuresCrs, props.crs || 'EPSG:3857'));
 
             if (props.style && (props.style !== props.layerStyle)) {
                 this._feature.forEach((f) => {


### PR DESCRIPTION
## Description
Circles are no longer transformed from Polygon to Circle to allow correct rendering
under projection changes

## Issues
 - #3842 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Circle annotations don't change size upon switching projections

**What is the new behavior?**
Circle annotations transform correctly with projection changes


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No