### PR TITLE
Fix Wrong selection behavior in Media Editor

### DIFF
--- a/web/client/components/mediaEditor/enhancers/__tests__/withSelectedMapReload-test.js
+++ b/web/client/components/mediaEditor/enhancers/__tests__/withSelectedMapReload-test.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {createSink} from 'recompose';
+import expect from 'expect';
+import withSelectedMapReload from '../withSelectedMapReload';
+import  {Provider} from 'react-redux';
+const  store = {
+    getState: () => {},
+    subscribe: () => {}};
+
+
+describe('media editor withSelectedMapReload enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('withSelectedMapReload throws onMapChoice  when needed', (done) => {
+        const actions = {
+            onMapChoice: () => { }
+        };
+        const spyOnMapChoice = expect.spyOn(actions, 'onMapChoice');
+
+        const resource = {id: 1};
+        const resources = [resource];
+
+        store.dispatch = () => {};
+        const Sink = withSelectedMapReload(createSink( props => {
+            expect(props).toExist();
+            expect(spyOnMapChoice).toHaveBeenCalled();
+            expect(spyOnMapChoice.getLastCall().arguments[0]).toBe(resource);
+            done();
+        }));
+
+        ReactDOM.render(<Provider store={store}>
+            <Sink onMapChoice={actions.onMapChoice}
+                selectedService="geostoreMap"
+                selected
+                resources={resources}
+                selectedItem={resource}
+            />
+        </Provider>, document.getElementById("container"));
+
+    });
+
+});

--- a/web/client/components/mediaEditor/enhancers/withSelectedMapReload.js
+++ b/web/client/components/mediaEditor/enhancers/withSelectedMapReload.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { mapPropsStream} from 'recompose';
+import {find} from 'lodash';
+
+/**
+ * This streams handle the reload of a selected map from geostore.
+ * It has to follow handleMapSelect enhancer
+ * If a map that is present in the resources is selected but the map configurations are missing
+ * this stream throws the reload the map configurations
+ */
+
+export default mapPropsStream(props$ =>
+    props$.distinctUntilKeyChanged("resources")
+        .filter(({selectedService, selected, selectedItem}) => selectedService === "geostoreMap" && selected && selectedItem && !selectedItem.center)
+        .do(({resources, selectedItem, onMapChoice}) => {
+            if (find(resources, ({id}) => id === selectedItem.id)) {
+                onMapChoice(selectedItem);
+            }
+        })
+        .ignoreElements() // don't want to emit props
+        .startWith({})
+        .combineLatest(props$, (emptyProps, props) =>  props)
+);

--- a/web/client/components/mediaEditor/map/MapList.jsx
+++ b/web/client/components/mediaEditor/map/MapList.jsx
@@ -18,7 +18,7 @@ import SideGrid from '../../misc/cardgrids/SideGrid';
 import { filterResources } from '../../../utils/GeoStoryUtils';
 import { SourceTypes } from '../../../utils/MediaEditorUtils';
 import withFilter from '../enhancers/withFilter';
-
+import  withSelectedMapReload from '../enhancers/withSelectedMapReload';
 
 const Icon = require('../../misc/FitIcon');
 
@@ -126,5 +126,6 @@ export default compose(
     withProps(() => ({
         includeMapId: true
     })),
-    handleMapSelect
+    handleMapSelect,
+    withSelectedMapReload
 )(MapList);


### PR DESCRIPTION
## Description
The current selectd map in media list is now reloaded when the selected map is present in the list 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4812
**What is the current behavior?**
see geosolutions-it/mapstore2-c039#137

**What is the new behavior?**
see geosolutions-it/mapstore2-c039#137

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
