### PR TITLE
Fix style for the wizard buttons.

### DIFF
--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -12,7 +12,7 @@ const React = require('react');
 const Message = require('../../I18N/Message');
 const LocaleUtils = require('../../../utils/LocaleUtils');
 let StyleUtils;
-const { Grid, Row, Col, Button, Alert} = require('react-bootstrap');
+const { Grid, Row, Col, Button, Alert, ButtonToolbar} = require('react-bootstrap');
 
 const {Promise} = require('es6-promise');
 
@@ -166,9 +166,11 @@ class StylePanel extends React.Component {
                     </Col>
                 </Row>
                 <Row>
-                    <Col xsOffset={6} xs={2}> <Button bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => { this.props.setLayers(null); }}>{this.props.cancelMessage}</Button></Col>
-                    <Col xs={2}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => this.props.onLayerSkipped(this.props.selected)}>{this.props.skipMessage}</Button></Col>
-                    <Col xs={2} style={{paddingLeft: 0}}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={this.addToMap}>{this.props.layers.length === 1 ? this.props.finishMessage : this.props.nextMessage}</Button></Col>
+                    <ButtonToolbar style={{display: 'flex', justifyContent: 'flex-end'}}>
+                        <Button bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => { this.props.setLayers(null); }}>{this.props.cancelMessage}</Button>
+                        <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => this.props.onLayerSkipped(this.props.selected)}>{this.props.skipMessage}</Button>
+                        <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={this.addToMap}>{this.props.layers.length === 1 ? this.props.finishMessage : this.props.nextMessage}</Button>
+                    </ButtonToolbar>
                 </Row>
             </Grid>
         );


### PR DESCRIPTION
## Description
With different languages, the space dimension between the buttons isn't the same. In particular, with English language set there's a space between buttons that could be considered as the ideal one, while on other languages it's less or it's absent.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#4678 

**What is the new behavior?**
The style of the buttons is fixed and equal for any language.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
