### PR TITLE
4781 create new map button is now configurable

### DIFF
--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -29,7 +29,12 @@ const dashboardsCountSelector = createSelector(
     count => ({ count })
 );
 
-
+/**
+ * Plugin for Dashboards resources
+ * @name Dashboards
+ * @memberof plugins
+ * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
+ */
 class Dashboards extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
@@ -99,10 +104,10 @@ const DashboardsPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        () => ({
+        ({showCreateButton = true}) => ({
             glyph: "dashboard",
             title: <Message msgId="resources.dashboards.noDashboardAvailable" />,
-            description: <EmptyDashboardsView />
+            description: <EmptyDashboardsView enabled={showCreateButton}/>
         })
 
     )

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -29,7 +29,12 @@ const geostoriesCountSelector = createSelector(
     count => ({ count })
 );
 
-
+/**
+ * Plugin for Geostories resources
+ * @name Geostories
+ * @memberof plugins
+ * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
+ */
 class Geostories extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
@@ -99,10 +104,10 @@ const GeoStoriesPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        () => ({
+        ({showCreateButton = true}) => ({
             glyph: "geostory",
             title: <Message msgId="resources.geostories.noGeostoryAvailable" />,
-            description: <EmptyGeostoriesView />
+            description: <EmptyGeostoriesView showCreateButton={showCreateButton}/>
         })
 
     )

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -60,6 +60,12 @@ const PaginationToolbar = connect((state) => {
     };
 })(require('../components/misc/PaginationToolbar'));
 
+/**
+ * Plugin for Maps resources
+ * @name Maps
+ * @memberof plugins
+ * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
+ */
 class Maps extends React.Component {
     static propTypes = {
         mapType: PropTypes.string,
@@ -132,10 +138,10 @@ const MapsPlugin = compose(
     }),
     emptyState(
         ({maps = [], loading}) => !loading && maps.length === 0,
-        () => ({
+        ({showCreateButton = true}) => ({
             glyph: "1-map",
             title: <Message msgId="resources.maps.noMapAvailable" />,
-            content: <EmptyMaps />
+            content: <EmptyMaps showCreateButton={showCreateButton} />
         })
     )
 )(Maps);

--- a/web/client/plugins/dashboard/EmptyDashboardsView.jsx
+++ b/web/client/plugins/dashboard/EmptyDashboardsView.jsx
@@ -17,14 +17,18 @@ const Message = require('../../components/I18N/Message');
 
 class EmptyDashboards extends React.Component {
     static propTypes = {
-        loggedIn: PropTypes.bool
+        loggedIn: PropTypes.bool,
+        showCreateButton: PropTypes.bool
     }
     static contextTypes = {
         router: PropTypes.object
     };
+    static defaultProps = {
+        showCreateButton: true
+    }
 
     render() {
-        return (<div style={{width: "100%", textAlign: "center"}}>{this.props.loggedIn
+        return (<div style={{width: "100%", textAlign: "center"}}>{this.props.loggedIn && this.props.showCreateButton
             ? (<Button bsStyle="primary" onClick={() => { this.context.router.history.push("/dashboard"); }}>
                 <Message msgId="resources.dashboards.createANewOne" />
             </Button>)

--- a/web/client/plugins/geostories/EmptyGeostoriesView.jsx
+++ b/web/client/plugins/geostories/EmptyGeostoriesView.jsx
@@ -17,14 +17,18 @@ const Message = require('../../components/I18N/Message');
 
 class EmptyGeostories extends React.Component {
     static propTypes = {
-        loggedIn: PropTypes.bool
+        loggedIn: PropTypes.bool,
+        showCreateButton: PropTypes.bool
     }
     static contextTypes = {
         router: PropTypes.object
     };
+    static defaultProps = {
+        showCreateButton: true
+    }
 
     render() {
-        return (<div style={{width: "100%", textAlign: "center"}}>{this.props.loggedIn
+        return (<div style={{width: "100%", textAlign: "center"}}>{this.props.loggedIn && this.props.showCreateButton
             ? (<Button bsStyle="primary" onClick={() => { this.context.router.history.push("/geostory/newgeostory"); }}>
                 <Message msgId="resources.geostories.createANewOne" />
             </Button>)

--- a/web/client/plugins/maps/EmptyMaps.jsx
+++ b/web/client/plugins/maps/EmptyMaps.jsx
@@ -18,14 +18,18 @@ import Message from '../../components/I18N/Message';
 class EmptyMaps extends React.Component {
     static propTypes = {
         loggedIn: PropTypes.bool,
+        showCreateButton: PropTypes.bool,
         mapType: PropTypes.string
     }
     static contextTypes = {
         router: PropTypes.object
     };
+    static defaultProps = {
+        showCreateButton: true
+    }
 
     render() {
-        return (<div style={{ width: "100%", textAlign: "center", marginBottom: '20px' }}>{this.props.loggedIn
+        return (<div style={{ width: "100%", textAlign: "center", marginBottom: '20px' }}>{this.props.loggedIn && this.props.showCreateButton
             ? (<Button bsStyle="primary" onClick={() => { this.context.router.history.push("/viewer/" + this.props.mapType + "/new"); }}>
                 <Message msgId="resources.maps.createNewOne" />
             </Button>)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
A new config property **showCreateButton** has been added and is now available for plugins:
- Maps
- Dashboards
- GeoStories

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4781 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
