### PR TITLE
Fix 4303 Groups editing modal window doesn't close

### DIFF
--- a/web/client/actions/__tests__/usergroups-test.js
+++ b/web/client/actions/__tests__/usergroups-test.js
@@ -106,6 +106,22 @@ describe('Test correctness of the usergroups actions', () => {
             }
         });
     });
+
+    it('close UserGroup edit', (done) => {
+        const retFun = editGroup();
+        expect(retFun).toExist();
+        let count = 0;
+        retFun((action) => {
+            expect(action.type).toBe(EDITGROUP);
+            count++;
+            if (count === 1) {
+                expect(action.group).toNotExist();
+                expect(action.status).toNotExist();
+                done();
+            }
+        });
+    });
+
     it('edit UserGroup error', (done) => {
         const retFun = editGroup({id: 99999});
         expect(retFun).toExist();

--- a/web/client/actions/usergroups.js
+++ b/web/client/actions/usergroups.js
@@ -127,7 +127,6 @@ function editGroupError(group, error) {
 function editNewGroup(group) {
     return {
         type: EDITGROUP,
-        status: STATUS_SUCCESS,
         group
     };
 }


### PR DESCRIPTION
## Description
Fix issue #4303 and #4282 

## Issues
 - #4303 
 - #4282

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4303 and #4282 

**What is the new behavior?**
Group editing modal works as expected

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
