### PR TITLE
Fix 4299 custom crs error

### DIFF
--- a/web/client/components/errors/ResourceUnavailable.jsx
+++ b/web/client/components/errors/ResourceUnavailable.jsx
@@ -31,14 +31,14 @@ const HTML = require('../I18N/HTML');
 
 const ResourceUnavailable = emptyState(
     ({enabled, login, status, alwaysVisible}) => enabled && alwaysVisible || enabled && login || enabled && status !== 403,
-    ({status, mode = 'map', glyphs = {map: '1-map', dashboard: 'dashboard'}, errorMessage, showHomeButton, homeButton}) => ({
+    ({status, mode = 'map', glyphs = {map: '1-map', dashboard: 'dashboard'}, errorMessage, errorMessageParams, showHomeButton, homeButton}) => ({
         glyph: glyphs[mode] || '1-map',
         title: status === 403 && <Message msgId={`${mode}.errors.loading.notAccessible`} />
         || status === 404 && <Message msgId={`${mode}.errors.loading.notFound`} />
         || <Message msgId={`${mode}.errors.loading.title`} />,
         description: (
             <div className="text-center">
-                {errorMessage && <Message msgId={errorMessage} />
+                {errorMessage && <Message msgId={errorMessage} msgParams={errorMessageParams} />
                 || <HTML msgId={`${mode}.errors.loading.unknownError`} />}
             </div>
         ),

--- a/web/client/components/map/BaseMap.jsx
+++ b/web/client/components/map/BaseMap.jsx
@@ -37,6 +37,7 @@ class BaseMap extends React.Component {
         eventHandlers: PropTypes.object,
         styleMap: PropTypes.object,
         layers: PropTypes.array,
+        projectionDefs: PropTypes.array,
         plugins: PropTypes.any,
         tools: PropTypes.array,
         getLayerProps: PropTypes.func
@@ -48,6 +49,7 @@ class BaseMap extends React.Component {
         map: {},
         styleMap: {},
         tools: [],
+        projectionDefs: [],
         eventHandlers: {
             onMapViewChanges: () => {},
             onClick: () => {},
@@ -73,7 +75,7 @@ class BaseMap extends React.Component {
     };
 
     renderLayers = () => {
-        const projection = this.props.map.projection || 'EPSG:3857';
+        const projection = this.props.map && this.props.map.projection || "EPSG:3857";
         const { plugins } = this.props;
         const { Layer } = plugins;
         return this.props.layers.map((layer, index) => {
@@ -125,9 +127,11 @@ class BaseMap extends React.Component {
     render() {
         const {plugins} = this.props;
         const {Map} = plugins;
+        const projection = this.props.map && this.props.map.projection || "EPSG:3857";
         if (this.props.map) {
             return (
                 <Map
+                    projectionDefs={this.props.projectionDefs}
                     style={this.props.styleMap}
                     id={this.props.id}
                     zoomControl={false}
@@ -136,6 +140,7 @@ class BaseMap extends React.Component {
                     mapStateSource={this.props.mapStateSource || this.props.id}
                     {...this.props.options}
                     {...this.props.map}
+                    projection={projection}
                     {...this.props.eventHandlers}
                 >
                     {this.renderLayers()}
@@ -146,4 +151,6 @@ class BaseMap extends React.Component {
         return null;
     }
 }
+
+
 module.exports = BaseMap;

--- a/web/client/components/map/enhancers/__tests__/handlingUnsupportedProjection-test.js
+++ b/web/client/components/map/enhancers/__tests__/handlingUnsupportedProjection-test.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import expect from 'expect';
+import ReactDOM from 'react-dom';
+const {createSink} = require('recompose');
+
+import {handlingUnsupportedProjection} from '../handlingUnsupportedProjection';
+
+describe('handlingUnsupportedProjection enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('handlingUnsupportedProjection for unsupported projection', () => {
+        const Sink = handlingUnsupportedProjection(createSink());
+        ReactDOM.render(<Sink projection="EPSG:31468" />, document.getElementById("container"));
+        const title = document.querySelector("h1 span");
+        const description = document.querySelector(".empty-state-description span");
+        expect(title).toExist();
+        expect(title.innerText).toBe("map.errors.loading.title");
+        expect(description).toExist();
+        expect(description.innerText).toBe("map.errors.loading.projectionError");
+
+    });
+
+});

--- a/web/client/components/map/enhancers/getProjectionDefs.js
+++ b/web/client/components/map/enhancers/getProjectionDefs.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {withProps} from "recompose";
+import ConfigUtils from '../../../utils/ConfigUtils';
+import {isArray} from 'lodash';
+
+
+/**
+ * Fetches the projectionDefs from the configuration if they are not present
+ */
+export const getProjectionDefs = withProps(
+    ({projectionDefs}) => ({
+        projectionDefs: isArray(projectionDefs) && projectionDefs.length ?
+            projectionDefs :
+            ConfigUtils.getConfigProp("projectionDefs") || []
+    })
+);
+
+export default getProjectionDefs;

--- a/web/client/components/map/enhancers/handlingUnsupportedProjection.js
+++ b/web/client/components/map/enhancers/handlingUnsupportedProjection.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import {compose, withProps} from 'recompose';
+import emptyState from '../../misc/enhancers/emptyState';
+import Message from '../../I18N/Message';
+import React from 'react';
+import ConfigUtils from '../../../utils/ConfigUtils';
+
+/**
+ * @returns the map projection
+ */
+export const fetchingProjection = withProps(({map, projection}) => ({ projection: projection || (map.data && map.data.map ? map.data.map.projection : map && map.projection) }));
+
+/**
+ * @returns {function} An empty state component for the map if the projection is not supported
+ */
+export const handlingUnsupportedProjection = compose(
+    fetchingProjection,
+    emptyState(
+        ({projectionDefs = ConfigUtils.getConfigProp("projectionDefs") || [], projection}) => {
+            return projection && projectionDefs.concat([{code: "EPSG:4326"}, {code: "EPSG:3857"}, {code: "EPSG:900913"}]).filter(({code}) => code === projection).length === 0;
+        },
+        ({projection}) => ({
+            glyph: "1-map",
+            style: { width: "100%", height: "100%", display: "flex" },
+            title: <Message msgId="map.errors.loading.title"/>,
+            mainViewStyle: {margin: "auto"},
+            imageStyle: {height: 120, width: 120, margin: "auto"},
+            description: <Message msgId="map.errors.loading.projectionError" msgParams={{projection}}/>
+        })
+    )
+);

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -32,12 +32,13 @@ import throttle from 'lodash/throttle';
 import isArray from 'lodash/isArray';
 import isNil from 'lodash/isNil';
 
+
 import 'ol/ol.css';
 
 // add overrides for css
 import './mapstore-ol-overrides.css';
 
-export default class OpenlayersMap extends React.Component {
+class OpenlayersMap extends React.Component {
     static propTypes = {
         id: PropTypes.string,
         style: PropTypes.object,
@@ -567,3 +568,5 @@ export default class OpenlayersMap extends React.Component {
         });
     };
 }
+
+export default OpenlayersMap;

--- a/web/client/components/mediaEditor/map/MapPreview.jsx
+++ b/web/client/components/mediaEditor/map/MapPreview.jsx
@@ -11,7 +11,7 @@ import { applyDefaults, MediaTypes } from '../../../utils/GeoStoryUtils';
 import {defaultLayerMapPreview} from '../../../utils/MediaEditorUtils';
 
 import emptyState from '../../misc/enhancers/emptyState';
-import PreviewMap from '../../widgets/builder/wizard/map/PreviewMap';
+import MapView from '../../widgets/builder/wizard/map/PreviewMap';
 import { isEmpty } from 'lodash';
 
 const Preview = ({
@@ -19,7 +19,7 @@ const Preview = ({
 }) => {
     const { layers = [], mapOptions, ...m} = selectedItem.data ? selectedItem.data : selectedItem; // remove mapOptions to not override options
     return (
-        <PreviewMap
+        <MapView
             styleMap={{height: "100%"}}
             map={{...m, id: "map" + m.id}}
             id={"preview" + selectedItem.id}

--- a/web/client/components/misc/EmptyView.jsx
+++ b/web/client/components/misc/EmptyView.jsx
@@ -24,9 +24,10 @@ const FitIcon = require('./FitIcon');
  * @param  {string|node} [content]             Additional content for the empty view (e.g. buttons...)
  */
 module.exports = ({
-    style,
-    mainViewStyle,
-    contentStyle,
+    style = {},
+    mainViewStyle = {},
+    contentStyle = {},
+    imageStyle = {},
     glyph = "info-sign",
     iconFit,
     title,
@@ -38,7 +39,7 @@ module.exports = ({
     (<div className="empty-state-container" style={{height: iconFit ? "100%" : undefined, ...style}}>
         <div key="main-view" className="empty-state-main-view" style={{height: iconFit ? "100%" : undefined, ...mainViewStyle}} >
             {glyph
-                ? <div key="glyph" className="empty-state-image" style={{height: iconFit ? "100%" : undefined}}>
+                ? <div key="glyph" className="empty-state-image" style={{height: iconFit ? "100%" : undefined, ...imageStyle}}>
                     <FitIcon iconFit={iconFit} tooltip={tooltip} tooltipId={tooltipId} glyph={glyph} />
                 </div>
                 : null}

--- a/web/client/components/widgets/widget/MapView.jsx
+++ b/web/client/components/widgets/widget/MapView.jsx
@@ -8,13 +8,17 @@
 const autoMapType = require('../../map/enhancers/autoMapType');
 const mapType = require('../../map/enhancers/mapType');
 const autoResize = require('../../map/enhancers/autoResize');
+const getProjectionDefs = require('../../map/enhancers/getProjectionDefs').default;
 const onMapViewChanges = require('../../map/enhancers/onMapViewChanges');
 const {compose} = require('recompose');
+const { handlingUnsupportedProjection } = require('../../map/enhancers/handlingUnsupportedProjection');
+
 module.exports = compose(
     onMapViewChanges,
     autoResize(0),
     autoMapType,
-    mapType
-
+    mapType,
+    getProjectionDefs,
+    handlingUnsupportedProjection
 )(require('../../map/BaseMap'));
 

--- a/web/client/components/widgets/widget/MapWidget.jsx
+++ b/web/client/components/widgets/widget/MapWidget.jsx
@@ -13,7 +13,6 @@ const MapView = withHandlers({
     onMapViewChanges: ({ updateProperty = () => { } }) => map => updateProperty('map', map)
 })(require('./MapView'));
 
-
 module.exports = ({
     updateProperty = () => { },
     toggleDeleteConfirm = () => { },
@@ -30,5 +29,12 @@ module.exports = ({
         icons={icons}
         topRightItems={topRightItems}
     >
-        <MapView updateProperty={updateProperty} id={id} map={omit(map, 'mapStateSource')} mapStateSource={mapStateSource} layers={map && map.layers} options={{ style: { margin: 10, height: 'calc(100% - 20px)' }}}/>
+        <MapView
+            updateProperty={updateProperty}
+            id={id}
+            map={omit(map, 'mapStateSource')}
+            mapStateSource={mapStateSource}
+            layers={map && map.layers}
+            options={{ style: { margin: 10, height: 'calc(100% - 20px)' }}}
+        />
     </WidgetContainer>);

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -40,6 +40,19 @@ describe('config epics', () => {
                 checkActions
             );
         });
+        it('load existing configuration file, with unsupported projection 31468', (done) => {
+            const checkActions = ([a]) => {
+                expect(a).toExist();
+                expect(a.type).toBe(MAP_CONFIG_LOAD_ERROR);
+                expect(a.error).toEqual({errorMessageParams: {projection: "EPSG:31468"}, messageId: "map.errors.loading.projectionError"});
+                done();
+            };
+            testEpic(loadMapConfigAndConfigureMap,
+                1,
+                [loadMapConfig('base/web/client/test-resources/testConfigEPSG31468.json')],
+                checkActions
+            );
+        });
         it('load existing configuration file with mapId', (done) => {
             const checkActions = ([a, b]) => {
                 expect(a).toExist();

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -7,6 +7,7 @@
  */
 import {Observable} from 'rxjs';
 import axios from '../libs/ajax';
+import {get} from 'lodash';
 import {
     LOAD_MAP_CONFIG,
     LOAD_MAP_INFO,
@@ -18,13 +19,19 @@ import {
     loadMapInfo
 } from '../actions/config';
 import Persistence from '../api/persistence';
+import {projectionDefsSelector} from '../selectors/map';
 
-export const loadMapConfigAndConfigureMap = action$ =>
+export const loadMapConfigAndConfigureMap = (action$, {getState = () => {}} = {}) =>
     action$.ofType(LOAD_MAP_CONFIG)
         .switchMap( ({configName, mapId}) =>
             Observable.defer(() => axios.get(configName))
                 .switchMap(response => {
                     if (typeof response.data === 'object') {
+                        const projectionDefs = projectionDefsSelector(getState());
+                        const projection = get(response, "data.map.projection", "EPSG:3857");
+                        if (projectionDefs.concat([{code: "EPSG:4326"}, {code: "EPSG:3857"}, {code: "EPSG:900913"}]).filter(({code}) => code === projection).length === 0) {
+                            return Observable.of(configureError({messageId: `map.errors.loading.projectionError`, errorMessageParams: {projection}}, mapId));
+                        }
                         return mapId ? Observable.of(configureMap(response.data, mapId), loadMapInfo(mapId)) :
                             Observable.of(configureMap(response.data, mapId));
                     }

--- a/web/client/plugins/FeedbackMask.jsx
+++ b/web/client/plugins/FeedbackMask.jsx
@@ -23,12 +23,13 @@ const feedbackMaskPluginSelector = createSelector([
     feedbackMaskSelector,
     isLoggedIn,
     state => !get(state, 'security')
-], ({loading, enabled, status, mode, errorMessage}, login, alwaysVisible) => ({
+], ({loading, enabled, status, mode, errorMessage, errorMessageParams}, login, alwaysVisible) => ({
     loading,
     enabled,
     status,
     mode,
     errorMessage,
+    errorMessageParams,
     login,
     alwaysVisible,
     showHomeButton: !alwaysVisible

--- a/web/client/reducers/feedbackMask.js
+++ b/web/client/reducers/feedbackMask.js
@@ -19,7 +19,8 @@ function feedbackMask(state = {}, action) {
             ...state,
             enabled: action.enabled,
             status: action.error && action.error.status,
-            errorMessage: action.error && action.error.messageId
+            errorMessage: action.error && action.error.messageId,
+            errorMessageParams: action.error && action.error.errorMessageParams
         };
     case DETECTED_NEW_PAGE:
         return {

--- a/web/client/test-resources/testConfigEPSG31468.json
+++ b/web/client/test-resources/testConfigEPSG31468.json
@@ -1,0 +1,21 @@
+{
+	"map": {
+		"projection": "EPSG:31468",
+		"units": "m",
+		"center": {"x": 1250000.000000, "y": 5370000.000000, "crs": "EPSG:900913"},
+		"zoom":5,
+		"maxExtent": [
+			-20037508.34, -20037508.34,
+			20037508.34, 20037508.34
+		],
+		"layers": [
+			{
+				"type": "osm",
+				"title": "Open Street Map",
+				"name": "mapnik",
+				"group": "background",
+        "visibility": true
+			}
+		]
+	}
+}

--- a/web/client/themes/default/less/media-editor.less
+++ b/web/client/themes/default/less/media-editor.less
@@ -1,6 +1,12 @@
 @ms-story-bg: @ms2-color-background;
 
 .ms-mediaEditor {
+    .empty-state-container {
+        position: relative;
+        .empty-state-main-view .empty-state-description {
+            text-align: center;
+        }
+    }
     /* render the scrollbar on the list */
     .ms-mediaList {
         display: flex;

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -388,6 +388,7 @@
                     "notFound": "Karte nicht gefunden",
                     "notAccessible": "Karte nicht zugänglich",
                     "unknownError": "<p> <small> Einer der folgenden Gründe könnte die Ursache sein: </small> <ul><li> Sie haben keine Zugriffsberechtigung </li> <li> Sie versuchen, auf eine nicht vorhandene Map zuzugreifen </li> <li> Die Karte wurde entfernt </li> <li>Die Projektion der Karte ist nicht konfiguriert</li></ul> <p>",
+                    "projectionError": "Die Projektion {projection} der Karte ist nicht konfiguriert",
                     "title" : "Karte kann nicht angezeigt werden"
                 }
             }

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -388,6 +388,7 @@
                     "notFound": "Map not found",
                     "notAccessible": "Map not accessible",
                     "unknownError": "<p><small>One of the following reason could be the cause:</small> <ul><li>you don't have permission to access</li> <li>you are trying to access a map that doesn't exist</li> <li>the map has been removed</li> <li>the projection of the map is not configured</li></ul> <p>",
+                    "projectionError": "The projection {projection} of the map is not configured",
                     "title" : "Map cannot be viewed"
                 }
             }

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -388,6 +388,7 @@
                     "notFound": "Mapa no encontrado",
                     "notAccessible": "Mapa no accesible",
                     "unknownError": "<p> <small> Uno de los siguientes motivos podría ser la causa: </small> <ul><li> no tiene permiso para acceder </li> <li> está intentando acceder a un mapa que no existe </li> <li> el mapa se ha eliminado </li> <li>La proyección del mapa no está configurada </li></ul> <p>",
+                    "projectionError": "La proyección {projection} del mapa no está configurada",
                     "title" : "El mapa no se puede ver"
                 }
             }

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -388,6 +388,7 @@
                     "notFound": "Carte introuvable",
                     "notAccessible": "Carte non accessible",
                     "unknownError": "<p> <small> L'une des raisons suivantes pourrait être la cause: </small> <ul><li> vous n'avez pas la permission d'accéder à </li> <li> vous essayez d'accéder à une carte qui n'existe pas </li> <li> la carte a été supprimée </li> <li>the projection of the map is not configured</li></ul> <p>",
+                    "projectionError": "La projection {projection} de la carte n'est pas configurée",
                     "title" : "La carte ne peut pas être vue"
                 }
             }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -388,6 +388,7 @@
                     "notFound": "Mappa non trovata",
                     "notAccessible": "Mappa non accessibile",
                     "unknownError": "<p> <small> Uno dei seguenti motivi potrebbe essere la causa: </small> <ul><li> non hai il permesso di accedere </li> <li> stai cercando di accedere a una mappa che non esiste </li> <li> la mappa è stata rimossa </li> <li>la proiezione della mappa non è configurata</li></ul> <p>",
+                    "projectionError": "La proiezione {projection} della mappa non è stata configurata",
                     "title" : "La mappa non può essere visualizzata"
                 }
             }

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -32,6 +32,7 @@ let defaultConfig = {
     geoStoreUrl: "/mapstore/rest/geostore/",
     printUrl: "/mapstore/print/info.json",
     translationsPath: "translations",
+    projectionDefs: [],
     themePrefix: "ms2",
     bingApiKey: null,
     mapquestApiKey: null

--- a/web/client/utils/openlayers/__tests__/projUtils-test.js
+++ b/web/client/utils/openlayers/__tests__/projUtils-test.js
@@ -7,7 +7,8 @@
  */
 
 import expect from 'expect';
-import projUtils from '../projUtils';
+import { addProjections, fallbackToSupportedProjection } from '../projUtils';
+
 import {get} from 'ol/proj';
 
 const SAMPLE_PROJECTION = {
@@ -29,15 +30,21 @@ const SAMPLE_PROJECTION = {
 
 describe('projUtils', () => {
     it('axis orientation', () => {
-        projUtils.addProjections(SAMPLE_PROJECTION.code, SAMPLE_PROJECTION.extent, SAMPLE_PROJECTION.worldExtent, "neu", "m");
+        addProjections(SAMPLE_PROJECTION.code, SAMPLE_PROJECTION.extent, SAMPLE_PROJECTION.worldExtent, "neu", "m");
         const prj = get(SAMPLE_PROJECTION.code);
         expect(prj).toExist();
         expect(prj.getAxisOrientation()).toBe("neu");
     });
     it('units', () => {
-        projUtils.addProjections(SAMPLE_PROJECTION.code, SAMPLE_PROJECTION.extent, SAMPLE_PROJECTION.worldExtent, "enu", "m");
+        addProjections(SAMPLE_PROJECTION.code, SAMPLE_PROJECTION.extent, SAMPLE_PROJECTION.worldExtent, "enu", "m");
         const prj = get(SAMPLE_PROJECTION.code);
         expect(prj).toExist();
         expect(prj.getUnits()).toBe("m");
+    });
+    it('test fallbackToSupportedProjection with unsupported custom crs', () => {
+        expect(fallbackToSupportedProjection([], "EPSG:31468")).toEqual("EPSG:3857");
+    });
+    it('test fallbackToSupportedProjection with supported custom crs', () => {
+        expect(fallbackToSupportedProjection([{code: "EPSG:31468"}], "EPSG:31468")).toEqual("EPSG:31468");
     });
 });

--- a/web/client/utils/openlayers/projUtils.js
+++ b/web/client/utils/openlayers/projUtils.js
@@ -7,19 +7,31 @@
  */
 
 import {addProjection, Projection} from 'ol/proj';
-export default {
+import ConfigUtils from '../ConfigUtils';
 
-    /**
-    * function needed in openlayer for adding new projection
-    */
-    addProjections: function(code, extent, worldExtent, axisOrientation, units) {
-        addProjection(new Projection({
-            code,
-            extent,
-            worldExtent,
-            axisOrientation,
-            units
-        })
-        );
-    }
+/**
+ * function needed in openlayers for adding new projection
+ */
+export const addProjections = function(code, extent, worldExtent, axisOrientation, units) {
+    addProjection(new Projection({
+        code,
+        extent,
+        worldExtent,
+        axisOrientation,
+        units
+    })
+    );
+};
+/**
+ * @returns {string} the default projection EPSG:3857 if no custom projectionDefs are defined
+ */
+export const fallbackToSupportedProjection = (projectionDefs = ConfigUtils.getConfigProp("projectionDefs") || [], projection) => {
+    const codes = (projectionDefs.length && projectionDefs.map(({code})  => code) || []).concat(["EPSG:4326", "EPSG:3857", "EPSG:900913"]);
+    return codes.filter(c => c === projection).length ? projection : "EPSG:3857";
+};
+
+
+export default {
+    addProjections,
+    fallbackToSupportedProjection
 };


### PR DESCRIPTION
## Description
The problem when a map is configured to use a custom projection not supported by default has been fixed.

[EDIT] Actually it prevents to render any map if the projection is not supported

For maps in the viewer it show a custom error for the projection (try to load [this](https://dev.mapstore.geo-solutions.it/mapstore/#/viewer/openlayers/10858) map )


## Issues
 - #4299

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
red page error when selecting stories with map terrestis, dashboard with map terrestris  or the map terrestris itself which has EPSG:31468 as configured projection

**What is the new behavior?**
if in the projectionDefs does not contain EPSG:31468 then a mask appear
![image](https://user-images.githubusercontent.com/11991428/68692048-17648e80-0575-11ea-9267-5ec362dbfeb7.png)
![image](https://user-images.githubusercontent.com/11991428/68692067-1f243300-0575-11ea-90c7-0e9f214240ee.png)


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
