### PR TITLE
#4865: Improved styler pluggability

### DIFF
--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -29,7 +29,7 @@ const Message = require('../I18N/Message');
  * @prop {string} className additional calss name
  */
 
-const TOCItemSettings = (props, context) => {
+const TOCItemSettings = (props) => {
     const {
         className = '',
         activeTab = 'general',
@@ -38,7 +38,6 @@ const TOCItemSettings = (props, context) => {
         groups = [],
         element = {},
         settings = {},
-        getTabs = () => [],
         onSave = () => {},
         onClose = () => {},
         onHideSettings = () => {},
@@ -53,10 +52,11 @@ const TOCItemSettings = (props, context) => {
         showFullscreen,
         draggable,
         position = 'left',
+        tabs,
         tabsConfig = {}
     } = props;
 
-    const tabs = getTabs(props, context);
+
     const ToolbarComponent = head(tabs.filter(tab => tab.id === activeTab && tab.toolbarComponent).map(tab => tab.toolbarComponent));
 
     const tabsCloseActions = tabs && tabs.map(tab => tab && tab.onClose).filter(val => val) || [];

--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -52,7 +52,7 @@ const TOCItemSettings = (props) => {
         showFullscreen,
         draggable,
         position = 'left',
-        tabs,
+        tabs = [],
         tabsConfig = {}
     } = props;
 

--- a/web/client/components/TOC/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/components/TOC/__tests__/TOCItemsSettings-test.jsx
@@ -38,7 +38,7 @@ describe("test TOCItemsSettings", () => {
     });
 
     it('test with tabs', () => {
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -63,13 +63,13 @@ describe("test TOCItemsSettings", () => {
     });
 
     it('test without tabs', () => {
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => []}/>, document.getElementById("container"));
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[]}/>, document.getElementById("container"));
         const navBar = document.getElementsByClassName('nav-justified')[0];
         expect(navBar).toNotExist();
     });
 
     it('test with tabs length 1', () => {
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [{
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[{
             id: 'general',
             titleId: 'layerProperties.general',
             tooltipId: 'layerProperties.general',
@@ -89,7 +89,7 @@ describe("test TOCItemsSettings", () => {
     });
 
     it('test with a title ', () => {
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -118,7 +118,7 @@ describe("test TOCItemsSettings", () => {
 
         const spyOnClick = expect.spyOn(testHandlers, 'onClick');
 
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -150,7 +150,7 @@ describe("test TOCItemsSettings", () => {
 
         const spyOnClose = expect.spyOn(testHandlers, 'onClose');
 
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[
             {
                 id: 'general',
                 titleId: 'layerProperties.general',
@@ -176,7 +176,7 @@ describe("test TOCItemsSettings", () => {
 
     it('test ToolbarComponent from tab', () => {
 
-        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" getTabs={() => [
+        ReactDOM.render(<TOCItemsSettings settings={settings} activeTab="general" tabs={[
             {
                 id: 'general',
                 titleId: 'layerProperties.general',

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -188,7 +188,12 @@ module.exports = {
     StyleEditorPlugin: assign(StyleEditorPlugin, {
         TOC: {
             priority: 1,
-            container: 'TOCItemSettings',
+            container: 'TOCItemSettings'
+        },
+        TOCItemsSettings: {
+            name: 'StyleEditor',
+            target: 'style',
+            priority: 1,
             ToolbarComponent: StyleToolbar
         }
     }),

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -10,7 +10,7 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const { connect } = require('react-redux');
 const { createSelector } = require('reselect');
-const { compose, branch, toClass } = require('recompose');
+const { compose, branch, toClass, lifecycle } = require('recompose');
 const assign = require('object-assign');
 const { isArray, isString } = require('lodash');
 
@@ -31,7 +31,7 @@ const {
 
 const { userRoleSelector } = require('../selectors/security');
 
-const { initStyleService } = require('../actions/styleeditor');
+const { initStyleService, toggleStyleEditor } = require('../actions/styleeditor');
 const { updateSettingsParams } = require('../actions/layers');
 
 const {
@@ -181,6 +181,16 @@ const StyleEditorPlugin = compose(
             }
         },
         props => <div style={{position: 'relative', height: '100%', display: 'flex'}}><Loader {...props}/></div>
+    ),
+    compose(
+        connect(() => ({}), {
+            toggleStyleEditor
+        }),
+        lifecycle({
+            componentDidMount() {
+                this.props.onToggleStyleEditor(null, true);
+            }
+        })
     )
 )(StyleEditorPanel);
 

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -188,7 +188,7 @@ const StyleEditorPlugin = compose(
         }),
         lifecycle({
             componentDidMount() {
-                this.props.onToggleStyleEditor(null, true);
+                this.props.toggleStyleEditor(null, true);
             }
         })
     )

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -87,7 +87,7 @@ const TOCItemsSettingsPlugin = compose(
     }),
     updateSettingsLifecycle,
     defaultProps({
-        getDimension: LayersUtils.getDimension,
+        getDimension: LayersUtils.getDimension
     }),
     getContext({
         loadedPlugins: PropTypes.object

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -7,8 +7,10 @@
  */
 
 import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+
 import {createSelector} from 'reselect';
-import {compose, defaultProps} from 'recompose';
+import { compose, defaultProps, withPropsOnChange, getContext} from 'recompose';
 import { createPlugin } from '../utils/PluginsUtils';
 import LayersUtils from '../utils/LayersUtils';
 import {hideSettings, updateSettings, updateNode, updateSettingsParams} from '../actions/layers';
@@ -86,8 +88,15 @@ const TOCItemsSettingsPlugin = compose(
     updateSettingsLifecycle,
     defaultProps({
         getDimension: LayersUtils.getDimension,
-        getTabs: defaultSettingsTabs
-    })
+    }),
+    getContext({
+        loadedPlugins: PropTypes.object
+    }),
+    withPropsOnChange(({items = []} = {}, {items: nextItems} = {}) => {
+        return items !== nextItems; // TODO: check if equal
+    }, (props) => ({
+        tabs: defaultSettingsTabs(props)
+    }))
 )(TOCItemsSettings);
 
 /**

--- a/web/client/plugins/ThematicLayer.jsx
+++ b/web/client/plugins/ThematicLayer.jsx
@@ -128,9 +128,12 @@ module.exports = {
             });
         }, enabler: (state) => state.layerSettings && state.layerSettings.expanded
     }, {
-        TOC: {
+        TOCItemsSettings: {
             priority: 1,
-            container: "TOCItemSettings"
+            name: 'ThematicLayer',
+            selector: ({ settings }) => settings && settings.options && settings.options.thematic,
+            container: "TOCItemSettings",
+            target: "style"
         }
     }),
     reducers: {

--- a/web/client/plugins/ThematicLayer.jsx
+++ b/web/client/plugins/ThematicLayer.jsx
@@ -131,7 +131,6 @@ module.exports = {
         TOCItemsSettings: {
             priority: 1,
             name: 'ThematicLayer',
-            selector: ({ settings }) => settings && settings.options && settings.options.thematic,
             container: "TOCItemSettings",
             target: "style"
         }

--- a/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
+++ b/web/client/plugins/__tests__/TOCItemsSettings-test.jsx
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TOCItemsSettingsPlugin from '../TOCItemsSettings';
+import { getPluginForTest } from './pluginsTestUtils';
+
+import StyleEditor from '../StyleEditor';
+import ThematicLayer from '../ThematicLayer';
+
+import { createStateMocker } from '../../reducers/__tests__/reducersTestUtils';
+
+import { addLayer, selectNode, showSettings, UPDATE_NODE } from '../../actions/layers';
+import { INIT_STYLE_SERVICE } from '../../actions/styleeditor';
+
+import layers from '../../reducers/layers';
+import controls from '../../reducers/controls';
+
+import { setControlProperty } from '../../actions/controls';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+import CAPABILITIES from 'raw-loader!../../test-resources/wms/GetCapabilities-1.3.0.xml';
+
+const STYLE_EDITOR_ITEM = {
+    ...StyleEditor.StyleEditorPlugin.TOCItemsSettings,
+    plugin: StyleEditor.StyleEditorPlugin
+};
+// sample plugin with alwaysVisible = true
+const THEMATIC_LAYER_ITEM = {
+    ...ThematicLayer.ThematicLayerPlugin.TOCItemsSettings,
+    plugin: ThematicLayer.ThematicLayerPlugin
+};
+
+
+const SETTINGS_SELECTOR = '.ms-side-panel';
+const NAV_SELECTOR = 'ul.nav-tabs';
+const TAB_INDEX_SELECTOR = `${NAV_SELECTOR} > li`;
+const TAB_CONTENT_SELECTOR = 'main';
+const TEST_LAYER = {
+    id: "TEST_WMS",
+    type: "wms",
+    name: "nurc:Arc_Sample",
+    url: "/geoserver/wms"
+};
+
+
+describe('TOCItemsSettings Plugin', () => {
+    let mockAxios;
+    const stateMocker = createStateMocker({ layers, controls });
+    const OPEN_PANEL_ACTIONS = [addLayer(TEST_LAYER), selectNode(TEST_LAYER.id, 'layer'), showSettings(TEST_LAYER.id, "layers", { opacity: 1 })];
+    const DISPLAY_PANEL_ACTIONS = [setControlProperty("layersettings", "activeTab", "display")];
+    const STYLE_PANEL_ACTIONS = [setControlProperty("layersettings", "activeTab", "style")];
+    const OPEN_PANEL_STATE = stateMocker(...OPEN_PANEL_ACTIONS);
+    const DISPLAY_PANEL_STATE = stateMocker(...OPEN_PANEL_ACTIONS, ...DISPLAY_PANEL_ACTIONS);
+    const STYLE_PANEL_STATE = stateMocker(...OPEN_PANEL_ACTIONS, ...STYLE_PANEL_ACTIONS);
+    beforeEach((done) => {
+        mockAxios = new MockAdapter(axios);
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        mockAxios.restore();
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates a Toolbar plugin with default configuration, general tab', () => {
+        const { Plugin } = getPluginForTest(TOCItemsSettingsPlugin, OPEN_PANEL_STATE);
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelector(SETTINGS_SELECTOR)).toExist();
+        const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
+        expect(tabIndexes.length).toBe(4);
+        expect(tabIndexes[0].className).toBe("active"); // general tab active
+        expect(document.querySelectorAll(`${TAB_CONTENT_SELECTOR} div.form-group`).length).toBe(4); // check content is general settings tab.
+
+    });
+    it('display panel', () => {
+        const { Plugin } = getPluginForTest(TOCItemsSettingsPlugin, DISPLAY_PANEL_STATE);
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelector(SETTINGS_SELECTOR)).toExist();
+        const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
+        expect(tabIndexes.length).toBe(4);
+        expect(tabIndexes[1].className).toBe("active");
+
+    });
+    it('default style selector', done => {
+        mockAxios.onGet().reply(() => {
+            return [200, CAPABILITIES];
+        });
+        const checkStylesEpic = action$ => action$
+            .ofType(UPDATE_NODE)
+            .filter(({ options = {} }) => !options.capabilitiesLoading) // skip loading event
+            .map(action => {
+                expect(action.options.availableStyles).toExist();
+                expect(action.options.availableStyles.length).toBe(2);
+                expect(document.querySelectorAll('.msSideGrid .items-list > div').length).toBe(2); // check layer list rendered
+                done();
+            }).ignoreElements();
+        const { Plugin } = getPluginForTest(TOCItemsSettingsPlugin, STYLE_PANEL_STATE, undefined, checkStylesEpic);
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(document.querySelector(SETTINGS_SELECTOR)).toExist();
+        const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
+        expect(tabIndexes.length).toBe(4);
+        expect(tabIndexes[2].className).toBe("active");
+    });
+
+    it('style panel with style editor', done => {
+        mockAxios.onGet().reply(() => {
+            return [200, CAPABILITIES];
+        });
+        const checkStylesEpic = action$ => action$
+            .ofType(INIT_STYLE_SERVICE)
+            .map(() => {
+                // TODO: continue, check GUI
+                done();
+            }).ignoreElements();
+        const { Plugin } = getPluginForTest(TOCItemsSettingsPlugin, STYLE_PANEL_STATE, {
+            StyleEditorPlugin: StyleEditor
+        }, checkStylesEpic);
+        ReactDOM.render(<Plugin items={[STYLE_EDITOR_ITEM]} />, document.getElementById("container"));
+        const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
+        expect(tabIndexes[2].className).toBe("active");
+    });
+    it('style panel with thematic layer', done => {
+        mockAxios.onGet().reply(() => {
+            return [200, CAPABILITIES];
+        });
+        const checkStylesEpic = action$ => action$
+            .map(() => {
+                done();
+            });
+        const { Plugin } = getPluginForTest(TOCItemsSettingsPlugin, STYLE_PANEL_STATE, { ThematicLayerPlugin: ThematicLayer }, checkStylesEpic);
+        ReactDOM.render(<Plugin items={[THEMATIC_LAYER_ITEM]} />, document.getElementById("container"));
+        const tabIndexes = document.querySelectorAll(TAB_INDEX_SELECTOR);
+        expect(tabIndexes[2].className).toBe("active");
+    });
+
+
+});

--- a/web/client/plugins/styleeditor/index.js
+++ b/web/client/plugins/styleeditor/index.js
@@ -238,7 +238,8 @@ const ReadOnlyStyleList = compose(
                 this.props.onInit(this.props.layer);
             }
         }
-    })
+    }),
+    loadingEnhancers(({ layer = {} }) => layer && layer.capabilitiesLoading)
 )(
     () =>
         <BorderLayout className="ms-style-editor-container" footer={<div style={{ height: 25 }} />}>

--- a/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
+++ b/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import defaultSettingsTabs, { getStyleTabPlugin } from '../defaultSettingsTabs';
+
+const BASE_STYLE_TEST_DATA = {
+    settings: {},
+    items: [],
+    loadedPlugins: {}
+};
+
+
+describe('TOCItemsSettings - getStyleTabPlugin', () => {
+    it('getStyleTabPlugin', () => {
+        const DEFAULT_TEST_PARAMS = {
+            ...BASE_STYLE_TEST_DATA
+        };
+        expect(getStyleTabPlugin(DEFAULT_TEST_PARAMS)).toEqual({});
+    });
+    it('defaultSettingsTabs', () => {
+        {
+            const items = defaultSettingsTabs(BASE_STYLE_TEST_DATA);
+            expect(items.length).toBe(1);
+            expect(items[0].id).toBe('general');
+        }
+        {
+            const items = defaultSettingsTabs(BASE_STYLE_TEST_DATA);
+            expect(items.length).toBe(1);
+        }
+    });
+});

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -165,11 +165,12 @@ export const getStyleTabPlugin = ({ settings, items = [], loadedPlugins, onToggl
     }
 
     const item = head(candidatePluginItems);
-    // StyleEditor
+    // StyleEditor case TODO: externalize `onClose` trigger (delegating action dispatch) and components creation to make the two plugins independent
     if (item && item.plugin) {
         return {
+            // This is connected on TOCItemsSettings close, not on StyleEditor unmount
+            // to prevent re-initialization on each tab switch.
             onClose: () => onToggleStyleEditor(null, false),
-            onClick: () => onToggleStyleEditor(null, true),
             Component: getConfiguredPlugin({ ...item, cfg: { ...item.plugin.cfg, active: true } }, loadedPlugins, <LoadingView width={100} height={100} />),
             toolbarComponent: item.ToolbarComponent
                 && (

--- a/web/client/utils/URLUtils.js
+++ b/web/client/utils/URLUtils.js
@@ -18,6 +18,7 @@ export const urlParts = (url) => {
         let location = window.location;
         urlPartsArray[1] = location.protocol;
         urlPartsArray[3] = location.hostname;
+        urlPartsArray[4] = location.port;
         urlPartsArray[5] = url;
 
     }

--- a/web/client/utils/__tests__/URLUtils-test.js
+++ b/web/client/utils/__tests__/URLUtils-test.js
@@ -11,7 +11,7 @@ const { urlParts, isSameUrl, sameQueryParams, isValidURL } = require('../URLUtil
 const url1 = "https://demo.geo-solutions.it:443/geoserver/wfs";
 const url2 = "https://demo.geo-solutions.it/geoserver/wfs";
 const url3 = "/geoserver/wfs";
-const url4 = "http://localhost/geoserver/wfs";
+const url4 = (location && location.origin || "FAIL") + "/geoserver/wfs";
 const urlPartsResult1 = {
     protocol: "https:",
     domain: "demo.geo-solutions.it",


### PR DESCRIPTION
## Description
This PR allows to plug/unplug style editor using user extensions.
It allows also to keep ThematicLayers plugin compatible and pluggable too (it has priority over style editor at the moment, if present. If we want to make the 2 tools alternative, we need to restructure the UI).

To test locally thematicLayers pluggability, use this context http://localhost:8081/#/context-creator/21352 I created it by adding to pluginsConfig thematic plugin and using GUI to add it as user extension, together with Style editor. Thematic maps doesn't work at all, because the SLD service is missing, but it will plug and unplug correctly.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)

 - [x] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4865 the style editor couldn't be used as user extension

**What is the new behavior?**
Now the style editor plugs and unplugs using user extensions

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**For DEVs/Reviewer**
This PR doesn't solve at all TOCItemsSettings pluggability problems (we should work a little bit more for this) but externalize some of the behaviours. 