### PR TITLE
#4884 update toolbar position when userextensions panel is open

### DIFF
--- a/web/client/epics/__tests__/maplayout-test.js
+++ b/web/client/epics/__tests__/maplayout-test.js
@@ -144,8 +144,8 @@ describe('map layout epics', () => {
         testEpic(updateMapLayoutEpic, 1, setControlProperty("drawer", "resizedWidth", 512), epicResult, state);
     });
 
-    it('tests layout updated on setControlProperties', (done) => {
-        const epicResult = actions => {
+    describe('tests layout updated for right panels', () => {
+        const epicResult = done => actions => {
             try {
                 expect(actions.length).toBe(1);
                 actions.map((action) => {
@@ -163,9 +163,24 @@ describe('map layout epics', () => {
             }
             done();
         };
-        const state = { controls: { metadataexplorer: { enabled: true, group: "parent" } } };
-        testEpic(updateMapLayoutEpic, 1, setControlProperties("metadataexplorer", "enabled", true, "group", "parent"), epicResult, state);
+        it('metadataexplorer', done => {
+            const state = { controls: { metadataexplorer: { enabled: true, group: "parent" } } };
+            testEpic(updateMapLayoutEpic, 1, setControlProperties("metadataexplorer", "enabled", true, "group", "parent"), epicResult(done), state);
+        });
+        it('userExtensions', (done) => {
+            const state = { controls: { userExtensions: { enabled: true, group: "parent" } } };
+            testEpic(updateMapLayoutEpic, 1, setControlProperties("userExtensions", "enabled", true, "group", "parent"), epicResult(done), state);
+        });
+        it('annotations', (done) => {
+            const state = { controls: { annotations: { enabled: true, group: "parent" } } };
+            testEpic(updateMapLayoutEpic, 1, setControlProperties("annotations", "enabled", true, "group", "parent"), epicResult(done), state);
+        });
+        it('details', (done) => {
+            const state = { controls: { details: { enabled: true, group: "parent" } } };
+            testEpic(updateMapLayoutEpic, 1, setControlProperties("details", "enabled", true, "group", "parent"), epicResult(done), state);
+        });
     });
+
 
     it('tests layout updated on noQueryableLayers', (done) => {
         const epicResult = actions => {

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -78,6 +78,7 @@ const updateMapLayoutEpic = (action$, store) =>
                 get(state, "controls.annotations.enabled") && {right: mapLayout.right.md} || null,
                 get(state, "controls.metadataexplorer.enabled") && {right: mapLayout.right.md} || null,
                 get(state, "controls.measure.enabled") && showCoordinateEditorSelector(state) && {right: mapLayout.right.md} || null,
+                get(state, "controls.userExtensions.enabled") && { right: mapLayout.right.md } || null,
                 get(state, "mapInfo.enabled") && isMapInfoOpen(state) && {right: mapLayout.right.md} || null
             ].filter(panel => panel)) || {right: 0};
 


### PR DESCRIPTION
## Description
Add maplayout updates (toolbar move) when user extensions panel is open.
Add and rationalized unit tests

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4884

**What is the new behavior?**
Now toolbar opens

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
