### PR TITLE
FIX 2479 FeatureInfo and TOC overlaps on Mobile

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1788,7 +1788,7 @@ describe('featuregrid Epics', () => {
             }
         };
 
-        it.only('toggle featureGrid when drawer is opened - MOBILE ONLY', done => {
+        it('toggle featureGrid when drawer is opened - MOBILE ONLY', done => {
             const epicResult = actions => {
                 expect(actions.length).toBe(2);
                 expect(actions[0].type).toBe(HIDE_MAPINFO_MARKER);
@@ -1798,7 +1798,7 @@ describe('featuregrid Epics', () => {
 
             testEpic(hideFeatureGridOnDrawerOpenMobile, 2, toggleControl('drawer', null), epicResult, TEST_STATE_BASE);
         });
-        it.only('do not toggle featureGrid when drawer is closed - MOBILE ONLY', done => {
+        it('do not toggle featureGrid when drawer is closed - MOBILE ONLY', done => {
             const TEST_STATE_CLOSED_DRAWER = set('controls.drawer.enabled', false, TEST_STATE_BASE);
             const epicResult = actions => {
                 expect(actions.length).toBe(1);
@@ -1808,7 +1808,7 @@ describe('featuregrid Epics', () => {
 
             testEpic(addTimeoutEpic(hideFeatureGridOnDrawerOpenMobile, 10), 1, toggleControl('drawer', null), epicResult, TEST_STATE_CLOSED_DRAWER);
         });
-        it.only('do not toggle featureGrid when drawer is opened - DESKTOP MODE', done => {
+        it('do not toggle featureGrid when drawer is opened - DESKTOP MODE', done => {
             const TEST_STATE_NOT_MOBILE = set('browser.mobile', false, TEST_STATE_BASE);
             const epicResult = actions => {
                 expect(actions.length).toBe(1);
@@ -1818,7 +1818,7 @@ describe('featuregrid Epics', () => {
 
             testEpic(addTimeoutEpic(hideFeatureGridOnDrawerOpenMobile, 10), 1, toggleControl('drawer', null), epicResult, TEST_STATE_NOT_MOBILE);
         });
-        it.only('do not toggle featureGrid when drawer is closed - DESKTOP MODE', done => {
+        it('do not toggle featureGrid when drawer is closed - DESKTOP MODE', done => {
             const TEST_STATE_CLOSED_DRAWER = set('controls.drawer.enabled', false, TEST_STATE_BASE);
             const TEST_STATE_NOT_MOBILE = set('browser.mobile', false, TEST_STATE_CLOSED_DRAWER);
             const epicResult = actions => {

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -54,6 +54,7 @@ const {ZOOM_TO_EXTENT} = require('../../actions/map');
 const { CLOSE_IDENTIFY } = require('../../actions/mapInfo');
 const {CHANGE_LAYER_PROPERTIES, changeLayerParams, browseData} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
+const { TOGGLE_CONTROL } = require('../../actions/controls');
 
 const {
     toggleSyncWms, QUERY, querySearchResponse, query, QUERY_CREATE, FEATURE_TYPE_SELECTED,
@@ -91,7 +92,8 @@ const {
     featureGridChangePage,
     featureGridSort,
     replayOnTimeDimensionChange,
-    hideFeatureGridOnDrawerOpenMobile
+    hideFeatureGridOnDrawerOpenMobile,
+    hideDrawerOnFeatureGridOpenMobile
 } = require('../featuregrid');
 const { onLocationChanged } = require('connected-react-router');
 
@@ -1828,6 +1830,46 @@ describe('featuregrid Epics', () => {
             };
 
             testEpic(addTimeoutEpic(hideFeatureGridOnDrawerOpenMobile, 10), 1, toggleControl('drawer', null), epicResult, TEST_STATE_NOT_MOBILE);
+        });
+        it('toggle drawer when featureGrid is opened - MOBILE ONLY', done => {
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TOGGLE_CONTROL);
+                done();
+            };
+
+            testEpic(hideDrawerOnFeatureGridOpenMobile, 1, featureInfoClick(), epicResult, TEST_STATE_BASE);
+        });
+        it('open featureGrid shouldn\'t toggle closed drawer - MOBILE ONLY', done => {
+            const TEST_STATE_CLOSED_DRAWER = set('controls.drawer.enabled', false, TEST_STATE_BASE);
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            };
+
+            testEpic(addTimeoutEpic(hideDrawerOnFeatureGridOpenMobile, 10), 1, featureInfoClick(), epicResult, TEST_STATE_CLOSED_DRAWER);
+        });
+        it('open featureGrid shouldn\'t toggle opened drawer- DESKTOP ONLY', done => {
+            const TEST_STATE_CLOSED_DRAWER = set('controls.drawer.enabled', false, TEST_STATE_BASE);
+            const TEST_STATE_NOT_MOBILE = set('browser.mobile', false, TEST_STATE_CLOSED_DRAWER);
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            };
+
+            testEpic(addTimeoutEpic(hideDrawerOnFeatureGridOpenMobile, 10), 1, featureInfoClick(), epicResult, TEST_STATE_NOT_MOBILE);
+        });
+        it('open featureGrid shouldn\'t toggle closed drawer - DESKTOP ONLY', done => {
+            const TEST_STATE_NOT_MOBILE = set('browser.mobile', false, TEST_STATE_BASE);
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            };
+
+            testEpic(addTimeoutEpic(hideDrawerOnFeatureGridOpenMobile, 10), 1, featureInfoClick(), epicResult, TEST_STATE_NOT_MOBILE);
         });
     });
 });

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -13,7 +13,7 @@ const { set } = require('../../utils/ImmutableUtils');
 
 
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
-const { hideMapinfoMarker, featureInfoClick} = require('../../actions/mapInfo');
+const { hideMapinfoMarker, featureInfoClick, HIDE_MAPINFO_MARKER} = require('../../actions/mapInfo');
 
 const {
     toggleEditMode,
@@ -90,7 +90,8 @@ const {
     autoReopenFeatureGridOnFeatureInfoClose,
     featureGridChangePage,
     featureGridSort,
-    replayOnTimeDimensionChange
+    replayOnTimeDimensionChange,
+    hideFeatureGridOnDrawerOpenMobile
 } = require('../featuregrid');
 const { onLocationChanged } = require('connected-react-router');
 
@@ -1774,5 +1775,59 @@ describe('featuregrid Epics', () => {
             }, TEST_STATE_TIME_ACTIVE_CLOSED);
         });
 
+    });
+    describe('hideFeatureGridOnDrawerOpenMobile', () => {
+        const TEST_STATE_BASE = {
+            controls: {
+                drawer: {
+                    enabled: true
+                }
+            },
+            browser: {
+                mobile: true
+            }
+        };
+
+        it.only('toggle featureGrid when drawer is opened - MOBILE ONLY', done => {
+            const epicResult = actions => {
+                expect(actions.length).toBe(2);
+                expect(actions[0].type).toBe(HIDE_MAPINFO_MARKER);
+                expect(actions[1].type).toBe(OPEN_FEATURE_GRID);
+                done();
+            };
+
+            testEpic(hideFeatureGridOnDrawerOpenMobile, 2, toggleControl('drawer', null), epicResult, TEST_STATE_BASE);
+        });
+        it.only('do not toggle featureGrid when drawer is closed - MOBILE ONLY', done => {
+            const TEST_STATE_CLOSED_DRAWER = set('controls.drawer.enabled', false, TEST_STATE_BASE);
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            };
+
+            testEpic(addTimeoutEpic(hideFeatureGridOnDrawerOpenMobile, 10), 1, toggleControl('drawer', null), epicResult, TEST_STATE_CLOSED_DRAWER);
+        });
+        it.only('do not toggle featureGrid when drawer is opened - DESKTOP MODE', done => {
+            const TEST_STATE_NOT_MOBILE = set('browser.mobile', false, TEST_STATE_BASE);
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            };
+
+            testEpic(addTimeoutEpic(hideFeatureGridOnDrawerOpenMobile, 10), 1, toggleControl('drawer', null), epicResult, TEST_STATE_NOT_MOBILE);
+        });
+        it.only('do not toggle featureGrid when drawer is closed - DESKTOP MODE', done => {
+            const TEST_STATE_CLOSED_DRAWER = set('controls.drawer.enabled', false, TEST_STATE_BASE);
+            const TEST_STATE_NOT_MOBILE = set('browser.mobile', false, TEST_STATE_CLOSED_DRAWER);
+            const epicResult = actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            };
+
+            testEpic(addTimeoutEpic(hideFeatureGridOnDrawerOpenMobile, 10), 1, toggleControl('drawer', null), epicResult, TEST_STATE_NOT_MOBILE);
+        });
     });
 });

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -26,7 +26,7 @@ const {zoomToExtent} = require('../actions/map');
 
 
 const { BROWSE_DATA, changeLayerProperties, refreshLayerVersion, CHANGE_LAYER_PARAMS} = require('../actions/layers');
-const { closeIdentify } = require('../actions/mapInfo');
+const { closeIdentify, hideMapinfoMarker } = require('../actions/mapInfo');
 
 
 const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURES, featureSaving, changePage,
@@ -38,7 +38,7 @@ const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURE
     STOP_SYNC_WMS, startSyncWMS, storeAdvancedSearchFilter, fatureGridQueryResult, LOAD_MORE_FEATURES, SET_TIME_SYNC } = require('../actions/featuregrid');
 
 const {TOGGLE_CONTROL, resetControls, setControlProperty} = require('../actions/controls');
-const {queryPanelSelector, showCoordinateEditorSelector} = require('../selectors/controls');
+const {queryPanelSelector, showCoordinateEditorSelector, drawerEnabledControlSelector} = require('../selectors/controls');
 const {setHighlightFeaturesPath} = require('../actions/highlight');
 const {selectedFeaturesSelector, changesMapSelector, newFeaturesSelector, hasChangesSelector, hasNewFeaturesSelector,
     selectedFeatureSelector, selectedFeaturesCount, selectedLayerIdSelector, isDrawingSelector, modeSelector,
@@ -756,5 +756,15 @@ module.exports = {
                 Rx.Observable.of(
                     createQuery(action.searchUrl, action.filterObj)
                 )
+            ),
+    hideFeatureGridOnDrawerOpenMobile: (action$, { getState } = {}) =>
+        action$
+            .ofType(TOGGLE_CONTROL)
+            .filter(({ control } = {}) =>
+                control === 'drawer'
+                && getState().browser
+                && getState().browser.mobile
+                && drawerEnabledControlSelector(getState())
             )
+            .switchMap(() => Rx.Observable.of(hideMapinfoMarker(), openFeatureGrid()))
 };

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -37,7 +37,7 @@ const {SORT_BY, CHANGE_PAGE, SAVE_CHANGES, SAVE_SUCCESS, DELETE_SELECTED_FEATURE
     openFeatureGrid, closeFeatureGrid, OPEN_FEATURE_GRID, CLOSE_FEATURE_GRID, CLOSE_FEATURE_GRID_CONFIRM, OPEN_ADVANCED_SEARCH, ZOOM_ALL, UPDATE_FILTER, START_SYNC_WMS,
     STOP_SYNC_WMS, startSyncWMS, storeAdvancedSearchFilter, fatureGridQueryResult, LOAD_MORE_FEATURES, SET_TIME_SYNC } = require('../actions/featuregrid');
 
-const {TOGGLE_CONTROL, resetControls, setControlProperty} = require('../actions/controls');
+const {TOGGLE_CONTROL, resetControls, setControlProperty, toggleControl} = require('../actions/controls');
 const {queryPanelSelector, showCoordinateEditorSelector, drawerEnabledControlSelector} = require('../selectors/controls');
 const {setHighlightFeaturesPath} = require('../actions/highlight');
 const {selectedFeaturesSelector, changesMapSelector, newFeaturesSelector, hasChangesSelector, hasNewFeaturesSelector,
@@ -766,5 +766,14 @@ module.exports = {
                 && getState().browser.mobile
                 && drawerEnabledControlSelector(getState())
             )
-            .switchMap(() => Rx.Observable.of(hideMapinfoMarker(), openFeatureGrid()))
+            .switchMap(() => Rx.Observable.of(hideMapinfoMarker(), openFeatureGrid())),
+    hideDrawerOnFeatureGridOpenMobile: (action$, { getState } = {}) =>
+        action$
+            .ofType(FEATURE_INFO_CLICK)
+            .filter(() =>
+                getState().browser
+                && getState().browser.mobile
+                && drawerEnabledControlSelector(getState())
+            )
+            .mapTo(toggleControl('drawer', 'enabled'))
 };


### PR DESCRIPTION
## Description
With this PR i've added new epic for handling action of open drawer and closing feature info at the same time with mobile version and viceversa

## Issues
 - #2479 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
