### PR TITLE
Fixed annotations panel to fit when not full window sized

### DIFF
--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -288,7 +288,7 @@ class Annotations extends React.Component {
                     </Col>
                 </Row>
                 <Row>
-                    <Col xs={12}>
+                    <Col xs={12} style={{padding: "0 15px"}}>
                         <Filter
                             filterPlaceholder={LocaleUtils.getMessageById(this.context.messages, "annotations.filter")}
                             filterText={this.props.filter}

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -260,8 +260,8 @@ class Annotations extends React.Component {
                         </Button>
                     </Col>
                 </Row>
-                {this.props.mode === "list" && <span><Row>
-                    <Col xs={12} className="text-center">
+                {this.props.mode === "list" && <span><Row style={{margin: "auto"}}>
+                    <Col xs={12} style={{margin: "auto"}} className="text-center">
                         <Toolbar
                             btnDefaultProps={{ className: 'square-button-md', bsStyle: 'primary'}}
                             buttons={[

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -161,7 +161,7 @@ class AnnotationsPanel extends React.Component {
         return this.props.active ? (
             <ContainerDimensions>
                 { ({ width }) =>
-                    <span className="ms-annotations-panel react-dock-no-resize">
+                    <span className="ms-annotations-panel react-dock-no-resize ms-absolute-dock ms-side-panel">
                         <Dock
                             dockStyle={this.props.dockStyle} {...this.props.dockProps}
                             isVisible={this.props.active}

--- a/web/client/plugins/__tests__/Annotations-test.jsx
+++ b/web/client/plugins/__tests__/Annotations-test.jsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import AnnotationsPlugin from '../Annotations';
+import { getPluginForTest } from './pluginsTestUtils';
+
+describe('Annotations Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates a Annotations plugin', () => {
+        const { Plugin } = getPluginForTest(AnnotationsPlugin, {
+            controls: {
+                annotations: {
+                    enabled: true
+                }
+            }
+        });
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        const panel = document.querySelector('.ms-annotations-panel');
+        expect(panel).toExist();
+        // check the annotation panel has the classes that fits even with headers (for embedded or other, not full window size context)
+        expect(panel.className.split(" ")).toInclude("ms-side-panel");
+        expect(panel.className.split(" ")).toInclude("ms-absolute-dock");
+    });
+});


### PR DESCRIPTION
## Description
In embedded context (e.g. when in georchestra, or anyway everytime the map is not full window sized) the annotation panel doesn't not fit correctly the window. 
![image](https://user-images.githubusercontent.com/1279510/69417871-ce9d9a00-0d19-11ea-8ff5-8951e4b75e35.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Annotation do not fit. 
Reproductable only in embedded (custom) context

**What is the new behavior?**
Annotations now fit in both ways

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

**Other information**:
This PR fixes this behaviour using the same classed of GFI. Testing I had also to align the buttons, that I noticed wasn't centered anymore. I added inline style to be more precise as possible in fixes.
Maybe in future we can improve this solution. 

**can you test fully annotations to verify that everything works?**