### PR TITLE
Browse stories in home 4366

### DIFF
--- a/web/client/actions/__tests__/geostories-test.js
+++ b/web/client/actions/__tests__/geostories-test.js
@@ -14,8 +14,6 @@ const {
     deleteGeostory, DELETE_GEOSTORY,
     geostoryDeleted, GEOSTORY_DELETED,
     reloadGeostories, RELOAD
-
-
 } = require('../geostories');
 describe('geostories (browse) actions', () => {
     it('setGeostoriesAvailable', () => {

--- a/web/client/actions/__tests__/geostories-test.js
+++ b/web/client/actions/__tests__/geostories-test.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var expect = require('expect');
+const {
+    setGeostoriesAvailable, SET_GEOSTORIES_AVAILABLE,
+    searchGeostories, SEARCH_GEOSTORIES,
+    geostoriesLoading, LOADING,
+    geostoriesListLoaded, GEOSTORIES_LIST_LOADED,
+    deleteGeostory, DELETE_GEOSTORY,
+    geostoryDeleted, GEOSTORY_DELETED,
+    reloadGeostories, RELOAD
+
+
+} = require('../geostories');
+describe('geostories (browse) actions', () => {
+    it('setGeostoriesAvailable', () => {
+        const retval = setGeostoriesAvailable(true);
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_GEOSTORIES_AVAILABLE);
+        expect(retval.available).toBe(true);
+
+    });
+    it('searchGeostories', () => {
+        const retval = searchGeostories();
+        expect(retval).toExist();
+        expect(retval.type).toBe(SEARCH_GEOSTORIES);
+    });
+    it('geostoriesLoading', () => {
+        const retval = geostoriesLoading(true, "test");
+        expect(retval).toExist();
+        expect(retval.type).toBe(LOADING);
+        expect(retval.value).toBe(true);
+        expect(retval.name).toBe("test");
+    });
+    it('geostoriesListLoaded', () => {
+        const retval = geostoriesListLoaded({
+            results: [{id: 1}],
+            success: true,
+            totalCount: 1
+        }, {
+            searchText: "test",
+            options: "someOptions"
+        });
+        expect(retval).toExist();
+        expect(retval.type).toBe(GEOSTORIES_LIST_LOADED);
+        expect(retval.results[0].id).toBe(1);
+        expect(retval.totalCount).toBe(1);
+        expect(retval.success).toBe(true);
+        expect(retval.searchText).toBe("test");
+        expect(retval.options).toBe("someOptions");
+    });
+    it('deleteGeostory', () => {
+        const retval = deleteGeostory(1);
+        expect(retval).toExist();
+        expect(retval.type).toBe(DELETE_GEOSTORY);
+        expect(retval.id).toBe(1);
+    });
+    it( 'geostoryDeleted', () => {
+        const retval =  geostoryDeleted();
+        expect(retval).toExist();
+        expect(retval.type).toBe(GEOSTORY_DELETED);
+    });
+    it('reloadGeostories', () => {
+        const retval = reloadGeostories();
+        expect(retval).toExist();
+        expect(retval.type).toBe(RELOAD);
+    });
+
+});

--- a/web/client/actions/geostories.js
+++ b/web/client/actions/geostories.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const SET_GEOSTORIES_AVAILABLE = "GEOSTORIES:SET_GEOSTORIES_AVAILABLE";
+const SEARCH_GEOSTORIES = "GEOSTORIES:SEARCH_GEOSTORIES";
+const GEOSTORIES_LIST_LOADED = "GEOSTORIES:GEOSTORIES_LIST_LOADED";
+const DELETE_GEOSTORY = "GEOSTORIES:DELETE_GEOSTORY";
+const GEOSTORY_DELETED = "GEOSTORIES:GEOSTORY_DELETED";
+const RELOAD = "GEOSTORIES:RELOAD_GEOSTORIES";
+const LOADING = "GEOSTORIES:LOADING";
+
+module.exports = {
+    SET_GEOSTORIES_AVAILABLE,
+    setGeostoriesAvailable: (available) => ({ type: SET_GEOSTORIES_AVAILABLE, available }),
+    SEARCH_GEOSTORIES,
+    searchGeostories: (searchText, params) => ({ type: SEARCH_GEOSTORIES, searchText, params }),
+    LOADING,
+    /**
+     * @param {boolean} value the value of the flag
+     * @param {string} [name] the name of the flag to set. loading is anyway always triggered
+     */
+    geostoriesLoading: (value, name = "loading") => ({
+        type: LOADING,
+        name,
+        value
+    }),
+    GEOSTORIES_LIST_LOADED,
+    geostoriesListLoaded: ({ results, success, totalCount }, { searchText, options } = {}) => ({ type: GEOSTORIES_LIST_LOADED, results, success, totalCount, searchText, options }),
+    DELETE_GEOSTORY,
+    deleteGeostory: id => ({type: DELETE_GEOSTORY, id}),
+    GEOSTORY_DELETED,
+    RELOAD,
+    reloadGeostories: () => ({ type: RELOAD}),
+    geostoryDeleted: id => ({type: GEOSTORY_DELETED, id})
+};

--- a/web/client/components/maps/enhancers/featuredMaps.js
+++ b/web/client/components/maps/enhancers/featuredMaps.js
@@ -61,6 +61,8 @@ const getIcon = record => {
         return "1-map";
     case "DASHBOARD":
         return "dashboard";
+    case "GEOSTORY":
+        return "geostory";
     default:
         return null;
     }

--- a/web/client/epics/__tests__/contenttabs-test.js
+++ b/web/client/epics/__tests__/contenttabs-test.js
@@ -11,6 +11,7 @@ const {testEpic} = require('./epicTestUtils');
 
 const {MAPS_LOAD_MAP, MAPS_LIST_LOADED} = require("../../actions/maps");
 const {DASHBOARDS_LIST_LOADED} = require("../../actions/dashboards");
+const {GEOSTORIES_LIST_LOADED} = require("../../actions/geostories");
 const {updateMapsDashboardTabs} = require("../contenttabs");
 
 describe('Test Maps Dashboard Content Tabs', () => {
@@ -18,7 +19,8 @@ describe('Test Maps Dashboard Content Tabs', () => {
         const act = [
             {type: MAPS_LOAD_MAP},
             {type: MAPS_LIST_LOADED, maps: {totalCount: 0}},
-            {type: DASHBOARDS_LIST_LOADED, totalCount: 1}
+            {type: DASHBOARDS_LIST_LOADED, totalCount: 1},
+            {type: GEOSTORIES_LIST_LOADED, totalCount: 2}
         ];
         testEpic(updateMapsDashboardTabs, 1, act, (res) => {
             const action = res[0];

--- a/web/client/epics/__tests__/geostories-test.js
+++ b/web/client/epics/__tests__/geostories-test.js
@@ -103,6 +103,7 @@ describe('geostories epics', () => {
                 }
             });
         });
+    });
     it('searchGeostories error', (done) => {
         const baseUrl = "base/web/client/test-resources/geostore/extjs/search/NODATA#";
         ConfigUtils.getDefaults = () => ({

--- a/web/client/epics/__tests__/geostories-test.js
+++ b/web/client/epics/__tests__/geostories-test.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var expect = require('expect');
+const { testEpic } = require('./epicTestUtils');
+const ConfigUtils = require('../../utils/ConfigUtils');
+
+const {
+    searchGeostoriesOnMapSearch,
+    searchGeostories: searchGeostoriesEpic,
+    reloadOnGeostories
+} = require('../geostories');
+
+const { storySaved } = require('../../actions/geostory');
+const { mapMetadataUpdated } = require('../../actions/maps');
+
+
+const {
+    SEARCH_GEOSTORIES,
+    searchGeostories,
+    LOADING,
+    GEOSTORIES_LIST_LOADED
+} = require('../../actions/geostories');
+
+const {
+    SHOW_NOTIFICATION
+} = require('../../actions/notifications');
+
+const {
+    mapsLoading
+} = require('../../actions/maps');
+let getDefaults = ConfigUtils.getDefaults;
+describe('geostories epics', () => {
+    beforeEach( () => {
+        getDefaults = ConfigUtils.getDefaults;
+    });
+    afterEach(() => {
+        ConfigUtils.getDefaults = getDefaults;
+    });
+    it('searchGeostoriesOnMapSearch', (done) => {
+        const startActions = [mapsLoading("Search Text")];
+        testEpic(searchGeostoriesOnMapSearch, 1, startActions, actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => {
+                switch (action.type) {
+                case LOADING:
+
+                    break;
+                case SEARCH_GEOSTORIES:
+                    expect(action.searchText).toBe("Search Text");
+                    done();
+                    break;
+                default:
+                    done(new Error("Action not recognized"));
+                }
+            });
+            done();
+        }, {});
+    });
+    it('searchGeostories', (done) => {
+        const baseUrl = "base/web/client/test-resources/geostore/extjs/search/search_1.json#";
+        ConfigUtils.getDefaults = () => ({
+            geoStoreUrl: baseUrl
+        });
+
+        const startActions = [searchGeostories("Search Text")];
+        testEpic(searchGeostoriesEpic, 3, startActions, actions => {
+            expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[0].name).toBe("loading");
+            expect(actions[0].value).toBe(true);
+            expect(actions[1].type).toBe(GEOSTORIES_LIST_LOADED);
+            expect(actions[1].totalCount).toBe(1);
+            expect(actions[2].type).toBe(LOADING);
+            expect(actions[2].name).toBe("loading");
+            expect(actions[2].value).toBe(false);
+            done();
+        }, {});
+    });
+    describe('reloadOnGeostories', () => {
+        it('reload on storySaved', (done) => {
+            const startActions = [storySaved("Search Text")];
+            testEpic(reloadOnGeostories, 1, startActions, ([a]) => {
+                expect(a.type).toBe(SEARCH_GEOSTORIES);
+                expect(a.params.start).toBe(0);
+                expect(a.params.limit).toBe(12);
+                expect(a.searchText).toBe("test");
+                done();
+            }, {
+                geostories: {
+                    searchText: "test",
+                    options: {
+                        params: {
+                            start: 0,
+                            limit: 12
+                        }
+                    }
+                }
+            });
+        });
+        it('reload on mapMetadataUpdate', (done) => {
+            const startActions = [mapMetadataUpdated(1, "name", "description")];
+            testEpic(reloadOnGeostories, 1, startActions, ([a]) => {
+                expect(a.type).toBe(SEARCH_GEOSTORIES);
+                expect(a.params.start).toBe(0);
+                expect(a.params.limit).toBe(12);
+                expect(a.searchText).toBe("test");
+                done();
+            }, {
+                geostories: {
+                    searchText: "test",
+                    options: {
+                        params: {
+                            start: 0,
+                            limit: 12
+                        }
+                    }
+                }
+            });
+        });
+    });
+    it('searchGeostories error', (done) => {
+        const baseUrl = "base/web/client/test-resources/geostore/extjs/search/NODATA#";
+        ConfigUtils.getDefaults = () => ({
+            geoStoreUrl: baseUrl
+        });
+
+        const startActions = [searchGeostories("Search Text")];
+        testEpic(searchGeostoriesEpic, 3, startActions, actions => {
+            expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[0].name).toBe("loading");
+            expect(actions[0].value).toBe(true);
+            expect(actions[1].type).toBe(SHOW_NOTIFICATION);
+            expect(actions[2].type).toBe(LOADING);
+            expect(actions[2].name).toBe("loading");
+            expect(actions[2].value).toBe(false);
+            done();
+        }, {});
+    });
+});

--- a/web/client/epics/__tests__/geostories-test.js
+++ b/web/client/epics/__tests__/geostories-test.js
@@ -17,7 +17,6 @@ const {
 } = require('../geostories');
 
 const { storySaved } = require('../../actions/geostory');
-const { mapMetadataUpdated } = require('../../actions/maps');
 
 
 const {

--- a/web/client/epics/__tests__/geostories-test.js
+++ b/web/client/epics/__tests__/geostories-test.js
@@ -103,27 +103,6 @@ describe('geostories epics', () => {
                 }
             });
         });
-        it('reload on mapMetadataUpdate', (done) => {
-            const startActions = [mapMetadataUpdated(1, "name", "description")];
-            testEpic(reloadOnGeostories, 1, startActions, ([a]) => {
-                expect(a.type).toBe(SEARCH_GEOSTORIES);
-                expect(a.params.start).toBe(0);
-                expect(a.params.limit).toBe(12);
-                expect(a.searchText).toBe("test");
-                done();
-            }, {
-                geostories: {
-                    searchText: "test",
-                    options: {
-                        params: {
-                            start: 0,
-                            limit: 12
-                        }
-                    }
-                }
-            });
-        });
-    });
     it('searchGeostories error', (done) => {
         const baseUrl = "base/web/client/test-resources/geostore/extjs/search/NODATA#";
         ConfigUtils.getDefaults = () => ({

--- a/web/client/epics/contenttabs.js
+++ b/web/client/epics/contenttabs.js
@@ -12,17 +12,18 @@ const {MAPS_LOAD_MAP, MAPS_LIST_LOADED} = require("../actions/maps");
 const {
     DASHBOARDS_LIST_LOADED
 } = require('../actions/dashboards');
+const {GEOSTORIES_LIST_LOADED} = require('../actions/geostories');
 const {onTabSelected} = require("../actions/contenttabs");
 /**
-* Update Maps and Dashboards counts to select contenttabs each tab has to have a key in its ContentTab configuration
+* Update Maps, Dashboards and Geostories counts to select contenttabs each tab has to have a key in its ContentTab configuration
 * @param {object} action
 */
 const updateMapsDashboardTabs = (action$, {getState = () => {}}) =>
     action$.ofType(MAPS_LOAD_MAP)
         .switchMap(() => {
-            return Rx.Observable.forkJoin(action$.ofType(MAPS_LIST_LOADED).take(1), action$.ofType(DASHBOARDS_LIST_LOADED).take(1))
+            return Rx.Observable.forkJoin(action$.ofType(MAPS_LIST_LOADED).take(1), action$.ofType(DASHBOARDS_LIST_LOADED).take(1), action$.ofType(GEOSTORIES_LIST_LOADED).take(1))
                 .switchMap((r) => {
-                    const results = {maps: r[0].maps, dashboards: r[1] };
+                    const results = {maps: r[0].maps, dashboards: r[1], geostories: r[2]};
                     const {contenttabs = {}} = getState() || {};
                     const {selected} = contenttabs;
                     if (results[selected] && results[selected].totalCount === 0) {

--- a/web/client/epics/geostories.js
+++ b/web/client/epics/geostories.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const Rx = require('rxjs');
+const { MAPS_LIST_LOADING, ATTRIBUTE_UPDATED} = require('../actions/maps');
+const { MAP_DELETED, MAP_METADATA_UPDATED } = require('../actions/maps');
+const { SAVED: GEOSTORY_SAVED } = require('../actions/geostory');
+
+const { SEARCH_GEOSTORIES, DELETE_GEOSTORY, GEOSTORY_DELETED, RELOAD, searchGeostories, geostoriesListLoaded, geostoryDeleted, geostoriesLoading } = require('../actions/geostories');
+const { searchParamsSelector, searchTextSelector, totalCountSelector} = require('../selectors/geostories');
+const GeoStoreApi = require('../api/GeoStoreDAO');
+const { wrapStartStop } = require('../observables/epics');
+const {error} = require('../actions/notifications');
+
+const {deleteResource} = require('../api/persistence');
+
+const calculateNewParams = state => {
+    const totalCount = totalCountSelector(state);
+    const {start, limit, ...params} = searchParamsSelector(state) || {};
+    if (start === totalCount - 1) {
+        return {
+            start: Math.max(0, start - limit),
+            limit
+        };
+    }
+    return {
+        start, limit, ...params
+    };
+};
+
+module.exports = {
+    searchGeostoriesOnMapSearch: action$ =>
+        action$.ofType(MAPS_LIST_LOADING)
+            .switchMap(({ searchText }) => Rx.Observable.of(searchGeostories(searchText))),
+    searchGeostories: (action$, { getState = () => { } }) =>
+        action$.ofType(SEARCH_GEOSTORIES)
+            .map( ({params, searchText, geoStoreUrl}) => ({
+                searchText,
+                options: {
+                    params: params || searchParamsSelector(getState()) || {start: 0, limit: 12},
+                    ...(geoStoreUrl ? { baseURL: geoStoreUrl } : {})
+                }
+            }))
+            .switchMap(
+                ({ searchText, options }) =>
+                    Rx.Observable.defer(() => GeoStoreApi.getResourcesByCategory("GEOSTORY", searchText, options))
+                        .map(results => geostoriesListLoaded(results, {searchText, options}))
+                        .let(wrapStartStop(
+                            geostoriesLoading(true, "loading"),
+                            geostoriesLoading(false, "loading"),
+                            () => Rx.Observable.of(error({
+                                title: "notification.error",
+                                message: "resources.geostories.errorLoadingGeostories",
+                                autoDismiss: 6,
+                                position: "tc"
+                            }))
+                        ))
+            ),
+    deleteDashboard: action$ => action$
+        .ofType(DELETE_GEOSTORY)
+        .switchMap(id => deleteResource(id).map(() => geostoryDeleted(id)))
+        .let(wrapStartStop(
+            geostoriesLoading(true, "loading"),
+            geostoriesLoading(false, "loading"),
+            () => Rx.Observable.of(error({
+                title: "notification.error",
+                message: "resources.geostories.deleteError",
+                autoDismiss: 6,
+                position: "tc"
+            }))
+        )),
+    reloadOnGeostories: (action$, { getState = () => { } }) =>
+        action$.ofType(GEOSTORY_DELETED, MAP_DELETED, MAP_METADATA_UPDATED, RELOAD, ATTRIBUTE_UPDATED, GEOSTORY_SAVED)
+            .delay(1000) // delay as a workaround for geostore issue #178
+            .switchMap( () => Rx.Observable.of(searchGeostories(
+                searchTextSelector(getState()),
+                calculateNewParams(getState())
+            )))
+};

--- a/web/client/epics/geostories.js
+++ b/web/client/epics/geostories.js
@@ -7,7 +7,7 @@
  */
 const Rx = require('rxjs');
 const { MAPS_LIST_LOADING, ATTRIBUTE_UPDATED} = require('../actions/maps');
-const { MAP_DELETED, MAP_METADATA_UPDATED } = require('../actions/maps');
+
 const { SAVED: GEOSTORY_SAVED } = require('../actions/geostory');
 
 const { SEARCH_GEOSTORIES, DELETE_GEOSTORY, GEOSTORY_DELETED, RELOAD, searchGeostories, geostoriesListLoaded, geostoryDeleted, geostoriesLoading } = require('../actions/geostories');
@@ -74,7 +74,7 @@ module.exports = {
             }))
         )),
     reloadOnGeostories: (action$, { getState = () => { } }) =>
-        action$.ofType(GEOSTORY_DELETED, MAP_DELETED, MAP_METADATA_UPDATED, RELOAD, ATTRIBUTE_UPDATED, GEOSTORY_SAVED)
+        action$.ofType(GEOSTORY_DELETED, RELOAD, ATTRIBUTE_UPDATED, GEOSTORY_SAVED)
             .delay(1000) // delay as a workaround for geostore issue #178
             .switchMap( () => Rx.Observable.of(searchGeostories(
                 searchTextSelector(getState()),

--- a/web/client/epics/geostories.js
+++ b/web/client/epics/geostories.js
@@ -60,7 +60,7 @@ module.exports = {
                             }))
                         ))
             ),
-    deleteDashboard: action$ => action$
+    deleteGeostory: action$ => action$
         .ofType(DELETE_GEOSTORY)
         .switchMap(id => deleteResource(id).map(() => geostoryDeleted(id)))
         .let(wrapStartStop(

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -532,7 +532,18 @@
               },
               "fluid": true
             }
-          }, "MailingLists", "Footer", {
+          },
+          {
+            "name": "GeoStories",
+            "cfg": {
+              "mapsOptions": {
+                "start": 0,
+                "limit": 12
+              },
+              "fluid": true
+            }
+          }
+          , "MailingLists", "Footer", {
           "name": "Cookie",
           "cfg": {
             "externalCookieUrl" : "",

--- a/web/client/plugins/CreateNewMap.jsx
+++ b/web/client/plugins/CreateNewMap.jsx
@@ -19,6 +19,7 @@ class CreateNewMap extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
         showNewDashboard: PropTypes.bool,
+        showNewGeostory: PropTypes.bool,
         colProps: PropTypes.object,
         isLoggedIn: PropTypes.bool,
         allowedRoles: PropTypes.array,
@@ -33,6 +34,7 @@ class CreateNewMap extends React.Component {
     static defaultProps = {
         mapType: "leaflet",
         showNewDashboard: true,
+        showNewGeostory: true,
         isLoggedIn: false,
         allowedRoles: ["ADMIN", "USER"],
         colProps: {
@@ -57,6 +59,11 @@ class CreateNewMap extends React.Component {
                             <Glyphicon glyph="add-dashboard" />
                         </Button>
                         : null}
+                    {this.props.showNewGeostory ?
+                        <Button tooltipId="resources.geostories.newGeostory" className="square-button" bsStyle="primary" onClick={() => { this.context.router.history.push("/geostory/newgeostory/"); }}>
+                            <Glyphicon glyph="geostory" />
+                        </Button>
+                        : null}
                 </ButtonToolbar>
             </Col>
         </Grid>);
@@ -70,6 +77,7 @@ class CreateNewMap extends React.Component {
  * @class CreateNewMap
  * @static
  * @prop {boolean} cfg.showNewDashboard show/hide th create new dashboard button.
+ * @prop {boolean} cfg.showNewGeostory show/hide th create new geostory button.
  * @prop {string[]} cfg.allowedRoles array of users roles allowed to create maps and/or dashboards. default: `["ADMIN", "USER"]`. Users that don't have these roles will never see the buttons.
  */
 module.exports = {

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -66,14 +66,14 @@ class FeaturedMaps extends React.Component {
                 title={<h3><Message msgId="manager.featuredMaps" /></h3>}
                 maps={items}
                 colProps={this.props.colProps}
-                viewerUrl={(map) => {
-                    if (map.category && map.category.name === "DASHBOARD") {
-                        return this.context.router.history.push(`/dashboard/${map.id}`);
+                viewerUrl={(res) => {
+                    if (res.category && res.category.name === "DASHBOARD") {
+                        return this.context.router.history.push(`/dashboard/${res.id}`);
                     }
-                    if (map.category && map.category.name === "GEOSTORY") {
-                        return this.context.router.history.push(`/geostory/${map.id}`);
+                    if (res.category && res.category.name === "GEOSTORY") {
+                        return this.context.router.history.push(`/geostory/${res.id}`);
                     }
-                    return this.context.router.history.push("/viewer/" + this.props.mapType + "/" + map.id);
+                    return this.context.router.history.push("/viewer/" + this.props.mapType + "/" + res.id);
                 }}
                 metadataModal={MetadataModal}
                 bottom={this.props.bottom}

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -66,11 +66,15 @@ class FeaturedMaps extends React.Component {
                 title={<h3><Message msgId="manager.featuredMaps" /></h3>}
                 maps={items}
                 colProps={this.props.colProps}
-                viewerUrl={(map) =>
-                    map.category && map.category.name === "DASHBOARD"
-                        ? this.context.router.history.push(`/dashboard/${map.id}`)
-                        : this.context.router.history.push("/viewer/" + this.props.mapType + "/" + map.id)
-                }
+                viewerUrl={(map) => {
+                    if (map.category && map.category.name === "DASHBOARD") {
+                        return this.context.router.history.push(`/dashboard/${map.id}`);
+                    }
+                    if (map.category && map.category.name === "GEOSTORY") {
+                        return this.context.router.history.push(`/geostory/${map.id}`);
+                    }
+                    return this.context.router.history.push("/viewer/" + this.props.mapType + "/" + map.id);
+                }}
                 metadataModal={MetadataModal}
                 bottom={this.props.bottom}
                 style={items.length === 0 ? {display: 'none'} : {}}/>

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -1,0 +1,132 @@
+/*
+* Copyright 2019, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+const React = require('react');
+const PropTypes = require('prop-types');
+const assign = require('object-assign');
+const {connect} = require('react-redux');
+const Message = require("../components/I18N/Message");
+const emptyState = require('../components/misc/enhancers/emptyState');
+
+const { setGeostoriesAvailable } = require('../actions/geostories');
+const {mapTypeSelector} = require('../selectors/maptype');
+const { userRoleSelector } = require('../selectors/security');
+const { isFeaturedMapsEnabled } = require('../selectors/featuredmaps');
+const { totalCountSelector } = require('../selectors/geostories');
+const {createSelector} = require('reselect');
+const { compose } = require('recompose');
+
+const GeostoryGrid = require('./geostories/GeostoriesGrid');
+const PaginationToolbar = require('./geostories/PaginationToolbar');
+const EmptyDashboardsView = require('./geostories/EmptyGeostoriesView');
+
+const geostoriesCountSelector = createSelector(
+    totalCountSelector,
+    count => ({ count })
+);
+
+
+class Dashboards extends React.Component {
+    static propTypes = {
+        mapType: PropTypes.string,
+        title: PropTypes.any,
+        onMount: PropTypes.func,
+        loadDashboards: PropTypes.func,
+        resources: PropTypes.array,
+        searchText: PropTypes.string,
+        mapsOptions: PropTypes.object,
+        colProps: PropTypes.object,
+        fluid: PropTypes.bool
+    };
+
+    static contextTypes = {
+        router: PropTypes.object
+    };
+
+    static defaultProps = {
+        mapType: "leaflet",
+        onMount: () => {},
+        loadDashboards: () => {},
+        fluid: false,
+        title: <h3><Message msgId="resources.geostories.titleNoCount" /></h3>,
+        mapsOptions: {start: 0, limit: 12},
+        colProps: {
+            xs: 12,
+            sm: 6,
+            lg: 3,
+            md: 4,
+            className: 'ms-map-card-col'
+        },
+        maps: []
+    };
+
+    componentDidMount() {
+        this.props.onMount();
+    }
+
+    render() {
+        return (<GeostoryGrid
+            resources={this.props.resources}
+            fluid={this.props.fluid}
+            title={this.props.title}
+            colProps={this.props.colProps}
+            viewerUrl={(geostory) => {this.context.router.history.push(`geostory/${geostory.id}`); }}
+            bottom={<PaginationToolbar />}
+        />);
+    }
+}
+
+const geostoriesPluginSelector = createSelector([
+    mapTypeSelector,
+    state => state.geostories && state.geostories.searchText,
+    state => state.geostories && state.geostories.results ? state.geostories.results : [],
+    isFeaturedMapsEnabled,
+    userRoleSelector
+], (mapType, searchText, resources, featuredEnabled, role) => ({
+    mapType,
+    searchText,
+    resources: resources.map(res => ({...res, featuredEnabled: featuredEnabled && role === 'ADMIN'})) // TODO: remove false to enable featuredEnabled
+}));
+
+const GeoStoriesPlugin = compose(
+    connect(geostoriesPluginSelector, {
+        onMount: () => setGeostoriesAvailable(true)
+    }),
+    emptyState(
+        ({resources = [], loading}) => !loading && resources.length === 0,
+        () => ({
+            glyph: "geostory",
+            title: <Message msgId="resources.geostories.noGeostoryAvailable" />,
+            description: <EmptyDashboardsView />
+        })
+
+    )
+)(Dashboards);
+
+module.exports = {
+    GeoStoriesPlugin: assign(GeoStoriesPlugin, {
+        NavMenu: {
+            position: 3,
+            label: <Message msgId="resources.geostories.menuText" />,
+            linkId: '#mapstore-geostories-grid',
+            glyph: 'geostory'
+        },
+        ContentTabs: {
+            name: 'geostories',
+            key: 'geostories',
+            TitleComponent:
+                connect(geostoriesCountSelector)(({ count = ""}) => <Message msgId="resources.geostories.title" msgParams={{ count: count + "" }} />),
+            position: 3,
+            tool: true,
+            priority: 1
+        }
+    }),
+    epics: require('../epics/geostories'),
+    reducers: {
+        geostories: require('../reducers/geostories')
+    }
+};

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -22,7 +22,7 @@ const { compose } = require('recompose');
 
 const GeostoryGrid = require('./geostories/GeostoriesGrid');
 const PaginationToolbar = require('./geostories/PaginationToolbar');
-const EmptyDashboardsView = require('./geostories/EmptyGeostoriesView');
+const EmptyGeostoriesView = require('./geostories/EmptyGeostoriesView');
 
 const geostoriesCountSelector = createSelector(
     totalCountSelector,
@@ -30,12 +30,12 @@ const geostoriesCountSelector = createSelector(
 );
 
 
-class Dashboards extends React.Component {
+class Geostories extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
         title: PropTypes.any,
         onMount: PropTypes.func,
-        loadDashboards: PropTypes.func,
+        loadGeostories: PropTypes.func,
         resources: PropTypes.array,
         searchText: PropTypes.string,
         mapsOptions: PropTypes.object,
@@ -50,7 +50,7 @@ class Dashboards extends React.Component {
     static defaultProps = {
         mapType: "leaflet",
         onMount: () => {},
-        loadDashboards: () => {},
+        loadGeostories: () => {},
         fluid: false,
         title: <h3><Message msgId="resources.geostories.titleNoCount" /></h3>,
         mapsOptions: {start: 0, limit: 12},
@@ -101,11 +101,11 @@ const GeoStoriesPlugin = compose(
         () => ({
             glyph: "geostory",
             title: <Message msgId="resources.geostories.noGeostoryAvailable" />,
-            description: <EmptyDashboardsView />
+            description: <EmptyGeostoriesView />
         })
 
     )
-)(Dashboards);
+)(Geostories);
 
 module.exports = {
     GeoStoriesPlugin: assign(GeoStoriesPlugin, {

--- a/web/client/plugins/geostories/EmptyGeostoriesView.jsx
+++ b/web/client/plugins/geostories/EmptyGeostoriesView.jsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const { createSelector } = require('reselect');
+const { connect } = require('react-redux');
+const { Button } = require('react-bootstrap');
+const { isLoggedIn } = require('../../selectors/security');
+
+const Message = require('../../components/I18N/Message');
+
+class EmptyDashboards extends React.Component {
+    static propTypes = {
+        loggedIn: PropTypes.bool
+    }
+    static contextTypes = {
+        router: PropTypes.object
+    };
+
+    render() {
+        return (<div style={{width: "100%", textAlign: "center"}}>{this.props.loggedIn
+            ? (<Button bsStyle="primary" onClick={() => { this.context.router.history.push("/geostory/newgeostory"); }}>
+                <Message msgId="resources.geostories.createANewOne" />
+            </Button>)
+            : null}</div>);
+    }
+}
+module.exports = connect(
+    createSelector(isLoggedIn, (loggedIn) => ({
+        loggedIn: !!loggedIn
+    })),
+)(EmptyDashboards);

--- a/web/client/plugins/geostories/EmptyGeostoriesView.jsx
+++ b/web/client/plugins/geostories/EmptyGeostoriesView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, GeoSolutions Sas.
+ * Copyright 2019, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -15,7 +15,7 @@ const { isLoggedIn } = require('../../selectors/security');
 
 const Message = require('../../components/I18N/Message');
 
-class EmptyDashboards extends React.Component {
+class EmptyGeostories extends React.Component {
     static propTypes = {
         loggedIn: PropTypes.bool
     }
@@ -35,4 +35,4 @@ module.exports = connect(
     createSelector(isLoggedIn, (loggedIn) => ({
         loggedIn: !!loggedIn
     })),
-)(EmptyDashboards);
+)(EmptyGeostories);

--- a/web/client/plugins/geostories/GeostoriesGrid.jsx
+++ b/web/client/plugins/geostories/GeostoriesGrid.jsx
@@ -1,0 +1,39 @@
+/*
+* Copyright 2019, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+const { compose, defaultProps, withHandlers } = require('recompose');
+const { deleteGeostory, reloadGeostories } = require('../../actions/geostories');
+const { updateAttribute, setFeaturedMapsLatestResource } = require('../../actions/maps'); // TODO: externalize
+const { userSelector } = require('../../selectors/security');
+const { createSelector } = require('reselect');
+const { connect } = require('react-redux');
+const resourceGrid = require('../../components/resources/enhancers/resourceGrid');
+const Grid = compose(
+    connect(createSelector(userSelector, user => ({ user })), {
+        onDelete: deleteGeostory,
+        reloadGeostories,
+        setFeaturedMapsLatestResource,
+        onUpdateAttribute: updateAttribute
+    }),
+    withHandlers({
+        onSaveSuccess: (props) => (resource) => {
+            if (props.reloadGeostories) {
+                props.reloadGeostories();
+            }
+            if (props.setFeaturedMapsLatestResource) {
+                props.setFeaturedMapsLatestResource(resource);
+            }
+        }
+    }),
+    defaultProps({
+        category: "GEOSTORY"
+    }),
+    resourceGrid
+)(require('../../components/resources/ResourceGrid'));
+
+module.exports = Grid;

--- a/web/client/plugins/geostories/PaginationToolbar.jsx
+++ b/web/client/plugins/geostories/PaginationToolbar.jsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+const { connect } = require('react-redux');
+const { searchGeostories } = require('../../actions/geostories');
+const { withHandlers, renameProp, compose } = require('recompose');
+const { searchTextSelector, resultsSelector, searchParamsSelector, totalCountSelector, isLoadingSelector } = require('../../selectors/geostories');
+const { createSelector } = require('reselect');
+const PaginationToolbar = compose(
+    connect(
+        createSelector(
+            searchTextSelector,
+            searchParamsSelector,
+            resultsSelector,
+            totalCountSelector,
+            isLoadingSelector,
+            () => false, // TODO: loading
+            (searchText, { start = 0, limit = 12 } = {}, results, totalCount, loading) => {
+                const total = Math.min(totalCount || 0, limit || 0);
+                const page = results && total && Math.ceil(start / total) || 0;
+                return {
+                    page: page,
+                    pageSize: limit,
+                    items: results,
+                    total: totalCount,
+                    searchText,
+                    loading
+                };
+            }
+        ),
+        {
+            searchGeostories
+        }
+    ),
+    renameProp('searchGeostories', 'loadPage'),
+    withHandlers({
+        onSelect: ({ loadPage = () => { }, searchText, pageSize }) => (pageNumber) => {
+            let start = pageSize * pageNumber;
+            let limit = pageSize;
+            loadPage(searchText, { start, limit });
+        }
+    })
+)(require('../../components/misc/PaginationToolbar'));
+module.exports = PaginationToolbar;

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -46,6 +46,7 @@ module.exports = {
         FloatingLegendPlugin: require('../plugins/FloatingLegend'),
         FullScreenPlugin: require('../plugins/FullScreen'),
         GeoStoryPlugin: require('../plugins/GeoStory').default,
+        GeoStoriesPlugin: require('../plugins/GeoStories'),
         GeoStoryEditorPlugin: require('../plugins/GeoStoryEditor').default,
         GeoStorySavePlugin: require('../plugins/GeoStorySave').GeoStorySave,
         GeoStorySaveAsPlugin: require('../plugins/GeoStorySave').GeoStorySaveAs,

--- a/web/client/reducers/__tests__/geostories-test.js
+++ b/web/client/reducers/__tests__/geostories-test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const expect = require('expect');
+
+var geostories = require('../geostories');
+const {
+    setGeostoriesAvailable,
+    geostoriesListLoaded,
+    geostoriesLoading
+} = require('../../actions/geostories');
+
+
+describe('Test the geostories reducer', () => {
+    it('geostories setGeostoriesAvailable', () => {
+        const action = setGeostoriesAvailable(true);
+        const state = geostories( undefined, action);
+        expect(state).toExist();
+        expect(state.available).toBe(true);
+    });
+    it('geostories geostoriesListLoaded', () => {
+        const action = geostoriesListLoaded({
+            results: ""
+        }, {
+            searchText: "TEST"
+        });
+        const state = geostories( undefined, action);
+        expect(state).toExist();
+        expect(state.results.length).toBe(0);
+        expect(state.searchText).toBe("TEST");
+    });
+    it('geostories geostoriesLoading', () => {
+        const action = geostoriesLoading(true);
+        const state = geostories( undefined, action);
+        expect(state).toExist();
+        expect(state.loading).toBe(true);
+    });
+    it('geostories geostoriesLoading save', () => {
+        const action = geostoriesLoading(true, "saving");
+        const state = geostories(undefined, action);
+        expect(state).toExist();
+        expect(state.loading).toBe(true);
+        expect(state.loadFlags.saving).toBe(true);
+    });
+});

--- a/web/client/reducers/geostories.js
+++ b/web/client/reducers/geostories.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { MAPS_LIST_LOADING } = require('../actions/maps');
+const { LOCATION_CHANGE } = require('connected-react-router');
+
+const { GEOSTORIES_LIST_LOADED, SET_GEOSTORIES_AVAILABLE, LOADING } = require('../actions/geostories');
+const {set} = require('../utils/ImmutableUtils');
+const { castArray } = require('lodash');
+
+function geostories(state = {
+    enabled: false,
+    start: 0,
+    limit: 12,
+    errors: [],
+    searchText: ""
+}, action) {
+    switch (action.type) {
+    case SET_GEOSTORIES_AVAILABLE: {
+        return set("available", action.available, state);
+    }
+    case LOCATION_CHANGE: {
+        return set('showModal', {}, state);
+    }
+    case GEOSTORIES_LIST_LOADED:
+        return {
+            ...state,
+            results: action.results !== "" ? castArray(action.results) : [],
+            success: action.success,
+            totalCount: action.totalCount,
+            start: action.params && action.params.start,
+            limit: action.params && action.params.limit,
+            searchText: action.searchText,
+            options: action.options
+        };
+    case MAPS_LIST_LOADING:
+        return {
+            ...state,
+            start: action.params && action.params.start,
+            limit: action.params && action.params.limit,
+            searchText: action.searchText
+        };
+    case LOADING: {
+        // anyway sets loading to true
+        return set(action.name === "loading" ? "loading" : `loadFlags.${action.name}`, action.value, set(
+            "loading", action.value, state
+        ));
+    }
+    default:
+        return state;
+    }
+}
+
+module.exports = geostories;

--- a/web/client/selectors/geostories.js
+++ b/web/client/selectors/geostories.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+    searchTextSelector: state => state && state.geostories && state.geostories.searchText,
+    searchParamsSelector: state => state && state.geostories && state.geostories.options && state.geostories.options.params,
+    resultsSelector: state => state && state.geostories && state.geostories.results,
+    totalCountSelector: state => state && state.geostories && state.geostories.totalCount,
+    isLoadingSelector: state => state && state.geostories && state.geostories.loading,
+    areDashboardsAvailable: state => state && state.geostories && state.geostories.available,
+    isEditDialogOpen: state => state && state.geostories && state.geostories.showModal && state.geostories.showModal.edit
+};

--- a/web/client/selectors/geostories.js
+++ b/web/client/selectors/geostories.js
@@ -12,6 +12,6 @@ module.exports = {
     resultsSelector: state => state && state.geostories && state.geostories.results,
     totalCountSelector: state => state && state.geostories && state.geostories.totalCount,
     isLoadingSelector: state => state && state.geostories && state.geostories.loading,
-    areDashboardsAvailable: state => state && state.geostories && state.geostories.available,
+    areGeostoriesAvailable: state => state && state.geostories && state.geostories.available,
     isEditDialogOpen: state => state && state.geostories && state.geostories.showModal && state.geostories.showModal.edit
 };

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -311,6 +311,16 @@
                 "title": "Karten ({count})",
                 "noMapAvailable": "Keine Karte verfügbar",
                 "createNewOne": "Erstelle ein neues"
+            },
+            "geostories": {
+                "newGeostory": "Neues Story",
+                "title": "Stories ({count})",
+                "titleNoCount": "Stories",
+                "create": "GeoStory erstellen",
+                "noGeostoryAvailable": "Kein story verfügbar",
+                "createANewOne": "Erstelle ein neues",
+                "deleteError": "Beim Löschen der Ressource ist ein Fehler aufgetreten",
+                "errorLoadingDashboards": "Beim Laden von stories ist ein Fehler aufgetreten"
             }
         },
         "map": {

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -320,7 +320,7 @@
                 "noGeostoryAvailable": "Kein story verfügbar",
                 "createANewOne": "Erstelle ein neues",
                 "deleteError": "Beim Löschen der Ressource ist ein Fehler aufgetreten",
-                "errorLoadingDashboards": "Beim Laden von stories ist ein Fehler aufgetreten"
+                "errorLoadingGeostories": "Beim Laden von stories ist ein Fehler aufgetreten"
             }
         },
         "map": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -311,6 +311,16 @@
                 "title": "Maps ({count})",
                 "noMapAvailable": "No map available",
                 "createNewOne": "Create a new one"
+            },
+            "geostories": {
+                "newGeostory": "New Story",
+                "title": "Stories ({count})",
+                "titleNoCount": "Stories",
+                "create": "Create Story",
+                "noGeostoryAvailable": "No story available",
+                "createANewOne": "Create a new one",
+                "deleteError": "There was an error deleting the resource",
+                "errorLoadingDashboards": "There was an error loading stories"
             }
         },
         "map": {

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -320,7 +320,7 @@
                 "noGeostoryAvailable": "No story available",
                 "createANewOne": "Create a new one",
                 "deleteError": "There was an error deleting the resource",
-                "errorLoadingDashboards": "There was an error loading stories"
+                "errorLoadingGeostories": "There was an error loading stories"
             }
         },
         "map": {

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -311,6 +311,16 @@
                 "title": "Mapas ({count})",
                 "noMapAvailable": "No hay mapa disponible",
                 "createNewOne": "Crea uno nuevo"
+            },
+            "geostories": {
+                "newGeostory": "Nuevo Story",
+                "title": "Stories ({count})",
+                "titleNoCount": "Stories",
+                "create": "Crear Story",
+                "noGeostoryAvailable": "No hay story disponible",
+                "createANewOne": "Crea uno nuevo",
+                "deleteError": "Hubo un error al eliminar el recurso",
+                "errorLoadingDashboards": "Hubo un error al cargar los stories"
             }
         },
         "map": {

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -320,7 +320,7 @@
                 "noGeostoryAvailable": "No hay story disponible",
                 "createANewOne": "Crea uno nuevo",
                 "deleteError": "Hubo un error al eliminar el recurso",
-                "errorLoadingDashboards": "Hubo un error al cargar los stories"
+                "errorLoadingGeostories": "Hubo un error al cargar los stories"
             }
         },
         "map": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -311,6 +311,16 @@
                 "title": "Cartes ({count})",
                 "noMapAvailable": "Aucune carte disponible",
                 "createNewOne": "Créer un nouveau"
+            },
+            "geostories": {
+                "newGeostory": "Nouveau Story",
+                "title": "Stories ({count})",
+                "titleNoCount": "Stories",
+                "create": "Créer un Story",
+                "noGeostoryAvailable": "Aucun story disponible",
+                "createANewOne": "Créer un nouveau",
+                "deleteError": "Une erreur s'est produite lors de la suppression de la ressource",
+                "errorLoadingDashboards": "Une erreur s'est produite lors du chargement des stories"
             }
         },
         "map": {

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -320,7 +320,7 @@
                 "noGeostoryAvailable": "Aucun story disponible",
                 "createANewOne": "Créer un nouveau",
                 "deleteError": "Une erreur s'est produite lors de la suppression de la ressource",
-                "errorLoadingDashboards": "Une erreur s'est produite lors du chargement des stories"
+                "errorLoadingGeostories": "Une erreur s'est produite lors du chargement des stories"
             }
         },
         "map": {

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -311,6 +311,16 @@
                 "title": "Mappe ({count})",
                 "noMapAvailable": "Nessuna mappa disponibile",
                 "createNewOne": "Creane una nuova"
+            },
+            "geostories": {
+                "newGeostory": "Nuova Storia",
+                "title": "Storie ({count})",
+                "titleNoCount": "Storie",
+                "create": "Crea Storia",
+                "noGeostoryAvailable": "Nessuna storia disponibile",
+                "createANewOne": "Creane una",
+                "deleteError": "C'è stato un errore eliminando la risorsa",
+                "errorLoadingDashboards": "C'è stato un errore caricando le storie"
             }
         },
         "map": {

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -320,7 +320,7 @@
                 "noGeostoryAvailable": "Nessuna storia disponibile",
                 "createANewOne": "Creane una",
                 "deleteError": "C'è stato un errore eliminando la risorsa",
-                "errorLoadingDashboards": "C'è stato un errore caricando le storie"
+                "errorLoadingGeostories": "C'è stato un errore caricando le storie"
             }
         },
         "map": {


### PR DESCRIPTION
## Description
It's now possible to interact with story resource as with maps and dashboard.
Notes: 
1) Geostories are a clone of dashbords resurces, in feature could be good to refactor the code and
abstract a generic respurce with a type.
2) Deleting a resource will be fixed as #4301 will.
## Issues
 - #4366
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Stories aren't browsable in home

**What is the new behavior?**
Stories resourcee heve the same behavior of maps and dashboard resources

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [n] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
