### PR TITLE
Fix #4286 maps unnecessary empty permission group

### DIFF
--- a/web/client/components/security/PermissionEditor.jsx
+++ b/web/client/components/security/PermissionEditor.jsx
@@ -194,7 +194,7 @@ class PermissionEditor extends React.Component {
                     if (rule && rule.group && rule.canRead) {
                         return {name: rule.group.groupName, permission: rule.canWrite ? "canWrite" : "canRead" };
                     }
-                    return {};
+                    return null;
                 }
                 ).filter(rule => rule);  // filter out undefined values
         } else {

--- a/web/client/components/security/__tests__/PermissionEditor-test.jsx
+++ b/web/client/components/security/__tests__/PermissionEditor-test.jsx
@@ -32,6 +32,13 @@ let setupEditor = (docElement, actions) => {
                             group: {
                                 groupName: "g11"
                             }
+                        }, {
+                            canRead: true,
+                            canWrite: true,
+                            user: {
+                                id: 3,
+                                name: "admin"
+                            }
                         }
                     ]
                 }
@@ -66,6 +73,7 @@ describe("Test the permission editor component", () => {
     it('creates component with some existing permission rules', () => {
         const cmp = setupEditor(document.getElementById("container"));
         expect(cmp).toExist();
+        expect(cmp.localGroups.length).toBe(2);
         const nodeEven = ReactTestUtils.scryRenderedDOMComponentsWithClass(cmp, "even");
         expect(nodeEven.length).toBe(1);
         const nodeOdd = ReactTestUtils.scryRenderedDOMComponentsWithClass(cmp, "odd");


### PR DESCRIPTION
## Description
Remove maps unnecessary permission group 

## Issues
 - #4286
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4286 

**What is the new behavior?**
Unnecessayr permission group no longer appear

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
