### PR TITLE
Fixes inclusion path for built js in standard project

### DIFF
--- a/project/standard/templates/prod-webpack.config.js
+++ b/project/standard/templates/prod-webpack.config.js
@@ -21,7 +21,7 @@ module.exports = require('./MapStore2/build/buildConfig')(
     paths,
     extractThemesPlugin,
     true,
-    "/__PROJECTNAME__/dist/",
+    "dist/",
     '.__PROJECTNAME__',
     [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
## Description
Inclusion path was absolute and included the war (project) name, so if you renamed the final war it would not work anymore.

## Issues

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

