### PR TITLE
Fix #3927 Error in console when exporting an empty dashboard chart

### DIFF
--- a/web/client/components/widgets/enhancers/tools/__tests__/withMenu-test.js
+++ b/web/client/components/widgets/enhancers/tools/__tests__/withMenu-test.js
@@ -72,7 +72,7 @@ describe('withMenu enhancer', () => {
         expect(spyCallback).toHaveBeenCalled();
     });
 
-    it('Widgets callback should be called when menu disabled', () => {
+    it('Widgets callback should not be called when menu disabled', () => {
         const actions = {
             callback: () => {}
         };

--- a/web/client/components/widgets/enhancers/tools/__tests__/withMenu-test.js
+++ b/web/client/components/widgets/enhancers/tools/__tests__/withMenu-test.js
@@ -71,4 +71,23 @@ describe('withMenu enhancer', () => {
         ReactTestUtils.Simulate.click(document.querySelector("#test-menu"));
         expect(spyCallback).toHaveBeenCalled();
     });
+
+    it('Widgets callback should be called when menu disabled', () => {
+        const actions = {
+            callback: () => {}
+        };
+        const spyCallback = expect.spyOn(actions, 'callback');
+        ReactDOM.render(<Widget
+            widgetType="text"
+            widgetTools={[{
+                glyph: "text",
+                target: "menu",
+                disabled: true,
+                text: <div id="test-menu" />,
+                onClick: actions.callback
+            }]}
+            />, document.getElementById("container"));
+        ReactTestUtils.Simulate.click(document.querySelector("#test-menu"));
+        expect(spyCallback).toNotHaveBeenCalled();
+    });
 });

--- a/web/client/components/widgets/enhancers/tools/withMenu.js
+++ b/web/client/components/widgets/enhancers/tools/withMenu.js
@@ -32,7 +32,7 @@ module.exports = ({ className = "widget-menu", menuIcon = "option-vertical"} = {
                         <MenuItem
                             active={active}
                             tooltipId={tooltipId}
-                        onClick={onClick}
+                        onSelect={onClick}
                         disabled={disabled}
                         eventKey={i}>
                             <Glyphicon className={glyphClassName} glyph={glyph} />

--- a/web/client/components/widgets/widget/__tests__/ChartWidget-test.jsx
+++ b/web/client/components/widgets/widget/__tests__/ChartWidget-test.jsx
@@ -52,25 +52,4 @@ describe('ChartWidget component', () => {
         ReactTestUtils.Simulate.click(el); // <-- trigger event callback
         expect(spyonEdit).toHaveBeenCalled();
     });
-    it('Test ChartWidget callbacks', () => {
-        const actions = {
-            onEdit: () => {},
-            exportCSV: () => {},
-            exportImage: () => {}
-        };
-        const spyonEdit = expect.spyOn(actions, 'onEdit');
-        const spyexportCSV = expect.spyOn(actions, 'exportCSV');
-        const spyexportImage = expect.spyOn(actions, 'exportImage');
-        ReactDOM.render(<ChartWidget exportCSV={actions.exportCSV} exportImage={actions.exportImage} onEdit={actions.onEdit} />, document.getElementById("container"));
-        const container = document.getElementById('container');
-        let el = container.querySelector('.glyphicon-pencil');
-        ReactTestUtils.Simulate.click(el); // <-- trigger event callback
-        expect(spyonEdit).toHaveBeenCalled();
-        el = container.querySelector('.exportCSV');
-        ReactTestUtils.Simulate.click(el);
-        expect(spyexportCSV).toHaveBeenCalled();
-        el = container.querySelector('.exportImage');
-        ReactTestUtils.Simulate.click(el);
-        expect(spyexportImage).toHaveBeenCalled();
-    });
 });


### PR DESCRIPTION
## Description
Fix the bug reported after merge of 4098, i.e disabled button remain clickable.

## Issues
 - #3927 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #3927 

**What is the new behavior?**
No console error

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

