### PR TITLE
#4751 Fix issues with map search reset

### DIFF
--- a/web/client/plugins/MapSearch.jsx
+++ b/web/client/plugins/MapSearch.jsx
@@ -54,7 +54,7 @@ const SearchBar = connect((state) => ({
         let searchText = text && text !== "" ? text : ConfigUtils.getDefaults().initialMapFilter || "*";
         return loadMaps(ConfigUtils.getDefaults().geoStoreUrl, searchText, options);
     },
-    onSearchReset: loadMaps.bind(null, ConfigUtils.getDefaults().geoStoreUrl, ConfigUtils.getDefaults().initialMapFilter || "*")
+    onSearchReset: (...params) => loadMaps(ConfigUtils.getDefaults().geoStoreUrl, ConfigUtils.getDefaults().initialMapFilter || "*", ...params)
 }, (stateProps, dispatchProps, ownProps) => {
 
     return {

--- a/web/client/plugins/__tests__/MapSearch-test.jsx
+++ b/web/client/plugins/__tests__/MapSearch-test.jsx
@@ -20,8 +20,6 @@ import {mapsSearchTextChanged, MAPS_LOAD_MAP} from '../../actions/maps';
 import ReactTestUtils from 'react-dom/test-utils';
 import ConfigUtils from '../../utils/ConfigUtils';
 
-
-
 describe('MapSearch Plugin', () => {
     const stateMocker = createStateMocker({ maps: maps });
     beforeEach((done) => {

--- a/web/client/plugins/__tests__/MapSearch-test.jsx
+++ b/web/client/plugins/__tests__/MapSearch-test.jsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MapSearch from '../MapSearch';
+
+import { getPluginForTest } from './pluginsTestUtils';
+
+import { createStateMocker } from '../../reducers/__tests__/reducersTestUtils';
+import maps from '../../reducers/maps';
+import {mapsSearchTextChanged, MAPS_LOAD_MAP} from '../../actions/maps';
+
+
+import ReactTestUtils from 'react-dom/test-utils';
+import ConfigUtils from '../../utils/ConfigUtils';
+
+
+
+describe('MapSearch Plugin', () => {
+    const stateMocker = createStateMocker({ maps: maps });
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    const DUMMY_ACTION = { type: "DUMMY_ACTION" };
+    it('default rendering', () => {
+        const { Plugin } = getPluginForTest(MapSearch, stateMocker(DUMMY_ACTION), {
+            BurgerMenuPlugin: {}
+        });
+        // check container for burger menu
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.getElementById('map-search-bar')).toExist();
+    });
+    describe('test search configuration', () => {
+        let oldURL;
+        const TEST_URL = "MY_GEOSTORE_CUSTOM_URL";
+        beforeEach(() => {
+            oldURL = ConfigUtils.getConfigProp('geoStoreUrl');
+        });
+
+        afterEach(() => {
+            ConfigUtils.setConfigProp('geoStoreUrl', oldURL);
+        });
+        it('clear button uses correct config utils and params', () => {
+            // simulate localConfig setup
+            const storeState = stateMocker(DUMMY_ACTION, mapsSearchTextChanged("test"));
+            const { Plugin, actions } = getPluginForTest(MapSearch, storeState);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            const clearButton = document.querySelector('.glyphicon-1-close');
+            expect(clearButton).toExist();
+            ConfigUtils.setConfigProp('geoStoreUrl', TEST_URL);
+            ReactTestUtils.Simulate.click(clearButton);
+            expect(actions.length).toBe(1);
+            const action = actions[0];
+            expect(action.type).toBe(MAPS_LOAD_MAP);
+            // check the URL of GeoStore is the one set (not the default one)
+            expect(action.geoStoreUrl).toBe(TEST_URL);
+            // check search params are reset
+            expect(action.searchText).toBe('*'); // reset text search
+            expect(action.params.start).toBe(0); // reset page
+        });
+    });
+
+});

--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -28,6 +28,7 @@ const isMobile = require('ismobilejs');
 let localConfigFile = 'localConfig.json';
 
 let defaultConfig = {
+    // TODO: these should be changed tp relative paths, without /mapstore/ or / (to avoid the needing of overriding in default cases)
     proxyUrl: "/mapstore/proxy/?url=",
     geoStoreUrl: "/rest/geostore/",
     printUrl: "/mapstore/print/info.json",


### PR DESCRIPTION
## Description
Action binding was done on build time, so `geoStoreUrl` was not updated with the value in localConfig.json. 

This error didn't happen in localhost:8081 because default URL is /rest/... (absolute path) that works in the local env, while it doesn't on deployed where path is /mapstore/rest... ( or, with relative path set in localConfig, rest/..., that works in both cases).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4751

**What is the new behavior?**
The search now is correctly reset, searching the correct URL.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
