### PR TITLE
4597 backport in 2020.01.xx - Make available to use an Embed tab to share featured maps (#4708)

### DIFF
--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -56,6 +56,21 @@ class FeaturedMaps extends React.Component {
         this.props.enableFeaturedMaps(true);
     }
 
+    getShareOptions = (res) => {
+        if (res.category && res.category.name === 'GEOSTORY') {
+            return {
+                embedPanel: false,
+                advancedSettings: {
+                    homeButton: true
+                }
+            };
+        }
+
+        return {
+            embedPanel: true
+        };
+    }
+
     render() {
         const items = this.props.items.length > 0 && this.props.items || this.props.previousItems || [];
         return (
@@ -68,7 +83,7 @@ class FeaturedMaps extends React.Component {
                 colProps={this.props.colProps}
                 viewerUrl={(res) => this.context.router.history.push('/' + this.makeShareUrl(res).url)}
                 getShareUrl={this.makeShareUrl}
-                shareOptions={{ embedPanel: false }} // embed is not enabled for featured maps. TODO: share options depending on the content type
+                shareOptions={this.getShareOptions} // TODO: share options depending on the content type
                 metadataModal={MetadataModal}
                 bottom={this.props.bottom}
                 style={items.length === 0 ? {display: 'none'} : {}}/>

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -66,8 +66,14 @@ class FeaturedMaps extends React.Component {
             };
         }
 
+        if (res.category && res.category.name === 'MAP') {
+            return {
+                embedPanel: true
+            };
+        }
+
         return {
-            embedPanel: true
+            embedPanel: false
         };
     }
 


### PR DESCRIPTION
## Description
Make available to use an Embed tab to share featured maps.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
Share tool - embed tab missing in featured maps.
#4597 

**What is the new behavior?**
Currently available to use an Embed tab to share featured maps.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
There is a typo in the name of the branch 4***6***97-backport should be 4***5***97-backport, never mind.