### PR TITLE
4658 backport in 2020.01.xx - Resource metadata for Dashboard and Geostory are not complete (#4658)

### DIFF
--- a/web/client/components/resources/forms/Metadata.jsx
+++ b/web/client/components/resources/forms/Metadata.jsx
@@ -97,7 +97,7 @@ class Metadata extends React.Component {
                 </FormGroup>
             }
             {
-                this.props.resource && this.props.resource.modifiedAt && this.props.resource.createdAt && <FormGroup>
+                this.props.resource && this.props.resource.createdAt && <FormGroup>
                     <ControlLabel>{this.props.modifiedAtFieldText}</ControlLabel>
                     <ControlLabel>{this.props.resource && this.renderDate(this.props.resource.modifiedAt || this.props.resource.createdAt) || ""}</ControlLabel>
                 </FormGroup>

--- a/web/client/components/resources/forms/__tests__/Metadata-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Metadata-test.jsx
@@ -82,4 +82,20 @@ describe('Metadata component', () => {
         expect(spyonChange).toHaveBeenCalled();
         expect(spyonChange.calls[0].arguments[1]).toBe('test,text,stuff');
     });
+    it('Metadata rendering Modified At label when modifiedAt prop is undefined', () => {
+        const resource = {
+            modifiedAt: undefined,
+            createdAt: new Date(),
+            metadata: {
+                name: "NAME",
+                description: "DESCRIPTION"
+            }
+        };
+        ReactDOM.render(<Metadata resource={resource} createdAtFieldText="Created" modifiedAtFieldText="Modified"/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const labels = container.querySelectorAll('label');
+        expect(labels.length).toBe(6);
+        expect(labels[2].innerText).toBe('Created');
+        expect(labels[4].innerText).toBe('Modified');
+    });
 });


### PR DESCRIPTION
## Description
The modification date for Dashboard and Geostory is not present on the edit properties even after the first save.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4658 

**What is the new behavior?**
The modification date for Dashboard and Geostory is present on the edit properties even after the first save.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
