### PR TITLE
Fix 4256 Add guidelines to title and backgrounds in GeoStory edit mode

### DIFF
--- a/web/client/components/geostory/layouts/Cascade.jsx
+++ b/web/client/components/geostory/layouts/Cascade.jsx
@@ -73,7 +73,7 @@ const Cascade = ({
     editMedia = () => {},
     update = () => {},
     remove = () => {}
-}) => (<BorderLayout className="ms-cascade-story">
+}) => (<BorderLayout className={`ms-cascade-story ms-${mode}`}>
     <ContainerDimensions
         sections={sections}
         add={add}>

--- a/web/client/components/geostory/layouts/__tests__/Cascade-test.jsx
+++ b/web/client/components/geostory/layouts/__tests__/Cascade-test.jsx
@@ -40,4 +40,10 @@ describe('Cascade component', () => {
         expect(el.querySelector('.ms-section-paragraph > .ms-section-contents')).toExist();
         expect(el.querySelector('.add-bar')).toNotExist();
     });
+    it('Cascade rendering mode edit', () => {
+        ReactDOM.render(<Cascade {...STORY} mode="edit" />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.ms-edit');
+        expect(el).toExist();
+    });
 });

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -2,6 +2,8 @@
 @ms-story-bg-grey: @ms2-color-shade-lighter;
 @ms-story-highlight: lighten(@ms2-color-primary, 20%);
 @ms-story-text: @ms2-color-text;
+@ms-story-bg-guidelines: #0571b0; // background guidelines color
+@ms-story-fg-guidelines: #ca0020; // foreground guidelines color
 
 @ms-story-font-size-base: 21px;
 @ms-story-font-size-large: ceil(@ms-story-font-size-base * 1.5);
@@ -570,6 +572,33 @@
     }
     .empty-state-container .empty-state-main-view .empty-state-description {
         text-align: center;
+    }
+
+    /////////////////////
+    // EDITING
+    /////////////////////
+
+    &.ms-edit {
+        .ms-section {
+            // background guidelines color for container size
+            & > div > .ms-content-toolbar,
+            .ms-section-background .ms-section-background-container .ms-content-toolbar {
+                border-top: 2px solid @ms-story-bg-guidelines;
+            }
+            .ms-section-background .ms-section-background-container .ms-media {
+                border-left: 2px dashed @ms-story-bg-guidelines;
+                border-right: 2px dashed @ms-story-bg-guidelines;
+            }
+
+            // foreground guidelines color for container size
+            &.ms-section-title .ms-content {
+                border-left: 2px dashed @ms-story-fg-guidelines;
+                border-right: 2px dashed @ms-story-fg-guidelines;
+                .ms-content-toolbar {
+                    border-top: 2px solid @ms-story-fg-guidelines;
+                }
+            }
+        }
     }
 
     /////////////////////


### PR DESCRIPTION
## Description
Add dashed guidelines with different color to display max width of background and foreground content.

edit mode: 
![image](https://user-images.githubusercontent.com/19175505/65676634-88e18f80-e050-11e9-8f5d-07544dabf6dd.png)

view mode:
![image](https://user-images.githubusercontent.com/19175505/65676848-e249be80-e050-11e9-80ba-3fabc6978584.png)

## Issues
 - #4256 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Other... Please describe: UX and Styling enhancement


**What is the current behavior?** (You can also link to an open issue here)
It not possible to understand the limits of content containers and with some configuration changes are not visible.

**What is the new behavior?**
Guidelines helps to understand the limit of edeitable container

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
