### PR TITLE
Fix 4476 add css style to userguide images

### DIFF
--- a/docs/theme/css/extra.css
+++ b/docs/theme/css/extra.css
@@ -67,3 +67,15 @@ li.md-tabs__item:hover{
 .rst-other-versions dl:nth-child(3), .rst-other-versions dl:nth-child(4) {
     display: none;
 }
+.ms-docimage {
+    display: block; 
+    margin-left: auto; 
+    margin-right: auto; 
+    box-shadow: 4px 4px 4px #cccccc, -.5px -.5px 4px #cccccc;
+    -moz-box-shadow: 4px 4px 4px #cccccc, -.5px -.5px 4px #cccccc;
+    -moz-box-shadow: 4px 4px 4px #cccccc, -.5px -.5px 4px #cccccc;
+}
+.ms-docbutton {
+    vertical-align: middle;
+    width: 30px;
+}


### PR DESCRIPTION
## Description
Two images classes defined with common style
- a class for images between paragraphs
- a class for button images inside the text

## Issues
 - #4476 

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [X] Other... Please describe: documentation