### PR TITLE
# 4609 Fixes logout on public contexts

### DIFF
--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -121,6 +121,17 @@ describe('config epics', () => {
                 done();
             });
         });
+        it('load a context with new map as anonymous user', (done) => {
+            mockAxios.onGet("/new.json").reply(() => ([ 200, {} ]));
+            const NUM_ACTIONS = 1;
+            testEpic(loadMapConfigAndConfigureMap, NUM_ACTIONS, loadMapConfig('new.json', null, { version: 2}), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                const [a] = actions;
+                expect(a).toExist();
+                expect(a.type).toBe(MAP_CONFIG_LOADED);
+                done();
+            });
+        });
         it('load new map as ADMIN', (done) => {
             const NUM_ACTIONS = 1;
             mockAxios.onGet("/new.json").reply(() => ([ 200, {} ]));

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -31,7 +31,8 @@ export const loadMapConfigAndConfigureMap = (action$, store) =>
             // TODO: investigate the root causes of the problem and come up with a better solution, if possible
             (config ? Observable.of({data: config}).delay(100) : Observable.defer(() => axios.get(configName)))
                 .switchMap(response => {
-                    if (configName === "new.json" && !isLoggedIn(store.getState())) {
+                    // added !config in order to avoid showing login modal when a new.json mapConfig is used in a public context
+                    if (configName === "new.json" && !config && !isLoggedIn(store.getState())) {
                         return Observable.of(configureError({status: 403}));
                     }
                     if (typeof response.data === 'object') {


### PR DESCRIPTION
## Description
Fix prompt login for public context that are using new.jsion as map configuration

## Issues
 - #4609

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
Logging out from tobaro context does not trigger prompt login

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
