### PR TITLE
#4744 Fix update notification syntrax error that caused error in UI

### DIFF
--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -45,8 +45,11 @@ const {
     setShowMapDetails, SHOW_DETAILS,
     updateAttribute, saveAll,
     SAVE_MAP_RESOURCE, saveMapResource,
-    FEATURED_MAPS_SET_LATEST_RESOURCE, setFeaturedMapsLatestResource
+    FEATURED_MAPS_SET_LATEST_RESOURCE, setFeaturedMapsLatestResource,
+    updateMapMetadata, RESET_CURRENT_MAP
 } = require('../maps');
+
+const { SHOW_NOTIFICATION } = require('../notifications');
 
 let GeoStoreDAO = require('../../api/GeoStoreDAO');
 let oldAddBaseUri = GeoStoreDAO.addBaseUrl;
@@ -411,6 +414,21 @@ describe('Test correctness of the maps actions', () => {
         const a = saveMapResource(resource);
         expect(a.type).toBe(SAVE_MAP_RESOURCE);
         expect(a.resource).toBe(resource);
+    });
+    it('updateMapMetadata', (done) => {
+        mockAxios.onPut().reply(200);
+        let actions = [];
+        const dispatch = a => {
+            actions.push(a);
+            // when finished, check and done
+            if (a.type === RESET_CURRENT_MAP) {
+                expect(actions[0].type).toBe(MAP_METADATA_UPDATED);
+                expect(actions[1].type).toBe(SHOW_NOTIFICATION);
+                done();
+
+            }
+        };
+        updateMapMetadata(2, "test", "desc", () => {}, {})(dispatch);
     });
     it('setFeaturedMapsLatestResource', () => {
         const resource = {

--- a/web/client/actions/maps.js
+++ b/web/client/actions/maps.js
@@ -497,7 +497,7 @@ function updateMapMetadata(resourceId, newName, newDescription, onReset, options
     return (dispatch) => {
         GeoStoreApi.putResourceMetadata(resourceId, newName, newDescription, options).then(() => {
             dispatch(mapMetadataUpdated(resourceId, newName, newDescription, "success"));
-            dispatch(() => success({ title: "success", message: "resources.successSaved" })());
+            dispatch(success({ title: "success", message: "resources.successSaved" }));
             if (onReset) {
                 dispatch(onReset);
                 dispatch(onDisplayMetadataEdit(false));

--- a/web/client/components/maps/MapCard.jsx
+++ b/web/client/components/maps/MapCard.jsx
@@ -85,7 +85,7 @@ class MapCard extends React.Component {
     };
 
     getCardStyle = () => {
-        if (this.props.map.thumbnail) {
+        if (this.props.map.thumbnail && this.props.map.thumbnail !== "NODATA") {
             return assign({}, this.props.style, {
                 backgroundImage: 'linear-gradient(rgba(0, 0, 0, '
                     + this.props.backgroundOpacityStart


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
`()=> success()()` had wrong syntax (try to execute the value returned by success). It should be at least` (() => success())()` anyway arrow function was unuseful, so it has been replaced by the direct action

If try to update the thumbnail, the image became darken (because of NODATA preview style). 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
