### PR TITLE
Simplified user flow to edit/import a remote map

### DIFF
--- a/web/client/components/mediaEditor/MediaList.jsx
+++ b/web/client/components/mediaEditor/MediaList.jsx
@@ -27,8 +27,7 @@ export default withMapEditing(({
     loadItems = () => {},
     setAddingMedia = () => {},
     setEditingMedia = () => {},
-    importInLocal = () => {},
-    localSource = SourceTypes.GEOSTORY,
+    editRemoteMap = () => {},
     buttons = [
         {
             glyph: 'plus',
@@ -43,10 +42,10 @@ export default withMapEditing(({
             onClick: () => setEditingMedia(true)
         },
         {
-            glyph: 'upload',
-            tooltipId: 'mediaEditor.mediaPicker.import',
+            glyph: 'pencil',
+            tooltipId: 'mediaEditor.mediaPicker.edit',
             visible: selectedSource.type === SourceTypes.GEOSTORE && mediaType === MediaTypes.MAP && !isNil(selectedItem),
-            onClick: () => importInLocal({resource: selectedItem, mediaType: localSource})
+            onClick: editRemoteMap
         }
 
     ]

--- a/web/client/components/mediaEditor/enhancers/__tests__/withMapEditing-test.js
+++ b/web/client/components/mediaEditor/enhancers/__tests__/withMapEditing-test.js
@@ -50,6 +50,7 @@ describe('media editor withMapEditing enhancer', () => {
             expect(props.openMapEditor).toExist();
             expect(props.importInLocal).toExist();
             expect(props.setAddingMedia).toExist();
+            expect(props.editRemoteMap).toExist();
             props.setAddingMedia(true);
         }));
         ReactDOM.render(<Provider store={store}><Sink setAddingMedia={actions.setAddingMedia} mediaType="map"/></Provider>, document.getElementById("container"));
@@ -65,6 +66,26 @@ describe('media editor withMapEditing enhancer', () => {
         }));
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         ReactDOM.render(<Provider store={store}><SinkAddingMedia setAddingMedia={actions.setAddingMedia} mediaType="imag"/></Provider>, document.getElementById("container"));
+
+    });
+    it('withMapEditing editRemoteMap call open map editor', (done) => {
+        store.dispatch = (a) => {
+            expect(a).toExist();
+            expect(a.type).toBe("MAP_EDITOR:SHOW");
+            expect(a.owner).toBe("mediaEditorEditRemote");
+            expect(a.map).toExist();
+        };
+
+        const Sink = withMapEditing(createSink( props => {
+            expect(props).toExist();
+            expect(props.openMapEditor).toExist();
+            expect(props.editRemoteMap).toExist();
+            expect(props.setAddingMedia).toExist();
+            props.editRemoteMap();
+            done();
+        }));
+        ReactDOM.render(<Provider store={store}><Sink mediaType="map"/></Provider>, document.getElementById("container"));
+        store.dispatch = () => {};
 
     });
 });

--- a/web/client/components/mediaEditor/enhancers/withMapEditing.js
+++ b/web/client/components/mediaEditor/enhancers/withMapEditing.js
@@ -27,7 +27,7 @@ const withMapEditing = compose(
             setAddingMedia(adding);
         },
         editRemoteMap: ({openMapEditor, selectedItem: {id, ...map} = {}} = {}) => () => {
-            openMapEditor("mediaEditorEditRemote", {data: map});
+            openMapEditor("mediaEditorEditRemote", {data: map, id});
         }
     })
 );

--- a/web/client/components/mediaEditor/enhancers/withMapEditing.js
+++ b/web/client/components/mediaEditor/enhancers/withMapEditing.js
@@ -20,11 +20,14 @@ import {MediaTypes} from '../../../utils/GeoStoryUtils';
 const withMapEditing = compose(
     connect(null, {openMapEditor: show, importInLocal}),
     withHandlers({
-        setAddingMedia: ({setAddingMedia, openMapEditor, mediaType}) => adding => {
+        setAddingMedia: ({setAddingMedia, openMapEditor, mediaType}) => (adding, map) => {
             if (mediaType === MediaTypes.MAP) {
-                openMapEditor("mediaEditor");
+                openMapEditor("mediaEditor", map);
             }
             setAddingMedia(adding);
+        },
+        editRemoteMap: ({openMapEditor, selectedItem: {id, ...map} = {}} = {}) => () => {
+            openMapEditor("mediaEditorEditRemote", {data: map});
         }
     })
 );

--- a/web/client/components/mediaEditor/map/MapPreview.jsx
+++ b/web/client/components/mediaEditor/map/MapPreview.jsx
@@ -18,14 +18,19 @@ const Preview = ({
     selectedItem
 }) => {
     const { layers = [], mapOptions, ...m} = selectedItem.data ? selectedItem.data : selectedItem; // remove mapOptions to not override options
+    /**
+     * On map change, we have to force the remount of the map to prevent Ol to add display: none to canvas
+     *  this will also recreate a correct ol mapView with current map extent.
+     */
     return (
-        <MapView
+        [<MapView
+            key={m.id || m.mapId}
             styleMap={{height: "100%"}}
             map={{...m, id: "map" + m.id}}
             id={"preview" + selectedItem.id}
             layers={layers || [defaultLayerMapPreview]}
             options={applyDefaults({})}
-        />
+        />]
     );
 };
 

--- a/web/client/components/misc/withConfirm.jsx
+++ b/web/client/components/misc/withConfirm.jsx
@@ -18,7 +18,7 @@ const ConfirmModal = compose(
     confirmNo = <Message msgId="no"/>,
     confirmTitle = <Message msgId="confirm"/>,
     confirmContent,
-    confirmButtonBSStyle = "default",
+    confirmButtonBSStyle = "primary",
     show = false,
     confirmModal = true,
     draggable = false,

--- a/web/client/epics/__tests__/mediaEditor-test.js
+++ b/web/client/epics/__tests__/mediaEditor-test.js
@@ -16,7 +16,8 @@ import {
     mediaEditorNewMap,
     mediaEditorEditMap,
     reloadMediaResources,
-    importInLocalSource
+    importInLocalSource,
+    editRemoteMap
 } from '../mediaEditor';
 import {
     show as showMapEditor,
@@ -305,6 +306,58 @@ describe('MediaEditor Epics', () => {
                     break;
                 case SELECT_ITEM:
                     expect(a.id).toExist();
+                    break;
+                default: expect(true).toEqual(false);
+                    break;
+                }
+            });
+            done();
+        }, {
+            geostory: {
+                resources: [{
+                    id: "102cbcf6-ff39-4b7f-83e4-78841ee13bb9",
+                    data: {
+                        src: "ht",
+                        title: "ti"
+                    }
+                }]
+            },
+            mediaEditor: {
+                saveState: {
+                    editing: false,
+                    adding: true
+                },
+                selected: "102cbcf6-ff39-4b7f-83e4-78841ee13bb9",
+                settings: {
+                    sourceId: "geostory",
+                    sources: {
+                        geostory: {
+                            name: "Current story",
+                            type: "geostory"
+                        }
+                    }
+                }
+            }
+        });
+    });
+    it('editRemoteMap epic handle new map creation save stream', (done) => {
+        const NUM_ACTIONS = 5;
+        testEpic(editRemoteMap, NUM_ACTIONS, [showMapEditor("mediaEditorEditRemote", {data: {id: 'testId', type: 'map'}}), save({}, "mediaEditor")], (actions) => {
+            expect(actions.length).toEqual(NUM_ACTIONS);
+            actions.map((a) => {
+                switch (a.type) {
+                case SET_MEDIA_SERVICE:
+                    expect(a.id).toEqual('geostory');
+                    break;
+                case SAVE_MEDIA_SUCCESS:
+                    expect(a.data.id).toExist();
+                    break;
+                case LOAD_MEDIA:
+                    break;
+                case SELECT_ITEM:
+                    expect(a.id).toExist();
+                    break;
+                case HIDE:
                     break;
                 default: expect(true).toEqual(false);
                     break;

--- a/web/client/epics/mediaEditor.js
+++ b/web/client/epics/mediaEditor.js
@@ -169,3 +169,28 @@ export const importInLocalSource = (action$, store) =>
                     );
                 });
         });
+
+/**
+ * It handles the edit of a remote map (GOSTORE). On mapEditor save the map is saved in local store, the media service switched to local,
+ * the local media reloaded, the saved map selected and the mapEditor hidden.
+ * @memberof epics.mediaEditor
+ * @param {Observable} action$  actions stream
+ * @param {*} application store
+ */
+export const editRemoteMap = (action$, store) =>
+    action$.ofType(MAP_EDITOR_SHOW).filter(({owner, map}) => owner === 'mediaEditorEditRemote' && !!map)
+        .switchMap(({map: {data: resource} = {}} = {}) => {
+            return action$.ofType(SAVE).switchMap(({map}) => {
+                const sources = sourcesSelector(store.getState());
+                const sourceId = findKey(sources, ({type}) => SourceTypes.GEOSTORY === type);
+                const handler = mediaAPI(sourceId).save(resource.type, sources[sourceId], { ...resource, ...map}, store);
+                return handler.switchMap(({id}) =>
+                    Observable.of(
+                        setMediaService(sourceId),
+                        saveMediaSuccess({mediaType: resource.type, source: sources[sourceId], data: resource, id}),
+                        loadMedia(undefined, resource.type, sources[sourceId]),
+                        selectItem(id),
+                        hideMapEditor()
+                    ));
+            }).takeUntil(action$.ofType(HIDE));
+        });


### PR DESCRIPTION
## Description
The editing of a Geostore map in geostory has been simplified.
It's no more needed to import a remote map before edit it.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4755 
**What is the current behavior?**
#4755 
geosolutions-it/mapstore2-c039#135
**What is the new behavior?**
To edit and import a remote map, a user has to:
1 - open mediaEditor
2 - select media type map
3 - select geostore dev source
4 - select a map
5 - click on edit button
6 - edit the map and click ok button in mapEditor footer.



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
