### PR TITLE
Revert "#4570 no story reload on language change"

### DIFF
--- a/web/client/epics/feedbackMask.js
+++ b/web/client/epics/feedbackMask.js
@@ -84,7 +84,7 @@ const updateDashboardVisibility = action$ =>
             const updateObservable = updateVisibility(action$, loadActions, isEnabled, 'dashboard');
             return Rx.Observable.merge(
                 updateObservable,
-                action$.ofType(LOGIN_SUCCESS, LOGOUT)
+                action$.ofType(LOGIN_SUCCESS, LOGOUT, LOCATION_CHANGE)
                     .switchMap(() => updateObservable)
                     .takeUntil(action$.ofType(DETECTED_NEW_PAGE))
             );
@@ -103,7 +103,7 @@ const updateGeoStoryFeedbackMaskVisibility = action$ =>
             const updateObservable = updateVisibility(action$, loadActions, isEnabled, 'geostory');
             return Rx.Observable.merge(
                 updateObservable,
-                action$.ofType(LOGIN_SUCCESS, LOGOUT)
+                action$.ofType(LOGIN_SUCCESS, LOGOUT, LOCATION_CHANGE)
                     .switchMap(() => updateObservable)
                     .takeUntil(action$.ofType(DETECTED_NEW_PAGE))
             );

--- a/web/client/product/pages/Dashboard.jsx
+++ b/web/client/product/pages/Dashboard.jsx
@@ -17,15 +17,13 @@ const { loadDashboard, resetDashboard } = require('../../actions/dashboard');
 const Page = require('../../containers/Page');
 const BorderLayout = require('../../components/layout/BorderLayout');
 
-let oldLocation;
 class DashboardPage extends React.Component {
     static propTypes = {
         mode: PropTypes.string,
         match: PropTypes.object,
         loadResource: PropTypes.func,
         reset: PropTypes.func,
-        plugins: PropTypes.object,
-        location: PropTypes.object
+        plugins: PropTypes.object
     };
 
     static defaultProps = {
@@ -37,12 +35,8 @@ class DashboardPage extends React.Component {
     UNSAFE_componentWillMount() {
         const id = get(this.props, "match.params.did");
         if (id) {
-            // this prevents for reloads due to re-mount (i.e. locale change)
-            if (oldLocation !== this.props.location) {
-                oldLocation = this.props.location;
-                this.props.reset();
-                this.props.loadResource(id);
-            }
+            this.props.reset();
+            this.props.loadResource(id);
         } else {
             this.props.reset();
         }
@@ -56,6 +50,9 @@ class DashboardPage extends React.Component {
                 this.props.loadResource(id);
             }
         }
+    }
+    componentWillUnmount() {
+        this.props.reset();
     }
     render() {
         return (<Page

--- a/web/client/product/pages/GeoStory.jsx
+++ b/web/client/product/pages/GeoStory.jsx
@@ -15,15 +15,14 @@ const urlQuery = url.parse(window.location.href, true).query;
 import Page from '../../containers/Page';
 import {loadGeostory} from '../../actions/geostory';
 import BorderLayout from '../../components/layout/BorderLayout';
-let oldLocation;
+
 class GeoStoryPage extends React.Component {
     static propTypes = {
         mode: PropTypes.string,
         match: PropTypes.object,
         loadResource: PropTypes.func,
         reset: PropTypes.func,
-        plugins: PropTypes.object,
-        location: PropTypes.object
+        plugins: PropTypes.object
     };
 
     static defaultProps = {
@@ -35,11 +34,7 @@ class GeoStoryPage extends React.Component {
     componentWillMount() {
         const id = get(this.props, "match.params.gid");
         this.props.reset();
-        // this prevents for reloads due to re-mount (i.e. locale change)
-        if (oldLocation !== this.props.location) {
-            oldLocation = this.props.location;
-            this.props.loadResource(id);
-        }
+        this.props.loadResource(id);
     }
     componentDidUpdate(oldProps) {
         const id = get(this.props, "match.params.gid");


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#4585 because of https://github.com/geosolutions-it/MapStore2/issues/4570#issuecomment-561240397 
This issue will be fixed probably later, with different approch. 
(language selector prompt or investigation on the workflow to avoid resets on mount/unmount.