### PR TITLE
Fix #4200 In qa.mapstore is impossible to Add to Feature maps and dashboards because the button is missing

### DIFF
--- a/web/client/components/maps/enhancers/__tests__/featuredMaps-test.jsx
+++ b/web/client/components/maps/enhancers/__tests__/featuredMaps-test.jsx
@@ -69,7 +69,7 @@ describe('featuredMaps enhancher', () => {
         });
     });
 
-    it('updateItemsLifecycle verify previews items, view size changes and enableFeaturedMaps called', () => {
+    it('updateItemsLifecycle verify previews items and view size changes', () => {
 
         const CMP = updateItemsLifecycle(({items, previousItems, viewSize = 4}) =>
             <div id="CMP">
@@ -114,7 +114,7 @@ describe('featuredMaps enhancher', () => {
         viewSize = el.querySelector('.view-size');
         expect(viewSize.innerHTML).toBe('4');
 
-        expect(spy.calls.length).toEqual(2);
+        expect(spy.calls.length).toEqual(0);
     });
 
 });

--- a/web/client/components/maps/enhancers/featuredMaps.js
+++ b/web/client/components/maps/enhancers/featuredMaps.js
@@ -109,17 +109,14 @@ const updateItemsLifecycle = compose(
                 pageSize = 4,
                 onChangeSize = () => {},
                 previousItems,
-                onUpdatePreviousItems = () => {},
-                enableFeaturedMaps = () => {}
+                onUpdatePreviousItems = () => {}
             } = this.props;
             if (!isEqual(newProps.items, items)) {
 
                 onUpdatePreviousItems(items);
                 if (newProps.items.length > 0) {
-                    enableFeaturedMaps(true);
                     onChangeSize(Math.ceil(newProps.items.length / pageSize) * pageSize);
                 } else if (newProps.items.length === 0 && newProps.searchText !== '*' && newProps.searchText) {
-                    enableFeaturedMaps(false);
                     onUpdatePreviousItems(null);
                 }
 

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -52,7 +52,7 @@ class FeaturedMaps extends React.Component {
     };
 
     componentWillMount() {
-        this.props.enableFeaturedMaps(false);
+        this.props.enableFeaturedMaps(true);
     }
 
     render() {


### PR DESCRIPTION
## Description
I assume that the issue references the following situation: when FeaturedMaps has no items, the button "Add to Favorites" is disabled, hence adding items to FeaturedMaps is impossible. The problem stems from the use of enableFeaturedMaps action in FeaturedMaps enhancer. Not sure what was the intention, but removing it solves the problem.

## Issues
 - #4200 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#4200 

**What is the new behavior?**
In the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No