### PR TITLE
Fix 4300 Timeline - Animation step's dropdown text error

### DIFF
--- a/web/client/components/I18N/Message.jsx
+++ b/web/client/components/I18N/Message.jsx
@@ -21,8 +21,24 @@ class Message extends React.Component {
         intl: PropTypes.object
     };
 
+    renderFormattedMsg = ({msgId, msgParams, children}) => {
+        if (children && typeof children === 'function') {
+            return (<FormattedMessage id={msgId} values={msgParams}>{msg => {
+                return children(msg);
+            }}</FormattedMessage>);
+        }
+        return (<FormattedMessage id={msgId} values={msgParams} />);
+    }
+
+    renderMsg = ({msgId, children}) => {
+        if (children && typeof children === 'function') {
+            return children(msgId);
+        }
+        return (<span>{msgId || ""}</span>);
+    }
+
     render() {
-        return this.context.intl ? <FormattedMessage id={this.props.msgId} values={this.props.msgParams}/> : <span>{this.props.msgId || ""}</span>;
+        return this.context.intl ? this.renderFormattedMsg(this.props) : this.renderMsg(this.props);
     }
 }
 

--- a/web/client/components/I18N/__tests__/I18N.Message-test.jsx
+++ b/web/client/components/I18N/__tests__/I18N.Message-test.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 var expect = require('expect');
-
+const TestUtils = require('react-dom/test-utils');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var I18N = require('../I18N');
@@ -64,5 +64,15 @@ describe('This test for I18N.Message', () => {
         const cmpDom = ReactDOM.findDOMNode(cmp);
         expect(cmpDom).toExist();
         expect(cmpDom.innerHTML).toBe(testMsg);
+    });
+
+    it('should be able to render functional children', () => {
+        const currentData = data["en-US"];
+        var testMsg = currentData.messages[msgId];
+
+        const cmp = ReactDOM.render(<Localized messages={eng.messages} locale="en-US"><I18N.Message msgId={msgId}>{msg => <option>{msg}</option>}</I18N.Message></Localized>, document.getElementById("container"));
+        const option = TestUtils.findRenderedDOMComponentWithTag(cmp, 'option');
+        expect(option).toExist();
+        expect(option.innerHTML).toBe(testMsg);
     });
 });

--- a/web/client/components/playback/Settings.jsx
+++ b/web/client/components/playback/Settings.jsx
@@ -10,6 +10,7 @@ const React = require('react');
 const moment = require('moment');
 const { isNaN } = require('lodash');
 const { Form, FormGroup, ControlLabel, FormControl, InputGroup } = require('react-bootstrap');
+
 const Message = require('../I18N/Message');
 const InfoPopover = require('../widgets/widget/InfoPopover');
 
@@ -121,12 +122,12 @@ module.exports = ({
                     }
                 )} />
             <FormControl disabled={!fixedStep} componentClass="select" value={stepUnit} onChange={({ target = {} }) => onSettingChange("stepUnit", target.value)} >
-                <option value="years"><Message msgId="playback.settings.step.year" msgParams={{ number: timeStep || 1 }} /></option>
-                <option value="weeks"><Message msgId="playback.settings.step.week" msgParams={{ number: timeStep || 1 }} /></option>
-                <option value="days"><Message msgId="playback.settings.step.day" msgParams={{ number: timeStep || 1 }} /></option>
-                <option value="hour"><Message msgId="playback.settings.step.hour" msgParams={{ number: timeStep || 1 }} /></option>
-                <option value="minutes"><Message msgId="playback.settings.step.minute" msgParams={{ number: timeStep || 1 }} /></option>
-                <option value="seconds"><Message msgId="playback.settings.step.second" msgParams={{ number: timeStep || 1 }} /></option>
+                <Message msgId="playback.settings.step.year" msgParams={{ number: timeStep || 1 }}>{msg => <option value="years">{msg}</option>}</Message>
+                <Message msgId="playback.settings.step.week" msgParams={{ number: timeStep || 1 }}>{msg => <option value="weeks">{msg}</option>}</Message>
+                <Message msgId="playback.settings.step.day" msgParams={{ number: timeStep || 1 }}>{msg => <option value="days">{msg}</option>}</Message>
+                <Message msgId="playback.settings.step.hour" msgParams={{ number: timeStep || 1 }}>{msg => <option value="hour">{msg}</option>}</Message>
+                <Message msgId="playback.settings.step.minute" msgParams={{ number: timeStep || 1 }}>{msg => <option value="minutes">{msg}</option>}</Message>
+                <Message msgId="playback.settings.step.second" msgParams={{ number: timeStep || 1 }}>{msg => <option value="seconds">{msg}</option>}</Message>
             </FormControl>
         </Form>
     </FormGroup>

--- a/web/client/components/playback/__tests__/Settings-test.jsx
+++ b/web/client/components/playback/__tests__/Settings-test.jsx
@@ -20,7 +20,7 @@ describe('Timeline/Playback Settings component', () => {
         expect(el).toExist();
     });
     it('rendering with values', () => {
-        ReactDOM.render(<Settings following stepUnit="days" timeStep={1} frameDuration={1} />, document.getElementById("container"));
+        ReactDOM.render(<Settings following stepUnit="days" timeStep={1} frameDuration={1} fixedStep />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('.ms-playback-settings');
         expect(el).toExist();


### PR DESCRIPTION
## Description
Fix timeline animation step dropdown text error, the text was unreadable because of the upgrade to react 16 which prevent non string and number data to be inside `<option>` tag as stated in https://github.com/facebook/react/issues/13586. The fix involves an extending of the core I18N Message component to include the react Intl FormattedMessage ability to render children function.

## Issues
 - #4300 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4300 

**What is the new behavior?**
The dropdown text become readable

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
