### PR TITLE
Explicit dependency of is-equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "immutable": "4.0.0-rc.12",
     "intersection-observer": "0.7.0",
     "intl": "1.2.2",
+    "is-equal": "1.5.5",
     "ismobilejs": "0.5.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "json-2-csv": "2.1.2",


### PR DESCRIPTION
## Description
Build failures like [this](https://build.geo-solutions.it/jenkins/view/MapStore2/job/MapStore2_Dev_Build/1429/console)
fail because of this error

```
SyntaxError: Illegal return statement
      at Object../node_modules/is-map/index.js (build/tests-travis.webpack.js:18071:1)
      at __webpack_require__ (build/tests-travis.webpack.js:64:30)
      at eval (webpack:///./node_modules/which-collection/index.js?:3:13)
      at Object../node_modules/which-collection/index.js (build/tests-travis.webpack.js:47583:1)
      at __webpack_require__ (build/tests-travis.webpack.js:64:30)
      at eval (webpack:///./node_modules/is-equal/why.js?:19:23)
      at Object../node_modules/is-equal/why.js (build/tests-travis.webpack.js:18047:1)
      at __webpack_require__ (build/tests-travis.webpack.js:64:30)
      at eval (webpack:///./node_modules/expect/lib/TestUtils.js?:14:12)
      at Object../node_modules/expect/lib/TestUtils.js (build/tests-travis.webpack.js:17121:1)
```

 should be caused by is-equal 1.6.1 that include some libs (which-collection --> is-map) that  has a return in module body. Locally I have 1.5.5 that doesn't include the lib causing the problems. 

They are included by expect 1.20.1 that seems to apply this changes without updating the version. 

This commit tries to force the use the working libs. 

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:


