### PR TITLE
Fixes resource map delete layer and  map state when editing form media editor

### DIFF
--- a/web/client/actions/__tests__/mediaEditor-test.js
+++ b/web/client/actions/__tests__/mediaEditor-test.js
@@ -95,9 +95,14 @@ describe('mediaEditor actions', () => {
     });
     it('updateItem', () => {
         const map = {id: "val"};
-        const action = updateItem(map);
+        let action = updateItem(map);
         expect(action.item).toEqual(map);
         expect(action.type).toEqual(UPDATE_ITEM);
+        expect(action.mode).toEqual("merge");
+        action = updateItem(map, "replace");
+        expect(action.item).toEqual(map);
+        expect(action.type).toEqual(UPDATE_ITEM);
+        expect(action.mode).toEqual("replace");
     });
     it('setAddingMedia', () => {
         const adding = true;

--- a/web/client/actions/mediaEditor.js
+++ b/web/client/actions/mediaEditor.js
@@ -84,7 +84,7 @@ export const selectItem = (id) => ({ type: SELECT_ITEM, id});
  * update item in media editor list
  * @param {object} param.item
  */
-export const updateItem = (item) => ({ type: UPDATE_ITEM, item});
+export const updateItem = (item, mode = 'merge') => ({ type: UPDATE_ITEM, item, mode});
 /**
  * adding media
  * @param {boolean} adding

--- a/web/client/components/mediaEditor/map/MapForm.jsx
+++ b/web/client/components/mediaEditor/map/MapForm.jsx
@@ -26,7 +26,6 @@ import withConfirm from '../../misc/withConfirm';
 
 const SaveButton = withConfirm(ToolbarButton);
 const SaveButtonWithConfirm = (props) => {
-    console.log(props);
     return (<SaveButton
         confirmTitle={<Message msgId = "mediaEditor.mapForm.confirmMapSaveTitle"/>}
         confirmContent={<Message msgId = "mediaEditor.mapForm.confirmMapSaveContent"/>} {...props}/>);
@@ -83,8 +82,7 @@ const enhance = compose(
             editing && setEditingMedia(false) || setAddingMedia(false);
         }
     }),
-    withPropsOnChange(["selectedItem", "initialResource", "properties"], ({initialResource, selectedItem: {data = {}} = {}, properties, ...rest}) => {
-        console.log(rest);
+    withPropsOnChange(["selectedItem", "initialResource", "properties"], ({initialResource, selectedItem: {data = {}} = {}, properties}) => {
         return {confirmPredicate: !isEqual(initialResource, {...data, ...properties})};
     }),
     withConfirm,

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -70,7 +70,7 @@ import { resourceIdSelectorCreator, createPathSelector, currentStorySelector, re
 import { currentMediaTypeSelector, sourceIdSelector} from '../selectors/mediaEditor';
 
 import { wrapStartStop } from '../observables/epics';
-import { scrollToContent, ContentTypes, isMediaSection, Controls, getEffectivePath, getFlatPath, isWebPageSection } from '../utils/GeoStoryUtils';
+import { scrollToContent, ContentTypes, isMediaSection, Controls, getEffectivePath, getFlatPath, isWebPageSection, MediaTypes } from '../utils/GeoStoryUtils';
 
 import { SourceTypes } from './../utils/MediaEditorUtils';
 
@@ -96,8 +96,8 @@ const updateMediaSection = (store, path) => action$ =>
                 resourceId = uuid();
                 actions = [...actions, addResource(resourceId, mediaType, resource)];
             }
-
-            actions = [...actions, update(`${path}`, {resourceId, type: mediaType}, "merge" )];
+            let media = mediaType === MediaTypes.MAP ? {resourceId, type: mediaType, map: undefined} : {resourceId, type: mediaType};
+            actions = [...actions, update(`${path}`, media, "merge" )];
             return Observable.from(actions);
         });
 

--- a/web/client/epics/mediaEditor.js
+++ b/web/client/epics/mediaEditor.js
@@ -129,7 +129,7 @@ export const mediaEditorEditMap = (action$, {getState}) =>
         .switchMap(() => action$.ofType(SAVE)
             .switchMap(({map: editedMap}) => {
                 const selectedItems = selectedItemSelector(getState());
-                return Observable.from([updateItem({...selectedItems, data: {...editedMap}}), hideMapEditor()]);
+                return Observable.from([updateItem({...selectedItems, data: {...editedMap}}, "replace"), hideMapEditor()]);
             })
             .takeUntil(action$.ofType(HIDE))
         );

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -49,6 +49,7 @@ import {
     settingsSelector
 } from '../../selectors/geostory';
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
+import TEST_STORY_1 from "../../test-resources/geostory/story_state.json";
 import { Controls, Modes, getDefaultSectionTemplate, lists } from '../../utils/GeoStoryUtils';
 
 describe('geostory reducer', () => {
@@ -354,5 +355,27 @@ describe('geostory reducer', () => {
                 expect(controlState).toBeTruthy();
             });
         });
+    });
+    it('On EDIT_RESOURCE of type map, customized maps are reset', () => {
+        const state = geostory(undefined, setCurrentStory(TEST_STORY_1));
+        let contA = state.currentStory.sections[0].contents[0].contents[0];
+        let contB = state.currentStory.sections[0].contents[0].contents[1];
+        let contC = state.currentStory.sections[0].contents[0].contents[2];
+        expect(contA).toExist();
+        expect(contA.map).toNotExist();
+        expect(contB).toExist();
+        expect(contB.map).toExist();
+        expect(contC).toExist();
+        expect(contC.map).toExist();
+        const newState = geostory(state, editResource('4ef233d3-6612-4b7c-9b3c-0b15b024ce76', 'map', {}));
+        contA = newState.currentStory.sections[0].contents[0].contents[0];
+        contB = newState.currentStory.sections[0].contents[0].contents[1];
+        contC = newState.currentStory.sections[0].contents[0].contents[2];
+        expect(contA).toExist();
+        expect(contA.map).toNotExist();
+        expect(contB).toExist();
+        expect(contB.map).toNotExist();
+        expect(contC).toExist();
+        expect(contC.map).toNotExist();
     });
 });

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -138,4 +138,30 @@ describe('Test the mediaEditor reducer', () => {
         }, updateItem(map));
         expect(state.data.map.geostoreMap.resultData.resources[0]).toEqual(map);
     });
+    it('UPDATE_ITEM with mode replace', () => {
+        const map = {
+            id: "resId",
+            layers: [{id: "layerId"}]
+        };
+
+        let state = mediaEditor({
+            settings: {
+                mediaType: "map",
+                sourceId: "geostoreMap"
+            },
+            data: {
+                map: {
+                    geostoreMap: {
+                        resultData: {
+                            resources: [{
+                                id: "resId",
+                                test: "has to disappear"
+                            }]
+                        }
+                    }
+                }
+            }
+        }, updateItem(map, "replace"));
+        expect(state.data.map.geostoreMap.resultData.resources[0]).toBe(map);
+    });
 });

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -7,7 +7,7 @@
  */
 import { get, isString, isNumber, findIndex, find, isObject, isArray, castArray } from "lodash";
 import { set, unset, arrayUpdate, compose } from '../utils/ImmutableUtils';
-import { getEffectivePath } from '../utils/GeoStoryUtils';
+import { getEffectivePath, MediaTypes } from '../utils/GeoStoryUtils';
 
 import {
     ADD,
@@ -59,6 +59,22 @@ const getIndexToInsert = (array, position) => {
         index = Math.min(position, array.length);
     }
     return index;
+};
+
+const getContentsByResourceId = (rId, path, {contents, background, id, resourceId}) => {
+    let cts = [];
+    let localPath = path + `{"id": "${id}"}]`;
+    if (resourceId === rId) {
+        return [localPath];
+    }
+    if (background && background.resourceId === rId) {
+        cts.push(localPath + ".background");
+    }
+    if (contents) {
+        return contents.reduce((acc, e) => [...acc, ...getContentsByResourceId(rId, localPath + ".contents[", e)],
+            cts);
+    }
+    return cts;
 };
 
 let INITIAL_STATE = {
@@ -165,7 +181,17 @@ export default (state = INITIAL_STATE, action) => {
     }
     case EDIT_RESOURCE: {
         const { id, mediaType: type, data } = action;
-        const newState = arrayUpdate("currentStory.resources", { id, type, data }, { id }, state);
+
+        let newState = arrayUpdate("currentStory.resources", { id, type, data }, { id }, state);
+        // With a map resource we have to reset all contents' custom map configurations.
+        if (type === MediaTypes.MAP) {
+            state.currentStory.sections.reduce((acc, section) =>  ([...acc, ...getContentsByResourceId(id, "sections[", section)])
+                , [])
+                .map(rawPath => {
+                    const path = getEffectivePath(`currentStory.${rawPath}.map`, state);
+                    newState = set(path, undefined, newState);
+                });
+        }
         return newState;
     }
     case LOADING_GEOSTORY: {

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -99,13 +99,13 @@ export default (state = DEFAULT_STATE, action) => {
         return set(`data["${mediaType}"]["${sourceId}"]`, { params, resultData }, state);
     }
     case UPDATE_ITEM: {
-        const {item} = action;
+        const {item, mode} = action;
         const sourceId = sourceIdSelector({mediaEditor: state});
         const mediaType = currentMediaTypeSelector({mediaEditor: state});
         const resources = resultDataSelector({mediaEditor: state}).resources;
         const indexItem = findIndex(resources, {id: item.id});
         const resource = find(resources, {id: item.id});
-        const newResource = merge({}, merge({}, resource), merge({}, item));
+        const newResource = mode === "merge" ? merge({}, merge({}, resource), merge({}, item)) : item;
         return set(`data["${mediaType}"]["${sourceId}"].resultData.resources[${indexItem}]`, newResource, state);
     }
     case SELECT_ITEM: {

--- a/web/client/selectors/__tests__/geostory-test.js
+++ b/web/client/selectors/__tests__/geostory-test.js
@@ -29,7 +29,8 @@ import {
     settingsChangedSelector,
     settingsItemsSelector,
     totalItemsSelector,
-    visibleItemsSelector
+    visibleItemsSelector,
+    isMediaResourceUsed
 } from "../geostory";
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
 
@@ -109,4 +110,7 @@ describe('geostory selectors', () => { // TODO: check default
     }} } })).toEqual({checked: [ 'col2' ], expanded: [ 'SomeID2' ] }));
     it('visibleItemsSelector ', () => expect(visibleItemsSelector({ geostory: { currentStory: {settings: {checked: ["id"]}} } })).toEqual({"id": true}));
     it('settingsChangedSelector ', () => expect(settingsChangedSelector({ geostory: { currentStory: {settings: {checked: ["id"]}}, oldSettings: {checked: ["id", "otherid"]} } })).toBe(true));
+    it('isMediaResourceUsed ', () => expect(isMediaResourceUsed({ geostory: { currentStory: TEST_STORY} }, "resId")).toBe(false));
+
+
 });

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -254,8 +254,9 @@ const findMediaResourceInContent = (rId, {contents, background, resourceId}) => 
         return true;
     }
     if (contents) {
-        return find(contents, e => findMediaResourceInContent(rId, e));
+        return !!find(contents, e => findMediaResourceInContent(rId, e));
     }
+    return false;
 };
 
 /**

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -239,3 +239,29 @@ export const settingsItemsSelector = state => {
         return [...p, {label: c.title || "", value: c.id}];
     }, []);
 };
+
+
+/**
+ * Traverse story elements tree checking if passed resource is used.
+ * @param {*} rId Media resource id
+ * @param {object} story content
+ */
+const findMediaResourceInContent = (rId, {contents, background, resourceId}) => {
+    if (resourceId === rId) {
+        return true;
+    }
+    if (background && background.resourceId === rId) {
+        return true;
+    }
+    if (contents) {
+        return find(contents, e => findMediaResourceInContent(rId, e));
+    }
+};
+
+/**
+ * Return true if passed resource is used somewhere in the current story tree
+ * @param {object*} state Application state
+ * @param {*} resId Media resource id
+ */
+export const isMediaResourceUsed = (state, resId) => !!find(sectionsSelector(state), section => findMediaResourceInContent(resId, section));
+

--- a/web/client/test-resources/geostory/story_state.json
+++ b/web/client/test-resources/geostory/story_state.json
@@ -1,0 +1,78 @@
+{
+    "type": "cascade",
+    "resources": [
+        {
+            "id": "4ef233d3-6612-4b7c-9b3c-0b15b024ce76",
+            "type": "map",
+            "data": {
+                "type": "map"
+            }
+        },
+        {
+            "id": "3025f52e-8d57-48df-9a56-8e21ac252282",
+            "type": "image",
+            "data": {
+                "src": "https://images.unsplash.com/photo-1566305828756-cacc74d3dd20?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60",
+                "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                "credits": "Lorem Ipsum and Internation Spatial Agency",
+                "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                "altText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+            }
+        }
+    ],
+    "sections": [
+        {
+            "id": "e4a68a35-52c2-4c20-b149-a165a494dd96",
+            "type": "paragraph",
+            "title": "Media Section",
+            "contents": [
+                {
+                    "id": "bee14408-9273-4297-b2c7-5406358744d7",
+                    "type": "column",
+                    "contents": [
+                        {
+                            "id": "e645c579-b314-4d58-991f-1a4e33ee8dc4",
+                            "type": "map",
+                            "size": "full",
+                            "align": "center",
+                            "resourceId": "4ef233d3-6612-4b7c-9b3c-0b15b024ce76",
+                            "editMap": false
+                        },
+                        {
+                            "id": "eb239b54-558b-4391-8ba3-375272b62fe4",
+                            "type": "map",
+                            "title": "UNKNOWN",
+                            "size": "full",
+                            "align": "center",
+                            "resourceId": "4ef233d3-6612-4b7c-9b3c-0b15b024ce76",
+                            "editMap": false,
+                            "map": {
+                                "center": {
+                                    "x": -73.85459295410156,
+                                    "y": 40.7731406109544,
+                                    "crs": "EPSG:4326"
+                                }
+                            }
+                        },
+                        {
+                            "id": "37c0fcae-8393-4f4b-acb7-de7567934859",
+                            "type": "map",
+                            "title": "UNKNOWN",
+                            "size": "full",
+                            "align": "center",
+                            "resourceId": "4ef233d3-6612-4b7c-9b3c-0b15b024ce76",
+                            "editMap": false,
+                            "map": {
+                                "layers": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "settings": {
+        "storyTitle": "Another test story"
+    }
+}

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2081,7 +2081,9 @@
                 "confirmExitContent": "Ausstehende Änderungen verwerfen?"
             },
             "mapForm": {
-                "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 98 x 98 Pixel sein, maximal 100 KB"
+                "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 98 x 98 Pixel sein, maximal 100 KB",
+                "confirmMapSaveTitle": "Kartenupdate",
+                "confirmMapSaveContent": "Durch das Aktualisieren dieser Karte werden alle abhängigen Karten in der Story zurückgesetzt, die zuvor über den Inline-Editor angepasst wurden. Bestätigen Sie?"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2085,7 +2085,9 @@
                 "confirmExitContent": "Discard pending changes?"
             },
             "mapForm": {
-                "thumbnailMessage": "Size of images should be a square of 98px x 98px, max 100kb"
+                "thumbnailMessage": "Size of images should be a square of 98px x 98px, max 100kb",
+                "confirmMapSaveTitle": "Map Update",
+                "confirmMapSaveContent": "Updating this map will reset all dependent maps in the story previously customized through the inline editor, confirm?"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2081,7 +2081,9 @@
                 "confirmExitContent": "¿Descartar cambios pendientes?"
             },
             "mapForm": {
-                "thumbnailMessage": "El tamaño de las imágenes debe ser un cuadrado de 98 px x 98 px, máximo 100 kb"
+                "thumbnailMessage": "El tamaño de las imágenes debe ser un cuadrado de 98 px x 98 px, máximo 100 kb",
+                "confirmMapSaveTitle": "Actualización de mapa",
+                "confirmMapSaveContent": "La actualización de este mapa restablecerá todos los mapas dependientes en la historia previamente personalizada a través del editor en línea, ¿confirma?"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2081,7 +2081,9 @@
                 "confirmExitContent": "Supprimer les modifications en attente?"
             },
             "mapForm": {
-                "thumbnailMessage": "La taille des images doit être un carré de 98px x 98px, maximum 100 Ko."
+                "thumbnailMessage": "La taille des images doit être un carré de 98px x 98px, maximum 100 Ko.",
+                "confirmMapSaveTitle": "Mise à jour de la carte",
+                "confirmMapSaveContent": "La mise à jour de cette carte réinitialisera toutes les cartes dépendantes de l'histoire précédemment personnalisées via l'éditeur en ligne, confirmez?"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2082,7 +2082,9 @@
                 "confirmExitContent": "Annuallare le modifiche ed uscire?"
             },
             "mapForm": {
-                "thumbnailMessage": "Le dimensioni delle immagini devono essere di un quadrato di 98 px x 98 px, max 100 KB"
+                "thumbnailMessage": "Le dimensioni delle immagini devono essere di un quadrato di 98 px x 98 px, max 100 KB",
+                "confirmMapSaveTitle": "Aggiornare la mapp",
+                "confirmMapSaveContent": "L'aggiornamento di questa mappa ripristinerà tutte le mappe dipendenti nella storia precedentemente personalizzate tramite l'editor in linea, conferma?"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2083,7 +2083,7 @@
             },
             "mapForm": {
                 "thumbnailMessage": "Le dimensioni delle immagini devono essere di un quadrato di 98 px x 98 px, max 100 KB",
-                "confirmMapSaveTitle": "Aggiornare la mapp",
+                "confirmMapSaveTitle": "Aggiornare la mappa",
                 "confirmMapSaveContent": "L'aggiornamento di questa mappa ripristinerà tutte le mappe dipendenti nella storia precedentemente personalizzate tramite l'editor in linea, conferma?"
             }
         },


### PR DESCRIPTION


## Description
This pull fixes map state layer when a map resource is edit or changed from the mediaeditor.
More it fixes the delete of a layer from a map resource.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
-  [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4702 it's related to geosolutions-it/mapstore2-c039/issues/122
**What is the current behavior?**
1) Isn't possible to remove a layer from a map!
2) If a map resource in a content is customized, changing the map resource or edit it from the mediaeditor map advanced editor will create a mas mixing old customizations and new or edited map resource
<!-- You can also link to an existing issue here -->
#geosolutions-it/mapstore2-c039/issues/122

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
1) It's possible to remove a layer from a map resource
2) When a map is edited or changed from the mediaeditor all the previous customizations are resetted
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
