### PR TITLE
#4593 Disabled permission only with owner attribute

### DIFF
--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -27,6 +27,8 @@ const {
     MAP_UPDATING, mapUpdating,
     DETAILS_LOADED, detailsLoaded,
     PERMISSIONS_UPDATED, permissionsUpdated,
+    loadPermissions,
+    PERMISSIONS_LIST_LOADING, PERMISSIONS_LIST_LOADED,
     ATTRIBUTE_UPDATED, attributeUpdated,
     SAVE_MAP, saveMap,
     DISPLAY_METADATA_EDIT, onDisplayMetadataEdit,
@@ -398,6 +400,24 @@ describe('Test correctness of the maps actions', () => {
         const a = setFeaturedMapsLatestResource(resource);
         expect(a.type).toBe(FEATURED_MAPS_SET_LATEST_RESOURCE);
         expect(a.resource).toBe(resource);
+    });
+    it('loadPermissions error', done => {
+        const NOT_EXISTING = "UNKNOWN_RESOURCE";
+        loadPermissions(NOT_EXISTING)(action => {
+            switch (action.type) {
+            case PERMISSIONS_LIST_LOADED:
+                expect(action.permissions).toBe(null);
+                expect(action.mapId).toBe(NOT_EXISTING);
+                done();
+                break;
+            case PERMISSIONS_LIST_LOADING:
+                expect(action.mapId).toBe(NOT_EXISTING);
+                break;
+            default:
+                done(`${action.type} action triggered, not expected`);
+                break;
+            }
+        });
     });
 
 });

--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -461,9 +461,8 @@ function loadPermissions(mapId) {
         GeoStoreApi.getPermissions(mapId, {}).then((response) => {
             dispatch(permissionsLoaded(response, mapId));
             dispatch(updateCurrentMapPermissions(response));
-        }).catch((e) => {
+        }).catch(() => {
             dispatch(permissionsLoaded(null, mapId));
-            dispatch(loadError(e));
         });
     };
 }

--- a/web/client/components/resources/modals/Save.jsx
+++ b/web/client/components/resources/modals/Save.jsx
@@ -19,6 +19,30 @@ const ruleEditor = require('./enhancers/ruleEditor');
 const PermissionEditor = ruleEditor(require('./fragments/PermissionEditor'));
 
 /**
+ * Defines if the resource permissions are available or not.
+ * Actually GeoStore allow editing of the permission to the owner or to the administrators.
+ * For new resources the owner (will be) the current user so if owner is missing (as for new resources),
+ * this returns true.
+ * @param {object} user the user object, with role and name properties
+ * @param {object} resource the resource object, with attributes (owner)
+ */
+const canEditResourcePermission = (user = {}, resource) => {
+    // anonymous users can not edit
+    if (!user) {
+        return false;
+    }
+    const { role, name } = user;
+    if (role === 'ADMIN') {
+        return true;
+    }
+    // if owner is present, permissions are editable only by him
+    const owner = resource && resource.attributes && resource.attributes.owner;
+    if (owner) {
+        return owner === name;
+    }
+    return true;
+};
+/**
  * A Modal window to show map metadata form
 */
 class SaveModal extends React.Component {
@@ -84,8 +108,8 @@ class SaveModal extends React.Component {
      * @return the modal for unsaved changes
     */
     render() {
-        const canEditResourcePermission = this.props.user && this.props.user.role === 'ADMIN' ||
-        this.props.resource && this.props.resource.attributes && this.props.resource.attributes.owner === this.props.user.name;
+        const canEditPermission = canEditResourcePermission(this.props.user, this.props.resource);
+
         return (<Portal key="saveDialog">
             {<ResizableModal
                 loading={this.props.loading}
@@ -116,7 +140,7 @@ class SaveModal extends React.Component {
                             nameFieldFilter={this.props.nameFieldFilter}
                             onUpdate={this.props.onUpdate} />
                         {
-                            !!canEditResourcePermission &&  <PermissionEditor
+                            !!canEditPermission &&  <PermissionEditor
                                 rules={this.props.rules}
                                 onUpdateRules={this.props.onUpdateRules}
                                 availableGroups={this.props.availableGroups}

--- a/web/client/components/resources/modals/__tests__/Save-test.jsx
+++ b/web/client/components/resources/modals/__tests__/Save-test.jsx
@@ -123,5 +123,20 @@ describe('This test for dashboard save form', () => {
         const permissionSection = document.querySelector(".permissions-table");
         expect(permissionSection).toBeNull;
     });
+    it('modal shows permissions when the map is new (no owner)', () => {
+        const user = { role: 'USER', name: 'solution' };
+        const resource = {  };
+        const metadataModalItem = ReactDOM.render(<MetadataModal show user={user} resource={resource} useModal id="MetadataModal" />, document.getElementById("container"));
+        expect(metadataModalItem).toExist();
+
+        const getModals = () => {
+            return document.getElementsByTagName("body")[0].getElementsByClassName('modal-dialog');
+        };
+
+        expect(getModals().length).toBe(1);
+
+        const permissionSection = document.querySelector(".permissions-table");
+        expect(permissionSection).toExist();
+    });
 
 });

--- a/web/client/reducers/__tests__/maps-test.js
+++ b/web/client/reducers/__tests__/maps-test.js
@@ -155,6 +155,7 @@ describe('Test the maps reducer', () => {
         }));
         state = maps(state, permissionsLoading(sampleMap.id));
         expect(state.results[0].permissionLoading).toBe(true);
+
         state = maps(state, permissionsLoaded(permissions, sampleMap.id));
         expect(state.results[0].permissionLoading).toBe(false);
         expect(state.results[0].permissions).toExist();
@@ -168,6 +169,11 @@ describe('Test the maps reducer', () => {
         expect(state.results[0].permissions.SecurityRuleList.SecurityRule).toExist();
         expect(state.results[0].permissions.SecurityRuleList.SecurityRule.length).toBe(1);
 
+        // check permission list loading doesn't fail if permission is undefined or null
+        // i.e. when some error occurs loading permissions
+        const errorState = maps({}, permissionsLoaded(null, sampleMap.id));
+        expect(errorState).toExist();
+        expect(errorState.results).toExist();
     });
 
 });

--- a/web/client/reducers/maps.js
+++ b/web/client/reducers/maps.js
@@ -211,7 +211,7 @@ function maps(state = {
         return newState;
     }
     case PERMISSIONS_LIST_LOADED: {
-        let newMaps = state.results === "" ? [] : [...state.results];
+        let newMaps = state.results === "" ? [] : [...(state.results || [])];
         // TODO: Add the fix for GeoStore single-item arrays
         let newState = assign({}, state, {
             results: newMaps.map(function(map) {


### PR DESCRIPTION
## Description
Maps have owner, so only owner can edit permissions, the other users can only edit the resource. In case you're not the owner, you will not see permission anymore. 
For other resources, all users with write/Delete granted can also edit permission

- Disabled Permissions when owner is present. 
- Minor bug fix in case of permission load errors
- Re-enabled permission setting functionalities for new resources in case of normal users 

(regression introduced in #4595 )

**note** : "ADMIN" users are not affected by this logic, they can do anything.

## Issues
 - #4593 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Bugfix
 

**What is the current behavior?** (You can also link to an open issue here)
- Normal user can not edit permissions for stories and dashboards

**What is the new behavior?**
- Normal user can edit permissions for stories and dashboards


**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [ ] Yes, and I documented them in migration notes
 - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
