### PR TITLE
Fix #3922 Query panel errors when switching CRS

### DIFF
--- a/web/client/components/data/query/QueryBuilder.jsx
+++ b/web/client/components/data/query/QueryBuilder.jsx
@@ -64,6 +64,7 @@ class QueryBuilder extends React.Component {
         emptyFilterWarning: PropTypes.bool,
         header: PropTypes.node,
         zoom: PropTypes.number,
+        projection: PropTypes.string,
         toolsOptions: PropTypes.object,
         appliedFilter: PropTypes.object,
         storedFilter: PropTypes.object,
@@ -195,7 +196,8 @@ class QueryBuilder extends React.Component {
                         spatialPanelExpanded={this.props.spatialPanelExpanded}
                         showDetailsPanel={this.props.showDetailsPanel}
                         actions={this.props.spatialFilterActions}
-                        zoom={this.props.zoom}/>}
+                        zoom={this.props.zoom}
+                        projection={this.props.projection}/>}
                 {this.props.toolsOptions.hideCrossLayer ? null : <CrossLayerFilter
                         spatialOperations={this.props.spatialOperations}
                         crossLayerExpanded={this.props.crossLayerExpanded}

--- a/web/client/components/data/query/SpatialFilter.jsx
+++ b/web/client/components/data/query/SpatialFilter.jsx
@@ -33,7 +33,8 @@ class SpatialFilter extends React.Component {
         showDetailsPanel: PropTypes.bool,
         withContainer: PropTypes.bool,
         actions: PropTypes.object,
-        zoom: PropTypes.number
+        zoom: PropTypes.number,
+        projection: PropTypes.string
     };
 
     static contextTypes = {
@@ -277,7 +278,8 @@ class SpatialFilter extends React.Component {
                 type={this.props.spatialField.method}
                 onShowPanel={this.props.actions.onShowSpatialSelectionDetails}
                 onChangeDrawingStatus={this.changeDrawingStatus}
-                zoom={this.props.zoom}/>)
+                zoom={this.props.zoom}
+                projection={this.props.projection}/>)
          :
             <span/>
         ;

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -44,6 +44,7 @@ describe('GeometryDetails', () => {
         const geometryDetails = ReactDOM.render(
             <GeometryDetails
                 geometry={geometry}
+                projection="EPSG:900913"
                 type={type}/>,
             document.getElementById("container")
         );
@@ -68,7 +69,8 @@ describe('GeometryDetails', () => {
 
         expect(pb.childNodes.length).toBe(1);
     });
-    it('Test GeometryDetails endDrawing with 900913', (done) => {
+
+    it('Test GeometryDetails endDrawing with 900913 and 900913', (done) => {
 
         let geometry = {
             center: {
@@ -85,25 +87,27 @@ describe('GeometryDetails', () => {
         const actions = {
             onChangeDrawingStatus: (drawStatus, notDef, owner, geom) => {
                 expect(drawStatus).toBe('endDrawing');
-                expect(geom).toEqual([{
-                    type: 'Polygon',
-                    center: { x: -1761074.34, y: 5852757.63 },
-                    coordinates: [ -1761074.34, 5852757.63],
-                    radius: 836584,
-                    projection: 'EPSG:900913'
-                }]);
+                expect(geom[0]).toExist();
+                expect(geom[0].type).toBe('Polygon');
+                expect(geom[0].center).toExist();
+                expect(geom[0].center.x).toExist();
+                expect(geom[0].center.x.toPrecision(9)).toBe('-1761074.34');
+                expect(geom[0].center.y).toExist();
+                expect(geom[0].center.y.toPrecision(9)).toBe('5852757.63');
+                expect(geom[0].radius).toBe(836584);
+                expect(geom[0].projection).toBe('EPSG:900913');
                 done();
             }
         };
 
         let type = "Circle";
 
-        const cmp = ReactDOM.render(<GeometryDetails geometry={geometry} type={type} onChangeDrawingStatus={actions.onChangeDrawingStatus} />, document.getElementById("container"));
+        const cmp = ReactDOM.render(<GeometryDetails geometry={geometry} projection="EPSG:900913" type={type} onChangeDrawingStatus={actions.onChangeDrawingStatus} />, document.getElementById("container"));
         expect(cmp).toExist();
         ReactTestUtils.Simulate.click(document.getElementsByClassName('glyphicon-ok')[0]); // <-- trigger event callback
     });
 
-    it('Test GeometryDetails endDrawing with 4326', (done) => {
+    it('Test GeometryDetails endDrawing with 4326 and 4326', (done) => {
 
         let geometry = {
             center: {
@@ -133,7 +137,7 @@ describe('GeometryDetails', () => {
 
         const type = "Circle";
 
-        const cmp = ReactDOM.render(<GeometryDetails geometry={geometry} type={type} onChangeDrawingStatus={actions.onChangeDrawingStatus} />, document.getElementById("container"));
+        const cmp = ReactDOM.render(<GeometryDetails geometry={geometry} projection="EPSG:4326" type={type} onChangeDrawingStatus={actions.onChangeDrawingStatus} />, document.getElementById("container"));
         expect(cmp).toExist();
         ReactTestUtils.Simulate.click(document.getElementsByClassName('glyphicon-ok')[0]); // <-- trigger event callback
     });
@@ -155,6 +159,7 @@ describe('GeometryDetails', () => {
         const geometryDetails = ReactDOM.render(
             <GeometryDetails
                 geometry={geometry}
+                projection="EPSG:900913"
                 type={type}/>,
             document.getElementById("container")
         );

--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -22,6 +22,7 @@ const {projectionDefsSelector, projectionSelector} = require('../selectors/map')
 const {bottomPanelOpenSelector} = require('../selectors/maplayout');
 const {crsInputValueSelector} = require('../selectors/crsselector');
 const {currentBackgroundSelector} = require('../selectors/layers');
+const {queryPanelSelector} = require('../selectors/controls');
 const{modeSelector} = require('../selectors/featuregrid');
 const {error} = require('../actions/notifications');
 const {userRoleSelector} = require('../selectors/security');
@@ -121,13 +122,14 @@ const crsSelector = connect(
             modeSelector,
             isCesium,
             bottomPanelOpenSelector,
-                ( currentRole, currentBackground, selected, projectionDefs, value, mode, cesium, bottomPanel) => ({
+            queryPanelSelector,
+                ( currentRole, currentBackground, selected, projectionDefs, value, mode, cesium, bottomPanel, queryPanelEnabled) => ({
                     currentRole,
                     currentBackground,
                     selected,
                     projectionDefs,
                     value,
-                    enabled: (mode !== 'EDIT') && !cesium && !bottomPanel
+                    enabled: (mode !== 'EDIT') && !cesium && !bottomPanel && !queryPanelEnabled
                 })
             ), {
                 typeInput: setInputValue,

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -123,7 +123,8 @@ const SmartQueryForm = connect((state) => {
         allowEmptyFilter: true,
         emptyFilterWarning: true,
         maxHeight: state.map && state.map.present && state.map.present.size && state.map.present.size.height,
-        zoom: (mapSelector(state) || {}).zoom
+        zoom: (mapSelector(state) || {}).zoom,
+        projection: (mapSelector(state) || {}).projection
     };
 }, dispatch => {
     return {

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -965,13 +965,20 @@ const FilterUtils = {
      @return a spatial filter with coordinates reprojected to nativeCrs
     */
     reprojectFilterInNativeCrs: (filter, nativeCrs) => {
-        let newCoords = CoordinatesUtils.reprojectGeoJson(filter.spatialField.geometry, filter.spatialField.geometry.projection || "EPSG:3857", nativeCrs).coordinates;
+        const srcProjection = filter.spatialField.geometry.projection;
+        const center = filter.spatialField.geometry.center;
+        const radius = filter.spatialField.geometry.radius;
+        const newCoords = CoordinatesUtils.reprojectGeoJson(filter.spatialField.geometry, filter.spatialField.geometry.projection || "EPSG:3857", nativeCrs).coordinates;
+        const newCenter = center && (({x, y}) => [x, y])(CoordinatesUtils.reproject(center, srcProjection, nativeCrs));
+        const newRadius = radius && CoordinatesUtils.reproject([radius, 0.0], srcProjection, nativeCrs).x;
         return {
             ...filter,
             spatialField: {
                 ...filter.spatialField,
                 geometry: {
                     ...filter.spatialField.geometry,
+                    center: newCenter,
+                    radius: newRadius,
                     coordinates: newCoords,
                     projection: nativeCrs
                 }


### PR DESCRIPTION
## Description
Added radius and center reprojection to reprojectFilterInNativeCrs so that the projection
property correctly reflects coordinate system that the filter's geometry is in. Added projection
parameter to GeometryDetails that is current crs, to correctly reproject coordinates in onUpdateCircle
for a drawLayer in DrawSupport. That parameter is also used to determine correctly the step to use for the radius field. Moreover, CRS Selector now hides when Query Panel is active.

## Issues
 - #3922 
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#3922 

**What is the new behavior?**
In the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

**Other information**:
I'm not sure what useMapProjection prop is supposed to do. Probably further modifications are needed
