### PR TITLE
Application Context Plugins various enhancements

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -282,7 +282,7 @@ class Toolbar extends React.Component {
                             </Button>
                         </OverlayTrigger>
                         : null}
-                    {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && !this.props.selectedLayers.length && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
+                    {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
                         <OverlayTrigger
                             key="widgets"
                             placement="top"

--- a/web/client/components/contextcreator/ConfigureMapStep.jsx
+++ b/web/client/components/contextcreator/ConfigureMapStep.jsx
@@ -24,6 +24,7 @@ export default ({
 }) => (
     <React.Fragment>
         <ConfirmDialog
+            draggable={false}
             modal
             show={showConfirm}
             onClose={() => {
@@ -34,6 +35,7 @@ export default ({
                 onMapViewerReload();
             }}
             confirmButtonBSStyle="default"
+            closeGlyph="1-close"
             confirmButtonContent={<Message msgId="confirm"/>}
             closeText={<Message msgId="cancel"/>}
         >

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -61,7 +61,7 @@ const pluginsToItems = (editedPlugin, editedCfg, cfgError, setEditor, documentat
                 tooltipId: 'contextCreator.configurePlugins.tooltips.mapTemplatesConfig',
                 onClick: () => onShowDialog('mapTemplatesConfig', true)
             }, {
-                visible: !isMandatory,
+                visible: !isMandatory && !plugin.denyUserSelection,
                 glyph: '1-user-mod',
                 tooltipId: plugin.isUserPlugin ?
                     'contextCreator.configurePlugins.tooltips.disableUserPlugin' :
@@ -69,7 +69,7 @@ const pluginsToItems = (editedPlugin, editedCfg, cfgError, setEditor, documentat
                 bsStyle: plugin.isUserPlugin ? 'success' : undefined,
                 onClick: () => changePluginsKey([plugin.name], 'isUserPlugin', !plugin.isUserPlugin)
             }, {
-                visible: plugin.isUserPlugin,
+                visible: plugin.isUserPlugin && !plugin.denyUserSelection,
                 glyph: plugin.active ? 'check' : 'unchecked',
                 tooltipId: plugin.active ?
                     'contextCreator.configurePlugins.tooltips.deactivatePlugin' :

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -35,7 +35,6 @@ describe('contextcreator epics', () => {
             expect(actions[0].error).toNotExist();
             expect(actions[1].type).toBe(SET_EDITED_PLUGIN);
             expect(actions[1].pluginName).toNotExist();
-            done();
         }, {
             contextcreator: {
                 editedPlugin: 'editedPlugin',
@@ -49,7 +48,7 @@ describe('contextcreator epics', () => {
                     children: []
                 }]
             }
-        });
+        }, done);
     });
     it('editPluginEpic', (done) => {
         const pluginName = 'pluginName';
@@ -60,13 +59,12 @@ describe('contextcreator epics', () => {
             expect(actions[0].pluginName).toBe(pluginName);
             expect(actions[1].type).toBe(SET_EDITED_CFG);
             expect(actions[1].pluginName).toBe(pluginName);
-            done();
         }, {
             contextcreator: {
                 editedPlugin: "editedPlugin",
                 validationStatus: true
             }
-        });
+        }, done);
     });
     it('enablePluginsEpic', (done) => {
         const pluginsToEnable = ['ZoomIn', 'ZoomOut'];
@@ -86,31 +84,36 @@ describe('contextcreator epics', () => {
             expect(actions[2].ids.length).toBe(0);
             expect(actions[2].key).toBe('forcedMandatory');
             expect(actions[2].value).toBe(true);
-            done();
         }, {
             contextcreator: {
                 plugins: [{
                     name: 'MetadataExplorer',
                     title: 'Catalog',
                     dependencies: [],
+                    children: [],
+                    autoEnableChildren: [],
                     enabled: false,
                     isUserPlugin: false,
                     active: false
                 }, {
                     name: 'ZoomIn',
                     dependencies: [],
+                    children: [],
+                    autoEnableChildren: [],
                     enabled: false,
                     isUserPlugin: false,
                     active: false
                 }, {
                     name: 'ZoomOut',
                     dependencies: [],
+                    children: [],
+                    autoEnableChildren: [],
                     enabled: false,
                     isUserPlugin: false,
                     active: false
                 }]
             }
-        });
+        }, done);
     });
     it('enablePluginsEpic with dependencies', (done) => {
         const pluginsToEnable = ['Widgets', 'WidgetsBuilder'];
@@ -133,7 +136,6 @@ describe('contextcreator epics', () => {
             expect(actions[3].ids).toEqual(['WidgetsTray']);
             expect(actions[3].key).toBe('enabledDependentPlugins');
             expect(actions[3].value).toEqual(['WidgetsBuilder']);
-            done();
         }, {
             contextcreator: {
                 plugins: [{
@@ -181,7 +183,7 @@ describe('contextcreator epics', () => {
                     children: []
                 }]
             }
-        });
+        }, done);
     });
     it('enablePluginsEpic with transitive dependencies', (done) => {
         const pluginsToEnable = ['Widgets', 'WidgetsBuilder'];
@@ -220,7 +222,6 @@ describe('contextcreator epics', () => {
             expect(enabledDependentPluginsActions[3].ids).toEqual(['WidgetsTray']);
             expect(enabledDependentPluginsActions[3].key).toBe('enabledDependentPlugins');
             expect(enabledDependentPluginsActions[3].value).toEqual(['WidgetsBuilder']);
-            done();
         }, {
             contextcreator: {
                 plugins: [{
@@ -295,7 +296,7 @@ describe('contextcreator epics', () => {
                     children: []
                 }]
             }
-        });
+        }, done);
     });
     it('disablePluginsEpic', (done) => {
         const pluginsToDisable = ['ZoomIn', 'ZoomOut'];
@@ -306,31 +307,36 @@ describe('contextcreator epics', () => {
             expect(actions[0].ids).toEqual(pluginsToDisable);
             expect(actions[0].key).toBe('enabled');
             expect(actions[0].value).toBe(false);
-            done();
         }, {
             contextcreator: {
                 plugins: [{
                     name: 'MetadataExplorer',
                     title: 'Catalog',
                     dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
                     enabled: true,
                     isUserPlugin: false,
                     active: false
                 }, {
                     name: 'ZoomIn',
                     dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
                     enabled: true,
                     isUserPlugin: false,
                     active: false
                 }, {
                     name: 'ZoomOut',
                     dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
                     enabled: true,
                     isUserPlugin: false,
                     active: false
                 }]
             }
-        });
+        }, done);
     });
     it('disablePluginsEpic with dependencies', (done) => {
         const pluginsToDisable = ['WidgetsBuilder'];
@@ -349,18 +355,20 @@ describe('contextcreator epics', () => {
             expect(actions[2].ids).toEqual(['WidgetsTray']);
             expect(actions[2].key).toBe('forcedMandatory');
             expect(actions[2].value).toBe(false);
-            done();
         }, {
             contextcreator: {
                 plugins: [{
                     name: 'Widgets',
                     dependencies: [],
+                    enabledDependentPlugins: [],
                     enabled: true,
                     isUserPlugin: false,
                     active: false,
                     children: [{
                         name: 'WidgetsBuilder',
                         dependencies: ['WidgetsTray'],
+                        enabledDependentPlugins: [],
+                        children: [],
                         parent: 'Widgets',
                         enabled: true,
                         isUserPlugin: false,
@@ -368,6 +376,7 @@ describe('contextcreator epics', () => {
                     }, {
                         name: 'WidgetsTray',
                         dependencies: [],
+                        children: [],
                         enabledDependentPlugins: ['WidgetsBuilder'],
                         forcedMandatory: true,
                         parent: 'Widgets',
@@ -378,30 +387,34 @@ describe('contextcreator epics', () => {
                 }, {
                     name: 'ZoomIn',
                     dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
                     enabled: true,
                     isUserPlugin: true,
                     active: false
                 }, {
                     name: 'ZoomOut',
                     dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
                     enabled: false,
                     isUserPlugin: false,
                     active: false
                 }]
             }
-        });
+        }, done);
     });
     it('disablePluginsEpic with transitive dependencies', (done) => {
         const pluginsToDisable = ['Widgets'];
         const startActions = [disablePlugins(pluginsToDisable)];
-        testEpic(disablePluginsEpic, 5, startActions, actions => {
-            expect(actions.length).toBe(5);
+        testEpic(disablePluginsEpic, 6, startActions, actions => {
+            expect(actions.length).toBe(6);
             expect(actions[0].type).toBe(CHANGE_PLUGINS_KEY);
-            expect(actions[0].ids.sort()).toEqual(['BurgerMenu', 'CheeseburgerMenu', 'OmniBar', 'Widgets']);
+            expect(actions[0].ids.sort()).toEqual(['BurgerMenu', 'CheeseburgerMenu', 'OmniBar', 'Widgets', 'WidgetsBuilder', 'WidgetsTray']);
             expect(actions[0].key).toBe('enabled');
             expect(actions[0].value).toBe(false);
 
-            const enabledDependentPluginsActions = actions.slice(1, 4);
+            const enabledDependentPluginsActions = actions.slice(1, 5);
             enabledDependentPluginsActions.sort((x, y) => x.ids[0] < y.ids[0] ? -1 : x.ids[0] > y.ids[0] ? 1 : 0);
 
             expect(enabledDependentPluginsActions[0].type).toBe(CHANGE_PLUGINS_KEY);
@@ -416,17 +429,21 @@ describe('contextcreator epics', () => {
             expect(enabledDependentPluginsActions[2].ids).toEqual(['OmniBar']);
             expect(enabledDependentPluginsActions[2].key).toBe('enabledDependentPlugins');
             expect(enabledDependentPluginsActions[2].value).toEqual([]);
+            expect(enabledDependentPluginsActions[3].type).toBe(CHANGE_PLUGINS_KEY);
+            expect(enabledDependentPluginsActions[3].ids).toEqual(['WidgetsTray']);
+            expect(enabledDependentPluginsActions[3].key).toBe('enabledDependentPlugins');
+            expect(enabledDependentPluginsActions[3].value).toEqual([]);
 
-            expect(actions[4].type).toBe(CHANGE_PLUGINS_KEY);
-            expect(actions[4].ids.sort()).toEqual(['BurgerMenu', 'CheeseburgerMenu', 'OmniBar']);
-            expect(actions[4].key).toBe('forcedMandatory');
-            expect(actions[4].value).toBe(false);
-            done();
+            expect(actions[5].type).toBe(CHANGE_PLUGINS_KEY);
+            expect(actions[5].key).toBe('forcedMandatory');
+            expect(actions[5].ids.sort()).toEqual(['BurgerMenu', 'CheeseburgerMenu', 'OmniBar', 'WidgetsTray']);
+            expect(actions[5].value).toBe(false);
         }, {
             contextcreator: {
                 plugins: [{
                     name: 'Widgets',
                     dependencies: ['BurgerMenu'],
+                    enabledDependentPlugins: [],
                     enabled: true,
                     isUserPlugin: false,
                     active: true,
@@ -434,6 +451,7 @@ describe('contextcreator epics', () => {
                     children: [{
                         name: 'WidgetsBuilder',
                         dependencies: ['WidgetsTray'],
+                        enabledDependentPlugins: [],
                         parent: 'Widgets',
                         enabled: true,
                         isUserPlugin: false,
@@ -454,6 +472,7 @@ describe('contextcreator epics', () => {
                 }, {
                     name: 'ZoomIn',
                     dependencies: [],
+                    enabledDependentPlugins: [],
                     enabled: true,
                     isUserPlugin: true,
                     active: false,
@@ -489,6 +508,7 @@ describe('contextcreator epics', () => {
                 }, {
                     name: 'ZoomOut',
                     dependencies: [],
+                    enabledDependentPlugins: [],
                     enabled: false,
                     isUserPlugin: false,
                     active: false,
@@ -496,7 +516,7 @@ describe('contextcreator epics', () => {
                     children: []
                 }]
             }
-        });
+        }, done);
     });
     it('disablePluginsEpic disable all', (done) => {
         const pluginsToDisable = ['Widgets', 'ZoomIn'];
@@ -504,7 +524,7 @@ describe('contextcreator epics', () => {
         testEpic(disablePluginsEpic, 4, startActions, actions => {
             expect(actions.length).toBe(4);
             expect(actions[0].type).toBe(CHANGE_PLUGINS_KEY);
-            expect(actions[0].ids).toEqual(['Widgets', 'ZoomIn', 'ZoomOut']);
+            expect(actions[0].ids).toEqual(['Widgets', 'WidgetsBuilder', 'WidgetsTray', 'ZoomIn', 'ZoomOut']);
             expect(actions[0].key).toBe('enabled');
             expect(actions[0].value).toBe(false);
             expect(actions[1].type).toBe(CHANGE_PLUGINS_KEY);
@@ -516,7 +536,6 @@ describe('contextcreator epics', () => {
             expect(actions[2].key).toBe('forcedMandatory');
             expect(actions[2].value).toBe(false);
             expect(actions[3].type).toBe(ENABLE_MANDATORY_PLUGINS);
-            done();
         }, {
             contextcreator: {
                 plugins: [{
@@ -556,6 +575,6 @@ describe('contextcreator epics', () => {
                     active: false
                 }]
             }
-        });
+        }, done);
     });
 });

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -9,7 +9,7 @@
 import Rx from 'rxjs';
 import axios from 'axios';
 import jsonlint from 'jsonlint-mod';
-import {omit, pick, get, flatten, uniq, intersection, head, keys, values, findIndex, cloneDeep} from 'lodash';
+import {omit, pick, get, flatten, uniq, intersection, head, keys, values, findIndex, find, cloneDeep} from 'lodash';
 import {push} from 'connected-react-router';
 
 import ConfigUtils from '../utils/ConfigUtils';
@@ -21,7 +21,8 @@ import {SAVE_CONTEXT, SAVE_TEMPLATE, LOAD_CONTEXT, LOAD_TEMPLATE, EDIT_TEMPLATE,
     startResourceLoad, loadFinished, loadTemplate, showDialog, setFileDropStatus, updateTemplate, isValidContextName,
     contextNameChecked, setCreationStep, contextLoadError, loading, mapViewerLoad, mapViewerLoaded, setEditedPlugin,
     setEditedCfg, setParsedCfg, validateEditedCfg, setValidationStatus, savePluginCfg, enableMandatoryPlugins,
-    enablePlugins, setCfgError, changePluginsKey, changeTemplatesKey, setEditedTemplate, pluginUploaded, pluginUploading, enableUploadPlugin} from '../actions/contextcreator';
+    enablePlugins, disablePlugins, setCfgError, changePluginsKey, changeTemplatesKey, setEditedTemplate, pluginUploaded,
+    pluginUploading, enableUploadPlugin} from '../actions/contextcreator';
 import {newContextSelector, resourceSelector, creationStepSelector, mapConfigSelector, mapViewerLoadedSelector, contextNameCheckedSelector,
     editedPluginSelector, editedCfgSelector, validationStatusSelector, parsedCfgSelector, cfgErrorSelector,
     pluginsSelector, initialEnabledPluginsSelector} from '../selectors/contextcreator';
@@ -386,7 +387,7 @@ export const enableMandatoryPluginsEpic = (action$, store) => action$
     .ofType(ENABLE_MANDATORY_PLUGINS)
     .switchMap(() => {
         const state = store.getState();
-        const plugins = flattenPluginTree(pluginsSelector(state));
+        const plugins = pluginsSelector(state);
 
         return Rx.Observable.of(enablePlugins(plugins.filter(plugin => plugin.mandatory).map(plugin => plugin.name)));
     });
@@ -412,30 +413,63 @@ export const enablePluginsEpic = (action$, store) => action$
         let depsToForce = []; // plugins that need to be temporarily flagged as mandatory
 
         const enablePlugin = (pluginName) => {
-            const processDependency = (parentName, dep) => {
-                // add the plugin where we came from to enabledDependentPlugins of dep
-                if (!enabledDependentPlugins[dep.name]) {
-                    enabledDependentPlugins[dep.name] = dep.enabledDependentPlugins.slice();
+            const handleChildren = (processDepFunc, plugin) => {
+                // enable mandatory children
+                plugin.children.forEach(childPlugin => {
+                    if (childPlugin.mandatory) {
+                        enablePlugin(childPlugin.name);
+                    }
+                });
+                // autoEnableChildren need to be handled only when the action is triggered by the user from ui,
+                // unless the parent plugin is mandatory
+                if (!isInitial && !plugin.mandatory) {
+                    plugin.autoEnableChildren.forEach(childName => {
+                        // treat autoEnableChildren as dependencies, but dont force mandatory
+                        processDepFunc(null, findPlugin(pluginsState, childName), true);
+                    });
                 }
-                enabledDependentPlugins[dep.name].push(parentName);
+            };
+
+            const processDependency = (parentName, dep, dontForceMandatory = false) => {
+                // if dep is mandatory ignore it; it's dependency tree either has already been enabled or will be enabled anyway
+                if (dep.mandatory) {
+                    return;
+                }
+
+                const isDepEnabled = dep.enabled || pluginsToEnable.reduce((result, cur) => result || cur === dep.name, false);
+
+                // add the plugin where we came from to enabledDependentPlugins of dep, unless dontForceMandatory === true
+                if (parentName && !dontForceMandatory) {
+                    if (!enabledDependentPlugins[dep.name]) {
+                        enabledDependentPlugins[dep.name] = dep.enabledDependentPlugins.slice();
+                    }
+                    enabledDependentPlugins[dep.name].push(parentName);
+                }
 
                 // if dep is flagged as forcedMandatory we've already been here
                 if (dep.forcedMandatory || depsToForce.reduce((result, cur) => result || cur === dep.name, false)) {
                     return;
                 }
 
-                // flag dep to have forcedMandatory enabled
-                depsToForce.push(dep.name);
+                // flag dep to have forcedMandatory enabled if dontForceMandatory === false
+                if (!dontForceMandatory) {
+                    depsToForce.push(dep.name);
+                }
 
                 // enable it if not already enabled
-                if (!dep.enabled && pluginsToEnable.reduce((result, cur) => result && cur !== dep.name, true)) {
+                if (!isDepEnabled) {
                     pluginsToEnable.push(dep.name);
                 }
 
-                // recursively process the dependencies of dep
+                // recursively process the dependencies
                 dep.dependencies.forEach(depName => {
                     processDependency(dep.name, findPlugin(pluginsState, depName));
                 });
+
+                // enable children only if dep was disabled
+                if (!isDepEnabled) {
+                    handleChildren(processDependency, dep);
+                }
             };
 
             const plugin = findPlugin(pluginsState, pluginName);
@@ -445,13 +479,8 @@ export const enablePluginsEpic = (action$, store) => action$
                 pluginsToEnable.push(pluginName);
                 plugin.dependencies.forEach(depName => {
                     processDependency(pluginName, findPlugin(pluginsState, depName));
-                    // autoEnableChildren only applies when the action is triggered by the user from ui
-                    if (!isInitial) {
-                        plugin.autoEnableChildren.forEach(childName => {
-                            enablePlugin(childName);
-                        });
-                    }
                 });
+                handleChildren(processDependency, plugin);
             }
         };
 
@@ -495,10 +524,10 @@ export const disablePluginsEpic = (action$, store) => action$
         const maxCount = pluginsState.filter(plugin => plugin.enabled && !plugin.mandatory && !plugin.forcedMandatory).length;
         if (intersection(plugins, rootPlugins).length < maxCount) {
             let enabledDependentPlugins = {}; // object {[pluginName]: modified enabledDependentPlugins array}
-            let pluginsToDisable = plugins.slice(); // plugins that need to be enabled after dependency resolution
+            let pluginsToDisable = []; // plugins that need to be enabled after dependency resolution
             let depsToUnforceMandatory = []; // plugins that need to have their forcedMandatory flag removed
 
-            const disablePlugin = pluginName => {
+            const disablePlugin = (pluginName, isChild) => {
                 const processDependency = (parentName, plugin) => {
                     // update enabledDependentPlugins of plugin
                     const enabledDependentPluginsArr = enabledDependentPlugins[plugin.name] || plugin.enabledDependentPlugins.slice();
@@ -517,19 +546,30 @@ export const disablePluginsEpic = (action$, store) => action$
                         depsToUnforceMandatory.push(plugin.name);
                         // if the plugin is not mandatory disable it and recursively process it's dependencies
                         if (!plugin.mandatory) {
-                            pluginsToDisable.push(plugin.name);
-                            plugin.dependencies.forEach(depName => {
-                                processDependency(plugin.name, findPlugin(pluginsState, depName));
-                            });
+                            disablePlugin(plugin.name);
                         }
                     }
                 };
 
-                // start processing dependencies
+
                 const plugin = findPlugin(pluginsState, pluginName);
-                plugin.dependencies.forEach(depName => {
-                    processDependency(pluginName, findPlugin(pluginsState, depName));
-                });
+                const enabledDependentPluginsArr = enabledDependentPlugins[plugin.name] || plugin.enabledDependentPlugins.slice();
+
+                // if we came here recursively from a parent in plugin tree hierarchy, ignore mandatory flag
+                if (enabledDependentPluginsArr.length === 0 &&
+                    pluginsToDisable.reduce((result, cur) => result && cur !== plugin.name, true) && (!plugin.mandatory || isChild)) {
+                    pluginsToDisable.push(plugin.name);
+
+                    // start processing dependencies
+                    plugin.dependencies.forEach(depName => {
+                        processDependency(pluginName, findPlugin(pluginsState, depName));
+                    });
+
+                    // disable children
+                    plugin.children.filter(childPlugin => childPlugin.enabled).forEach(childPlugin => {
+                        disablePlugin(childPlugin.name, true);
+                    });
+                }
             };
 
             plugins.forEach(pluginName => {
@@ -547,7 +587,7 @@ export const disablePluginsEpic = (action$, store) => action$
 
         // disable everything and reenable initial mandatory plugins
         return Rx.Observable.of(
-            changePluginsKey(rootPlugins, 'enabled', false),
+            changePluginsKey(allPlugins, 'enabled', false),
             changePluginsKey(allPlugins, 'enabledDependentPlugins', []),
             changePluginsKey(allPlugins, 'forcedMandatory', false),
             enableMandatoryPlugins()
@@ -579,6 +619,30 @@ export const resetConfigOnPluginKeyChange = (action$, store) => action$
         }
 
         return Rx.Observable.empty();
+    });
+
+/**
+ * Enables/disables user extensions plugin when enabled user plugins are present
+ * @param {observable} action$
+ * @param {object} store
+ */
+export const handleUserExtensionsPlugin = (action$, store) => action$
+    .ofType(CHANGE_PLUGINS_KEY)
+    .filter(({key}) => key === 'enabled' || key === 'isUserPlugin')
+    .mergeMap(() => {
+        const state = store.getState();
+        const plugins = flattenPluginTree(pluginsSelector(state));
+
+        const enabledUserPluginsCount =
+            plugins.filter(({name, enabled, isUserPlugin}) => name !== 'UserExtensions' && enabled && isUserPlugin).length;
+        const isUserExtensionsEnabled = (find(plugins, ({name}) => name === 'UserExtensions') || {}).enabled;
+        const action = enabledUserPluginsCount > 0 && !isUserExtensionsEnabled ?
+            enablePlugins :
+            enabledUserPluginsCount === 0 && isUserExtensionsEnabled ?
+                disablePlugins :
+                null;
+
+        return action ? Rx.Observable.of(action(['UserExtensions'])) : Rx.Observable.empty();
     });
 
 /**

--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -37,6 +37,7 @@ const CoordinatesUtils = require('../utils/CoordinatesUtils');
 const {warning} = require('../actions/notifications');
 const {resetControls} = require('../actions/controls');
 const {clearLayers} = require('../actions/layers');
+const {clearWarning: clearMapInfoWarning} = require('../actions/mapInfo');
 const {removeAllAdditionalLayers} = require('../actions/additionallayers');
 const { head, isArray, isObject, mapValues } = require('lodash');
 
@@ -108,7 +109,12 @@ const resetLimitsOnInit = (action$, store) =>
         });
 
 const resetMapOnInit = action$ =>
-    action$.ofType(INIT_MAP).switchMap(() => Rx.Observable.of(removeAllAdditionalLayers(), resetControls(), clearLayers()));
+    action$.ofType(INIT_MAP).switchMap(() => Rx.Observable.of(
+        removeAllAdditionalLayers(),
+        resetControls(),
+        clearLayers(),
+        clearMapInfoWarning()
+    ));
 
 /**
  * Convert and normalize the extent into an array `minx,miny,maxx, maxy`

--- a/web/client/pluginsConfig.json
+++ b/web/client/pluginsConfig.json
@@ -76,7 +76,8 @@
       "title": "plugins.FeatureEditor.title",
       "description": "plugins.FeatureEditor.description",
       "dependencies": [
-        "QueryPanel"
+        "QueryPanel",
+        "WFSDownload"
       ],
       "denyUserSelection": true,
       "defaultConfig": {}
@@ -437,13 +438,15 @@
       "title": "plugins.Save.title",
       "description": "plugins.Save.description",
       "dependencies": [
-        "BurgerMenu"
+        "BurgerMenu",
+        "SaveAs"
       ]
     },
     {
       "name": "SaveAs",
       "glyph": "floppy-open",
       "title": "plugins.SaveAs.title",
+      "hidden": true,
       "description": "plugins.SaveAs.description",
       "dependencies": [
         "BurgerMenu"

--- a/web/client/pluginsConfig.json
+++ b/web/client/pluginsConfig.json
@@ -50,7 +50,9 @@
         "removeLayersPermissions": true,
         "sortingPermissions": true,
         "addGroupsPermissions": true,
-        "removeGroupsPermissions": true
+        "removeGroupsPermissions": true,
+        "activateWidgetTool": true,
+        "activateMetedataTool": false
       },
       "children": [
         "TOCItemsSettings",
@@ -76,13 +78,18 @@
       "dependencies": [
         "QueryPanel"
       ],
+      "denyUserSelection": true,
       "defaultConfig": {}
     },
     {
       "name": "TOCItemsSettings",
       "glyph": "wrench",
       "title": "plugins.TOCItemsSettings.title",
-      "description": "plugins.TOCItemsSettings.description"
+      "description": "plugins.TOCItemsSettings.description",
+      "children": [
+          "StyleEditor"
+      ],
+      "denyUserSelection": true
     },
     {
       "name": "MapFooter",
@@ -101,6 +108,7 @@
         "WidgetsTray"
       ],
       "dependencies": [
+        "TOC",
         "WidgetsBuilder"
       ]
     },
@@ -108,7 +116,8 @@
       "name": "WidgetsTray",
       "glyph": "import",
       "title": "plugins.WidgetsTray.title",
-      "description": "plugins.WidgetsTray.description"
+      "description": "plugins.WidgetsTray.description",
+      "denyUserSelection": true
     },
     {
       "name": "WidgetsBuilder",
@@ -122,12 +131,6 @@
       "glyph": "sheet",
       "title": "plugins.Details.title",
       "description": "plugins.Details.description"
-    },
-    {
-      "name": "AutoMapUpdate",
-      "glyph": "refresh",
-      "title": "plugins.AutoMapUpdate.title",
-      "description": "plugins.AutoMapUpdate.description"
     },
     {
       "name": "HelpLink",
@@ -242,12 +245,14 @@
       "name": "AddGroup",
       "glyph": "add-folder",
       "title": "plugins.AddGroup.title",
-      "description": "plugins.AddGroup.description"
+      "description": "plugins.AddGroup.description",
+      "denyUserSelection": true
     }, {
       "name": "FilterLayer",
       "glyph": "filter-layer",
       "title": "plugins.FilterLayer.title",
       "description": "plugins.FilterLayer.description",
+      "denyUserSelection": true,
       "dependencies": ["QueryPanel"]
     },
     {
@@ -455,6 +460,7 @@
     },
     {
       "name": "Expander",
+      "hidden": true,
       "glyph": "option-horizontal",
       "title": "plugins.Expander.title",
       "description": "plugins.Expander.description"
@@ -463,14 +469,16 @@
       "name": "Undo",
       "glyph": "1-screen-backward",
       "dependencies": [
-        "Toolbar"
+        "Toolbar",
+        "Expander"
       ]
     },
     {
       "name": "Redo",
       "glyph": "1-screen-forward",
       "dependencies": [
-        "Toolbar"
+        "Toolbar",
+        "Expander"
       ]
     },
     {
@@ -505,7 +513,8 @@
       "name": "StyleEditor",
       "glyph": "1-stilo",
       "title": "plugins.StyleEditor.title",
-      "description": "plugins.StyleEditor.description"
+      "description": "plugins.StyleEditor.description",
+      "mandatory": true
     },
     {
       "name": "MapLoading",
@@ -518,11 +527,15 @@
     },
     {
       "name": "MapTemplates",
-      "title": "Map Templates"
+      "title": "Map Templates",
+      "dependencies": [
+          "BurgerMenu"
+      ]
     }, {
       "name": "UserExtensions",
       "glyph": "1-user-add",
       "title": "plugins.UserExtensions.title",
+      "hidden": true,
       "description": "plugins.UserExtensions.description",
       "dependencies": ["BurgerMenu"]
     }

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -83,6 +83,7 @@ const makeNode = (plugin, parent = null, plugins = [], localPlugins = []) => ({
     dependencies: plugin.dependencies || [],
     enabled: false,
     active: false,
+    denyUserSelection: plugin.denyUserSelection || false,
     isUserPlugin: false,
     pluginConfig: {
         ...omit(head(localPlugins.filter(localPlugin => localPlugin.name === plugin.name)) || {}, 'cfg'),

--- a/web/client/selectors/context.js
+++ b/web/client/selectors/context.js
@@ -7,7 +7,7 @@
  */
 import { createSelector } from 'reselect';
 import { monitorStateSelector } from './localConfig';
-import { get } from 'lodash';
+import { get, findIndex } from 'lodash';
 import ConfigUtils from '../utils/ConfigUtils';
 
 
@@ -66,6 +66,19 @@ export const pluginsSelector = state =>
     isLoadingSelector(state)
         ? loadingPluginsSelector(state)
         : currentPluginsSelector(state) || defaultPluginsSelector(state);
+
+/**
+ * Creates a selector that will return true if mapstore currently has a context active,
+ * and it has a specific plugin activated
+ * @param {string} pluginName plugin name
+ */
+export const isPluginInContext = pluginName => createSelector(
+    currentContextSelector,
+    pluginsSelector,
+    (currentContext, contextPlugins = {}) => !currentContext ||
+        findIndex(get(contextPlugins, 'desktop', []), plugin => plugin.name === pluginName) > -1
+);
+
 /*
  * Adds the current context to the monitoredState. To update on every change of it.
  */

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -18,6 +18,8 @@ const {defaultQueryableFilter} = require('../utils/MapInfoUtils');
 const {get, head, isEmpty, find, isObject, isArray, castArray} = require('lodash');
 const {flattenGroups} = require('../utils/TOCUtils');
 
+const {isPluginInContext} = require('./context');
+
 const layersSelector = ({layers, config} = {}) => layers && isArray(layers) ? layers : layers && layers.flat || config && config.layers || [];
 const currentBackgroundLayerSelector = state => head(layersSelector(state).filter(l => l && l.visibility && l.group === "background"));
 const getLayerFromId = (state, id) => head(layersSelector(state).filter(l => l.id === id));
@@ -32,10 +34,13 @@ const geoColderSelector = state => state.search && state.search;
 const centerToMarkerSelector = (state) => get(state, "mapInfo.centerToMarker", '');
 const additionalLayersSelector = state => get(state, "additionallayers", []);
 
-
 const layerSelectorWithMarkers = createSelector(
-    [layersSelector, clickedPointWithFeaturesSelector, geoColderSelector, centerToMarkerSelector, additionalLayersSelector, highlightPointSelector],
-    (layers = [], markerPosition, geocoder, centerToMarker, additionalLayers, highlightPoint) => {
+    [layersSelector, clickedPointWithFeaturesSelector, geoColderSelector, centerToMarkerSelector, additionalLayersSelector,
+        highlightPointSelector, isPluginInContext('Identify')],
+    (layers = [], markerPosition, geocoder, centerToMarker, additionalLayers, highlightPoint, isVisible) => {
+        if (!isVisible) {
+            return layers;
+        }
 
         // Perform an override action on the layers using options retrieved from additional layers
         const overrideLayers = additionalLayers.filter(({actionType}) => actionType === 'override');

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -10,7 +10,8 @@ const { get, omit, isArray } = require('lodash');
 
 const { createSelector, createStructuredSelector } = require('reselect');
 
-const {mapSelector} = require('./map');
+const { mapSelector } = require('./map');
+const { isPluginInContext } = require('./context');
 const { currentLocaleSelector } = require('./locale');
 const MapInfoUtils = require('../utils/MapInfoUtils');
 
@@ -29,7 +30,11 @@ const MapInfoUtils = require('../utils/MapInfoUtils');
   * @return {object} the mapinfo requests
   */
 const mapInfoRequestsSelector = state => get(state, "mapInfo.requests") || [];
-const isMapInfoOpen = state => !!mapInfoRequestsSelector(state) && mapInfoRequestsSelector(state).length > 0;
+const isMapInfoOpen = createSelector(
+    mapInfoRequestsSelector,
+    isPluginInContext('Identify'),
+    (mapInfoRequests, isIdentifyInContext) => !!mapInfoRequests && mapInfoRequests.length > 0 && isIdentifyInContext
+);
 
 /**
  * selects generalInfoFormat from state

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2269,6 +2269,7 @@
           },
           "Version": {
             "description": "Zeigt die Version von MapStore in den Karteneinstellungen an",
+            "descriptionGeorchestra": "Zeigt die Version von GeOrchestra in den Karteneinstellungen an",
             "title": "Ausführung"
           },
           "WFSDownload": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2273,6 +2273,7 @@
           },
           "Version": {
             "description": "Shows the version of MapStore in map settings tool",
+            "descriptionGeorchestra": "Shows the version of GeOrchestra in map settings tool",
             "title": "Version"
           },
           "WFSDownload": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2269,6 +2269,7 @@
           },
           "Version": {
             "description": "Muestra la versión de MapStore en la herramienta de configuración de mapas",
+            "descriptionGeorchestra": "Muestra la versión de GeOrchestra en la herramienta de configuración de mapas",
             "title": "Versión"
           },
           "WFSDownload": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2269,6 +2269,7 @@
           },
           "Version": {
             "description": "Affiche la version de MapStore dans l'outil de paramètres de carte",
+            "descriptionGeorchestra": "Affiche la version de GeOrchestra dans l'outil de paramètres de carte",
             "title": "Version"
           },
           "WFSDownload": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2270,6 +2270,7 @@
           },
           "Version": {
             "description": "Mostra la versione di MapStore nellla finestra di settings",
+            "descriptionGeorchestra": "Mostra la versione di GeOrchestra nellla finestra di settings",
             "title": "Versione"
           },
           "WFSDownload": {


### PR DESCRIPTION
## Description
This is the MapStore part of [the issue](https://github.com/georchestra/mapstore2-georchestra/issues/155). The GeOrchestra part is [here](https://github.com/georchestra/mapstore2-georchestra/pull/159).

Configure Plugins step of context creator was improved. It was identified that dependencies were not resolved correctly if not on the same level in plugin tree, that was fixed. Due to new requirements autoEnableChildren work not only if enabled directly but when enabled through a dependency as well, also now children plugins can have mandatory flag on them, that will make that plugin mandatory, if it's parent is enabled.

Comments on some of the points:

> The Query panel plugin should probably be hidden from plugin list, and should be enabled by default when others plugins that use the Query panel are added (like Attribute Table, layer filter, Widgets). There's probably a problem related to Query panel plugin because sometimes it enables adding the List of Layers plugin and sometimes does not). Moreover I can add this plugin alone also if it depends from other plugins.

As @offtherailz pointed out it is configurable so it should stay listed. Also I didn't get the "There's probably a problem related to Query panel plugin because sometimes it enables adding the List of Layers plugin and sometimes does not)" part. This plugin can be added alone because it has no dependencies.

> Style Editor plugin what is it for? Seems that nothing change adding or not this plugin (if this plugin serves to create new styles it doesn't work). Moreover this plugin can be added alone, also if it probably depends from TOC and from layer settings

Style Editor is a style editor in TOC layer settings. It seems to be directly handled by TOCItemsSettings, and so is always enabled when layer settings button is present. I've made StyleEditor a child of TOCItemsSettings plugin and made it mandatory.

> Widgets plugin should depends from List of Layers plugin, but I can actually add it alone. If you add both Widgets plugin and List of Layers plugin, the widgets button is not present in toc selecting a layer

The widgets button not being present in toc is not a context specific issue. It seems it was introduced with [this change](https://github.com/geosolutions-it/MapStore2/pull/4718/files#diff-fce06684499b5cd749478bbc3c2bd4a9). It effectively disabled the create widget button for all layers in TOC. That was rolled back.

> The show metadata option should be disabled by default, so the related button in TOC toolbar does not appears (the button is automatically enabled when you ad a layer from a CSW source)

I've added "activateMetedataTool: false" to TOC defaultConfig in pluginsConfig.json. Is this correct?

> Adding "Save" plugin, the Burger Menu is added together but after the save option is not present in the Menu

The Save plugin is not present by design. It is hiddent, if there is no id in mapInfo, which there isn't, because the map is loaded from context, not from a MAP resource and so mapId is null. In any case Save should be either hidden from the list, or it's functionality should be expanded to deal with contexts.

> The Download data from attribute table plugin can be added alone, but should be related to Attribute Table plugin

What is an "Attribute Table" plugin? Is it FeatureEditor? And what is "Download data"???

Also testEpic helper function was expanded a little to allow to use in a way, so that when expect fails inside a callback it actually prints out the error instead of a test just timing out.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

## Issue
[mapstore2-georchestra/#155](https://github.com/georchestra/mapstore2-georchestra/issues/155)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No