### PR TITLE
#4212 Fix Uglify build failure issue

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -154,7 +154,11 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
                 use: [{
                     loader: "babel-loader"
                 }],
-                include: paths.code
+                include: [
+                    paths.code,
+                    path.join(__dirname, "..", "node_modules", "query-string"),
+                    path.join(__dirname, "..", "node_modules", "strict-uri-encode"), path.join(__dirname, "..", "node_modules", "split-on-first")
+                ]
             }
         ].concat(prod ? [{
                 test: /\.html$/,

--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -156,8 +156,12 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
                 }],
                 include: [
                     paths.code,
+                    // the followings are here to skip issues caused by uglifyPlugin (see #4212)
+                    // TODO: a solution to this issue that uses only libs
+                    // like https://www.npmjs.com/package/uglify-js-es6#harmony when stable, terser, babel-minify ...
                     path.join(__dirname, "..", "node_modules", "query-string"),
-                    path.join(__dirname, "..", "node_modules", "strict-uri-encode"), path.join(__dirname, "..", "node_modules", "split-on-first")
+                    path.join(__dirname, "..", "node_modules", "strict-uri-encode"),
+                    path.join(__dirname, "..", "node_modules", "split-on-first")
                 ]
             }
         ].concat(prod ? [{


### PR DESCRIPTION
## Description
This changes to buildConfig.js (webpack configuration) compile the es6 libs before UglifyPlugin to skip the build failure. 

All possible alternative solutions we can try require an update of webpack already scheduled in [this branch](https://github.com/mbarto/MapStore2/tree/react_16). So then a cleaner solution is postponed during or after the update.

## Issues
 - #4212


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Build related changes


**What is the current behavior?** (You can also link to an open issue here)
Build failure

**What is the new behavior?**
Build success

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

**Other information**:
