### PR TITLE
#4864: Expander improved with auto-hide

### DIFF
--- a/web/client/plugins/Expander.jsx
+++ b/web/client/plugins/Expander.jsx
@@ -10,8 +10,6 @@ const React = require('react');
 const {Glyphicon} = require('react-bootstrap');
 const assign = require('object-assign');
 
-const Message = require('../components/I18N/Message');
-
 const ExpanderPlugin = require('../components/buttons/ToggleButton');
 
 module.exports = {

--- a/web/client/plugins/Expander.jsx
+++ b/web/client/plugins/Expander.jsx
@@ -21,8 +21,9 @@ module.exports = {
             position: 10000,
             alwaysVisible: true,
             tooltip: "expandtoolbar.tooltip",
+            // it is visible when Toolbar allVisible property is set to false or when there are no other items to hide
+            showWhen: ({ items = [] } = {}) => items.filter((i = {}) => !i.name !== 'expand' && !i.alwaysVisible).length > 1,
             icon: <Glyphicon glyph="option-horizontal"/>,
-            help: <Message msgId="helptexts.expandToolbar"/>,
             toggle: true,
             toggleControl: 'toolbar',
             toggleProperty: 'expanded',

--- a/web/client/plugins/__tests__/Toolbar-test.jsx
+++ b/web/client/plugins/__tests__/Toolbar-test.jsx
@@ -37,7 +37,7 @@ const EXPANDER_ITEM = {
 const FULL_SCREEN_ITEM = {
     ...FullScreen.FullScreenPlugin.Toolbar,
     plugin: FullScreen.FullScreenPlugin
-}
+};
 
 describe('Toolbar Plugin', () => {
     beforeEach((done) => {

--- a/web/client/plugins/__tests__/Toolbar-test.jsx
+++ b/web/client/plugins/__tests__/Toolbar-test.jsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import plugin from '../Toolbar';
+import { getPluginForTest } from './pluginsTestUtils';
+const toPluginCmp = plugin.ToolbarPlugin;
+const ToolbarPlugin = {
+    ...plugin,
+    ToolbarPlugin: toPluginCmp('toolbar')
+};
+import Expander from '../Expander';
+import ZoomIn from '../ZoomIn';
+import ZoomOut from '../ZoomOut';
+import FullScreen from '../FullScreen';
+
+const ZOOM_IN_ITEM = {
+    ...ZoomIn.ZoomInPlugin.Toolbar,
+    plugin: ZoomIn.ZoomInPlugin
+};
+const ZOOM_OUT_ITEM = {
+    ...ZoomOut.ZoomOutPlugin.Toolbar,
+    plugin: ZoomOut.ZoomOutPlugin
+};
+const EXPANDER_ITEM = {
+    ...Expander.ExpanderPlugin.Toolbar,
+    plugin: Expander.ExpanderPlugin
+};
+// sample plugin with alwaysVisible = true
+const FULL_SCREEN_ITEM = {
+    ...FullScreen.FullScreenPlugin.Toolbar,
+    plugin: FullScreen.FullScreenPlugin
+}
+
+describe('Toolbar Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates a Toolbar plugin with default configuration', () => {
+        const { Plugin } = getPluginForTest(ToolbarPlugin, { controls: { toolbar: { expanded: false } } }, {ExpanderPlugin: Expander, ZoomInPlugin: ZoomIn});
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelector('#mapstore-toolbar')).toExist();
+    });
+    it('items rendering', () => {
+        const { Plugin } = getPluginForTest(ToolbarPlugin, { controls: { toolbar: { expanded: false } }});
+        // ONLY ONE BUTTON TO HIDE, EXPANDER DO NOT SHOW, button is directly visible
+        ReactDOM.render(<Plugin disableAnimation items={[ZOOM_IN_ITEM, EXPANDER_ITEM]} />, document.getElementById("container"));
+        expect(document.querySelector('#mapstore-toolbar')).toExist();
+        expect(document.querySelector('#zoomin-btn')).toExist();
+        expect(document.querySelectorAll('#mapstore-toolbar button').length).toBe(1);
+        let expander = document.querySelector('#mapstore-toolbar button .glyphicon-option-horizontal');
+        expect(expander).toNotExist();
+        // TWO BUTTONS TO HIDE, EXPANDER SHOWS, all buttons are hidden
+        ReactDOM.render(<Plugin disableAnimation items={[ZOOM_IN_ITEM, ZOOM_OUT_ITEM, EXPANDER_ITEM]} />, document.getElementById("container"));
+        expect(document.querySelectorAll('#mapstore-toolbar button').length).toBe(1);
+        expect(document.querySelector('#mapstore-toolbar')).toExist();
+        expect(document.querySelector('#zoomin-btn')).toNotExist();
+        expander = document.querySelector('#mapstore-toolbar button .glyphicon-option-horizontal');
+        expect(expander).toExist();
+        expect(document.querySelector('#mapstore-toolbar button.btn-success .glyphicon-option-horizontal')).toNotExist(); // btn-success means active, it should be collapsed because state contains {expanded: false}
+        // Buttons with alwaysVisible = true always shown (FULL SCREEN)
+        ReactDOM.render(<Plugin disableAnimation items={[ZOOM_IN_ITEM, ZOOM_OUT_ITEM, FULL_SCREEN_ITEM, EXPANDER_ITEM]} />, document.getElementById("container"));
+        expect(document.querySelectorAll('#mapstore-toolbar button').length).toBe(2);
+        expect(document.querySelector('#mapstore-toolbar')).toExist();
+        expect(document.querySelector('#zoomin-btn')).toNotExist();
+        expect(document.querySelector('#fullscreen-btn')).toExist();
+        expander = document.querySelector('#mapstore-toolbar button .glyphicon-option-horizontal');
+        expect(expander).toExist();
+        expect(document.querySelector('#mapstore-toolbar button.btn-success .glyphicon-option-horizontal')).toNotExist(); // btn-success means active, it should be collapsed because state contains {expanded: false}
+        // SIMULATE EXPANDER OPEN, all buttons are visible, expander active
+        expander.click();
+        expect(document.querySelectorAll('#mapstore-toolbar button').length).toBe(4);
+        expect(document.querySelector('#zoomin-btn')).toExist();
+        expect(document.querySelector('#zoomout-btn')).toExist();
+        expect(document.querySelector('#mapstore-toolbar')).toExist();
+        expect(document.querySelector('#fullscreen-btn')).toExist();
+        expander = document.querySelector('#mapstore-toolbar button.btn-success .glyphicon-option-horizontal'); // btn-success means active
+        expect(expander).toExist();
+    });
+
+});


### PR DESCRIPTION
## Description
Now the expander automatically hides if no button is in the toolbar. If only one button need to be hidden by the expander, the button will be shown automatically instead of the expander.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Expander shows even if it is the only button present in the toolbar

**What is the new behavior?**
#4864

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
