### PR TITLE
#4903 Solved issue with Widgets button

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -282,7 +282,7 @@ class Toolbar extends React.Component {
                             </Button>
                         </OverlayTrigger>
                         : null}
-                    {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
+                    {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && this.props.selectedLayers[0].type !== 'vector' && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
                         <OverlayTrigger
                             key="widgets"
                             placement="top"

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -507,5 +507,69 @@ describe('TOC Toolbar', () => {
         expect(btn.length).toBe(3);
         expect(btn[0].style.cursor).toBe('default');
     });
+    describe('Widget tool', () => {
+        const WIDGET_TOOL_SELECTOR = 'button .glyphicon-stats';
+        it('enable if activateWidgetTool is true', () => {
+            const actions = {
+                onNewWidget: () => {}
+            };
+            const spyNewWidget = expect.spyOn(actions, 'onNewWidget');
+            const selectedLayers = [{
+                id: 'l001',
+                title: 'layer001',
+                type: 'wms',
+                name: 'layer001name',
+                bbox: {
+                    bounds: {
+                        maxx: 10,
+                        maxy: 9,
+                        minx: -10,
+                        miny: -9
+                    }, crs: 'EPSG:3003'
+                }
+            }];
+            const activateTool = {
+                activateWidgetTool: true,
+                activateToolsContainer: true,
+                activateRemoveLayer: true,
+                activateRemoveGroup: true,
+                activateZoomTool: true,
+                activateQueryTool: true,
+                activateDownloadTool: true,
+                activateSettingsTool: true,
+                activateAddLayer: true,
+                activateAddGroup: true,
+                includeDeleteButtonInSettings: false,
+                activateMetedataTool: true,
+                activateLayerFilterTool: true
+            };
+
+            ReactDOM.render(<Toolbar activateTool={activateTool} selectedLayers={selectedLayers} onToolsActions={actions} />, document.getElementById("container"));
+            const widgetButton = document.querySelector(WIDGET_TOOL_SELECTOR);
+            expect(widgetButton).toExist();
+            widgetButton.click();
+            expect(spyNewWidget).toHaveBeenCalled();
+        });
+        it('deactivate for vector layers', () => {
+            const selectedLayers = [{
+                id: 'l002',
+                title: 'layer002',
+                type: 'vector',
+                name: 'layer001name',
+                bbox: {
+                    bounds: {
+                        maxx: 10,
+                        maxy: 9,
+                        minx: -10,
+                        miny: -9
+                    }, crs: 'EPSG:3003'
+                }
+            }];
+            ReactDOM.render(<Toolbar activateTool={{ activateWidgetTool: true }} selectedLayers={selectedLayers} />, document.getElementById("container"));
+            const widgetButton = document.querySelector(WIDGET_TOOL_SELECTOR);
+            expect(widgetButton).toNotExist();
+
+        });
+    });
 
 });


### PR DESCRIPTION
## Description
#4903 fix for master. Avoid to show it for local vector layers (see #4678) and allow to show the button in other cases.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4903
#4678

**What is the new behavior?**
Widget button is visible for layers that are not local vector layers (annotations or vector imported layers)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
