### PR TITLE
Fix 4333 Login modal window closes with a click on backdrop

### DIFF
--- a/web/client/components/security/modals/LoginModal.jsx
+++ b/web/client/components/security/modals/LoginModal.jsx
@@ -86,7 +86,7 @@ class LoginModal extends React.Component {
     };
 
     render() {
-        return (<Modal {...this.props.options} show={this.props.show} onHide={this.handleOnHide}>
+        return (<Modal {...this.props.options} backdrop="static" show={this.props.show} onHide={this.handleOnHide}>
             <Modal.Header key="passwordChange" closeButton>
                 <Modal.Title><Message msgId="user.login"/></Modal.Title>
             </Modal.Header>


### PR DESCRIPTION
## Description
Fix Login modal window closes with a click on backdrop

## Issues
 - #4333 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4333 

**What is the new behavior?**
The login modal does not close on click backdrop

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
