### PR TITLE
4678 backport in 2020.01.xx - Modify logic of the mapImport reducer (#4783, #4718)

### DIFF
--- a/web/client/actions/mapimport.js
+++ b/web/client/actions/mapimport.js
@@ -13,6 +13,7 @@ const ON_LAYER_ADDED = 'IMPORT::ON_LAYER_ADDED';
 const UPDATE_BBOX = 'IMPORT::UPDATE_BBOX';
 const ON_SUCCESS = 'IMPORT::ON_SUCCESS';
 const ON_SHAPE_ERROR = 'ON_SHAPE_ERROR';
+const ON_LAYER_SKIPPED = 'IMPORT::ON_LAYER_SKIPPED';
 
 function setLayers(layers, errors) {
     return {
@@ -63,6 +64,12 @@ function onShapeError(message) {
         message
     };
 }
+function onLayerSkipped(layer) {
+    return {
+        type: ON_LAYER_SKIPPED,
+        layer
+    };
+}
 
 module.exports = {
     SET_LAYERS,
@@ -73,6 +80,7 @@ module.exports = {
     UPDATE_BBOX,
     ON_SUCCESS,
     ON_SHAPE_ERROR,
+    ON_LAYER_SKIPPED,
     onShapeError,
     setLayers,
     onError,
@@ -80,5 +88,6 @@ module.exports = {
     onSelectLayer,
     onLayerAdded,
     updateBBox,
-    onSuccess
+    onSuccess,
+    onLayerSkipped
 };

--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -282,7 +282,7 @@ class Toolbar extends React.Component {
                             </Button>
                         </OverlayTrigger>
                         : null}
-                    {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
+                    {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && !this.props.selectedLayers.length && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
                         <OverlayTrigger
                             key="widgets"
                             placement="top"

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -12,7 +12,7 @@ const React = require('react');
 const Message = require('../../I18N/Message');
 const LocaleUtils = require('../../../utils/LocaleUtils');
 let StyleUtils;
-const { Grid, Row, Col, Button, Alert} = require('react-bootstrap');
+const { Grid, Row, Col, Button, Alert, ButtonToolbar} = require('react-bootstrap');
 
 const {Promise} = require('es6-promise');
 
@@ -166,9 +166,11 @@ class StylePanel extends React.Component {
                     </Col>
                 </Row>
                 <Row>
-                    <Col xsOffset={6} xs={2}> <Button bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => { this.props.setLayers(null); }}>{this.props.cancelMessage}</Button></Col>
-                    <Col xs={2}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => this.props.onLayerSkipped(this.props.selected)}>{this.props.skipMessage}</Button></Col>
-                    <Col xs={2} style={{paddingLeft: 0}}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={this.addToMap}>{this.props.layers.length === 1 ? this.props.finishMessage : this.props.nextMessage}</Button></Col>
+                    <ButtonToolbar style={{display: 'flex', justifyContent: 'flex-end'}}>
+                        <Button bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => { this.props.setLayers(null); }}>{this.props.cancelMessage}</Button>
+                        <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => this.props.onLayerSkipped(this.props.selected)}>{this.props.skipMessage}</Button>
+                        <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={this.addToMap}>{this.props.layers.length === 1 ? this.props.finishMessage : this.props.nextMessage}</Button>
+                    </ButtonToolbar>
                 </Row>
             </Grid>
         );

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -14,8 +14,6 @@ const LocaleUtils = require('../../../utils/LocaleUtils');
 let StyleUtils;
 const { Grid, Row, Col, Button, Alert} = require('react-bootstrap');
 
-const Combo = require('react-widgets').DropdownList;
-
 const {Promise} = require('es6-promise');
 
 class StylePanel extends React.Component {
@@ -31,6 +29,7 @@ class StylePanel extends React.Component {
         addLayer: PropTypes.func,
         onSelectLayer: PropTypes.func,
         onLayerAdded: PropTypes.func,
+        onLayerSkipped: PropTypes.func,
         onZoomSelected: PropTypes.func,
         updateBBox: PropTypes.func,
         errors: PropTypes.array,
@@ -39,7 +38,10 @@ class StylePanel extends React.Component {
         buttonSize: PropTypes.string,
         cancelMessage: PropTypes.object,
         addMessage: PropTypes.object,
-        stylers: PropTypes.object
+        stylers: PropTypes.object,
+        nextMessage: PropTypes.object,
+        finishMessage: PropTypes.object,
+        skipMessage: PropTypes.object
     };
 
     static contextTypes = {
@@ -59,11 +61,16 @@ class StylePanel extends React.Component {
 
     state = {
         useDefaultStyle: false,
-        zoomOnShapefiles: true
+        zoomOnShapefiles: true,
+        initialLayers: []
     };
 
     UNSAFE_componentWillMount() {
         StyleUtils = require('../../../utils/StyleUtils')(this.props.mapType);
+    }
+
+    componentDidMount() {
+        this.setState({initialLayers: [...this.props.layers]});
     }
 
     getGeometryType = (geometry) => {
@@ -132,11 +139,13 @@ class StylePanel extends React.Component {
 
     render() {
         return (
-            <Grid role="body" style={{width: "300px"}} fluid>
+            <Grid role="body" style={{width: "400px"}} fluid>
                 {this.props.errors ? this.renderError() : null}
                 {this.props.success ? this.renderSuccess() : null}
-                <Row key="select" style={{textAlign: "center"}}>
-                    <Combo data={this.props.layers} value={this.props.selected} onSelect={(value)=> this.props.onSelectLayer(value)} valueField={"id"} textField={"name"} />
+                <Row>
+                    <h4>
+                        <span style={{fontWeight: 'bold'}}><Message msgId="shapefile.layerOf" msgParams={{ count: this.findLayerSerialNumber(this.props.selected), total: this.state.initialLayers.length}} /></span> {this.props.selected.name}
+                    </h4>
                 </Row>
                 <Row key="styler" style={{marginBottom: 10}}>
                     {this.state.useDefaultStyle ? null : this.props.stylers[this.getGeomType(this.props.selected)]}
@@ -157,11 +166,18 @@ class StylePanel extends React.Component {
                     </Col>
                 </Row>
                 <Row>
-                    <Col xsOffset={6} xs={3}> <Button bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => { this.props.setLayers(null); }}>{this.props.cancelMessage}</Button></Col>
-                    <Col xs={3}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={this.addToMap}>{this.props.addMessage}</Button></Col>
+                    <Col xsOffset={6} xs={2}> <Button bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => { this.props.setLayers(null); }}>{this.props.cancelMessage}</Button></Col>
+                    <Col xs={2}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={() => this.props.onLayerSkipped(this.props.selected)}>{this.props.skipMessage}</Button></Col>
+                    <Col xs={2} style={{paddingLeft: 0}}> <Button bsStyle="primary" bsSize={this.props.buttonSize} disabled={!this.props.selected} onClick={this.addToMap}>{this.props.layers.length === 1 ? this.props.finishMessage : this.props.nextMessage}</Button></Col>
                 </Row>
             </Grid>
         );
+    }
+
+    findLayerSerialNumber = ({name}) => {
+        const {initialLayers} = this.state;
+        const serialNumber = initialLayers.findIndex(initLayer => initLayer.name === name) + 1;
+        return serialNumber;
     }
 
     addToMap = () => {

--- a/web/client/components/import/style/__tests__/StylePanel-test.jsx
+++ b/web/client/components/import/style/__tests__/StylePanel-test.jsx
@@ -29,7 +29,7 @@ describe('StylePanel component', () => {
     it('StylePanel rendering with layers', () => {
         ReactDOM.render(<StylePanel layers={[L1, L2]} selected={L1} stylers={{"Point": <div></div>}}/>, document.getElementById("container"));
         const container = document.getElementById('container');
-        expect(container.querySelector('.rw-dropdownlist')).toExist();
+        expect(container.querySelector('h4')).toExist();
         const checkBoxes = Array.slice(container.querySelectorAll('input[type=checkbox]'));
         expect(checkBoxes.length).toBe(2);
         expect(checkBoxes.filter(e => e.checked).length).toBe(1);
@@ -44,7 +44,7 @@ describe('StylePanel component', () => {
         const container = document.getElementById('container');
         expect(container.querySelector('.alert')).toExist();
     });
-    it('Test StylePanel onSuccess to have been called on add button click', (done) => {
+    it('Test StylePanel onSuccess to have been called on NEXT / FINISH button click', (done) => {
         const actions = {
             onSuccess: () => {
             }
@@ -58,7 +58,7 @@ describe('StylePanel component', () => {
 
         const cmp = ReactDOM.render(<StylePanel shapeStyle={{marker: true}} errors={[W1]} layers={[L1, L2]} selected={L1} stylers={{ "Point": <div></div> }} onLayerAdded={onLayerAdded} onSuccess={actions.onSuccess} />, document.getElementById("container"));
         expect(cmp).toExist();
-        const btn = document.querySelectorAll('button')[1];
+        const btn = document.querySelectorAll('button')[2];
         ReactTestUtils.Simulate.click(btn); // <-- trigger event callback
     });
     it('Test StylePanel onError to have been called on error during add', (done) => {
@@ -82,7 +82,7 @@ describe('StylePanel component', () => {
             onLayerAdded={actions.onLayerAdded}
             onSuccess={actions.onSuccess} />, document.getElementById("container"));
         expect(cmp).toExist();
-        const btn = document.querySelectorAll('button')[1];
+        const btn = document.querySelectorAll('button')[2];
         ReactTestUtils.Simulate.click(btn); // <-- trigger event callback
     });
 });

--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 
 const Message = require('./locale/Message');
 
-const { onError, setLoading, setLayers, onSelectLayer, onLayerAdded, updateBBox, onSuccess} = require('../actions/mapimport');
+const { onError, setLoading, setLayers, onSelectLayer, onLayerAdded, onLayerSkipped, updateBBox, onSuccess} = require('../actions/mapimport');
 const {zoomToExtent} = require('../actions/map');
 const {addLayer} = require('../actions/layers');
 const {toggleControl} = require('../actions/controls');
@@ -39,6 +39,7 @@ module.exports = {
             ), {
                 setLayers,
                 onLayerAdded,
+                onLayerSkipped,
                 onSelectLayer,
                 onError,
                 onSuccess,

--- a/web/client/plugins/import/StyleDialog.jsx
+++ b/web/client/plugins/import/StyleDialog.jsx
@@ -79,7 +79,9 @@ class StyleDialog extends React.Component {
             stylers={stylers}
             uploadMessage={<Message msgId={this.props.uploadMessage}/>}
             cancelMessage={<Message msgId="shapefile.cancel"/>}
-            addMessage={<Message msgId="shapefile.add"/>}
+            nextMessage={<Message msgId="shapefile.next"/>}
+            finishMessage={<Message msgId="shapefile.finish"/>}
+            skipMessage={<Message msgId="shapefile.skip"/>}
         />);
 
 

--- a/web/client/reducers/__tests__/mapimport-test.js
+++ b/web/client/reducers/__tests__/mapimport-test.js
@@ -78,4 +78,13 @@ describe('mapimport reducer', () => {
         expect(state).toExist();
         expect(state.success).toBe(MESSAGE);
     });
+    it('state change on setLayers when import is canceled', () => {
+        const action = setLayers(null);
+        const state = mapimport( undefined, action);
+        expect(state).toExist();
+        expect(state.layers).toBe(null);
+        expect(state.errors).toBe(null);
+        expect(state.selected).toBe(null);
+        expect(state.success).toBe(null);
+    });
 });

--- a/web/client/reducers/mapimport.js
+++ b/web/client/reducers/mapimport.js
@@ -14,7 +14,8 @@ const {
     ON_LAYER_ADDED,
     UPDATE_BBOX,
     ON_SUCCESS,
-    ON_SHAPE_ERROR
+    ON_SHAPE_ERROR,
+    ON_LAYER_SKIPPED
 } = require('../actions/mapimport');
 const {uniqWith} = require('lodash');
 const {TOGGLE_CONTROL} = require('../actions/controls');
@@ -73,6 +74,13 @@ function mapimport(state = initialState, action) {
             return assign({}, state, {errors: null, success: null});
         }
         return state;
+    }
+    case ON_LAYER_SKIPPED: {
+        const newLayers = state.layers.filter((l) => {
+            return action.layer.name !== l.name;
+        }, this);
+        const selected = newLayers && newLayers[0] ? newLayers[0] : null;
+        return assign({}, state, {layers: newLayers, selected, success: null});
     }
     default:
         return state;

--- a/web/client/reducers/mapimport.js
+++ b/web/client/reducers/mapimport.js
@@ -38,7 +38,7 @@ function mapimport(state = initialState, action) {
     case SET_LAYERS: {
         let selected = action.layers && action.layers[0] ? action.layers[0] : null;
         const errors = action.layers ? action.errors : null;
-        return assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190], errors});
+        return assign({}, state, {layers: action.layers, selected: selected, bbox: [190, 190, -190, -190], errors}, selected ? {} : {success: null});
     }
     case ON_ERROR: {
         return assign({}, state, {

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -1099,7 +1099,11 @@
             },
             "add": "Hinzufügen",
             "cancel": "Abbrechen",
-            "success": " erfolgreich importiert"
+            "success": " erfolgreich importiert",
+            "next": "Nächster",
+            "skip": "springen",
+            "finish": "Fertig",
+            "layerOf": "Schicht {count} von {total}:"
         },
         "mapImport": {
                 "title": "Einführen",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -1100,7 +1100,11 @@
             },
             "add": "Add",
             "cancel": "Cancel",
-            "success": " correctly imported"
+            "success": " correctly imported",
+            "next": "Next",
+            "skip": "Skip",
+            "finish": "Finish",
+            "layerOf": "Layer {count} of {total}:"
         },
         "mapImport": {
             "title": "Import",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -1099,7 +1099,11 @@
             },
             "add": "Añadir",
             "cancel": "Cancelar",
-            "success": " Importación correcta"
+            "success": " Importación correcta",
+            "next": "Siguiente",
+            "skip": "Saltar",
+            "finish": "Terminar",
+            "layerOf": "Capa {count} de {total}:"
         },
         "mapImport": {
             "title": "Importar",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -1099,7 +1099,11 @@
             },
             "add": "Ajouter",
             "cancel": "Annuler",
-            "success": " Import correct"
+            "success": " Import correct",
+            "next": "Suivant",
+            "skip": "Passer",
+            "finish": "Terminer",
+            "layerOf": "Couchez {count} des {total}:"
         },
         "mapImport": {
             "title": "Importer",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -1099,7 +1099,11 @@
             },
             "add": "Importa",
             "cancel": "Annulla",
-            "success": " correttamente importato"
+            "success": " correttamente importato",
+            "next": "Avanti",
+            "skip": "Salta",
+            "finish": "Fine",
+            "layerOf": "Strato {count} dei {total}:"
         },
         "mapImport": {
             "title": "Importa",


### PR DESCRIPTION
## Description
Change UI of the import vector files functionality. Remove the widgets button from the TOC toolbar for imported files.

Add translations for needed phrases. Modify tests to fit new functionality.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#4678 

**What is the new behavior?**
UI of the import vector files functionality has been changed. Removed the widgets button from the TOC toolbar for imported files.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
