### PR TITLE
Fixed add new media content

### DIFF
--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -60,7 +60,8 @@ import {
     EDIT_MEDIA,
     CHOOSE_MEDIA,
     selectItem,
-    setMediaType
+    setMediaType,
+    hide
 } from '../actions/mediaEditor';
 import { show, error } from '../actions/notifications';
 
@@ -100,7 +101,7 @@ const updateMediaSection = (store, path) => action$ =>
                 actions = [...actions, addResource(resourceId, mediaType, resource)];
             }
             let media = mediaType === MediaTypes.MAP ? {resourceId, type: mediaType, map: undefined} : {resourceId, type: mediaType};
-            actions = [...actions, update(`${path}`, media, "merge" )];
+            actions = [...actions, update(`${path}`, media, "merge" ), hide()];
             return Observable.from(actions);
         });
 
@@ -130,7 +131,7 @@ export const openMediaEditorForNewMedia = (action$, store) =>
                         .switchMap(() => {
                             return Observable.of(remove(
                                 path));
-                        })
+                        }).takeUntil(action$.ofType(UPDATE))
                 ).takeUntil(action$.ofType(EDIT_MEDIA));
         });
 

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -42,18 +42,9 @@ describe('Test the mediaEditor reducer', () => {
         expect(state.saveState.editing).toEqual(editing);
     });
     it('CHOOSE_MEDIA', () => {
-        let state = mediaEditor({}, chooseMedia());
-        expect(state.open).toEqual(false);
-        expect(state.owner).toEqual(undefined);
-        expect(state.settings).toEqual(DEFAULT_STATE.settings);
-        expect(state.stashedSettings).toEqual(undefined);
-
-        // if there is a stashed change
-        state = mediaEditor({stashedSettings: {setting1: true}}, chooseMedia());
-        expect(state.open).toEqual(false);
-        expect(state.owner).toEqual(undefined);
-        expect(state.settings).toEqual({setting1: true});
-        expect(state.stashedSettings).toEqual(undefined);
+        const oState = {};
+        let state = mediaEditor(oState, chooseMedia());
+        expect(state).toBe(oState);
     });
     it('HIDE', () => {
         let state = mediaEditor({}, hide());

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -11,7 +11,6 @@ import { MediaTypes } from '../utils/GeoStoryUtils';
 import { SourceTypes } from '../utils/MediaEditorUtils';
 import {
     ADDING_MEDIA,
-    CHOOSE_MEDIA,
     EDITING_MEDIA,
     HIDE,
     LOAD_MEDIA_SUCCESS,
@@ -85,7 +84,6 @@ export default (state = DEFAULT_STATE, action) => {
     // hide resets the media editor as well as selected
     // resets all media editor settings
     case HIDE:
-    case CHOOSE_MEDIA:
         return compose(
             set('open', false),
             set('owner', undefined),


### PR DESCRIPTION
## Description
Decoupled hide media editor and choose_media media editor actions in the reducer.
On hide we clean the state while the choose_media doesn't!

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4854 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
