### PR TITLE
Fix 4274 Annotations circle has problem with radius

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -421,7 +421,7 @@ export default class DrawSupport extends React.Component {
                     // TODO verify center is projected in 4326 and is an array
                     center = reproject(center, this.getMapCrs(), "EPSG:4326", false);
                     const originalId = newProps && newProps.features && newProps.features.length && newProps.features[0] && newProps.features[0].features && newProps.features[0].features.length && newProps.features[0].features.filter(f => f.properties.isDrawing)[0].properties.id || id;
-                    newFeature.setProperties({isCircle: true, radius, center: [center.x, center.y], id: originalId});
+                    newFeature.setProperties({isCircle: true, radius, center: [center.x, center.y], id: originalId, crs: this.getMapCrs()});
                 } else if (drawMethod === "Polygon") {
                     newDrawMethod = this.props.drawMethod;
                     let coordinates = drawnGeom.getCoordinates();

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -1377,6 +1377,41 @@ describe('Test the annotations reducer', () => {
         expect(state.selected.geometry.coordinates[0]).toBe(1);
         expect(state.selected.geometry.coordinates[1]).toBe(1);
     });
+    it('changeSelected, changing coords of a Circle Feature', () => {
+        const selected = {
+            properties: {
+                canEdit: true,
+                center: [-6.576492309570317, 41.6007838467891],
+                id: "259d79d0-053e-11ea-b0b3-379d853a3ff4",
+                isCircle: true,
+                isValidFeature: true,
+                radius: 3567
+            },
+            geometry: {
+                type: "Circle",
+                coordinates: [-6.576492309570317, 41.6007838467891]
+            }
+        };
+        const featureColl = {
+            type: "FeatureCollection",
+            features: [selected],
+            tempFeatures: [],
+            properties: {
+                id: '1asdfads'
+            },
+            style: {}
+        };
+        const coordinates = [[1, 1]];
+        const state = annotations({
+            editing: featureColl,
+            selected,
+            featureType: "Text",
+            unsavedGeometry: true
+        }, changeSelected(coordinates, 3567));
+        expect(state.selected.geometry.type).toBe("Circle");
+        expect(state.selected.geometry.coordinates[0]).toBe(1);
+        expect(state.selected.geometry.coordinates[1]).toBe(1);
+    });
     it('UPDATE_SYMBOLS', () => {
         let annotationsState = annotations({}, updateSymbols());
         expect(annotationsState.symbolList.length).toBe(0);

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -93,6 +93,7 @@ function annotations(state = { validationErrors: {} }, action) {
                 // polygonGeom setting
             if (validateCoordsArray(selected.properties.center)) {
                 center = selected.properties.center;
+                // turf/circle by default use km unit hence we divide by 1000 the radius(in meters)
                 c = circle(center, radius / 1000, { steps: 100 }).geometry;
             } else {
                 selected = set("properties.center", [], selected);

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -93,7 +93,7 @@ function annotations(state = { validationErrors: {} }, action) {
                 // polygonGeom setting
             if (validateCoordsArray(selected.properties.center)) {
                 center = selected.properties.center;
-                c = circle(center, radius * 1000, { steps: 100 }).geometry;
+                c = circle(center, radius / 1000, { steps: 100 }).geometry;
             } else {
                 selected = set("properties.center", [], selected);
             }
@@ -233,7 +233,7 @@ function annotations(state = { validationErrors: {} }, action) {
 
         // need to change the polygon coords after radius changes
         // but this implementation is ugly. is using openlayers to do that and maybe we need to refactor this
-        let feature = circle(selected.properties.center, action.radius * 1000, { steps: 100 });
+        let feature = circle(selected.properties.center, action.radius / 1000, { steps: 100 });
         selected = set("properties.polygonGeom", feature.geometry, selected);
 
         let ftChangedIndex = findIndex(state.editing.features, (f) => f.properties.id === state.selected.properties.id);

--- a/web/client/utils/openlayers/DrawSupportUtils.js
+++ b/web/client/utils/openlayers/DrawSupportUtils.js
@@ -41,7 +41,7 @@ export const transformPolygonToCircle = (feature, mapCrs, coordinateCrs = mapCrs
         } else {
             center = getCenter(extent);
         }
-        const radius = calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, coordinateCrs);
+        const radius = feature.getProperties().radius || calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, coordinateCrs);
         feature.setGeometry(new Circle(center, radius));
         return feature;
     }

--- a/web/client/utils/openlayers/DrawSupportUtils.js
+++ b/web/client/utils/openlayers/DrawSupportUtils.js
@@ -41,7 +41,8 @@ export const transformPolygonToCircle = (feature, mapCrs, coordinateCrs = mapCrs
         } else {
             center = getCenter(extent);
         }
-        const radius = feature.getProperties().radius || calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, coordinateCrs);
+        // check if projection equal to the one used when drawing the circle
+        const radius = feature.getProperties().crs === mapCrs ? feature.getProperties().radius : calculateRadius(center, feature.getGeometry().getCoordinates(), mapCrs, coordinateCrs);
         feature.setGeometry(new Circle(center, radius));
         return feature;
     }

--- a/web/client/utils/openlayers/__tests__/DrawSupportUtils-test.js
+++ b/web/client/utils/openlayers/__tests__/DrawSupportUtils-test.js
@@ -21,7 +21,8 @@ describe('DrawSupportUtils openlayers', () => {
             isCircle: true,
             id: uuid.v1(),
             radius,
-            center: makePoint(reproject(center, crs, "EPSG:4326"))
+            center: makePoint(reproject(center, crs, "EPSG:4326")),
+            crs
         });
     };
 
@@ -85,5 +86,16 @@ describe('DrawSupportUtils openlayers', () => {
         const feature = new Feature({geometry: new Polygon([[1.0, 2.0], [-1.0, -1.0]])});
         const newFeature = transformPolygonToCircle(feature);
         expect(newFeature).toEqual(feature);
+    });
+
+    it('test transformPolygonToCircle when feature crs differ with mapCrs', () => {
+        const mapCrs = "EPSG:4326";
+        const coordinateCrs = "EPSG:3857";
+        const testFeature = makeTestFeature("EPSG:3857");
+        const newFeature = transformPolygonToCircle(testFeature, mapCrs, coordinateCrs);
+        expect(newFeature).toExist();
+        const geometry = newFeature.getGeometry();
+        expect(geometry).toBeA(Circle);
+        expect(numberToPrecision(geometry.getRadius())).toNotEqual(numberToPrecision(radius));
     });
 });


### PR DESCRIPTION
## Description
Fix annotations circle when changing radius or coordinates, a bug which caused by https://github.com/geosolutions-it/MapStore2/pull/4131. This PR restore some code which was removed by 4131 and apply fix which work for both 4274 and 3842

## Issues
 - #4274 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4274 

**What is the new behavior?**
The circle change smoothly

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
