### PR TITLE
#4899: allow injection of custom sections into saved maps

### DIFF
--- a/web/client/selectors/__tests__/mapsave-test.js
+++ b/web/client/selectors/__tests__/mapsave-test.js
@@ -8,10 +8,14 @@
 
 const expect = require('expect');
 const {
-    mapOptionsToSaveSelector
+    mapOptionsToSaveSelector,
+    registerCustomSaveHandler
 } = require("../mapsave");
 
 const state = {
+    custom: {
+        someProperty: "some value"
+    },
     widgets: {
         containers: {
             floating: {
@@ -28,11 +32,21 @@ const state = {
     }
 };
 describe('Test mapsave selectors', () => {
+    afterEach(() => {
+        registerCustomSaveHandler('custom', null);
+    });
     it('check widgets state is correctly selected', () => {
         const retVal = mapOptionsToSaveSelector(state);
         expect(retVal.widgetsConfig).toExist();
         expect(retVal.widgetsConfig.widgets).toBe(state.widgets.containers.floating.widgets);
         expect(retVal.widgetsConfig.layouts).toBe(state.widgets.containers.floating.layouts);
         expect(retVal.widgetsConfig.collapsed).toBe(state.widgets.containers.floating.collapsed);
+    });
+
+    it('check custom save handlers', () => {
+        registerCustomSaveHandler('custom', (s) => s.custom);
+        const retVal = mapOptionsToSaveSelector(state);
+        expect(retVal.custom).toExist();
+        expect(retVal.custom.someProperty).toBe("some value");
     });
 });

--- a/web/client/selectors/mapsave.js
+++ b/web/client/selectors/mapsave.js
@@ -11,8 +11,17 @@ const {servicesSelector, selectedServiceSelector} = require('./catalog');
 const {getFloatingWidgets, getCollapsedState, getFloatingWidgetsLayout} = require('./widgets');
 const { mapInfoConfigurationSelector } = require('./mapInfo');
 
+const customSaveHandlers = {};
 
-const mapOptionsToSaveSelector = createStructuredSelector({
+const registerCustomSaveHandler = (section, handler) => {
+    if (handler) {
+        customSaveHandlers[section] = handler;
+    } else {
+        delete customSaveHandlers[section];
+    }
+};
+
+const basicMapOptionsToSaveSelector = createStructuredSelector({
     catalogServices: createStructuredSelector({
         services: servicesSelector,
         selectedService: selectedServiceSelector
@@ -24,4 +33,15 @@ const mapOptionsToSaveSelector = createStructuredSelector({
     }),
     mapInfoConfiguration: mapInfoConfigurationSelector
 });
-module.exports = {mapOptionsToSaveSelector};
+
+const mapOptionsToSaveSelector = (state) => {
+    const customState = Object.keys(customSaveHandlers).reduce((acc, fragment) => {
+        return {
+            ...acc,
+            [fragment]: customSaveHandlers[fragment](state)
+        };
+    }, {});
+    return { ...basicMapOptionsToSaveSelector(state), ...customState};
+};
+
+module.exports = {mapOptionsToSaveSelector, registerCustomSaveHandler};


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This one allows inject custom save handlers that add custom sections to each saved map, so that a custom project can save its own information.

Needed by https://github.com/geosolutions-it/webmapper-halliburton/issues/1081

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4899


