### PR TITLE
Fix 4940 CRS Selector and allowed Roles

### DIFF
--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -86,8 +86,8 @@ class Selector extends React.Component {
                 });
             }
         };
-        const allowed = (role) => includes(this.props.allowedRoles, "ALL") ? true : includes(role, this.props.allowedRoles);
-        return (this.props.enabled && allowed(this.props.currentRole) ? <Dropdown
+        const isAllowed = includes(this.props.allowedRoles, "ALL") || includes(this.props.allowedRoles, this.props.currentRole);
+        return (this.props.enabled && isAllowed ? <Dropdown
             dropup
             className="ms-prj-selector">
             <Button

--- a/web/client/plugins/__tests__/CRSSelector-test.jsx
+++ b/web/client/plugins/__tests__/CRSSelector-test.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 
 import CRSSelectorPlugin from '../CRSSelector';
 import { getPluginForTest } from './pluginsTestUtils';
+import security from '../../reducers/security';
 
 describe('CRSSelector Plugin', () => {
     beforeEach((done) => {
@@ -16,6 +17,14 @@ describe('CRSSelector Plugin', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
+
+    const CRSPluginCustomized = {
+        ...CRSSelectorPlugin,
+        reducers: {
+            ...CRSSelectorPlugin.reducers,
+            security
+        }
+    };
 
     it('Shows CRSSelector Plugin', () => {
         const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
@@ -30,9 +39,98 @@ describe('CRSSelector Plugin', () => {
         ReactDOM.render(<Plugin filterAllowedCRS={["EPSG:4326", "EPSG:3857"]} additionalCRS={{}}/>, document.getElementById("container"));
         expect(document.getElementsByClassName('ms-prj-selector').length).toBe(1);
     });
+    it('render the plugin for role ADMIN with allowedRoles ADMIN, USER', () => {
+        const { Plugin } = getPluginForTest(CRSPluginCustomized, {
+            map: {
+                projection: "EPSG:900913"
+            },
+            localConfig: {
+                projectionDefs: []
+            },
+            security: {
+                user: {
+                    role: "ADMIN"
+                }
+            }
+        });
+
+        ReactDOM.render(<Plugin
+            filterAllowedCRS={["EPSG:4326", "EPSG:3857"]}
+            additionalCRS={{}}
+            allowedRoles={["ADMIN", "USER"]}
+        />, document.getElementById("container"));
+        expect(document.getElementsByClassName('ms-prj-selector').length).toBe(1);
+    });
+    it('render the plugin for role USER with allowedRoles ADMIN, USER', () => {
+        const { Plugin } = getPluginForTest(CRSPluginCustomized, {
+            map: {
+                projection: "EPSG:900913"
+            },
+            localConfig: {
+                projectionDefs: []
+            },
+            security: {
+                user: {
+                    role: "ADMIN"
+                }
+            }
+        });
+
+        ReactDOM.render(<Plugin
+            filterAllowedCRS={["EPSG:4326", "EPSG:3857"]}
+            additionalCRS={{}}
+            allowedRoles={["ADMIN", "USER"]}
+        />, document.getElementById("container"));
+        expect(document.getElementsByClassName('ms-prj-selector').length).toBe(1);
+    });
+    it('render the plugin ignoring user role USER if allowedRoles contains ALL', () => {
+        const { Plugin } = getPluginForTest(CRSPluginCustomized, {
+            map: {
+                projection: "EPSG:900913"
+            },
+            localConfig: {
+                projectionDefs: []
+            },
+            security: {
+                user: {
+                    role: "IGNORES_EVEN_FAKE_ROLES"
+                }
+            }
+        });
+
+        ReactDOM.render(<Plugin
+            filterAllowedCRS={["EPSG:4326", "EPSG:3857"]}
+            additionalCRS={{}}
+            allowedRoles={["ALL"]}
+        />, document.getElementById("container"));
+        expect(document.getElementsByClassName('ms-prj-selector').length).toBe(1);
+    });
+    it('does not render the plugin for role that is not among allowedRoles', () => {
+        const { Plugin } = getPluginForTest(CRSPluginCustomized, {
+            map: {
+                projection: "EPSG:900913"
+            },
+            localConfig: {
+                projectionDefs: []
+            },
+            security: {
+                user: {
+                    role: "FAKE_ROLE"
+                }
+            }
+        });
+
+        ReactDOM.render(<Plugin
+            filterAllowedCRS={["EPSG:4326", "EPSG:3857"]}
+            additionalCRS={{}}
+            allowedRoles={["ADMIN", "USER"]}
+        />, document.getElementById("container"));
+        expect(document.getElementsByClassName('ms-prj-selector').length).toBe(0);
+    });
+
 
     it('CRSSelector is not rendered when Print Panel is enabled', () => {
-        const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
+        const { Plugin } = getPluginForTest(CRSPluginCustomized, {
             controls: {
                 print: {
                     enabled: true


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixing allowedRoles for CRS Selector


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4940 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When configuring a list of roles, it works as expected,
if role ALL is present among allowedRoles then it will win over other checks

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
