### PR TITLE
4382 gfi mobile coord editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "clean": "rimraf ./web/client/dist",
     "compile": "npm run clean && mkdirp ./web/client/dist && node --max_old_space_size=2048 ./node_modules/webpack/bin/webpack.js --progress  --colors --config build/prod-webpack.config.js",
     "analyze": "npm run clean && mkdirp ./web/client/dist && webpack --json --config build/prod-webpack.config.js | webpack-bundle-size-analyzer",
-    "start": "webpack-dev-server --progress --colors --port 8081 --hot --inline --host 192.168.1.176 --config build/webpack.config.js --content-base web/client",
+    "start": "webpack-dev-server --progress --colors --port 8081 --hot --inline --config build/webpack.config.js --content-base web/client",
     "startprod": "webpack-dev-server --progress --colors --port 8081 --hot --inline --content-base web/client  --config build/prod-webpack.config.js",
     "examples": "webpack-dev-server --progress --colors --port 8081 --hot --inline --content-base web/client --config build/examples-webpack.config.js",
     "test": "karma start ./build/karma.conf.single-run.js --colors",

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "clean": "rimraf ./web/client/dist",
     "compile": "npm run clean && mkdirp ./web/client/dist && node --max_old_space_size=2048 ./node_modules/webpack/bin/webpack.js --progress  --colors --config build/prod-webpack.config.js",
     "analyze": "npm run clean && mkdirp ./web/client/dist && webpack --json --config build/prod-webpack.config.js | webpack-bundle-size-analyzer",
-    "start": "webpack-dev-server --progress --colors --port 8081 --hot --inline  --config build/webpack.config.js --content-base web/client",
+    "start": "webpack-dev-server --progress --colors --port 8081 --hot --inline --host 192.168.1.176 --config build/webpack.config.js --content-base web/client",
     "startprod": "webpack-dev-server --progress --colors --port 8081 --hot --inline --content-base web/client  --config build/prod-webpack.config.js",
     "examples": "webpack-dev-server --progress --colors --port 8081 --hot --inline --content-base web/client --config build/examples-webpack.config.js",
     "test": "karma start ./build/karma.conf.single-run.js --colors",

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -73,7 +73,7 @@ class CoordinatesRow extends React.Component {
                     {this.props.showDraggable ? this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton : null}
                 </Col>
                 <Col xs={5}>
-                    {this.props.showLabels && <span><Message msgId="latitude"/></span>}
+                    {this.props.showLabels && <div><Message msgId="latitude"/></div>}
                     <CoordinateEntry
                         format={this.props.format}
                         aeronauticalOptions={this.props.aeronauticalOptions}
@@ -96,7 +96,7 @@ class CoordinatesRow extends React.Component {
                     />
                 </Col>
                 <Col xs={5}>
-                    {this.props.showLabels && <span><Message msgId="longitude"/></span>}
+                    {this.props.showLabels && <div><Message msgId="longitude"/></div>}
                     <CoordinateEntry
                         format={this.props.format}
                         aeronauticalOptions={this.props.aeronauticalOptions}

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -60,7 +60,7 @@ class CoordinatesRow extends React.Component {
             </Button></div>);
 
         return (
-            <Row className={`coordinateRow ${this.props.customClassName || ""}`} style={!this.props.customClassName ? rowStyle : {}} onMouseEnter={() => {
+            <Row className={`coordinateRow ${this.props.format || ""} ${this.props.customClassName || ""}`} style={!this.props.customClassName ? rowStyle : {}} onMouseEnter={() => {
                 if (this.props.onMouseEnter && this.props.component.lat && this.props.component.lon) {
                     this.props.onMouseEnter(this.props.component);
                 }
@@ -69,55 +69,60 @@ class CoordinatesRow extends React.Component {
                     this.props.onMouseLeave();
                 }
             }}>
+
                 <Col xs={1}>
                     {this.props.showDraggable ? this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton : null}
                 </Col>
-                <Col xs={5}>
-                    {this.props.showLabels && <div><Message msgId="latitude"/></div>}
-                    <CoordinateEntry
-                        format={this.props.format}
-                        aeronauticalOptions={this.props.aeronauticalOptions}
-                        coordinate="lat"
-                        idx={idx}
-                        value={this.props.component.lat}
-                        onChange={(dd) => this.props.onChange(idx, "lat", dd)}
-                        constraints={{
-                            decimal: {
-                                lat: {
-                                    min: -90,
-                                    max: 90
-                                },
-                                lon: {
-                                    min: -180,
-                                    max: 180
+                <div className="coordinate lat" style={{width: "100%"}}>
+                    <Col xs={5}>
+                        {this.props.showLabels && <div><Message msgId="latitude"/></div>}
+                        <CoordinateEntry
+                            format={this.props.format}
+                            aeronauticalOptions={this.props.aeronauticalOptions}
+                            coordinate="lat"
+                            idx={idx}
+                            value={this.props.component.lat}
+                            onChange={(dd) => this.props.onChange(idx, "lat", dd)}
+                            constraints={{
+                                decimal: {
+                                    lat: {
+                                        min: -90,
+                                        max: 90
+                                    },
+                                    lon: {
+                                        min: -180,
+                                        max: 180
+                                    }
                                 }
-                            }
-                        }}
-                    />
-                </Col>
-                <Col xs={5}>
-                    {this.props.showLabels && <div><Message msgId="longitude"/></div>}
-                    <CoordinateEntry
-                        format={this.props.format}
-                        aeronauticalOptions={this.props.aeronauticalOptions}
-                        coordinate="lon"
-                        idx={idx}
-                        value={this.props.component.lon}
-                        onChange={(dd) => this.props.onChange(idx, "lon", dd)}
-                        constraints={{
-                            decimal: {
-                                lat: {
-                                    min: -90,
-                                    max: 90
-                                },
-                                lon: {
-                                    min: -180,
-                                    max: 180
+                            }}
+                        />
+                    </Col>
+                </div>
+                <div className="coordinate lon" style={{width: "100%"}}>
+                    <Col xs={5}>
+                        {this.props.showLabels && <div><Message msgId="longitude"/></div>}
+                        <CoordinateEntry
+                            format={this.props.format}
+                            aeronauticalOptions={this.props.aeronauticalOptions}
+                            coordinate="lon"
+                            idx={idx}
+                            value={this.props.component.lon}
+                            onChange={(dd) => this.props.onChange(idx, "lon", dd)}
+                            constraints={{
+                                decimal: {
+                                    lat: {
+                                        min: -90,
+                                        max: 90
+                                    },
+                                    lon: {
+                                        min: -180,
+                                        max: 180
+                                    }
                                 }
-                            }
-                        }}
-                    />
-                </Col>
+                            }}
+                        />
+                    </Col>
+                </div>
                 <Col xs={1}>
                     <Toolbar
                         btnGroupProps={{ className: 'pull-right' }}

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -164,7 +164,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                     />
                     <span style={labelStyle}>&prime;</span>
                 </div>
-                <div style={{minWidth: "85px", display: 'flex'}}>
+                <div className="seconds" style={{display: 'flex'}}>
                     <FormControl
                         key={this.props.coordinate + "seconds"}
                         value={this.props.seconds}

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -121,7 +121,7 @@ class AeronauticalCoordinateEditor extends React.Component {
             top: 0,
             overflow: "visible",
             zIndex: 3,
-            left: -23,
+            left: -13,
             width: 0,
             height: 0
         };
@@ -164,7 +164,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                     />
                     <span style={labelStyle}>&prime;</span>
                 </div>
-                <div style={{flex: 1, display: 'flex'}}>
+                <div style={{minWidth: "85px", display: 'flex'}}>
                     <FormControl
                         key={this.props.coordinate + "seconds"}
                         value={this.props.seconds}

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -1,4 +1,24 @@
 
+#identify-container {
+    .coordinateRow.coord-editor.aeronautical {
+        @media screen and (max-width: 660px) {
+            display: block;
+            & .col-xs-1 .pull-right.btn-group {
+                margin-top: -70px;
+            }
+
+        }
+        & .form-group {
+            left: ~'calc(50% - 133px)';
+            position: relative;
+            & .seconds {
+                min-width: 120px;
+                flex: unset !important;
+            }
+        }
+    }
+}
+
 .coordinateRow {
     margin: 8px 0px;
     border: 1px solid #dddddd;
@@ -6,6 +26,7 @@
     display: flex;
     align-items: center;
     box-sizing: border-box;
+
     input {
         font-size: 12px;
         font-family: Menlo, Monaco, Consolas, Courier New, monospace;


### PR DESCRIPTION
## Description
Fixing the style of coordinate editor for aeronautical format in mobile mode when width is lower than 660px

This is the result, with a screen with width lower than 660px
![image](https://user-images.githubusercontent.com/11991428/70539206-a27c7880-1b63-11ea-89c4-3cb45eaeb8e9.png)

Only aeronautical changes like this, the decimal should stay unchanged.

## Issues
 - #4382

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
use dev tool to enter the mapo in mobile mode
![image](https://user-images.githubusercontent.com/11991428/70539703-5e3da800-1b64-11ea-9662-d8b10fcfdb35.png)

- Open a map 
- click on the map (will open Feature info)
- open coordinate editor
- change format
- play with the width to see what happens across 660px 

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This will need to be backported

**for tester:**

You should test the coordinate editor also the GFI in desktop mode, in annotations (desktop mode only) in measure tool with editor enabled (if configured) se Measure plugin documentation about this.
