### PR TITLE
Fix warning message on defaultProps in components/misc/coordinateeditors

### DIFF
--- a/web/client/components/misc/coordinateeditors/CoordinateEntry.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinateEntry.jsx
@@ -17,7 +17,6 @@ const no90Lat = require('./enhancers/no90Lat');
  This component can render an input field in two different formats: 'decimal' or 'aeronautical'
 */
 class CoordinateEntry extends React.Component {
-
     static propTypes = {
         idx: PropTypes.number,
         value: PropTypes.number,
@@ -28,7 +27,8 @@ class CoordinateEntry extends React.Component {
         onChange: PropTypes.func,
         onKeyDown: PropTypes.func
     };
-    defaultProps = {
+
+    static defaultProps = {
         format: "decimal",
         constraints: {
             decimal: {
@@ -43,6 +43,7 @@ class CoordinateEntry extends React.Component {
             }
         }
     }
+
     render() {
         const {format} = this.props;
         return format === "decimal" || isNil(format) ?

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -37,7 +37,8 @@ class CoordinatesRow extends React.Component {
         formatVisible: PropTypes.bool,
         removeEnabled: PropTypes.bool
     };
-    defaultProps = {
+
+    static defaultProps = {
         showLabels: false,
         formatVisible: false,
         onMouseEnter: () => {},
@@ -69,7 +70,6 @@ class CoordinatesRow extends React.Component {
                     this.props.onMouseLeave();
                 }
             }}>
-
                 <Col xs={1}>
                     {this.props.showDraggable ? this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton : null}
                 </Col>


### PR DESCRIPTION
## Description
Fix warning message : `Warning: Setting defaultProps as an instance property on CoordinateEntry is not supported and will be ignored. Instead, define defaultProps as a static property on CoordinateEntry.`

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Refactoring (no functional changes, no api changes)
