### PR TITLE
updated API to upload attributes

### DIFF
--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -50,10 +50,11 @@ const {
 
 let GeoStoreDAO = require('../../api/GeoStoreDAO');
 let oldAddBaseUri = GeoStoreDAO.addBaseUrl;
-let mockAxios = new MockAdapter(axios);
+
 const BASE_URL = 'base/web/client/test-resources/geostore/';
 
 describe('Test correctness of the maps actions', () => {
+    let mockAxios;
     beforeEach(() => {
         mockAxios = new MockAdapter(axios);
         GeoStoreDAO.addBaseUrl = (options) => {

--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -8,6 +8,8 @@
 
 var expect = require('expect');
 const assign = require('object-assign');
+const axios = require("../../libs/ajax");
+const MockAdapter = require("axios-mock-adapter");
 const {
     toggleDetailsSheet, TOGGLE_DETAILS_SHEET,
     toggleGroupProperties, TOGGLE_GROUP_PROPERTIES,
@@ -48,15 +50,19 @@ const {
 
 let GeoStoreDAO = require('../../api/GeoStoreDAO');
 let oldAddBaseUri = GeoStoreDAO.addBaseUrl;
+let mockAxios = new MockAdapter(axios);
+const BASE_URL = 'base/web/client/test-resources/geostore/';
 
 describe('Test correctness of the maps actions', () => {
     beforeEach(() => {
+        mockAxios = new MockAdapter(axios);
         GeoStoreDAO.addBaseUrl = (options) => {
-            return assign(options, {baseURL: 'base/web/client/test-resources/geostore/'});
+            return assign(options, {baseURL: BASE_URL});
         };
     });
     afterEach(() => {
         GeoStoreDAO.addBaseUrl = oldAddBaseUri;
+        mockAxios.restore();
     });
     it('updateAttribute with error', (done) => {
         const value = "asdSADs";
@@ -77,6 +83,18 @@ describe('Test correctness of the maps actions', () => {
         const name = "thumbnail";
         const resourceId = 1;
         const type = "STRING";
+
+        mockAxios.onPut().reply(({url, data }) => {
+            expect(url).toBe(`${BASE_URL}resources/resource/${resourceId}/attributes/`);
+            expect(JSON.parse(data)).toEqual({
+                "restAttribute": {
+                    name,
+                    value
+                }
+            });
+            return [200];
+        });
+
         const retFun = updateAttribute(resourceId, name, value, type, {});
         expect(retFun).toExist();
         let count = 0;

--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -170,10 +170,15 @@ const Api = {
     },
     updateResourceAttribute: function(resourceId, name, value, type, options) {
         return axios.put(
-            "resources/resource/" + resourceId + "/attributes/" + name + "/" + value, null,
+            "resources/resource/" + resourceId + "/attributes/", {
+                "restAttribute": {
+                    name,
+                    value
+                }
+            },
             this.addBaseUrl(merge({
                 headers: {
-                    'Content-Type': "application/xml"
+                    'Content-Type': "application/json"
                 }
             }, options)));
     },

--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -87,7 +87,16 @@ class MapCard extends React.Component {
     getCardStyle = () => {
         if (this.props.map.thumbnail) {
             return assign({}, this.props.style, {
-                backgroundImage: 'linear-gradient(rgba(0, 0, 0, ' + this.props.backgroundOpacityStart + '), rgba(0, 0, 0, ' + this.props.backgroundOpacityEnd + ') ), url(' + (this.props.map.thumbnail === null || this.props.map.thumbnail === "NODATA" ? thumbUrl : decodeURIComponent(this.props.map.thumbnail)) + ')'
+                backgroundImage: 'linear-gradient(rgba(0, 0, 0, '
+                    + this.props.backgroundOpacityStart
+                    + '), rgba(0, 0, 0, ' + this.props.backgroundOpacityEnd
+                    + ') ), url('
+                    + (this.props.map.thumbnail === null || this.props.map.thumbnail === "NODATA"
+                        ? thumbUrl
+                        // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
+                        : decodeURIComponent(this.props.map.thumbnail)
+                    )
+                    + ')'
             });
         }
         return this.props.style;

--- a/web/client/components/maps/forms/Thumbnail.jsx
+++ b/web/client/components/maps/forms/Thumbnail.jsx
@@ -81,7 +81,10 @@ class Thumbnail extends React.Component {
     };
 
     getThumbnailUrl = () => {
-        return this.props.map && this.props.map.newThumbnail && this.props.map.newThumbnail !== "NODATA" ? decodeURIComponent(this.props.map.newThumbnail) : null;
+        return this.props.map && this.props.map.newThumbnail && this.props.map.newThumbnail !== "NODATA"
+            // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
+            ? decodeURIComponent(this.props.map.newThumbnail)
+            : null;
     };
 
     isImage = (images) => {

--- a/web/client/components/maps/forms/Thumbnail.jsx
+++ b/web/client/components/maps/forms/Thumbnail.jsx
@@ -12,6 +12,8 @@ const {Glyphicon} = require('react-bootstrap');
 const Dropzone = require('react-dropzone');
 const Spinner = require('react-spinkit');
 const Message = require('../../../components/I18N/Message');
+const { getResourceIdFromURL } = require('../../../utils/ResourceUtils');
+
 
 const errorMessages = {
     "FORMAT": <Message msgId="map.errorFormat" />,
@@ -188,14 +190,10 @@ class Thumbnail extends React.Component {
 
     deleteThumbnail = (thumbnail, mapId) => {
         if (thumbnail && thumbnail.indexOf("geostore") !== -1) {
-            // this doesn't work if the URL is not encoded (because of GeoStore / Tomcat parameter encoding issues)
-            let start = thumbnail.indexOf("data%2F") + 7;
-            let end = thumbnail.indexOf("%2Fraw");
-            let idThumbnail = thumbnail.slice(start, end);
-
+            const idThumbnail = getResourceIdFromURL(thumbnail);
             // delete the old thumbnail
             if (idThumbnail) {
-                // with mapId != null it will ovveride thumbnail attribute with NODATA value for that map
+                // with mapId != null it will override thumbnail attribute with NODATA value for that map
                 this.props.onDeleteThumbnail(idThumbnail, mapId);
             }
         }

--- a/web/client/components/mediaEditor/map/MapList.jsx
+++ b/web/client/components/mediaEditor/map/MapList.jsx
@@ -43,6 +43,7 @@ const MapCatalog = compose(
                                     id: i.map.id,
                                     type: "map",
                                     ...i.map,
+                                    // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
                                     thumbnail: decodeURIComponent(i.map.thumbnail || "")
                                 }))
                             }

--- a/web/client/components/resources/ResourceCard.jsx
+++ b/web/client/components/resources/ResourceCard.jsx
@@ -83,7 +83,16 @@ class ResourceCard extends React.Component {
     getCardStyle = () => {
         if (this.props.resource.thumbnail) {
             return assign({}, this.props.style, {
-                backgroundImage: 'linear-gradient(rgba(0, 0, 0, ' + this.props.backgroundOpacityStart + '), rgba(0, 0, 0, ' + this.props.backgroundOpacityEnd + ') ), url(' + (this.props.resource.thumbnail === null || this.props.resource.thumbnail === "NODATA" ? thumbUrl : decodeURIComponent(this.props.resource.thumbnail)) + ')'
+                backgroundImage: 'linear-gradient(rgba(0, 0, 0, '
+                    + this.props.backgroundOpacityStart + '), rgba(0, 0, 0, '
+                    + this.props.backgroundOpacityEnd
+                    + ') ), url('
+                    + (this.props.resource.thumbnail === null || this.props.resource.thumbnail === "NODATA"
+                        ? thumbUrl
+                        // this decode is for old thumbnails `rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` new are `rest/geostore/data/2/raw?decode=datauri`, so not needed
+                        : decodeURIComponent(this.props.resource.thumbnail)
+                    )
+                    + ')'
             });
         }
         return this.props.style;

--- a/web/client/components/resources/forms/Thumbnail.jsx
+++ b/web/client/components/resources/forms/Thumbnail.jsx
@@ -62,7 +62,10 @@ class Thumbnail extends React.Component {
     };
 
     getThumbnailUrl = () => {
-        return this.props.thumbnail && this.props.thumbnail !== "NODATA" ? decodeURIComponent(this.props.thumbnail) : null;
+        return this.props.thumbnail && this.props.thumbnail !== "NODATA"
+            // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
+            ? decodeURIComponent(this.props.thumbnail)
+            : null;
     };
 
     isImage = (images) => {

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -121,7 +121,6 @@ const setDetailsChangedEpic = (action$, store) =>
             return Rx.Observable.from(actions);
         });
 
-
 /**
  * If the details resource does not exist it saves it, and it updates its permission with the one set for the mapPermissionsFromIdSelector
  * and it updates the attribute details in map resource
@@ -190,9 +189,6 @@ const fetchDetailsFromResourceEpic = (action$, store) =>
                 });
         });
 
-/**
-         Epics used to load Maps
-     */
 const loadMapsEpic = (action$) =>
     action$.ofType(MAPS_LOAD_MAP)
         .switchMap((action) => {

--- a/web/client/observables/__tests__/geoStoreMock.js
+++ b/web/client/observables/__tests__/geoStoreMock.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const axios = require("../../libs/ajax");
+const MockAdapter = require("axios-mock-adapter");
+const getDummySecurityRuleList = (id) => ({ "SecurityRuleList": { "SecurityRule": { "canRead": true, "canWrite": true, "user": { id, "name": "admin" } } } });
+
+/**
+ * Create Mock GeoStore using mockAxios
+ * @param {object} options the options for the creation of the mock
+ * @param {string} [options.baseURL='/rest/geostore/'] the base URL of geostore
+ * @param {object} [callbacks] the callbacks of the various handlers, useful to make checks. You can return something like `[200, body]`
+ *  - onCreateResource = () => {},
+    - onGetPermissions = () => {},
+    - onUpdatePermission = () => {},
+    - onUpdateAttribute = () => {}
+ * @param {MockAdapter} mock the axios-mock-adapter to customize.
+ */
+export default ({ baseURL = '/rest/geostore/', callbacks = {}} = {}, mm) => {
+    const mock = mm || new MockAdapter(axios);
+    const {
+        onCreateResource = () => {},
+        onGetPermissions = () => {},
+        onUpdatePermission = () => {},
+        onUpdateAttribute = () => {}
+    } = callbacks;
+    let index = 0;
+
+    // PATHS
+    const CREATE_RESOURCE = new RegExp(`.*${baseURL}resources\/`);
+    const PERMISSION_REGEX = new RegExp(`${baseURL}resources\/resource\/([0-9]{1,})\/permissions[\/]?`);
+    const ATTRIBUTES_REGEX = new RegExp(`${baseURL}resources\/resource\/([0-9]{1,})\/attributes[\/]?`);
+
+    // RESOURCE
+    mock.onPost(CREATE_RESOURCE).reply( (config) => {
+        return onCreateResource(config) || [200, `${index++}`];
+    });
+
+    // RESOURCE ATTRIBUTE
+    mock.onGet(ATTRIBUTES_REGEX).reply(config => {
+        const { url } = config;
+        const id = ATTRIBUTES_REGEX.exec(url);
+        return onUpdateAttribute(config) || [204, { id }];
+    });
+    mock.onPut().reply( config => {
+        const { url } = config;
+        const id = ATTRIBUTES_REGEX.exec(url);
+        return onUpdateAttribute(config) || [200, `${id}`];
+    });
+
+    // RESOURCE PERMISSION
+    mock.onGet(PERMISSION_REGEX).reply( config => {
+        const { url } = config;
+        const id = PERMISSION_REGEX.exec(url);
+        return onGetPermissions(config) || [200, getDummySecurityRuleList(id)]; // TODO: put the id of the resource
+    });
+    mock.onPost(PERMISSION_REGEX).reply( config => {
+        const { url } = config;
+        const id = PERMISSION_REGEX.exec(url);
+        return onUpdatePermission(config) || [204, `${id}`];
+    });
+
+    return {
+        mock
+    };
+
+};

--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -88,7 +88,6 @@ describe('geostore observables for resources management', () => {
         );
     });
     describe('linked resources', () => {
-        let mockAxios;
 
         const RES_1 = {
             data: {},
@@ -103,25 +102,20 @@ describe('geostore observables for resources management', () => {
                 }
             }
         };
-        beforeEach(() => {
-            const { mock } = geoStoreMock();
-            mockAxios = mock;
-        });
-        afterEach(() => {
-            mockAxios.restore();
-        });
 
         it('update linked resources', done => {
+            let mockAxios;
+
             const { mock } = geoStoreMock({
                 callbacks: {
                     onUpdateAttribute: ({data}) => {
                         expect(data).toEqual(JSON.stringify({
                             restAttribute: {
                                 name: 'thumbnail',
-                                value: 'rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri' // the URL is encoded
+                                value: 'rest/geostore/data/2/raw?decode=datauri' // the URL is encoded
                             }
                         }));
-                        done();
+
                     }
                 }
             });
@@ -129,10 +123,13 @@ describe('geostore observables for resources management', () => {
             createResource(RES_1).subscribe(
                 v => {
                     expect(v).toBe(0);
-
+                    mockAxios.restore();
+                    done();
                 },
                 e => {
+                    mockAxios.restore();
                     done(e);
+
                 });
         });
     });

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -11,12 +11,14 @@ import uuid from 'uuid/v1';
 import { includes, isNil } from 'lodash';
 import GeoStoreDAO from '../api/GeoStoreDAO';
 
-const createLinkedResourceURL = (id, tail = "") => encodeURIComponent(`rest/geostore/data/${id}${tail}`);
+const createLinkedResourceURL = (id, tail = "") => `rest/geostore/data/${id}${tail}`;
 const LINKED_RESOURCE_REGEX = /rest\/geostore\/data\/(\d+)/;
 const getResourceIdFromURL = path => {
-    // double decoding is needed for backward compatibility with old linked resources
-    // the second one doesn't have effect to URLS like /rest/geostore/data/1
-    // but correctly decodes old thumbnails
+    /* double decoding is needed for backward compatibility with old linked resources
+    * the second one doesn't have effect to URLS like /rest/geostore/data/1
+    * but correctly decodes old thumbnails
+    * This is correct here because this function only retrieves the ID from the URL, to identify linked resources.
+    */
     const decodedUrl = decodeURIComponent(decodeURIComponent(path));
     const res = LINKED_RESOURCE_REGEX.exec(decodedUrl);
     return res && !!res[0] && res[1];

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -12,17 +12,7 @@ import { includes, isNil } from 'lodash';
 import GeoStoreDAO from '../api/GeoStoreDAO';
 
 const createLinkedResourceURL = (id, tail = "") => `rest/geostore/data/${id}${tail}`;
-const LINKED_RESOURCE_REGEX = /rest\/geostore\/data\/(\d+)/;
-const getResourceIdFromURL = path => {
-    /* double decoding is needed for backward compatibility with old linked resources
-    * the second one doesn't have effect to URLS like /rest/geostore/data/1
-    * but correctly decodes old thumbnails
-    * This is correct here because this function only retrieves the ID from the URL, to identify linked resources.
-    */
-    const decodedUrl = decodeURIComponent(decodeURIComponent(path));
-    const res = LINKED_RESOURCE_REGEX.exec(decodedUrl);
-    return res && !!res[0] && res[1];
-};
+import {getResourceIdFromURL} from "../utils/ResourceUtils";
 
 
 const getLinkedAttributesIds = (id, filterFunction = () => true, API = GeoStoreDAO) =>

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -11,9 +11,12 @@ import uuid from 'uuid/v1';
 import { includes, isNil } from 'lodash';
 import GeoStoreDAO from '../api/GeoStoreDAO';
 
-const createLinkedResourceURL = (id, tail = "") => encodeURIComponent(encodeURIComponent(`rest/geostore/data/${id}${tail}`));
+const createLinkedResourceURL = (id, tail = "") => encodeURIComponent(`rest/geostore/data/${id}${tail}`);
 const LINKED_RESOURCE_REGEX = /rest\/geostore\/data\/(\d+)/;
 const getResourceIdFromURL = path => {
+    // double decoding is needed for backward compatibility with old linked resources
+    // the second one doesn't have effect to URLS like /rest/geostore/data/1
+    // but correctly decodes old thumbnails
     const decodedUrl = decodeURIComponent(decodeURIComponent(path));
     const res = LINKED_RESOURCE_REGEX.exec(decodedUrl);
     return res && !!res[0] && res[1];

--- a/web/client/reducers/featuredmaps.js
+++ b/web/client/reducers/featuredmaps.js
@@ -16,6 +16,7 @@ function dashboard(state = {}, action) {
     case ATTRIBUTE_UPDATED: {
         return set("latestResource", {
             resourceId: action.resourceId,
+            // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
             [action.name]: decodeURIComponent(action.value)
         }, state);
     }

--- a/web/client/reducers/maps.js
+++ b/web/client/reducers/maps.js
@@ -138,7 +138,8 @@ function maps(state = {
         let newMaps = state.results === "" ? [] : [...state.results];
         for (let i = 0; i < newMaps.length; i++) {
             if (newMaps[i].id && newMaps[i].id === action.resourceId) {
-                newMaps[i] = assign({}, newMaps[i], {[action.name]: decodeURIComponent(action.value), updating: false, loadingError: action.error ? action.error : null}); // TODO remove decodeURIComponent to reuse this reducer!!!
+                // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
+                newMaps[i] = assign({}, newMaps[i], {[action.name]: decodeURIComponent(action.value), updating: false, loadingError: action.error ? action.error : null});
             }
         }
         return assign({}, state, {results: newMaps});

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -389,6 +389,7 @@ function getSimpleGeomType(geomType = "Point") {
 }
 
 const getIdFromUri = (uri, regex = /data\/(\d+)/) => {
+    // this decode is for backward compatibility with old linked resources`rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri` not needed for new ones `rest/geostore/data/2/raw?decode=datauri`
     const decodedUri = decodeURIComponent(uri);
     const findDataDigit = regex.exec(decodedUri);
     return findDataDigit && findDataDigit.length && findDataDigit.length > 1 ? findDataDigit[1] : null;

--- a/web/client/utils/ResourceUtils.js
+++ b/web/client/utils/ResourceUtils.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export const LINKED_RESOURCE_REGEX = /rest\/geostore\/data\/(\d+)/;
+
+
+/**
+ * Extracts the ID of a resource from the attribute value.
+ * Linked resources are by default absolute paths as attributes. They have this shape: `/rest/geostore/data/1`
+ * Old linked resources, because of old limitations of geostore, had to te encoded, so they looked more similar to `rest%2Fgeostore%2Fdata%2F11558`
+ * For thumbnails, the urls will be something like `rest/geostore/data/11558/raw?decode=datauri&v=ea756fc0-f4df-11e9-8355-ebd99ddbebe0`
+ * or`rest%2Fgeostore%2Fdata%2F11558%2Fraw%3Fdecode%3Ddatauri%26v%3Dea756fc0-f4df-11e9-8355-ebd99ddbebe0` (encoded).
+ * v is used to invalidate cache, raw?decode=datauri to convert to base64 into image.
+ * @param {string} path attribute value
+ */
+export const getResourceIdFromURL = path => {
+    /* double decoding is needed for backward compatibility with old linked resources
+    * the second one doesn't have effect to URLS like /rest/geostore/data/1
+    * but correctly decodes old thumbnails
+    * This is correct here because this function only retrieves the ID from the URL, to identify linked resources.
+    */
+    const decodedUrl = decodeURIComponent(decodeURIComponent(path));
+    const res = LINKED_RESOURCE_REGEX.exec(decodedUrl);
+    return res && !!res[0] && res[1];
+};
+


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Update mapstore to use the new REST entry point for attribute update, instead of URL double encoded one.

See https://github.com/geosolutions-it/geostore/pull/198

TODO: 
 - test
- verify retro-comatibility with old connected resources


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

#4687 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
