### PR TITLE
4931 Copying the context share URL the tooltip is not centered..

### DIFF
--- a/web/client/components/share/ShareCopyToClipboard.jsx
+++ b/web/client/components/share/ShareCopyToClipboard.jsx
@@ -15,7 +15,7 @@ const CopyToClipboard = tooltip(RCopyToClipboard);
 
 const ShareCopyToClipboard = ({
     shareUrl = '',
-    copied,
+    copied = false,
     onCopy = () => {},
     onMouseLeave = () => {}
 }) => {
@@ -24,6 +24,7 @@ const ShareCopyToClipboard = ({
             text={shareUrl}
             tooltipId={copied ? 'share.msgCopiedUrl' : 'share.msgToCopyUrl'}
             tooltipPosition="bottom"
+            key={copied.toString()}
             onCopy={ () => onCopy(shareUrl) } >
             <Button
                 bsStyle="primary"


### PR DESCRIPTION
## Description
Copying the context share URL the tooltip is not centered. The same for all resource types, issue of the share button.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4931 

**What is the new behavior?**
Copying the context share URL the tooltip is now centered.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
