### PR TITLE
Modify logic of the mapimport reducer for the SET_LAYER case to remov…

### DIFF
--- a/web/client/reducers/__tests__/mapimport-test.js
+++ b/web/client/reducers/__tests__/mapimport-test.js
@@ -78,4 +78,13 @@ describe('mapimport reducer', () => {
         expect(state).toExist();
         expect(state.success).toBe(MESSAGE);
     });
+    it('state change on setLayers when import is canceled', () => {
+        const action = setLayers(null);
+        const state = mapimport( undefined, action);
+        expect(state).toExist();
+        expect(state.layers).toBe(null);
+        expect(state.errors).toBe(null);
+        expect(state.selected).toBe(null);
+        expect(state.success).toBe(null);
+    });
 });

--- a/web/client/reducers/mapimport.js
+++ b/web/client/reducers/mapimport.js
@@ -38,7 +38,7 @@ function mapimport(state = initialState, action) {
     case SET_LAYERS: {
         let selected = action.layers && action.layers[0] ? action.layers[0] : null;
         const errors = action.layers ? action.errors : null;
-        return assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190], errors});
+        return assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190], errors}, selected ? {} : {success: null});
     }
     case ON_ERROR: {
         return assign({}, state, {


### PR DESCRIPTION
…e useless success alert.

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#4678 

**What is the new behavior?**
If you try to import the layers for the second time, the first validation message does not remain on the modal window.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
