### PR TITLE
Fix 4293 Removing details from a map, the 'about this map' button on burger menu is maintained

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -809,7 +809,7 @@ export default class DrawSupport extends React.Component {
                     newDrawMethod = "Polygon";
                     const radius = previousFt && previousFt.getProperties() && previousFt.getProperties().radius || 10000;
                     let center = event.coordinate;
-                    const coords = this.polygonCoordsFromCircle(center, 100);
+                    const coords = this.polygonCoordsFromCircle(center, radius);
                     olFt = this.getNewFeature(newDrawMethod, coords);
                     // TODO verify center is projected in 4326 and is an array
                     center = reproject(center, this.getMapCrs(), "EPSG:4326", false);

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -34,7 +34,7 @@ const mockStore = configureMockStore([epicMiddleware]);
 const {testEpic, addTimeoutEpic, TEST_TIMEOUT} = require('./epicTestUtils');
 const axios = require('../../libs/ajax');
 const MockAdapter = require('axios-mock-adapter');
-const { EMPTY_RESOURCE_VALUE } = require('../utils/MapInfoUtils');
+const { EMPTY_RESOURCE_VALUE } = require('../../utils/MapInfoUtils');
 
 const ConfigUtils = require('../../utils/ConfigUtils');
 const params = {start: 0, limit: 12 };

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -506,6 +506,7 @@ describe('maps Epics', () => {
         testEpic(addTimeoutEpic(storeDetailsInfoEpic), 1, mapInfoLoaded(map2, mapId2), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => expect(action.type).toBe(TEST_TIMEOUT));
+            mock.restore();
             done();
         }, {mapInitialConfig: {
             "mapId": mapId2
@@ -517,6 +518,7 @@ describe('maps Epics', () => {
         testEpic(addTimeoutEpic(storeDetailsInfoEpic), 1, mapInfoLoaded(map2, mapId2), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => expect(action.type).toBe(TEST_TIMEOUT));
+            mock.restore();
             done();
         }, {mapInitialConfig: {
             "mapId": mapId2

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -27,14 +27,14 @@ const {
     setDetailsChangedEpic, loadMapsEpic, getMapsResourcesByCategoryEpic,
     closeDetailsPanelEpic, fetchDataForDetailsPanel,
     fetchDetailsFromResourceEpic, deleteMapAndAssociatedResourcesEpic,
-    storeDetailsInfoEpic, mapSaveMapResourceEpic, reloadMapsEpic,
-    EMPTY_RESOURCE_VALUE } = require('../maps');
+    storeDetailsInfoEpic, mapSaveMapResourceEpic, reloadMapsEpic } = require('../maps');
 const rootEpic = combineEpics(setDetailsChangedEpic, closeDetailsPanelEpic);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
 const {testEpic, addTimeoutEpic, TEST_TIMEOUT} = require('./epicTestUtils');
 const axios = require('../../libs/ajax');
 const MockAdapter = require('axios-mock-adapter');
+const { EMPTY_RESOURCE_VALUE } = require('../utils/MapInfoUtils');
 
 const ConfigUtils = require('../../utils/ConfigUtils');
 const params = {start: 0, limit: 12 };

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -116,6 +116,11 @@ const mapAttributesEmptyDetails = {
         ]
     }
 };
+const mapAttributesWithoutDetails = {
+    "AttributeList": {
+        "Attribute": []
+    }
+};
 
 describe('maps Epics', () => {
     const oldGetDefaults = ConfigUtils.getDefaults;
@@ -498,6 +503,17 @@ describe('maps Epics', () => {
     it('test storeDetailsInfoEpic when api returns NODATA value', (done) => {
         const mock = new MockAdapter(axios);
         mock.onGet().reply(200, mapAttributesEmptyDetails);
+        testEpic(addTimeoutEpic(storeDetailsInfoEpic), 1, mapInfoLoaded(map2, mapId2), actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => expect(action.type).toBe(TEST_TIMEOUT));
+            done();
+        }, {mapInitialConfig: {
+            "mapId": mapId2
+        }});
+    });
+    it.only('test storeDetailsInfoEpic when api doesnt return details', (done) => {
+        const mock = new MockAdapter(axios);
+        mock.onGet().reply(200, mapAttributesWithoutDetails);
         testEpic(addTimeoutEpic(storeDetailsInfoEpic), 1, mapInfoLoaded(map2, mapId2), actions => {
             expect(actions.length).toBe(1);
             actions.map((action) => expect(action.type).toBe(TEST_TIMEOUT));

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -27,11 +27,14 @@ const {
     setDetailsChangedEpic, loadMapsEpic, getMapsResourcesByCategoryEpic,
     closeDetailsPanelEpic, fetchDataForDetailsPanel,
     fetchDetailsFromResourceEpic, deleteMapAndAssociatedResourcesEpic,
-    storeDetailsInfoEpic, mapSaveMapResourceEpic, reloadMapsEpic} = require('../maps');
+    storeDetailsInfoEpic, mapSaveMapResourceEpic, reloadMapsEpic,
+    EMPTY_RESOURCE_VALUE } = require('../maps');
 const rootEpic = combineEpics(setDetailsChangedEpic, closeDetailsPanelEpic);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);
 const {testEpic, addTimeoutEpic, TEST_TIMEOUT} = require('./epicTestUtils');
+const axios = require('../../libs/ajax');
+const MockAdapter = require('axios-mock-adapter');
 
 const ConfigUtils = require('../../utils/ConfigUtils');
 const params = {start: 0, limit: 12 };
@@ -101,6 +104,19 @@ const testMap = {
         }
     ]
 };
+
+const mapAttributesEmptyDetails = {
+    "AttributeList": {
+        "Attribute": [
+            {
+                "name": "details",
+                "type": "STRING",
+                "value": EMPTY_RESOURCE_VALUE
+            }
+        ]
+    }
+};
+
 describe('maps Epics', () => {
     const oldGetDefaults = ConfigUtils.getDefaults;
     let store;
@@ -355,8 +371,8 @@ describe('maps Epics', () => {
     });
     it('test deleteMapAndAssociatedResourcesEpic, only map deleted, details and thumbnail not provided', (done) => {
         testEpic(addTimeoutEpic(deleteMapAndAssociatedResourcesEpic, 50), 3, deleteMap(mapId8, {}), actions => {
-            map8.thumbnail = "NODATA";
-            map8.details = "NODATA";
+            map8.thumbnail = EMPTY_RESOURCE_VALUE;
+            map8.details = EMPTY_RESOURCE_VALUE;
             expect(actions.length).toBe(3);
             actions.map((action) => {
                 switch (action.type) {
@@ -474,6 +490,17 @@ describe('maps Epics', () => {
                     expect(true).toBe(false);
                 }
             });
+            done();
+        }, {mapInitialConfig: {
+            "mapId": mapId2
+        }});
+    });
+    it('test storeDetailsInfoEpic when api returns NODATA value', (done) => {
+        const mock = new MockAdapter(axios);
+        mock.onGet().reply(200, mapAttributesEmptyDetails);
+        testEpic(addTimeoutEpic(storeDetailsInfoEpic), 1, mapInfoLoaded(map2, mapId2), actions => {
+            expect(actions.length).toBe(1);
+            actions.map((action) => expect(action.type).toBe(TEST_TIMEOUT));
             done();
         }, {mapInitialConfig: {
             "mapId": mapId2

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -511,7 +511,7 @@ describe('maps Epics', () => {
             "mapId": mapId2
         }});
     });
-    it.only('test storeDetailsInfoEpic when api doesnt return details', (done) => {
+    it('test storeDetailsInfoEpic when api doesnt return details', (done) => {
         const mock = new MockAdapter(axios);
         mock.onGet().reply(200, mapAttributesWithoutDetails);
         testEpic(addTimeoutEpic(storeDetailsInfoEpic), 1, mapInfoLoaded(map2, mapId2), actions => {

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -49,8 +49,7 @@ const {getIdFromUri} = require('../utils/MapUtils');
 
 const {getErrorMessage} = require('../utils/LocaleUtils');
 const Persistence = require("../api/persistence");
-
-const EMPTY_RESOURCE_VALUE = "NODATA";
+const { EMPTY_RESOURCE_VALUE } = require('../utils/MapInfoUtils');
 
 const manageMapResource = ({map = {}, attribute = "", resource = null, type = "STRING", optionsDel = {}, messages = {}} = {}) => {
     const attrVal = map[attribute];
@@ -368,6 +367,6 @@ module.exports = {
     fetchDetailsFromResourceEpic,
     saveResourceDetailsEpic,
     mapSaveMapResourceEpic,
-    reloadMapsEpic,
-    EMPTY_RESOURCE_VALUE
+    reloadMapsEpic
+    // EMPTY_RESOURCE_VALUE
 };

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -368,5 +368,4 @@ module.exports = {
     saveResourceDetailsEpic,
     mapSaveMapResourceEpic,
     reloadMapsEpic
-    // EMPTY_RESOURCE_VALUE
 };

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -50,11 +50,13 @@ const {getIdFromUri} = require('../utils/MapUtils');
 const {getErrorMessage} = require('../utils/LocaleUtils');
 const Persistence = require("../api/persistence");
 
+const EMPTY_RESOURCE_VALUE = "NODATA";
+
 const manageMapResource = ({map = {}, attribute = "", resource = null, type = "STRING", optionsDel = {}, messages = {}} = {}) => {
     const attrVal = map[attribute];
     const mapId = map.id;
     // create
-    if ((isNil(attrVal) || attrVal === "NODATA") && !isNil(resource)) {
+    if ((isNil(attrVal) || attrVal === EMPTY_RESOURCE_VALUE) && !isNil(resource)) {
         return createAssociatedResource({...resource, attribute, mapId, type, messages});
     }
     if (isNil(resource)) {
@@ -151,7 +153,7 @@ const fetchDetailsFromResourceEpic = (action$, store) =>
             const state = store.getState();
             const mapId = currentMapIdSelector(state);
             const detailsUri = currentMapDetailsUriSelector(state);
-            if (!detailsUri || detailsUri === "NODATA") {
+            if (!detailsUri || detailsUri === EMPTY_RESOURCE_VALUE) {
                 return Rx.Observable.of(
                     updateDetails("", true, "")
                 );
@@ -300,7 +302,7 @@ const storeDetailsInfoEpic = (action$, store) =>
                 )
                     .switchMap((attributes) => {
                         let details = find(attributes, {name: 'details'});
-                        if (!details) {
+                        if (!details || details.value === EMPTY_RESOURCE_VALUE) {
                             return Rx.Observable.empty();
                         }
                         return Rx.Observable.of(
@@ -366,5 +368,6 @@ module.exports = {
     fetchDetailsFromResourceEpic,
     saveResourceDetailsEpic,
     mapSaveMapResourceEpic,
-    reloadMapsEpic
+    reloadMapsEpic,
+    EMPTY_RESOURCE_VALUE
 };

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -82,7 +82,7 @@
                 max-height: 30%;
                 height: unset;
             }
-    
+
             &.ms-sm {
                 max-height: 40%;
                 height: unset;
@@ -225,6 +225,8 @@
 }
 
 .ms-modal-quill-container {
+    min-height: 300px;
+
     .quill {
         display: flex;
         flex-direction: column;

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -19,6 +19,8 @@ const MapInfoUtils = {
     //           default format ↴
     AVAILABLE_FORMAT: ['TEXT', 'PROPERTIES', 'HTML', 'TEMPLATE'],
 
+    EMPTY_RESOURCE_VALUE: 'NODATA',
+
     VIEWERS: {},
     /**
      * @return a filtered version of INFO_FORMATS object.


### PR DESCRIPTION
## Description
Removed maintained 'about this map' when user delete map details. Also after call with @tdipisa we decided to add fix for WYSIWYG editor height in normal mode with this PR.

## Issues
 - #4293
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
