### PR TITLE
Fix 4392 Hide timestamp on new resource save (Backport #4625) for 2019.03.xx

### DIFF
--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -77,7 +77,7 @@ class Metadata extends React.Component {
                     disabled={this.props.resource.saving}
                     placeholder={this.props.namePlaceholderText}
                     defaultValue={this.props.resource ? this.props.resource.name : ""}
-                    value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.name || ""}/>
+                    value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.name || ""} />
             </FormGroup>
             <FormGroup>
                 <ControlLabel>{this.props.descriptionFieldText}</ControlLabel>
@@ -88,16 +88,20 @@ class Metadata extends React.Component {
                     disabled={this.props.resource.saving}
                     placeholder={this.props.descriptionPlaceholderText}
                     defaultValue={this.props.resource ? this.props.resource.description : ""}
-                    value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.description || ""}/>
+                    value={this.props.resource && this.props.resource.metadata && this.props.resource.metadata.description || ""} />
             </FormGroup>
-            <FormGroup>
-                <ControlLabel>{this.props.createdAtFieldText}</ControlLabel>
-                <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.createdAt) || ""}</ControlLabel>
-            </FormGroup>
-            <FormGroup>
-                <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
-                <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt || this.props.resource.createdAt) || ""}</ControlLabel>
-            </FormGroup>
+            {
+                this.props.resource && this.props.resource.createdAt && <FormGroup>
+                    <ControlLabel>{this.props.createdAtFieldText}</ControlLabel>
+                    <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.createdAt) || ""}</ControlLabel>
+                </FormGroup>
+            }
+            {
+                this.props.resource && this.props.resource.modifiedAt && this.props.resource.createdAt && <FormGroup>
+                    <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
+                    <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt || this.props.resource.createdAt) || ""}</ControlLabel>
+                </FormGroup>
+            }
         </form>);
     }
 

--- a/web/client/components/resources/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Metadata-test.jsx
@@ -30,6 +30,7 @@ describe('Metadata component', () => {
     it('Metadata rendering with meta-data', () => {
         const resource = {
             modifiedAt: new Date(),
+            createdAt: new Date(),
             metadata: {
                 name: "NAME",
                 description: "DESCRIPTION"
@@ -38,10 +39,24 @@ describe('Metadata component', () => {
         ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelectorAll('input');
-        expect(el.length).toBe(2);
+        const labels = container.querySelectorAll('label');
+        expect(labels.length).toBe(6);
         expect(el[0].value).toBe("NAME");
         expect(el[1].value).toBe("DESCRIPTION");
     });
+    it('Metadata rendering without timestamp', () => {
+        const resource = {
+            metadata: {
+                name: "NAME",
+                description: "DESCRIPTION"
+            }
+        };
+        ReactDOM.render(<Metadata resource={resource}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const labels = container.querySelectorAll('label');
+        expect(labels.length).toBe(2);
+    });
+
     it('Test Metadata onChange', () => {
         const actions = {
             onChange: () => {}


### PR DESCRIPTION
see #4625