### PR TITLE
Fix Map preview for widget

### DIFF
--- a/web/client/components/mediaEditor/map/MapList.jsx
+++ b/web/client/components/mediaEditor/map/MapList.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from "react";
-import {compose, withHandlers, mapPropsStream} from 'recompose';
+import {compose, withProps, withHandlers, mapPropsStream} from 'recompose';
 
 import MapCatalogComp from '../../maps/MapCatalog';
 import mapCatalog from '../../maps/enhancers/mapCatalog';
@@ -114,5 +114,8 @@ export default compose(
             onMapSelected(map);
         }
     }),
+    withProps(() => ({
+        includeMapId: true
+    })),
     handleMapSelect
 )(MapList);

--- a/web/client/components/widgets/builder/wizard/map/enhancers/handleMapSelect.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/handleMapSelect.js
@@ -17,7 +17,7 @@ import { excludeGoogleBackground } from '../../../../../../utils/LayersUtils';
 const handleMapSelect = compose(
     withState('selected', "setSelected", null),
     withHandlers({
-        onMapChoice: ({ onMapSelected = () => { }, selectedSource = {} } = {}) => map =>
+        onMapChoice: ({ onMapSelected = () => { }, selectedSource = {}, includeMapId = false } = {}) => map =>
             (typeof map.id === 'string'
                 ? axios.get(map.id).then(response => response.data)
                 : GeoStoreDAO.getData(map.id, {baseURL: selectedSource.baseURL})
@@ -25,7 +25,7 @@ const handleMapSelect = compose(
                 let mapState = (!config.version && typeof map.id !== 'string') ? ConfigUtils.convertFromLegacy(config) : ConfigUtils.normalizeConfig(config.map);
                 return {
                     ...(mapState && mapState.map || {}),
-                    id: map.id,
+                    ...(includeMapId ? {id: map.id} : {}),
                     layers: excludeGoogleBackground(mapState.layers.map(l => {
                         if (l.group === "background" && (l.type === "ol" || l.type === "OpenLayers.Layer")) {
                             l.type = "empty";


### PR DESCRIPTION
## Description
* without breaking geostory preview in the media editor
* the id is needed there

## Issues
 - #4614

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
see issue

**What is the new behavior?**
the preview of the map widget now renders in the correct place.
The preview of map in media editor continues to work as usual

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

for testes, this change involves also geostory preview map in the media editor in the sense that everything should continue to work there