### PR TITLE
Fix bug when connecting widgets to map in dashboard

### DIFF
--- a/web/client/components/widgets/widget/MapWidget.jsx
+++ b/web/client/components/widgets/widget/MapWidget.jsx
@@ -11,10 +11,7 @@ const BorderLayout = require('../../layout/BorderLayout');
 const { omit } = require('lodash');
 const {withHandlers} = require('recompose');
 const MapView = withHandlers({
-    onMapViewChanges: ({ updateProperty = () => { } }) => map => {
-        const {layers, ...other} = map;
-        updateProperty('map', other, "merge" );
-    }
+    onMapViewChanges: ({ updateProperty = () => { } }) => ({layers, ...map}) => updateProperty('map', map, "merge" )
 })(require('./MapView'));
 const LoadingSpinner = require('../../misc/LoadingSpinner');
 

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -16,8 +16,9 @@ const {
     DASHBOARD_RESET
 } = require('../actions/dashboard');
 
+const assign = require('object-assign');
 const set = require('lodash/fp/set');
-const { merge, get, find, omit, mapValues, castArray} = require('lodash');
+const { get, find, omit, mapValues, castArray} = require('lodash');
 const {arrayUpsert, compose, arrayDelete} = require('../utils/ImmutableUtils');
 
 const emptyState = {
@@ -100,7 +101,7 @@ function widgetsReducer(state = emptyState, action) {
         return arrayUpsert(`containers[${action.target}].widgets`,
             set(
                 action.key,
-                action.mode === "merge" ? merge(oldWidget[action.key], action.value) : action.value,
+                action.mode === "merge" ? assign(oldWidget[action.key], action.value) : action.value,
                 oldWidget,
             ), {
                 id: action.id


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fix [this](https://github.com/geosolutions-it/MapStore2/issues/4674#issuecomment-583338842) comment on connecting widgets to map. (viewport was not passed as dependency)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
see previous link to the comment.
viewport was not passed as dependency

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
all work as expected in the issue, when changing viewport in the map the filter on the connected widget updates too

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
