### PR TITLE
Fix 4293 Removing details from a map, the 'about this map' button on burger menu is maintained

### DIFF
--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -300,7 +300,7 @@ const storeDetailsInfoEpic = (action$, store) =>
                 )
                     .switchMap((attributes) => {
                         let details = find(attributes, {name: 'details'});
-                        if (!details) {
+                        if (!details || details.value === 'NODATA') {
                             return Rx.Observable.empty();
                         }
                         return Rx.Observable.of(

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -82,7 +82,7 @@
                 max-height: 30%;
                 height: unset;
             }
-    
+
             &.ms-sm {
                 max-height: 40%;
                 height: unset;
@@ -225,6 +225,8 @@
 }
 
 .ms-modal-quill-container {
+    min-height: 300px;
+
     .quill {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Description
Removed maintained 'about this map' when user delete map details. Also after call with @tdipisa we decided to add fix for WYSIWYG editor height in normal mode with this PR. 

## Issues
 - #4293 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
