### PR TITLE
fixedSideScroll

### DIFF
--- a/web/client/components/misc/cardgrids/SideCard.jsx
+++ b/web/client/components/misc/cardgrids/SideCard.jsx
@@ -56,7 +56,6 @@ module.exports = ({
     ...props
 } = {}) =>
     <div
-        id={props.id ? `sd_${props.id}` : undefined}
         className={`mapstore-side-card${selected ? ' selected' : ''}${size ? ' ms-' + size : ''}${className ? ` ${className}` : ''}${fullText ? ' full-text' : ''}`}
         onClick={(event) => onClick({title, preview, description, caption, tools, ...props}, event)}
         onMouseEnter={onMouseEnter}

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -424,10 +424,10 @@ export const scrollSideBar = (action$, {getState}) =>
     action$.ofType(UPDATE_CURRENT_PAGE)
         .filter(({columnId, sectionId}) => modeSelector(getState()) === 'edit' && ((columnId && columnId !== "EMPTY") || sectionId))
         .debounceTime(100)
-        .do(({columnId, sectionId}) => {
-            const id = `sd_${columnId || sectionId}`;
-            let el = document.getElementById(id);
+        .switchMap(() => {
+            const el = Array.from(document.querySelectorAll(".ms-geostory-builder .mapstore-side-card.ms-highlight")).pop();
             if (el) {
-                el.scrollIntoView({behavior: "smooth", block: "nearest"});
+                el.scrollIntoView({block: "center", inline: "nearest", behavior: "smooth"});
             }
-        }).ignoreElements();
+            return Observable.empty();
+        });

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -423,8 +423,12 @@ export const closeShareOnGeostoryChangeMode = action$ =>
 export const scrollSideBar = (action$, {getState}) =>
     action$.ofType(UPDATE_CURRENT_PAGE)
         .filter(({columnId, sectionId}) => modeSelector(getState()) === 'edit' && ((columnId && columnId !== "EMPTY") || sectionId))
-        .debounceTime(100)
+        .debounceTime(50) // little delay if too many UPDATE_CURRENT_PAGE actions come
         .switchMap(() => {
+            /* We need to select the most inner highlighted element of the preview list
+             * The selector will query all the highlighted elements and the pop will extract
+             * the most inner (i.e a section content column in an immersive section)
+             */
             const el = Array.from(document.querySelectorAll(".ms-geostory-builder .mapstore-side-card.ms-highlight")).pop();
             if (el) {
                 el.scrollIntoView({block: "center", inline: "nearest", behavior: "smooth"});


### PR DESCRIPTION
## Description
Some time the intersection-observer throws UPDATE_CURRENT_PAGE action with a wrong content.
To reproduce try to scroll very fast from the bottom to the top of the stories.
So it's not possible to get the element to scroll by the sectionId/columnId present in the action but
we have to use a querySelector.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4832
**What is the current behavior?**
#4832

**What is the new behavior?**
#4832
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
