### PR TITLE
Fix #4142 First display problem on dashbord elements on mobile

### DIFF
--- a/web/client/components/misc/AdaptiveGrid.jsx
+++ b/web/client/components/misc/AdaptiveGrid.jsx
@@ -29,6 +29,7 @@ module.exports = (props) => (<ContainerDimensions>
                     {...props}
                     minHeight={height}
                     minWidth={width}
+                    enableCellAutoFocus={false}
                     />
             </div>
             }


### PR DESCRIPTION
## Description
React DataGrid seems to have enableCellAutoFocus prop that by default is true which seems to be causing the problem. Added explicit enableCellAutoFocus=false.

## Issues
 - #4142 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#4142 

**What is the new behavior?**
Dashboard's scrollTop doesn't change

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No