### PR TITLE
Fix #4145 Layer groups in TOC cannot be removed

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -315,10 +315,9 @@ class Toolbar extends React.Component {
                 onHide={this.closeDeleteDialog}
                 onClose={this.closeDeleteDialog}
                 onConfirm={this.removeNodes}
-                titleText={this.props.text.confirmDeleteText}
-                confirmText={this.props.text.confirmDeleteText}
+                titleText={this.props.selectedGroups && this.props.selectedGroups.length ? this.props.text.confirmDeleteLayerGroupText : this.props.text.confirmDeleteText}
                 cancelText={this.props.text.confirmDeleteCancelText}
-                body={this.props.text.confirmDeleteMessage} />
+                body={this.props.selectedGroups && this.props.selectedGroups.length ? this.props.text.confirmDeleteLayerGroupMessage : this.props.text.confirmDeleteMessage} />
             {layerMetadataModal}
         </ButtonGroup>) : null;
     }

--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -258,7 +258,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                 : null}
-                    {this.props.activateTool.activateRemoveLayer && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS' || status === 'LAYER_LOAD_ERROR' || status === 'LAYERS_LOAD_ERROR') && this.props.selectedLayers.length > 0 && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
+                    {this.props.activateTool.activateRemoveLayer && (status === 'LAYER' || status === 'GROUP' || status === 'LAYERS' || status === 'GROUPS' || status === 'LAYER_LOAD_ERROR' || status === 'LAYERS_LOAD_ERROR') && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
                     <OverlayTrigger
                         key="removeNode"
                         placement="top"
@@ -382,6 +382,9 @@ class Toolbar extends React.Component {
     removeNodes = () => {
         this.props.selectedLayers.forEach((layer) => {
             this.props.onToolsActions.onRemove(layer.id, 'layers');
+        });
+        this.props.selectedGroups.forEach((group) => {
+            this.props.onToolsActions.onRemove(group.id, 'groups');
         });
         this.props.onToolsActions.onClear();
         this.closeDeleteDialog();

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -387,7 +387,7 @@ describe('TOC Toolbar', () => {
         const el = ReactDOM.findDOMNode(cmp);
         expect(el).toExist();
         const btn = el.getElementsByClassName("btn");
-        expect(btn.length).toBe(3);
+        expect(btn.length).toBe(4);
     });
 
     it('add group max depth reached', () => {
@@ -405,7 +405,7 @@ describe('TOC Toolbar', () => {
         const el = ReactDOM.findDOMNode(cmp);
         expect(el).toExist();
         const btn = el.getElementsByClassName("btn");
-        expect(btn.length).toBe(2);
+        expect(btn.length).toBe(3);
     });
 
     it('group multiple selections', () => {

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -390,6 +390,8 @@ class LayerTree extends React.Component {
                                 closeText: <Message msgId="close"/>,
                                 confirmDeleteText: <Message msgId="layerProperties.deleteLayer" />,
                                 confirmDeleteMessage: <Message msgId="layerProperties.deleteLayerMessage" />,
+                                confirmDeleteLayerGroupText: <Message msgId="layerProperties.deleteLayerGroup" />,
+                                confirmDeleteLayerGroupMessage: <Message msgId="layerProperties.deleteLayerGroupMessage" />,
                                 confirmDeleteCancelText: <Message msgId="cancel"/>,
                                 addLayer: <Message msgId="toc.addLayer"/>,
                                 addLayerTooltip: <Message msgId="toc.addLayer" />,

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -62,6 +62,8 @@
             "delete": "Löschen",
             "deleteLayer":"Ebene löschen",
             "deleteLayerMessage": "Möchtest du wirklich diese Ebene löschen?",
+            "deleteLayerGroup":"Gruppe löschen",
+            "deleteLayerGroupMessage": "Möchten Sie diese Gruppe und alle ihre Ebenen wirklich löschen?",
             "confirmDelete": "Bist du sicher?",
             "featureTypeError": "Layerattribute können nicht geladen werden",
             "featureTypeErrorInvalidJSON": "Layerattribute können nicht geladen werden. Antwort ist nicht gültig",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -62,6 +62,8 @@
             "delete": "Delete",
             "deleteLayer":"Delete Layer",
             "deleteLayerMessage": "Do you really want to delete this Layer?",
+            "deleteLayerGroup":"Delete Group",
+            "deleteLayerGroupMessage": "Do you really want to delete this group and all of its layers?",
             "confirmDelete": "Are you sure?",
             "featureTypeError": "Cannot load layer attributes",
             "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -62,6 +62,8 @@
             "delete": "Borrar",
             "deleteLayer":"Borrar el mapa",
             "deleteLayerMessage": "¿Está totalmente seguro de querer borrar este mapa?",
+            "deleteLayerGroup":"Eliminar grupo",
+            "deleteLayerGroupMessage": "¿Realmente quieres eliminar este grupo y todas sus capas?",
             "confirmDelete": "¿Está seguro?",
             "featureTypeError": "Imposible cargar los atributos del mapa",
             "featureTypeErrorInvalidJSON": "Imposible cargar los atributos del mapa. La respuesta no es válida",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -62,6 +62,8 @@
             "delete": "Effacer",
             "deleteLayer":"Supprimer le calque",
             "deleteLayerMessage": "Voulez-vous vraiment supprimer cette couche?",
+            "deleteLayerGroup":"Supprimer le groupe",
+            "deleteLayerGroupMessage": "Voulez-vous vraiment supprimer ce groupe et toutes ses couches?",
             "confirmDelete": "Êtes-vous sûr?",
             "featureTypeError": "Impossible de charger les attributs de calque",
             "featureTypeErrorInvalidJSON": "Impossible de charger les attributs de calque. La réponse n'est pas valide",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -62,6 +62,8 @@
             "delete": "Izbriši",
             "deleteLayer":"Izbriši sloj",
             "deleteLayerMessage": "Želite li zaista izbrisati ovaj sloj?",
+            "deleteLayerGroup":"Izbriši grupu",
+            "deleteLayerGroupMessage": "Želite li stvarno izbrisati ovu grupu i sve njezine slojeve?",
             "confirmDelete": "Jeste li sigurni?",
             "featureTypeError": "Nije moguće učitavanje atributa sloja",
             "featureTypeErrorInvalidJSON": "Nije moguće učitavanje atributa sloja. Odziv nije ispravan",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -62,6 +62,8 @@
             "delete": "Elimina",
             "deleteLayer":"Elimina Livello",
             "deleteLayerMessage": "Sei sicuro di voler eliminare questo livello?",
+            "deleteLayerGroup":"Elimina gruppo",
+            "deleteLayerGroupMessage": "Vuoi veramente cancellare questo gruppo e tutti i suoi livelli?",
             "confirmDelete": "Sei sicuro?",
             "featureTypeError": "Impossibile caricare gli attributi del layer",
             "featureTypeErrorInvalidJSON": "Impossibile caricare gli attributi del layer. La risposta non è valida",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -61,6 +61,8 @@
             "delete": "Wissen",
             "deleteLayer":"Verwijder de laag",
             "deleteLayerMessage": "Weet u zeker dat u deze laag wilt verwijderen?",
+            "deleteLayerGroup":"Groep verwijderen",
+            "deleteLayerGroupMessage": "Wilt u deze groep en alle lagen ervan echt verwijderen?",
             "confirmDelete": "Bent u zeker?",
             "featureTypeError": "De atributen van de laag kunnen niet geladen worden",
             "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -63,6 +63,8 @@
             "delete": "Apagar",
             "deleteLayer":"Apagar Tema",
             "deleteLayerMessage": "Deseja realmente apagar este Tema?",
+            "deleteLayerGroup":"Excluir grupo",
+            "deleteLayerGroupMessage": "Deseja realmente excluir este grupo e todas as suas camadas?",
             "confirmDelete": "Tem a certeza?",
             "featureTypeError": "Não foi possível ler os atributos do tema",
             "featureTypeErrorInvalidJSON": "Não é possível ler os atributos do tema. Resposta não é válida.",

--- a/web/client/translations/data.vi-VN
+++ b/web/client/translations/data.vi-VN
@@ -653,6 +653,8 @@
             "delete": "Xóa",
             "deleteLayer": "Xóa lớp",
             "deleteLayerMessage": "Bạn có thực sự muốn xóa lớp này?",
+            "deleteLayerGroup":"Xóa nhóm",
+            "deleteLayerGroupMessage": "Bạn có thực sự muốn xóa nhóm này và tất cả các lớp của nó không?",
             "description": "Mô tả",
             "display": "Hiển thị",
             "editCustomFormat": "Chỉnh sửa định dạng tùy chỉnh",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -62,6 +62,8 @@
             "delete": "删除",
             "deleteLayer":"删除图层",
             "deleteLayerMessage": "你真的想删除这个层？",
+            "deleteLayerGroup":"删除组",
+            "deleteLayerGroupMessage": "你真的想要删除这个组及其所有图层吗?",
             "confirmDelete": "你确定?",
             "featureTypeError": "无法加载图层属性",
             "featureTypeErrorInvalidJSON": "Cannot load layer attributes. Response is not valid",


### PR DESCRIPTION
## Description
Enable removal of layer group from TOC

## Issues
 - #4145 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4145 

**What is the new behavior?**
![TOC removal](https://user-images.githubusercontent.com/1956062/64697408-75a7bf00-d4a9-11e9-95a1-e65a47dccde7.gif)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
