### PR TITLE
#4876. Introduced noRoot option to skip root rendering playback

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -180,8 +180,8 @@ class PluginsContainer extends React.Component {
             0
         );
         // render on root if container is root (plugin === null || plugin.impl === null) or plugin explicitly wants to render on root (doNotHide = true)
-        // in addition to the container
-        return !container.plugin || !container.plugin.impl || container.plugin.impl.doNotHide;
+        // in addition to the container. If the plugin impl has option "noRoot", rendering is skipped for root by default.
+        return !get(plugin, "impl.noRoot") && (!container.plugin || !container.plugin.impl || container.plugin.impl.doNotHide);
     };
 
     loadPlugins = (state, newProps) => {

--- a/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
+++ b/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 const expect = require('expect');
+const assign = require('object-assign');
+const PropTypes = require('prop-types');
 
 const React = require('react');
 const ReactDOM = require('react-dom');
@@ -17,9 +19,41 @@ class My extends React.Component {
     }
     myFunc() {}
 }
+class Container extends React.Component {
+    static propTypes = {
+        items: PropTypes.any
+    }
+    render() {
+        const {items} = this.props;
+        const renderCmp = (item = {}) => {
+            const ItemCmp = item.plugin;
+            if (ItemCmp) {
+                return <ItemCmp />;
+            }
+            return <div id={`no-impl-item-${item.name}`} />;
+
+        };
+        return (<React.Fragment>
+            {items.map(renderCmp)}
+        </React.Fragment>);
+    }
+
+};
+
+class NoRootPlugin extends React.Component {
+    render() {
+        return <div id="no-root"/>;
+    }
+}
 const plugins = {
     MyPlugin: My,
-    OtherPlugin: My
+    OtherPlugin: My,
+    ContainerPlugin: Container,
+    NoRootPlugin: assign(NoRootPlugin, { noRoot: true, Container: {
+        name: 'no-root-plugin',
+        position: 1,
+        priority: 1
+    }})
 };
 
 const pluginsCfg = {
@@ -34,6 +68,13 @@ const pluginsCfg = {
 const pluginsCfg2 = {
     desktop: ["My", "Other"]
 };
+
+const pluginsCfg3 = {
+    desktop: ["My", "NoRoot"]
+}
+const pluginsCfg4 = {
+    desktop: ["Container", "NoRoot"]
+}
 
 describe('PluginsContainer', () => {
     beforeEach((done) => {
@@ -69,5 +110,29 @@ describe('PluginsContainer', () => {
 
         const rendered = cmpDom.getElementsByTagName("div");
         expect(rendered.length).toBe(2);
+    });
+    it('test noRoot option disable root rendering of plugins', () => {
+        // Not rendered without container
+        let cmp = ReactDOM.render(<PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
+            plugins={plugins} pluginsConfig={pluginsCfg3} />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        let cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        let rendered = cmpDom.getElementsByTagName("div");
+
+        // rendered in container
+        expect(rendered.length).toBe(1);
+        cmp = ReactDOM.render(<PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
+            plugins={plugins} pluginsConfig={pluginsCfg4} />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        rendered = cmpDom.getElementsByTagName("div");
+        expect(document.getElementById('no-impl-item-no-root-plugin')).toNotExist();
+        expect(document.getElementById('no-root')).toExist();
     });
 });

--- a/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
+++ b/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
@@ -38,7 +38,7 @@ class Container extends React.Component {
         </React.Fragment>);
     }
 
-};
+}
 
 class NoRootPlugin extends React.Component {
     render() {
@@ -71,10 +71,10 @@ const pluginsCfg2 = {
 
 const pluginsCfg3 = {
     desktop: ["My", "NoRoot"]
-}
+};
 const pluginsCfg4 = {
     desktop: ["Container", "NoRoot"]
-}
+};
 
 describe('PluginsContainer', () => {
     beforeEach((done) => {

--- a/web/client/plugins/Playback.jsx
+++ b/web/client/plugins/Playback.jsx
@@ -56,6 +56,7 @@ class PlaybackPlugin extends React.Component {
 
 module.exports = {
     PlaybackPlugin: assign(PlaybackPlugin, {
+        noRoot: true,
         disablePluginIf: "{state('featuregridmode') === 'EDIT'}",
         Timeline: {
             name: 'playback',


### PR DESCRIPTION

## Description
 Introduced noRoot option to skip root rendering of plugins that doesn't make sense in a stand-alone context. This solves also the problem notified in #4876 setting `noRoot` option for the Playback plugin. 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4876

**What is the new behavior?**
Playback is rendered only in timeline. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
