### PR TITLE
Fix #4168 Prevent login and edit user dialog hide on click out

### DIFF
--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -202,7 +202,6 @@ class GroupDialog extends React.Component {
 
     render() {
         return (<Dialog
-              onClickOut={this.props.onClose}
               modal
               maskLoading={this.props.group && (this.props.group.status === "loading" || this.props.group.status === "saving")}
               id="mapstore-group-dialog"

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -223,7 +223,7 @@ class UserDialog extends React.Component {
     };
 
     render() {
-        return (<Dialog onClickOut={this.props.onClose} modal draggable={false} maskLoading={this.props.user && (this.props.user.status === "loading" || this.props.user.status === "saving")} id="mapstore-user-dialog" className="user-edit-dialog" style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
+        return (<Dialog modal draggable={false} maskLoading={this.props.user && (this.props.user.status === "loading" || this.props.user.status === "saving")} id="mapstore-user-dialog" className="user-edit-dialog" style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
 
           <span role="header">
               <span className="user-panel-title">{(this.props.user && this.props.user.name) || <Message msgId="users.newUser" />}</span>

--- a/web/client/components/security/modals/LoginModal.jsx
+++ b/web/client/components/security/modals/LoginModal.jsx
@@ -81,7 +81,7 @@ class LoginModal extends React.Component {
               key="closeButton"
               ref="closeButton"
               bsSize={this.props.buttonSize}
-              onClick={this.props.onClose}><Message msgId="close"/></Button> : <span/>}
+              onClick={this.handleOnHide}><Message msgId="close"/></Button> : <span/>}
         </span>);
     };
 
@@ -99,9 +99,15 @@ class LoginModal extends React.Component {
         </Modal>);
     }
 
+    /**
+     * This is called when close button clicked or
+     * when user click out(modal overlay). Hide when
+     * it is triggered from button otherwise don't hide the
+     * modal
+     */
     handleOnHide = (event) => {
         if (event) {
-            // onHide coming from header closeButton
+            // it is coming from the hide or close button
             this.props.onClose();
         }
     }

--- a/web/client/components/security/modals/LoginModal.jsx
+++ b/web/client/components/security/modals/LoginModal.jsx
@@ -86,7 +86,7 @@ class LoginModal extends React.Component {
     };
 
     render() {
-        return (<Modal {...this.props.options} show={this.props.show} onHide={this.props.onClose}>
+        return (<Modal {...this.props.options} show={this.props.show} onHide={this.handleOnHide}>
             <Modal.Header key="passwordChange" closeButton>
               <Modal.Title><Message msgId="user.login"/></Modal.Title>
             </Modal.Header>
@@ -97,6 +97,13 @@ class LoginModal extends React.Component {
                 {this.getFooter()}
             </Modal.Footer>
         </Modal>);
+    }
+
+    handleOnHide = (event) => {
+        if (event) {
+            // onHide coming from header closeButton
+            this.props.onClose();
+        }
     }
 
     loginSubmit = () => {


### PR DESCRIPTION
## Description
see title

## Issues
 - #4168 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4168 

**What is the new behavior?**
login and edit user modal does not hide on click out

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
