### PR TITLE
Fix ssl certificate errors with tiles.wmflabs.org

### DIFF
--- a/web/client/utils/ConfigProvider.js
+++ b/web/client/utils/ConfigProvider.js
@@ -14,7 +14,7 @@ const CONFIGPROVIDER = {
         variants: {
             Mapnik: {},
             BlackAndWhite: {
-                url: 'http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
+                url: 'http://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
                 options: {
                     maxZoom: 18,
                     maxNativeZoom: 18


### PR DESCRIPTION
Fix ssl certificate errors with tiles.wmflabs.org

## Description
Because browers will redirect HTTP to HTTPS, and the ssl certificate for tiles.wmflabs.org is not valid for a.tiles.wmflabs.org etc.  These layers will not work with browsers that force HTTPS.  This fix makes this layer work again.

## Issues

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see above

**What is the new behavior?**
see above

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
