### PR TITLE
Fix 4392 Enrich visualized resource metadata

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -26,6 +26,10 @@ This is the main structure:
   },
   // API keys for bing and mapquest services
   "bingApiKey",
+  // force dates to be in this specified format. use moment js format pattern
+  "forceDateFormat": "YYYY-MM-DD",
+  // force time to be in this specified format. use moment js format pattern
+  "forceTimeFormat": "hh:mm A",
   "mapquestApiKey",
   // list of actions types that are available to be launched dynamically from query param (#3817)
   "initialActionsWhiteList": ["ZOOM_TO_EXTENT", "ADD_LAYER", ...],

--- a/web/client/components/maps/forms/Metadata.jsx
+++ b/web/client/components/maps/forms/Metadata.jsx
@@ -16,6 +16,8 @@ const PropTypes = require('prop-types');
 
 const React = require('react');
 const {FormControl, FormGroup, ControlLabel} = require('react-bootstrap');
+const moment = require('moment');
+const ConfigUtils = require('../../../utils/ConfigUtils');
 
 /**
  * A DropDown menu for user details:
@@ -30,8 +32,14 @@ class Metadata extends React.Component {
         nameFieldText: PropTypes.node,
         descriptionFieldText: PropTypes.node,
         namePlaceholderText: PropTypes.string,
-        descriptionPlaceholderText: PropTypes.string
+        descriptionPlaceholderText: PropTypes.string,
+        createdAtFieldText: PropTypes.string,
+        modifiedAtFieldText: PropTypes.string
     };
+
+    static contextTypes = {
+        intl: PropTypes.object
+    }
 
     static defaultProps = {
         // CALLBACKS
@@ -43,6 +51,18 @@ class Metadata extends React.Component {
         namePlaceholderText: "Map Name",
         descriptionPlaceholderText: "Map Description"
     };
+
+
+    renderDate = (date) => {
+        if (!date) {
+            return '';
+        }
+        const dateFormat = ConfigUtils.getConfigProp('forceDateFormat');
+        const timeFormat = ConfigUtils.getConfigProp('forceTimeFormat');
+        const newDate = dateFormat ? moment(date).format(dateFormat) : this.context.intl ? this.context.intl.formatDate(date) : '';
+        const time = timeFormat ? moment(date).format(timeFormat) : this.context.intl ? this.context.intl.formatTime(date) : '';
+        return `${newDate} ${time}` || '';
+    }
 
     render() {
         return (<form ref="metadataForm" onSubmit={this.handleSubmit}>
@@ -67,6 +87,14 @@ class Metadata extends React.Component {
                     placeholder={this.props.descriptionPlaceholderText}
                     defaultValue={this.props.map ? this.props.map.description : ""}
                     value={this.props.map && this.props.map.metadata && this.props.map.metadata.description || ""}/>
+            </FormGroup>
+            <FormGroup>
+                <ControlLabel>{this.props.createdAtFieldText}</ControlLabel>
+                <ControlLabel>{this.props.map && this.renderDate(this.props.map.creation) || ""}</ControlLabel>
+            </FormGroup>
+            <FormGroup>
+                <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
+                <ControlLabel>{this.props.map && this.renderDate(this.props.map.lastUpdate || this.props.map.creation) || ""}</ControlLabel>
             </FormGroup>
         </form>);
     }

--- a/web/client/components/maps/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/maps/forms/__tests__/Metadata-test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, GeoSolutions Sas.
+ * Copyright 2019, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -8,9 +8,9 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const ReactTestUtils = require('react-dom/test-utils');
 const expect = require('expect');
 const Metadata = require('../Metadata');
+
 describe('Metadata component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -22,36 +22,24 @@ describe('Metadata component', () => {
         setTimeout(done);
     });
     it('Metadata rendering with defaults', () => {
-        ReactDOM.render(<Metadata />, document.getElementById("container"));
+        ReactDOM.render(<Metadata map={{}} />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
         expect(el.length).toBe(2);
     });
     it('Metadata rendering with meta-data', () => {
         const resource = {
-            modifiedAt: new Date(),
+            lastUpdate: new Date(),
             metadata: {
                 name: "NAME",
                 description: "DESCRIPTION"
             }
         };
-        ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
+        ReactDOM.render(<Metadata map={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
         expect(el.length).toBe(2);
         expect(el[0].value).toBe("NAME");
         expect(el[1].value).toBe("DESCRIPTION");
-    });
-    it('Test Metadata onChange', () => {
-        const actions = {
-            onChange: () => {}
-        };
-        const spyonChange = expect.spyOn(actions, 'onChange');
-        ReactDOM.render(<Metadata onChange={actions.onChange} />, document.getElementById("container"));
-        const container = document.getElementById('container');
-        const input = container.querySelector('input');
-        input.value = "test";
-        ReactTestUtils.Simulate.change(input); // <-- trigger event callback
-        expect(spyonChange).toHaveBeenCalled();
     });
 });

--- a/web/client/components/maps/modals/MetadataModal.jsx
+++ b/web/client/components/maps/modals/MetadataModal.jsx
@@ -455,6 +455,8 @@ class MetadataModal extends React.Component {
                                     metadata={this.props.metadata}
                                     nameFieldText={<Message msgId="map.name" />}
                                     descriptionFieldText={<Message msgId="map.description" />}
+                                    createdAtFieldText={<Message msgId="saveDialog.createdAt" />}
+                                    modifiedAtFieldText={<Message msgId="saveDialog.modifiedAt" />}
                                     namePlaceholderText={LocaleUtils.getMessageById(this.context.messages, "map.namePlaceholder") || "Map Name"}
                                     descriptionPlaceholderText={LocaleUtils.getMessageById(this.context.messages, "map.descriptionPlaceholder") || "Map Description"}
                                 />

--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -31,8 +31,14 @@ class Metadata extends React.Component {
         nameFieldText: PropTypes.node,
         descriptionFieldText: PropTypes.node,
         namePlaceholderText: PropTypes.string,
-        descriptionPlaceholderText: PropTypes.string
+        descriptionPlaceholderText: PropTypes.string,
+        createdAtFieldText: PropTypes.string,
+        modifiedAtFieldText: PropTypes.string
     };
+
+    static contextTypes = {
+        intl: PropTypes.object
+    }
 
     static defaultProps = {
         // CALLBACKS
@@ -44,6 +50,10 @@ class Metadata extends React.Component {
         namePlaceholderText: "Map Name",
         descriptionPlaceholderText: "Map Description"
     };
+
+    renderDate = (date) => {
+        return date && this.context.intl && `${this.context.intl.formatDate(date)} ${this.context.intl.formatTime(date)}` || '';
+    }
 
     render() {
         return (<form ref="metadataForm" onSubmit={this.handleSubmit}>
@@ -69,6 +79,24 @@ class Metadata extends React.Component {
                     defaultValue={this.props.resource ? this.props.resource.description : ""}
                     value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.description || ""}/>
             </FormGroup>
+            <FormGroup>
+                <ControlLabel>{this.props.createdAtFieldText}</ControlLabel>
+                <FormControl
+                    key="mapCreatedAt"
+                    type="text"
+                    readOnly
+                    disabled
+                    value={this.props.resource && this.renderDate(this.props.resource.createdAt) || ""}/>
+            </FormGroup>
+            {this.props.resource && this.props.resource.modifiedAt && <FormGroup>
+                <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
+                <FormControl
+                    key="mapModifiedAt"
+                    type="text"
+                    readOnly
+                    disabled
+                    value={this.props.resource && this.renderDate(this.props.resource.modifiedAt) || ""}/>
+            </FormGroup>}
         </form>);
     }
 

--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -15,7 +15,9 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
+const moment = require('moment');
 const {FormControl: BFormControl, FormGroup, ControlLabel} = require('react-bootstrap');
+const ConfigUtils = require('../../../utils/ConfigUtils');
 const FormControl = require('../../misc/enhancers/localizedProps')('placeholder')(BFormControl);
 
 /**
@@ -52,7 +54,14 @@ class Metadata extends React.Component {
     };
 
     renderDate = (date) => {
-        return date && this.context.intl && `${this.context.intl.formatDate(date)} ${this.context.intl.formatTime(date)}` || '';
+        if (!date) {
+            return '';
+        }
+        const dateFormat = ConfigUtils.getConfigProp('forceDateFormat');
+        const timeFormat = ConfigUtils.getConfigProp('forceTimeFormat');
+        const newDate = dateFormat ? moment(date).format(dateFormat) : this.context.intl ? this.context.intl.formatDate(date) : '';
+        const time = timeFormat ? moment(date).format(timeFormat) : this.context.intl ? this.context.intl.formatTime(date) : '';
+        return `${newDate} ${time}` || '';
     }
 
     render() {
@@ -83,10 +92,10 @@ class Metadata extends React.Component {
                 <ControlLabel>{this.props.createdAtFieldText}</ControlLabel>
                 <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.createdAt) || ""}</ControlLabel>
             </FormGroup>
-            {this.props.resource && this.props.resource.modifiedAt && <FormGroup>
+            <FormGroup>
                 <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
-                <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt) || ""}</ControlLabel>
-            </FormGroup>}
+                <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt || this.props.resource.createdAt) || ""}</ControlLabel>
+            </FormGroup>
         </form>);
     }
 

--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -81,21 +81,11 @@ class Metadata extends React.Component {
             </FormGroup>
             <FormGroup>
                 <ControlLabel>{this.props.createdAtFieldText}</ControlLabel>
-                <FormControl
-                    key="mapCreatedAt"
-                    type="text"
-                    readOnly
-                    disabled
-                    value={this.props.resource && this.renderDate(this.props.resource.createdAt) || ""}/>
+                <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.createdAt) || ""}</ControlLabel>
             </FormGroup>
             {this.props.resource && this.props.resource.modifiedAt && <FormGroup>
                 <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
-                <FormControl
-                    key="mapModifiedAt"
-                    type="text"
-                    readOnly
-                    disabled
-                    value={this.props.resource && this.renderDate(this.props.resource.modifiedAt) || ""}/>
+                <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt) || ""}</ControlLabel>
             </FormGroup>}
         </form>);
     }

--- a/web/client/components/resources/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Metadata-test.jsx
@@ -25,10 +25,11 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
-        expect(el.length).toBe(2);
+        expect(el.length).toBe(3);
     });
     it('Metadata rendering with meta-data', () => {
         const resource = {
+            modifiedAt: new Date(),
             metadata: {
                 name: "NAME",
                 description: "DESCRIPTION"
@@ -37,7 +38,7 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
-        expect(el.length).toBe(2);
+        expect(el.length).toBe(4);
         expect(el[0].value).toBe("NAME");
         expect(el[1].value).toBe("DESCRIPTION");
     });

--- a/web/client/components/resources/modals/enhancers/handleResourceData.jsx
+++ b/web/client/components/resources/modals/enhancers/handleResourceData.jsx
@@ -29,7 +29,9 @@ module.exports = compose(
                 metadata: {
                     name: resource.name,
                     description: resource.description
-                }
+                },
+                createdAt: resource.creation,
+                modifiedAt: resource.lastUpdate
             }
 
         }),

--- a/web/client/components/resources/modals/fragments/MainForm.jsx
+++ b/web/client/components/resources/modals/fragments/MainForm.jsx
@@ -44,6 +44,8 @@ module.exports = class MainForm extends React.Component {
                     resource={resource}
                     nameFieldText={<Message msgId="saveDialog.name" />}
                     descriptionFieldText={<Message msgId="saveDialog.description" />}
+                    createdAtFieldText={<Message msgId="saveDialog.createdAt" />}
+                    modifiedAtFieldText={<Message msgId="saveDialog.modifiedAt" />}
                     namePlaceholderText={"saveDialog.namePlaceholder"}
                     descriptionPlaceholderText={"saveDialog.descriptionPlaceholder"}
                 />

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1996,6 +1996,8 @@
             "title": "Eigenschaften bearbeiten",
             "name": "Name",
             "description": "Beschreibung",
+            "createdAt": "Erstellt",
+            "modifiedAt": "Geändert",
             "namePlaceholder": "Geben Sie einen Namen ein ...",
             "descriptionPlaceholder": "Geben Sie eine Beschreibung ein ...",
             "confirmCloseText": "Es gibt ausstehende Änderungen, sind Sie sicher, dass Sie schließen möchten, ohne zu speichern?",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -2000,6 +2000,8 @@
             "title": "Edit properties",
             "name": "Name",
             "description": "Description",
+            "createdAt": "Created",
+            "modifiedAt": "Modified",
             "namePlaceholder": "Type a name...",
             "descriptionPlaceholder": "Type a description...",
             "confirmCloseText": "There are pending changes, are you sure that you want to close without saving?",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1996,6 +1996,8 @@
             "title": "Editar propiedades",
             "name": "Nombre",
             "description": "Descripción",
+            "createdAt": "Creado",
+            "modifiedAt": "Modificado",
             "namePlaceholder": "Escriba un nombre ...",
             "descriptionPlaceholder": "Escriba una descripción ...",
             "confirmCloseText": "Hay cambios pendientes, ¿está seguro que quiere cerrar sin guardar?",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1996,6 +1996,8 @@
             "title": "Modifier les propriétés",
             "name": "Nom",
             "description": "Description",
+            "createdAt": "établi",
+            "modifiedAt": "modifié",
             "namePlaceholder": "Tapez un nom...",
             "descriptionPlaceholder": "Tapez une description...",
             "confirmCloseText": "Des modifications sont en attente, êtes-vous sûr de vouloir fermer sans enregistrer?",

--- a/web/client/translations/data.hr-HR
+++ b/web/client/translations/data.hr-HR
@@ -1592,6 +1592,8 @@
                 "title": "Izmijeni svojstva kontrolne ploče",
                 "name": "Naziv",
                 "description": "Opis",
+                "createdAt": "Stvorio",
+                "modifiedAt": "Promijenjen",
                 "namePlaceholder": "Unesi ime...",
                 "descriptionPlaceholder": "Unesi opis...",
                 "confirmCloseText": "U tijeku su izmjene, jeste li sigurni da želite zatvoriti bez spremanja?",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1997,6 +1997,8 @@
             "title": "Modifica proprietà",
             "name": "Nome",
             "description": "Descrizione",
+            "createdAt": "Creato",
+            "modifiedAt": "Modificata",
             "namePlaceholder": "Inserisci un nome..",
             "descriptionPlaceholder": "Inserisci una descrizione...",
             "confirmCloseText": "Ci sono modifiche non salvate, sei sicuro di voler chiudere senza salvare?",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1997,7 +1997,7 @@
             "title": "Modifica proprietà",
             "name": "Nome",
             "description": "Descrizione",
-            "createdAt": "Creato",
+            "createdAt": "Creata",
             "modifiedAt": "Modificata",
             "namePlaceholder": "Inserisci un nome..",
             "descriptionPlaceholder": "Inserisci una descrizione...",

--- a/web/client/translations/data.nl-NL
+++ b/web/client/translations/data.nl-NL
@@ -1408,6 +1408,8 @@
                 "title": "Edit dashboard properties",
                 "name": "Name",
                 "description": "Description",
+                "createdAt": "Aangemaakt",
+                "modifiedAt": "Gemodificeerde",
                 "namePlaceholder": "Type a name...",
                 "descriptionPlaceholder": "Type a description...",
                 "confirmCloseText": "There are pending changes, are you sure that you want to close without saving?",

--- a/web/client/translations/data.pt-PT
+++ b/web/client/translations/data.pt-PT
@@ -1558,6 +1558,8 @@
                 "title": "Edit dashboard properties",
                 "name": "Name",
                 "description": "Description",
+                "createdAt": "Criado",
+                "modifiedAt": "Modificado",
                 "namePlaceholder": "Type a name...",
                 "descriptionPlaceholder": "Type a description...",
                 "confirmCloseText": "There are pending changes, are you sure that you want to close without saving?",

--- a/web/client/translations/data.vi-VN
+++ b/web/client/translations/data.vi-VN
@@ -228,6 +228,8 @@
                 "description": "Mô tả",
                 "descriptionPlaceholder": "Nhập mô tả ...",
                 "name": "Tên",
+                "createdAt": "Tạo",
+                "modifiedAt": "Sửa đổi",
                 "namePlaceholder": "Nhập tên ...",
                 "saveSuccessMessage": "Bảng điều khiển được lưu thành công",
                 "saveSuccessTitle": "Thành công",

--- a/web/client/translations/data.zh-ZH
+++ b/web/client/translations/data.zh-ZH
@@ -1532,6 +1532,8 @@
                 "title": "Edit dashboard properties",
                 "name": "Name",
                 "description": "Description",
+                "createdAt": "被创造",
+                "modifiedAt": "改性",
                 "namePlaceholder": "Type a name...",
                 "descriptionPlaceholder": "Type a description...",
                 "confirmCloseText": "There are pending changes, are you sure that you want to close without saving?",


### PR DESCRIPTION
## Description
Enrich visualized resource metadata by adding resource created and modified date. This PR has added this feature across all resources that are using resource save modal visible from home page by clicking resource card setting or on save and saveAs of the resource. Please note that this does not enrich metadata of map save dialog triggered from home page simply because the map save dialog does not currently use resource component.

## Issues
 - #4392 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see #4392 

**What is the new behavior?**
<img width="523" alt="Screenshot 2019-11-20 at 17 15 18" src="https://user-images.githubusercontent.com/1956062/69249024-51a9dd80-0bbe-11ea-883f-938172753abe.png">


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
