### PR TITLE
Fix 4319 Dropdown list fails to update immediately after input clear

### DIFF
--- a/web/client/components/manager/users/GroupDialog.jsx
+++ b/web/client/components/manager/users/GroupDialog.jsx
@@ -268,7 +268,7 @@ class GroupDialog extends React.Component {
         if (typeof selected === 'string') {
             this.selectMemberPage = 0;
             this.setState({selectedMember: selected});
-            this.searchUsers(selected);
+            this.searchUsers(selected, true);
             return;
         }
 
@@ -282,7 +282,7 @@ class GroupDialog extends React.Component {
                 newUsers = [...newUsers, newMember];
                 this.props.onChange("newUsers", newUsers);
                 this.setState({selectedMember: '', openSelectMember: false});
-                this.searchUsers('*');
+                this.searchUsers('*', true);
             }
             return;
         }
@@ -309,9 +309,9 @@ class GroupDialog extends React.Component {
         this.searchUsers();
     }
 
-    searchUsers = (q) => {
+    searchUsers = (q, textChanged) => {
         const start = this.selectMemberPage;
-        const text = q || (typeof this.state.selectedMember === 'string' && this.state.selectedMember ? this.state.selectedMember : q);
+        const text = textChanged ? q : (typeof this.state.selectedMember === 'string' && this.state.selectedMember ? this.state.selectedMember : q);
         this.props.searchUsers(text, start, PAGINATION_LIMIT);
     }
 

--- a/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/GroupDialog-test.jsx
@@ -201,4 +201,19 @@ describe("Test GroupDialog Component", () => {
             expect(onCloseSpy).toHaveBeenCalled();
         });
     });
+
+    it('search user result from text change must be called with text changed', () => {
+        const actions = {
+            searchUsers: () => { }
+        };
+        const spySearchUsers = expect.spyOn(actions, 'searchUsers');
+        ReactDOM.render(
+            <GroupDialog group={group1} searchUsers={actions.searchUsers} />,
+            document.getElementById("container"));
+        const input = document.querySelector('.rw-input');
+        input.value = 'test';
+        ReactTestUtils.Simulate.change(input);
+        expect(spySearchUsers).toHaveBeenCalledWith('test', 0, 5);
+        spySearchUsers.restore();
+    });
 });


### PR DESCRIPTION
## Description
see title

## Issues
 - #4319 
 - ...

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
see https://github.com/geosolutions-it/MapStore2/issues/4319#issuecomment-559449472

**What is the new behavior?**
Dropdown update immediately

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
