### PR TITLE
4944 Impossible to remove all plugins from the right list of wizard s…

### DIFF
--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -430,6 +430,68 @@ describe('contextcreator epics', () => {
             }
         }, done);
     });
+    it('disablePluginsEpic with dependencies when value of the enabledDependentPlugins of one of the dependent children is []', (done) => {
+        const pluginsToDisable = ['WidgetsBuilder'];
+        const startActions = [disablePlugins(pluginsToDisable)];
+        testEpic(disablePluginsEpic, 2, startActions, actions => {
+            expect(actions.length).toBe(2);
+            expect(actions[0].type).toBe(CHANGE_PLUGINS_KEY);
+            expect(actions[0].ids.sort()).toEqual(['WidgetsBuilder', 'WidgetsTray']);
+            expect(actions[0].key).toBe('enabled');
+            expect(actions[0].value).toBe(false);
+            expect(actions[1].type).toBe(CHANGE_PLUGINS_KEY);
+            expect(actions[1].ids).toEqual(['WidgetsTray']);
+            expect(actions[1].key).toBe('forcedMandatory');
+            expect(actions[1].value).toBe(false);
+        }, {
+            contextcreator: {
+                plugins: [{
+                    name: 'Widgets',
+                    dependencies: [],
+                    enabledDependentPlugins: [],
+                    enabled: true,
+                    isUserPlugin: false,
+                    active: false,
+                    children: [{
+                        name: 'WidgetsBuilder',
+                        dependencies: ['WidgetsTray'],
+                        enabledDependentPlugins: [],
+                        children: [],
+                        parent: 'Widgets',
+                        enabled: true,
+                        isUserPlugin: false,
+                        active: false
+                    }, {
+                        name: 'WidgetsTray',
+                        dependencies: [],
+                        children: [],
+                        enabledDependentPlugins: [],
+                        forcedMandatory: true,
+                        parent: 'Widgets',
+                        enabled: true,
+                        isUserPlugin: false,
+                        active: false
+                    }]
+                }, {
+                    name: 'ZoomIn',
+                    dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
+                    enabled: true,
+                    isUserPlugin: true,
+                    active: false
+                }, {
+                    name: 'ZoomOut',
+                    dependencies: [],
+                    enabledDependentPlugins: [],
+                    children: [],
+                    enabled: false,
+                    isUserPlugin: false,
+                    active: false
+                }]
+            }
+        }, done);
+    });
     it('disablePluginsEpic with transitive dependencies', (done) => {
         const pluginsToDisable = ['Widgets'];
         const startActions = [disablePlugins(pluginsToDisable)];

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -585,7 +585,7 @@ export const disablePluginsEpic = (action$, store) => action$
                     }
 
                     // if there are no more plugins that are enabled and have this plugin as a dependency, unforce it
-                    if (enabledDependentPlugins[plugin.name].length === 0 &&
+                    if ((!enabledDependentPlugins[plugin.name] || enabledDependentPlugins[plugin.name].length === 0) &&
                         pluginsToDisable.reduce((result, cur) => result && cur !== plugin.name, true)
                     ) {
                         depsToUnforceMandatory.push(plugin.name);


### PR DESCRIPTION
…tep n2 while editing an existing contexts (it seems to happen only in geOrchestra MS project).

## Description
Impossible to remove all plugins from the rigth list of wizard step n2 while editing an existing contexts (it seems to happen only in geOrchestra MS project).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#4944 

**What is the new behavior?**
It is now possible to remove all plugins from the rigth list of wizard step n2 while editing an existing ncontexts (it seems to happen only in geOrchestra MS project).

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
