### PR TITLE
Fixed path to node_modules dir in es6 uglyfier fix

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -159,9 +159,9 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
                     // the followings are here to skip issues caused by uglifyPlugin (see #4212)
                     // TODO: a solution to this issue that uses only libs
                     // like https://www.npmjs.com/package/uglify-js-es6#harmony when stable, terser, babel-minify ...
-                    path.join(__dirname, "..", "node_modules", "query-string"),
-                    path.join(__dirname, "..", "node_modules", "strict-uri-encode"),
-                    path.join(__dirname, "..", "node_modules", "split-on-first")
+                    path.join(paths.base, "node_modules", "query-string"),
+                    path.join(paths.base, "node_modules", "strict-uri-encode"),
+                    path.join(paths.base, "node_modules", "split-on-first")
                 ]
             }
         ].concat(prod ? [{


### PR DESCRIPTION
## Description
This fix is related to #3490 , fixing the buildConfig.js to work also with dependent projects.

@mbarto please take this changes into account in your PR for #3693 