### PR TITLE
fix attribution for basemap.at

### DIFF
--- a/web/client/utils/ConfigProvider.js
+++ b/web/client/utils/ConfigProvider.js
@@ -526,7 +526,7 @@ const CONFIGPROVIDER = {
         options: {
             maxZoom: 19,
             maxNativeZoom: 19,
-            attribution: 'Datenquelle: <a href="www.basemap.at">basemap.at</a>',
+            attribution: 'Datenquelle: <a href="https://www.basemap.at">basemap.at</a>',
             subdomains: ['', '1', '2', '3', '4'],
             format: 'png',
             bounds: [[46.358770, 8.782379], [49.037872, 17.189532]],


### PR DESCRIPTION
## Description
The attribution link for basemap.at is missing the protocol, thus it opens relative to the Mapstore2 host. This is a trivial fix in a link, thus no tests or documentation is needed.


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Click on the attribution link sets the browser relative to current location

**What is the new behavior?**
Click on attribution link opens correct URL.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
