### PR TITLE
issues 4314 and 4315 fixed regression on lines drawing

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -516,7 +516,7 @@ export default class DrawSupport extends React.Component {
                         this.appendToMultiGeometry(drawMethod, geomAlreadyPresent, drawnGeom);
                     } else {
                         // create new multi geom
-                        newMultiGeom = this.toMulti(this.createOLGeometry({type: drawMethod, coordinates: [drawnGeom.getCoordinates()]}));
+                        newMultiGeom = this.toMulti(this.createOLGeometry({type: drawMethod, coordinates: drawnGeom.getCoordinates()}));
                     }
 
                     if (drawnGeom.getType() !== getSimpleGeomType(previousGeometries.getType())) {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -1278,13 +1278,13 @@ export default class DrawSupport extends React.Component {
     };
 
     olGeomFromType = ({type, coordinates, radius, center, projection, options}) => {
-
+        // TODO check correct number of nesting arrays of coordinates for each case
         let geometry;
         switch (type) {
         case "Point": case "Marker": case "Text": { geometry = new Point(coordinates ? coordinates : []); break; }
         case "LineString": { geometry = new LineString(coordinates ? coordinates : []); break; }
-        case "MultiPoint": { geometry = new MultiPoint(coordinates ? coordinates : []); break; } // TODO move text on "Point"
-        case "MultiLineString": { geometry = new MultiLineString(coordinates ? [coordinates] : []); break; }
+        case "MultiPoint": { geometry = new MultiPoint(coordinates ? coordinates : []); break; }
+        case "MultiLineString": { geometry = new MultiLineString(coordinates ? coordinates : []); break; }
         case "MultiPolygon": { geometry = new MultiPolygon(coordinates ? coordinates : []); break; }
         // default is Polygon
         default: {

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -72,7 +72,7 @@ const renderAndClick = (props = {}, options = {}) => {
 };
 
 
-describe.only('Test DrawSupport', () => {
+describe('Test DrawSupport', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="map"></div><div id="container"></div>';
         setTimeout(done);

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -14,7 +14,7 @@ import {DEFAULT_ANNOTATIONS_STYLES} from '../../../../utils/AnnotationsUtils';
 import {circle, geomCollFeature} from '../../../../test-resources/drawsupport/features';
 
 import {Map, View, Feature} from 'ol';
-import {Point, Circle, Polygon, LineString, MultiLineString} from 'ol/geom';
+import {Point, Circle, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString} from 'ol/geom';
 import Collection from 'ol/Collection';
 
 const viewOptions = {
@@ -72,7 +72,7 @@ const renderAndClick = (props = {}, options = {}) => {
 };
 
 
-describe('Test DrawSupport', () => {
+describe.only('Test DrawSupport', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="map"></div><div id="container"></div>';
         setTimeout(done);
@@ -1963,6 +1963,41 @@ describe('Test DrawSupport', () => {
         done();
     });
 
+    it('test drawend callbacks with MultiPolygon, exported as geomColl', (done) => {
+        const spyOnGeometryChanged = expect.spyOn(testHandlers, "onGeometryChanged");
+        const spyOnEndDrawing = expect.spyOn(testHandlers, "onEndDrawing");
+        let support = renderDrawSupport();
+        support = renderDrawSupport({
+            drawMethod: "MultiPolygon",
+            drawStatus: "drawOrEdit",
+            features: [geomCollFeature],
+            options: {
+                transformToFeatureCollection: false,
+                drawEnabled: true
+            }
+        });
+        expect(support).toExist();
+        support.drawInteraction.dispatchEvent({
+            type: 'drawend',
+            feature: new Feature({
+                geometry: new MultiPolygon([[[[1300, 4300], [1300, 5300], [1380, 4380], [1300, 4300]]]])
+            })
+        });
+        expect(spyOnGeometryChanged).toHaveBeenCalled();
+        expect(spyOnGeometryChanged.calls.length).toBe(1);
+        const ArgsGeometryChanged = spyOnGeometryChanged.calls[0].arguments;
+        expect(ArgsGeometryChanged.length).toBe(5);
+
+        expect(spyOnEndDrawing).toHaveBeenCalled();
+        expect(spyOnEndDrawing.calls.length).toBe(1);
+        const ArgsEndDrawing = spyOnEndDrawing.calls[0].arguments;
+        expect(ArgsEndDrawing.length).toBe(2);
+        expect(ArgsEndDrawing[0].geometry.type).toBe("GeometryCollection");
+        expect(ArgsEndDrawing[0].geometry.geometries.length).toBe(2);
+
+        done();
+    });
+
     it('test drawend callbacks with MultiPoint, exported as geomColl', (done) => {
         const spyOnGeometryChanged = expect.spyOn(testHandlers, "onGeometryChanged");
         const spyOnEndDrawing = expect.spyOn(testHandlers, "onEndDrawing");
@@ -1980,7 +2015,7 @@ describe('Test DrawSupport', () => {
         support.drawInteraction.dispatchEvent({
             type: 'drawend',
             feature: new Feature({
-                geometry: new Point([1300, 4300])
+                geometry: new MultiPoint([[1300, 4300]])
             })
         });
         expect(spyOnGeometryChanged).toHaveBeenCalled();


### PR DESCRIPTION
## Description
There was a regression on MultiLineStrings geometry. it were added a [] when creating the feature in ol [here](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/components/map/openlayers/DrawSupport.jsx#L1287)

## Issues
 - #4314
 - #4315

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
cannot draw MultiLineString or view them in edit mode

**What is the new behavior?**
you can see the drawn yellow lines and be able to see it in edit mode by user selection

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
