### PR TITLE
Fix #4205 Run-time error when creating charts from Attribute Table

### DIFF
--- a/web/client/components/data/query/AutocompleteFieldHOC.jsx
+++ b/web/client/components/data/query/AutocompleteFieldHOC.jsx
@@ -56,6 +56,10 @@ class AutocompleteFieldHOC extends React.Component {
     };
 
     getPagination = (options) => {
+        if (!this.props.filterField.options) {
+            return {};
+        }
+
         const numberOfPages = Math.ceil(this.props.filterField.fieldOptions.valuesCount / this.props.maxFeaturesWPS);
         const firstPage = this.props.filterField.fieldOptions.currentPage === 1 || !this.props.filterField.fieldOptions.currentPage;
         const lastPage = this.props.filterField.fieldOptions.currentPage === numberOfPages || !this.props.filterField.fieldOptions.currentPage;

--- a/web/client/components/data/query/__tests__/AutocompleteFieldHOC-test.jsx
+++ b/web/client/components/data/query/__tests__/AutocompleteFieldHOC-test.jsx
@@ -80,4 +80,28 @@ describe('AutocompleteFieldHOC', () => {
         expect(cmp).toExist();
 
     });
+
+    it('create a AutocompleteFieldHOC without pagination fields', () => {
+        let conf = {
+            filterField: {
+                attribute: "NAME",
+                options: {
+                    "NAME": [{
+                        value: "val1",
+                        label: "val1"
+                    }, {
+                        value: "val2",
+                        label: "val2"
+                    }]
+                },
+                value: "someVAlue"
+            },
+            maxFeaturesWPS: 5,
+            pagination: {
+                paginated: true
+            }
+        };
+        const cmp = ReactDOM.render(<AutocompleteFieldHOC {...conf} />, document.getElementById("container"));
+        expect(cmp).toExist();
+    });
 });


### PR DESCRIPTION
## Description
Run-time error when creating charts from Attribute Table

## Issues
 - #4205

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
https://github.com/geosolutions-it/MapStore2/issues/4205

Cannot create a chart, a run-time error is thrown while creating new chart with attribute filter.

**What is the new behavior?**

   After you filled the attribute filter, we've updated the static filter field values such as (attribute name, groping default options, filter value), but not the dynamic (filtered options), because they loaded from the API after triggered event updateFilterField for autocomplete. Because of dynamic options was undefined, this bug is appeared. And paginated autocomplete expect non-empty filterField options.
   Fixed, by check options field.



**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
