### PR TITLE
Change the logic of the getShareOptions method to display the Embed t…

### DIFF
--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -66,8 +66,14 @@ class FeaturedMaps extends React.Component {
             };
         }
 
+        if (res.category && res.category.name === 'MAP') {
+            return {
+                embedPanel: true
+            };
+        }
+
         return {
-            embedPanel: true
+            embedPanel: false
         };
     }
 


### PR DESCRIPTION
…ab only for maps.

## Description
The embed tab is present in the featured dashboard but it is not required.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#4597 

**What is the new behavior?**
The embed tab is not present in the featured dashboard.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
