### PR TITLE
Fix #4182 Remove all annotations geometry fail without initial state

### DIFF
--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -433,6 +433,27 @@ describe('annotations Epics', () => {
         const action = confirmRemoveAnnotation('geometry');
         store.dispatch(action);
     });
+
+    it('remove annotation geometry when initial state is not set', (done) => {
+        const tempStore = mockStore({
+            annotations: {
+                editing: {
+                    style: {},
+                    features: [],
+                    type: "FeatureCollection"
+                }
+            }
+        });
+        tempStore.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 2) {
+                expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                done();
+            }
+        });
+        const action = confirmRemoveAnnotation('geometry');
+        store.dispatch(action);
+    });
     it('save annotation', (done) => {
         store.subscribe(() => {
             const actions = store.getActions();

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -238,7 +238,7 @@ module.exports = (viewer) => ({
                 const feature = state.annotations.editing;
                 const drawing = state.annotations.drawing;
                 const type = state.annotations.featureType;
-                const multiGeom = state.annotations.config.multiGeometry;
+                const multiGeom = get(state, 'annotations.config.multiGeometry');
                 const drawOptions = {
                     featureProjection: "EPSG:4326",
                     stopAfterDrawing: !multiGeom,

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -8,7 +8,6 @@
 
 const Rx = require('rxjs');
 const {saveAs} = require('file-saver');
-const {get} = require('lodash');
 const {MAP_CONFIG_LOADED} = require('../actions/config');
 const {TOGGLE_CONTROL, toggleControl, setControlProperty} = require('../actions/controls');
 const {addLayer, updateNode, changeLayerProperties, removeLayer} = require('../actions/layers');
@@ -34,7 +33,7 @@ const {PURGE_MAPINFO_RESULTS} = require('../actions/mapInfo');
 
 const {head, findIndex, castArray, isArray, find} = require('lodash');
 const assign = require('object-assign');
-const {annotationsLayerSelector} = require('../selectors/annotations');
+const {annotationsLayerSelector, multiGeometrySelector} = require('../selectors/annotations');
 const {normalizeAnnotation, removeDuplicate, validateCoordsArray, getStartEndPointsForLinestring, DEFAULT_ANNOTATIONS_STYLES} = require('../utils/AnnotationsUtils');
 
 const {mapNameSelector} = require('../selectors/map');
@@ -70,7 +69,7 @@ const validateFeatureCollection = (feature) => {
 
 const getSelectDrawStatus = (state) => {
     let feature = state.annotations.editing;
-    const multiGeom = state.annotations.config.multiGeometry;
+    const multiGeom = multiGeometrySelector(state);
     const drawOptions = {
         featureProjection: "EPSG:4326",
         stopAfterDrawing: !multiGeom,
@@ -86,7 +85,7 @@ const getSelectDrawStatus = (state) => {
 };
 const getReadOnlyDrawStatus = (state) => {
     let feature = state.annotations.editing;
-    const multiGeom = state.annotations.config.multiGeometry;
+    const multiGeom = multiGeometrySelector(state);
     const drawOptions = {
         featureProjection: "EPSG:4326",
         stopAfterDrawing: !multiGeom,
@@ -101,7 +100,7 @@ const getReadOnlyDrawStatus = (state) => {
 };
 const getEditingGeomDrawStatus = (state) => {
     let feature = state.annotations.editing;
-    const multiGeom = state.annotations.config.multiGeometry;
+    const multiGeom = multiGeometrySelector(state);
     const drawOptions = {
         featureProjection: "EPSG:4326",
         stopAfterDrawing: !multiGeom,
@@ -191,7 +190,7 @@ module.exports = (viewer) => ({
             const state = store.getState();
             const feature = state.annotations.editing;
             const type = state.annotations.featureType;
-            const multiGeom = state.annotations.config.multiGeometry;
+            const multiGeom = multiGeometrySelector(state);
             const drawOptions = {
                 featureProjection: "EPSG:4326",
                 stopAfterDrawing: !multiGeom,
@@ -238,7 +237,7 @@ module.exports = (viewer) => ({
                 const feature = state.annotations.editing;
                 const drawing = state.annotations.drawing;
                 const type = state.annotations.featureType;
-                const multiGeom = get(state, 'annotations.config.multiGeometry');
+                const multiGeom = multiGeometrySelector(state);
                 const drawOptions = {
                     featureProjection: "EPSG:4326",
                     stopAfterDrawing: !multiGeom,
@@ -321,7 +320,7 @@ module.exports = (viewer) => ({
             const feature = state.annotations.editing;
             const type = state.annotations.featureType;
             const defaultTextAnnotation = state.annotations.defaultTextAnnotation;
-            const multiGeom = get(state, 'annotations.config.multiGeometry');
+            const multiGeom = multiGeometrySelector;
             const drawOptions = {
                 featureProjection: "EPSG:4326",
                 stopAfterDrawing: !multiGeom,
@@ -341,7 +340,7 @@ module.exports = (viewer) => ({
         .switchMap( (action) => {
             return Rx.Observable.from([
                 updateAnnotationGeometry(mergeGeometry(action.features), action.textChanged, action.circleChanged)
-            ].concat(!store.getState().annotations.config.multiGeometry && store.getState().annotations.drawing ? [toggleAdd()] : []));
+            ].concat(!multiGeometrySelector(store.getState()) && store.getState().annotations.drawing ? [toggleAdd()] : []));
         }),
     endDrawTextEpic: (action$, store) => action$.ofType(SAVE_TEXT)
         .switchMap( () => {
@@ -351,13 +350,13 @@ module.exports = (viewer) => ({
             return Rx.Observable.from([
                 changeDrawingStatus("replace", store.getState().annotations.featureType, "annotations", [feature], {featureProjection: "EPSG:3857",
                 transformToFeatureCollection: true}, assign({}, style, {highlight: false}))
-            ].concat(!store.getState().annotations.config.multiGeometry ? [toggleAdd()] : []));
+            ].concat(!multiGeometrySelector(store.getState()) ? [toggleAdd()] : []));
         }),
     cancelTextAnnotationsEpic: (action$, store) => action$.ofType(CANCEL_CLOSE_TEXT)
         .switchMap( () => {
             const state = store.getState();
             const feature = state.annotations.editing;
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
             return Rx.Observable.from([
                 changeDrawingStatus("drawOrEdit", "Text", "annotations", [feature], {
@@ -538,7 +537,7 @@ module.exports = (viewer) => ({
             /*if (!selected.properties.isValidFeature) {
                 feature = feature.features.filter((f, i) => selectedIndex !== i);
             }*/
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
             const action = changeDrawingStatus("drawOrEdit", method, "annotations", [feature], {
                 featureProjection: "EPSG:4326",
@@ -557,7 +556,7 @@ module.exports = (viewer) => ({
         .switchMap(({}) => {
             const state = getState();
             const feature = state.annotations.editing;
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
 
             const action = changeDrawingStatus("drawOrEdit", "", "annotations", [feature], {
@@ -575,7 +574,7 @@ module.exports = (viewer) => ({
             const state = getState();
             let feature = state.annotations.editing;
             let selected = state.annotations.selected;
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
 
             selected = set("geometry.coordinates", [selected.geometry.coordinates].filter(validateCoordsArray)[0] || [], selected);
@@ -616,7 +615,7 @@ module.exports = (viewer) => ({
             const state = getState();
             let feature = state.annotations.editing;
             let selected = state.annotations.selected;
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
 
             // selected = set("geometry.coordinates", [selected.geometry.coordinates].filter(validateCoordsArray)[0] || [], selected);
@@ -654,7 +653,7 @@ module.exports = (viewer) => ({
             const state = getState();
             const feature = state.annotations.editing;
             const selected = state.annotations.selected;
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
             let method = selected.geometry.type;
             if (selected.properties.isCircle) {
@@ -683,7 +682,7 @@ module.exports = (viewer) => ({
         .switchMap(() => {
             const state = getState();
             const feature = state.annotations.editing;
-            const multiGeometry = state.annotations.config.multiGeometry;
+            const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
 
             const action = changeDrawingStatus("drawOrEdit", "Circle", "annotations", [feature], {

--- a/web/client/selectors/__tests__/annotations-test.js
+++ b/web/client/selectors/__tests__/annotations-test.js
@@ -10,6 +10,7 @@ const expect = require('expect');
 const {isEmpty, isArray} = require('lodash');
 const {
     annotationsLayerSelector,
+    multiGeometrySelector,
     removingSelector,
     showUnsavedChangesModalSelector,
     showUnsavedStyleModalSelector,
@@ -432,6 +433,10 @@ describe('Test annotations selectors', () => {
     it('test removingSelector', () => {
         const retVal = removingSelector(state);
         expect(retVal).toBe(null);
+    });
+    it('test multiGeometrySelector', () => {
+        const multiGeometry = multiGeometrySelector(state);
+        expect(multiGeometry).toBeTruthy();
     });
     it('test showUnsavedChangesModalSelector', () => {
         const retVal = showUnsavedChangesModalSelector(state);

--- a/web/client/selectors/__tests__/annotations-test.js
+++ b/web/client/selectors/__tests__/annotations-test.js
@@ -434,9 +434,13 @@ describe('Test annotations selectors', () => {
         const retVal = removingSelector(state);
         expect(retVal).toBe(null);
     });
-    it('test multiGeometrySelector', () => {
+    it('test multiGeometrySelector when it is set', () => {
         const multiGeometry = multiGeometrySelector(state);
-        expect(multiGeometry).toBeTruthy();
+        expect(multiGeometry).toBe(true);
+    });
+    it('test multiGeometrySelector when it is not set', () => {
+        const multiGeometry = multiGeometrySelector({});
+        expect(multiGeometry).toBe(false);
     });
     it('test showUnsavedChangesModalSelector', () => {
         const retVal = showUnsavedChangesModalSelector(state);

--- a/web/client/selectors/annotations.js
+++ b/web/client/selectors/annotations.js
@@ -18,7 +18,7 @@ const annotationsLayerSelector = createSelector([
     ], (layers) => head(layers.filter(l => l.id === 'annotations'))
 );
 
-const multiGeometrySelector = (state) => get(state, 'annotations.config.multiGeometry');
+const multiGeometrySelector = (state) => get(state, 'annotations.config.multiGeometry', false);
 const removingSelector = (state) => get(state, "annotations.removing");
 const formatSelector = (state) => get(state, "annotations.format");
 const aeronauticalOptionsSelector = (state) => get(state, "annotations.aeronauticalOptions");

--- a/web/client/selectors/annotations.js
+++ b/web/client/selectors/annotations.js
@@ -18,6 +18,7 @@ const annotationsLayerSelector = createSelector([
     ], (layers) => head(layers.filter(l => l.id === 'annotations'))
 );
 
+const multiGeometrySelector = (state) => get(state, 'annotations.config.multiGeometry');
 const removingSelector = (state) => get(state, "annotations.removing");
 const formatSelector = (state) => get(state, "annotations.format");
 const aeronauticalOptionsSelector = (state) => get(state, "annotations.aeronauticalOptions");
@@ -110,6 +111,7 @@ const annotationSelector = createSelector([annotationsListSelector], (annotation
 });
 
 module.exports = {
+    multiGeometrySelector,
     symbolErrorsSelector,
     modeSelector,
     annotationsLayerSelector,


### PR DESCRIPTION
## Description
Fix failure to remove annotation geometry when annotation initial state is not set

## Issue
 - #4182 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4182 

**What is the new behavior?**
Remove all annotations works regardless of the initial state

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
