### PR TITLE
Fix #4397 Layers/backgrounds default format is not selectable

### DIFF
--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -328,7 +328,7 @@ class RecordItem extends React.Component {
             removeParams: this.props.authkeyParamNames,
             ...(type === 'wms' ? {catalogURL: this.props.catalogType === 'csw' && this.props.catalogURL ?
                 this.props.catalogURL + "?request=GetRecordById&service=CSW&version=2.0.2&elementSetName=full&id=" +
-                this.props.record.identifier : null} : {})
+                this.props.record.identifier : null, format: this.props.defaultFormat} : {format: this.props.defaultFormat})
         }, this.props.layerBaseConfig);
     }
 

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -745,4 +745,26 @@ describe('This test for RecordItem', () => {
         expect(desc.length).toBe(1);
         expect(desc[0].innerText.indexOf("sample title and description catalog.notAvailable") !== -1).toBe(true);
     });
+    it('check default format is added to layer props', () => {
+        const defaultFormat = 'image/jpeg';
+        let actions = {
+            onLayerAdd: () => {}
+        };
+        let actionsSpy = expect.spyOn(actions, "onLayerAdd");
+        const item = ReactDOM.render(<RecordItem
+            defaultFormat={defaultFormat}
+            record={sampleRecord}
+            onLayerAdd={actions.onLayerAdd}/>, document.getElementById("container"));
+        expect(item).toExist();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toExist();
+        let button = TestUtils.findRenderedDOMComponentWithTag(
+            item, 'button'
+        );
+        expect(button).toExist();
+        button.click();
+        expect(actionsSpy.calls.length).toBe(1);
+        expect(actionsSpy.calls[0].arguments[0].format).toBe(defaultFormat);
+    });
 });

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -416,7 +416,7 @@ const CatalogUtils = {
      *  - `removeParameters` if you didn't provided an `url` option and you want to use record's one, you can remove some params (typically authkey params) using this.
      *  - `url`, if you already have the correct service URL (typically when you want to use you URL already stripped from some parameters, e.g. authkey params)
      */
-    recordToLayer: (record, type = "wms", {removeParams = [], catalogURL, url} = {}, baseConfig = {}) => {
+    recordToLayer: (record, type = "wms", {removeParams = [], format, catalogURL, url} = {}, baseConfig = {}) => {
         if (!record || !record.references) {
             // we don't have a valid record so no buttons to add
             return null;
@@ -451,6 +451,7 @@ const CatalogUtils = {
             type: type,
             requestEncoding: record.requestEncoding, // WMTS KVP vs REST, KVP by default
             style: record.style,
+            format,
             url: layerURL,
             capabilitiesURL: record.capabilitiesURL,
             queryable: record.queryable,


### PR DESCRIPTION
## Description
Layers added using TOC, now have format prop set to default format of the service, that the layer
was added from.

## Issues
 - #4397
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
#4397 

**What is the new behavior?**
In the description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No
