### PR TITLE
Restore #4627: Updated geostore version to 1.5-SNAPSHOT (latest master)

### DIFF
--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -22,14 +22,14 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.4.3-SNAPSHOT</version>
+      <version>1.5-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -22,14 +22,14 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.4.3-SNAPSHOT</version>
+      <version>1.5-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -20,14 +20,14 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.4.3-SNAPSHOT</version>
+      <version>1.5-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
Restore previously reverted update of for geostore and http-proxy.