### PR TITLE
Fix 4523 fixed not perfectly visible masked content

### DIFF
--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -326,10 +326,12 @@ export const sortContentEpic = (action$, {getState = () => {}}) =>
 export const setFocusOnMapEditing = (action$, {getState = () =>{}}) =>
          action$.ofType(UPDATE).filter(({path = ""}) => path.endsWith("editMap"))
      .map(({path: rowPath, element: status}) => {
-                const {flatPath, path} = getFlatPath(rowPath, currentStorySelector(getState()));
-                const target = flatPath.pop();
-                const section = flatPath.shift();
-                const hideContent = path[path.length - 2] === "background";
-                const selector = hideContent && `#${section.id} .ms-section-background-container` || `#${target.id}`;
+            const {flatPath, path} = getFlatPath(rowPath, currentStorySelector(getState()));
+            const target = flatPath.pop();
+            const section = flatPath.shift();
+            const hideContent = path[path.length - 2] === "background";
+            const selector = hideContent && `#${section.id} .ms-section-background-container` || `#${target.id}`;
+            scrollToContent(target.id);
+
             return setFocusOnContent(status, target, selector, hideContent, rowPath.replace(".editMap", ""));
      });


### PR DESCRIPTION
## Description
fixed not perfectly visible masked content when inline editing is enabled

## Issues
 - #4523

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
now when clicking on editMap it **_always_** scroll up to make the content be fully visibile

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
