### PR TITLE
#4489 Improved re-rendering of content toolbar for geostory

### DIFF
--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -9,82 +9,18 @@
 
 import React from "react";
 import Toolbar from '../../misc/toolbar/Toolbar';
-import ToolbarDropdownButton from '../common/ToolbarDropdownButton';
-import ToolbarButton from '../../misc/toolbar/ToolbarButton';
-import Message from '../../I18N/Message';
-import withConfirm from "../../misc/toolbar/withConfirm";
-const DeleteButton = withConfirm(ToolbarButton);
+import {SizeButtonToolbar, AlignButtonToolbar, ThemeButtonToolbar, DeleteButtonToolbar} from "./ToolbarButtons";
+
 const BUTTON_CLASSES = 'square-button-md no-border';
 const toolButtons = {
-    size: ({editMap: disabled = false, align, sectionType, size, update = () => {} }) => ({
-        Element: () => <ToolbarDropdownButton
-            value={size}
-            disabled={disabled}
-            glyph="resize-horizontal"
-            pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
-            tooltipId="geostory.contentToolbar.contentSize"
-            options={[{
-                value: 'small',
-                glyph: 'size-small',
-                label: <Message msgId="geostory.contentToolbar.smallSizeLabel"/>
-            }, {
-                value: 'medium',
-                glyph: 'size-medium',
-                label: <Message msgId="geostory.contentToolbar.mediumSizeLabel"/>
-            }, {
-                value: 'large',
-                glyph: 'size-large',
-                label: <Message msgId="geostory.contentToolbar.largeSizeLabel"/>
-            }, {
-                value: 'full',
-                glyph: 'size-extra-large',
-                label: <Message msgId="geostory.contentToolbar.fullSizeLabel"/>
-            }]}
-            onSelect={(selected) => update('size', selected)}/>
+    size: (props) => ({
+        renderButton: <SizeButtonToolbar {...props}/>
     }),
-    align: ({ editMap: disabled = false, size, align, sectionType, update = () => {} }) => ({
-        Element: () => <ToolbarDropdownButton
-            value={align}
-            disabled={size === 'full' || disabled}
-            glyph="align-center"
-            pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
-            tooltipId="geostory.contentToolbar.contentAlign"
-            options={[{
-                value: 'left',
-                label: <Message msgId="geostory.contentToolbar.leftAlignLabel"/>,
-                glyph: 'align-left'
-            }, {
-                value: 'center',
-                label: <Message msgId="geostory.contentToolbar.centerAlignLabel"/>,
-                glyph: 'align-center'
-            }, {
-                value: 'right',
-                label: <Message msgId="geostory.contentToolbar.rightAlignLabel"/>,
-                glyph: 'align-right'
-            }]}
-            onSelect={(selected) => update('align', selected)}/>
+    align: (props) => ({
+        renderButton: <AlignButtonToolbar {...props}/>
     }),
-    theme: ({ editMap: disabled = false, theme, align, sectionType, update = () => {}, fit, themeOptions, size }) => ({
-        Element: () => <ToolbarDropdownButton
-            value={theme}
-            pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
-            glyph="dropper"
-            tooltipId="geostory.contentToolbar.contentTheme"
-            disabled={fit === 'cover' && size === 'full' || disabled}
-            options={themeOptions || [{
-                value: 'bright',
-                label: <Message msgId="geostory.contentToolbar.brightThemeLabel"/>
-            }, {
-                value: 'bright-text',
-                label: <Message msgId="geostory.contentToolbar.brightTextThemeLabel"/>
-            }, {
-                value: 'dark',
-                label: <Message msgId="geostory.contentToolbar.darkThemeLabel"/>
-            }, {
-                value: 'dark-text',
-                label: <Message msgId="geostory.contentToolbar.darkTextThemeLabel"/>
-            }]}
-            onSelect={(selected) => update('theme', selected)}/>
+    theme: (props) => ({
+        renderButton: <ThemeButtonToolbar {...props}/>
     }),
     fit: ({editMap: disabled = false, fit, update = () => {} }) => ({
         // using normal ToolbarButton because this is a toggle button without options
@@ -115,18 +51,8 @@ const toolButtons = {
         }
     }),
     // remove content
-    remove: ({ editMap: disabled = false, path, remove = () => { } }) => ({
-        Element: () => (<DeleteButton
-            glyph={"trash"}
-            visible
-            disabled={disabled}
-            className={BUTTON_CLASSES}
-            tooltipId={"geostory.contentToolbar.remove"}
-            confirmTitle={<Message msgId="geostory.contentToolbar.removeConfirmTitle" />}
-            confirmContent={<Message msgId="geostory.contentToolbar.removeConfirmContent" />}
-            onClick={ () => {
-                remove(path);
-            }} />)
+    remove: (props) => ({
+        renderButton: <DeleteButtonToolbar {...props}/>
 
     }),
     editMap: ({editMap = false, update = () => {}}) => ({

--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -1,0 +1,108 @@
+
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
+import Message from '../../I18N/Message';
+import ToolbarButton from '../../misc/toolbar/ToolbarButton';
+import ToolbarDropdownButton from '../common/ToolbarDropdownButton';
+import withConfirm from "../../misc/toolbar/withConfirm";
+const DeleteButton = withConfirm(ToolbarButton);
+const BUTTON_CLASSES = 'square-button-md no-border';
+
+/**
+ * these components have been created because it was causing an excessive re-rendering
+ */
+
+export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {} }) =>
+    (<ToolbarDropdownButton
+        value={size}
+        disabled={disabled}
+        glyph="resize-horizontal"
+        pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
+        tooltipId="geostory.contentToolbar.contentSize"
+        options={[{
+            value: 'small',
+            glyph: 'size-small',
+            label: <Message msgId="geostory.contentToolbar.smallSizeLabel"/>
+        }, {
+            value: 'medium',
+            glyph: 'size-medium',
+            label: <Message msgId="geostory.contentToolbar.mediumSizeLabel"/>
+        }, {
+            value: 'large',
+            glyph: 'size-large',
+            label: <Message msgId="geostory.contentToolbar.largeSizeLabel"/>
+        }, {
+            value: 'full',
+            glyph: 'size-extra-large',
+            label: <Message msgId="geostory.contentToolbar.fullSizeLabel"/>
+        }]}
+        onSelect={(selected) => update('size', selected)}/>
+    );
+
+export const AlignButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {} }) =>
+    (<ToolbarDropdownButton
+        value={align}
+        disabled={size === 'full' || disabled}
+        glyph="align-center"
+        pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
+        tooltipId="geostory.contentToolbar.contentAlign"
+        options={[{
+            value: 'left',
+            label: <Message msgId="geostory.contentToolbar.leftAlignLabel"/>,
+            glyph: 'align-left'
+        }, {
+            value: 'center',
+            label: <Message msgId="geostory.contentToolbar.centerAlignLabel"/>,
+            glyph: 'align-center'
+        }, {
+            value: 'right',
+            label: <Message msgId="geostory.contentToolbar.rightAlignLabel"/>,
+            glyph: 'align-right'
+        }]}
+        onSelect={(selected) => update('align', selected)}/>
+    );
+
+export const ThemeButtonToolbar = ({editMap: disabled = false, theme, align, sectionType, update = () => {}, fit, themeOptions, size }) =>
+    (<ToolbarDropdownButton
+        value={theme}
+        pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
+        glyph="dropper"
+        tooltipId="geostory.contentToolbar.contentTheme"
+        disabled={fit === 'cover' && size === 'full' || disabled}
+        options={themeOptions || [{
+            value: 'bright',
+            label: <Message msgId="geostory.contentToolbar.brightThemeLabel"/>
+        }, {
+            value: 'bright-text',
+            label: <Message msgId="geostory.contentToolbar.brightTextThemeLabel"/>
+        }, {
+            value: 'dark',
+            label: <Message msgId="geostory.contentToolbar.darkThemeLabel"/>
+        }, {
+            value: 'dark-text',
+            label: <Message msgId="geostory.contentToolbar.darkTextThemeLabel"/>
+        }]}
+        onSelect={(selected) => update('theme', selected)}/>
+    );
+
+
+export const DeleteButtonToolbar = ({ editMap: disabled = false, path, remove = () => { } }) =>
+    (<DeleteButton
+        glyph={"trash"}
+        visible
+        disabled={disabled}
+        className={BUTTON_CLASSES}
+        tooltipId={"geostory.contentToolbar.remove"}
+        confirmTitle={<Message msgId="geostory.contentToolbar.removeConfirmTitle" />}
+        confirmContent={<Message msgId="geostory.contentToolbar.removeConfirmContent" />}
+        onClick={ () => {
+            remove(path);
+        }} />
+    );

--- a/web/client/components/geostory/contents/__tests__/Column-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/Column-test.jsx
@@ -41,27 +41,34 @@ describe('Column component', () => {
         const el = container.querySelector('.add-bar');
         expect(el).toExist();
     });
-    it('Column contents has proper toolbars', () => {
-        // text content should contain only delete button
-        ReactDOM.render(<Column mode={Modes.EDIT} contents={[{ type: ContentTypes.TEXT, html: '<p id="TEST_HTML">something</p>' }]} />, document.getElementById("container"));
-        const textToolbar = document.querySelector('.ms-content-toolbar .btn-group');
-        expect(textToolbar).toExist();
-        expect(textToolbar.querySelectorAll('button').length).toBe(1);
-        expect(textToolbar.querySelector('button .glyphicon-trash')).toExist(); // align tool
+    describe('Column contents has proper toolbars', () => {
+        it('text', () => {
+            // text content should contain only delete button
+            ReactDOM.render(<Column mode={Modes.EDIT} contents={[{ type: ContentTypes.TEXT, html: '<p id="TEST_HTML">something</p>' }]} />, document.getElementById("container"));
+            const textToolbar = document.querySelector('.ms-content-toolbar .btn-group');
+            expect(textToolbar).toExist();
+            expect(textToolbar.querySelectorAll('button').length).toBe(1);
+            expect(textToolbar.querySelector('button .glyphicon-trash')).toExist(); // align tool
+        });
+        it('media', () => {
+            // media and image contents must have edit, resize and align tools
+            ReactDOM.render(<Column mode={Modes.EDIT} contents={[{ type: ContentTypes.MEDIA }]} />, document.getElementById("container"));
+            let mediaToolbar = document.querySelector('.ms-content-toolbar .btn-group');
+            expect(mediaToolbar).toExist();
 
-        // media and image contents must have edit, resize and align tools
-        ReactDOM.render(<Column mode={Modes.EDIT} contents={[{ type: ContentTypes.MEDIA }]} />, document.getElementById("container"));
-        let mediaToolbar = document.querySelector('.ms-content-toolbar .btn-group');
-        expect(mediaToolbar).toExist();
-        // TODO:  check (empty) media button (Should be type: media)
-        // image contents must have edit, resize align and delete tools
-        ReactDOM.render(<Column mode={Modes.EDIT} contents={[{ type: MediaTypes.IMAGE }]} />, document.getElementById("container"));
-        mediaToolbar = document.querySelector('.ms-content-toolbar .btn-group');
-        expect(mediaToolbar).toExist();
-        expect(mediaToolbar.querySelectorAll('button').length).toBe(4);
-        expect(mediaToolbar.querySelector('button .glyphicon-pencil')).toExist(); // edit tool
-        expect(mediaToolbar.querySelector('button .glyphicon-resize-horizontal')).toExist(); // resize tool
-        expect(mediaToolbar.querySelector('button .glyphicon-align-center')).toExist(); // align tool
-        expect(mediaToolbar.querySelector('button .glyphicon-trash')).toExist(); // delete tool
+        });
+        it('image', () => {
+            // TODO:  check (empty) media button (Should be type: media)
+            // image contents must have edit, resize align and delete tools
+            ReactDOM.render(<Column mode={Modes.EDIT} contents={[{ type: MediaTypes.IMAGE }]} />, document.getElementById("container"));
+            let mediaToolbar = document.querySelector('.ms-content-toolbar .btn-group');
+            expect(mediaToolbar).toExist();
+            const buttons = mediaToolbar.querySelectorAll('.ms-content-toolbar .btn-group button');
+            expect(buttons.length).toBe(4);
+            expect(mediaToolbar.querySelector('button .glyphicon-pencil')).toExist(); // edit tool
+            expect(mediaToolbar.querySelector('button .glyphicon-resize-horizontal')).toExist(); // resize tool
+            expect(mediaToolbar.querySelector('button .glyphicon-align-center')).toExist(); // align tool
+            expect(mediaToolbar.querySelector('button .glyphicon-trash')).toExist(); // delete tool
+        });
     });
 });

--- a/web/client/components/misc/toolbar/Toolbar.jsx
+++ b/web/client/components/misc/toolbar/Toolbar.jsx
@@ -34,8 +34,8 @@ module.exports = ({
         transitionLeaveTimeout: 300
     }} = {}) => {
     const renderButtons = () => buttons.map(
-        ({ visible = true, Element, ...props }, index) => visible
-            ? (Element && <Element key={props.key || index} {...props} /> || <ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />)
+        ({ visible = true, Element, renderButton, ...props }, index) => visible
+            ? (renderButton ? renderButton : (Element && <Element key={props.key || index} {...props} /> || <ToolbarButton key={props.key || index} {...btnDefaultProps} {...props} />))
             : null
     );
     return (<ButtonGroup {...btnGroupProps}>

--- a/web/client/components/misc/toolbar/withConfirm.jsx
+++ b/web/client/components/misc/toolbar/withConfirm.jsx
@@ -10,6 +10,8 @@ import React from 'react';
 import Confirm from '../ConfirmDialog';
 import Portal from '../Portal';
 import Message from '../../I18N/Message';
+import { compose, withHandlers, withState, withProps, nest} from 'recompose';
+
 const ConfirmModal = ({
     confirmYes = <Message msgId="yes" />,
     confirmNo = <Message msgId="no"/>,
@@ -35,9 +37,6 @@ const ConfirmModal = ({
         {confirmContent}
     </Confirm>
 </Portal>);
-
-
-import { compose, withHandlers, withState, withProps, nest} from 'recompose';
 
 const withChildren = (...children) => mainComponent => nest(mainComponent, ...children);
 /**


### PR DESCRIPTION
## Description
improving re-render of content toolbar, now it does not re-render on scroll event

## Issues
 - #4489

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
No more re-rendering of toolbars and also improving re-rendering of confirm modal

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
