### PR TITLE
Fix #3926 Wrong area in printing when using EPSG:4326

### DIFF
--- a/web/client/actions/__tests__/map-test.js
+++ b/web/client/actions/__tests__/map-test.js
@@ -21,7 +21,9 @@ var {
     ZOOM_TO_EXTENT,
     RESIZE_MAP,
     CHANGE_MAP_LIMITS,
-    ZOOM_TO_POINT, zoomToPoint,
+    ZOOM_TO_POINT,
+    SET_MAP_RESOLUTIONS,
+    zoomToPoint,
     errorLoadingFont,
     changeMapView,
     clickOnMap,
@@ -35,7 +37,8 @@ var {
     initMap,
     zoomToExtent,
     resizeMap,
-    changeMapLimits
+    changeMapLimits,
+    setMapResolutions
 } = require('../map');
 const {
     SHOW_NOTIFICATION
@@ -212,5 +215,13 @@ describe('Test correctness of the map actions', () => {
         expect(retval.pos).toEqual(pos);
         expect(retval.zoom).toEqual(zoom);
         expect(retval.crs).toEqual(crs);
+    });
+
+    it('setMapResolutions', () => {
+        const resolutions = [4, 2];
+        const retval = setMapResolutions(resolutions);
+        expect(retval).toExist();
+        expect(retval.type).toEqual(SET_MAP_RESOLUTIONS);
+        expect(retval.resolutions).toEqual(resolutions);
     });
 });

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -23,6 +23,7 @@ const UPDATE_VERSION = 'UPDATE_VERSION';
 const INIT_MAP = 'INIT_MAP';
 const RESIZE_MAP = 'RESIZE_MAP';
 const CHANGE_MAP_LIMITS = 'CHANGE_MAP_LIMITS';
+const SET_MAP_RESOLUTIONS = 'SET_MAP_RESOLUTIONS';
 
 
 function errorLoadingFont(err = {family: ""}) {
@@ -172,6 +173,13 @@ function changeMapLimits({restrictedExtent, crs, minZoom}) {
     };
 }
 
+function setMapResolutions(resolutions) {
+    return {
+        type: SET_MAP_RESOLUTIONS,
+        resolutions
+    };
+}
+
 /**
  * Actions for map
  * @name actions.map
@@ -193,6 +201,7 @@ module.exports = {
     INIT_MAP,
     RESIZE_MAP,
     CHANGE_MAP_LIMITS,
+    SET_MAP_RESOLUTIONS,
     changeMapView,
     clickOnMap,
     changeMousePointer,
@@ -208,5 +217,6 @@ module.exports = {
     updateVersion,
     initMap,
     resizeMap,
-    changeMapLimits
+    changeMapLimits,
+    setMapResolutions
 };

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -47,6 +47,7 @@ export default class OpenlayersMap extends React.Component {
         projection: PropTypes.string,
         projectionDefs: PropTypes.array,
         onMapViewChanges: PropTypes.func,
+        onResolutionsChange: PropTypes.func,
         onClick: PropTypes.func,
         mapOptions: PropTypes.object,
         zoomControl: PropTypes.bool,
@@ -70,6 +71,7 @@ export default class OpenlayersMap extends React.Component {
     static defaultProps = {
         id: 'map',
         onMapViewChanges: () => { },
+        onResolutionsChange: () => { },
         onCreationError: () => { },
         onClick: null,
         onMouseMove: () => { },
@@ -214,6 +216,7 @@ export default class OpenlayersMap extends React.Component {
         // NOTE: this re-call render function after div creation to have the map initialized.
         this.forceUpdate();
 
+        this.props.onResolutionsChange(this.getResolutions());
         if (this.props.registerHooks) {
             this.registerHooks();
         }
@@ -250,6 +253,7 @@ export default class OpenlayersMap extends React.Component {
                     newProps.center.y
                 ], 'EPSG:4326', mapProjection);
                 this.map.setView(this.createView(center, newProps.zoom, newProps.projection, newProps.mapOptions && newProps.mapOptions.view, newProps.limits));
+                this.props.onResolutionsChange(this.getResolutions());
             }
             // We have to force ol to drop tile and reload
             this.map.getLayers().forEach((l) => {

--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -20,6 +20,7 @@ const {connect} = require('react-redux');
 const CrsSelectorMenu = require('../components/mapcontrols/crsselectormenu/CrsSelectorMenu');
 const {projectionDefsSelector, projectionSelector} = require('../selectors/map');
 const {bottomPanelOpenSelector} = require('../selectors/maplayout');
+const {printSelector} = require('../selectors/controls');
 const {crsInputValueSelector} = require('../selectors/crsselector');
 const {currentBackgroundSelector} = require('../selectors/layers');
 const{modeSelector} = require('../selectors/featuregrid');
@@ -121,13 +122,14 @@ const crsSelector = connect(
             modeSelector,
             isCesium,
             bottomPanelOpenSelector,
-                ( currentRole, currentBackground, selected, projectionDefs, value, mode, cesium, bottomPanel) => ({
+            printSelector,
+                ( currentRole, currentBackground, selected, projectionDefs, value, mode, cesium, bottomPanel, printEnabled) => ({
                     currentRole,
                     currentBackground,
                     selected,
                     projectionDefs,
                     value,
-                    enabled: (mode !== 'EDIT') && !cesium && !bottomPanel
+                    enabled: (mode !== 'EDIT') && !cesium && !bottomPanel && !printEnabled
                 })
             ), {
                 typeInput: setInputValue,

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -19,7 +19,7 @@ require('./map/css/map.css');
 
 const Message = require('../components/I18N/Message');
 const ConfigUtils = require('../utils/ConfigUtils');
-const {errorLoadingFont} = require('../actions/map');
+const {errorLoadingFont, setMapResolutions} = require('../actions/map');
 
 const {isString} = require('lodash');
 let plugins;
@@ -196,6 +196,7 @@ class MapPlugin extends React.Component {
         projectionDefs: PropTypes.array,
         toolsOptions: PropTypes.object,
         onFontError: PropTypes.func,
+        onResolutionsChange: PropTypes.func,
         actions: PropTypes.object,
         features: PropTypes.array,
         securityToken: PropTypes.string,
@@ -236,7 +237,8 @@ class MapPlugin extends React.Component {
         additionalLayers: [],
         shouldLoadFont: false,
         elevationEnabled: false,
-        onFontError: () => {}
+        onFontError: () => {},
+        onResolutionsChange: () => {}
     };
     state = {
         canRender: true
@@ -352,7 +354,8 @@ class MapPlugin extends React.Component {
                     projectionDefs={this.props.projectionDefs}
                     {...this.props.map}
                     mapOptions={assign({}, mapOptions, this.getMapOptions())}
-                    zoomControl={this.props.zoomControl}>
+                    zoomControl={this.props.zoomControl}
+                    onResolutionsChange={this.props.onResolutionsChange}>
                     {this.renderLayers()}
                     {this.renderSupportTools()}
                 </plugins.Map>
@@ -420,7 +423,8 @@ const selector = createSelector(
 );
 module.exports = {
     MapPlugin: connect(selector, {
-        onFontError: errorLoadingFont
+        onFontError: errorLoadingFont,
+        onResolutionsChange: setMapResolutions
     })(MapPlugin),
     reducers: {
         draw: require('../reducers/draw'),

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -30,7 +30,7 @@ const assign = require('object-assign');
 
 const {head} = require('lodash');
 
-const {projectionSelector} = require('../selectors/map');
+const {scalesSelector} = require('../selectors/map');
 const {currentLocaleSelector} = require('../selectors/locale');
 const {mapTypeSelector} = require('../selectors/maptype');
 
@@ -137,7 +137,7 @@ module.exports = {
                         mapPreviewOptions: PropTypes.object,
                         syncMapPreview: PropTypes.bool,
                         useFixedScales: PropTypes.bool,
-                        projection: PropTypes.string,
+                        scales: PropTypes.array,
                         ignoreLayers: PropTypes.array,
                         defaultBackground: PropTypes.string,
                         closeGlyph: PropTypes.string,
@@ -189,7 +189,7 @@ module.exports = {
                         },
                         syncMapPreview: true,
                         useFixedScales: false,
-                        projection: "EPSG:900913",
+                        scales: [],
                         ignoreLayers: ["google", "bing"],
                         defaultBackground: "osm",
                         closeGlyph: "1-close",
@@ -383,18 +383,10 @@ module.exports = {
                                 this.props.configurePrintMap(newMap.center, mapZoom, scaleZoom, scales[scaleZoom],
                                     this.filterLayers(newPrintSpec), newMap.projection, this.props.currentLocale);
                             } else {
-                                const scales = this.computeScales();
-                                this.props.configurePrintMap(newMap.center, newMap.zoom, newMap.zoom, scales[newMap.zoom],
+                                this.props.configurePrintMap(newMap.center, newMap.zoom, newMap.zoom, this.props.scales[newMap.zoom],
                                     this.filterLayers(newPrintSpec), newMap.projection, this.props.currentLocale);
                             }
                         }
-                    };
-
-                    computeScales = () => {
-                        const resolutions = MapUtils.getResolutions();
-                        const units = CoordinatesUtils.getUnits(this.props.projection);
-                        const dpm = 96 * (100 / 2.54);
-                        return resolutions.map((resolution) => resolution * dpm * (units === 'degrees' ? 111194.87428468118 : 1));
                     };
 
                     print = () => {
@@ -413,11 +405,11 @@ module.exports = {
                     (state) => state.print && state.print.error,
                     mapSelector,
                     layersSelector,
-                    projectionSelector,
+                    scalesSelector,
                     (state) => state.browser && (!state.browser.ie || state.browser.ie11),
                     currentLocaleSelector,
                     mapTypeSelector
-                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, projection, usePreview, currentLocale, mapType) => ({
+                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, scales, usePreview, currentLocale, mapType) => ({
                     open,
                     capabilities,
                     printSpec,
@@ -425,7 +417,7 @@ module.exports = {
                     error,
                     map,
                     layers: layers.filter(l => !l.loadingError),
-                    projection,
+                    scales,
                     usePreview,
                     currentLocale,
                     mapType

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -30,7 +30,7 @@ const assign = require('object-assign');
 
 const {head} = require('lodash');
 
-const {scalesSelector} = require('../selectors/map');
+const {projectionSelector} = require('../selectors/map');
 const {currentLocaleSelector} = require('../selectors/locale');
 const {mapTypeSelector} = require('../selectors/maptype');
 
@@ -137,7 +137,7 @@ module.exports = {
                         mapPreviewOptions: PropTypes.object,
                         syncMapPreview: PropTypes.bool,
                         useFixedScales: PropTypes.bool,
-                        scales: PropTypes.array,
+                        projection: PropTypes.string,
                         ignoreLayers: PropTypes.array,
                         defaultBackground: PropTypes.string,
                         closeGlyph: PropTypes.string,
@@ -189,7 +189,7 @@ module.exports = {
                         },
                         syncMapPreview: true,
                         useFixedScales: false,
-                        scales: [],
+                        projection: "EPSG:900913",
                         ignoreLayers: ["google", "bing"],
                         defaultBackground: "osm",
                         closeGlyph: "1-close",
@@ -383,10 +383,18 @@ module.exports = {
                                 this.props.configurePrintMap(newMap.center, mapZoom, scaleZoom, scales[scaleZoom],
                                     this.filterLayers(newPrintSpec), newMap.projection, this.props.currentLocale);
                             } else {
-                                this.props.configurePrintMap(newMap.center, newMap.zoom, newMap.zoom, this.props.scales[newMap.zoom],
+                                const scales = this.computeScales();
+                                this.props.configurePrintMap(newMap.center, newMap.zoom, newMap.zoom, scales[newMap.zoom],
                                     this.filterLayers(newPrintSpec), newMap.projection, this.props.currentLocale);
                             }
                         }
+                    };
+
+                    computeScales = () => {
+                        const resolutions = MapUtils.getResolutions();
+                        const units = CoordinatesUtils.getUnits(this.props.projection);
+                        const dpm = 96 * (100 / 2.54);
+                        return resolutions.map((resolution) => resolution * dpm * (units === 'degrees' ? 111194.87428468118 : 1));
                     };
 
                     print = () => {
@@ -405,11 +413,11 @@ module.exports = {
                     (state) => state.print && state.print.error,
                     mapSelector,
                     layersSelector,
-                    scalesSelector,
+                    projectionSelector,
                     (state) => state.browser && (!state.browser.ie || state.browser.ie11),
                     currentLocaleSelector,
                     mapTypeSelector
-                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, scales, usePreview, currentLocale, mapType) => ({
+                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, projection, usePreview, currentLocale, mapType) => ({
                     open,
                     capabilities,
                     printSpec,
@@ -417,7 +425,7 @@ module.exports = {
                     error,
                     map,
                     layers: layers.filter(l => !l.loadingError),
-                    scales,
+                    projection,
                     usePreview,
                     currentLocale,
                     mapType

--- a/web/client/plugins/__tests__/CRSSelector-test.jsx
+++ b/web/client/plugins/__tests__/CRSSelector-test.jsx
@@ -1,0 +1,52 @@
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import CRSSelectorPlugin from '../CRSSelector';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('CRSSelector Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('Shows CRSSelector Plugin', () => {
+        const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
+            map: {
+                projection: "EPSG:900913"
+            },
+            localConfig: {
+                projectionDefs: []
+            }
+        });
+
+        ReactDOM.render(<Plugin filterAllowedCRS={["EPSG:4326", "EPSG:3857"]} additionalCRS={{}}/>, document.getElementById("container"));
+        expect(document.getElementsByClassName('ms-prj-selector').length).toBe(1);
+    });
+
+    it('CRSSelector is not rendered when Print Panel is enabled', () => {
+        const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
+            controls: {
+                print: {
+                    enabled: true
+                }
+            },
+            map: {
+                projection: "EPSG:900913"
+            },
+            localConfig: {
+                projectionDefs: []
+            }
+        });
+
+        ReactDOM.render(<Plugin filterAllowedCRS={["EPSG:4326", "EPSG:3857"]} additionalCRS={{}}/>, document.getElementById("container"));
+        expect(document.getElementsByClassName('ms-prj-selector').length).toBe(0);
+    });
+});

--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -9,7 +9,7 @@ const expect = require('expect');
 const {round} = require('lodash');
 
 var mapConfig = require('../map');
-const { changeMapLimits, PAN_TO } = require('../../actions/map');
+const { changeMapLimits, PAN_TO, SET_MAP_RESOLUTIONS } = require('../../actions/map');
 
 describe('Test the map reducer', () => {
     it('returns original state on unrecognized action', () => {
@@ -157,6 +157,16 @@ describe('Test the map reducer', () => {
         expect(state.mapOptions).toExist();
         expect(state.mapOptions.view).toExist();
         expect(state.mapOptions.view.resolutions).toExist();
+    });
+
+    it('sets new resolutions', () => {
+        const resolutions = [2.54, 0.254];
+        const action = {
+            type: SET_MAP_RESOLUTIONS,
+            resolutions
+        };
+        const state = mapConfig({}, action);
+        expect(state.resolutions).toEqual(resolutions);
     });
 
     it('pan to with center as array', () => {

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -8,7 +8,7 @@
 
 var {CHANGE_MAP_VIEW, CHANGE_MOUSE_POINTER,
     CHANGE_ZOOM_LVL, CHANGE_MAP_CRS, CHANGE_MAP_SCALES, PAN_TO,
-    CHANGE_MAP_STYLE, CHANGE_ROTATION, UPDATE_VERSION, ZOOM_TO_POINT, RESIZE_MAP, CHANGE_MAP_LIMITS } = require('../actions/map');
+    CHANGE_MAP_STYLE, CHANGE_ROTATION, UPDATE_VERSION, ZOOM_TO_POINT, RESIZE_MAP, CHANGE_MAP_LIMITS, SET_MAP_RESOLUTIONS } = require('../actions/map');
 
 var assign = require('object-assign');
 var MapUtils = require('../utils/MapUtils');
@@ -72,6 +72,11 @@ function mapConfig(state = null, action) {
             return newState;
         }
         return state;
+    case SET_MAP_RESOLUTIONS: {
+        return assign({}, state, {
+            resolutions: action.resolutions
+        });
+    }
     case ZOOM_TO_POINT: {
         return assign({}, state, {
             center: CoordinatesUtils.reproject(action.pos, action.crs, 'EPSG:4326'),

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -17,6 +17,7 @@ module.exports = {
     showCoordinateEditorSelector,
     measureSelector: (state) => get(state, "controls.measure.enabled"),
     queryPanelSelector: (state) => get(state, "controls.queryPanel.enabled"),
+    printSelector: (state) => get(state, "controls.print.enabled"),
     wfsDownloadAvailable: state => !!get(state, "controls.wfsdownload.available"),
     wfsDownloadSelector: state => !!get(state, "controls.wfsdownload.enabled"),
     widgetBuilderAvailable: state => get(state, "controls.widgetBuilder.available", false),

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -7,7 +7,6 @@
 */
 
 const CoordinatesUtils = require('../utils/CoordinatesUtils');
-const MapUtils = require('../utils/MapUtils');
 const {createSelector} = require('reselect');
 const {get} = require('lodash');
 
@@ -47,6 +46,7 @@ const configuredMinZoomSelector = state => {
 
 const mapLimitsSelector = state => get(mapSelector(state), "limits");
 const minZoomSelector = state => get(mapLimitsSelector(state), "minZoom" );
+const resolutionsSelector = state => get(mapSelector(state), "resolutions");
 
 /**
  * Get the scales of the current map
@@ -56,10 +56,9 @@ const minZoomSelector = state => get(mapLimitsSelector(state), "minZoom" );
  * @return {number[]} the scales of the map
  */
 const scalesSelector = createSelector(
-    [projectionSelector],
-    (projection) => {
-        if (projection) {
-            const resolutions = MapUtils.getResolutions();
+    [resolutionsSelector, projectionSelector],
+    (resolutions, projection) => {
+        if (resolutions && projection) {
             const units = CoordinatesUtils.getUnits(projection);
             const dpm = 96 * (100 / 2.54);
             return resolutions.map((resolution) => resolution * dpm * (units === 'degrees' ? 111194.87428468118 : 1));


### PR DESCRIPTION
## Description
CRS now hides when print panel is enabled. In terms of the wrong area in printing bug, it's that the map layer is not being printed in the pdf(the states layer in US population map prints just fine), looking at data that is sent to api seems fine, so maybe the bug is not on the client? I also fixed another bug, wrongfully thinking that it is the one that is in the issue. If you open print panel with default projection, then close it, change projection, open it again and try to print, the printed area will be wrong.

## Issues
 - #3926 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#3926 

**What is the new behavior?**
In the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
