### PR TITLE
Fix 4391 Map refresh after save

### DIFF
--- a/web/client/actions/config.js
+++ b/web/client/actions/config.js
@@ -71,29 +71,6 @@ function loadMapInfo(mapId) {
 const mapSaveError = error => ({type: MAP_SAVE_ERROR, error});
 
 const mapSaved = () => ({type: MAP_SAVED});
-// function loadMapInfo(mapId) {
-//     return (dispatch) => {
-//         dispatch(mapInfoLoadStart(mapId));
-//         return axios.get(url).then((response) => {
-//             if (typeof response.data === 'object') {
-//                 if (response.data.ShortResource) {
-//                     dispatch(mapInfoLoaded(response.data.ShortResource, mapId));
-//                 } else {
-//                     dispatch(mapInfoLoaded(response.data, mapId));
-//                 }
-
-//             } else {
-//                 try {
-//                     JSON.parse(response.data);
-//                 } catch (e) {
-//                     dispatch(mapInfoLoadError( mapId, e));
-//                 }
-//             }
-//         }).catch((e) => {
-//             dispatch(mapInfoLoadError(mapId, e));
-//         });
-//     };
-// }
 
 module.exports = {
     LOAD_MAP_CONFIG,

--- a/web/client/reducers/__tests__/maps-test.js
+++ b/web/client/reducers/__tests__/maps-test.js
@@ -167,6 +167,13 @@ describe('Test the maps reducer', () => {
         expect(state.results[0].permissions.SecurityRuleList.SecurityRule.length).toBe(1);
 
     });
-
+    it('on map info loaded', () => {
+        const prevState = {
+            results: [{id: 1, name: 'Map'}]
+        };
+        const state = maps(prevState, {type: "MAP_INFO_LOADED", mapId: 1, info: {canEdit: true, canDelete: true, name: 'Map 1'}});
+        const found = state.results.find(item => item.id === 1);
+        expect(found.name).toEqual('Map 1');
+    });
 
 });

--- a/web/client/reducers/maps.js
+++ b/web/client/reducers/maps.js
@@ -13,6 +13,7 @@ const {
     MAPS_SEARCH_TEXT_CHANGED, METADATA_CHANGED, SHOW_DETAILS} = require('../actions/maps');
 const {
     EDIT_MAP, RESET_CURRENT_MAP} = require('../actions/currentMap');
+const {MAP_INFO_LOADED} = require('../actions/config');
 const assign = require('object-assign');
 const {isArray, isNil} = require('lodash');
 /**
@@ -250,6 +251,17 @@ function maps(state = {
         }
         );
         return newState;
+    }
+    case MAP_INFO_LOADED: {
+        let newMaps = state.results === "" ? [] : [...state.results];
+
+        for (let i = 0; i < newMaps.length; i++) {
+            if (newMaps[i].id && newMaps[i].id === action.mapId ) {
+                const {data, permissions, attributes, ...others} = action.info;
+                newMaps[i] = assign({}, newMaps[i], {...others, thumbnail: attributes && attributes.thumbnail});
+            }
+        }
+        return assign({}, state, {results: newMaps});
     }
     default:
         return state;


### PR DESCRIPTION
## Description
This commits complete the implementation of 4391 by adding maps refresh on save

## Issues
 - #4391 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see comments https://github.com/geosolutions-it/MapStore2/issues/4391#issuecomment-554372769

**What is the new behavior?**
Home page maps get refreshed after save

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
