### PR TITLE
Fix 4369 Error message missing trying to save an untitled map

### DIFF
--- a/web/client/components/maps/forms/Metadata.jsx
+++ b/web/client/components/maps/forms/Metadata.jsx
@@ -46,7 +46,7 @@ class Metadata extends React.Component {
 
     render() {
         return (<form ref="metadataForm" onSubmit={this.handleSubmit}>
-            <FormGroup>
+            <FormGroup validationState={this.isMapNameValid}>
                 <ControlLabel>{this.props.nameFieldText}</ControlLabel>
                 <FormControl ref="mapName"
                     key="mapName"
@@ -77,6 +77,10 @@ class Metadata extends React.Component {
 
     changeDescription = (e) => {
         this.props.onChange('description', e.target.value);
+    };
+
+    isMapNameValid = () => {
+        return (this.props.map && this.props.map.metadata && this.props.map.metadata.name === '') ? 'error' : null;
     };
 }
 

--- a/web/client/components/maps/modals/MetadataModal.jsx
+++ b/web/client/components/maps/modals/MetadataModal.jsx
@@ -407,7 +407,7 @@ class MetadataModal extends React.Component {
                 }, {
                     text: <Message msgId="save" />,
                     onClick: () => { this.onSave(); },
-                    disabled: this.props.map.saving
+                    disabled: this.props.map.saving || !this.isValidForm()
                 }]}
                 showClose={!this.props.map.saving}
                 onClose={this.onCloseMapPropertiesModal}>
@@ -504,6 +504,8 @@ class MetadataModal extends React.Component {
     isThumbnailChanged = () => {
         return this.refs && this.refs.thumbnail && this.refs.thumbnail.files && this.refs.thumbnail.files.length > 0;
     };
+
+    isValidForm = () => get(this.props.map, "metadata.name");
 }
 
 module.exports = MetadataModal;

--- a/web/client/components/maps/modals/__tests__/MetaDataModal-test.jsx
+++ b/web/client/components/maps/modals/__tests__/MetaDataModal-test.jsx
@@ -188,4 +188,65 @@ describe('This test for MetadataModal', () => {
         expect(detailsSheetArray.length).toBe(0);
     });
 
+    it('save button is disabled when name is empty and user is unable to save', () => {
+        const thumbnail = "myThumnbnailUrl";
+        const errors = [];
+        const map = {
+            thumbnail: thumbnail,
+            id: 123,
+            canWrite: true,
+            category: {
+                name: "MAP"
+            },
+            metadata: {
+                name: '',
+                description: ''
+            },
+            errors: errors
+        };
+        const actions = {
+            onSave: () => { }
+        };
+
+        const spyonOnSave = expect.spyOn(actions, 'onSave');
+        const metadataModalItem = ReactDOM.render(<MetadataModal show useModal map={map} id="MetadataModal" onSave={actions.onSave} />, document.getElementById("container"));
+        expect(metadataModalItem).toExist();
+        const modalDivList = document.getElementsByClassName("modal-content");
+        const modalButtons = modalDivList.item(0).getElementsByTagName('button');
+        const saveButton = modalButtons[1];
+        expect(saveButton.disabled).toBeTruthy();
+        ReactTestUtils.Simulate.click(saveButton);
+        expect(spyonOnSave).toNotHaveBeenCalled();
+    });
+
+    it('save button is enabled when name is filled and user is able to save', () => {
+        const thumbnail = "myThumnbnailUrl";
+        const errors = [];
+        const map = {
+            thumbnail: thumbnail,
+            id: 123,
+            canWrite: true,
+            category: {
+                name: "MAP"
+            },
+            metadata: {
+                name: 'some name',
+                description: ''
+            },
+            errors: errors
+        };
+        const actions = {
+            onSave: () => { }
+        };
+
+        const spyonOnSave = expect.spyOn(actions, 'onSave');
+        const metadataModalItem = ReactDOM.render(<MetadataModal show useModal map={map} id="MetadataModal" onSave={actions.onSave} />, document.getElementById("container"));
+        expect(metadataModalItem).toExist();
+        const modalDivList = document.getElementsByClassName("modal-content");
+        const modalButtons = modalDivList.item(0).getElementsByTagName('button');
+        const saveButton = modalButtons[1];
+        expect(saveButton.disabled).toBeFalsy();
+        ReactTestUtils.Simulate.click(saveButton);
+        expect(spyonOnSave).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Description
Fix for missing name field validation when user tries to save an untitled map

## Issues
 - #4369 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
