### PR TITLE
#4602 fix the editor error in geostory

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -167,7 +167,7 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
                     paths.code,
                     path.join(paths.base, "node_modules", "query-string"),
                     path.join(paths.base, "node_modules", "strict-uri-encode"),
-                    path.join(paths.base, "node_modules", "react-draft-wysiwyg"),
+                    path.join(paths.base, "node_modules", "react-draft-wysiwyg"), // added for issue #4602
                     path.join(paths.base, "node_modules", "split-on-first")
                 ]
             }

--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -167,6 +167,7 @@ module.exports = (bundles, themeEntries, paths, extractThemesPlugin, prod, publi
                     paths.code,
                     path.join(paths.base, "node_modules", "query-string"),
                     path.join(paths.base, "node_modules", "strict-uri-encode"),
+                    path.join(paths.base, "node_modules", "react-draft-wysiwyg"),
                     path.join(paths.base, "node_modules", "split-on-first")
                 ]
             }

--- a/web/client/components/geostory/contents/enhancers/editableText.jsx
+++ b/web/client/components/geostory/contents/enhancers/editableText.jsx
@@ -71,7 +71,7 @@ export default compose(
                 placeholder,
                 toolbarStyle,
                 toolbar: {
-                    // [here](https://jpuri.github.io/react-draft-wysiwyg/#/docs) you can find some examples (hard to find in the official drafjs doc)
+                    // [here](https://jpuri.github.io/react-draft-wysiwyg/#/docs) you can find some examples (hard to find them in the official draft-js doc)
                     options: ['fontFamily', 'blockType', 'inline', 'textAlign', 'colorPicker', 'list', 'link', 'remove'],
                     fontFamily: {
                         options: ['inherit', 'Arial', 'Georgia', 'Impact', 'Tahoma', 'Times New Roman', 'Verdana'],


### PR DESCRIPTION
## Description
This pr is a tentative fix for the problem that occurs only in production.

After some investigation i discovered that the problem is inside [this](https://github.com/jpuri/react-draft-wysiwyg/blob/master/docs/static/bundle.js) static bundle of react-draft-wysiwyg library

it seems that the minifycation of it creates problem described in the issue.

To discover this file i run several searches
especially searching in the repo locally with vscode these : 
- getModifierState("Shift")
- 13===

in order to fix this i used the same approach being used for other libraries. 
i then tested it locally with a tomcat 7

## Issues
 - #4602 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
a crash happen when you click on Enter in the editor of text content in geostory 

**What is the new behavior?**
no crash happens, tested

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
