### PR TITLE
Fix 4332 Resize cursor appear for non-resize right side panels

### DIFF
--- a/web/client/components/details/DetailsPanel.jsx
+++ b/web/client/components/details/DetailsPanel.jsx
@@ -74,19 +74,23 @@ class DetailsPanel extends React.Component {
             </span>);
 
         return (<ContainerDimensions>
-            { ({ width }) =>
-                <Dock dockStyle={this.props.dockStyle} {...this.props.dockProps} isVisible={this.props.active} size={this.props.width / width > 1 ? 1 : this.props.width / width} >
-                    <Panel id={this.props.id} header={panelHeader} style={this.props.panelStyle} className={this.props.panelClassName}>
-                        <BorderLayout>
-                            <div className="ms-details-preview-container">
-                                {!this.props.detailsText ?
-                                    <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/> :
-                                    <div className="ms-details-preview" dangerouslySetInnerHTML={{ __html:
-                                                this.props.detailsText === NO_DETAILS_AVAILABLE ? LocaleUtils.getMessageById(this.context.messages, "maps.feedback.noDetailsAvailable") : this.props.detailsText }} />}
-                            </div>
-                        </BorderLayout>
-                    </Panel>
-                </Dock>
+            {({ width }) =>
+                <div className="react-dock-no-resize">
+                    <Dock dockStyle={this.props.dockStyle} {...this.props.dockProps} isVisible={this.props.active} size={this.props.width / width > 1 ? 1 : this.props.width / width} >
+                        <Panel id={this.props.id} header={panelHeader} style={this.props.panelStyle} className={this.props.panelClassName}>
+                            <BorderLayout>
+                                <div className="ms-details-preview-container">
+                                    {!this.props.detailsText ?
+                                        <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner" /> :
+                                        <div className="ms-details-preview" dangerouslySetInnerHTML={{
+                                            __html:
+                                                this.props.detailsText === NO_DETAILS_AVAILABLE ? LocaleUtils.getMessageById(this.context.messages, "maps.feedback.noDetailsAvailable") : this.props.detailsText
+                                        }} />}
+                                </div>
+                            </BorderLayout>
+                        </Panel>
+                    </Dock>
+                </div>
             }
         </ContainerDimensions>);
     }

--- a/web/client/components/misc/panels/DockPanel.jsx
+++ b/web/client/components/misc/panels/DockPanel.jsx
@@ -54,9 +54,10 @@ module.exports = withState('fullscreen', 'onFullscreen', false)(
         children,
         onFullscreen = () => {},
         fixed = false,
+        noResize = false,
         hideHeader
     }) =>
-        <div className={'ms-side-panel ' + (!fixed ? 'ms-absolute-dock ' : '') + className}>
+        <div className={'ms-side-panel ' + (!fixed ? 'ms-absolute-dock ' : '') +  (noResize ? 'react-dock-no-resize ' : '') + className}>
             <Dock
                 fluid={fluid || fullscreen}
                 position={position}

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -161,7 +161,7 @@ class AnnotationsPanel extends React.Component {
         return this.props.active ? (
             <ContainerDimensions>
                 { ({ width }) =>
-                    <span className="ms-annotations-panel">
+                    <span className="ms-annotations-panel react-dock-no-resize">
                         <Dock
                             dockStyle={this.props.dockStyle} {...this.props.dockProps}
                             isVisible={this.props.active}

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -165,7 +165,8 @@ class MetadataExplorerComponent extends React.Component {
                         title={<Message msgId="catalog.title"/>}
                         onClose={() => this.props.toggleControl()}
                         glyph="folder-open"
-                        style={this.props.dockStyle}>
+                        style={this.props.dockStyle}
+                        noResize>
                         <Panel id={this.props.id} style={this.props.panelStyle} className={this.props.panelClassName}>
                             {panel}
                         </Panel>

--- a/web/client/themes/default/less/dock.less
+++ b/web/client/themes/default/less/dock.less
@@ -1,0 +1,5 @@
+.react-dock-no-resize {
+  > div > div > div {
+      cursor: auto !important;
+  }
+}

--- a/web/client/themes/default/ms2-theme.less
+++ b/web/client/themes/default/ms2-theme.less
@@ -8,6 +8,7 @@
 @import "./less/colorrangeselector.less";
 @import "./less/dashboard.less";
 @import "./less/dock-panel.less";
+@import "./less/dock.less";
 @import "./less/draggable.less";
 @import "./less/drawer-menu.less";
 @import "./less/dropdown-menu.less";


### PR DESCRIPTION
## Description
Some of the right side panels use [react-dock](https://www.npmjs.com/package/react-dock) component which keeps showing resize cursor even when resize is not activated. I changed that by introducing custom style to override the react dock internal div. The solution is more of a hack but I could not find another solution since the author of the react-dock did never want to externalize resize style. 

## Issues
 - #4332 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
