### PR TITLE
#4688. Fixed issue when router is not present

### DIFF
--- a/web/client/plugins/OmniBar.jsx
+++ b/web/client/plugins/OmniBar.jsx
@@ -66,7 +66,7 @@ module.exports = {
     OmniBarPlugin: assign(
         OmniBar,
         {
-            disablePluginIf: "{state('featuregridmode') === 'EDIT' || (state('router').includes('/geostory/shared') && state('geostorymode') !== 'edit')}"
+            disablePluginIf: "{state('featuregridmode') === 'EDIT' || (state('router') && state('router').includes('/geostory/shared') && state('geostorymode') !== 'edit')}"
         }
     ),
     reducers: {}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
When router doesn't exist, Omnibar fail because trying to access to it's state.  

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4688

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now it not fails anymore 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
