### PR TITLE
Problems in switch/exit fullscreen (browser related) #4324

### DIFF
--- a/web/client/epics/__tests__/fullscreen-test.js
+++ b/web/client/epics/__tests__/fullscreen-test.js
@@ -15,7 +15,7 @@ const {toggleFullscreen} = require('../../actions/fullscreen');
 const {SET_CONTROL_PROPERTY} = require('../../actions/controls');
 const screenfull = require('screenfull');
 
-const {toggleFullscreenEpic } = require('../fullscreen');
+const {toggleFullscreenEpic} = require('../fullscreen');
 const rootEpic = combineEpics(toggleFullscreenEpic);
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const mockStore = configureMockStore([epicMiddleware]);

--- a/web/client/epics/fullscreen.js
+++ b/web/client/epics/fullscreen.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const screenfull = require('screenfull');
+const {head, last} = require('lodash');
 const {setControlProperty} = require('../actions/controls');
 const {TOGGLE_FULLSCREEN} = require('../actions/fullscreen');
 const ConfigUtils = require('../utils/ConfigUtils');
@@ -19,8 +20,7 @@ const getFullScreenEvent = () => {
         ['mozCancelFullScreen', 'mozfullscreenchange'],
         ['msExitFullscreen', 'MSFullscreenChange']
     ];
-    const event = candidates.find(c => document[c[0]]);
-    return event && event[1];
+    return last(head(candidates.filter((c) => document[c[0]])));
 };
 /**
  * Gets every `TOGGLE_FULLSCREEN` event.

--- a/web/client/epics/fullscreen.js
+++ b/web/client/epics/fullscreen.js
@@ -19,7 +19,8 @@ const getFullScreenEvent = () => {
         ['mozCancelFullScreen', 'mozfullscreenchange'],
         ['msExitFullscreen', 'MSFullscreenChange']
     ];
-    return candidates.filter((c) => document[c[0]]).reduce( eventMapping => eventMapping && eventMapping[1] );
+    const event = candidates.find(c => document[c[0]]);
+    return event && event[1];
 };
 /**
  * Gets every `TOGGLE_FULLSCREEN` event.


### PR DESCRIPTION
## Description
Contains a fix for a chrome specific problem. Concerning F11 fullscreen, it seems that it is not part of Fullscreen API and thus there is no supported way of detecting that browser is in fullscreen or going back from fullscreen in this case. Fullscreen button in Safari is hidden on purpose with a stated reason that Fullscreen API in Safari is not fully supported. Looks like [not much has changed](https://caniuse.com/#feat=fullscreen) on that front, so it probably should stay disabled.(the button was disabled in [this pull request](https://github.com/geosolutions-it/MapStore2/pull/2166)).

## Issues
 - #4324 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No