### PR TITLE
#4921, #4922: WMS and WMTS issues with mapproxy servers

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -73,7 +73,7 @@ const sampleTileMatrixConfig900913 = {
                     "MatrixHeight": "1",
                     "MatrixWidth": "1",
                     "ScaleDenominator": "5.590822639508929E8",
-                    "TileHeight": "256",
+                    "TileHeight": "512",
                     "TileWidth": "256",
                     "TopLeftCorner": "-2.003750834E7 2.0037508E7",
                     "ows:Identifier": "EPSG:900913:0"
@@ -82,7 +82,7 @@ const sampleTileMatrixConfig900913 = {
                     "MatrixHeight": "2",
                     "MatrixWidth": "2",
                     "ScaleDenominator": "2.7954113197544646E8",
-                    "TileHeight": "256",
+                    "TileHeight": "512",
                     "TileWidth": "256",
                     "TopLeftCorner": "-2.003750834E7 2.0037508E7",
                     "ows:Identifier": "EPSG:900913:1"
@@ -91,7 +91,7 @@ const sampleTileMatrixConfig900913 = {
                     "MatrixHeight": "4",
                     "MatrixWidth": "4",
                     "ScaleDenominator": "1.3977056598772323E8",
-                    "TileHeight": "256",
+                    "TileHeight": "512",
                     "TileWidth": "256",
                     "TopLeftCorner": "-2.003750834E7 2.0037508E7",
                     "ows:Identifier": "EPSG:900913:2"
@@ -524,6 +524,30 @@ describe('Openlayers layer', () => {
         expect(map.getLayers().item(0).getSource().getUrl()).toExist();
         expect(map.getLayers().item(0).getSource().getAttributions()).toNotExist();
     });
+    it('single tile wms layer for openlayers map sends tiled=false', (done) => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "singleTile": true,
+            "url": "http://sample.server/geoserver/wms"
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        const loadFun = (image, src) => {
+            const tiled = src.match(/TILED=([^&]+)/i)[1];
+            expect(tiled.toLowerCase()).toBe("false");
+            done();
+        };
+        map.getLayers().item(0).getSource().setImageLoadFunction(loadFun);
+        map.getLayers().item(0).getSource().refresh();
+    });
     it('creates a single tile credits', () => {
         var options = {
             "type": "wms",
@@ -670,6 +694,38 @@ describe('Openlayers layer', () => {
         const wmtsLayer = map.getLayers().item(0);
         const expectedResolutions = sampleTileMatrixConfig900913.tileMatrixSet[0].TileMatrix.map( e => e.ScaleDenominator * 0.28E-3);
         wmtsLayer.getSource().getTileGrid().getResolutions().map((v, i) => expect(v).toBe(expectedResolutions[i]));
+    });
+    it('test wmts sizes and tile sizes', () => {
+        var options = {
+            "type": "wmts",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            ...sampleTileMatrixConfig900913,
+            "url": "http://sample.server/geoserver/gwc/service/wmts"
+        };
+        // create layers
+        const layer = ReactDOM.render(
+            <OpenlayersLayer type="wmts"
+                options={options} map={map} />, document.getElementById("container"));
+
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+
+        const wmtsLayer = map.getLayers().item(0);
+        expect(wmtsLayer.getSource().getTileGrid().getTileSize(1)[0]).toBe(256);
+        expect(wmtsLayer.getSource().getTileGrid().getTileSize(1)[1]).toBe(512);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(1).minX).toBe(0);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(1).maxX).toBe(1);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(1).minY).toBe(0);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(1).maxY).toBe(1);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(2).minX).toBe(0);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(2).maxX).toBe(3);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(2).minY).toBe(0);
+        expect(wmtsLayer.getSource().getTileGrid().getFullTileRange(2).maxY).toBe(3);
     });
     it('test fix for OL draw image (remove when OL > 5.3.0) ', () => {
         // see https://github.com/openlayers/openlayers/issues/8700
@@ -1562,6 +1618,38 @@ describe('Openlayers layer', () => {
 
         expect(spyRefresh).toHaveBeenCalled();
         expect(layer.layer.getSource().getParams().time).toBe("2019-01-01T00:00:00Z");
+    });
+    it('wms empty params not removed on update', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "opacity": 1.0,
+            "url": "http://sample.server/geoserver/wms",
+            "params": {
+                "cql_filter": "INCLUDE"
+            }
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+
+        expect(layer.layer.getSource()).toExist();
+        expect(layer.layer.getSource().getParams()).toExist();
+        expect(layer.layer.getSource().getParams().STYLES).toBe("");
+
+        layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={assign({}, options, { format: "image/jpeg" })} map={map} />, document.getElementById("container"));
+
+        expect(layer.layer.getSource().getParams().STYLES).toBe("");
     });
     it('test wms security token on SLD param', () => {
         const options = {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -52,7 +52,7 @@ function wmsToOpenlayersOptions(options) {
         TRANSPARENT: options.transparent !== undefined ? options.transparent : true,
         SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
-        TILED: !isNil(options.tiled) ? options.tiled : true,
+        TILED: options.singleTile ? false : (!isNil(options.tiled) ? options.tiled : true),
         VERSION: options.version || "1.3.0"
     }, assign(
         {},
@@ -303,7 +303,7 @@ Layers.registerType('wms', {
                 const params = assign(newParams, SecurityUtils.addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
 
                 wmsSource.updateParams(assign(params, Object.keys(oldParams || {}).reduce((previous, key) => {
-                    return params[key] ? previous : assign(previous, {
+                    return !isNil(params[key]) ? previous : assign(previous, {
                         [key]: undefined
                     });
                 }, {})));

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -19,8 +19,7 @@ import MapUtils from '../../../../utils/MapUtils';
 import { isVectorFormat} from '../../../../utils/VectorTileUtils';
 import urlParser from 'url';
 
-import {get, getTransform} from 'ol/proj';
-import {applyTransform} from 'ol/extent';
+import {get} from 'ol/proj';
 import TileLayer from 'ol/layer/Tile';
 import VectorTileLayer from 'ol/layer/VectorTile';
 import WMTS from 'ol/source/WMTS';
@@ -75,24 +74,23 @@ const createLayer = options => {
     * - wnu - westing, north-ing, up - some planetary coordinate systems have "west positive" coordinate systems
     */
     const switchOriginXY = projection.getAxisOrientation().substr(0, 2) === 'ne';
-    let origins = tileMatrixSet
+    const origins = tileMatrixSet
         && tileMatrixSet.TileMatrix
         && tileMatrixSet.TileMatrix
             .map(({ TopLeftCorner } = {}) => TopLeftCorner && CoordinatesUtils.parseString(TopLeftCorner))
             .map(({ x, y } = {}) => switchOriginXY ? [y, x] : [x, y]);
 
-    const bbox = options.bbox;
+    const sizes = tileMatrixSet
+        && tileMatrixSet.TileMatrix
+        && tileMatrixSet.TileMatrix
+            .map(({ MatrixWidth, MatrixHeight } = {}) => ([parseInt(MatrixWidth, 10), parseInt(MatrixHeight, 10)]));
 
-    const extent = bbox
-        ? applyTransform([
-            parseFloat(bbox.bounds.minx),
-            parseFloat(bbox.bounds.miny),
-            parseFloat(bbox.bounds.maxx),
-            parseFloat(bbox.bounds.maxy)
-        ], getTransform(bbox.crs, options.srs))
-        : null;
+    const tileSizes = tileMatrixSet
+        && tileMatrixSet.TileMatrix
+        && tileMatrixSet.TileMatrix
+            .map(({ TileWidth, TileHeight } = {}) => ([parseInt(TileWidth, 10), parseInt(TileHeight, 10)]));
 
-    let queryParameters = {};
+    const queryParameters = {};
     urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters, options.securityToken));
     const queryParametersString = urlParser.format({ query: { ...queryParameters } });
 
@@ -117,11 +115,12 @@ const createLayer = options => {
         tileGrid: new WMTSTileGrid({
             origins,
             origin: !origins ? [20037508.3428, -20037508.3428] : undefined, // Either origin or origins must be configured, never both.
-            // extent: extent,
             resolutions,
             matrixIds,
-            // TODO: matrixLimits from ranges
-            tileSize: options.tileSize || [TILE_SIZE, TILE_SIZE]
+            sizes,
+            extent: projection.getExtent(),
+            tileSizes,
+            tileSize: !tileSizes && (options.tileSize || [TILE_SIZE, TILE_SIZE])
         }),
         wrapX: true
     };
@@ -131,7 +130,6 @@ const createLayer = options => {
     const wmtsLayer = new Layer({
         opacity: options.opacity !== undefined ? options.opacity : 1,
         zIndex: options.zIndex,
-        extent: extent,
         maxResolution,
         visible: options.visibility !== false,
         source: isVector


### PR DESCRIPTION
## Description
Fixes and completes WMS and WMTS interactions with mapproxy services related to:
 * missing styles parameter after update
 * wrong TILED param in single tile mode
 * wrong extent for WMTS when reprojecting (solved using more TileMatrixSet info instead of extent to initialize the layers properly)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4921 #4922 
