### PR TITLE
Removed clear btn in service selector

### DIFF
--- a/web/client/components/mediaEditor/MediaEditor.jsx
+++ b/web/client/components/mediaEditor/MediaEditor.jsx
@@ -77,13 +77,12 @@ export default ({
                 </div>
                 <Select
                     disabled={saveState && saveState.addingMedia}
-                    clearValueText="mediaEditor.mediaPicker.clean"
                     noResultsText="mediaEditor.mediaPicker.noResults"
                     placeholder="mediaEditor.mediaPicker.selectService"
-                    clearable
                     options={services.map(s => ({label: s.name, value: s.id}))}
                     onChange={setMediaService}
                     value={selectedService}
+                    clearable={false}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Description
Removed clear button on media editor service selector

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4807
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
geosolutions-it/mapstore2-c039#146

**What is the new behavior?**
geosolutions-it/mapstore2-c039#146

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
