### PR TITLE
Speed up OpenLayers map loading (#4750)

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -143,6 +143,7 @@ class OpenlayersMap extends React.Component {
             layers: [],
             controls: controls,
             interactions: interactions,
+            maxTilesLoading: Infinity,
             target: `${this.props.id}`,
             view: this.createView(center, Math.round(this.props.zoom), this.props.projection, this.props.mapOptions && this.props.mapOptions.view, this.props.limits)
         });


### PR DESCRIPTION
Allow unlimited concurrent tile loading for OpenLayers maps

## Description
By default OpenLayers will only load 16 tiles concurrently, which significantly slows down rendering for MS2 maps with a large number of layers.

This PR removes OpenLayers' default limit to bring it more in line with leaflet performance. We have chosen `Infinity` over an arbitrary maximum value, but happy to change this.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) (N/A)
- [ ] Docs have been added / updated (for bug fixes / features) (N/A)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Improvement

## Issue
https://github.com/geosolutions-it/MapStore2/issues/4750

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No