### PR TITLE
Fix 4521 removed fit tool for maps

### DIFF
--- a/web/client/components/geostory/layouts/sections/Immersive.jsx
+++ b/web/client/components/geostory/layouts/sections/Immersive.jsx
@@ -51,7 +51,7 @@ const Immersive = ({
             disableToolbarPortal
             tools={{
                 [MediaTypes.IMAGE]: ['editMedia', 'fit', 'size', 'align', 'theme'],
-                [MediaTypes.MAP]: ['editMedia', 'editMap', 'fit', 'size', 'align', 'theme']
+                [MediaTypes.MAP]: ['editMedia', 'editMap', 'size', 'align', 'theme']
             }}
             // selector used by sticky polyfill to detect scroll events
             scrollContainerSelector="#ms-sections-container"

--- a/web/client/components/geostory/layouts/sections/Title.jsx
+++ b/web/client/components/geostory/layouts/sections/Title.jsx
@@ -76,7 +76,7 @@ export default backgroundPropWithHandler(({
                         }}
                         tools={{
                             [MediaTypes.IMAGE]: ['editMedia', 'cover', 'fit', 'size', 'align', 'theme'],
-                            [MediaTypes.MAP]: ['editMedia', 'cover', 'editMap', 'fit', 'size', 'align', 'theme']
+                            [MediaTypes.MAP]: ['editMedia', 'cover', 'editMap', 'size', 'align', 'theme']
                         }}
                         height={height >= viewHeight
                             ? viewHeight

--- a/web/client/components/geostory/layouts/sections/__tests__/Immersive-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Immersive-test.jsx
@@ -146,6 +146,6 @@ describe('Immersive component', () => {
 
         const contentToolbar = container.querySelector('.ms-content-toolbar');
         expect(contentToolbar).toExist();
-        testToolbarButtons(["pencil", "1-map", "1-full-screen", "resize-horizontal", "align-center", "dropper"], container);
+        testToolbarButtons(["pencil", "1-map", "size-extra-large", "align-center", "dropper"], container);
     });
 });

--- a/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
@@ -54,7 +54,7 @@ describe('Title component', () => {
         const buttonsInToolbar = container.querySelectorAll('.ms-section-background-container .btn-group .glyphicon');
         expect(buttonsInToolbar).toExist();
         expect(buttonsInToolbar.length).toBe(6);
-        testToolbarButtons(["pencil", "1-full-screen", "resize-vertical", "resize-horizontal", "align-center", "dropper"], container);
+        testToolbarButtons(["pencil", "height-view", "fit-contain", "size-extra-large", "align-center", "dropper"], container);
 
     });
     it('Title rendering cover set to true', () => {
@@ -80,7 +80,7 @@ describe('Title component', () => {
         expect(backgroundContainer.clientHeight).toBe(VIEW_HEIGHT);
         const contentToolbar = container.querySelector('.ms-content-toolbar');
         expect(contentToolbar).toExist();
-        testToolbarButtons(["pencil", "cover"], container);
+        testToolbarButtons(["pencil", "height-auto"], container);
     });
 
     it('Title rendering cover set to false', () => {
@@ -138,6 +138,6 @@ describe('Title component', () => {
         expect(backgroundContainer.clientHeight).toBe(VIEW_HEIGHT);
         const contentToolbar = container.querySelector('.ms-content-toolbar');
         expect(contentToolbar).toExist();
-        testToolbarButtons(["pencil", "1-map", "fit", "resize-vertical", "resize-horizontal", "align-center", "dropper"], container);
+        testToolbarButtons(["pencil", "height-auto", "1-map", "size-extra-large", "align-center", "dropper"], container);
     });
 });

--- a/web/client/components/geostory/layouts/sections/__tests__/testUtils.js
+++ b/web/client/components/geostory/layouts/sections/__tests__/testUtils.js
@@ -5,6 +5,6 @@ export const testToolbarButtons = (buttons = [], container, selector = ".ms-sect
     expect(buttonsInToolbar).toExist();
     expect(buttonsInToolbar.length).toBe(buttons.length);
     buttonsInToolbar.forEach((b, i) => {
-        expect(b.className === `glyphicon glyphicon-${buttons[i]}`);
+        expect(b.className === `glyphicon glyphicon-${buttons[i]}`).toBe(true, `expect ${b.className} === glyphicon glyphicon-${buttons[i]}`);
     });
 };


### PR DESCRIPTION
## Description
Fit tool has been removed from maps backgrounds

## Issues
 - #4521

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
see description

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
