### PR TITLE
FIX 4352 Dashboards Edit Properties - Missing text with no permissions groups

### DIFF
--- a/web/client/components/resources/modals/fragments/PermissionEditor.jsx
+++ b/web/client/components/resources/modals/fragments/PermissionEditor.jsx
@@ -137,11 +137,11 @@ class PermissionEditor extends React.Component {
     };
 
     renderPermissionRows = () => {
-        if (this.props.rules.length === 0) {
+        const rules = this.props.rules.filter(rule => rule.group);
+        if (rules.length === 0) {
             return <tr><td colSpan="3"><Message msgId="map.permissions.noRules" /></td></tr>;
         }
-        return this.props.rules
-            .filter(rule => rule.group)
+        return rules
             .map(({canWrite, group}, index) => {
                 return (
                     <tr key={index} className={index / 2 === 0 ? "even" : "odd"}>
@@ -172,7 +172,6 @@ class PermissionEditor extends React.Component {
             });
     }
     render() {
-
         return (
             <div>
                 <Table className="permissions-table" stripped condensed hover>


### PR DESCRIPTION
## Description
Fixed permission rules validation for groups. I've to add filter permissions for length validation.

## Issues
 - #4352 
 - ...

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
