### PR TITLE
4902 application context templates style review

### DIFF
--- a/web/client/components/contextcreator/ConfigureMapTemplates.jsx
+++ b/web/client/components/contextcreator/ConfigureMapTemplates.jsx
@@ -179,6 +179,7 @@ export default ({
             fileDropStatus={fileDropStatus}
             fileDropLabel="contextCreator.configureTemplates.fileDrop.label"
             fileDropClearMessage={<Message msgId="contextCreator.configureTemplates.fileDrop.clear"/>}
+            dialogClassName=" modal-higher"
             onFileDrop={onTemplateDrop.bind(null, setParsedTemplate, setFileDropStatus)}
             onFileDropClear={() => {
                 setParsedTemplate();

--- a/web/client/components/misc/ResizableModal.jsx
+++ b/web/client/components/misc/ResizableModal.jsx
@@ -57,6 +57,7 @@ const fullscreen = {
  * @prop {string} bodyClassName custom class for modal body.
  * @prop {bool} draggable enable modal drag.
  * @prop {bool} fitContent try to fit content if modal height is less than maximum size
+ * @prop {string} dialogClassName custom class for the dialog component
  */
 
 const ResizableModal = ({
@@ -78,7 +79,8 @@ const ResizableModal = ({
     onFullscreen,
     fade = false,
     fitContent,
-    modalClassName = ''
+    modalClassName = '',
+    dialogClassName = ''
 }) => {
     const sizeClassName = sizes[size] || '';
     const fullscreenClassName = showFullscreen && fullscreenState === 'expanded' && fullscreen.className[fullscreenType] || '';
@@ -91,7 +93,7 @@ const ResizableModal = ({
                 containerClassName="ms-resizable-modal"
                 draggable={draggable}
                 modal
-                className={'modal-dialog modal-content' + sizeClassName + fullscreenClassName + (fitContent ? ' ms-fit-content' : '')}>
+                className={'modal-dialog modal-content' + sizeClassName + fullscreenClassName + dialogClassName + (fitContent ? ' ms-fit-content' : '')}>
                 <span role="header">
                     <h4 className="modal-title">
                         <div className="ms-title">{title}</div>

--- a/web/client/components/notifications/NotificationContainer.jsx
+++ b/web/client/components/notifications/NotificationContainer.jsx
@@ -11,6 +11,7 @@ const PropTypes = require('prop-types');
 const {injectIntl, intlShape, defineMessages} = require('react-intl');
 
 var LocaleUtils = require('../../utils/LocaleUtils');
+const Portal = require('../misc/Portal');
 
 /**
  * Container for Notifications. Allows to display notifications by passing
@@ -64,7 +65,7 @@ class NotificationContainer extends React.Component {
 
     render() {
         const {notifications, onRemove, ...rest} = this.props;
-        return (<NotificationSystem ref="notify" { ...rest } />);
+        return (<Portal><NotificationSystem ref="notify" { ...rest } /></Portal>);
     }
 
     system = () => {

--- a/web/client/components/resources/modals/Save.jsx
+++ b/web/client/components/resources/modals/Save.jsx
@@ -78,7 +78,8 @@ class SaveModal extends React.Component {
         metadataChanged: PropTypes.func,
         availablePermissions: PropTypes.arrayOf(PropTypes.string),
         availableGroups: PropTypes.arrayOf(PropTypes.object),
-        user: PropTypes.object
+        user: PropTypes.object,
+        dialogClassName: PropTypes.string
     };
 
     static contextTypes = {
@@ -107,7 +108,8 @@ class SaveModal extends React.Component {
         availablePermissions: ["canRead", "canWrite"],
         availableGroups: [],
         canSave: true,
-        user: {}
+        user: {},
+        dialogClassName: ''
     };
     onCloseMapPropertiesModal = () => {
         this.props.onClose();
@@ -130,6 +132,7 @@ class SaveModal extends React.Component {
                 show={this.props.show}
                 clickOutEnabled={this.props.clickOutEnabled}
                 bodyClassName="ms-flex modal-properties-container"
+                dialogClassName={this.props.dialogClassName}
                 buttons={[{
                     text: <Message msgId="close"/>,
                     onClick: this.onCloseMapPropertiesModal,

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -43,6 +43,11 @@
         border: none;
         .shadow;
 
+        &.modal-higher {
+            height: 80%;
+            top: 10%;
+        }
+
         &.ms-xs {
             height: 30%;
             top: 35%;

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2317,7 +2317,7 @@
                 "pluginsFilterPlaceholder": "Plugins nach Namen filtern...",
                 "availablePlugins": "Verfügbare Plugins",
                 "enabledPlugins": "Aktivierte Plugins",
-                "availablePluginsEmpty": "Aktiviert alle verfügbaren Plugins",
+                "availablePluginsEmpty": "Alle verfügbaren Plugins sind aktiviert",
                 "enabledPluginsEmpty": "Fügen Sie der Konfiguration Plugins aus der Liste der verfügbaren Plugins hinzu",
                 "searchResultsEmpty": "Es wurden keine Plugins gefunden, die den Suchkriterien entsprechen",
                 "cfgParsingError": {
@@ -2345,8 +2345,8 @@
                 "title": "Vorlagen konfigurieren",
                 "availableTemplates": "Verfügbare Vorlagen",
                 "enabledTemplates": "Aktivierte Vorlagen",
-                "templatesFilterPlaceholder": "Vorlagen filtern",
-                "availableTemplatesEmpty": "Aktiviert alle verfügbaren Vorlagen",
+                "templatesFilterPlaceholder": "Vorlagen nach Namen filtern...",
+                "availableTemplatesEmpty": "Alle verfügbaren Vorlagen sind aktiviert",
                 "enabledTemplatesEmpty": "Fügen Sie der Konfiguration Vorlagen aus der Liste der verfügbaren Vorlagen hinzu",
                 "searchResultsEmpty": "Es wurden keine Vorlagen gefunden, die den Suchkriterien entsprechen",
                 "fileDrop": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2321,7 +2321,7 @@
                 "pluginsFilterPlaceholder": "Filter plugins by name...",
                 "availablePlugins": "Available Plugins",
                 "enabledPlugins": "Enabled Plugins",
-                "availablePluginsEmpty": "Enabled all available plugins",
+                "availablePluginsEmpty": "All available plugins are enabled",
                 "enabledPluginsEmpty": "Add plugins to configuration from list of available plugins",
                 "searchResultsEmpty": "No plugins found that satisfy the search criteria",
                 "cfgParsingError": {
@@ -2349,8 +2349,8 @@
                 "title": "Configure Templates",
                 "availableTemplates": "Available Templates",
                 "enabledTemplates": "Enabled Templates",
-                "templatesFilterPlaceholder": "Filter templates...",
-                "availableTemplatesEmpty": "Enabled all available templates",
+                "templatesFilterPlaceholder": "Filter templates by name...",
+                "availableTemplatesEmpty": "All available templates are enabled",
                 "enabledTemplatesEmpty": "Add templates to configuration from list of available templates",
                 "searchResultsEmpty": "No templates found that satisfy the search criteria",
                 "fileDrop": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2317,7 +2317,7 @@
                 "pluginsFilterPlaceholder": "Filtrar complementos por nombre...",
                 "availablePlugins": "Complementos disponibles",
                 "enabledPlugins": "Complementos habilitados",
-                "availablePluginsEmpty": "Habilitado todos los complementos disponibles",
+                "availablePluginsEmpty": "Todos los complementos disponibles están habilitados",
                 "enabledPluginsEmpty": "Agregue complementos a la configuración desde la lista de complementos disponibles",
                 "searchResultsEmpty": "No se encontraron complementos que satisfagan los criterios de búsqueda.",
                 "cfgParsingError": {
@@ -2345,8 +2345,8 @@
                 "title": "Configurar plantillas",
                 "availableTemplates": "Plantillas Disponibles",
                 "enabledTemplates": "Plantillas habilitadas",
-                "templatesFilterPlaceholder": "Filtrar plantillas",
-                "availableTemplatesEmpty": "Habilitado todas las plantillas disponibles.",
+                "templatesFilterPlaceholder": "Filtrar plantillas por nombre...",
+                "availableTemplatesEmpty": "Todas las plantillas disponibles están habilitadas",
                 "enabledTemplatesEmpty": "Agregar plantillas a la configuración de la lista de plantillas disponibles",
                 "searchResultsEmpty": "No se encontraron plantillas que satisfagan los criterios de búsqueda.",
                 "fileDrop": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2317,7 +2317,7 @@
                 "pluginsFilterPlaceholder": "Filtrer les plugins par nom...",
                 "availablePlugins": "Plugins disponibles",
                 "enabledPlugins": "Plugins activés",
-                "availablePluginsEmpty": "Activé tous les plugins disponibles",
+                "availablePluginsEmpty": "Tous les plugins disponibles sont activés",
                 "enabledPluginsEmpty": "Ajouter des plugins à la configuration à partir de la liste des plugins disponibles",
                 "searchResultsEmpty": "Aucun plugin trouvé répondant aux critères de recherche",
                 "cfgParsingError": {
@@ -2345,8 +2345,8 @@
                 "title": "Configurer le modèles",
                 "availableTemplates": "Modèles disponibles",
                 "enabledTemplates": "Modèles activés",
-                "templatesFilterPlaceholder": "Modèles de filtres",
-                "availableTemplatesEmpty": "Activé tous les modèles disponibles",
+                "templatesFilterPlaceholder": "Filtrer les modèles par nom...",
+                "availableTemplatesEmpty": "Tous les modèles disponibles sont activés",
                 "enabledTemplatesEmpty": "Ajouter des modèles à la configuration à partir de la liste des modèles disponibles",
                 "searchResultsEmpty": "Aucun modèle trouvé répondant aux critères de recherche",
                 "fileDrop": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2318,7 +2318,7 @@
                 "pluginsFilterPlaceholder": "Filtra plug-in per nome...",
                 "availablePlugins": "Plugin disponibili",
                 "enabledPlugins": "Plugin abilitati",
-                "availablePluginsEmpty": "Abilitato tutti i plugin disponibili",
+                "availablePluginsEmpty": "Tutti i plugin disponibili sono abilitati",
                 "enabledPluginsEmpty": "Aggiungi plug-in alla configurazione dall'elenco dei plug-in disponibili",
                 "searchResultsEmpty": "Nessun plugin trovato che soddisfa i criteri di ricerca",
                 "cfgParsingError": {
@@ -2348,8 +2348,8 @@
                 "title": "Configura modelli",
                 "availableTemplates": "Modelli disponibili",
                 "enabledTemplates": "Modelli abilitati",
-                "templatesFilterPlaceholder": "Modelli di filtro...",
-                "availableTemplatesEmpty": "Abilitato tutti i modelli disponibili",
+                "templatesFilterPlaceholder": "Filtra i modelli per nome...",
+                "availableTemplatesEmpty": "Tutti i modelli disponibili sono abilitati",
                 "enabledTemplatesEmpty": "Aggiungi modelli alla configurazione dall'elenco dei modelli disponibili",
                 "searchResultsEmpty": "Nessun modello trovato che soddisfa i criteri di ricerca",
                 "fileDrop": {


### PR DESCRIPTION
## Description
Application Context Templates style review

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/issues/4902

**What is the new behavior?**
Translations are updated.
The modal window size is changed.
The problem related to the modal window and notification in the background is fixed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
I decided to changes the logic for the SaveModal component to solve the problem related to the modal window and notification. The problem is when we have one modal opened and we open another one (which uses the Portal component for rendering) z-index doesn't work properly. 