### PR TITLE
Fix 4445 no more glitch on content toolbars

### DIFF
--- a/web/client/components/geostory/common/ToolbarDropdownButton.jsx
+++ b/web/client/components/geostory/common/ToolbarDropdownButton.jsx
@@ -23,6 +23,7 @@ export default function ToolbarDropdownButton({
     onSelect = () => {},
     glyph = '',
     tooltipId,
+    pullRight = false,
     className = 'square-button-md no-border',
     disabled
 }) {
@@ -31,6 +32,7 @@ export default function ToolbarDropdownButton({
         <DropdownButton
             noCaret
             tooltipId={tooltipId}
+            pullRight={pullRight}
             className={className}
             disabled={disabled}
             title={<Glyphicon glyph={glyphOption || glyph}/>}>

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -16,10 +16,11 @@ import withConfirm from "../../misc/toolbar/withConfirm";
 const DeleteButton = withConfirm(ToolbarButton);
 const BUTTON_CLASSES = 'square-button-md no-border';
 const toolButtons = {
-    size: ({ size, update = () => {} }) => ({
+    size: ({ align, sectionType, size, update = () => {} }) => ({
         Element: () => <ToolbarDropdownButton
             value={size}
             glyph="resize-horizontal"
+            pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
             tooltipId="geostory.contentToolbar.contentSize"
             options={[{
                 value: 'small',
@@ -40,11 +41,12 @@ const toolButtons = {
             }]}
             onSelect={(selected) => update('size', selected)}/>
     }),
-    align: ({ size, align, update = () => {} }) => ({
+    align: ({ size, align, sectionType, update = () => {} }) => ({
         Element: () => <ToolbarDropdownButton
             value={align}
             disabled={size === 'full'}
             glyph="align-center"
+            pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
             tooltipId="geostory.contentToolbar.contentAlign"
             options={[{
                 value: 'left',
@@ -61,9 +63,10 @@ const toolButtons = {
             }]}
             onSelect={(selected) => update('align', selected)}/>
     }),
-    theme: ({ theme, update = () => {}, fit, themeOptions, size }) => ({
+    theme: ({ theme, align, sectionType, update = () => {}, fit, themeOptions, size }) => ({
         Element: () => <ToolbarDropdownButton
             value={theme}
+            pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
             glyph="dropper"
             tooltipId="geostory.contentToolbar.contentTheme"
             disabled={fit === 'cover' && size === 'full'}

--- a/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
@@ -96,6 +96,56 @@ describe('ContentToolbar component', () => {
     });
     describe('tools', () => {
         // TODO: align, theme, size...
+        it(`align`, (done) => {
+            ReactDOM.render(<ContentToolbar
+                tools={["align"]}
+                fit="contain"
+                align="center"
+                path="TEST_PATH"
+            />, document.getElementById("container"));
+            const list = document.querySelectorAll('.ms-content-toolbar li a span');
+            expect(list).toExist();
+            expect(list.length).toBe(3);
+            expect(list[0].innerText).toBe("geostory.contentToolbar.leftAlignLabel");
+            expect(list[1].innerText).toBe("geostory.contentToolbar.centerAlignLabel");
+            expect(list[2].innerText).toBe("geostory.contentToolbar.rightAlignLabel");
+            done();
+        });
+        it(`size`, (done) => {
+            ReactDOM.render(<ContentToolbar
+                tools={["size"]}
+                fit="contain"
+                size="full"
+                align="center"
+                path="TEST_PATH"
+            />, document.getElementById("container"));
+            const list = document.querySelectorAll('.ms-content-toolbar li a span');
+            expect(list).toExist();
+            expect(list.length).toBe(4);
+            expect(list[0].innerText).toBe("geostory.contentToolbar.smallSizeLabel");
+            expect(list[1].innerText).toBe("geostory.contentToolbar.mediumSizeLabel");
+            expect(list[2].innerText).toBe("geostory.contentToolbar.largeSizeLabel");
+            expect(list[3].innerText).toBe("geostory.contentToolbar.fullSizeLabel");
+            done();
+        });
+        it(`theme`, (done) => {
+            ReactDOM.render(<ContentToolbar
+                tools={["theme"]}
+                fit="contain"
+                size="full"
+                align="center"
+                theme="bright"
+                path="TEST_PATH"
+            />, document.getElementById("container"));
+            const list = document.querySelectorAll('.ms-content-toolbar li a span');
+            expect(list).toExist();
+            expect(list.length).toBe(4);
+            expect(list[0].innerText).toBe("geostory.contentToolbar.brightThemeLabel");
+            expect(list[1].innerText).toBe("geostory.contentToolbar.brightTextThemeLabel");
+            expect(list[2].innerText).toBe("geostory.contentToolbar.darkThemeLabel");
+            expect(list[3].innerText).toBe("geostory.contentToolbar.darkTextThemeLabel");
+            done();
+        });
         it(`remove`, (done) => {
             ReactDOM.render(<ContentToolbar
                 tools={["remove"]}

--- a/web/client/configs/observatories.json
+++ b/web/client/configs/observatories.json
@@ -249,6 +249,7 @@
               "id": "paragraph_1_content_2",
               "type": "image",
               "title": "Image",
+              "align": "center",
               "resourceId": "eaebe073-d514-4601-8c85-94f00f67ef70",
               "size": "medium"
             }
@@ -341,6 +342,8 @@
               "id": "immersive_2_content_2",
               "type": "image",
               "title": "Image",
+              "size": "full",
+              "align": "center",
               "resourceId": "c4b1a878-e12d-40e8-983c-4c35ea721447"
             }
           ],
@@ -379,6 +382,8 @@
               "id": "immersive_3_content_2",
               "type": "image",
               "title": "Image",
+              "size": "full",
+              "align": "center",
               "resourceId": "95170aa4-ad68-4a57-9be8-7ff00b30eda6"
             }
           ],
@@ -409,14 +414,16 @@
           "title": "Immersive Content",
           "contents": [
             {
-              "id": "immersive_3_content_1",
+              "id": "immersive_4_content_1",
               "type": "text",
               "html": "<h5><strong><ins>Indian Astronomical Observatory</ins></strong></h5>\n"
             },
             {
-              "id": "immersive_3_content_2",
+              "id": "immersive_4_content_2",
               "type": "image",
               "title": "Image",
+              "size": "full",
+              "align": "center",
               "resourceId": "23b34678-9f0c-4498-9ba2-ceffe0b071be"
             }
           ],
@@ -447,7 +454,7 @@
           "title": "Immersive Content",
           "contents": [
             {
-              "id": "immersive_4_content_1",
+              "id": "immersive_5_content_1",
               "type": "text",
               "html": "<h5><strong><ins>The Best Stargazing is at the Northern Tip of India</ins></strong></h5>\n<p>For some of the best stargazing in the world, many make the trek to Ladakh at the northern tip of India. The region is home to the Indian Astronomical Observatory, specifically situated for its unique geology. Located on cold, remote desert land, the area experiences very little rainfall and hardly any snow. The high altitude—2.5 miles above sea level—also allows scientists to collect more data than would be possible at a lower altitude. For visitors of the observatory, the summer months give way to a perfectly clear sky. As soon as the sun sets, visitors are treated to a blanket of extraordinary stars and light.</p>\n<p></p>\n<p>From Great Big Story</p>\n"
             }
@@ -470,7 +477,7 @@
           "title": "Immersive Content",
           "contents": [
             {
-              "id": "immersive_5_content_1",
+              "id": "immersive_6_content_1",
               "type": "text",
               "html": "<p style=\"text-align:center;\"><strong><ins>Map of all Observatories listed in Wikipedia</ins></strong></p>\n"
             }

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -260,14 +260,18 @@ export const getDefaultSectionTemplate = (type, localize = v => v) => {
         return {
             id: uuid(),
             type,
-            title: localize("geostory.builder.defaults.titleMedia")
+            title: localize("geostory.builder.defaults.titleMedia"),
+            size: 'full',
+            align: 'center'
         };
     }
     default:
         return {
             id: uuid(),
             type,
-            title: localize("geostory.builder.defaults.titleUnknown")
+            title: localize("geostory.builder.defaults.titleUnknown"),
+            size: 'full',
+            align: 'center'
         };
     }
 };

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -168,6 +168,8 @@ describe("GeoStory Utils", () => {
             expect(data.id).toExist();
             expect(data.type).toBe(wrongType);
             expect(data.title).toBe("geostory.builder.defaults.titleUnknown");
+            expect(data.size).toBe("full");
+            expect(data.align).toBe("center");
         });
         it("SectionTypes.TITLE", () => {
             const data = getDefaultSectionTemplate(SectionTypes.TITLE);


### PR DESCRIPTION
## Description
This pr aims to fix the glitch on content toolbar.
when some comment is aligned to the right the dropdown of theme, size and align present the glitch described in the issue

## Issues
 - #4445

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
no more glitches, the menu causing problems now opens on the left of the button

**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications: ... -->

**Other information**:
<details>
<summary> <b>see results</b></summary>

- Backgrounds (Title) should have the dropdown menu on that is left aligned as this image, no matter the size or align
![image](https://user-images.githubusercontent.com/11991428/68301610-a0c12000-00a0-11ea-91a4-5be759201b29.png)

- even for its content, the dropdown menu should be left aligned
![image](https://user-images.githubusercontent.com/11991428/68301764-ef6eba00-00a0-11ea-95fb-de947d2b36cf.png)

- for media inside paragraph, if size=full or align=right then the dropdown menu will be right aligned
![image](https://user-images.githubusercontent.com/11991428/68302100-a10deb00-00a1-11ea-8e80-838f96cbf5a8.png)

- the same of images for paragraph happens for images inside immersive content
![image](https://user-images.githubusercontent.com/11991428/68302159-be42b980-00a1-11ea-87d7-95aa5b9633dd.png)


</details>