### PR TITLE
Fix 4332 Remove resize cursor on about this map

### DIFF
--- a/web/client/components/details/DetailsPanel.jsx
+++ b/web/client/components/details/DetailsPanel.jsx
@@ -76,23 +76,25 @@ class DetailsPanel extends React.Component {
         return (
             <ResizeDetector handleWidth>
                 { ({ width }) =>
-                    <Dock dockStyle={this.props.dockStyle} {...this.props.dockProps} isVisible={this.props.active} fluid size={this.props.width / width > 1 ? 1 : this.props.width / width} noResize>
-                        <Panel id={this.props.id} header={panelHeader} style={this.props.panelStyle} className={this.props.panelClassName}>
-                            <BorderLayout>
-                                <div className="ms-details-preview-container">
-                                    {!this.props.detailsText ?
+                    <div className="react-dock-no-resize">
+                        <Dock dockStyle={this.props.dockStyle} {...this.props.dockProps} isVisible={this.props.active} fluid size={this.props.width / width > 1 ? 1 : this.props.width / width}>
+                            <Panel id={this.props.id} header={panelHeader} style={this.props.panelStyle} className={this.props.panelClassName}>
+                                <BorderLayout>
+                                    <div className="ms-details-preview-container">
+                                        {!this.props.detailsText ?
 
-                                        <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/> :
-                                        <div className="ms-details-preview" dangerouslySetInnerHTML={{ __html:
-                                                    this.props.detailsText === NO_DETAILS_AVAILABLE
-                                                        ? LocaleUtils.getMessageById(this.context.messages, "maps.feedback.noDetailsAvailable")
-                                                        : this.props.detailsText
+                                            <Spinner spinnerName="circle" noFadeIn overrideSpinnerClassName="spinner"/> :
+                                            <div className="ms-details-preview" dangerouslySetInnerHTML={{ __html:
+                                                this.props.detailsText === NO_DETAILS_AVAILABLE
+                                                    ? LocaleUtils.getMessageById(this.context.messages, "maps.feedback.noDetailsAvailable")
+                                                    : this.props.detailsText
 
-                                        }} />}
-                                </div>
-                            </BorderLayout>
-                        </Panel>
-                    </Dock>
+                                            }} />}
+                                    </div>
+                                </BorderLayout>
+                            </Panel>
+                        </Dock>
+                    </div>
                 }
             </ResizeDetector>
         );


### PR DESCRIPTION
## Description
Use styles and wrapper container to disable resize cursor. This approach is safe since it does not modify the react-dock component

## Issues
 - #4332 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4332 

**What is the new behavior?**
No resize cursor

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
