### PR TITLE
Fix #4179 When only everyone group is present, the assign permission group selector is empty

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -34,8 +34,13 @@ const createAttributeList = (metadata = {}) => {
 let parseOptions = (opts) => opts;
 
 let parseAdminGroups = (groupsObj) => {
-    if (!groupsObj || !groupsObj.UserGroupList || !groupsObj.UserGroupList.UserGroup || !isArray(groupsObj.UserGroupList.UserGroup)) return [];
-    return groupsObj.UserGroupList.UserGroup.filter(obj => !!obj.id).map((obj) => pick(obj, ["id", "groupName", "description"]));
+    if (!groupsObj || !groupsObj.UserGroupList || !groupsObj.UserGroupList.UserGroup) return [];
+
+    const pickFromObj = (obj) => pick(obj, ["id", "groupName", "description"]);
+    if (isArray(groupsObj.UserGroupList.UserGroup)) {
+        return groupsObj.UserGroupList.UserGroup.filter(obj => !!obj.id).map(pickFromObj);
+    }
+    return [pickFromObj(groupsObj.UserGroupList.UserGroup)];
 };
 
 let parseUserGroups = (groupsObj) => {

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -184,4 +184,93 @@ describe('Test correctness of the GeoStore APIs', () => {
             "</Attributes>"
         );
     });
+    it("test getAvailableGroups for ADMIN multiple groups", () => {
+        const sampleResponse = {
+            "UserGroupList": {
+                "UserGroup": [
+                    {
+                        "groupName": "everyone",
+                        "id": 1,
+                        "restUsers": {
+                            "User": [
+                                {
+                                    "groupsNames": "everyone",
+                                    "id": 3,
+                                    "name": "user",
+                                    "role": "USER"
+                                },
+                                {
+                                    "groupsNames": "everyone",
+                                    "id": 2,
+                                    "name": "admin",
+                                    "role": "ADMIN"
+                                },
+                                {
+                                    "groupsNames": "everyone",
+                                    "id": 1,
+                                    "name": "guest",
+                                    "role": "GUEST"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "description": "test",
+                        "groupName": "test",
+                        "id": 5,
+                        "restUsers": ""
+                    }
+                ]
+            }
+        };
+
+        mockAxios.onGet().reply(200, sampleResponse);
+        API.getAvailableGroups({role: "ADMIN"}).then((data) => {
+            expect(data).toExist();
+            expect(data.length).toBe(2);
+            const everyoneGroup = data.find(g => g.id === 1);
+            expect(everyoneGroup).toEqual({id: 1, groupName: "everyone"});
+            const testGroup = data.find(g => g.id === 5);
+            expect(testGroup).toEqual({id: 5, groupName: "test"});
+        });
+    });
+    it("test getAvailableGroups for ADMIN single group", () => {
+        const sampleResponse = {
+            "UserGroupList": {
+                "UserGroup": {
+                    "groupName": "everyone",
+                    "id": 1,
+                    "restUsers": {
+                        "User": [
+                            {
+                                "groupsNames": "everyone",
+                                "id": 3,
+                                "name": "user",
+                                "role": "USER"
+                            },
+                            {
+                                "groupsNames": "everyone",
+                                "id": 2,
+                                "name": "admin",
+                                "role": "ADMIN"
+                            },
+                            {
+                                "groupsNames": "everyone",
+                                "id": 1,
+                                "name": "guest",
+                                "role": "GUEST"
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+
+        mockAxios.onGet().reply(200, sampleResponse);
+        API.getAvailableGroups({role: "ADMIN"}).then((data) => {
+            expect(data).toExist();
+            expect(data.length).toBe(1);
+            expect(data[0]).toEqual({id: 1, groupName: "everyone"});
+        });
+    });
 });


### PR DESCRIPTION
## Description
When there is only one group, groupsObj.UserGroupList.UserGroup is not an array with one element, but the element itself. The parseAdminGroups function now takes this into account.

## Issues
 - #4179 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#4179 

**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No