### PR TITLE
Fix 4399 Export map doesn't work anymore

### DIFF
--- a/web/client/epics/__tests__/mapexport-test.js
+++ b/web/client/epics/__tests__/mapexport-test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+const { testEpic } = require('./epicTestUtils');
+const { exportMapContext: exportMapContextEpic } = require('../mapexport');
+const { exportMap } = require('../../actions/mapexport');
+const { SET_CONTROL_PROPERTY } = require('../../actions/controls');
+
+describe('Map Export Epics', () => {
+    it('export map', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            const action = actions[0];
+            expect(action.type).toBe(SET_CONTROL_PROPERTY);
+            done();
+        };
+        const state = {
+            map: {
+                present: {
+                    center: {
+                        x: -71.88845339541245,
+                        y: 37.25911173702324,
+                        crs: 'EPSG:4326'
+                    },
+                    maxExtent: [
+                        -20037508.34,
+                        -20037508.34,
+                        20037508.34,
+                        20037508.34
+                    ]
+                }
+            }
+        };
+        testEpic(exportMapContextEpic, 1, exportMap(), epicResult, state);
+    });
+});

--- a/web/client/epics/__tests__/mapexport-test.js
+++ b/web/client/epics/__tests__/mapexport-test.js
@@ -6,11 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-const { testEpic } = require('./epicTestUtils');
-const { exportMapContext: exportMapContextEpic } = require('../mapexport');
-const { exportMap } = require('../../actions/mapexport');
-const { SET_CONTROL_PROPERTY } = require('../../actions/controls');
+import expect from 'expect';
+import { testEpic } from './epicTestUtils';
+import { exportMapContext as exportMapContextEpic } from '../mapexport';
+import { exportMap } from '../../actions/mapexport';
+import { SET_CONTROL_PROPERTY } from '../../actions/controls';
+import { SHOW_NOTIFICATION } from '../../actions/notifications';
 
 describe('Map Export Epics', () => {
     it('export map', (done) => {
@@ -18,6 +19,7 @@ describe('Map Export Epics', () => {
             expect(actions.length).toBe(1);
             const action = actions[0];
             expect(action.type).toBe(SET_CONTROL_PROPERTY);
+            expect(action.control).toBe('export');
             done();
         };
         const state = {
@@ -38,5 +40,16 @@ describe('Map Export Epics', () => {
             }
         };
         testEpic(exportMapContextEpic, 1, exportMap(), epicResult, state);
+    });
+
+    it('fail to export map', (done) => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            const action = actions[0];
+            expect(action.type).toBe(SHOW_NOTIFICATION);
+            expect(action.level).toBe('error');
+            done();
+        };
+        testEpic(exportMapContextEpic, 1, exportMap(), epicResult, {});
     });
 });

--- a/web/client/epics/mapexport.js
+++ b/web/client/epics/mapexport.js
@@ -15,6 +15,8 @@ const { mapSelector } = require('../selectors/map');
 const { layersSelector, groupsSelector } = require('../selectors/layers');
 const { backgroundListSelector } = require('../selectors/backgroundselector');
 const { mapOptionsToSaveSelector } = require('../selectors/mapsave');
+const {basicError} = require('../utils/NotificationUtils');
+const {getErrorMessage} = require('../utils/LocaleUtils');
 const textSearchConfigSelector = state => state.searchconfig && state.searchconfig.textSearchConfig;
 
 const PersistMap = {
@@ -31,4 +33,9 @@ module.exports = {
                     .do((data) => download(data, "map.json", "application/json"))
                     .map(() => setControlProperty('export', 'enabled', false))
             )
+            .catch((e) => Rx.Observable.of(basicError({
+                ...getErrorMessage(e),
+                autoDismiss: 6,
+                position: 'tc'
+            })))
 };

--- a/web/client/epics/mapexport.js
+++ b/web/client/epics/mapexport.js
@@ -13,11 +13,12 @@ const { setControlProperty } = require('../actions/controls');
 
 const { mapSelector } = require('../selectors/map');
 const { layersSelector, groupsSelector } = require('../selectors/layers');
+const { backgroundListSelector } = require('../selectors/backgroundselector');
 const { mapOptionsToSaveSelector } = require('../selectors/mapsave');
 const textSearchConfigSelector = state => state.searchconfig && state.searchconfig.textSearchConfig;
 
 const PersistMap = {
-    mapstore2: (state) => JSON.stringify(MapUtils.saveMapConfiguration(mapSelector(state), layersSelector(state), groupsSelector(state), textSearchConfigSelector(state), mapOptionsToSaveSelector(state)))
+    mapstore2: (state) => JSON.stringify(MapUtils.saveMapConfiguration(mapSelector(state), layersSelector(state), groupsSelector(state), backgroundListSelector(state), textSearchConfigSelector(state), mapOptionsToSaveSelector(state)))
 };
 
 

--- a/web/client/plugins/MapExport.jsx
+++ b/web/client/plugins/MapExport.jsx
@@ -24,6 +24,7 @@ const { Glyphicon, Button } = require('react-bootstrap');
 
 const Dialog = require('../components/misc/StandardDialog');
 const Select = require('react-select');
+import * as epics from '../epics/mapexport';
 
 const enhanceExport = compose(
     connect(
@@ -68,7 +69,7 @@ const MapExport = enhanceExport(
     </Dialog>
 );
 
-module.exports = {
+const MapExportPlugin = {
     MapExportPlugin: assign(MapExport, {
         disablePluginIf: "{state('mapType') === 'cesium'}",
         BurgerMenu: {
@@ -82,5 +83,7 @@ module.exports = {
             doNotHide: true
         }
     }),
-    epics: require('../epics/mapexport')
+    epics: epics
 };
+
+export default MapExportPlugin;

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -64,7 +64,7 @@ module.exports = {
         LoginPlugin: require('../plugins/Login'),
         ManagerMenuPlugin: require('../plugins/manager/ManagerMenu'),
         ManagerPlugin: require('../plugins/manager/Manager'),
-        MapExportPlugin: require('../plugins/MapExport'),
+        MapExportPlugin: require('../plugins/MapExport').default,
         MapFooterPlugin: require('../plugins/MapFooter'),
         MapImportPlugin: require('../plugins/MapImport'),
         MapLoadingPlugin: require('../plugins/MapLoading'),

--- a/web/client/selectors/__tests__/backgroundselector-test.js
+++ b/web/client/selectors/__tests__/backgroundselector-test.js
@@ -38,6 +38,10 @@ describe('Test backgroundselector selectors', () => {
         const list = backgroundListSelector(state);
         expect(list).toEqual(backgrounds);
     });
+    it('backgroundListSelector return empty when backgrounds is not defined', () => {
+        const list = backgroundListSelector({backgroundSelector: {}});
+        expect(list).toEqual([]);
+    });
     it('test isDeletedIdSelector', () => {
         const deleted = isDeletedIdSelector(state);
         expect(deleted).toBe('61c9e030-4967-11e9-a528-a79c388c845f');

--- a/web/client/selectors/backgroundselector.js
+++ b/web/client/selectors/backgroundselector.js
@@ -13,7 +13,7 @@ import {invalidateUnsupportedLayer} from '../utils/LayersUtils';
 
 export const metadataSourceSelector = (state) => state.backgroundSelector && state.backgroundSelector.source;
 export const modalParamsSelector = (state) => state.backgroundSelector && state.backgroundSelector.modalParams;
-export const backgroundListSelector = (state) => state.backgroundSelector && state.backgroundSelector.backgrounds;
+export const backgroundListSelector = (state) => state.backgroundSelector && state.backgroundSelector.backgrounds || [];
 export const isDeletedIdSelector = (state) => state.backgroundSelector && state.backgroundSelector.lastRemovedId;
 export const removedBackgroundsThumbIdsSelector = (state) => state.backgroundSelector && state.backgroundSelector.removedBackgroundsThumbIds;
 export const confirmDeleteBackgroundModalSelector = (state) => state.backgroundSelector && state.backgroundSelector.confirmDeleteBackgroundModal;


### PR DESCRIPTION
## Description
Fix map export functionality. This https://github.com/geosolutions-it/MapStore2/pull/4343/ introduced this bug, it added the requirement of passing background layers in saveMapConfiguration so it was necessary for all parts of code to be updated with that changes.

## Issues
 - #4399 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4399 

**What is the new behavior?**
Map export works

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
