### PR TITLE
Fixed Hyper link, scroll and focus on Text editor component

### DIFF
--- a/web/client/components/geostory/media/Map.jsx
+++ b/web/client/components/geostory/media/Map.jsx
@@ -51,12 +51,12 @@ export default compose(
         className="ms-media ms-media-map" style={{
             objectFit: fit
         }}>
+        {/* BaseMap component overrides the MapView id with map's id */}
         <MapView
             onMapViewChanges={onMapViewChanges}
-            id={"media" + id}
             map={{
                 ...m,
-                id
+                id: `media-${id}`
             }} // if map id is passed as number, the resource id, ol throws an error
             layers={layers}
             options={applyDefaults(options)}

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -473,7 +473,7 @@
                         outline: 2px solid @ms-story-highlight;
                     }
                     /* enable horizontal scroll bar only if needed of color picker*/
-                    .rdw-colorpicker-modal-options {
+                    .rdw-colorpicker-modal-options{
                         overflow-x: auto;
                     }
                     /* enable vertical scroll bar only if needed of font family and tag dropdown */
@@ -487,6 +487,21 @@
                     /* changed border color of color picker tab*/
                     .rdw-colorpicker-modal-style-label-active {
                         border-bottom-color: @ms-story-highlight;
+                    }
+                    .rdw-link-modal-label {
+                        font-size: 12px;
+                    }
+                    .rdw-link-modal {
+                        overflow-y: auto;
+                        
+                    }
+                    .rdw-link-modal-btn {
+                        width: 50px;
+                        height: 25px;
+                        font-size: 10px;
+                    }
+                    .rdw-link-modal-input{
+                        margin-bottom: 10px;
                     }
                 }
 


### PR DESCRIPTION
## Description
It fixes the style and scroll for the hyperlink and fixes the state update on component blur.
Fixed also the margin of media-map content
## Issues
 - #4260


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Hyperlink style not uniformed, scroll doesn't work, when in editing if a user switch to preview 
the application looses the changes.

**What is the new behavior?**
Style scroll and state fixed.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
