### PR TITLE
Fixed StandardContainer rendering in Ms2 jsapi

### DIFF
--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -167,15 +167,15 @@ const MapStore2 = {
         const {loadVersion} = require('../actions/version');
         const {versionSelector} = require('../selectors/version');
         const {loadAfterThemeSelector} = require('../selectors/config');
-
+        const componentConfig = {
+            component: component || embedded,
+            config: {
+                pluginsConfig: options.plugins || defaultPlugins
+            }
+        };
         const StandardContainer = connect((state) => ({
             locale: state.locale || {},
-            componentConfig: {
-                component: component || embedded,
-                config: {
-                    pluginsConfig: options.plugins || defaultPlugins
-                }
-            },
+            componentConfig,
             version: versionSelector(state),
             loadAfterTheme: loadAfterThemeSelector(state)
         }))(require('../components/app/StandardContainer'));


### PR DESCRIPTION
## Description
With Chrome (78.0.3904.87) Ms2-geonode integration has become unsable,
on any state change all the app is rerndered starting from the StandardContainer.
This pull fixes the function that connect the to the component.
Has to be backported in 2019.02.xx

## Issues
 - #4455
 - ...

**Please check if the PR fulfills these #4455 rements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Continuos rerendering of standarcontainer

**What is the new behavior?**
Fixed

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
