### PR TITLE
Backport(2019.02.xx): Fix #4168 Prevent login and edit user dialog hide on click out (#4196)

### DIFF
--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -202,7 +202,6 @@ class GroupDialog extends React.Component {
 
     render() {
         return (<Dialog
-              onClickOut={this.props.onClose}
               modal
               maskLoading={this.props.group && (this.props.group.status === "loading" || this.props.group.status === "saving")}
               id="mapstore-group-dialog"

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -223,7 +223,7 @@ class UserDialog extends React.Component {
     };
 
     render() {
-        return (<Dialog onClickOut={this.props.onClose} modal draggable={false} maskLoading={this.props.user && (this.props.user.status === "loading" || this.props.user.status === "saving")} id="mapstore-user-dialog" className="user-edit-dialog" style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
+        return (<Dialog modal draggable={false} maskLoading={this.props.user && (this.props.user.status === "loading" || this.props.user.status === "saving")} id="mapstore-user-dialog" className="user-edit-dialog" style={assign({}, this.props.style, {display: this.props.show ? "block" : "none"})}>
 
           <span role="header">
               <span className="user-panel-title">{(this.props.user && this.props.user.name) || <Message msgId="users.newUser" />}</span>

--- a/web/client/components/security/modals/LoginModal.jsx
+++ b/web/client/components/security/modals/LoginModal.jsx
@@ -81,12 +81,12 @@ class LoginModal extends React.Component {
               key="closeButton"
               ref="closeButton"
               bsSize={this.props.buttonSize}
-              onClick={this.props.onClose}><Message msgId="close"/></Button> : <span/>}
+              onClick={this.handleOnHide}><Message msgId="close"/></Button> : <span/>}
         </span>);
     };
 
     render() {
-        return (<Modal {...this.props.options} show={this.props.show} onHide={this.props.onClose}>
+        return (<Modal {...this.props.options} show={this.props.show} onHide={this.handleOnHide}>
             <Modal.Header key="passwordChange" closeButton>
               <Modal.Title><Message msgId="user.login"/></Modal.Title>
             </Modal.Header>
@@ -97,6 +97,19 @@ class LoginModal extends React.Component {
                 {this.getFooter()}
             </Modal.Footer>
         </Modal>);
+    }
+
+    /**
+     * This is called when close button clicked or
+     * when user click out(modal overlay). Hide when
+     * it is triggered from button otherwise don't hide the
+     * modal
+     */
+    handleOnHide = (event) => {
+        if (event) {
+            // it is coming from the hide or close button
+            this.props.onClose();
+        }
     }
 
     loginSubmit = () => {


### PR DESCRIPTION
* Fix #4168 Prevent login and edit user dialog hide on click out

* disable hide on clickout on groupDialog

## Description
A few sentences describing the overall goals of the pull request' s commits.

## Issues
 - #<issue>
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
