### PR TITLE
Fix 4906 Errors not handled for resources

### DIFF
--- a/web/client/components/resources/modals/fragments/ErrorBox.jsx
+++ b/web/client/components/resources/modals/fragments/ErrorBox.jsx
@@ -7,7 +7,11 @@
  */
 
 const React = require('react');
-const DEFAULT_MESSAGES = { "FORMAT": "map.errorFormat", "SIZE": "map.errorSize", 409: "dashboard.errors.resourceAlreadyExists"};
+const DEFAULT_MESSAGES = {
+    "FORMAT": "map.errorFormat",
+    "SIZE": "map.errorSize",
+    409: "dashboard.errors.resourceAlreadyExists"
+};
 
 const Message = require('../../../I18N/Message');
 const { Row } = require('react-bootstrap');

--- a/web/client/components/resources/modals/fragments/ErrorBox.jsx
+++ b/web/client/components/resources/modals/fragments/ErrorBox.jsx
@@ -10,7 +10,9 @@ const React = require('react');
 const DEFAULT_MESSAGES = {
     "FORMAT": "map.errorFormat",
     "SIZE": "map.errorSize",
-    409: "dashboard.errors.resourceAlreadyExists"
+    409: "dashboard.errors.resourceAlreadyExists",
+    403: "dashboard.errors.forbidden",
+    405: "dashboard.errors.forbidden405"
 };
 
 const Message = require('../../../I18N/Message');

--- a/web/client/components/resources/modals/fragments/__tests__/ErrorBox-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/ErrorBox-test.jsx
@@ -1,0 +1,87 @@
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ErrorBox from '../ErrorBox';
+
+describe("ErrorBox component", () => {
+    const getContainerDiv = () => document.getElementById("container");
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(getContainerDiv());
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('creates component with defaults', () => {
+        ReactDOM.render(<ErrorBox />, getContainerDiv());
+        expect(document.querySelector(".dropzone-errorBox")).toNotExist();
+
+    });
+
+    it('test 403 Error', () => {
+        const errors = [{
+            status: 403,
+            statusText: "Forbidden"
+        }];
+        ReactDOM.render(<ErrorBox errors={errors}/>, getContainerDiv());
+
+        const ErrorSpan = document.querySelector(".errorForbidden");
+        expect(ErrorSpan).toExist();
+        expect(ErrorSpan.innerHTML).toContain("<span>dashboard.errors.forbidden</span>");
+    });
+    it('test 405 Error', () => {
+        const errors = [{
+            status: 405,
+            statusText: "Forbidden"
+        }];
+        ReactDOM.render(<ErrorBox errors={errors}/>, getContainerDiv());
+        const ErrorSpan = document.querySelector(`.error${errors[0].statusText}`);
+        expect(ErrorSpan).toExist();
+        expect(ErrorSpan.innerHTML).toBe("<span>dashboard.errors.forbidden405</span>");
+    });
+    it('test 409 Error', () => {
+        const errors = [{
+            status: 409,
+            statusText: "Forbidden"
+        }];
+        ReactDOM.render(<ErrorBox errors={errors}/>, getContainerDiv());
+        const ErrorSpan = document.querySelector(`.error${errors[0].statusText}`);
+        expect(ErrorSpan).toExist();
+        expect(ErrorSpan.innerHTML).toBe("<span>dashboard.errors.resourceAlreadyExists</span>");
+    });
+    it('test FORMAT Error', () => {
+        const errors = [{
+            status: "FORMAT",
+            statusText: "error"
+        }];
+        ReactDOM.render(<ErrorBox errors={errors}/>, getContainerDiv());
+        const ErrorSpan = document.querySelector(`.error${errors[0].statusText}`);
+        expect(ErrorSpan).toExist();
+        expect(ErrorSpan.innerHTML).toBe(`<span>map.errorFormat</span>`);
+    });
+    it('test SIZE Error', () => {
+        const errors = [{
+            status: "SIZE",
+            statusText: "error"
+        }];
+        ReactDOM.render(<ErrorBox errors={errors}/>, getContainerDiv());
+        const ErrorSpan = document.querySelector(`.error${errors[0].statusText}`);
+        expect(ErrorSpan).toExist();
+        expect(ErrorSpan.innerHTML).toBe(`<span>map.errorSize</span>`);
+    });
+    it('test 404 Error, not handled', () => {
+        const errors = [{
+            status: 404,
+            statusText: "ForbiddenMethod"
+        }];
+        // this will not track the lack for statusText that could be missing in locale.messages
+        ReactDOM.render(<ErrorBox errors={errors}/>, getContainerDiv());
+        const ErrorSpan = document.querySelector(`.error${errors[0].statusText}`);
+        expect(ErrorSpan).toExist();
+        expect(ErrorSpan.innerHTML).toBe(`<span>${errors[0].statusText}</span>`);
+    });
+
+});

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -27,6 +27,7 @@
         "showMore": "Zeig mehr...",
         "collapse": "Kollabiert",
         "expand": "Erweitern",
+        "Forbidden": "Verboten",
         "version": {
             "label": "Version"
         },

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1627,7 +1627,9 @@
                     "notFound": "Dashboard nicht gefunden",
                     "notAccessible": "Dashboard nicht zugänglich"
                 },
-                "resourceAlreadyExists": "Eine Ressource mit diesem Namen existiert bereits"
+                "resourceAlreadyExists": "Eine Ressource mit diesem Namen existiert bereits",
+                "forbidden": "Ein unerwarteter Fehler ist aufgetreten (403 Verboten). Bitte wenden Sie sich an den Administrator",
+                "forbidden405": "Ein unerwarteter Fehler ist aufgetreten (405 Verboten). Bitte wenden Sie sich an den Administrator"
             },
             "editor": {
                 "save": "Speichern Sie das Dashboard",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -27,6 +27,7 @@
         "showMore": "Show more...",
         "collapse": "Collapse",
         "expand": "Expand",
+        "Forbidden": "Forbidden",
         "version": {
             "label": "Version"
         },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1628,7 +1628,9 @@
                     "notFound": "Dashboard not found",
 	                "notAccessible": "Dashboard not accessible"
                 },
-                "resourceAlreadyExists": "A resource with this name already exists"
+                "resourceAlreadyExists": "A resource with this name already exists",
+                "forbidden": "An unexpected error occured (403 Forbidden). Please contact the Administrator",
+                "forbidden405": "An unexpected error occured (405 Forbidden). Please contact the Administrator"
             },
             "editor": {
                 "save": "Save the dashboard",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -27,6 +27,7 @@
         "showMore": "Mostrar más...",
         "collapse": "Colapso",
         "expand": "Expandir",
+        "Forbidden": "Prohibido",
         "version": {
             "label": "Versión"
         },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1627,7 +1627,9 @@
                     "notFound": "Panel de control no encontrado",
                     "notAccessible": "Panel de control no accesible"
                 },
-                "resourceAlreadyExists":  "Ya existe un recurso con este nombre"
+                "resourceAlreadyExists":  "Ya existe un recurso con este nombre",
+                "forbidden": "Ocurrió un error inesperado (403 Prohibido). Por favor contacte al administrador",
+                "forbidden405": "Ocurrió un error inesperado (405 Prohibido). Por favor contacte al administrador"
             },
             "editor": {
                 "save": "Guardar el panel de control",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1627,7 +1627,9 @@
                     "notFound": "Tableau de bord introuvable",
                     "notAccessible": "Tableau de bord non accessible"
                 },
-                "resourceAlreadyExists": "Une ressource avec ce nom existe déjà"
+                "resourceAlreadyExists": "Une ressource avec ce nom existe déjà",
+                "forbidden": "Une erreur inattendue s'est produite (403 interdit). Veuillez contacter l'administrateur",
+                "forbidden405": "Une erreur inattendue s'est produite (405 interdit). Veuillez contacter l'administrateur"
             },
             "editor": {
                 "save": "Sauvegarder le tableau de bord",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -27,6 +27,7 @@
         "showMore": "Montrer plus...",
         "collapse": "réduire",
         "expand": "étendre",
+        "Forbidden": "Interdit",
         "version": {
             "label": "Version"
         },

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -1617,7 +1617,9 @@
                     "notFound": "Kontrolna ploča nije pronađena",
                     "notAccessible": "Kontrolna ploča nije dostupna"
                 },
-                "resourceAlreadyExists": "Resurs sa ovim imenom već postoji"
+                "resourceAlreadyExists": "Resurs sa ovim imenom već postoji",
+                "forbidden": "An unexpected error occured (403 Forbidden). Please contact the Administrator",
+                "forbidden405": "An unexpected error occured (405 Forbidden). Please contact the Administrator"
             },
             "editor": {
                 "save": "Spremi kontrolnu ploču",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1627,7 +1627,9 @@
                     "notFound": "Dashboard non trovata",
                     "notAccessible": "Dashboard non accessibile"
                 },
-                "resourceAlreadyExists": "Una risorsa con questo nome esiste già"
+                "resourceAlreadyExists": "Una risorsa con questo nome esiste già",
+                "forbidden": "Si è verificato un errore imprevisto (403 vietato). Si prega di contattare l'amministratore",
+                "forbidden405": "Si è verificato un errore imprevisto (405 vietato). Si prega di contattare l'amministratore"
             },
             "editor": {
                 "save": "Salva la dashboard",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -27,6 +27,7 @@
         "showMore": "Mostra altri...",
         "collapse": "Collassa",
         "expand": "Espandi",
+        "Forbidden": "Vietato",
         "version": {
             "label": "Versione"
         },

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -27,6 +27,7 @@
         "showMore": "Show more...",
         "collapse": "Collapse",
         "expand": "Expand",
+        "Forbidden": "Forbidden",
         "version": {
             "label": "Versie"
         },

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1433,7 +1433,9 @@
                     "notFound": "Dashboard not found",
 	                "notAccessible": "Dashboard not accessible"
                 },
-                "resourceAlreadyExists": "A resource with this name already exists"
+                "resourceAlreadyExists": "A resource with this name already exists",
+                "forbidden": "An unexpected error occured (403 Forbidden). Please contact the Administrator",
+                "forbidden405": "An unexpected error occured (405 Forbidden). Please contact the Administrator"
             },
             "editor": {
                 "save": "Save the dashboard",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -27,6 +27,7 @@
         "showMore": "Mostrar mais...",
         "collapse": "Collapse",
         "expand": "Expand",
+        "Forbidden": "Forbidden",
         "version": {
             "label": "Versão"
         },

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -1583,7 +1583,9 @@
                     "notFound": "Dashboard not found",
 	                "notAccessible": "Dashboard not accessible"
                 },
-                "resourceAlreadyExists": "A resource with this name already exists"
+                "resourceAlreadyExists": "A resource with this name already exists",
+                "forbidden": "An unexpected error occured (403 Forbidden). Please contact the Administrator",
+                "forbidden405": "An unexpected error occured (405 Forbidden). Please contact the Administrator"
             },
             "editor": {
                 "save": "Save the dashboard",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -20,6 +20,7 @@
             "addbtn": "Thêm vào",
             "groupName": "Tên nhóm"
         },
+        "Forbidden": "Forbidden",
         "annotations": {
             "add": "Mới",
             "addMarker": "Thêm một hình mới",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -218,7 +218,9 @@
                     "title": "Lỗi tải bảng điều khiển",
                     "unknownError": "Có lỗi khi tải bảng điều khiển. Vui lòng liên hệ với quản trị viên"
                 },
-                "resourceAlreadyExists": "Một tài nguyên với tên này đã tồn tại"
+                "resourceAlreadyExists": "Một tài nguyên với tên này đã tồn tại",
+                "forbidden": "An unexpected error occured (403 Forbidden). Please contact the Administrator",
+                "forbidden405": "An unexpected error occured (405 Forbidden). Please contact the Administrator"
             },
             "loadingSpinner": "Đang tải Bảng điều khiển",
             "saveDialog": {

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -1557,7 +1557,9 @@
                     "notFound": "Dashboard not found",
 	                "notAccessible": "Dashboard not accessible"
                 },
-                "resourceAlreadyExists": "A resource with this name already exists"
+                "resourceAlreadyExists": "A resource with this name already exists",
+                "forbidden": "An unexpected error occured (403 Forbidden). Please contact the Administrator",
+                "forbidden405": "An unexpected error occured (405 Forbidden). Please contact the Administrator"
             },
             "editor": {
                 "save": "Save the dashboard",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -27,6 +27,7 @@
         "showMore": "Show more...",
         "collapse": "Collapse",
         "expand": "Expand",
+        "Forbidden": "Forbidden",
         "version": {
             "label": "版本"
         },


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixing the problem of errors not handled in resource edit panel 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4096

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now the app should not crash if a method is not handled by the error box in case statusText is Fordbidden.

Ans in case the errors are handled a proper message will appear at the top of the resource edit panel

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
