### PR TITLE
Closes #4339 Add toolbar to section media type map

### DIFF
--- a/web/client/components/geostory/contents/Column.jsx
+++ b/web/client/components/geostory/contents/Column.jsx
@@ -46,6 +46,7 @@ export default ({
         tools={{
             [ContentTypes.TEXT]: ['remove'],
             [MediaTypes.IMAGE]: ['editMedia', 'size', 'align', 'remove'],
+            [MediaTypes.MAP]: ['editMedia', 'editMap', 'size', 'align', 'remove'],
             [MediaTypes.VIDEO]: ['editMedia', 'remove'] // TODO change this list for video
         }}
         addButtons={[{

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -120,6 +120,16 @@ const toolButtons = {
                 remove(path);
             }} />)
 
+    }),
+    editMap: ({editMap = false, update = () => {}}) => ({
+        // using normal ToolbarButton because this has no options
+        glyph: "1-map",
+        visible: true,
+        active: editMap,
+        tooltipId: "geostory.contentToolbar.editMap",
+        onClick: () => {
+            update( 'editMap', !editMap);
+        }
     })
 };
 

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -125,7 +125,7 @@ const toolButtons = {
         // using normal ToolbarButton because this has no options
         glyph: "1-map",
         visible: true,
-        active: editMap,
+        bsStyle: editMap ? "success" : "default",
         tooltipId: "geostory.contentToolbar.editMap",
         onClick: () => {
             update( 'editMap', !editMap);

--- a/web/client/components/geostory/layouts/sections/Immersive.jsx
+++ b/web/client/components/geostory/layouts/sections/Immersive.jsx
@@ -44,7 +44,7 @@ const Immersive = ({
             disableToolbarPortal
             tools={{
                 [MediaTypes.IMAGE]: ['editMedia', 'fit', 'size', 'align', 'theme'],
-                [MediaTypes.MAP]: ['editMedia', 'fit', 'size', 'align', 'theme']
+                [MediaTypes.MAP]: ['editMedia', 'editMap', 'fit', 'size', 'align', 'theme']
             }}
             // selector used by sticky polyfill to detect scroll events
             scrollContainerSelector="#ms-sections-container"

--- a/web/client/components/geostory/layouts/sections/Title.jsx
+++ b/web/client/components/geostory/layouts/sections/Title.jsx
@@ -71,7 +71,7 @@ export default backgroundPropWithHandler(({
                     }}
                     tools={{
                         [MediaTypes.IMAGE]: ['editMedia', 'fit', 'cover', 'size', 'align', 'theme'],
-                        [MediaTypes.MAP]: ['editMedia', 'size', 'cover', 'align', 'theme']
+                        [MediaTypes.MAP]: ['editMedia', 'editMap', 'size', 'cover', 'align', 'theme']
                     }}
                     height={height >= viewHeight
                         ? viewHeight

--- a/web/client/components/geostory/layouts/sections/__tests__/Immersive-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Immersive-test.jsx
@@ -148,6 +148,6 @@ describe('Immersive component', () => {
 
         const contentToolbar = container.querySelector('.ms-content-toolbar');
         expect(contentToolbar).toExist();
-        testToolbarButtons(["pencil", "1-full-screen", "resize-horizontal", "align-center", "dropper"], container);
+        testToolbarButtons(["pencil", "1-map", "1-full-screen", "resize-horizontal", "align-center", "dropper"], container);
     });
 });

--- a/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
@@ -139,6 +139,6 @@ describe('Title component', () => {
         expect(backgroundContainer.clientHeight).toBe(VIEW_HEIGHT);
         const contentToolbar = container.querySelector('.ms-content-toolbar');
         expect(contentToolbar).toExist();
-        testToolbarButtons(["pencil", "resize-vertical", "resize-horizontal", "align-center", "dropper"], container);
+        testToolbarButtons(["pencil", "1-map", "resize-vertical", "resize-horizontal", "align-center", "dropper"], container);
     });
 });

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1884,7 +1884,8 @@
                 "editMedia": "Ändern Sie die Medienquelle",
                 "remove": "Entfernen",
                 "removeConfirmTitle": "Bist du sicher?",
-                "removeConfirmContent": "Wollen Sie diesen Inhalt aus der Geschichte entfernen?"
+                "removeConfirmContent": "Wollen Sie diesen Inhalt aus der Geschichte entfernen?",
+                "editMap": "Bearbeiten Sie die ursprüngliche Kartenausdehnung"
             },
             "builder": {
                 "defaults": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1885,7 +1885,8 @@
                 "editMedia": "Change media source",
                 "remove": "Remove",
                 "removeConfirmTitle": "Are you sure?",
-                "removeConfirmContent": "Do you want to remove this content from the story?"
+                "removeConfirmContent": "Do you want to remove this content from the story?",
+                "editMap": "Edit initial map extent"
             },
             "builder": {
                 "defaults": {

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1884,7 +1884,8 @@
                 "editMedia": "Cambiar fuente de medios",
                 "remove": "Eliminar",
                 "removeConfirmTitle": "¿Estás seguro?",
-                "removeConfirmContent": "¿Quieres eliminar este contenido de la historia?"
+                "removeConfirmContent": "¿Quieres eliminar este contenido de la historia?",
+                "editMap": "Modifier l'étendue initiale de la carte"
             },
             "builder": {
                 "defaults": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1884,7 +1884,8 @@
                 "editMedia": "Changer de source média",
                 "remove": "Supprimer",
                 "removeConfirmTitle": "Bist du sicher?",
-                "removeConfirmContent": "Wollen Sie diesen Inhalt aus der Geschichte entfernen?"
+                "removeConfirmContent": "Wollen Sie diesen Inhalt aus der Geschichte entfernen?",
+                "editMap": "Edit initial map extent"
             },
             "builder": {
                 "defaults": {

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1884,7 +1884,8 @@
                 "editMedia": "Cambia la sorgente del media",
                 "remove": "Elimina",
                 "removeConfirmTitle": "Sei sicuro?",
-                "removeConfirmContent": "Vuoi rimuovere questi contenuti dalla storia?"
+                "removeConfirmContent": "Vuoi rimuovere questi contenuti dalla storia?",
+                "editMap": "Modifica l'estensione iniziale della mappa"
             },
             "builder": {
                 "defaults": {


### PR DESCRIPTION
## Description
The toolbar is added to a content of media/map
In the toolbar a new button that enable initial map extent editing is also added

## Issues
 - #4339 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Content of type media/map doesn't have any toolbar and isn't possible to define the map initial extent.

**What is the new behavior?**
A toolbar is shown above a content of type media/map.
A new button that allow to define initial map extent has been added

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
