### PR TITLE
#4845: makes ConfigUtils returned default properties object immutable

### DIFF
--- a/web/client/utils/ConfigUtils.js
+++ b/web/client/utils/ConfigUtils.js
@@ -128,7 +128,7 @@ var ConfigUtils = {
         return null;
     },
     getDefaults: function() {
-        return defaultConfig;
+        return {...defaultConfig};
     },
     setLocalConfigurationFile(file) {
         localConfigFile = file;
@@ -139,11 +139,11 @@ var ConfigUtils = {
                 if (typeof response.data === 'object') {
                     defaultConfig = assign({}, defaultConfig, response.data);
                 }
-                return defaultConfig;
+                return {...defaultConfig};
             });
         }
         return new Promise((resolve) => {
-            resolve(defaultConfig);
+            resolve({...defaultConfig});
         });
     },
 

--- a/web/client/utils/__tests__/ConfigUtils-test.js
+++ b/web/client/utils/__tests__/ConfigUtils-test.js
@@ -124,7 +124,7 @@ describe('ConfigUtils', () => {
     });
     afterEach((done) => {
         document.body.innerHTML = '';
-
+        ConfigUtils.setLocalConfigurationFile("localConfig.json");
         setTimeout(done);
     });
     it('convert from legacy and check projection conversion', () => {
@@ -276,6 +276,32 @@ describe('ConfigUtils', () => {
     it('loadConfiguration', (done) => {
         var retval = ConfigUtils.loadConfiguration();
         expect(retval).toExist();
+        done();
+    });
+
+    it("loadConfiguration returns a copied config", done => {
+        var retval = ConfigUtils.loadConfiguration();
+        expect(retval).toExist();
+        retval.newProperty = 'newValue';
+        expect(ConfigUtils.getDefaults().newProperty).toNotExist();
+        done();
+    });
+
+    it("loadConfiguration returns a copied config as a promise", done => {
+        ConfigUtils.setLocalConfigurationFile("");
+        ConfigUtils.loadConfiguration().then((retval) => {
+            expect(retval).toExist();
+            retval.newProperty = "newValue";
+            expect(ConfigUtils.getDefaults().newProperty).toNotExist();
+            done();
+        });
+    });
+
+    it("getDefaults returns a copied config", done => {
+        var retval = ConfigUtils.getDefaults();
+        expect(retval).toExist();
+        retval.newProperty = "newValue";
+        expect(ConfigUtils.getDefaults().newProperty).toNotExist();
         done();
     });
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Makes ConfigUtils returned default properties object immutable

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4845 

