### PR TITLE
Fixed context creator default viewerTools

### DIFF
--- a/web/client/components/contextcreator/__tests__/ContextCreator-test.jsx
+++ b/web/client/components/contextcreator/__tests__/ContextCreator-test.jsx
@@ -13,7 +13,7 @@ import {Provider} from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 
 import expect from 'expect';
-import ContextCreator from '../ContextCreator';
+import ContextCreator, { pluginsFilterOverride } from '../ContextCreator';
 
 const mockStore = configureMockStore();
 
@@ -69,5 +69,33 @@ describe('ContextCreator component', () => {
             // check customization of destination path
             expect(spyonSave).toHaveBeenCalledWith("MY_DESTINATION");
         });
+    });
+    describe('viewerPlugins filtering', () => {
+        it('filter plugins accordingly', () => {
+            expect(pluginsFilterOverride(["P1", "P2"], ["P1"])).toEqual(["P1"]);
+        });
+        it('apply plugins overrides', () => {
+            // add cfg where missing
+            expect(pluginsFilterOverride(["P1", "P2"], [{
+                "name": "P1",
+                "overrides": {
+                    "cfg": { test: "newValue" }
+                }
+            }])).toEqual([{
+                "name": "P1",
+                "cfg": { test: "newValue" }
+            }]);
+            // not modifies the existing cfg
+            expect(pluginsFilterOverride(["P1", { name: "P2", "cfg": { test: "value1", test2: "value2"}}], [{
+                "name": "P2",
+                "overrides": {
+                    "cfg": { test: "newValue" }
+                }
+            }])).toEqual([{
+                "name": "P2",
+                "cfg": { test: "newValue", test2: "value2" }
+            }]);
+        });
+
     });
 });


### PR DESCRIPTION
## Description
This PR add some enhancements to solve layout issues in context creator map editor. Because map layout can not be handled, and it's hard to manage also the georchestra use case, we decided to : 
 - Remove FeatureEditor

To remove the FeatureEditor, the button in the TOC that links to it must be hidden. To do this, it has been necessary to enhance ContextCreator to also override plugins configurations. 

An entry "overrides" in the viewerPlugins property configuration allows to override the "cfg" entries.

In addition:
 - Add Annotations and MapImport plugins for the context editor

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 
**What is the current behavior?** (You can also link to an open issue here)
Context creator is does not correctly handle the feature grid and other panel because of maplayout

**What is the new behavior?**
Removed FeatureEditor from context creator viewer.
Add annotations and MapImport

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No


