### PR TITLE
#4735 add background visible only with catalog

### DIFF
--- a/web/client/components/background/BackgroundSelector.jsx
+++ b/web/client/components/background/BackgroundSelector.jsx
@@ -39,6 +39,8 @@ class BackgroundSelector extends React.Component {
         onLayerChange: PropTypes.func,
         onStartChange: PropTypes.func,
         onAdd: PropTypes.func,
+        hasCatalog: PropTypes.bool,
+        alwaysVisible: PropTypes.bool, // useful for tests
         enabledCatalog: PropTypes.bool,
         onRemove: PropTypes.func,
         onBackgroundEdit: PropTypes.func,
@@ -219,7 +221,7 @@ class BackgroundSelector extends React.Component {
         };
         const {show: showConfirm, layerId: confirmLayerId, layerTitle: confirmLayerTitle} =
             this.props.confirmDeleteBackgroundModal || {show: false};
-        return visibleIconsLength <= 0 && this.props.enabled ? null : (
+        return (visibleIconsLength <= 0 && !this.props.alwaysVisible) && this.props.enabled ? null : (
             <span>
                 <ConfirmDialog
                     draggable={false}
@@ -249,8 +251,7 @@ class BackgroundSelector extends React.Component {
                 <div className={'background-plugin-position'} style={this.props.style}>
                     <PreviewButton
                         layers={this.props.layers}
-                        enabledCatalog={this.props.enabledCatalog}
-                        currentLayer={this.props.currentLayer}
+                        showAdd={this.props.mode !== 'mobile' && this.props.mapIsEditable && this.props.hasCatalog && !this.props.enabledCatalog}
                         onAdd={() => this.props.onAdd(this.props.source || 'backgroundSelector')}
                         showLabel={configuration.label}
                         src={this.getThumb(layer)}
@@ -260,8 +261,7 @@ class BackgroundSelector extends React.Component {
                         labelHeight={labelHeight}
                         label={layer.title}
                         onToggle={this.props.onToggle}
-                        mode={this.props.mode}
-                        mapIsEditable={this.props.mapIsEditable}/>
+                    />
                     <div className="background-list-container" style={listContainerStyle}>
                         <PreviewList vertical={configuration.vertical} start={this.props.start} bottom={0} height={previewListStyle.height} width={previewListStyle.width} icons={icons} pagination={pagination} length={visibleIconsLength} onStartChange={this.props.onStartChange} />
                     </div>

--- a/web/client/components/background/PreviewButton.jsx
+++ b/web/client/components/background/PreviewButton.jsx
@@ -14,7 +14,6 @@ require('./css/previewbutton.css');
 
 class PreviewButton extends React.Component {
     static propTypes = {
-        mode: PropTypes.string,
         src: PropTypes.string,
         side: PropTypes.number,
         frame: PropTypes.number,
@@ -24,14 +23,10 @@ class PreviewButton extends React.Component {
         showLabel: PropTypes.bool,
         onToggle: PropTypes.func,
         onAdd: PropTypes.func,
-        currentLayer: PropTypes.object,
-        enabledCatalog: PropTypes.bool,
-        layers: PropTypes.array,
-        mapIsEditable: PropTypes.bool
+        showAdd: PropTypes.bool
     };
 
     static defaultProps = {
-        mode: 'desktop',
         src: './images/mapthumbs/none.jpg',
         side: 50,
         frame: 4,
@@ -40,9 +35,7 @@ class PreviewButton extends React.Component {
         label: '',
         showLabel: true,
         onToggle: () => {},
-        onAdd: () => {},
-        currentLayer: {},
-        layers: []
+        onAdd: () => {}
     };
 
     render() {
@@ -60,12 +53,11 @@ class PreviewButton extends React.Component {
                         className: 'square-button-md',
                         bsStyle: 'primary'
                     }}
-                    buttons={this.props.mode !== 'mobile' && this.props.mapIsEditable ? [
+                    buttons={ this.props.showAdd ? [
                         {
                             glyph: 'plus',
                             tooltipId: "backgroundSelector.addTooltip",
-                            onClick: () => this.props.onAdd(),
-                            visible: !this.props.enabledCatalog
+                            onClick: () => this.props.onAdd()
                         }
                     ] : []}/> : null}
             </div>

--- a/web/client/components/background/__tests__/BackgroundSelector-test.jsx
+++ b/web/client/components/background/__tests__/BackgroundSelector-test.jsx
@@ -191,7 +191,7 @@ describe("test the BackgroundSelector", () => {
             }
         ];
 
-        const backgroundSelector = ReactDOM.render(<BackgroundSelector enabled size={size} layers={layers} mapIsEditable/>, document.getElementById("container"));
+        const backgroundSelector = ReactDOM.render(<BackgroundSelector enabled size={size} layers={layers} mapIsEditable hasCatalog/>, document.getElementById("container"));
         expect(backgroundSelector).toExist();
         const node = ReactDOM.findDOMNode(backgroundSelector);
         expect(node).toExist();

--- a/web/client/plugins/BackgroundSelector.jsx
+++ b/web/client/plugins/BackgroundSelector.jsx
@@ -118,7 +118,7 @@ compose(
             ...ownProps.thumbs
         }
     })),
-    // check if to show catalog
+    // check if catalog is present to render the + button. TODO: move the add button in the catalog
     withProps(({ items = [] }) => ({
         hasCatalog: !!find(items, { name: 'MetadataExplorer' })
     }))

--- a/web/client/plugins/BackgroundSelector.jsx
+++ b/web/client/plugins/BackgroundSelector.jsx
@@ -7,6 +7,10 @@
  */
 
 const {connect} = require('react-redux');
+const {compose, withProps} = require('recompose');
+const {find} = require('lodash');
+
+
 const {toggleControl, setControlProperty} = require('../actions/controls');
 const {changeLayerProperties, updateNode} = require('../actions/layers');
 const {addBackground, addBackgroundProperties, confirmDeleteBackgroundModal,
@@ -88,30 +92,36 @@ const backgroundSelector = createSelector([
   * }
   */
 
-const BackgroundSelectorPlugin = connect(backgroundSelector, {
-    onPropertiesChange: changeLayerProperties,
-    onToggle: toggleControl.bind(null, 'backgroundSelector', null),
-    onLayerChange: setControlProperty.bind(null, 'backgroundSelector'),
-    onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start'),
-    onAdd: addBackground,
-    onRemove: removeNode,
-    onBackgroundEdit: backgroundEdited,
-    updateNode,
-    onUpdateThumbnail: updateThumbnail,
-    removeBackground,
-    clearModal: clearModalParameters,
-    addBackgroundProperties,
-    onRemoveBackground: confirmDeleteBackgroundModal,
-    setCurrentBackgroundLayer
-}, (stateProps, dispatchProps, ownProps) => ({
-    ...stateProps,
-    ...dispatchProps,
-    ...ownProps,
-    thumbs: {
-        ...thumbs,
-        ...ownProps.thumbs
-    }
-})
+const BackgroundSelectorPlugin =
+compose(
+    connect(backgroundSelector, {
+        onPropertiesChange: changeLayerProperties,
+        onToggle: toggleControl.bind(null, 'backgroundSelector', null),
+        onLayerChange: setControlProperty.bind(null, 'backgroundSelector'),
+        onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start'),
+        onAdd: addBackground,
+        onRemove: removeNode,
+        onBackgroundEdit: backgroundEdited,
+        updateNode,
+        onUpdateThumbnail: updateThumbnail,
+        removeBackground,
+        clearModal: clearModalParameters,
+        addBackgroundProperties,
+        onRemoveBackground: confirmDeleteBackgroundModal,
+        setCurrentBackgroundLayer
+    }, (stateProps, dispatchProps, ownProps) => ({
+        ...stateProps,
+        ...dispatchProps,
+        ...ownProps,
+        thumbs: {
+            ...thumbs,
+            ...ownProps.thumbs
+        }
+    })),
+    // check if to show catalog
+    withProps(({ items = [] }) => ({
+        hasCatalog: !!find(items, { name: 'MetadataExplorer' })
+    }))
 )(require('../components/background/BackgroundSelector'));
 
 module.exports = {

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -263,6 +263,10 @@ module.exports = {
             action: setControlProperty.bind(null, "metadataexplorer", "enabled", true, true),
             doNotHide: true
         },
+        BackgroundSelector: {
+            name: 'MetadataExplorer',
+            doNotHide: true
+        },
         TOC: {
             name: 'MetadataExplorer',
             doNotHide: true

--- a/web/client/plugins/__tests__/BackgroundSelector-test.jsx
+++ b/web/client/plugins/__tests__/BackgroundSelector-test.jsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import BackgroundSelectorPlugin from '../BackgroundSelector';
+import { getPluginForTest } from './pluginsTestUtils';
+
+const BG_PLUGIN_SELECTOR = '.background-plugin-position';
+const ADD_BTN_SELECTOR = `${BG_PLUGIN_SELECTOR} button`;
+describe('BackgroundSelector Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('Render plugin with layers', () => {
+        const { Plugin } = getPluginForTest(BackgroundSelectorPlugin, { layers: { flat: [{ group: 'background' }] } });
+        ReactDOM.render(<Plugin alwaysVisible />, document.getElementById("container"));
+        expect(document.querySelector(BG_PLUGIN_SELECTOR)).toExist();
+        expect(document.querySelector(ADD_BTN_SELECTOR)).toNotExist();
+    });
+    it('Add button present only if catalog available', () => {
+        const { Plugin } = getPluginForTest(BackgroundSelectorPlugin, {
+            layers: { flat: [{ group: 'background' }] },
+            controls: {
+                backgroundSelector: {
+                    enabled: true
+                }
+            }});
+        ReactDOM.render(<Plugin alwaysVisible/>, document.getElementById("container"));
+
+        expect(document.querySelector(ADD_BTN_SELECTOR)).toNotExist();
+        ReactDOM.render(<Plugin alwaysVisible items={[{ name: "MetadataExplorer" }]} />, document.getElementById("container"));
+        expect(document.querySelector(ADD_BTN_SELECTOR)).toExist();
+    });
+});


### PR DESCRIPTION
## Description
See #4735. With this changes background selector shows add button only if catalog is present. 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4735

**What is the new behavior?**
Now background add button is hidden when catalog is not present.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
