### PR TITLE
#4895: layerOptions and domain sharding support for catalog wms services

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -18,7 +18,8 @@ const capabilitiesCache = {};
 
 const {isArray, castArray, get} = require('lodash');
 
-const parseUrl = (url) => {
+const parseUrl = (urls) => {
+    const url = (isArray(urls) && urls || urls.split(','))[0];
     const parsed = urlUtil.parse(url, true);
     return urlUtil.format(assign({}, parsed, {search: null}, {
         query: assign({

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -14,6 +14,12 @@ import axios from '../../libs/ajax';
 let mockAxios;
 
 describe('Test correctness of the WMS APIs', () => {
+    it('parseUrl uses the first array element', () => {
+        expect(API.parseUrl(["http://first", "https://second"]).indexOf("http://first/")).toBe(0);
+    });
+    it('parseUrl uses the first string of a comma delimited list', () => {
+        expect(API.parseUrl(["http://first,https://second"]).indexOf("http://first/")).toBe(0);
+    });
     it('describeLayers', (done) => {
         API.describeLayers('base/web/client/test-resources/wms/DescribeLayers.xml', "workspace:vector_layer").then((result) => {
             try {

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -27,7 +27,7 @@ const {resultSelector, serviceListOpenSelector, newServiceSelector,
     newServiceTypeSelector, selectedServiceTypeSelector, searchOptionsSelector, servicesSelector,
     servicesSelectorWithBackgrounds, formatsSelector, loadingErrorSelector, selectedServiceSelector,
     modeSelector, layerErrorSelector, activeSelector, savingSelector, authkeyParamNameSelector,
-    searchTextSelector, groupSelector, pageSizeSelector, loadingSelector
+    searchTextSelector, groupSelector, pageSizeSelector, loadingSelector, selectedServiceLayerOptionsSelector
 } = require("../selectors/catalog");
 const {projectionSelector} = require('../selectors/map');
 
@@ -49,12 +49,13 @@ const catalogSelector = createSelector([
     (state) => newServiceTypeSelector(state),
     (state) => selectedServiceTypeSelector(state),
     (state) => searchOptionsSelector(state),
+    (state) => selectedServiceLayerOptionsSelector(state),
     (state) => currentLocaleSelector(state),
     (state) => currentMessagesSelector(state),
     (state) => pageSizeSelector(state),
     (state) => loadingSelector(state),
     (state) => projectionSelector(state)
-], (layers, modalParams, authkeyParamNames, result, saving, openCatalogServiceList, newService, newformat, selectedFormat, options, currentLocale, locales, pageSize, loading, crs) => ({
+], (layers, modalParams, authkeyParamNames, result, saving, openCatalogServiceList, newService, newformat, selectedFormat, options, layerOptions, currentLocale, locales, pageSize, loading, crs) => ({
     layers,
     modalParams,
     authkeyParamNames,
@@ -66,7 +67,7 @@ const catalogSelector = createSelector([
     pageSize,
     loading,
     crs,
-    records: result && CatalogUtils.getCatalogRecords(selectedFormat, result, options, locales) || []
+    records: result && CatalogUtils.getCatalogRecords(selectedFormat, result, { ...options, layerOptions }, locales) || []
 }));
 
 

--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -23,6 +23,7 @@ const {
     resultSelector,
     searchTextSelector,
     searchOptionsSelector,
+    selectedServiceLayerOptionsSelector,
     selectedServiceTypeSelector,
     selectedServiceSelector,
     servicesSelector,
@@ -49,7 +50,10 @@ const state = {
             'Basic WMS Service': {
                 url: 'https://demo.geo-solutions.it/geoserver/wms',
                 type: 'wms',
-                title: 'Basic WMS Service'
+                title: 'Basic WMS Service',
+                layerOptions: {
+                    tileSize: 512
+                }
             },
             'Basic WMTS Service': {
                 url: 'https://demo.geo-solutions.it/geoserver/gwc/service/wmts',
@@ -154,6 +158,11 @@ describe('Test catalog selectors', () => {
         const retVal = selectedServiceTypeSelector(state2);
         expect(retVal).toExist();
         expect(retVal).toBe("wmts");
+    });
+    it('selectedServiceLayerOptionsSelector', () => {
+        const retVal = selectedServiceLayerOptionsSelector(state);
+        expect(retVal).toExist();
+        expect(retVal.tileSize).toBe(512);
     });
     it('test searchOptionsSelector', () => {
         const retVal = searchOptionsSelector(state);

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -31,6 +31,7 @@ module.exports = {
     selectedCatalogSelector: (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"]`),
     selectedStaticServiceTypeSelector,
     selectedServiceTypeSelector: (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"].type`, selectedStaticServiceTypeSelector(state)),
+    selectedServiceLayerOptionsSelector: (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"].layerOptions`, {}),
     searchOptionsSelector: (state) => get(state, "catalog.searchOptions"),
     formatsSelector: (state) => get(state, "catalog.supportedFormats") || [{name: "csw", label: "CSW"}, {name: "wms", label: "WMS"}, {name: "wmts", label: "WMTS"}],
     loadingErrorSelector: (state) => get(state, "catalog.loadingError"),

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -199,6 +199,7 @@ const converters = {
                 return {
                     boundingBox: record.boundingBox,
                     description: dc && isString(dc.abstract) && dc.abstract || '',
+                    layerOptions: options && options.layerOptions || {},
                     identifier: dc && isString(dc.identifier) && dc.identifier || '',
                     references: references,
                     thumbnail: thumbURL,
@@ -221,6 +222,7 @@ const converters = {
                     identifier: record.Name,
                     service: records.service,
                     tags: "",
+                    layerOptions: options && options.layerOptions || {},
                     title: LayersUtils.getLayerTitleTranslations(record) || record.Name,
                     formats: castArray(record.formats || []),
                     dimensions: (record.Dimension && castArray(record.Dimension) || []).map((dim) => assign({}, {
@@ -292,6 +294,7 @@ const converters = {
                     description: getNodeText(record["ows:Abstract"] || record["ows:Title"] || record["ows:Identifier"]),
                     identifier: getNodeText(record["ows:Identifier"]),
                     tags: "",
+                    layerOptions: options && options.layerOptions || {},
                     style: record.style,
                     capabilitiesURL: capabilitiesURL,
                     queryable: record.queryable,
@@ -478,7 +481,8 @@ const CatalogUtils = {
             params: params,
             allowedSRS: allowedSRS,
             catalogURL,
-            ...baseConfig
+            ...baseConfig,
+            ...record.layerOptions
         };
     },
     getCatalogRecords: (format, records, options, locales) => {

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -98,6 +98,20 @@ describe('Test the CatalogUtils', () => {
         expect(layer.allowedSRS['EPSG:5041']).toNotExist();
     });
 
+    it('wms layer options', () => {
+        const records = CatalogUtils.getCatalogRecords('wms', {
+            records: [{}]
+        }, {
+            url: 'http://sample',
+            layerOptions: {
+                tileSize: 512
+            }
+        });
+        expect(records.length).toBe(1);
+        const layer = CatalogUtils.recordToLayer(records[0]);
+        expect(layer.tileSize).toBe(512);
+    });
+
     it('wms with no ogcServiceReference.url', () => {
         const records = CatalogUtils.getCatalogRecords(
             'wms',


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Support for:
 * options to add to each layer of a wms service
 * domain sharding of service urls

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:
