### PR TITLE
#4711 Fixed minor issues in style editor

### DIFF
--- a/web/client/api/geoserver/Layers.js
+++ b/web/client/api/geoserver/Layers.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const axios = require('../../libs/ajax');
-const { uniqBy } = require('lodash');
+const { uniqBy, castArray } = require('lodash');
 const { getNameParts } = require('../../utils/StyleEditorUtils');
 
 /**
@@ -33,9 +33,9 @@ const Api = {
         return axios.get(url, options)
             .then(({data}) => {
                 const layer = data.layer || {};
-                const currentAvailableStyle = layer.styles && layer.styles.style || [];
+                const currentAvailableStyles = layer.styles && layer.styles.style && castArray(layer.styles.style) || [];
                 const stylesNames = styles.map(({name: styleName}) => styleName);
-                const filteredStyles = currentAvailableStyle.filter(({name: styleName}) => stylesNames.indexOf(styleName) === -1);
+                const filteredStyles = currentAvailableStyles.filter(({name: styleName}) => stylesNames.indexOf(styleName) === -1);
                 const layerObj = {
                     'layer': {
                         ...layer,
@@ -64,14 +64,14 @@ const Api = {
         return axios.get(url, options)
             .then(({data}) => {
                 const layer = data.layer || {};
-                const currentAvailableStyle = layer.styles && layer.styles.style || [];
+                const currentAvailableStyles = layer.styles && layer.styles.style && castArray(layer.styles.style) || [];
                 const layerObj = {
                     'layer': {
                         ...layer,
                         'styles': {
                             '@class': 'linked-hash-set',
                             'style': [
-                                ...currentAvailableStyle,
+                                ...currentAvailableStyles,
                                 ...styles
                             ]
                         }
@@ -96,13 +96,13 @@ const Api = {
         return axios.get(url, options)
             .then(({ data }) => {
                 const layer = data.layer || {};
-                const currentAvailableStyle = layer.styles && layer.styles.style || {};
+                const currentAvailableStyles = layer.styles && layer.styles.style && castArray(layer.styles.style) || [];
                 const defaultStyle = layer.defaultStyle || {};
 
                 // add old default to available styles to ensure to display it in the style list
                 const style = uniqBy([
                     defaultStyle,
-                    ...currentAvailableStyle
+                    ...currentAvailableStyles
                 ], 'name');
 
                 const layerObj = {

--- a/web/client/api/geoserver/Layers.js
+++ b/web/client/api/geoserver/Layers.js
@@ -64,7 +64,7 @@ const Api = {
         return axios.get(url, options)
             .then(({data}) => {
                 const layer = data.layer || {};
-                const currentAvailableStyle = layer.styles && layer.styles.style || {};
+                const currentAvailableStyle = layer.styles && layer.styles.style || [];
                 const layerObj = {
                     'layer': {
                         ...layer,

--- a/web/client/api/geoserver/Styles.js
+++ b/web/client/api/geoserver/Styles.js
@@ -58,7 +58,7 @@ const formatRequestData = ({options = {}, format, baseUrl, name, workspace, lang
     };
 };
 
-const getStyleBaseUrl = ({geoserverBaseUrl, workspace, name, fileName}) => `${geoserverBaseUrl}rest/${workspace && `workspaces/${workspace}/` || ''}styles/${ fileName ? fileName : `${encodeURIComponent(name)}.json`}`;
+export const getStyleBaseUrl = ({geoserverBaseUrl, workspace, name}) => `${geoserverBaseUrl}rest/${workspace && `workspaces/${workspace}/` || ''}styles/${ `${encodeURIComponent(name)}.json`}`;
 
 /**
 * Api for GeoServer styles via rest

--- a/web/client/api/geoserver/__tests__/Layers-test.js
+++ b/web/client/api/geoserver/__tests__/Layers-test.js
@@ -232,17 +232,7 @@ describe('Test default style update with layers rest API', () => {
                 const layer = JSON.parse(config.data).layer;
                 expect(layer.defaultStyle).toEqual({ "name": "workspace001:new_default_style" });
                 expect(layer.styles.style).toEqual([
-                    OLD_DEFAULT_STYLE,
-                    {
-                        "name": "workspace001:new_default_style",
-                        "workspace": "workspace001",
-                        "href": "/geoserver/rest/workspaces/workspace001/styles/new_default_style.json"
-                    },
-                    {
-                        "name": "workspace001:other_style",
-                        "workspace": "workspace001",
-                        "href": "/geoserver/rest/workspaces/workspace001/styles/other_style.json"
-                    }
+                    OLD_DEFAULT_STYLE
                 ]);
             } catch (e) {
                 done(e);

--- a/web/client/api/geoserver/__tests__/Layers-test.js
+++ b/web/client/api/geoserver/__tests__/Layers-test.js
@@ -209,4 +209,52 @@ describe('Test default style update with layers rest API', () => {
             styleName: 'workspace001:new_default_style'
         });
     });
+    it('test updateDefaultStyle, when styles are not available, it have to add the new style to the list', (done) => {
+
+        const OLD_DEFAULT_STYLE = {
+            name: 'workspace001:old_default_style',
+            workspace: 'workspace001',
+            href: '/geoserver/rest/workspaces/workspace001/styles/old_default_style.json'
+        };
+
+        mockAxios.onGet(/\/layers/).reply((config) => {
+            expect(config.url).toBe('/geoserver/rest/workspaces/workspace001/layers/layer001.json');
+            return [200, {
+                layer: {
+                    name: 'layer001',
+                    defaultStyle: OLD_DEFAULT_STYLE
+                }
+            }];
+        });
+
+        mockAxios.onPut(/\/layers/).reply((config) => {
+            try {
+                const layer = JSON.parse(config.data).layer;
+                expect(layer.defaultStyle).toEqual({ "name": "workspace001:new_default_style" });
+                expect(layer.styles.style).toEqual([
+                    OLD_DEFAULT_STYLE,
+                    {
+                        "name": "workspace001:new_default_style",
+                        "workspace": "workspace001",
+                        "href": "/geoserver/rest/workspaces/workspace001/styles/new_default_style.json"
+                    },
+                    {
+                        "name": "workspace001:other_style",
+                        "workspace": "workspace001",
+                        "href": "/geoserver/rest/workspaces/workspace001/styles/other_style.json"
+                    }
+                ]);
+            } catch (e) {
+                done(e);
+            }
+            done();
+            return [200, {}];
+        });
+
+        API.updateDefaultStyle({
+            baseUrl: '/geoserver/',
+            layerName: 'workspace001:layer001',
+            styleName: 'workspace001:new_default_style'
+        });
+    });
 });

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -103,7 +103,7 @@ const StyleToolbar = ({
                     glyph: 'code',
                     tooltipId: 'styleeditor.editSelectedStyle',
                     visible: !status && editEnabled ? true : false,
-                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1 || disableCodeEditing,
+                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1 || !selectedStyle || disableCodeEditing,
                     onClick: () => onEditStyle()
                 },
                 {

--- a/web/client/components/styleeditor/StyleToolbar.jsx
+++ b/web/client/components/styleeditor/StyleToolbar.jsx
@@ -36,6 +36,7 @@ const StyleToolbar = ({
     onShowModal,
     loading,
     selectedStyle,
+    layerDefaultStyleName,
     editEnabled,
     enableSetDefaultStyle,
     defaultStyles = [
@@ -103,7 +104,12 @@ const StyleToolbar = ({
                     glyph: 'code',
                     tooltipId: 'styleeditor.editSelectedStyle',
                     visible: !status && editEnabled ? true : false,
-                    disabled: !!loading || defaultStyles.indexOf(selectedStyle) !== -1 || !selectedStyle || disableCodeEditing,
+                    disabled: !!loading
+                        || defaultStyles.indexOf(selectedStyle) !== -1
+                        // empty or "" means layer's default style.
+                        // You can edit this only if it not one of GeoServer's default
+                        || !selectedStyle && defaultStyles.indexOf(layerDefaultStyleName) !== -1
+                        || disableCodeEditing,
                     onClick: () => onEditStyle()
                 },
                 {

--- a/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
@@ -64,4 +64,20 @@ describe('test StyleToolbar module component', () => {
         const modalContainer = document.body.children[1].querySelector('.ms-resizable-modal');
         expect(modalContainer).toExist();
     });
+    it('in case of default style, editable only if not default GeoServer style ', () => {
+        const checkButtons = ({present, disabled}) => {
+            const buttons = document.querySelectorAll('.btn');
+            expect(buttons.length).toBe(present);
+            const disabledButtons = document.querySelectorAll('button:disabled');
+            expect(disabledButtons.length).toBe(disabled);
+        }
+        ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="polygon" editEnabled />, document.getElementById("container"));
+        checkButtons({ present: 3, disabled: 2 }); // default is "" and it's name is one of GeoServer's default styles
+        ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="custom" editEnabled />, document.getElementById("container"));
+        checkButtons({ present: 3, disabled: 1 }); // only remove is disabled, because you can not remove the default style of the layer
+        ReactDOM.render(<StyleToolbar selectedStyle="polygon" editEnabled />, document.getElementById("container"));
+        checkButtons({ present: 3, disabled: 2 }); // default is in the list and is one of the GeoServer's default styles
+        ReactDOM.render(<StyleToolbar selectedStyle="custom" editEnabled />, document.getElementById("container"));
+        checkButtons({ present: 3, disabled: 0 });
+    } );
 });

--- a/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
+++ b/web/client/components/styleeditor/__tests__/StyleToolbar-test.jsx
@@ -70,7 +70,7 @@ describe('test StyleToolbar module component', () => {
             expect(buttons.length).toBe(present);
             const disabledButtons = document.querySelectorAll('button:disabled');
             expect(disabledButtons.length).toBe(disabled);
-        }
+        };
         ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="polygon" editEnabled />, document.getElementById("container"));
         checkButtons({ present: 3, disabled: 2 }); // default is "" and it's name is one of GeoServer's default styles
         ReactDOM.render(<StyleToolbar selectedStyle="" layerDefaultStyleName="custom" editEnabled />, document.getElementById("container"));

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -201,6 +201,7 @@ const StyleToolbar = compose(
                 error,
                 isCodeChanged: initialCode !== code,
                 loading,
+                layerDefaultStyleName: defaultStyle,
                 selectedStyle: defaultStyle === selectedStyle ? '' : selectedStyle,
                 editEnabled: canEdit,
                 // enable edit only if service support current format


### PR DESCRIPTION
## Description
See #4711 
The issues was due to : 

- issues handling old styles and arrays
- wrong usage of filename instead of layer name as REST style entry point (probably because of confusion between file extension and style format). It was causing issues because default styles have not the same filename of the entry point.
- handling empty style special case.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4711 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4711

**What is the new behavior?**
Styler now works. 


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
## FOR TESTERS

You can test it with  `test.point` layer, it doesn't have available styles. Now you can add styles to this layer too. It's default style should not be editable. 
