### PR TITLE
4667 wmts background problems

### DIFF
--- a/web/client/components/import/dragZone/ErrorContent.jsx
+++ b/web/client/components/import/dragZone/ErrorContent.jsx
@@ -11,7 +11,8 @@ const { Glyphicon, Alert } = require('react-bootstrap');
 const DropText = require('./DropText');
 const Message = require('../../I18N/Message');
 const errorMessages = {
-    "FILE_NOT_SUPPORTED": <Message msgId="mapImport.errors.fileNotSupported" />
+    "FILE_NOT_SUPPORTED": <Message msgId="mapImport.errors.fileNotSupported" />,
+    "PROJECTION_NOT_SUPPORTED": <Message msgId="mapImport.errors.projectionNotSupported" />
 };
 const toErrorMessage = error =>
     error

--- a/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
+++ b/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
@@ -149,7 +149,7 @@ describe('processFiles enhancer', () => {
         }));
         ReactDOM.render(<Sink />, document.getElementById("container"));
     });
-    it('processFiles read map file', (done) => {
+    it('an error was thrown while processFiles read map file that contains a projection field in it', (done) => {
         const Sink = compose(
             processFiles,
             mapPropsStream(props$ => props$.merge(
@@ -158,7 +158,9 @@ describe('processFiles enhancer', () => {
                     .switchMap(({ onDrop = () => { } }) => getMapFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
             expect(props).toExist();
-            done();
+            if (props.error) {
+                done();
+            }
         }));
         ReactDOM.render(<Sink />, document.getElementById("container"));
     });

--- a/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
+++ b/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
@@ -158,11 +158,7 @@ describe('processFiles enhancer', () => {
                     .switchMap(({ onDrop = () => { } }) => getMapFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
             expect(props).toExist();
-            if (props.files) {
-                expect(props.files.layers.length).toBe(0);
-                expect(props.files.maps.length).toBe(1);
-                done();
-            }
+            done();
         }));
         ReactDOM.render(<Sink />, document.getElementById("container"));
     });

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -80,7 +80,7 @@ const readFile = (onWarnings) => (file) => {
                     if (areProjectionsValid) {
                         return geoJsonArr;
                     }
-                    throw new Error("FILE_NOT_SUPPORTED");
+                    throw new Error("PROJECTION_NOT_SUPPORTED");
                 }
                 return geoJsonArr;
             });
@@ -93,7 +93,7 @@ const readFile = (onWarnings) => (file) => {
                 if (supportedProjections.includes(projection)) {
                     return [{...f, "fileName": file.name}];
                 }
-                throw new Error("FILE_NOT_SUPPORTED");
+                throw new Error("PROJECTION_NOT_SUPPORTED");
             }
             return [{...f, "fileName": file.name}];
         });

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -7,8 +7,10 @@
  */
 const Rx = require('rxjs');
 const { compose, mapPropsStream, createEventHandler} = require('recompose');
+const { get } = require('lodash');
 const FileUtils = require('../../../../utils/FileUtils');
 const LayersUtils = require('../../../../utils/LayersUtils');
+const ConfigUtils = require('../../../../utils/ConfigUtils');
 
 const JSZip = require('jszip');
 
@@ -47,6 +49,7 @@ const checkFileType = (file) => {
 const readFile = (onWarnings) => (file) => {
     const ext = FileUtils.recognizeExt(file.name);
     const type = file.type || FileUtils.MIME_LOOKUPS[ext];
+    const supportedProjections = ConfigUtils.getConfigProp('projectionDefs');
     if (type === 'application/vnd.google-earth.kml+xml') {
         return FileUtils.readKml(file).then((xml) => {
             return FileUtils.kmlToGeoJSON(xml);
@@ -69,12 +72,31 @@ const readFile = (onWarnings) => (file) => {
                 if (warnings.length > 0) {
                     onWarnings({type: 'warning', filename: file.name, message: 'shapefile.error.missingPrj'});
                 }
-                return FileUtils.shpToGeoJSON(buffer).map(json => ({ ...json, filename: file.name }));
+                const geoJsonArr = FileUtils.shpToGeoJSON(buffer).map(json => ({ ...json, filename: file.name }));
+                const areProjectionsPresented = geoJsonArr.some(geoJson => !!get(geoJson, 'map.projection'));
+                if (areProjectionsPresented) {
+                    const filteredGeoJsonArr = geoJsonArr.filter(item => !!get(item, 'map.projection'));
+                    const areProjectionsValid = filteredGeoJsonArr.every(geoJson => supportedProjections.includes(geoJson.map.projection));
+                    if (areProjectionsValid) {
+                        return geoJsonArr;
+                    }
+                    throw new Error("FILE_NOT_SUPPORTED");
+                }
+                return geoJsonArr;
             });
         });
     }
     if (type === 'application/json') {
-        return FileUtils.readJson(file).then(f => [{...f, "fileName": file.name}]);
+        return FileUtils.readJson(file).then(f => {
+            const projection = get(f, 'map.projection');
+            if (projection) {
+                if (supportedProjections.includes(projection)) {
+                    return [{...f, "fileName": file.name}];
+                }
+                throw new Error("FILE_NOT_SUPPORTED");
+            }
+            return [{...f, "fileName": file.name}];
+        });
     }
     return null;
 };

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1120,7 +1120,8 @@
                 },
                 "errors": {
                     "fileNotSupported": "Datei wird nicht unterstützt",
-                    "unknownError": "Beim Import ist ein unbekannter Fehler aufgetreten"
+                    "unknownError": "Beim Import ist ein unbekannter Fehler aufgetreten",
+                    "projectionNotSupported": "Die Projektion der Datei, die Sie importieren möchten, wird nicht unterstützt"
                 }
             },
         "mapExport": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1121,7 +1121,8 @@
             },
             "errors": {
                 "fileNotSupported": "File not supported",
-                "unknownError": "there was an unknown error during import"
+                "unknownError": "there was an unknown error during import",
+                "projectionNotSupported": "The projection of the file(s) you're trying to import is not supported"
             }
         },
         "mapExport": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1120,7 +1120,8 @@
             },
             "errors": {
                 "fileNotSupported": "Archivo no compatible",
-                "unknownError": "hubo un error desconocido durante la importación"
+                "unknownError": "hubo un error desconocido durante la importación",
+                "projectionNotSupported": "La proyección del archivo que está intentando importar no es compatible"
             }
         },
         "mapExport": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1120,7 +1120,8 @@
             },
             "errors": {
                 "fileNotSupported": "Fichier non pris en charge",
-                "unknownError": "il y avait une erreur inconnue lors de l'importation"
+                "unknownError": "il y avait une erreur inconnue lors de l'importation",
+                "projectionNotSupported": "La projection du fichier que vous essayez d'importer n'est pas prise en charge"
             }
         },
         "mapExport": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1120,7 +1120,8 @@
             },
             "errors": {
                 "fileNotSupported": "File non supportato",
-                "unknownError": "si è verificato un errore sconosciuto durante l'importazione"
+                "unknownError": "si è verificato un errore sconosciuto durante l'importazione",
+                "projectionNotSupported": "La proiezione del file che stai tentando di importare non è supportata"
             }
         },
         "mapExport": {


### PR DESCRIPTION
## Description
It is not possible to import the CRS map background on a map because the CRS is not supported but now the error page opens.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4667 

**What is the new behavior?**
Now the alert message will be displayed to the user in case he tries to import file with unsupported projection:
![image](https://user-images.githubusercontent.com/32982343/72722758-262c7a80-3b90-11ea-96c3-56dfb0c56c8c.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
