### PR TITLE
Fixed rich text with background map

### DIFF
--- a/web/client/components/geostory/contents/Column.jsx
+++ b/web/client/components/geostory/contents/Column.jsx
@@ -31,7 +31,8 @@ export default ({
     editMedia = () => {},
     editWebPage = () => {},
     update = () => {},
-    remove = () => {}
+    remove = () => {},
+    bubblingTextEditing = () => {}
 }) => (
     <Contents
         className="ms-column-contents"
@@ -45,6 +46,7 @@ export default ({
         remove={remove}
         viewWidth={viewWidth}
         viewHeight={viewHeight}
+        bubblingTextEditing={bubblingTextEditing}
         tools={{
             [ContentTypes.TEXT]: ['remove'],
             [MediaTypes.IMAGE]: ['editMedia', 'size', 'align', 'remove'],

--- a/web/client/components/geostory/contents/ContentWrapper.jsx
+++ b/web/client/components/geostory/contents/ContentWrapper.jsx
@@ -15,12 +15,12 @@ import { Modes, getClassNameFromProps } from "../../../utils/GeoStoryUtils";
  *  - center the content accordingly.
  *  - Add inViewRef property, to apply IntersectionObserver
  */
-export default ({ id, inViewRef, children, type, contentWrapperStyle, mode, textEditorActiveClass, ...props }) =>
+export default ({ id, inViewRef, children, type, contentWrapperStyle, mode, textEditorActiveClass = "", ...props }) =>
     (<div
         id={id}
         ref={inViewRef}
         style={contentWrapperStyle}
-        className={`ms-content ms-content-${type}${getClassNameFromProps(props)} ${textEditorActiveClass}`}>
+        className={`ms-content ms-content-${type}${getClassNameFromProps(props)}${textEditorActiveClass}`}>
         <div className="ms-content-body">
             {mode === Modes.EDIT
                 && <ContentToolbar

--- a/web/client/components/geostory/contents/ContentWrapper.jsx
+++ b/web/client/components/geostory/contents/ContentWrapper.jsx
@@ -15,12 +15,12 @@ import { Modes, getClassNameFromProps } from "../../../utils/GeoStoryUtils";
  *  - center the content accordingly.
  *  - Add inViewRef property, to apply IntersectionObserver
  */
-export default ({ id, inViewRef, children, type, contentWrapperStyle, mode, ...props }) =>
+export default ({ id, inViewRef, children, type, contentWrapperStyle, mode, textEditorActiveClass, ...props }) =>
     (<div
         id={id}
         ref={inViewRef}
         style={contentWrapperStyle}
-        className={`ms-content ms-content-${type}${getClassNameFromProps(props)}`}>
+        className={`ms-content ms-content-${type}${getClassNameFromProps(props)} ${textEditorActiveClass}`}>
         <div className="ms-content-body">
             {mode === Modes.EDIT
                 && <ContentToolbar

--- a/web/client/components/geostory/contents/Contents.jsx
+++ b/web/client/components/geostory/contents/Contents.jsx
@@ -49,7 +49,8 @@ export default ({
     editWebPage = () => {},
     add = () => {},
     update = () => {},
-    remove = () => {}
+    remove = () => {},
+    bubblingTextEditing = () => {}
 }) =>
     (<div className={className}>
         {contents.reduce(( rendered = [], { id, ...props }) => {
@@ -69,6 +70,7 @@ export default ({
                     remove={(path, ...args) => remove(`contents[{"id": "${id}"}]` + (path ? "." + path : ""), ...args)}
                     {...contentProps}
                     {...props}
+                    bubblingTextEditing={bubblingTextEditing}
                     tools={tools && tools[props.type]} />)];
             if (mode === Modes.EDIT && addButtons.length > 0) {
                 content.push(

--- a/web/client/components/geostory/contents/SectionContent.jsx
+++ b/web/client/components/geostory/contents/SectionContent.jsx
@@ -28,7 +28,7 @@ export default compose(
     visibilityHandler({ threshold: DEFAULT_THRESHOLD}),
     withStateHandlers({textEditorActive: false}, {
         bubblingTextEditing: () => (editing) => {
-            return  {textEditorActiveClass: editing ? 'ms-text-editor-active' : ''};
+            return  {textEditorActiveClass: editing ? ' ms-text-editor-active' : ''};
         }
     }),
     wrap(ContentWrapper),

--- a/web/client/components/geostory/contents/SectionContent.jsx
+++ b/web/client/components/geostory/contents/SectionContent.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { compose, nest, setDisplayName, branch, renderComponent } from "recompose";
+import { compose, nest, setDisplayName, branch, renderComponent, withStateHandlers } from "recompose";
 import visibilityHandler from './enhancers/visibilityHandler';
 import ContentWrapper from './ContentWrapper';
 import Content from './Content';
@@ -26,6 +26,11 @@ export default compose(
     // make maths for contents relative to their scope for edit methods
     // so inside the content you can simply call update('html', value) or add update('contents[{id: "some-sub-content-id"}])
     visibilityHandler({ threshold: DEFAULT_THRESHOLD}),
+    withStateHandlers({textEditorActive: false}, {
+        bubblingTextEditing: () => (editing) => {
+            return  {textEditorActiveClass: editing ? 'ms-text-editor-active' : ''};
+        }
+    }),
     wrap(ContentWrapper),
     setDisplayName("SectionContent"),
     branch(

--- a/web/client/components/geostory/contents/enhancers/editableText.jsx
+++ b/web/client/components/geostory/contents/enhancers/editableText.jsx
@@ -28,9 +28,10 @@ export default compose(
     withState('contentEditing', 'setContentEditing', false),
     withState('editorState', 'onEditorStateChange'),
     withHandlers({
-        toggleEditing: ({ sectionType, onEditorStateChange = () => {}, setContentEditing = () => {} }) => (editing, html) => {
+        toggleEditing: ({ bubblingTextEditing = () => {}, sectionType, onEditorStateChange = () => {}, setContentEditing = () => {} }) => (editing, html) => {
             if (!editing) {
                 setContentEditing(false);
+                bubblingTextEditing(false);
             } else {
                 const contentBlock = htmlToDraft(html);
                 let contentState = ContentState.createFromBlockArray(contentBlock.contentBlocks);
@@ -42,6 +43,7 @@ export default compose(
                 }
                 onEditorStateChange(editorState);
                 setContentEditing(true);
+                bubblingTextEditing(true);
             }
         }
     }),

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -61,6 +61,13 @@
             background-color: @ms-story-bg-grey;
         }
     }
+    .ms-cascade-story.ms-edit {
+        .ms-section-title, .ms-section-immersive {
+            .ms-text-editor-active {
+                pointer-events: all;
+            }
+        }
+    }
 }
 .ms-geostory-map-controls {
     padding-top: 8px;


### PR DESCRIPTION
## Description
It's now possible to close the rich text editor clicking on the background map.
Consider that clicking on any neighbor map, will not close the editor.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4830 
**What is the current behavior?**
refer to geosolutions-it/mapstore2-c039#141
**What is the new behavior?**
refer to geosolutions-it/mapstore2-c039#141

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
