### PR TITLE
Close #4331 - Map is not loaded in a new media section

### DIFF
--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -421,7 +421,7 @@ describe('Geostory Epics', () => {
             geostory: {}
         });
     });
-    it('test openMediaEditorForNewMedia, adding a media content and choosing an image', (done) => {
+    it('test openMediaEditorForNewMedia, adding a media content and choosing an image already present in resources', (done) => {
         const NUM_ACTIONS = 2;
         testEpic(openMediaEditorForNewMedia, NUM_ACTIONS, [
             add(`sections[{id: "abc"}].contents[{id: "def"}]`, undefined, {type: ContentTypes.MEDIA, id: "102cbcf6-ff39-4b7f-83e4-78841ee13bb9"}),
@@ -444,7 +444,14 @@ describe('Geostory Epics', () => {
             });
             done();
         }, {
-            geostory: {},
+            geostory: {
+                currentStory: {
+                    resources: [{
+                        id: "geostory",
+                        data: {}
+                    }]
+                }
+            },
             mediaEditor: {
                 settings: {
                     mediaType: "image"
@@ -452,7 +459,43 @@ describe('Geostory Epics', () => {
             }
         });
     });
-    it('test openMediaEditorForNewMedia, adding an empty media content (image)', (done) => {
+    it('test openMediaEditorForNewMedia, adding a media content and choosing an image not present in resources', (done) => {
+        const NUM_ACTIONS = 3;
+        testEpic(openMediaEditorForNewMedia, NUM_ACTIONS, [
+            add(`sections[{id: "abc"}].contents[{id: "def"}]`, undefined, {type: ContentTypes.MEDIA, id: "102cbcf6-ff39-4b7f-83e4-78841ee13bb9"}),
+            chooseMedia({id: "geostory"})
+        ], (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map(a => {
+                switch (a.type) {
+                case ADD_RESOURCE:
+                    expect(a.data.id).toBe("geostory");
+                    expect(a.mediaType).toBe(MediaTypes.IMAGE);
+                    break;
+                case UPDATE:
+                    expect(a.element.type).toEqual(MediaTypes.IMAGE);
+                    expect(a.mode).toEqual("merge");
+                    expect(a.path).toEqual(`sections[{id: "abc"}].contents[{id: "def"}][{"id":"102cbcf6-ff39-4b7f-83e4-78841ee13bb9"}]`);
+                    break;
+                case SHOW:
+                    expect(a.owner).toEqual("geostory");
+                    break;
+                default: expect(true).toBe(false);
+                    break;
+                }
+            });
+            done();
+        }, {
+            geostory: {
+            },
+            mediaEditor: {
+                settings: {
+                    mediaType: "image"
+                }
+            }
+        });
+    });
+    it('test openMediaEditorForNewMedia, and hide without applying', (done) => {
         const NUM_ACTIONS = 2;
         testEpic(openMediaEditorForNewMedia, NUM_ACTIONS, [
             add(`sections[{id: "abc"}].contents[{id: "def"}]`, undefined, {type: ContentTypes.MEDIA, id: ""}),
@@ -461,9 +504,7 @@ describe('Geostory Epics', () => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map(a => {
                 switch (a.type) {
-                case UPDATE:
-                    expect(a.element).toEqual({type: MediaTypes.IMAGE});
-                    expect(a.mode).toEqual("merge");
+                case REMOVE:
                     expect(a.path).toEqual(`sections[{id: "abc"}].contents[{id: "def"}][{"id":""}]`);
                     break;
                 case SHOW:
@@ -484,7 +525,7 @@ describe('Geostory Epics', () => {
         });
     });
     it('test openMediaEditorForNewMedia, adding a media section and choosing an image', (done) => {
-        const NUM_ACTIONS = 2;
+        const NUM_ACTIONS = 3;
         const element = {
             id: '57cd0993-ad29-438a-b02a-d8f110de5d81',
             type: 'paragraph',
@@ -510,8 +551,12 @@ describe('Geostory Epics', () => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map(a => {
                 switch (a.type) {
+                case ADD_RESOURCE:
+                    expect(a.data.id).toBe("geostory");
+                    expect(a.mediaType).toBe(MediaTypes.IMAGE);
+                    break;
                 case UPDATE:
-                    expect(a.element).toEqual({resourceId: "geostory", type: MediaTypes.IMAGE});
+                    expect(a.element.type).toEqual(MediaTypes.IMAGE);
                     expect(a.mode).toEqual("merge");
                     expect(a.path).toEqual(`sections[{"id":"57cd0993-ad29-438a-b02a-d8f110de5d81"}].contents[0].contents[0]`);
                     break;


### PR DESCRIPTION
## Description
Adding a map in a new section now adds the map to the geostory resources.
Hiding the mediaEditor now removes the new added media section.

## Issues
 - #4331 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Adding a map in a new mediaSection shows an empty map.
Hiding mediaEditor without applying leave an empty media section

**What is the new behavior?**
Adding a new media map shows correctly
Hiding a new mediaSection remove the new section.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
