### PR TITLE
change chrome browser for continuous-run for tests

### DIFF
--- a/build/karma.conf.continuous-test.js
+++ b/build/karma.conf.continuous-test.js
@@ -8,6 +8,7 @@ module.exports = function karmaConfig(config) {
             { pattern: './web/client/test-resources/**/*', included: false },
             { pattern: './web/client/translations/**/*', included: false }
         ],
+        browsers: ["Chrome"],
         basePath: "..",
         path: path.join(__dirname, "..", "web", "client"),
         testFile: 'build/tests.webpack.js',

--- a/build/testConfig.js
+++ b/build/testConfig.js
@@ -1,8 +1,8 @@
 const assign = require('object-assign');
 const nodePath = require('path');
 
-module.exports = ({files, path, testFile, singleRun, basePath = ".", alias = {}}) => ({
-    browsers: [ 'ChromeHeadless' ],
+module.exports = ({browsers = [ 'ChromeHeadless' ], files, path, testFile, singleRun, basePath = ".", alias = {}}) => ({
+    browsers,
 
     browserNoActivityTimeout: 30000,
 


### PR DESCRIPTION
not touching single run

## Description
just changed browser for internal tests run because when using continuous run you want also if not always to debug the tests

## Issues
 - #

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: changes to local continuous run


**What is the current behavior?** (You can also link to an open issue here)
browser app does not appear when running continuoustest run

**What is the new behavior?**
browser app will appear when running it


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
