### PR TITLE
#4732 Fix MapFooter update issue

### DIFF
--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -263,7 +263,11 @@ class LeafletMap extends React.Component {
     componentWillUnmount() {
         const attributionContainer = this.props.mapOptions.attribution && this.props.mapOptions.attribution.container && document.querySelector(this.props.mapOptions.attribution.container);
         if (attributionContainer && this.attribution.getContainer() && attributionContainer.querySelector('.leaflet-control-attribution')) {
-            attributionContainer.removeChild(this.attribution.getContainer());
+            try {
+                attributionContainer.removeChild(this.attribution.getContainer());
+            } catch (e) {
+                // do nothing... probably an old configuration
+            }
         }
         this.map.remove();
     }

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -306,7 +306,12 @@ class OpenlayersMap extends React.Component {
         const attributionContainer = this.props.mapOptions.attribution && this.props.mapOptions.attribution.container
             && document.querySelector(this.props.mapOptions.attribution.container);
         if (attributionContainer && attributionContainer.querySelector('.ol-attribution')) {
-            attributionContainer.removeChild(attributionContainer.querySelector('.ol-attribution'));
+            try {
+                attributionContainer.removeChild(attributionContainer.querySelector('.ol-attribution'));
+            } catch (e) {
+                // do nothing... probably an old configuration
+            }
+
         }
         if (this.map) {
             this.map.setTarget(null);

--- a/web/client/components/map/openlayers/ScaleBar.jsx
+++ b/web/client/components/map/openlayers/ScaleBar.jsx
@@ -38,7 +38,12 @@ export default class ScaleBar extends React.Component {
 
     componentWillUnmount() {
         if (this.props.container && document.querySelector('.ol-scale-line')) {
-            document.querySelector(this.props.container).removeChild(document.querySelector('.ol-scale-line'));
+            try {
+                document.querySelector(this.props.container).removeChild(document.querySelector('.ol-scale-line'));
+            } catch (e) {
+                // do nothing... probably an old configuration
+            }
+
         }
     }
 

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -276,18 +276,18 @@
                     "altShiftDragRotate": false
                   },
                   "attribution": {
-                    "container": "#mapstore-map-footer-container"
+                    "container": "#footer-attribution-container"
                   }
                 },
                 "leaflet": {
                   "attribution": {
-                    "container": "#mapstore-map-footer-container"
+                    "container": "#footer-attribution-container"
                   }
                 }
               },
               "toolsOptions": {
                 "scalebar": {
-                  "container" : "#mapstore-map-footer-container"
+                  "container" : "#footer-scalebar-container"
                 }
               }
             }
@@ -464,18 +464,18 @@
                         "altShiftDragRotate": false
                       },
                       "attribution": {
-                        "container": "#mapstore-map-footer-container"
+                        "container": "#footer-attribution-container"
                       }
                     },
                     "leaflet": {
                       "attribution": {
-                        "container": "#mapstore-map-footer-container"
+                        "container": "#footer-attribution-container"
                       }
                     }
                   },
                   "toolsOptions": {
                     "scalebar": {
-                      "container" : "#mapstore-map-footer-container"
+                      "container" : "#footer-scalebar-container"
                     }
                   }
                 }

--- a/web/client/plugins/MapFooter.jsx
+++ b/web/client/plugins/MapFooter.jsx
@@ -22,7 +22,7 @@ const fix = lifecycle({
     },
     shouldComponentUpdate() { return false; },
     componentWillUnmount() {
-        fixedElements[this.props.id] = document.getElementById(this.props.id)
+        fixedElements[this.props.id] = document.getElementById(this.props.id);
     }
 });
 const FixedContainer = fix(({ id }) => <div id={id}></div>);

--- a/web/client/plugins/MapFooter.jsx
+++ b/web/client/plugins/MapFooter.jsx
@@ -8,6 +8,31 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const ToolsContainer = require('./containers/ToolsContainer');
+const { lifecycle } = require('recompose');
+
+let fixedElements = {};
+const fix = lifecycle({
+    componentDidMount() {
+        if (fixedElements[this.props.id]) {
+            const el = document.getElementById(this.props.id);
+            if (el && el.parentNode && !el.hasChildNodes()) {
+                el.parentNode.replaceChild(fixedElements[this.props.id], el);
+            }
+        }
+    },
+    shouldComponentUpdate() { return false; },
+    componentWillUnmount() {
+        fixedElements[this.props.id] = document.getElementById(this.props.id)
+    }
+});
+const FixedContainer = fix(({ id }) => <div id={id}></div>);
+
+// these two elements are retained in fixedElementObject and reused when unmount/re-mount
+// this prevents the div to be re-rendered so the component can be connected with map attribution tool.
+const fixedTools = [
+    {element: <FixedContainer key="attribution" id="footer-attribution-container" />},
+    {element: <FixedContainer key="scalebar" id="footer-scalebar-container" />}
+];
 
 class MapFooter extends React.Component {
     static propTypes = {
@@ -26,10 +51,6 @@ class MapFooter extends React.Component {
         mapType: "leaflet"
     };
 
-    shouldComponentUpdate() {
-        return false;
-    }
-
     getPanels = () => {
         return this.props.items.filter((item) => item.tools).reduce((previous, current) => {
             return previous.concat(
@@ -44,7 +65,7 @@ class MapFooter extends React.Component {
     };
 
     getTools = () => {
-        return this.props.items.sort((a, b) => b.position - a.position);
+        return [fixedTools[0], ...this.props.items.sort((a, b) => b.position - a.position), fixedTools[1]];
     };
 
     render() {

--- a/web/client/plugins/mapEditor/DefaultConfiguration.js
+++ b/web/client/plugins/mapEditor/DefaultConfiguration.js
@@ -10,18 +10,18 @@ export default {
                             "altShiftDragRotate": false
                         },
                         "attribution": {
-                            "container": "#mapstore-map-footer-container"
+                            "container": "#footer-attribution-container"
                         }
                     },
                     "leaflet": {
                         "attribution": {
-                            "container": "#mapstore-map-footer-container"
+                            "container": "#footer-attribution-container"
                         }
                     }
                 },
                 "toolsOptions": {
                     "scalebar": {
-                        "container": "#mapstore-map-footer-container"
+                        "container": "#footer-scalebar-container"
                     }
                 }
             }

--- a/web/client/pluginsConfig.json
+++ b/web/client/pluginsConfig.json
@@ -12,18 +12,18 @@
               "altShiftDragRotate": false
             },
             "attribution": {
-              "container": "#mapstore-map-footer-container"
+              "container": "#footer-attribution-container"
             }
           },
           "leaflet": {
             "attribution": {
-              "container": "#mapstore-map-footer-container"
+              "container": "#footer-attribution-container"
             }
           }
         },
         "toolsOptions": {
           "scalebar": {
-            "container": "#mapstore-map-footer-container"
+            "container": "#footer-scalebar-container"
           }
         }
       }

--- a/web/client/test-resources/geostore/data/context_1.json
+++ b/web/client/test-resources/geostore/data/context_1.json
@@ -14,18 +14,18 @@
                 "altShiftDragRotate": false
               },
               "attribution": {
-                "container": "#mapstore-map-footer-container"
+                "container": "#footer-attribution-container"
               }
             },
             "leaflet": {
               "attribution": {
-                "container": "#mapstore-map-footer-container"
+                "container": "#footer-attribution-container"
               }
             }
           },
           "toolsOptions": {
             "scalebar": {
-              "container": "#mapstore-map-footer-container"
+              "container": "#footer-scalebar-container"
             }
           }
         }

--- a/web/client/themes/default/less/map-footer.less
+++ b/web/client/themes/default/less/map-footer.less
@@ -12,7 +12,9 @@
     & > div {
         float: right;
     }
-
+    #footer-attribution-container {
+        float: none;
+    }
     .map-footer-btn {
         height: 25px;
         width: 25px !important;


### PR DESCRIPTION
## Description
The issue #4732 was due to a `shouldComponentUpdate` that always return false. This to prevent attribution and scalebar to disappear. 

The solutions proposed keeps the divs to restore them after re-mount, because it's impossible to avoid re-mount. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#4732

**What is the new behavior?**
Now a context with optional plugins in footer will update immedialy, when user switches them in user extensions plugins (need to be merged yet)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

--> we need to update localConfig.json in dependent projects. 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information


Probably old context will not render attribution well