### PR TITLE
 #3781 Allow drag&drop of layers/groups between groups

### DIFF
--- a/web/client/components/TOC/DefaultGroup.jsx
+++ b/web/client/components/TOC/DefaultGroup.jsx
@@ -23,6 +23,7 @@ class DefaultGroup extends React.Component {
         onToggle: PropTypes.func,
         level: PropTypes.number,
         onSort: PropTypes.func,
+        onError: PropTypes.func,
         propertiesChangeHandler: PropTypes.func,
         groupVisibilityCheckbox: PropTypes.bool,
         visibilityCheckType: PropTypes.string,
@@ -103,6 +104,7 @@ class DefaultGroup extends React.Component {
             <GroupChildren
                 level={this.props.level + 1}
                 onSort={this.props.onSort}
+                onError={this.props.onError}
                 setDndState={this.props.setDndState}
                 position="collapsible">
                 {this.props.children}
@@ -112,7 +114,7 @@ class DefaultGroup extends React.Component {
         if (this.props.node.showComponent && !this.props.node.hide) {
             return (
                 <Node className={(this.props.isDragging || this.props.node.placeholder ? "is-placeholder " : "") + "toc-default-group toc-group-" + this.props.level + selected + error} sortableStyle={this.props.sortableStyle} style={this.props.style} type="group" {...other}>
-                    {this.props.isDraggable ? connectDragPreview(connectDropTarget(connectDragSource(groupHead))) : groupHead}
+                    {connectDragPreview(connectDropTarget(this.props.isDraggable ? connectDragSource(groupHead) : groupHead))}
                     {this.props.isDragging || this.props.node.placeholder ? null : groupChildren}
                 </Node>
             );

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -198,9 +198,7 @@ class DefaultLayer extends React.Component {
             </div>
         );
         if (other.node.showComponent !== false && !other.node.hide && this.props.filter(this.props.node)) {
-            return other.isDraggable ? connectDropTarget(connectDragSource(
-                tocListItem
-            )) : tocListItem;
+            return connectDropTarget(other.isDraggable ? connectDragSource(tocListItem) : tocListItem);
         }
         return null;
     }

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -178,8 +178,8 @@ class DefaultLayer extends React.Component {
         return (
             <Node className={(this.props.isDragging || this.props.node.placeholder ? "is-placeholder " : "") + 'toc-default-layer' + hide + selected + error + warning} style={this.props.style} type="layer" {...other}>
                 {other.isDraggable && !isDummy ? this.props.connectDragPreview(head) : head}
-                {!isDummy || !this.props.activateOpacityTool || this.props.node.expanded || !this.props.node.visibility || this.props.node.loadingError === 'Error' ? null : this.renderOpacitySlider(this.props.hideOpacityTooltip)}
-                {isDummy && isEmpty ? null : this.renderCollapsible()}
+                {isDummy || !this.props.activateOpacityTool || this.props.node.expanded || !this.props.node.visibility || this.props.node.loadingError === 'Error' ? null : this.renderOpacitySlider(this.props.hideOpacityTooltip)}
+                {isDummy || isEmpty ? null : this.renderCollapsible()}
             </Node>
         );
     }

--- a/web/client/components/TOC/Node.jsx
+++ b/web/client/components/TOC/Node.jsx
@@ -58,7 +58,7 @@ var Node = createReactClass({
         if (this.props.animateCollapse) {
             collapsible = <CSSTransitionGroup transitionName="TOC-Node" transitionEnterTimeout={250} transitionLeaveTimeout={250}>{collapsible}</CSSTransitionGroup>;
         }
-        let content = (<div key={this.props.node.name} className={(expanded ? prefix + "-expanded" : prefix + "-collapsed") + " " + this.props.className} style={nodeStyle} >
+        let content = (<div key={this.props.node.name} className={(expanded ? prefix + "-expanded" : prefix + "-collapsed") + " " + this.props.className} style={this.props.node.dummy ? {padding: 0} : nodeStyle} >
             {this.renderChildren((child) => child && child.props.position !== 'collapsible')}
             {collapsible}
         </div>);

--- a/web/client/components/TOC/TOC.jsx
+++ b/web/client/components/TOC/TOC.jsx
@@ -17,6 +17,7 @@ class TOC extends React.Component {
         nodes: PropTypes.array,
         id: PropTypes.string,
         onSort: PropTypes.func,
+        onError: PropTypes.func,
         setDndState: PropTypes.func
     };
 
@@ -37,9 +38,10 @@ class TOC extends React.Component {
                 node: node,
                 parentNodeId: 'root',
                 onSort: this.props.onSort,
+                onError: this.props.onError,
                 sortIndex: node.hide ? i : i++,
                 key: node.name || 'default',
-                isDraggable: !!this.props.onSort,
+                isDraggable: !!this.props.onSort && !(node.nodes && node.name === 'Default'),
                 setDndState: this.props.setDndState
             }));
         }

--- a/web/client/components/TOC/TOC.jsx
+++ b/web/client/components/TOC/TOC.jsx
@@ -39,8 +39,8 @@ class TOC extends React.Component {
                 parentNodeId: 'root',
                 onSort: this.props.onSort,
                 onError: this.props.onError,
-                sortIndex: node.hide ? i : i++,
-                key: node.name || 'default',
+                sortIndex: node.hide || node.dummy ? i : i++,
+                key: node.name || node.id || 'default',
                 isDraggable: !!this.props.onSort && !(node.nodes && node.name === 'Default'),
                 setDndState: this.props.setDndState
             }));

--- a/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
+++ b/web/client/components/TOC/__tests__/DefaultLayer-test.jsx
@@ -372,4 +372,21 @@ describe('test DefaultLayer module component', () => {
         const domNode = ReactDOM.findDOMNode(comp);
         expect(domNode).toExist();
     });
+
+    it('test dummy node', () => {
+        const node = {
+            id: 'Group1__dummy',
+            dummy: true
+        };
+
+        const comp = ReactDOM.render(<Layer node={node}/>, document.getElementById("container"));
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+        expect(domNode.style).toExist();
+        expect(domNode.style.opacity).toBe('0');
+        expect(domNode.style.boxShadow).toBe('none');
+        const headNode = domNode.getElementsByClassName('toc-default-layer-head')[0];
+        expect(headNode).toExist();
+        expect(headNode.childNodes.length).toBe(0);
+    });
 });

--- a/web/client/components/TOC/__tests__/TOC-test.jsx
+++ b/web/client/components/TOC/__tests__/TOC-test.jsx
@@ -9,6 +9,7 @@
 const expect = require('expect');
 const React = require('react');
 const ReactDOM = require('react-dom');
+const TestUtils = require('react-dom/test-utils');
 const dragDropContext = require('react-dnd').DragDropContext;
 const testBackend = require('react-dnd-test-backend');
 
@@ -146,5 +147,58 @@ describe('Layers component', () => {
         const domNode = ReactDOM.findDOMNode(element);
         expect(domNode).toExist();
         expect(domNode.children.length).toBe(layers.length);
+    });
+
+    it('test node sortIndex assignment', () => {
+        const nodes = [{
+            id: 'layer00',
+            name: 'layer00',
+            visibility: true,
+            type: 'wms',
+            url: 'fakeurl'
+        }, {
+            id: 'Group1',
+            name: 'Group1',
+            nodes: []
+        }, {
+            id: 'layer01',
+            name: 'layer01',
+            visibility: true,
+            type: 'wms',
+            url: 'fakeurl'
+        }, {
+            id: 'layer02',
+            hide: true
+        }, {
+            id: 'Group2',
+            name: 'Group2',
+            nodes: []
+        }];
+
+        class TestComponent extends React.Component {
+            render() {
+                return <div></div>;
+            }
+        }
+
+        const comp = ReactDOM.render(<TOC nodes={nodes}><TestComponent/></TOC>, document.getElementById("container"));
+
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+
+        const elements = TestUtils.scryRenderedComponentsWithType(comp, TestComponent);
+        expect(elements.length).toBe(7);
+
+        const sortIndexes = {
+            "layer00": 0,
+            "Group1": 1,
+            "Group1__dummy": 2,
+            "layer01": 2,
+            "layer02": 3,
+            "Group2": 3,
+            "Group2__dummy": 4
+        };
+
+        elements.forEach(el => expect(el.props.sortIndex).toBe(sortIndexes[el.props.node.id]));
     });
 });

--- a/web/client/components/TOC/enhancers/__tests__/dndTree-test.jsx
+++ b/web/client/components/TOC/enhancers/__tests__/dndTree-test.jsx
@@ -1,0 +1,517 @@
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {compose, shouldUpdate} from 'recompose';
+import {isEqual} from 'lodash';
+import dndTree from '../dndTree';
+
+const testNodes = [{
+    id: 'Default',
+    name: 'Default',
+    nodes: [{
+        id: 'layer00',
+        name: 'layer00',
+        visibility: true,
+        type: 'wms',
+        url: 'fakeurl'
+    }, {
+        id: 'layer01',
+        name: 'layer01',
+        visibility: true,
+        type: 'wms',
+        url: 'fakeurl'
+    }, {
+        id: 'Group2',
+        name: 'Group2',
+        nodes: []
+    }]
+}, {
+    id: 'Group1',
+    name: 'Group1',
+    nodes: [{
+        id: 'Group1.Group11',
+        name: 'Group11',
+        nodes: [{
+            id: 'layer02',
+            name: 'layer02',
+            visibility: true,
+            type: 'wms',
+            url: 'fakeurl'
+        }, {
+            id: 'Group1.Group11.Group111',
+            name: 'Group111',
+            nodes: []
+        }]
+    }, {
+        id: 'layer03',
+        name: 'layer03',
+        visibility: true,
+        type: 'wms',
+        url: 'fakeurl'
+    }, {
+        id: 'layer04',
+        name: 'layer04',
+        visibility: true,
+        type: 'wms',
+        url: 'fakeurl'
+    }]
+}, {
+    id: 'Group3',
+    name: 'Group3',
+    nodes: [{
+        id: 'layer05',
+        name: 'layer05',
+        visibility: true,
+        type: 'wms',
+        url: 'fakeurl'
+    }]
+}];
+
+const EnhancedComponent = compose(
+    dndTree,
+    shouldUpdate((props, nextProps) => !isEqual(props.nodes, nextProps.nodes)),
+)(({nodes, setDndState, testDndState, testFunc}) => {
+    if (testDndState) {
+        setDndState(testDndState);
+    }
+    testFunc(nodes);
+    return <div></div>;
+});
+
+describe('dndTree TOC enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHtml = '';
+        setTimeout(done);
+    });
+
+    it('dndTree with default dnd state', () => {
+        const test = {
+            testFunc: () => {}
+        };
+
+        const testFuncSpy = expect.spyOn(test, 'testFunc');
+
+        ReactDOM.render(<EnhancedComponent testFunc={test.testFunc} nodes={testNodes}/>, document.getElementById("container"));
+
+        expect(testFuncSpy.calls.length).toBe(1);
+        expect(testFuncSpy.calls[0].arguments[0]).toEqual([{
+            id: 'Default',
+            name: 'Default',
+            nodes: [{
+                id: 'layer00',
+                name: 'layer00',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'layer01',
+                name: 'layer01',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'Group2',
+                name: 'Group2',
+                nodes: []
+            }, {
+                id: 'Group2__dummy',
+                dummy: true
+            }]
+        }, {
+            id: 'Default__dummy',
+            dummy: true
+        }, {
+            id: 'Group1',
+            name: 'Group1',
+            nodes: [{
+                id: 'Group1.Group11',
+                name: 'Group11',
+                nodes: [{
+                    id: 'layer02',
+                    name: 'layer02',
+                    visibility: true,
+                    type: 'wms',
+                    url: 'fakeurl'
+                }, {
+                    id: 'Group1.Group11.Group111',
+                    name: 'Group111',
+                    nodes: []
+                }, {
+                    id: 'Group1.Group11.Group111__dummy',
+                    dummy: true
+                }]
+            }, {
+                id: 'Group1.Group11__dummy',
+                dummy: true
+            }, {
+                id: 'layer03',
+                name: 'layer03',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'layer04',
+                name: 'layer04',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }]
+        }, {
+            id: 'Group1__dummy',
+            dummy: true
+        }, {
+            id: 'Group3',
+            name: 'Group3',
+            nodes: [{
+                id: 'layer05',
+                name: 'layer05',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }]
+        }, {
+            id: 'Group3__dummy',
+            dummy: true
+        }]);
+    });
+
+    it('dndTree with parentNodeId === newParentNodeId', () => {
+        const test = {
+            testFunc: () => {}
+        };
+
+        const testFuncSpy = expect.spyOn(test, 'testFunc');
+
+        const dndState = {
+            node: {
+                id: 'layer03',
+                name: 'layer03',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            },
+            parentNodeId: 'Group1',
+            newParentNodeId: 'Group1',
+            sortIndex: 0
+        };
+
+        ReactDOM.render(<EnhancedComponent testFunc={test.testFunc} testDndState={dndState} nodes={testNodes}/>, document.getElementById("container"));
+
+        expect(testFuncSpy.calls.length).toBe(2);
+        expect(testFuncSpy.calls[1].arguments[0]).toEqual([{
+            id: 'Default',
+            name: 'Default',
+            nodes: [{
+                id: 'layer00',
+                name: 'layer00',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'layer01',
+                name: 'layer01',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'Group2',
+                name: 'Group2',
+                nodes: []
+            }, {
+                id: 'Group2__dummy',
+                dummy: true
+            }]
+        }, {
+            id: 'Default__dummy',
+            dummy: true
+        }, {
+            id: 'Group1',
+            name: 'Group1',
+            nodes: [{
+                id: 'layer03',
+                name: 'layer03',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'Group1.Group11',
+                name: 'Group11',
+                nodes: [{
+                    id: 'layer02',
+                    name: 'layer02',
+                    visibility: true,
+                    type: 'wms',
+                    url: 'fakeurl'
+                }, {
+                    id: 'Group1.Group11.Group111',
+                    name: 'Group111',
+                    nodes: []
+                }, {
+                    id: 'Group1.Group11.Group111__dummy',
+                    dummy: true
+                }]
+            }, {
+                id: 'Group1.Group11__dummy',
+                dummy: true
+            }, {
+                id: 'layer04',
+                name: 'layer04',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }]
+        }, {
+            id: 'Group1__dummy',
+            dummy: true
+        }, {
+            id: 'Group3',
+            name: 'Group3',
+            nodes: [{
+                id: 'layer05',
+                name: 'layer05',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }]
+        }, {
+            id: 'Group3__dummy',
+            dummy: true
+        }]);
+    });
+
+    it('dndTree with parentNodeId !== newParentNodeId', () => {
+        const test = {
+            testFunc: () => {}
+        };
+
+        const testFuncSpy = expect.spyOn(test, 'testFunc');
+
+        const dndState = {
+            node: {
+                id: 'layer03',
+                name: 'layer03',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            },
+            parentNodeId: 'Group1',
+            newParentNodeId: 'Default',
+            sortIndex: 2
+        };
+
+        ReactDOM.render(<EnhancedComponent testFunc={test.testFunc} testDndState={dndState} nodes={testNodes}/>, document.getElementById("container"));
+
+        expect(testFuncSpy.calls.length).toBe(2);
+        expect(testFuncSpy.calls[1].arguments[0]).toEqual([{
+            id: 'Default',
+            name: 'Default',
+            nodes: [{
+                id: 'layer00',
+                name: 'layer00',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'layer01',
+                name: 'layer01',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'layer03__placeholder',
+                name: 'layer03',
+                visibility: true,
+                placeholder: true,
+                hide: false,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'Group2',
+                name: 'Group2',
+                nodes: []
+            }, {
+                id: 'Group2__dummy',
+                dummy: true
+            }]
+        }, {
+            id: 'Default__dummy',
+            dummy: true
+        }, {
+            id: 'Group1',
+            name: 'Group1',
+            nodes: [{
+                id: 'Group1.Group11',
+                name: 'Group11',
+                nodes: [{
+                    id: 'layer02',
+                    name: 'layer02',
+                    visibility: true,
+                    type: 'wms',
+                    url: 'fakeurl',
+                    nodes: undefined
+                }, {
+                    id: 'Group1.Group11.Group111',
+                    name: 'Group111',
+                    nodes: []
+                }, {
+                    id: 'Group1.Group11.Group111__dummy',
+                    dummy: true
+                }]
+            }, {
+                id: 'Group1.Group11__dummy',
+                dummy: true
+            }, {
+                id: 'layer03',
+                name: 'layer03',
+                visibility: true,
+                hide: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'layer04',
+                name: 'layer04',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }]
+        }, {
+            id: 'Group1__dummy',
+            dummy: true
+        }, {
+            id: 'Group3',
+            name: 'Group3',
+            nodes: [{
+                id: 'layer05',
+                name: 'layer05',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }]
+        }, {
+            id: 'Group3__dummy',
+            dummy: true
+        }]);
+    });
+
+    it('dndTree with moved group', () => {
+        const test = {
+            testFunc: () => {}
+        };
+
+        const testFuncSpy = expect.spyOn(test, 'testFunc');
+
+        const dndState = {
+            node: {
+                id: 'Group2',
+                name: 'Group2',
+                nodes: []
+            },
+            parentNodeId: 'Default',
+            newParentNodeId: 'root',
+            sortIndex: 1
+        };
+
+        ReactDOM.render(<EnhancedComponent testFunc={test.testFunc} testDndState={dndState} nodes={testNodes}/>, document.getElementById("container"));
+
+        expect(testFuncSpy.calls.length).toBe(2);
+        expect(testFuncSpy.calls[1].arguments[0]).toEqual([{
+            id: 'Default',
+            name: 'Default',
+            nodes: [{
+                id: 'layer00',
+                name: 'layer00',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'layer01',
+                name: 'layer01',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'Group2',
+                name: 'Group2',
+                nodes: [],
+                hide: true
+            }]
+        }, {
+            id: 'Group2__placeholder',
+            name: 'Group2',
+            nodes: [],
+            placeholder: true,
+            hide: false
+        }, {
+            id: 'Group1',
+            name: 'Group1',
+            nodes: [{
+                id: 'Group1.Group11',
+                name: 'Group11',
+                nodes: [{
+                    id: 'layer02',
+                    name: 'layer02',
+                    visibility: true,
+                    type: 'wms',
+                    url: 'fakeurl',
+                    nodes: undefined
+                }, {
+                    id: 'Group1.Group11.Group111',
+                    name: 'Group111',
+                    nodes: []
+                }, {
+                    id: 'Group1.Group11.Group111__dummy',
+                    dummy: true
+                }]
+            }, {
+                id: 'Group1.Group11__dummy',
+                dummy: true
+            }, {
+                id: 'layer03',
+                name: 'layer03',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }, {
+                id: 'layer04',
+                name: 'layer04',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }]
+        }, {
+            id: 'Group1__dummy',
+            dummy: true
+        }, {
+            id: 'Group3',
+            name: 'Group3',
+            nodes: [{
+                id: 'layer05',
+                name: 'layer05',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl',
+                nodes: undefined
+            }]
+        }, {
+            id: 'Group3__dummy',
+            dummy: true
+        }]);
+    });
+});

--- a/web/client/components/TOC/enhancers/dndTree.jsx
+++ b/web/client/components/TOC/enhancers/dndTree.jsx
@@ -17,7 +17,7 @@ const changeNode = (nodes, id, objToMerge) => {
 };
 
 const updateNodes = (nodes, dndState) => {
-    const {node: draggedNode, sortIndex, parentNodeId, newParentNodeId} = dndState;
+    const {node: draggedNode, sortIndex, parentNodeId, newParentNodeId, illegalDrop} = dndState;
 
     if (!nodes || !draggedNode) {
         return nodes;
@@ -26,7 +26,9 @@ const updateNodes = (nodes, dndState) => {
     return nodes.map(node => {
         if (node.nodes && node.id === newParentNodeId) {
             let newNodes = newParentNodeId === parentNodeId ? changeNode(node.nodes, draggedNode.id, null) : node.nodes.slice();
-            newNodes.splice(sortIndex, 0, {...draggedNode, ...(newParentNodeId === parentNodeId ? {} : {id: draggedNode.id + '__placeholder', placeholder: true})});
+            newNodes.splice(sortIndex, 0, {...draggedNode, ...(newParentNodeId === parentNodeId ?
+                {} :
+                {id: draggedNode.id + '__placeholder', placeholder: true, hide: !!illegalDrop})});
             return {...node, nodes: newNodes};
         }
         return {...node, nodes: updateNodes(node.nodes, dndState)};
@@ -47,13 +49,15 @@ const dndTree = branch(
             node: null,
             parentNodeId: '',
             newParentNodeId: '',
-            sortIndex: 0
+            sortIndex: 0,
+            illegalDrop: null
         }),
         Component => ({dndState, nodes, ...props}) => {
-            const {node: draggedNode, parentNodeId, newParentNodeId} = dndState;
+            const {node: draggedNode, parentNodeId, newParentNodeId, illegalDrop} = dndState;
             const newNodes = updateNodes([{id: 'root', nodes}], dndState)[0].nodes;
             return (
-                <Component {...props} nodes={newParentNodeId === parentNodeId ? newNodes : changeNode(newNodes, draggedNode.id, {hide: true})}/>
+                <Component {...props} nodes={newParentNodeId === parentNodeId &&
+                    !illegalDrop ? newNodes : changeNode(newNodes, draggedNode.id, {hide: true})}/>
             );
         }
     )

--- a/web/client/components/TOC/enhancers/draggableComponent.jsx
+++ b/web/client/components/TOC/enhancers/draggableComponent.jsx
@@ -20,13 +20,23 @@ const dragSpec = {
         };
     },
     endDrag: (props, monitor) => {
-        const {sortIndex, newParentNodeId} = monitor.getItem();
+        const {sortIndex, newParentNodeId, illegalDrop} = monitor.getItem();
         if (props.setDndState) {
             props.setDndState({
-                node: null
+                node: null,
+                illegalDrop: null
             });
         }
-        if (props.onSort) {
+        if (illegalDrop) {
+            if (props.onError) {
+                props.onError({
+                    title: 'notification.warning',
+                    autoDismiss: 5,
+                    position: 'tc',
+                    ...illegalDrop
+                });
+            }
+        } else if (props.onSort) {
             props.onSort(props.node.id, newParentNodeId, sortIndex);
         }
     }
@@ -53,7 +63,7 @@ const dropSpec = {
         // For group list items it inserts dragged element above the group item in it's parent node if we
         // are hovering above the upper third of a component, into the group item if we are hovering above the lower
         // third of a component and into the group itself if hovering above the middle(that's where group's name text is)
-        if (monitor.isOver({shallow: true}) && (item.newParentNodeId !== props.parentNodeId || draggedItemIndex !== hoveredItemIndex)) {
+        if (monitor.isOver({shallow: true})) {
             const componentDomNode = ReactDOM.findDOMNode(component);
             const headDomNode = componentDomNode.getElementsByClassName('toc-default-group-head')[0];
             const domNode = headDomNode || componentDomNode;
@@ -71,15 +81,29 @@ const dropSpec = {
                     if (clientY < thirdY) {
                         item.sortIndex = props.sortIndex;
                         item.newParentNodeId = props.parentNodeId;
+                        // check if we are over the Default group
+                        if (props.node.name === 'Default') {
+                            item.illegalDrop = {
+                                message: 'toc.error.defaultGroupOnTop',
+                                values: {
+                                    groupTitle: props.node.title
+                                }
+                            };
+                        }
                     } else if (clientY >= thirdY && clientY <= 2 * thirdY) {
                         item.sortIndex = 0;
                         item.newParentNodeId = props.node.id;
+                        item.illegalDrop = null;
                     } else {
                         item.sortIndex = props.sortIndex + 1;
                         item.newParentNodeId = props.parentNodeId;
+                        item.illegalDrop = null;
                     }
                 } else {
                     const middleY = (boundingRect.bottom - boundingRect.top) / 2;
+                    if (draggedItemIndex === hoveredItemIndex && item.newParentNodeId === props.parentNodeId) {
+                        return;
+                    }
                     if (item.newParentNodeId === props.parentNodeId && draggedItemIndex < hoveredItemIndex && clientY < middleY) {
                         return;
                     }
@@ -88,6 +112,7 @@ const dropSpec = {
                     }
                     item.sortIndex = props.sortIndex;
                     item.newParentNodeId = props.parentNodeId;
+                    item.illegalDrop = null;
                 }
                 if (props.setDndState) {
                     props.setDndState(item);
@@ -116,6 +141,9 @@ module.exports = (type, ...args) => {
         ({isDraggable} = {}) => isDraggable,
         compose(
             dragSource(type, dragSpec, dragCollect),
+            dropTarget(type, dropSpec, dropCollect)
+        ),
+        compose(
             dropTarget(type, dropSpec, dropCollect)
         )
     )(...args);

--- a/web/client/components/TOC/enhancers/draggableComponent.jsx
+++ b/web/client/components/TOC/enhancers/draggableComponent.jsx
@@ -61,8 +61,8 @@ const dropSpec = {
         // Currently for layer list item it sets sortIndex of a dragged element to a sortIndex of that item,
         // when user's cursor passes a Y coordinate that divides item's bounding rect in half
         // For group list items it inserts dragged element above the group item in it's parent node if we
-        // are hovering above the upper third of a component, into the group item if we are hovering above the lower
-        // third of a component and into the group itself if hovering above the middle(that's where group's name text is)
+        // are hovering above the upper third of a component and into the group item if we are hovering above the lower
+        // two thirds of a component
         if (monitor.isOver({shallow: true})) {
             const componentDomNode = ReactDOM.findDOMNode(component);
             const headDomNode = componentDomNode.getElementsByClassName('toc-default-group-head')[0];
@@ -93,13 +93,9 @@ const dropSpec = {
                                 }
                             };
                         }
-                    } else if (clientY >= thirdY && clientY <= 2 * thirdY) {
+                    } else {
                         item.sortIndex = 0;
                         item.newParentNodeId = props.node.id;
-                        item.illegalDrop = null;
-                    } else {
-                        item.sortIndex = props.sortIndex + 1;
-                        item.newParentNodeId = props.parentNodeId;
                         item.illegalDrop = null;
                     }
                 } else {

--- a/web/client/components/TOC/enhancers/draggableComponent.jsx
+++ b/web/client/components/TOC/enhancers/draggableComponent.jsx
@@ -72,6 +72,9 @@ const dropSpec = {
                 const clientY = monitor.getClientOffset().y - boundingRect.top;
                 if (headDomNode) {
                     const thirdY = (boundingRect.bottom - boundingRect.top) / 3;
+                    if (props.isDragging || (props.node && props.node.placeholder)) {
+                        return;
+                    }
                     if (item.newParentNodeId === props.parentNodeId && draggedItemIndex < hoveredItemIndex && clientY < thirdY) {
                         return;
                     }

--- a/web/client/components/TOC/fragments/GroupChildren.jsx
+++ b/web/client/components/TOC/fragments/GroupChildren.jsx
@@ -15,6 +15,7 @@ class GroupChildren extends React.Component {
         node: PropTypes.object,
         filter: PropTypes.func,
         onSort: PropTypes.func,
+        onError: PropTypes.func,
         setDndState: PropTypes.func,
         level: PropTypes.number
     };
@@ -40,6 +41,7 @@ class GroupChildren extends React.Component {
                 key: node.id,
                 sortIndex: node.hide ? i : i++,
                 onSort: this.props.onSort,
+                onError: this.props.onError,
                 level: this.props.level,
                 isDraggable: !!this.props.onSort,
                 setDndState: this.props.setDndState

--- a/web/client/components/TOC/fragments/GroupChildren.jsx
+++ b/web/client/components/TOC/fragments/GroupChildren.jsx
@@ -13,7 +13,6 @@ require('./css/groupchildren.css');
 class GroupChildren extends React.Component {
     static propTypes = {
         node: PropTypes.object,
-        dndDummy: PropTypes.object,
         filter: PropTypes.func,
         onSort: PropTypes.func,
         onError: PropTypes.func,

--- a/web/client/components/TOC/fragments/GroupChildren.jsx
+++ b/web/client/components/TOC/fragments/GroupChildren.jsx
@@ -13,6 +13,7 @@ require('./css/groupchildren.css');
 class GroupChildren extends React.Component {
     static propTypes = {
         node: PropTypes.object,
+        dndDummy: PropTypes.object,
         filter: PropTypes.func,
         onSort: PropTypes.func,
         onError: PropTypes.func,
@@ -39,7 +40,7 @@ class GroupChildren extends React.Component {
                 node: node,
                 parentNodeId: this.props.node ? this.props.node.id : '',
                 key: node.id,
-                sortIndex: node.hide ? i : i++,
+                sortIndex: node.hide || node.dummy ? i : i++,
                 onSort: this.props.onSort,
                 onError: this.props.onError,
                 level: this.props.level,

--- a/web/client/components/TOC/fragments/__tests__/GroupChildren-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/GroupChildren-test.jsx
@@ -6,11 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var GroupChildren = require('../GroupChildren');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const TestUtils = require('react-dom/test-utils');
+const GroupChildren = require('../GroupChildren');
 
-var expect = require('expect');
+const expect = require('expect');
 
 describe('test GroupChildren module component', () => {
     beforeEach((done) => {
@@ -47,5 +48,68 @@ describe('test GroupChildren module component', () => {
         const layers = domNode.getElementsByClassName('layer');
         expect(layers).toExist();
         expect(layers.length).toBe(1);
+    });
+
+    it('tests GroupChildren sortIndex assignment', () => {
+        const node = {
+            id: 'Group',
+            name: 'Group',
+            nodes: [{
+                id: 'layer00',
+                name: 'layer00',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'Group.Group1',
+                name: 'Group1',
+                nodes: []
+            }, {
+                id: 'Group.Group1__dummy',
+                dummy: true
+            }, {
+                id: 'layer01',
+                name: 'layer01',
+                visibility: true,
+                type: 'wms',
+                url: 'fakeurl'
+            }, {
+                id: 'layer02',
+                hide: true
+            }, {
+                id: 'Group.Group2',
+                name: 'Group2',
+                nodes: []
+            }, {
+                id: 'Group.Group2__dummy',
+                dummy: true
+            }]
+        };
+
+        class TestComponent extends React.Component {
+            render() {
+                return <div></div>;
+            }
+        }
+
+        const comp = ReactDOM.render(<GroupChildren node={node}><TestComponent/></GroupChildren>, document.getElementById("container"));
+
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+
+        const elements = TestUtils.scryRenderedComponentsWithType(comp, TestComponent);
+        expect(elements.length).toBe(7);
+
+        const sortIndexes = {
+            "layer00": 0,
+            "Group.Group1": 1,
+            "Group.Group1__dummy": 2,
+            "layer01": 2,
+            "layer02": 3,
+            "Group.Group2": 3,
+            "Group.Group2__dummy": 4
+        };
+
+        elements.forEach(el => expect(el.props.sortIndex).toBe(sortIndexes[el.props.node.id]));
     });
 });

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -18,6 +18,7 @@ const {changeLayerProperties, changeGroupProperties, toggleNode, contextNode,
 const {openQueryBuilder} = require("../actions/layerFilter");
 const {getLayerCapabilities} = require('../actions/layerCapabilities');
 const {zoomToExtent} = require('../actions/map');
+const {error} = require('../actions/notifications');
 const {groupsSelector, layersSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector, layerMetadataSelector, wfsDownloadSelector} = require('../selectors/layers');
 const {mapSelector, mapNameSelector} = require('../selectors/map');
 const {currentLocaleSelector} = require("../selectors/locale");
@@ -204,6 +205,7 @@ class LayerTree extends React.Component {
         noFilterResults: PropTypes.bool,
         onAddLayer: PropTypes.func,
         onAddGroup: PropTypes.func,
+        onError: PropTypes.func,
         onGetMetadataRecord: PropTypes.func,
         hideLayerMetadata: PropTypes.func,
         activateAddLayerButton: PropTypes.bool,
@@ -281,6 +283,7 @@ class LayerTree extends React.Component {
         noFilterResults: false,
         onAddLayer: () => {},
         onAddGroup: () => {},
+        onError: () => {},
         onGetMetadataRecord: () => {},
         hideLayerMetadata: () => {},
         activateAddLayerButton: false,
@@ -449,7 +452,7 @@ class LayerTree extends React.Component {
                             <div className="toc-filter-no-results"><Message msgId="toc.noFilteredResults" /></div>
                         </div>
                         :
-                        <TOC onSort={!this.props.filterText && this.props.activateSortLayer ? this.props.onSort : null} filter={this.getNoBackgroundLayers} nodes={this.props.filteredGroups}>
+                        <TOC onError={this.props.onError} onSort={!this.props.filterText && this.props.activateSortLayer ? this.props.onSort : null} filter={this.getNoBackgroundLayers} nodes={this.props.filteredGroups}>
                             <DefaultLayerOrGroup groupElement={Group} layerElement={Layer}/>
                         </TOC>
                     }
@@ -602,6 +605,7 @@ const TOCPlugin = connect(tocSelector, {
     onAddLayer: setControlProperties.bind(null, "metadataexplorer", "enabled", true, "group"),
     onAddGroup: setControlProperties.bind(null, "addgroup", "enabled", true, "parent"),
     onGetMetadataRecord: getMetadataRecordById,
+    onError: error,
     hideLayerMetadata,
     onNewWidget: () => createWidget(),
     refreshLayerVersion

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -488,6 +488,9 @@
                 "invalid_object": "Ungültige Serviceantwort",
                 "invalid_geometry": "Der Geometrietyp ist nicht gültig, kein Punkt, Linie oder Polygon",
                 "invalid_classes": "Max muss in jeder Klasse größer als min sein"
+            },
+            "error": {
+                "defaultGroupOnTop": "Die Gruppe {groupTitle} ist als Standardzielgruppe festgelegt und muss daher oben bleiben"
             }
         },
         "print":{

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -488,6 +488,9 @@
                 "invalid_object": "Invalid service response",
                 "invalid_geometry": "Geometry type is not valid, not a point, line or polygon",
                 "invalid_classes": "Max must be greater than min in every class"
+            },
+            "error": {
+                "defaultGroupOnTop": "The {groupTitle} group is set as default target group, therefore it must remain on top"
             }
         },
         "print":{

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -488,6 +488,9 @@
                 "invalid_object": "Respuesta de servicio no válida",
                 "invalid_geometry": "El tipo de geometría no es válido, no es un punto, línea o polígono",
                 "invalid_classes": "Max debe ser mayor que min en todas las clases"
+            },
+            "error": {
+                "defaultGroupOnTop": "El grupo {groupTitle} se establece como grupo objetivo predeterminado, por lo tanto, debe permanecer en la parte superior"
             }
         },
         "print":{

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -488,6 +488,9 @@
                 "invalid_object": "Réponse au service non valide",
                 "invalid_geometry": "Le type de géométrie n'est pas valide, pas un point, une ligne ou un polygone",
                 "invalid_classes": "Max doit être supérieur à min dans chaque classe"
+            },
+            "error": {
+                "defaultGroupOnTop": "Le groupe {groupTitle} est défini comme groupe cible par défaut, il doit donc rester au premier plan"
             }
         },
         "print":{

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -488,6 +488,9 @@
                 "invalid_object": "Risposta del servizio non valida",
                 "invalid_geometry": "Il tipo di geometria non è valido, deve essere un punto, una linea o un poligono",
                 "invalid_classes": "Il valore massimo di ogni classe deve essere maggiore del relativo minimo"
+            },
+            "error": {
+                "defaultGroupOnTop": "Il gruppo {groupTitle} è impostato come gruppo target predefinito, quindi deve rimanere in cima"
             }
         },
         "print":{


### PR DESCRIPTION
## Description
Default group is not draggable anymore. When something is inserted before the Default group, the operation is canceled and a warning notification is shown.

## Issues
 - #3781 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#3781 

**What is the new behavior?**
In the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No