### PR TITLE
Fix 4358 height tool always visible for title section

### DIFF
--- a/web/client/components/geostory/layouts/sections/Background.jsx
+++ b/web/client/components/geostory/layouts/sections/Background.jsx
@@ -16,6 +16,7 @@ import ContentToolbar from '../../contents/ContentToolbar';
 import Message from '../../../I18N/Message';
 import { Portal } from 'react-overlays';
 import pattern from './patterns/grid.svg';
+import { SectionTypes } from './../../../../utils/GeoStoryUtils';
 
 /**
  * Background.
@@ -45,6 +46,7 @@ class Background extends Component {
         type: PropTypes.oneOf(lists.MediaTypes),
         disableToolbarPortal: PropTypes.bool,
         backgroundPlaceholder: PropTypes.object,
+        sectionType: PropTypes.string,
         src: PropTypes.string
     };
 
@@ -61,6 +63,7 @@ class Background extends Component {
 
     render() {
         const parentNode = !this.props.disableToolbarPortal && this.refs && this.refs.div && this.refs.div.parentNode;
+        const defaultTools = this.props.sectionType === SectionTypes.TITLE ? ['editMedia', 'cover' ] : ['editMedia' ];
         const toolbar = (
             <ContentToolbar
                 {...this.props}
@@ -71,7 +74,7 @@ class Background extends Component {
                     value: 'dark',
                     label: <Message msgId="geostory.contentToolbar.darkThemeLabel"/>
                 }]}
-                tools={this.props.tools && this.props.tools[this.props.type] || [ 'editMedia' ]}
+                tools={this.props.tools && this.props.type && this.props.tools[this.props.type] || defaultTools}
             />
         );
         return (

--- a/web/client/components/geostory/layouts/sections/Title.jsx
+++ b/web/client/components/geostory/layouts/sections/Title.jsx
@@ -70,8 +70,8 @@ export default backgroundPropWithHandler(({
                         backgroundSize: `${cover ? 64 : 600 }px auto`
                     }}
                     tools={{
-                        [MediaTypes.IMAGE]: ['editMedia', 'fit', 'cover', 'size', 'align', 'theme'],
-                        [MediaTypes.MAP]: ['editMedia', 'editMap', 'size', 'cover', 'align', 'theme']
+                        [MediaTypes.IMAGE]: ['editMedia', 'cover', 'fit', 'size', 'align', 'theme'],
+                        [MediaTypes.MAP]: ['editMedia', 'cover', 'editMap', 'size', 'align', 'theme']
                     }}
                     height={height >= viewHeight
                         ? viewHeight

--- a/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
@@ -67,7 +67,7 @@ describe('Title component', () => {
                 html: '<h1>Title</h1>'
             }
         ];
-        ReactDOM.render(<Title contents={CONTENTS} viewHeight={VIEW_HEIGHT} cover mode="edit"/>, document.getElementById("container"));
+        ReactDOM.render(<Title contents={CONTENTS} viewHeight={VIEW_HEIGHT} sectionType="title" cover mode="edit"/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('.ms-section-title');
         expect(el).toExist();
@@ -81,7 +81,7 @@ describe('Title component', () => {
         expect(backgroundContainer.clientHeight).toBe(VIEW_HEIGHT);
         const contentToolbar = container.querySelector('.ms-content-toolbar');
         expect(contentToolbar).toExist();
-        testToolbarButtons(["pencil"], container);
+        testToolbarButtons(["pencil", "cover"], container);
     });
 
     it('Title rendering cover set to false', () => {


### PR DESCRIPTION
## Description
Height tool now is always visible for title section
## Issues
 - #4358

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
height tool is visible only when a the title background has content (map or image)

**What is the new behavior?**
height tool is always visible for title

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
