### PR TITLE
issue 4924 - fix dashboard crash for boolean attributes

### DIFF
--- a/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
+++ b/web/client/components/data/featuregrid/formatters/__tests__/index-test.jsx
@@ -11,16 +11,16 @@ var expect = require('expect');
 describe('Tests for the formatter functions', () => {
     it('test getFormatter for strings', () => {
         const formatter = getFormatter({localType: "string"});
-        expect(formatter).toBe(undefined);
+        expect(formatter).toBe(null);
     });
     it('test getFormatter for booleans', () => {
         const formatter = getFormatter({localType: "boolean"});
         expect(typeof formatter).toBe("function");
-        expect(formatter()).toBe(undefined);
+        expect(formatter()).toBe(null);
         expect(formatter({value: true}).type).toBe("span");
         expect(formatter({value: true}).props.children).toBe("true");
         expect(formatter({value: false}).props.children).toBe("false");
-        expect(formatter({value: null})).toBe(undefined);
-        expect(formatter({value: undefined})).toBe(undefined);
+        expect(formatter({value: null})).toBe(null);
+        expect(formatter({value: undefined})).toBe(null);
     });
 });

--- a/web/client/components/data/featuregrid/formatters/index.js
+++ b/web/client/components/data/featuregrid/formatters/index.js
@@ -10,6 +10,6 @@ const {isNil} = require('lodash');
 
 module.exports = {
     getFormatter: (desc) => desc.localType === 'boolean' ?
-        ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : undefined :
-        undefined
+        ({value} = {}) => !isNil(value) ? <span>{value.toString()}</span> : null :
+        null
 };

--- a/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
+++ b/web/client/components/data/featuregrid/renderers/CellRenderer.jsx
@@ -13,6 +13,11 @@ class CellRenderer extends React.Component {
         isProperty: PropTypes.func,
         isValid: PropTypes.func
     };
+    static defaultProps = {
+        value: null,
+        rowData: {},
+        column: {}
+    }
     constructor(props) {
         super(props);
         this.setScrollLeft = (scrollBy) => this.refs.cell.setScrollLeft(scrollBy);

--- a/web/client/components/data/featuregrid/renderers/__tests__/CellRenderer-test.jsx
+++ b/web/client/components/data/featuregrid/renderers/__tests__/CellRenderer-test.jsx
@@ -47,7 +47,17 @@ describe('Tests <CellRenderer> component', () => {
             get: () => null
         }
     };
-
+    const CellRendererWithContext = compose(
+        withContext({
+            isProperty: () => null,
+            isModified: () => null,
+            isValid: () => null
+        },
+        () => ({
+            isProperty: () => true,
+            isModified: () => false,
+            isValid: () => true
+        })))(CellRenderer);
 
     it('should not crash when rendering <CellRenderer> with value=null, using boolean formatter', () => {
         /* Integration Test: CellRenderer & boolean formatter
@@ -57,50 +67,17 @@ describe('Tests <CellRenderer> component', () => {
          * that something must be returned. in particular the renderCellContent of
          * react-data-grid is returning the formatter value
         */
-        const CellRendererWithContext = compose(
-            withContext({
-                isProperty: () => null,
-                isModified: () => null,
-                isValid: () => null
-            },
-            () => ({
-                isProperty: () => true,
-                isModified: () => false,
-                isValid: () => true
-            })))(CellRenderer);
         const comp = ReactDOM.render(<CellRendererWithContext {...props} />, document.getElementById("container"));
         expect(comp).toExist();
     });
 
     it('should not crash when rendering <CellRenderer> with value=true, using boolean formatter', () => {
-        const CellRendererWithContext = compose(
-            withContext({
-                isProperty: () => null,
-                isModified: () => null,
-                isValid: () => null
-            },
-            () => ({
-                isProperty: () => true,
-                isModified: () => false,
-                isValid: () => true
-            })))(CellRenderer);
         const comp = ReactDOM.render(<CellRendererWithContext {...set("value", true, props)} />, document.getElementById("container"));
         expect(comp).toExist();
         expect(document.querySelectorAll("span")[1].innerHTML).toBe("true");
     });
 
     it('should not crash when rendering <CellRenderer> with value=false, using boolean formatter', () => {
-        const CellRendererWithContext = compose(
-            withContext({
-                isProperty: () => null,
-                isModified: () => null,
-                isValid: () => null
-            },
-            () => ({
-                isProperty: () => true,
-                isModified: () => false,
-                isValid: () => true
-            })))(CellRenderer);
         const comp = ReactDOM.render(<CellRendererWithContext {...set("value", false, props)} />, document.getElementById("container"));
         expect(comp).toExist();
         expect(document.querySelectorAll("span")[1].innerHTML).toBe("false");

--- a/web/client/components/data/featuregrid/renderers/__tests__/CellRenderer-test.jsx
+++ b/web/client/components/data/featuregrid/renderers/__tests__/CellRenderer-test.jsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import {compose, withContext} from 'recompose';
+
+import CellRenderer from '../CellRenderer';
+import booleanFormatter from '../../formatters';
+import { set } from '../../../../../utils/ImmutableUtils';
+
+
+describe('Tests <CellRenderer> component', () => {
+
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    const props = {
+        value: null,
+        column: {
+            key: "Boolean",
+            name: "Boolean",
+            formatter: booleanFormatter.getFormatter({localType: "boolean"})
+        },
+        cellMetaData: {
+            onDeleteSubRow: () => {}
+        },
+        rowData: {
+            type: "Feature",
+            geometry: null,
+            properties: {
+                Boolean: null
+            },
+            get: () => null
+        }
+    };
+
+
+    it('should not crash when rendering <CellRenderer> with value=null, using boolean formatter', () => {
+        /* Integration Test: CellRenderer & boolean formatter
+         * by using the current boolean formatter we ensure that boolean values
+         * that are NOT true or false, (i.e. null, undefined) will not throw error
+         * because when column.formatter returns undefined, will break the react rule
+         * that something must be returned. in particular the renderCellContent of
+         * react-data-grid is returning the formatter value
+        */
+        const CellRendererWithContext = compose(
+            withContext({
+                isProperty: () => null,
+                isModified: () => null,
+                isValid: () => null
+            },
+            () => ({
+                isProperty: () => true,
+                isModified: () => false,
+                isValid: () => true
+            })))(CellRenderer);
+        const comp = ReactDOM.render(<CellRendererWithContext {...props} />, document.getElementById("container"));
+        expect(comp).toExist();
+    });
+
+    it('should not crash when rendering <CellRenderer> with value=true, using boolean formatter', () => {
+        const CellRendererWithContext = compose(
+            withContext({
+                isProperty: () => null,
+                isModified: () => null,
+                isValid: () => null
+            },
+            () => ({
+                isProperty: () => true,
+                isModified: () => false,
+                isValid: () => true
+            })))(CellRenderer);
+        const comp = ReactDOM.render(<CellRendererWithContext {...set("value", true, props)} />, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(document.querySelectorAll("span")[1].innerHTML).toBe("true");
+    });
+
+    it('should not crash when rendering <CellRenderer> with value=false, using boolean formatter', () => {
+        const CellRendererWithContext = compose(
+            withContext({
+                isProperty: () => null,
+                isModified: () => null,
+                isValid: () => null
+            },
+            () => ({
+                isProperty: () => true,
+                isModified: () => false,
+                isValid: () => true
+            })))(CellRenderer);
+        const comp = ReactDOM.render(<CellRendererWithContext {...set("value", false, props)} />, document.getElementById("container"));
+        expect(comp).toExist();
+        expect(document.querySelectorAll("span")[1].innerHTML).toBe("false");
+    });
+
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The crash has been resolved and a test has been added to ensure this will continues to work in the future

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4294

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No longer it crashes, but if no boolean values is present an empty cell will be shown

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
The problem was because the formatter was returning undefined and in react it is a non correct value, causing the crash. the null values is preferable.
