### PR TITLE
Fixed editor toolbar tooltips

### DIFF
--- a/web/client/components/geostory/common/MapEditor.jsx
+++ b/web/client/components/geostory/common/MapEditor.jsx
@@ -87,7 +87,8 @@ const MapEditor = ({
                         }}
                         btnDefaultProps={{
                             className: "square-button-md no-border",
-                            bsStyle: "primary"
+                            bsStyle: "primary",
+                            noTooltipWhenDisabled: true
                         }}
                         buttons={buttons}/>
                 </div>

--- a/web/client/components/geostory/common/ToolbarDropdownButton.jsx
+++ b/web/client/components/geostory/common/ToolbarDropdownButton.jsx
@@ -9,7 +9,7 @@
 
 import React from "react";
 import { DropdownButton as DropdownButtonRB, Glyphicon, MenuItem } from 'react-bootstrap';
-import tooltip from '../../misc/enhancers/tooltip';
+import tooltip from '../../misc/enhancers/buttonTooltip';
 import find from 'lodash/find';
 
 const DropdownButton = tooltip(DropdownButtonRB);
@@ -25,12 +25,14 @@ export default function ToolbarDropdownButton({
     tooltipId,
     pullRight = false,
     className = 'square-button-md no-border',
-    disabled
+    disabled,
+    noTooltipWhenDisabled = false
 }) {
     const glyphOption = (find(options, (option) => option.value === value) || { }).glyph;
     return (
         <DropdownButton
             noCaret
+            noTooltipWhenDisabled={noTooltipWhenDisabled}
             tooltipId={tooltipId}
             pullRight={pullRight}
             className={className}

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -96,7 +96,8 @@ export default function ContentToolbar({
         <div className="ms-content-toolbar">
             <Toolbar
                 btnDefaultProps={{
-                    className: BUTTON_CLASSES
+                    className: BUTTON_CLASSES,
+                    noTooltipWhenDisabled: true
                 }}
                 buttons={tools
                     .filter((id) => toolButtons[id])

--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -22,6 +22,7 @@ const BUTTON_CLASSES = 'square-button-md no-border';
 export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {} }) =>
     (<ToolbarDropdownButton
         value={size}
+        noTooltipWhenDisabled
         disabled={disabled}
         glyph="resize-horizontal"
         pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
@@ -49,6 +50,7 @@ export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType
 export const AlignButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {} }) =>
     (<ToolbarDropdownButton
         value={align}
+        noTooltipWhenDisabled
         disabled={size === 'full' || disabled}
         glyph="align-center"
         pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
@@ -72,6 +74,7 @@ export const AlignButtonToolbar = ({editMap: disabled = false, align, sectionTyp
 export const ThemeButtonToolbar = ({editMap: disabled = false, theme, align, sectionType, update = () => {}, fit, themeOptions, size }) =>
     (<ToolbarDropdownButton
         value={theme}
+        noTooltipWhenDisabled
         pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
         glyph="dropper"
         tooltipId="geostory.contentToolbar.contentTheme"
@@ -97,6 +100,7 @@ export const DeleteButtonToolbar = ({ editMap: disabled = false, path, remove = 
     (<DeleteButton
         glyph={"trash"}
         visible
+        noTooltipWhenDisabled
         disabled={disabled}
         className={BUTTON_CLASSES}
         tooltipId={"geostory.contentToolbar.remove"}


### PR DESCRIPTION
## Description
When a button changes its state from enable to disable, its tooltip can remain persistent in the ui.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

#4792  
geosolutions-it/mapstore2-c039#132

**What is the current behavior?**

#geosolutions-it/mapstore2-c039#132
**What is the new behavior?**

Tooltip properly disappear

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
