### PR TITLE
Attempt to fix jenkins build

### DIFF
--- a/web/client/components/contextcreator/__tests__/ContextCreator-test.jsx
+++ b/web/client/components/contextcreator/__tests__/ContextCreator-test.jsx
@@ -12,6 +12,9 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 
+import { isEqual } from 'lodash';
+
+
 import expect from 'expect';
 import ContextCreator, { pluginsFilterOverride } from '../ContextCreator';
 
@@ -72,29 +75,32 @@ describe('ContextCreator component', () => {
     });
     describe('viewerPlugins filtering', () => {
         it('filter plugins accordingly', () => {
-            expect(pluginsFilterOverride(["P1", "P2"], ["P1"])).toEqual(["P1"]);
+            expect(isEqual(pluginsFilterOverride(["P1", "P2"], ["P1"]), ["P1"]));
         });
         it('apply plugins overrides', () => {
             // add cfg where missing
-            expect(pluginsFilterOverride(["P1", "P2"], [{
-                "name": "P1",
-                "overrides": {
+            expect(isEqual(
+                pluginsFilterOverride(["P1", "P2"], [{
+                    "name": "P1",
+                    "overrides": {
+                        "cfg": { test: "newValue" }
+                    }
+                }]),
+                [{
+                    "name": "P1",
                     "cfg": { test: "newValue" }
-                }
-            }])).toEqual([{
-                "name": "P1",
-                "cfg": { test: "newValue" }
-            }]);
+                }]
+            )).toBeTruthy();
             // not modifies the existing cfg
-            expect(pluginsFilterOverride(["P1", { name: "P2", "cfg": { test: "value1", test2: "value2"}}], [{
+            expect(isEqual(pluginsFilterOverride(["P1", { name: "P2", "cfg": { test: "value1", test2: "value2" } }], [{
                 "name": "P2",
                 "overrides": {
                     "cfg": { test: "newValue" }
                 }
-            }])).toEqual([{
+            }]), [{
                 "name": "P2",
                 "cfg": { test: "newValue", test2: "value2" }
-            }]);
+            }])).toBeTruthy();
         });
 
     });


### PR DESCRIPTION
## Description
Jenkins failing with this log:
```
06 12 2019 11:04:03.794:INFO [HeadlessChrome 78.0.3904 (Linux 0.0.0)]: Connected on socket Ig7gQiBXGeDEKmluAAAA with id 14947181
HeadlessChrome 78.0.3904 (Linux 0.0.0) ERROR
Uncaught SyntaxError: Illegal return statement
at http://localhost:9876/context.html:12:2

SyntaxError: Illegal return statement
at Object../node_modules/is-map/index.js (build/tests-travis.webpack.js:18071:1)
at __webpack_require__ (build/tests-travis.webpack.js:64:30)
at eval (webpack:///./node_modules/which-collection/index.js?:3:13)
at Object../node_modules/which-collection/index.js (build/tests-travis.webpack.js:47583:1)
at __webpack_require__ (build/tests-travis.webpack.js:64:30)
at eval (webpack:///./node_modules/is-equal/why.js?:19:23)
at Object../node_modules/is-equal/why.js (build/tests-travis.webpack.js:18047:1)
at __webpack_require__ (build/tests-travis.webpack.js:64:30)
at eval (webpack:///./node_modules/expect/lib/TestUtils.js?:14:12)
at Object../node_modules/expect/lib/TestUtils.js (build/tests-travis.webpack.js:17121:1)

https://travis-ci.org/geosolutions-it/MapStore2
```

This error doesn't happen on travis or locally, probably a problems of node or npm on jenkins, anyway the issue is caused by `toEqual` function dependencies. So creating a different test should temporary make the build work.