### PR TITLE
fix 4365 geostory login and anonymous users

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/epics', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/epics', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/components/geostory/navigation/Navigation.jsx
+++ b/web/client/components/geostory/navigation/Navigation.jsx
@@ -24,6 +24,7 @@ export default ({
     setEditing = () => {},
     story = {},
     currentPage,
+    isEditAllowed,
     progress = 0 // current page progress (current page + 1/totPages)
 }) => (<div
     className="ms-geostory-navigation-bar"
@@ -63,6 +64,7 @@ export default ({
                 {
                     glyph: 'pencil',
                     tooltip: 'Edit story',
+                    visible: isEditAllowed,
                     onClick: () => setEditing(true)
                 }
             ]} />

--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -43,7 +43,8 @@ import {
     SET_RESOURCE,
     GEOSTORY_LOADED,
     ADD_RESOURCE,
-    move
+    move,
+    CHANGE_MODE
 } from '../../actions/geostory';
 import {
     SHOW,
@@ -54,7 +55,7 @@ import {
 } from '../../actions/mediaEditor';
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import {testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
-import { ContentTypes, MediaTypes, Controls } from '../../utils/GeoStoryUtils';
+import { Modes, ContentTypes, MediaTypes, Controls } from '../../utils/GeoStoryUtils';
 
 let mockAxios;
 describe('Geostory Epics', () => {
@@ -211,217 +212,276 @@ describe('Geostory Epics', () => {
             });
         });
     });
-    it('loadGeostoryEpic loading one sample story', (done) => {
-        const NUM_ACTIONS = 4;
-        mockAxios.onGet().reply(200, TEST_STORY);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("sampleStory"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual(TEST_STORY);
-                    break;
-                case SET_RESOURCE: {
-                    expect(a.resource).toExist(); // TODO: test values
-                    break;
-                }
-                case GEOSTORY_LOADED: {
-                    expect(a.id).toExist();
-                    break;
-                }
-                default: expect(true).toBe(false);
-                    break;
-                }
-            });
-            done();
-        }, {
-            geostory: {}
-        });
-    });
-    it('loadGeostoryEpic loading wrong story', (done) => {
-        const NUM_ACTIONS = 5;
-        mockAxios.onGet().reply(404);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual({});
-                    break;
-                case LOAD_GEOSTORY_ERROR:
-                    expect(a.error.messageId).toEqual("geostory.errors.loading.geostoryDoesNotExist");
-                    break;
-                case SHOW_NOTIFICATION:
-                    expect(a.message).toEqual("geostory.errors.loading.geostoryDoesNotExist");
-                    break;
-                default: expect(true).toBe(false);
-                    break;
+    describe('loadGeostoryEpic', () => {
+        it('loadGeostoryEpic loading one sample story, as USER', (done) => {
+            const NUM_ACTIONS = 6;
+            mockAxios.onGet().reply(200, TEST_STORY);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("sampleStory"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual(TEST_STORY);
+                        break;
+                    case SET_RESOURCE: {
+                        expect(a.resource).toExist();
+                        break;
+                    }
+                    case CHANGE_MODE: {
+                        expect(a.mode).toBe(Modes.EDIT);
+                        break;
+                    }
+                    case GEOSTORY_LOADED: {
+                        expect(a.id).toExist();
+                        break;
+                    }
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: {
+                        role: "USER"
+                    }
                 }
             });
-            done();
-        }, {
-            geostory: {}
         });
-    });
+        it('loadGeostoryEpic loading one sample story, as ADMIN', (done) => {
+            const NUM_ACTIONS = 6;
+            mockAxios.onGet().reply(200, TEST_STORY);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("sampleStory"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual(TEST_STORY);
+                        break;
+                    case SET_RESOURCE: {
+                        expect(a.resource).toExist();
+                        break;
+                    }
+                    case CHANGE_MODE: {
+                        expect(a.mode).toBe(Modes.EDIT);
+                        break;
+                    }
+                    case GEOSTORY_LOADED: {
+                        expect(a.id).toExist();
+                        break;
+                    }
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: {
+                        role: "ADMIN"
+                    }
+                }
+            });
+        });
+        it('loadGeostoryEpic loading wrong story', (done) => {
+            const NUM_ACTIONS = 5;
+            mockAxios.onGet().reply(404);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual({});
+                        break;
+                    case LOAD_GEOSTORY_ERROR:
+                        expect(a.error.messageId).toEqual("geostory.errors.loading.geostoryDoesNotExist");
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(a.message).toEqual("geostory.errors.loading.geostoryDoesNotExist");
+                        break;
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: {
+                        role: "ADMIN"
+                    }
+                }
+            });
+        });
 
-    it('loadGeostoryEpic loading a story without permissions for a non logged user', (done) => {
-        const NUM_ACTIONS = 5;
-        mockAxios.onGet().reply(403);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual({});
-                    break;
-                case LOAD_GEOSTORY_ERROR:
-                    expect(a.error.messageId).toEqual("geostory.errors.loading.pleaseLogin");
-                    break;
-                case SHOW_NOTIFICATION:
-                    expect(a.message).toEqual("geostory.errors.loading.pleaseLogin");
-                    break;
-                default: expect(true).toBe(false);
-                    break;
+        it('loadGeostoryEpic loading a story without permissions for a non logged user', (done) => {
+            const NUM_ACTIONS = 1;
+            mockAxios.onGet().reply(403);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("sampleStory"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a) => {
+                    switch (a.type) {
+                    case LOAD_GEOSTORY_ERROR:
+                        expect(a.error.status).toEqual(403);
+                        break;
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: null
                 }
             });
-            done();
-        }, {
-            geostory: {}
         });
-    });
-    it('loadGeostoryEpic loading a story without permissions for a logged user', (done) => {
-        const NUM_ACTIONS = 5;
-        mockAxios.onGet().reply(403);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual({});
-                    break;
-                case LOAD_GEOSTORY_ERROR:
-                    expect(a.error.messageId).toEqual("geostory.errors.loading.geostoryNotAccessible");
-                    break;
-                case SHOW_NOTIFICATION:
-                    expect(a.message).toEqual("geostory.errors.loading.geostoryNotAccessible");
-                    break;
-                default: expect(true).toBe(false);
-                    break;
+        it('loadGeostoryEpic loading a story without permissions for a logged user', (done) => {
+            const NUM_ACTIONS = 5;
+            mockAxios.onGet().reply(403);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual({});
+                        break;
+                    case LOAD_GEOSTORY_ERROR:
+                        expect(a.error.messageId).toEqual("geostory.errors.loading.geostoryNotAccessible");
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(a.message).toEqual("geostory.errors.loading.geostoryNotAccessible");
+                        break;
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: {
+                        name: "Nina"
+                    }
                 }
             });
-            done();
-        }, {
-            geostory: {},
-            security: {
-                user: {
-                    name: "Nina"
-                }
-            }
         });
-    });
-    it('loadGeostoryEpic loading a story with unknownError', (done) => {
-        const NUM_ACTIONS = 5;
-        mockAxios.onGet().reply(500);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual({});
-                    break;
-                case LOAD_GEOSTORY_ERROR:
-                    expect(a.error.messageId).toEqual("geostory.errors.loading.unknownError");
-                    break;
-                case SHOW_NOTIFICATION:
-                    expect(a.message).toEqual("geostory.errors.loading.unknownError");
-                    break;
-                default: expect(true).toBe(false);
-                    break;
+        it('loadGeostoryEpic loading a story with unknownError', (done) => {
+            const NUM_ACTIONS = 5;
+            mockAxios.onGet().reply(500);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual({});
+                        break;
+                    case LOAD_GEOSTORY_ERROR:
+                        expect(a.error.messageId).toEqual("geostory.errors.loading.unknownError");
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(a.message).toEqual("geostory.errors.loading.unknownError");
+                        break;
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: {
+                        name: "Nina"
+                    }
                 }
             });
-            done();
-        }, {
-            geostory: {}
         });
-    });
-    /*
-     * TODO: investigate why it fails only in travis, (tested locally with both firefox and chrome),
-     * with firefox it works but i have some problems of stability
-    */
-    it.skip('loadGeostoryEpic loading a story with malformed json configuration', (done) => {
-        const NUM_ACTIONS = 6;
-        mockAxios.onGet().reply(200, `{"description":"Sample story with 1 paragraph and 1 immersive section, two columns","type":"cascade","sections":[{"type":"paragraph","id":"SomeID","title":"Abstract","contents":[{"id":"SomeID","type":'text',"background":{},"html":"<p>this is some html content</p>"}]}]}`);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("StoryWithError"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual({});
-                    break;
-                case LOAD_GEOSTORY_ERROR:
-                    expect(a.error.messageId).toEqual("Unexpected token \' in JSON at position 200");
-                    break;
-                case SHOW_NOTIFICATION:
-                    expect(a.message).toEqual("Unexpected token \' in JSON at position 200");
-                    break;
-                default: expect(true).toBe(false);
-                    break;
-                }
+        /*
+        * TODO: investigate why it fails only in travis, (tested locally with both firefox and chrome),
+        * with firefox it works but i have some problems of stability
+        */
+        it.skip('loadGeostoryEpic loading a story with malformed json configuration', (done) => {
+            const NUM_ACTIONS = 6;
+            mockAxios.onGet().reply(200, `{"description":"Sample story with 1 paragraph and 1 immersive section, two columns","type":"cascade","sections":[{"type":"paragraph","id":"SomeID","title":"Abstract","contents":[{"id":"SomeID","type":'text',"background":{},"html":"<p>this is some html content</p>"}]}]}`);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("StoryWithError"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual({});
+                        break;
+                    case LOAD_GEOSTORY_ERROR:
+                        expect(a.error.messageId).toEqual("Unexpected token \' in JSON at position 200");
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(a.message).toEqual("Unexpected token \' in JSON at position 200");
+                        break;
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {}
             });
-            done();
-        }, {
-            geostory: {}
         });
-    });
-    it('loadGeostoryEpic loading a bad story format', (done) => {
-        const NUM_ACTIONS = 4;
-        mockAxios.onGet().reply(200, false);
-        testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
-            actions.map((a, i) => {
-                switch (a.type) {
-                case LOADING_GEOSTORY:
-                    expect(a.name).toBe("loading");
-                    expect(a.value).toBe(i === 0);
-                    break;
-                case SET_CURRENT_STORY:
-                    expect(a.story).toEqual({});
-                    break;
-                case LOAD_GEOSTORY_ERROR:
-                    break;
-                case SHOW_NOTIFICATION:
-                    break;
-                default: expect(true).toBe(false);
-                    break;
+        it('loadGeostoryEpic loading a bad story format', (done) => {
+            const NUM_ACTIONS = 4;
+            mockAxios.onGet().reply(200, false);
+            testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("wrongStoryName"), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((a, i) => {
+                    switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual({});
+                        break;
+                    case LOAD_GEOSTORY_ERROR:
+                        break;
+                    case SHOW_NOTIFICATION:
+                        break;
+                    default: expect(true).toBe(false);
+                        break;
+                    }
+                });
+                done();
+            }, {
+                geostory: {},
+                security: {
+                    user: {
+                        name: "Nina"
+                    }
                 }
             });
-            done();
-        }, {
-            geostory: {}
         });
     });
     it('test openMediaEditorForNewMedia, adding a media content and choosing an image already present in resources', (done) => {

--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -329,14 +329,24 @@ describe('Geostory Epics', () => {
         });
 
         it('loadGeostoryEpic loading a story without permissions for a non logged user', (done) => {
-            const NUM_ACTIONS = 1;
+            const NUM_ACTIONS = 5;
             mockAxios.onGet().reply(403);
             testEpic(loadGeostoryEpic, NUM_ACTIONS, loadGeostory("sampleStory"), (actions) => {
                 expect(actions.length).toBe(NUM_ACTIONS);
-                actions.map((a) => {
+                actions.map((a, i) => {
                     switch (a.type) {
+                    case LOADING_GEOSTORY:
+                        expect(a.name).toBe("loading");
+                        expect(a.value).toBe(i === 0);
+                        break;
                     case LOAD_GEOSTORY_ERROR:
                         expect(a.error.status).toEqual(403);
+                        break;
+                    case SET_CURRENT_STORY:
+                        expect(a.story).toEqual({});
+                        break;
+                    case SHOW_NOTIFICATION:
+                        expect(a.message).toEqual("geostory.errors.loading.pleaseLogin");
                         break;
                     default: expect(true).toBe(false);
                         break;

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -41,6 +41,7 @@ import {
     saveGeoStoryError,
     setControl,
     setResource,
+    setEditing,
     storySaved,
     update
 } from '../actions/geostory';
@@ -57,7 +58,7 @@ import { show, error } from '../actions/notifications';
 import { LOGIN_SUCCESS, LOGOUT } from '../actions/security';
 
 
-import { isLoggedIn } from '../selectors/security';
+import { isLoggedIn, isAdminUserSelector } from '../selectors/security';
 import { resourceIdSelectorCreator, createPathSelector, currentStorySelector, resourcesSelector} from '../selectors/geostory';
 import { currentMediaTypeSelector, sourceIdSelector} from '../selectors/mediaEditor';
 
@@ -204,13 +205,17 @@ export const editMediaForBackgroundEpic = (action$, store) =>
  */
 export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
     .ofType(LOAD_GEOSTORY)
-    .switchMap( ({id}) =>
-        Observable.defer(() => {
+    .switchMap( ({id}) => {
+        const user = isLoggedIn(getState());
+        if (!user) {
+            return Observable.of(loadGeostoryError({status: 403}));
+        }
+        return Observable.defer(() => {
             if (id && isNaN(parseInt(id, 10))) {
                 return axios.get(`configs/${id}.json`)
                     // not return anything else that data in this case
                     // to match with data/resource object structure of getResource
-                    .then(({data}) => ({data}));
+                    .then(({data}) => ({data, canEdit: true}));
             }
             return getResource(id);
         })
@@ -220,13 +225,15 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
                 }
                 return true;
             })
-            .switchMap(({ data, ...resource }) =>
-                Observable.of(
+            .switchMap(({ data, ...resource }) => {
+                const isAdmin = isAdminUserSelector(getState());
+                return Observable.from([
+                    setEditing(resource && resource.canEdit || isAdmin),
                     geostoryLoaded(id),
                     setCurrentStory(isString(data) ? JSON.parse(data) : data),
                     setResource(resource)
-                )
-            )
+                ]);
+            })
             // adds loading status to the start and to the end of the stream and handles exceptions
             .let(wrapStartStop(
                 loadingGeostory(true, "loading"),
@@ -236,6 +243,7 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
                     if (e.status === 403 ) {
                         message = "geostory.errors.loading.pleaseLogin";
                         if (isLoggedIn(getState())) {
+                            // TODO only in view mode
                             message = "geostory.errors.loading.geostoryNotAccessible";
                         }
                     } else if (e.status === 404) {
@@ -253,8 +261,8 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
                         loadGeostoryError({...e, messageId: message})
                     );
                 }
-            ))
-    );
+            ));
+    });
 /**
  * Triggers reload of last loaded story when user login-logout
  * @param {Observable} action$ the stream of redux actions

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -206,10 +206,6 @@ export const editMediaForBackgroundEpic = (action$, store) =>
 export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
     .ofType(LOAD_GEOSTORY)
     .switchMap( ({id}) => {
-        const user = isLoggedIn(getState());
-        if (!user) {
-            return Observable.of(loadGeostoryError({status: 403}));
-        }
         return Observable.defer(() => {
             if (id && isNaN(parseInt(id, 10))) {
                 return axios.get(`configs/${id}.json`)
@@ -227,6 +223,10 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
             })
             .switchMap(({ data, ...resource }) => {
                 const isAdmin = isAdminUserSelector(getState());
+                const user = isLoggedIn(getState());
+                if (!user && isNaN(parseInt(id, 10))) {
+                    return Observable.of(loadGeostoryError({status: 403}));
+                }
                 return Observable.from([
                     setEditing(resource && resource.canEdit || isAdmin),
                     geostoryLoaded(id),

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -54,6 +54,9 @@
         "maptype": {
             "mapType": "{context.mode === 'desktop' ? 'openlayers' : 'leaflet'}"
         },
+        "geostory": {
+
+        },
         "catalog": {
           "default": {
             "newService": {

--- a/web/client/plugins/GeoStoryNavigation.jsx
+++ b/web/client/plugins/GeoStoryNavigation.jsx
@@ -14,6 +14,7 @@ import { Modes, scrollToContent } from '../utils/GeoStoryUtils';
 import { setEditing } from '../actions/geostory';
 import {
     currentStorySelector,
+    isEditAllowedSelector,
     currentPageSelector,
     modeSelector
 } from '../selectors/geostory';
@@ -23,6 +24,7 @@ import Navigation from '../components/geostory/navigation/Navigation';
 const GeoStoryNavigation = ({
     mode = Modes.VIEW,
     currentPage,
+    isEditAllowed,
     setEditingMode = () => { },
     story = {}
 }) => (mode === Modes.VIEW ? <div
@@ -31,6 +33,7 @@ const GeoStoryNavigation = ({
     style={{width: "100%", position: 'relative' }}>
     <Navigation
         currentPage={currentPage}
+        isEditAllowed={isEditAllowed}
         scrollTo={(id, options = { behavior: "smooth" }) => () => {
             scrollToContent(id, options);
         }}
@@ -47,6 +50,7 @@ export default createPlugin('GeoStoryNavigation', {
         createStructuredSelector({
             mode: modeSelector,
             currentPage: currentPageSelector,
+            isEditAllowed: isEditAllowedSelector,
             story: currentStorySelector
         }), {
             setEditingMode: setEditing

--- a/web/client/selectors/__tests__/geostory-test.js
+++ b/web/client/selectors/__tests__/geostory-test.js
@@ -12,9 +12,12 @@ import {
     isCollapsedSelector,
     createPathSelector,
     currentStorySelector,
+    isEditAllowedSelector,
     sectionsSelector,
     sectionSelectorCreator,
     sectionAtIndexSelectorCreator,
+    resourceSelector,
+    canEditSelector,
     resourcesSelector,
     resourceByIdSelectorCreator,
     resourceIdSelectorCreator,
@@ -40,6 +43,12 @@ describe('geostory selectors', () => { // TODO: check default
     it('sectionSelectorCreator', () => { expect(sectionSelectorCreator("id")({geostory: {currentStory: {sections: [{id: "id"}]}}})).toEqual({id: "id"}); });
     it('sectionAtIndexSelectorCreator', () => { expect(sectionAtIndexSelectorCreator(0)({geostory: {currentStory: {sections: [{id: "id"}]}}})).toEqual({id: "id"}); });
     it('resourcesSelector', () => { expect(resourcesSelector({geostory: {currentStory: {resources: []}}})).toEqual([]); });
+    it('canEditSelector false', () => { expect(canEditSelector({geostory: {resource: {id: 123}}})).toEqual(false); });
+    it('canEditSelector true', () => { expect(canEditSelector({geostory: {resource: {canEdit: true}}})).toEqual(true); });
+    it('isEditAllowedSelector, logged ADMIN, can edit', () => { expect(isEditAllowedSelector({geostory: {resource: {canEdit: true}}, security: {user: {role: "ADMIN"}}})).toEqual(true); });
+    it('isEditAllowedSelector, logged USER, cannot edit', () => { expect(isEditAllowedSelector({geostory: {resource: {canEdit: false}}, security: {user: {role: "USER"}}})).toEqual(false); });
+    it('isEditAllowedSelector, logged ADMIN, local resource', () => { expect(isEditAllowedSelector({geostory: {resource: {}}, security: {user: {role: "ADMIN"}}})).toEqual(true); });
+    it('resourceSelector', () => { expect(resourceSelector({geostory: {resource: {id: 123}}})).toEqual({id: 123}); });
     it('resourceByIdSelectorCreator', () => { expect(resourceByIdSelectorCreator("id")({geostory: {currentStory: {resources: [{id: "id"}]}}})).toEqual({id: "id"}); });
     it('saveDialogSelector', () => {
         expect(saveDialogSelector({

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -7,6 +7,7 @@
  */
 import {get, find} from 'lodash';
 import { Controls, getEffectivePath } from '../utils/GeoStoryUtils';
+import { isAdminUserSelector, isUserSelector } from './security';
 
 /**
  * Returns a selector using a path inside the current story
@@ -53,6 +54,11 @@ export const saveDialogSelector = state => controlSelectorCreator(Controls.SHOW_
  * @param {object} state application state
  */
 export const resourceSelector = state => get(state, 'geostory.resource');
+/**
+ * Selects the edit permission of the resource
+ * @param {object} state the application state
+ */
+export const canEditSelector = state => get(resourceSelector(state), 'canEdit', false);
 /**
  * Selects the loading state of geostory.
  * @param {object} state the application state
@@ -110,3 +116,8 @@ export const resourcesSelector = state => get(currentStorySelector(state), "reso
  * @returns {function} function that returns a selector
  */
 export const resourceByIdSelectorCreator = id => state => find(resourcesSelector(state), {id});
+/**
+ * return the status of the possibility to edit the story
+ * @param {object} state
+ */
+export const isEditAllowedSelector = state => isAdminUserSelector(state) || (isUserSelector(state) && canEditSelector(state));

--- a/web/client/selectors/security.js
+++ b/web/client/selectors/security.js
@@ -48,5 +48,6 @@ module.exports = {
     userRoleSelector,
     securityTokenSelector: state => state.security && state.security.token,
     userGroupSecuritySelector,
-    isAdminUserSelector: (state) => userRoleSelector(state) === "ADMIN"
+    isAdminUserSelector: (state) => userRoleSelector(state) === "ADMIN",
+    isUserSelector: (state) => userRoleSelector(state) === "USER"
 };


### PR DESCRIPTION
## Description
This pr will (for local geostory configurations): 
- block anonymous user loading
- disable edit mode for USER role

## Issues
 - #4365 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see issue #4365

**What is the new behavior?**
- a prompt login appear if anonymous user enter local geostory config.
- USER can login, but only the view mode will be available

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
