### PR TITLE
Fix #4329 Attribute layer filter - 'Match none' display problem

### DIFF
--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -1503,4 +1503,69 @@ describe('FilterUtils', () => {
         expect(filter.filterFields[2].groupId).toBe(filter.groupFields[3].id);
         expect(filter.filterFields[3].groupId).toBe(filter.groupFields[4].id);
     });
+    it('check CQL filter when logic is NOR', () => {
+        const filterObject = {
+            "groupFields": [
+                {
+                    "id": 1,
+                    "logic": "NOR",
+                    "index": 0
+                },
+                {
+                    "id": 1573134118982,
+                    "logic": "NOR",
+                    "groupId": 1,
+                    "index": 1
+                }
+            ],
+            "filterFields": [
+                {
+                    "rowId": 1573131371566,
+                    "groupId": 1,
+                    "attribute": "STATE_NAME",
+                    "operator": "like",
+                    "value": "Ar",
+                    "type": "string",
+                    "fieldOptions": {
+                        "valuesCount": 6,
+                        "currentPage": 1
+                    },
+                    "exception": null,
+                    "openAutocompleteMenu": false,
+                    "loading": false,
+                    "options": {
+                        "STATE_NAME": []
+                    }
+                },
+                {
+                    "rowId": 1573131515197,
+                    "groupId": 1,
+                    "attribute": "PERSONS",
+                    "operator": "<",
+                    "value": 1000000,
+                    "type": "number",
+                    "fieldOptions": {
+                        "valuesCount": 0,
+                        "currentPage": 1
+                    },
+                    "exception": null
+                },
+                {
+                    "rowId": 1573134121577,
+                    "groupId": 1573134118982,
+                    "attribute": "LAND_KM",
+                    "operator": "<",
+                    "value": 5000,
+                    "type": "number",
+                    "fieldOptions": {
+                        "valuesCount": 0,
+                        "currentPage": 1
+                    },
+                    "exception": null
+                }
+            ]
+        };
+        const filter = FilterUtils.toCQLFilter(filterObject);
+        expect(filter).toBe(`(NOT ("STATE_NAME" LIKE '%Ar%') AND NOT ("PERSONS" < '1000000') AND NOT (NOT ("LAND_KM" < '5000')))`);
+    });
 });


### PR DESCRIPTION
## Description
toCQLFilter function now handles 'Match none' option correctly.

## Issues
 - #4329 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
