### PR TITLE
Fixes for 4501 zoom control alignment in geostory

### DIFF
--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -298,11 +298,6 @@
                 &.ms-dark {
                     background-color: contrast(@ms-story-bg);
                 }
-                &.ms-align-right .ms-media.ms-media-map .ol-zoom {
-                    top: 50px;
-                    right: 10px;
-                    left: auto;
-                }
             }
         }
         /*
@@ -790,21 +785,29 @@
     }
 }
 
+.ms-media-map.topLeft .ol-zoom.ol-unselectable.ol-control {
+    top: 50px;
+    right: unset;
+    bottom: unset;
+    left: 10px;
+}
 .ms-media-map.topRight .ol-zoom.ol-unselectable.ol-control {
+    top: 50px;
     right: 10px;
+    bottom: unset;
     left: unset;
 }
 
 .ms-media-map.bottomRight .ol-zoom.ol-unselectable.ol-control {
     top: unset;
     right: 10px;
-    bottom: 10px;
+    bottom: 50px;
     left: unset;
 }
 
 .ms-media-map.bottomLeft .ol-zoom.ol-unselectable.ol-control {
     top: unset;
     right: unset;
-    bottom: 10px;
+    bottom: 50px;
     left: 10px;
 }

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -2002,7 +2002,7 @@
                 "topLeft": "Angolo in alto a sinistra",
                 "topRight": "Angolo in alto a destra",
                 "bottomLeft": "Angolo in basso a sinistra",
-                "bottomRight": "Angolo in basse a destra"
+                "bottomRight": "Angolo in basso a destra"
             }
         },
          "saveDialog": {


### PR DESCRIPTION
## Description
Fixes for zoom control in geostory 

## Issues
 - #4501

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
zoom control works fine when positioned in the four angles and with any alignmenet of the content

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Report of the issues fixed by this PR:

- [ ] Writing mistake in zoom in/out interactions dropdown menu. Is not 'Angolo in basse a destra' but 'Angolo in basso a destra'. 
![issue 4501](https://user-images.githubusercontent.com/56537133/69791801-8ec92d80-11c5-11ea-92c3-1d6f4124b82b.JPG)

- [ ] If the map is aligned to the right, the zoom in / out button is not correctly displayed on map on these positions:
- top left
- bottom right
- bottom left 
![issue 4501 2](https://user-images.githubusercontent.com/56537133/69794052-dc479980-11c9-11ea-9aec-3acaded45a6b.JPG)
