### PR TITLE
Fix 4424 regression for catalog records using metadata template

### DIFF
--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -284,7 +284,6 @@ class Catalog extends React.Component {
                 modalParams= {this.props.modalParams}
                 onAddBackgroundProperties={this.props.onAddBackgroundProperties}
                 source={this.props.source}
-                records={this.props.records}
                 authkeyParamNames={this.props.authkeyParamNames}
                 catalogURL={this.isValidServiceSelected() && this.props.services[this.props.selectedService].url || ""}
                 catalogType={this.props.services[this.props.selectedService] && this.props.services[this.props.selectedService].type}

--- a/web/client/components/catalog/__tests__/Catalog-test.jsx
+++ b/web/client/components/catalog/__tests__/Catalog-test.jsx
@@ -90,4 +90,28 @@ describe('Test Catalog panel', () => {
         expect(formatSelect.props.value).toBe('image/png8');
         expect(formatSelect.props.options).toEqual(formatOptions);
     });
+    it('test rendering records with expand button', () => {
+        const title = "title";
+        const description = "description";
+        const item = ReactDOM.render(<Catalog
+            services={{"csw": {
+                type: "csw",
+                url: "url",
+                title: "csw",
+                format: "image/png8",
+                metadataTemplate: "<p>${title} and ${description}</p>",
+                showTemplate: true
+            }}}
+            searchOptions={{}}
+            selectedService="csw"
+            loading={false}
+            mode="view"
+            result={{numberOfRecordsMatched: 1}}
+            records={[{title, description, references: []}]}
+        />, document.getElementById("container"));
+        expect(item).toExist();
+        const expandClass = ".glyphicon-chevron-left";
+        const expandButton = document.querySelector(expandClass);
+        expect(expandButton).toExist(`${expandClass} does not exist`);
+    });
 });


### PR DESCRIPTION
## Description
Fix regression on catalog records

the problem was property hiding introduced [here](https://github.com/geosolutions-it/MapStore2/blame/master/web/client/components/catalog/Catalog.jsx#L287)

## Issues
 - #4424

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
now metadata template is applied correctly (as before)

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
