### PR TITLE
Fix #4236 Tooltips problem in Homepage maps/dashboards settings button

### DIFF
--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -109,7 +109,7 @@ class MapCard extends React.Component {
                 glyph: 'wrench',
                 disabled: this.props.map.updating,
                 loading: this.props.map.updating,
-                tooltipId: 'manager.editMapMetadata',
+                tooltipId: this.props.tooltips.editResource,
                 onClick: evt => {
                     this.stopPropagate(evt);
                     this.onEdit(this.props.map, true);


### PR DESCRIPTION
## Description
All tooltips now say "Edit properties"(and equivalents in other languages)

## Issues
 - #4236 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#4236 

**What is the new behavior?**
In the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
