### PR TITLE
#4716. Fixed issues with map details and thumbnail creation in home page

### DIFF
--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -591,8 +591,7 @@ function createThumbnail(map, metadataMap, nameThumbnail, dataThumbnail, categor
             };
             dispatch(updatePermissions(response.data, groupPermission, group, userPermission, user, options)); // UPDATE resource permissions
             const thumbnailUrl = ConfigUtils.getDefaults().geoStoreUrl + "data/" + response.data + "/raw?decode=datauri";
-            const encodedThumbnailUrl = encodeURIComponent(encodeURIComponent(thumbnailUrl));
-            dispatch(updateAttribute(resourceIdMap, "thumbnail", encodedThumbnailUrl, "STRING", options)); // UPDATE resource map with new attribute
+            dispatch(updateAttribute(resourceIdMap, "thumbnail", thumbnailUrl, "STRING", options)); // UPDATE resource map with new attribute
             if (onSuccess) {
                 dispatch(onSuccess);
             }

--- a/web/client/utils/ObservableUtils.js
+++ b/web/client/utils/ObservableUtils.js
@@ -49,10 +49,9 @@ const createAssociatedResource = ({attribute, permissions, mapId, metadata, valu
             // update permissions
             let actions = [];
             actions.push(updatePermissions(resourceId, permissions));
-            const attibuteUri = ConfigUtils.getDefaults().geoStoreUrl + "data/" + resourceId + "/raw?decode=datauri";
-            const encodedResourceUri = encodeURIComponent(encodeURIComponent(attibuteUri));
+            const attributeUri = ConfigUtils.getDefaults().geoStoreUrl + "data/" + resourceId + "/raw?decode=datauri";
             // UPDATE resource map with new attribute
-            actions.push(updateAttribute(mapId, attribute, encodedResourceUri, type, optionsAttr));
+            actions.push(updateAttribute(mapId, attribute, attributeUri, type, optionsAttr));
             // display a success message
             actions.push(basicSuccess({message: "maps.feedback." + attribute + ".savedSuccesfully" }));
             return Rx.Observable.from(actions);


### PR DESCRIPTION
## Description
Removed unnecessary and remaining double encoding due to the new API entry (PUT with Body, instead of URL encoded value, see #4673).
These caused an effective double encoding of the real respources (previously one encoding was removed by decoding by geostore, but the new API use a JSON as body, so no encoding is necessary anymore) and this made impossible to decode on a second load (only one decodeURIComponent is present, for retro-compatibility, but URLs was encoded 2 times in error.)

NOTE: didn't add unit tests because these where not covered and this part will be replaced soon with the Resource Observable. (see #2908)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#4716 comment (thumbnails and details created in home page for maps are not available anymore after refresh)

**What is the new behavior?**
Thumb and detail card URLs are saved correctly (no double encoding anymore). Decoding is still present for retro-compatibility.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
