### PR TITLE
#4928 minor changes to context editor and plugin pluggability

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -174,7 +174,10 @@ export default class ContextCreator extends React.Component {
             "ZoomOut",
             "ZoomAll",
             "Annotations",
-            "MapImport"
+            "MapImport",
+            "Undo",
+            "Redo",
+            "Expander"
         ],
         ignoreViewerPlugins: false,
         allAvailablePlugins: [],

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -551,7 +551,9 @@ const checkPluginsEnhancer = branch(
             activateSettingsTool: activateSettingsTool && !!find(items, { name: "TOCItemsSettings"}) || false,
             activateQueryTool: activateQueryTool && !!find(items, {name: "FeatureEditor"}) || false,
             activateLayerFilterTool: activateLayerFilterTool && !!find(items, {name: "FilterLayer"}) || false,
-            activateWidgetTool: activateWidgetTool && !!find(items, { name: "WidgetBuilder" }) // NOTE: activateWidgetTool is already controlled by a selector. TODO: Simplify investigating on the best approch
+            // NOTE: activateWidgetTool is already controlled by a selector. TODO: Simplify investigating on the best approach
+            // the button should hide if also widgets plugins is not available. Maybe is a good idea to merge the two plugins
+            activateWidgetTool: activateWidgetTool && !!find(items, { name: "WidgetBuilder" }) && !!find(items, { name: "Widgets" })
         })
     )
 );

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -6,21 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
-const {connect} = require('react-redux');
-const {createSelector} = require('reselect');
-const { compose, defaultProps, withProps, withPropsOnChange} = require('recompose');
-const {mapIdSelector} = require('../selectors/map');
-const { getVisibleFloatingWidgets, dependenciesSelector, getFloatingWidgetsLayout, isTrayEnabled} = require('../selectors/widgets');
-const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage, toggleCollapse} = require('../actions/widgets');
-const editOptions = require('./widgets/editOptions');
-const autoDisableWidgets = require('./widgets/autoDisableWidgets');
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {createSelector} from 'reselect';
+import { compose, defaultProps, withProps, withPropsOnChange} from 'recompose';
+
+
+import { createPlugin } from '../utils/PluginsUtils';
+
+import {mapIdSelector} from '../selectors/map';
+import { getVisibleFloatingWidgets, dependenciesSelector, getFloatingWidgetsLayout, isTrayEnabled} from '../selectors/widgets';
+import { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage, toggleCollapse} from '../actions/widgets';
+import editOptions from './widgets/editOptions';
+import autoDisableWidgets from './widgets/autoDisableWidgets';
 
 const RIGHT_MARGIN = 70;
-const {heightProvider} = require('../components/layout/enhancers/gridLayout');
-const ContainerDimensions = require('react-container-dimensions').default;
+import {heightProvider} from '../components/layout/enhancers/gridLayout';
+import ContainerDimensions from 'react-container-dimensions';
 
-const PropTypes = require('prop-types');
+import WidgetsViewBase from '../components/widgets/view/WidgetsView';
+
 const WidgetsView =
 compose(
     connect(
@@ -105,7 +111,7 @@ compose(
             })
         )
     )
-)(require('../components/widgets/view/WidgetsView'));
+)(WidgetsViewBase);
 
 
 class Widgets extends React.Component {
@@ -139,10 +145,16 @@ class Widgets extends React.Component {
  */
 const WidgetsPlugin = autoDisableWidgets(Widgets);
 
-module.exports = {
-    WidgetsPlugin,
+export default createPlugin("WidgetsPlugin", {
+    component: WidgetsPlugin,
+    containers: {
+        TOC: {
+            doNotHide: true,
+            name: "Widgets"
+        }
+    },
     reducers: {
         widgets: require('../reducers/widgets')
     },
     epics: require('../epics/widgets')
-};
+});

--- a/web/client/plugins/WidgetsTray.jsx
+++ b/web/client/plugins/WidgetsTray.jsx
@@ -7,8 +7,9 @@
  */
 
 
-const WidgetsTray = require('./widgets/WidgetsTray');
-const autoDisableWidgets = require('./widgets/autoDisableWidgets');
+import WidgetsTray from './widgets/WidgetsTray';
+import autoDisableWidgets from './widgets/autoDisableWidgets';
+import * as epics from '../epics/widgetsTray';
 
 /**
  * Plugin that allow to collapse widgets. Shows a small tray where to see the collapsed plugins list.
@@ -17,7 +18,7 @@ const autoDisableWidgets = require('./widgets/autoDisableWidgets');
  * @prop {boolean|string|array} [toolsOptions.seeHidden] hides the widgets under particular conditions. **Must** be the same of rule of the Widget plugin. @see plugins.Widgets.
  * @class
  */
-module.exports = {
+export default {
     WidgetsTrayPlugin: autoDisableWidgets(WidgetsTray),
-    epics: require('../epics/widgetsTray')
+    epics
 };

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -339,11 +339,13 @@ describe('TOCPlugin Plugin', () => {
             expect(document.querySelector(FILTER_LAYER_SELECTOR)).toExist();
             expect(document.querySelector(REMOVE_SELECTOR)).toExist();
         });
-        it.skip('render WidgetBuilder', () => { // this test fails only on travis (not locally)
+        it('render WidgetBuilder', () => { // this test fails only on travis (not locally)
             const { Plugin } = getPluginForTest(TOCPlugin, { ...SELECTED_LAYER_STATE, controls: { widgetBuilder: {available: true}}});
             const WrappedPlugin = dndContext(Plugin);
             ReactDOM.render(<WrappedPlugin items={[{
                 name: "WidgetBuilder"
+            }, {
+                name: "Widgets"
             }]} />, document.getElementById("container"));
             // check tools
 

--- a/web/client/pluginsConfig.json
+++ b/web/client/pluginsConfig.json
@@ -435,6 +435,7 @@
     },
     {
       "name": "Save",
+      "denyUserSelection": true,
       "title": "plugins.Save.title",
       "description": "plugins.Save.description",
       "dependencies": [
@@ -454,6 +455,7 @@
     },
     {
       "name": "BurgerMenu",
+      "hidden": true,
       "glyph": "menu-hamburger",
       "title": "plugins.BurgerMenu.title",
       "description": "plugins.BurgerMenu.description",

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -118,8 +118,8 @@ module.exports = {
         VersionPlugin: require('../plugins/Version'),
         WFSDownloadPlugin: require('../plugins/WFSDownload'),
         WidgetsBuilderPlugin: require('../plugins/WidgetsBuilder').default,
-        WidgetsPlugin: require('../plugins/Widgets'),
-        WidgetsTrayPlugin: require('../plugins/WidgetsTray'),
+        WidgetsPlugin: require('../plugins/Widgets').default,
+        WidgetsTrayPlugin: require('../plugins/WidgetsTray').default,
         ZoomAllPlugin: require('../plugins/ZoomAll'),
         ZoomInPlugin: require('../plugins/ZoomIn'),
         ZoomOutPlugin: require('../plugins/ZoomOut')


### PR DESCRIPTION
## Description
See #4928 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)



## Issue
 #4928 

**What is the current behavior?**

#4928

**What is the new behavior?**

- Now widgets button depends also on Widgets plugin. 
- Save button can not be a user extension anymore (old context with this should be removed) 
- Other minor changes, see issue

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No



note: I converted Widgets plugin to use import instead of require