### PR TITLE
Fix 4623 WMS GetCapabilities and DescribeLayer do not support custom query parameters (2019.03.xx)

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -134,7 +134,7 @@ const Api = {
             });
         });
     },
-    describeLayer: function(url, layers) {
+    describeLayer: function(url, layers, options = {}) {
         const parsed = urlUtil.parse(url, true);
         const describeLayerUrl = urlUtil.format(assign({}, parsed, {
             query: assign({
@@ -142,7 +142,9 @@ const Api = {
                 version: "1.1.1",
                 layers: layers,
                 request: "DescribeLayer"
-            }, parsed.query)
+            },
+            parsed.query,
+            options.query || {})
         }));
         return new Promise((resolve) => {
             require.ensure(['../utils/ogc/WMS'], () => {

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -257,7 +257,8 @@ module.exports = {
 
                 const layer = getUpdatedLayer(state);
 
-                const describeAction = layer && !layer.describeFeatureType && getDescribeLayer(layer.url, layer);
+                const query = layer && layer.params || {};
+                const describeAction = layer && !layer.describeFeatureType && getDescribeLayer(layer.url, layer, { query });
                 const selectedStyle = selectedStyleSelector(state);
                 const styleName = selectedStyle || layer.availableStyles && layer.availableStyles[0] && layer.availableStyles[0].name;
 

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -533,7 +533,11 @@ const LayersUtils = {
                 }
             }
         }
-        return addBaseParams(reqUrl, layer.baseParams || {});
+        const params = {
+            ...layer.baseParams,
+            ...layer.params
+        };
+        return addBaseParams(reqUrl, params);
     },
     /**
      * Gets the layer search url or the current url

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1017,4 +1017,20 @@ describe('LayersUtils', () => {
                 availableStyles: [{ name: 'generic' }]
             });
     });
+
+    it('test getCapabilitiesUrl with custom params in in layer options', () => {
+
+        const EXPECTED_CAPABILITIES_URL = 'localhost:8080/geoserver/woekspace/layer/wms?token=value';
+
+        const layer = {
+            url: 'localhost:8080/geoserver/wms',
+            name: 'woekspace:layer',
+            params: {
+                token: 'value'
+            }
+        };
+
+        expect(LayersUtils.getCapabilitiesUrl(layer)).toEqual(EXPECTED_CAPABILITIES_URL);
+
+    });
 });


### PR DESCRIPTION
## Description
This PR introduces the possibilities to add custom parameter to GetCapabilities and DescribeLayer.

Note:
I'm wondering if this solution could break some other GetCapabilities or DescribeLayer requests:
eg: Server rejects some request because of specific params

## Issues
 - #4623 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
#4623 

**What is the new behavior?**
Params in layer options are used inside GetCapabilities and DescribeLayer requests of style editor.

**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
