### PR TITLE
#4869. Disable Identify when not present in context

### DIFF
--- a/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
+++ b/web/client/components/data/identify/enhancers/__tests__/identify-test.jsx
@@ -92,6 +92,37 @@ describe("test identify enhancers", () => {
         expect(spyPurgeResults).toHaveBeenCalled();
         expect(spyHideMarker).toHaveBeenCalled();
     });
+    it("test reset on unmount", () => {
+        const Component = identifyLifecycle(({ onClose = () => { } }) => <div id="test-component" onClick={() => onClose()}></div>);
+        const testHandlers = {
+            changeMousePointer: () => { },
+            purgeResults: () => { },
+            hideMarker: () => { }
+        };
+        const spyChangeMousePointer = expect.spyOn(testHandlers, 'changeMousePointer');
+        const spyPurgeResults = expect.spyOn(testHandlers, 'purgeResults');
+        const spyHideMarker = expect.spyOn(testHandlers, 'hideMarker');
+        ReactDOM.render(
+            <Component
+                enabled
+                responses={[{}]}
+                changeMousePointer={testHandlers.changeMousePointer}
+                purgeResults={testHandlers.purgeResults}
+                hideMarker={testHandlers.hideMarker} />,
+            document.getElementById("container")
+        );
+
+        ReactDOM.render(<div></div>, document.getElementById("container"));
+        // this ensure that when the is un-mounted, the cursor of the mouse pointer, the marker and result are correctly reset.
+        expect(spyChangeMousePointer).toHaveBeenCalled();
+        expect(spyChangeMousePointer.calls.length).toBe(2);
+        expect(spyChangeMousePointer.calls[0].arguments[0]).toBe('pointer'); // cursor change on mount
+        expect(spyChangeMousePointer.calls[1].arguments[0]).toBe('auto'); // this is the reset on unmount
+        expect(spyPurgeResults).toHaveBeenCalled();
+        expect(spyPurgeResults.calls.length).toBe(1);
+        expect(spyHideMarker).toHaveBeenCalled();
+        expect(spyHideMarker.calls.length).toBe(1);
+    });
 
     it("test identifyLifecycle onChangeFormat", () => {
         const testHandlers = {

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -81,6 +81,16 @@ const identifyLifecycle = compose(
                 onEnableCenterToMarker();
             }
         },
+        componentWillUnmount() {
+            const {
+                hideMarker = () => { },
+                purgeResults = () => { },
+                changeMousePointer = () => { }
+            } = this.props;
+            changeMousePointer('auto');
+            hideMarker();
+            purgeResults();
+        },
         componentWillReceiveProps(newProps) {
             const {
                 hideMarker = () => {},

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -494,7 +494,7 @@ describe('identify Epics', () => {
             }
         });
     });
-    it('onMapClick do not trigger when mapinfo is not elabled', done => {
+    it('onMapClick do not trigger when mapinfo is not enabled', done => {
         testEpic(addTimeoutEpic(onMapClick, 10), 1, [clickOnMap()], ([action]) => {
             if (action.type === TEST_TIMEOUT) {
                 done();
@@ -506,6 +506,45 @@ describe('identify Epics', () => {
             }
         });
     });
+    it('onMapClick do not trigger when Indentify is not in context', done => {
+        testEpic(addTimeoutEpic(onMapClick, 10), 1, [clickOnMap()], ([action]) => {
+            if (action.type === TEST_TIMEOUT) {
+                done();
+            }
+        }, {
+            mapInfo: {
+                enabled: true,
+                disableAlwaysOn: false
+            },
+            context: {
+                currentContext: {
+                    plugins: {
+                        desktop: []
+                    }
+                }
+            }
+        });
+    });
+    it('onMapClick trigger when mapinfo is not enabled', done => {
+        testEpic(onMapClick, 1, [clickOnMap()], ([action]) => {
+            if (action.type === FEATURE_INFO_CLICK) {
+                done();
+            }
+        }, {
+            mapInfo: {
+                enabled: true,
+                disableAlwaysOn: false
+            },
+            context: {
+                currentContext: {
+                    plugins: {
+                        desktop: [{name: "Identify"}]
+                    }
+                }
+            }
+        });
+    });
+
     it('closeFeatureAndAnnotationEditing closes annotations', (done) => {
 
         const sentActions = closeIdentify();

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -213,6 +213,36 @@ describe('Test mapinfo selectors', () => {
         });
         expect(props).toEqual(true);
     });
+    it('test stopGetFeatureInfoSelector with identify in context', () => {
+        const stop = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            },
+            context: {
+                currentContext: {
+                    plugins: {
+                        desktop: [{ name: "Identify" }]
+                    }
+                }
+            }
+        });
+        expect(stop).toEqual(false); // it should pass
+    });
+    it('test stopGetFeatureInfoSelector with identify not in context', () => {
+        const stop = stopGetFeatureInfoSelector({
+            mapInfo: {
+                enabled: true
+            },
+            context: {
+                currentContext: {
+                    plugins: {
+                        desktop: []
+                    }
+                }
+            }
+        });
+        expect(stop).toEqual(true); // it should be stopped
+    });
     it('test mapInfoConfigurationSelector', () => {
         const infoFormat = "text/html";
         const showEmptyMessageGFI = true;

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -75,11 +75,13 @@ const stopGetFeatureInfoSelector = createSelector(
     measureActiveSelector,
     drawSupportActiveSelector,
     annotationsEditingSelector,
-    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isAnnotationsEditing) =>
+    isPluginInContext('Identify'),
+    (isMapInfoDisabled, isMeasureActive, isDrawSupportActive, isAnnotationsEditing, identifyPluginPresent) =>
         isMapInfoDisabled
         || !!isMeasureActive
         || isDrawSupportActive
         || !!isAnnotationsEditing
+        || !identifyPluginPresent
 );
 
 /**


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
With this PR I disable the Identify plugin side effects when the tool is not in context. 
- When unmount, the cursor of the mouse pointer is disabled and results are removed (also marker)
- Map click are not intercepted when GFI is not in context


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4869 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now the marker doesn't show anymore on click, while Identify tool is not present.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
