### PR TITLE
Hide drawer menu when empty

### DIFF
--- a/web/client/plugins/DrawerMenu.jsx
+++ b/web/client/plugins/DrawerMenu.jsx
@@ -161,14 +161,14 @@ class DrawerMenu extends React.Component {
     };
 
     render() {
-        return (
+        return this.getTools().length > 0 ? (
             <div id={this.props.id}>
                 <DrawerButton {...this.props} id="drawer-menu-button"/>
                 <Menu single={this.props.singleSection} {...this.props.menuOptions} title={<Message msgId="menu" />} alignment="left">
                     {this.renderItems()}
                 </Menu>
             </div>
-        );
+        ) : null;
     }
 }
 

--- a/web/client/plugins/__tests__/DrawerMenu-test.jsx
+++ b/web/client/plugins/__tests__/DrawerMenu-test.jsx
@@ -13,6 +13,19 @@ import ReactTestUtils from 'react-dom/test-utils';
 import DrawerMenuPlugin from '../DrawerMenu';
 import { getPluginForTest } from './pluginsTestUtils';
 
+const SAMPLE_ITEM = {
+    plugin: "TEST",
+    name: 'toc',
+    position: 1,
+    glyph: "1-layer",
+    icon: <div></div>,
+    buttonConfig: {
+        buttonClassName: "square-button no-border",
+        tooltip: "toc.layers"
+    },
+    priority: 2
+};
+
 const mouseMove = (x, y, node) => {
     const doc = node ? node.ownerDocument : document;
     const evt = doc.createEvent('MouseEvents');
@@ -41,12 +54,23 @@ describe('DrawerMenu Plugin', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
+    it('does\'t render if empty', () => {
+        const { Plugin } = getPluginForTest(DrawerMenuPlugin, {
+            controls: {
+                drawer: {}
+            }
+        });
+        ReactDOM.render(<Plugin menuOptions={{ resizable: true }} />, document.getElementById("container"));
+        expect(document.getElementById('mapstore-drawermenu')).toNotExist();
 
+        ReactDOM.render(<Plugin items={[SAMPLE_ITEM]} menuOptions={{ resizable: true }} />, document.getElementById("container"));
+        expect(document.getElementById('mapstore-drawermenu')).toExist();
+    });
     it('creates a resizable DrawerMenu plugin', () => {
         const { Plugin, store } = getPluginForTest(DrawerMenuPlugin, { controls: {
             drawer: {}
         } });
-        ReactDOM.render(<Plugin menuOptions={{resizable: true}} />, document.getElementById("container"));
+        ReactDOM.render(<Plugin items={[SAMPLE_ITEM]} menuOptions={{resizable: true}} />, document.getElementById("container"));
         expect(document.getElementById('mapstore-drawermenu')).toExist();
 
         const drag = document.getElementsByClassName('react-resizable-handle')[0];


### PR DESCRIPTION
## Description
Hide Drawer menu when empty. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#4699

**What is the new behavior?**
See #4699 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
