### PR TITLE
fix docs urls

### DIFF
--- a/docs/developer-guide/plugins-howto.md
+++ b/docs/developer-guide/plugins-howto.md
@@ -1,11 +1,11 @@
 # Creating a MapStore2 plugin
-The MapStore2 [plugins architecture](plugins-architecture) allows building your own independent modules that will integrate seamlessly into your project.
+The MapStore2 [plugins architecture](../plugins-architecture) allows building your own independent modules that will integrate seamlessly into your project.
 
 Creating a plugin is like assembling and connecting several pieces together into an atomic module. This happens by writing a plugin module, a ReactJS JSX file exporting the plugin descriptor.
 
 ## Introduction
 During this tutorial, you will learn how to create and configure plugins in a MapStore project.
-If you don't know how to work with MapStore projects, please read the [Projects Guide](mapstore-projects).
+If you don't know how to work with MapStore projects, please read the [Projects Guide](../mapstore-projects).
 
 ## A plugin example
 
@@ -210,7 +210,7 @@ export const reducers = {sample};
 Side effects should be limited as much as possible, but there are cases where a side effect cannot be avoided.
 In particular all asynchronous operations are side effects in Redux, but we obviously need to handle them, in particular we need to asynchronously load the data that we need from ore or more web services.
 
-To handle data fetching a plugin can define Epics. To have more detail about epics look at the [Epics developers guide](writing-epics) section of this documentation.
+To handle data fetching a plugin can define Epics. To have more detail about epics look at the [Epics developers guide](../writing-epics) section of this documentation.
 
 ### js/actions/sample.js
 ```javascript


### PR DESCRIPTION
## Description
fix broken urls in docs (writing plugins page)

## Issues
 - #<issue>
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe:
Fix docs broken urls

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
