### PR TITLE
4932 I can copy and paste a context title with spaces and then save.

### DIFF
--- a/web/client/components/contextcreator/GeneralSettingsStep.jsx
+++ b/web/client/components/contextcreator/GeneralSettingsStep.jsx
@@ -28,7 +28,7 @@ export default ({contextName = "", windowTitle = "", isValidContextName = true, 
                     type="text"
                     value={contextName}
                     placeholder={LocaleUtils.getMessageById(context.messages, "contextCreator.generalSettings.namePlaceholder")}
-                    onChange={e => onChange('name', e.target.value && e.target.value.replace(/[^a-zA-Z0-9\-_]/, ''))}/>
+                    onChange={e => onChange('name', e.target.value && e.target.value.replace(/[^a-zA-Z0-9\-_]/g, ''))}/>
             </FormGroup>
             <FormGroup validationState={windowTitle.length > 0 ? 'success' : null}>
                 <ControlLabel>

--- a/web/client/components/contextcreator/__tests__/GeneralSettingsStep-test.jsx
+++ b/web/client/components/contextcreator/__tests__/GeneralSettingsStep-test.jsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
+import ReactTestUtils from 'react-dom/test-utils';
 import GeneralSettingsStep from '../GeneralSettingsStep';
 
 describe('GeneralSettingsStep component', () => {
@@ -25,6 +26,19 @@ describe('GeneralSettingsStep component', () => {
         ReactDOM.render(<GeneralSettingsStep />, document.getElementById("container"));
         const container = document.getElementById('container');
         expect(container.getElementsByClassName('general-settings-step')).toExist();
+    });
+    it('accepts only letters, numbers, dashes, and underscores for the context name', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyonChange = expect.spyOn(actions, 'onChange');
+        const container = document.getElementById('container');
+        ReactDOM.render(<GeneralSettingsStep onChange={actions.onChange} />, container);
+        const contextNameInput = container.querySelector('.general-settings-step .form-group input');
+        contextNameInput.value = "_tes24 t-- 5*  __=+''...,";
+        ReactTestUtils.Simulate.change(contextNameInput);
+        expect(spyonChange.calls.length).toEqual(1);
+        expect(spyonChange).toHaveBeenCalledWith("name", "_tes24t--5__");
     });
 });
 


### PR DESCRIPTION
## Description
I can copy and paste a context title with spaces and then save.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4932 

**What is the new behavior?**
I can't copy and paste a context title with spaces and then save.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
