### PR TITLE
Advanced Editor from Inline Editor

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -315,6 +315,10 @@ class Toolbar extends React.Component {
                 </ReactCSSTransitionGroup>
                 <ConfirmModal
                     ref="removelayer"
+                    options={{
+                        animation: false,
+                        className: "modal-fixed"
+                    }}
                     show= {this.state.showDeleteDialog}
                     onHide={this.closeDeleteDialog}
                     onClose={this.closeDeleteDialog}

--- a/web/client/components/geostory/common/MapEditor.jsx
+++ b/web/client/components/geostory/common/MapEditor.jsx
@@ -18,7 +18,8 @@ import connectMap, {withFocusedContentMap,
     handleToolbar,
     withToolbar,
     withSaveChanges,
-    withConfirmClose} from './enhancers/map';
+    withConfirmClose,
+    handleAdvancedMapEditor} from './enhancers/map';
 
 import localizeStringMap from '../../misc/enhancers/localizeStringMap';
 
@@ -107,6 +108,7 @@ export default branch(
         withSaveChanges,
         handleMapUpdate,
         handleToolbar,
+        handleAdvancedMapEditor,
         withToolbar,
         withConfirmClose
     )

--- a/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
+++ b/web/client/components/geostory/common/enhancers/__tests__/map-test.jsx
@@ -6,12 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
 import ReactDOM from 'react-dom';
+
+import Toolbar from '../../../../misc/toolbar/Toolbar';
 
 import expect from 'expect';
 import {createSink} from  'recompose';
 
-import {withLocalMapState, withMapEditingAndLocalMapState} from '../map';
+import {withLocalMapState, withMapEditingAndLocalMapState, withToolbar} from '../map';
 
 
 describe("geostory media map component enhancers", () => {
@@ -73,6 +76,38 @@ describe("geostory media map component enhancers", () => {
         ReactDOM.render(<SinkLocalChanges map={map} update={actions.update} onMapViewLocalChanges={actions.onMapViewLocalChanges}/>, document.getElementById("container"));
 
 
+    });
+
+    it('withToolbar it correctly sets buttons', (done) => {
+
+        const actions = {
+            toggleEditing: () => {},
+            onReset: () => {},
+            toggleAdvancedEditing: () => {}
+        };
+
+        const SpyToggleEditing = expect.spyOn(actions, 'toggleEditing');
+        const SpyOnReset = expect.spyOn(actions, 'onReset');
+        const SpyToggleAdvancedEditing = expect.spyOn(actions, 'toggleAdvancedEditing');
+
+        const Component = withToolbar(Toolbar);
+
+        ReactDOM.render(<Component pendingChanges disableReset={false} {...actions}/>, document.getElementById("container"));
+
+        const buttons = document.querySelectorAll("button");
+        expect(buttons).toExist();
+        expect(buttons.length).toBe(3);
+        for (let btn of buttons) {
+            ReactTestUtils.Simulate.click(btn);
+        }
+        const confirmButtons = document.querySelectorAll(".with-confirm-modal button");
+        expect(confirmButtons).toExist();
+        expect(confirmButtons.length).toBe(3);
+        ReactTestUtils.Simulate.click(confirmButtons[1]);
+        expect(SpyToggleEditing).toHaveBeenCalled();
+        expect(SpyOnReset).toHaveBeenCalled();
+        expect(SpyToggleAdvancedEditing).toHaveBeenCalled();
+        done();
     });
 
 });

--- a/web/client/components/geostory/common/enhancers/map.jsx
+++ b/web/client/components/geostory/common/enhancers/map.jsx
@@ -11,6 +11,8 @@ import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import { find, isEqual} from 'lodash';
 
+import {show} from '../../../../actions/mapEditor';
+
 import {createMapObject} from '../../../../utils/GeoStoryUtils';
 import {resourcesSelector, getCurrentFocusedContentEl} from '../../../../selectors/geostory';
 
@@ -55,7 +57,19 @@ export const handleMapUpdate = withHandlers({
             update(focusedContent.path + `.${path}`, value, "merge");
         }});
 /**
- * Handle edit map toggle and map rest.
+ * Connect and toggle advanced Editor
+ */
+export const handleAdvancedMapEditor = compose(
+    connect(null, {toggleAdvancedEditing: show}),
+    withHandlers({
+        toggleAdvancedEditing: ({toggleAdvancedEditing = () => {}, map = {}}) => () => {
+            const {id, ...data} = map;
+            toggleAdvancedEditing('inlineEditor', {data, id});
+        }
+    })
+);
+/**
+ * Handle edit map toggle, map rest and open AdvancedMapEditor.
  * Map reset restores the original resource map configuration by removing all content map configs
  */
 export const handleToolbar = withHandlers({
@@ -74,7 +88,6 @@ export const handleToolbar = withHandlers({
  */
 const ResetButton = (props) => (<ConfirmButton
     glyph="repeat"
-    visible
     bsStyle= "primary"
     className="square-button-md no-border"
     tooltipId="geostory.contentToolbar.resetMap"
@@ -84,15 +97,19 @@ const ResetButton = (props) => (<ConfirmButton
 />);
 
 export const withToolbar = compose(
-    withProps(({pendingChanges, toggleEditing, disableReset, onReset}) => ({
+    withProps(({pendingChanges, toggleEditing, disableReset, onReset, toggleAdvancedEditing = () => {}}) => ({
         buttons: [{
             glyph: "floppy-disk",
-            visible: true,
             disabled: !pendingChanges,
             tooltipId: "geostory.contentToolbar.saveChanges",
             onClick: toggleEditing
         }, {
             renderButton: <ResetButton disabled={disableReset} onClick={onReset}/>
+        },
+        {
+            glyph: "pencil",
+            tooltipId: "geostory.contentToolbar.advancedMapEditor",
+            onClick: toggleAdvancedEditing
         }]
     })),
     withNodeSelection,      // Node selection

--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -1089,7 +1089,7 @@ describe('Geostory Epics', () => {
             actions.forEach(({type, ...a}) => {
                 switch (type) {
                 case UPDATE:
-                    a.path.endsWith(".map") || a.path.endsWith(".editMap");
+                    expect(a.path.endsWith(".map") || a.path.endsWith(".editMap")).toBeTruthy();
                     break;
                 case HIDE_MAP_EDITOR:
                     break;

--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -26,7 +26,8 @@ import {
     saveGeoStoryResource,
     reloadGeoStoryOnLoginLogout,
     sortContentEpic,
-    setFocusOnMapEditing
+    setFocusOnMapEditing,
+    inlineEditorEditMap
 } from '../geostory';
 import {
     ADD,
@@ -58,6 +59,13 @@ import {
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import {testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import { Modes, ContentTypes, MediaTypes, Controls } from '../../utils/GeoStoryUtils';
+
+import {
+    show as mapEditorShow,
+    save as saveMapEditor,
+    HIDE as HIDE_MAP_EDITOR
+
+} from '../../actions/mapEditor';
 
 let mockAxios;
 describe('Geostory Epics', () => {
@@ -1068,6 +1076,40 @@ describe('Geostory Epics', () => {
                         ]
                     }
                 ]
+            }
+        }
+        });
+    });
+    it('inlineEditorEditMap on advancedEditing save', done => {
+        const launchActions = [mapEditorShow("inlineEditor", {data: {}, id: 1}), saveMapEditor({}, "inlineEditor")];
+
+        const NUM_ACTIONS = 3;
+        testEpic(inlineEditorEditMap, NUM_ACTIONS, launchActions, (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.forEach(({type, ...a}) => {
+                switch (type) {
+                case UPDATE:
+                    a.path.endsWith(".map") || a.path.endsWith(".editMap");
+                    break;
+                case HIDE_MAP_EDITOR:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                    break;
+                }
+            });
+            done();
+
+        }, {geostory: {
+            focusedContent: {
+                target: {
+                    id: '07b34499-c74e-4fde-9fb3-973fef729093',
+                    type: 'contents',
+                    contentType: 'map'
+                },
+                selector: '#07b34499-c74e-4fde-9fb3-973fef729093',
+                hideContent: false,
+                path: 'sections[{"id": "eae41574-9799-44b8-b701-9f45f203a8cd"}].contents[{"id": "226889e0-c5ae-495b-8386-5cd4aa16c799"}].contents[{"id": "07b34499-c74e-4fde-9fb3-973fef729093"}]'
             }
         }
         });

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -62,13 +62,15 @@ import { LOGIN_SUCCESS, LOGOUT } from '../actions/security';
 
 
 import { isLoggedIn, isAdminUserSelector } from '../selectors/security';
-import { resourceIdSelectorCreator, createPathSelector, currentStorySelector, resourcesSelector} from '../selectors/geostory';
+import { resourceIdSelectorCreator, createPathSelector, currentStorySelector, resourcesSelector, getFocusedContentSelector} from '../selectors/geostory';
 import { currentMediaTypeSelector, sourceIdSelector} from '../selectors/mediaEditor';
 
 import { wrapStartStop } from '../observables/epics';
 import { scrollToContent, ContentTypes, isMediaSection, Controls, getEffectivePath, getFlatPath } from '../utils/GeoStoryUtils';
 
 import { SourceTypes } from './../utils/MediaEditorUtils';
+
+import { HIDE as HIDE_MAP_EDITOR, SAVE as SAVE_MAP_EDITOR, hide as hideMapEditor, SHOW as MAP_EDITOR_SHOW} from '../actions/mapEditor';
 
 const updateMediaSection = (store, path) => action$ =>
     action$.ofType(CHOOSE_MEDIA)
@@ -335,3 +337,25 @@ export const setFocusOnMapEditing = (action$, {getState = () =>{}}) =>
 
             return setFocusOnContent(status, target, selector, hideContent, rowPath.replace(".editMap", ""));
      });
+
+/**
+* Handles map editing from inline editor
+* On map save:
+* update current edited map in current story resources
+* hide mapEditor,
+* toggle inline map editor
+* @memberof epics.mediaEditor
+* @param {Observable} action$ stream of actions
+* @param {object} store redux store
+*/
+export const inlineEditorEditMap = (action$, {getState}) =>
+    action$.ofType(MAP_EDITOR_SHOW)
+        .filter(({owner, map}) => owner === 'inlineEditor' && !!map)
+        .switchMap(() => {
+            return action$.ofType(SAVE_MAP_EDITOR)
+            .switchMap(({map}) => {
+                const {path} = getFocusedContentSelector(getState());
+                return  Observable.of(update(`${path}.map`, map), update(`${path}.editMap`, false), hideMapEditor())
+                        .takeUntil(action$.ofType(HIDE_MAP_EDITOR));
+            });
+        });

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1935,7 +1935,8 @@
                 "saveChanges": "Änderungen speichern",
                 "closeMapEditing": "Schließen",
                 "confirmCloseMapEditing": "Schließen Sie die Kartenbearbeitung",
-                "pendingChangesDiscardConfirm": "Aktuelle Kartenänderungen verwerfen?"
+                "pendingChangesDiscardConfirm": "Aktuelle Kartenänderungen verwerfen?",
+                "advancedMapEditor": "Öffnen Sie den erweiterten Karteneditor"
             },
             "navigation": {
                 "edit": "Bearbeiten Sie die Geschichte"

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1939,7 +1939,8 @@
                 "saveChanges": "Save changes",
                 "closeMapEditing": "Close",
                 "confirmCloseMapEditing": "Close Map Editing",
-                "pendingChangesDiscardConfirm": "Discard current map changes?"
+                "pendingChangesDiscardConfirm": "Discard current map changes?",
+                "advancedMapEditor": "Open advanced map editor"
             },
             "navigation": {
                 "edit": "Edit story"

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1935,7 +1935,8 @@
                 "saveChanges": "Guardar cambios",
                 "closeMapEditing": "Cerrar",
                 "confirmCloseMapEditing": "Cerrar edición de mapas",
-                "pendingChangesDiscardConfirm": "¿Descartar los cambios actuales en el mapa?"
+                "pendingChangesDiscardConfirm": "¿Descartar los cambios actuales en el mapa?",
+                "advancedMapEditor": "Abrir editor de mapas avanzado"
             },
             "navigation": {
                 "edit": "Editar historia"

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1935,7 +1935,8 @@
                 "saveChanges": "Sauvegarder les modifications",
                 "closeMapEditing": "Proche",
                 "confirmCloseMapEditing": "Fermer l'édition de la carte",
-                "pendingChangesDiscardConfirm": "Annuler les modifications de la carte actuelle?"
+                "pendingChangesDiscardConfirm": "Annuler les modifications de la carte actuelle?",
+                "advancedMapEditor": "Ouvrir l'éditeur de carte avancé"
             },
             "navigation": {
                 "edit": "Modifier l'histoire"

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1935,7 +1935,8 @@
                 "saveChanges": "Salva le modifiche",
                 "closeMapEditing": "Chiudi editing",
                 "confirmCloseMapEditing": "Chiudi editing mappa",
-                "pendingChangesDiscardConfirm": "Vuoi scartare le modifiche?"
+                "pendingChangesDiscardConfirm": "Vuoi scartare le modifiche?",
+                "advancedMapEditor": "Apri editor di mappe avanzato"
             },
             "navigation": {
                 "edit": "Modifica storia"


### PR DESCRIPTION
## Description
refer to geosolutions-it/mapstore2-c039/issues/122
## Issues
 - #4563 


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
It's not possible to open the advanced map editor from the inline editor toolbar.

**What is the new behavior?**
It's now possible to launch the advanced map editor plugin from the inline map editor.
On cancel the user ii brought back to online editor, on save, the map is saved inside the geostory content as it is and the inline editor is closed


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
