### PR TITLE
Fix 4461 Custom layer and group nodes for TOC plugin

### DIFF
--- a/web/client/components/TOC/enhancers/dndTree.jsx
+++ b/web/client/components/TOC/enhancers/dndTree.jsx
@@ -1,6 +1,7 @@
 const React = require('react');
 const {compose, branch, withState} = require('recompose');
 const isArray = require('lodash/isArray');
+const flatten = require('lodash/flatten');
 
 const changeNode = (nodes, id, objToMerge) => {
     const targetIndex = nodes.findIndex(node => node.id === id);
@@ -37,8 +38,8 @@ const updateNodes = (nodes, dndState) => {
 
 const insertDummies = (node, dndState) => {
     const {node: draggedNode, newParentNodeId, parentNodeId} = dndState;
-
-    return {...node, nodes: node.nodes.map((curNode, ix) => {
+    // use flatten instead of .flat() because it's not supported on edge
+    return {...node, nodes: flatten(node.nodes.map((curNode, ix) => {
         if (curNode.nodes && !curNode.placeholder && !curNode.hide && !(draggedNode && curNode.id === draggedNode.id)) {
             const newCurNode = insertDummies(curNode, dndState);
             return [newCurNode].concat(node.nodes[ix + 1] &&
@@ -48,7 +49,7 @@ const insertDummies = (node, dndState) => {
                 [{id: curNode.id + '__dummy', dummy: true}]);
         }
         return [curNode];
-    }).flat()};
+    }))};
 };
 
 /**

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -213,7 +213,9 @@ class LayerTree extends React.Component {
         activateLayerFilterTool: PropTypes.bool,
         catalogActive: PropTypes.bool,
         refreshLayerVersion: PropTypes.func,
-        hideOpacityTooltip: PropTypes.bool
+        hideOpacityTooltip: PropTypes.bool,
+        layerNodeComponent: PropTypes.func,
+        groupNodeComponent: PropTypes.func
     };
 
     static contextTypes = {
@@ -298,8 +300,9 @@ class LayerTree extends React.Component {
     };
 
     getDefaultGroup = () => {
+        const GroupNode = this.props.groupNodeComponent || DefaultGroup;
         return (
-            <DefaultGroup
+            <GroupNode
                 onSort={!this.props.filterText && this.props.activateSortLayer ? this.props.onSort : null}
                 {...this.props.groupOptions}
                 titleTooltip={this.props.activateTitleTooltip}
@@ -314,8 +317,9 @@ class LayerTree extends React.Component {
     }
 
     getDefaultLayer = () => {
+        const LayerNode = this.props.layerNodeComponent || DefaultLayer;
         return (
-            <DefaultLayer
+            <LayerNode
                 {...this.props.layerOptions}
                 titleTooltip={this.props.activateTitleTooltip}
                 showFullTitleOnExpand={this.props.showFullTitleOnExpand}
@@ -492,6 +496,8 @@ class LayerTree extends React.Component {
  * @prop {boolean} cfg.showFullTitleOnExpand shows full length title in the legend. default `false`.
  * @prop {boolean} cfg.hideOpacityTooltip hide toolip on opacity sliders
  * @prop {string[]|string|object|function} cfg.metadataTemplate custom template for displaying metadata
+ * @prop {element} cfg.groupNodeComponent render a custom component for group node
+ * @prop {element} cfg.layerNodeComponent render a custom component for layer node
  * example :
  * ```
  * {

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -117,4 +117,72 @@ describe('TOCPlugin Plugin', () => {
         ReactDOM.render(<WrappedPlugin />, document.getElementById("container"));
         expect(document.querySelectorAll('.mapstore-filter.form-group').length).toBe(0);
     });
+    it('TOCPlugin use custom group node', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [{
+                    expanded: true,
+                    id: 'Default',
+                    name: 'Default',
+                    nodes: [ 'layer_01', 'layer_02' ],
+                    title: 'Default'
+                }],
+                flat: [{
+                    id: 'layer_01',
+                    title: 'title_01'
+                }, {
+                    id: 'layer_02',
+                    title: 'title_02'
+                }]
+            },
+            maptype: {
+                mapType: 'openlayers'
+            }
+        });
+        const GroupNode = ({ node }) => {
+            return <div className="custom-group-node">{node.title}</div>;
+        };
+        const WrappedPlugin = dndContext(Plugin);
+        ReactDOM.render(<WrappedPlugin
+            groupNodeComponent={GroupNode}/>, document.getElementById("container"));
+        const groupNodes = document.querySelectorAll('.custom-group-node');
+        expect(groupNodes.length).toBe(1);
+        const [ groupNode ] = groupNodes;
+        expect(groupNode.innerHTML).toBe('Default');
+    });
+    it('TOCPlugin use custom layer node', () => {
+        const { Plugin } = getPluginForTest(TOCPlugin, {
+            layers: {
+                groups: [{
+                    expanded: true,
+                    id: 'Default',
+                    name: 'Default',
+                    nodes: [ 'layer_01', 'layer_02' ],
+                    title: 'Default'
+                }],
+                flat: [{
+                    id: 'layer_01',
+                    title: 'title_01'
+                }, {
+                    id: 'layer_02',
+                    title: 'title_02'
+                }]
+            },
+            maptype: {
+                mapType: 'openlayers'
+            }
+        });
+        const LayerNode = ({ node }) => {
+            return <div className="custom-layer-node">{node.dummy ? 'dummy' : node.title}</div>;
+        };
+        const WrappedPlugin = dndContext(Plugin);
+        ReactDOM.render(<WrappedPlugin
+            layerNodeComponent={LayerNode}/>, document.getElementById("container"));
+        const groupNodes = document.querySelectorAll('.custom-layer-node');
+        expect(groupNodes.length).toBe(3);
+        const [ layerNode01, layerNode02, layerNodeDummy ] = groupNodes;
+        expect(layerNode01.innerHTML).toBe('title_01');
+        expect(layerNode02.innerHTML).toBe('title_02');
+        expect(layerNodeDummy.innerHTML).toBe('dummy');
+    });
 });


### PR DESCRIPTION
## Description
Introduced the possibility to use custom group and layer nodes in TOC plugin.
Replaced `.flat()` with `lodash/flatten` to avoid error in Edge browser.

## Issues
 - #4461

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature


**What is the current behavior?** (You can also link to an open issue here)
#4461

**What is the new behavior?**
use case:
```js
import { TOCPlugin as ImportedTOCPlugin } from '@mapstore/plugins/TOC';
import GroupNode from '../components/GroupNode';
import LayerNode from '../components/LayerNode';

function TOCPlugin({ props }) {
    return (
        <ImportedTOCPlugin
            {...props}
            groupNodeComponent={GroupNode}
            layerNodeComponent={LayerNode}/>
    );
}

```

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
