### PR TITLE
#4570 no story reload on language change

### DIFF
--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -84,7 +84,7 @@ const updateDashboardVisibility = action$ =>
             const updateObservable = updateVisibility(action$, loadActions, isEnabled, 'dashboard');
             return Rx.Observable.merge(
                 updateObservable,
-                action$.ofType(LOGIN_SUCCESS, LOGOUT, LOCATION_CHANGE)
+                action$.ofType(LOGIN_SUCCESS, LOGOUT)
                     .switchMap(() => updateObservable)
                     .takeUntil(action$.ofType(DETECTED_NEW_PAGE))
             );

--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -103,7 +103,7 @@ const updateGeoStoryFeedbackMaskVisibility = action$ =>
             const updateObservable = updateVisibility(action$, loadActions, isEnabled, 'geostory');
             return Rx.Observable.merge(
                 updateObservable,
-                action$.ofType(LOGIN_SUCCESS, LOGOUT, LOCATION_CHANGE)
+                action$.ofType(LOGIN_SUCCESS, LOGOUT)
                     .switchMap(() => updateObservable)
                     .takeUntil(action$.ofType(DETECTED_NEW_PAGE))
             );

--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -133,7 +133,7 @@ module.exports = {
                     const newLocationDifference = newLocation[newLocation.length - 1];
                     return newLocationDifference !== loctionDifference;
                 }).switchMap( ({payload = {}} = {}) => {
-                    if (payload && payload.location && payload.location.pathname) {
+                    if (payload && payload.location && payload.location.pathname && payload.location.pathname) {
                         return Rx.Observable.of(clearWidgets());
                     }
                     return Rx.Observable.empty();

--- a/web/client/epics/widgets.js
+++ b/web/client/epics/widgets.js
@@ -133,7 +133,7 @@ module.exports = {
                     const newLocationDifference = newLocation[newLocation.length - 1];
                     return newLocationDifference !== loctionDifference;
                 }).switchMap( ({payload = {}} = {}) => {
-                    if (payload && payload.location && payload.location.pathname && payload.location.pathname) {
+                    if (payload && payload.location && payload.location.pathname) {
                         return Rx.Observable.of(clearWidgets());
                     }
                     return Rx.Observable.empty();

--- a/web/client/product/pages/Dashboard.jsx
+++ b/web/client/product/pages/Dashboard.jsx
@@ -24,7 +24,8 @@ class DashboardPage extends React.Component {
         match: PropTypes.object,
         loadResource: PropTypes.func,
         reset: PropTypes.func,
-        plugins: PropTypes.object
+        plugins: PropTypes.object,
+        location: PropTypes.object
     };
 
     static defaultProps = {

--- a/web/client/product/pages/Dashboard.jsx
+++ b/web/client/product/pages/Dashboard.jsx
@@ -17,6 +17,7 @@ const { loadDashboard, resetDashboard } = require('../../actions/dashboard');
 const Page = require('../../containers/Page');
 const BorderLayout = require('../../components/layout/BorderLayout');
 
+let oldLocation;
 class DashboardPage extends React.Component {
     static propTypes = {
         mode: PropTypes.string,
@@ -35,8 +36,12 @@ class DashboardPage extends React.Component {
     UNSAFE_componentWillMount() {
         const id = get(this.props, "match.params.did");
         if (id) {
-            this.props.reset();
-            this.props.loadResource(id);
+            // this prevents for reloads due to re-mount (i.e. locale change)
+            if (oldLocation !== this.props.location) {
+                oldLocation = this.props.location;
+                this.props.reset();
+                this.props.loadResource(id);
+            }
         } else {
             this.props.reset();
         }
@@ -50,9 +55,6 @@ class DashboardPage extends React.Component {
                 this.props.loadResource(id);
             }
         }
-    }
-    componentWillUnmount() {
-        this.props.reset();
     }
     render() {
         return (<Page

--- a/web/client/product/pages/GeoStory.jsx
+++ b/web/client/product/pages/GeoStory.jsx
@@ -15,14 +15,15 @@ const urlQuery = url.parse(window.location.href, true).query;
 import Page from '../../containers/Page';
 import {loadGeostory} from '../../actions/geostory';
 import BorderLayout from '../../components/layout/BorderLayout';
-
+let oldLocation;
 class GeoStoryPage extends React.Component {
     static propTypes = {
         mode: PropTypes.string,
         match: PropTypes.object,
         loadResource: PropTypes.func,
         reset: PropTypes.func,
-        plugins: PropTypes.object
+        plugins: PropTypes.object,
+        location: PropTypes.object
     };
 
     static defaultProps = {
@@ -34,7 +35,11 @@ class GeoStoryPage extends React.Component {
     componentWillMount() {
         const id = get(this.props, "match.params.gid");
         this.props.reset();
-        this.props.loadResource(id);
+        // this prevents for reloads due to re-mount (i.e. locale change)
+        if (oldLocation !== this.props.location) {
+            oldLocation = this.props.location;
+            this.props.loadResource(id);
+        }
     }
     componentDidUpdate(oldProps) {
         const id = get(this.props, "match.params.gid");


### PR DESCRIPTION
## Description
This pull request do not trigger story reload on language change.
The reload was caused by a global re-mount of all the components. The componentWillMount triggered the load event. I use the same approch used in MapViewer.

## Issues
 - #4570

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
On locale change, the story reloads

**What is the new behavior?**
On locale change, the story don't reload

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

