### PR TITLE
Fix #4195 Layer opacity issue for imported SHPs

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -1080,4 +1080,113 @@ describe('Leaflet layer', () => {
         expect(layer.layer.wmtsParams.format).toBe(JPEG);
 
     });
+
+    it('creates a vector layer with opacity for leaflet map', (done) => {
+        const opacity = 0.45;
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "vector_sample",
+            "group": "sample",
+            "styleName": "marker",
+            "opacity": opacity,
+            "features": [
+                { "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+                    "properties": {"prop0": "value0"}
+                },
+                { "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                        [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": 0.0
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
+                           [100.0, 1.0], [100.0, 0.0] ]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "MultiPoint",
+                        "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "MultiLineString",
+                        "coordinates": [
+                            [ [100.0, 0.0], [101.0, 1.0] ],
+                            [ [102.0, 2.0], [103.0, 3.0] ]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "MultiPolygon",
+                        "coordinates": [
+                          [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+                            [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+                           [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "GeometryCollection",
+                        "geometries": [
+                            { "type": "Point",
+                                "coordinates": [100.0, 0.0]
+                            },
+                            { "type": "LineString",
+                                "coordinates": [ [101.0, 0.0], [102.0, 1.0] ]
+                            }
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                }
+            ]
+        };
+        // create layers
+        const layer = ReactDOM.render(
+            <LeafLetLayer type="vector"
+                 options={options} map={map}>
+                {options.features.map((feature) => <Feature
+                    key={feature.id}
+                    type={feature.type}
+                    geometry={feature.geometry}
+                    style={{...DEFAULT_ANNOTATIONS_STYLES, highlight: false}}
+                    msId={feature.id}
+                    featuresCrs={ 'EPSG:4326' }
+                        />)}</LeafLetLayer>, document.getElementById("container"));
+        layer.layer.on('layeradd', function(newLayer) {
+            expect(newLayer.layer.options.opacity).toEqual(opacity);
+            done();
+        });
+    });
 });

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -1189,4 +1189,113 @@ describe('Leaflet layer', () => {
             done();
         });
     });
+
+    it('creates a vector layer with zero opacity for leaflet map', (done) => {
+        const opacity = 0;
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "vector_sample",
+            "group": "sample",
+            "styleName": "marker",
+            "opacity": opacity,
+            "features": [
+                { "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+                    "properties": {"prop0": "value0"}
+                },
+                { "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                        [102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": 0.0
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
+                           [100.0, 1.0], [100.0, 0.0] ]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "MultiPoint",
+                        "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "MultiLineString",
+                        "coordinates": [
+                            [ [100.0, 0.0], [101.0, 1.0] ],
+                            [ [102.0, 2.0], [103.0, 3.0] ]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "MultiPolygon",
+                        "coordinates": [
+                          [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+                            [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+                           [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                },
+                { "type": "Feature",
+                    "geometry": { "type": "GeometryCollection",
+                        "geometries": [
+                            { "type": "Point",
+                                "coordinates": [100.0, 0.0]
+                            },
+                            { "type": "LineString",
+                                "coordinates": [ [101.0, 0.0], [102.0, 1.0] ]
+                            }
+                        ]
+                    },
+                    "properties": {
+                        "prop0": "value0",
+                        "prop1": {"this": "that"}
+                    }
+                }
+            ]
+        };
+        // create layers
+        const layer = ReactDOM.render(
+            <LeafLetLayer type="vector"
+                 options={options} map={map}>
+                {options.features.map((feature) => <Feature
+                    key={feature.id}
+                    type={feature.type}
+                    geometry={feature.geometry}
+                    style={{...DEFAULT_ANNOTATIONS_STYLES, highlight: false}}
+                    msId={feature.id}
+                    featuresCrs={ 'EPSG:4326' }
+                        />)}</LeafLetLayer>, document.getElementById("container"));
+        layer.layer.on('layeradd', function(newLayer) {
+            expect(newLayer.layer.options.opacity).toEqual(opacity);
+            done();
+        });
+    });
 });

--- a/web/client/components/map/leaflet/plugins/VectorLayer.jsx
+++ b/web/client/components/map/leaflet/plugins/VectorLayer.jsx
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var Layers = require('../../../../utils/leaflet/Layers');
-var L = require('leaflet');
+const Layers = require('../../../../utils/leaflet/Layers');
+const {isNil} = require('lodash');
+const L = require('leaflet');
 
-var defaultStyle = {
+const defaultStyle = {
     radius: 5,
     color: "red",
     weight: 1,
@@ -45,7 +46,7 @@ var createVectorLayer = function(options) {
         setOpacity(layer, opacity);
     };
     layer.on('layeradd', () => {
-        layer.setOpacity(layer.opacity || options.opacity);
+        layer.setOpacity(!isNil(layer.opacity) ? layer.opacity : options.opacity);
     });
     return layer;
 };
@@ -55,7 +56,7 @@ Layers.registerType('vector', {
         const layer = createVectorLayer(options);
         // layer.opacity will store the opacity value
         // to be applied to layer style once the layer is ready
-        layer.opacity = options.opacity || 1.0;
+        layer.opacity = !isNil(options.opacity) ? options.opacity : 1.0;
         return layer;
     },
     update: (layer, newOptions, oldOptions) => {

--- a/web/client/components/map/leaflet/plugins/VectorLayer.jsx
+++ b/web/client/components/map/leaflet/plugins/VectorLayer.jsx
@@ -31,7 +31,7 @@ const setOpacity = (layer, opacity) => {
 };
 
 var createVectorLayer = function(options) {
-    const {hideLoading} = options;
+    const { hideLoading } = options;
     const layer = L.geoJson([]/* options.features */, {
         pointToLayer: options.styleName !== "marker" ? function(feature, latlng) {
             return L.circleMarker(latlng, options.style || defaultStyle);
@@ -40,16 +40,28 @@ var createVectorLayer = function(options) {
         style: options.nativeStyle || options.style || defaultStyle // TODO ol nativeStyle should not be taken from the store
     });
     layer.setOpacity = (opacity) => {
-        const style = assign({}, layer.options.style || defaultStyle, {opacity: opacity, fillOpacity: opacity});
+        const style = assign({}, layer.options.style || defaultStyle, { opacity: opacity, fillOpacity: opacity });
         layer.setStyle(style);
         setOpacity(layer, opacity);
     };
+    layer.on('layeradd', () => {
+        layer.setOpacity(layer.opacity || options.opacity);
+    });
     return layer;
 };
 
 Layers.registerType('vector', {
     create: (options) => {
-        return createVectorLayer(options);
+        const layer = createVectorLayer(options);
+        // layer.opacity will store the opacity value
+        // to be applied to layer style once the layer is ready
+        layer.opacity = options.opacity || 1.0;
+        return layer;
+    },
+    update: (layer, newOptions, oldOptions) => {
+        if (newOptions.opacity !== oldOptions.opacity) {
+            layer.opacity = newOptions.opacity;
+        }
     },
     render: () => {
         return null;

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1004,6 +1004,43 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().getLength()).toBe(1);
     });
 
+    it('creates a vector layer with opacity for openlayers map', () => {
+        const opacity = 0.45;
+        var options = {
+            crs: 'EPSG:4326',
+            opacity,
+            features: {
+                'type': 'FeatureCollection',
+                'crs': {
+                    'type': 'name',
+                    'properties': {
+                        'name': 'EPSG:4326'
+                    }
+                },
+                'features': [
+                    {
+                        'type': 'Feature',
+                        'geometry': {
+                            'type': 'Polygon',
+                            'coordinates': [[
+                              [13, 43],
+                              [15, 43],
+                              [15, 44],
+                              [13, 44]
+                            ]]
+                        }
+                    }
+                ]
+            }
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="vector"
+                 options={options} map={map}/>, document.getElementById("container"));
+
+        expect(layer.layer.values_.opacity).toEqual(opacity);
+    });
+
     it('creates a vector layer specifying the feature CRS for openlayers map', () => {
         var options = {
             crs: 'EPSG:4326',

--- a/web/client/components/map/openlayers/plugins/VectorLayer.js
+++ b/web/client/components/map/openlayers/plugins/VectorLayer.js
@@ -27,7 +27,8 @@ Layers.registerType('vector', {
             source: source,
             visible: options.visibility !== false,
             zIndex: options.zIndex,
-            style
+            style,
+            opacity: options.opacity
         });
     },
     update: (layer, newOptions, oldOptions) => {


### PR DESCRIPTION
## Description
Maintain vector layer opacity on map refresh/initial loading

## Issues
 - #4195 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4195 

**What is the new behavior?**
layer opacity is maintained on map refresh

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
