### PR TITLE
Fixed media editor state 

### DIFF
--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -45,7 +45,7 @@ describe('Test the mediaEditor reducer', () => {
         let state = mediaEditor({}, chooseMedia());
         expect(state.open).toEqual(false);
         expect(state.owner).toEqual(undefined);
-        expect(state.settings).toEqual(undefined);
+        expect(state.settings).toEqual(DEFAULT_STATE.settings);
         expect(state.stashedSettings).toEqual(undefined);
 
         // if there is a stashed change
@@ -59,7 +59,7 @@ describe('Test the mediaEditor reducer', () => {
         let state = mediaEditor({}, hide());
         expect(state.open).toEqual(false);
         expect(state.owner).toEqual(undefined);
-        expect(state.settings).toEqual(undefined);
+        expect(state.settings).toEqual(DEFAULT_STATE.settings);
         expect(state.selected).toEqual(undefined);
         expect(state.saveState).toEqual({editing: false, addingMedia: false});
         expect(state.stashedSettings).toEqual(undefined);

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -22,7 +22,7 @@ import {
     SHOW
 } from '../actions/mediaEditor';
 import {LOCATION_CHANGE} from 'connected-react-router';
-import { compose, set } from '../utils/ImmutableUtils';
+import { compose, set, unset} from '../utils/ImmutableUtils';
 import {
     sourceIdSelector,
     currentMediaTypeSelector,
@@ -91,8 +91,9 @@ export default (state = DEFAULT_STATE, action) => {
             set('owner', undefined),
             set('saveState.addingMedia', false),
             set('saveState.editing', false),
-            set('settings', state.stashedSettings || state.settings), // restore defaults, TODO SOURCE ID IS NOT RESTORED
-            set('stashedSettings', undefined)
+            set('settings', state.stashedSettings || DEFAULT_STATE.settings), // restore defaults, TODO SOURCE ID IS NOT RESTORED
+            set('stashedSettings', undefined),
+            unset('selected')
         )(state);
     // set adding media state (to toggle add/select in media selectors)
     case LOAD_MEDIA_SUCCESS: {


### PR DESCRIPTION
## Description
The state of media editor is now reseted on hide action

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4767
**What is the current behavior?**
#4767

**What is the new behavior?**
#4767
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
