### PR TITLE
Fix 4963 GeoStory on Mobile

### DIFF
--- a/web/client/components/geostory/layouts/Cascade.jsx
+++ b/web/client/components/geostory/layouts/Cascade.jsx
@@ -112,6 +112,7 @@ const Cascade = ({
         {({ width, height }) => {
             const containerSize = getSize({ width, height, mode });
             const sizeClassName = containerSize ? ` ms-${containerSize}` : '';
+            const isBackgroundMediaExpandable = containerSize === 'sm';
             return (<div
                 id="ms-sections-container"
                 className={`ms-sections-container${sizeClassName}`}>
@@ -123,6 +124,7 @@ const Cascade = ({
                                 onVisibilityChange={onVisibilityChange}
                                 add={add}
                                 editMedia={editMedia}
+                                expandableBackgroundMedia={isBackgroundMediaExpandable}
                                 editWebPage={editWebPage}
                                 updateCurrentPage={updateCurrentPage}
                                 update={update}

--- a/web/client/components/geostory/layouts/Cascade.jsx
+++ b/web/client/components/geostory/layouts/Cascade.jsx
@@ -78,6 +78,20 @@ const ContainerDimensions = emptyState(
     )
 )(ContainerDimensionsBase);
 
+const defaultGetSize = ({ width, mode }) => {
+    // don't apply custom style while editing
+    if (mode === Modes.EDIT) {
+        return '';
+    }
+    if (width < 640) {
+        return 'sm';
+    }
+    if (width >= 640 && width < 1024) {
+        return 'md';
+    }
+    return '';
+};
+
 const Cascade = ({
     mode = Modes.VIEW,
     sections = [],
@@ -89,15 +103,18 @@ const Cascade = ({
     update = () => {},
     remove = () => {},
     focusedContent,
-    isContentFocused = false
+    isContentFocused = false,
+    getSize = defaultGetSize
 }) => (<BorderLayout  className={`ms-cascade-story ms-${mode}`} bodyClassName={`ms2-border-layout-body ${isContentFocused ? 'no-overflow' : ''}`}>
     <ContainerDimensions
         sections={sections}
         add={add}>
-        {({ width, height }) =>
-            <div
+        {({ width, height }) => {
+            const containerSize = getSize({ width, height, mode });
+            const sizeClassName = containerSize ? ` ms-${containerSize}` : '';
+            return (<div
                 id="ms-sections-container"
-                className="ms-sections-container">
+                className={`ms-sections-container${sizeClassName}`}>
                 {
                     sections.map(({ contents = [], id: sectionId, type: sectionType, cover }) => {
                         return (
@@ -122,7 +139,8 @@ const Cascade = ({
                         );
                     })
                 }
-            </div>}
+            </div>);
+        }}
     </ContainerDimensions>
 </BorderLayout>);
 

--- a/web/client/components/geostory/layouts/__tests__/Cascade-test.jsx
+++ b/web/client/components/geostory/layouts/__tests__/Cascade-test.jsx
@@ -46,4 +46,36 @@ describe('Cascade component', () => {
         const el = container.querySelector('.ms-edit');
         expect(el).toExist();
     });
+    it('should apply layout class name on small devices', () => {
+        ReactDOM.render(<div style={{ width: 400 }}><Cascade {...STORY} /></div>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const smallGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-sm');
+        const mediumGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-md');
+        expect(smallGeoStoryLayoutNode).toExist();
+        expect(mediumGeoStoryLayoutNode).toNotExist();
+    });
+    it('should apply layout class name on medium devices', () => {
+        ReactDOM.render(<div style={{ width: 1000 }}><Cascade {...STORY} /></div>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const smallGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-sm');
+        const mediumGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-md');
+        expect(smallGeoStoryLayoutNode).toNotExist();
+        expect(mediumGeoStoryLayoutNode).toExist();
+    });
+    it('should not apply layout class name on large devices', () => {
+        ReactDOM.render(<div style={{ width: 1920 }}><Cascade {...STORY} /></div>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const smallGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-sm');
+        const mediumGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-md');
+        expect(smallGeoStoryLayoutNode).toNotExist();
+        expect(mediumGeoStoryLayoutNode).toNotExist();
+    });
+    it('should not apply layout class name with edit mode', () => {
+        ReactDOM.render(<div style={{ width: 400 }}><Cascade {...STORY} mode="edit" /></div>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const smallGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-sm');
+        const mediumGeoStoryLayoutNode = container.querySelector('.ms-sections-container.ms-md');
+        expect(smallGeoStoryLayoutNode).toNotExist();
+        expect(mediumGeoStoryLayoutNode).toNotExist();
+    });
 });

--- a/web/client/components/geostory/layouts/sections/Immersive.jsx
+++ b/web/client/components/geostory/layouts/sections/Immersive.jsx
@@ -40,12 +40,14 @@ const Immersive = ({
     focusedContent,
     contentId,
     bubblingTextEditing = () => {},
-    textEditorActiveClass = ""
+    textEditorActiveClass = "",
+    expandableBackgroundMedia = false
 }) => {
     const hideContent = focusedContent && focusedContent.hideContent && (get(focusedContent, "target.id") === contentId);
     const visibility = hideContent ? 'hidden' : 'visible';
+    const expandableBackgroundClassName = expandableBackgroundMedia && background && background.type === 'map' ? ' ms-expandable-background' : '';
     return (<section
-        className="ms-section ms-section-immersive"
+        className={`ms-section ms-section-immersive${expandableBackgroundClassName}`}
         id={id}
         ref={inViewRef}
     >
@@ -61,6 +63,7 @@ const Immersive = ({
             scrollContainerSelector="#ms-sections-container"
             add={add}
             editMedia={editMedia}
+            expandable={expandableBackgroundMedia}
             path={path}
             update={updateBackground}
             updateCurrentPage={updateCurrentPage}

--- a/web/client/components/geostory/layouts/sections/Section.jsx
+++ b/web/client/components/geostory/layouts/sections/Section.jsx
@@ -47,7 +47,8 @@ class Section extends React.Component {
         inViewRef: PropTypes.func,
         excludeClassName: PropTypes.string,
         cover: PropTypes.bool,
-        focusedContent: PropTypes.object
+        focusedContent: PropTypes.object,
+        expandableBackgroundMedia: PropTypes.bool
     };
 
     static defaultProps = {
@@ -61,7 +62,8 @@ class Section extends React.Component {
         storyType: StoryTypes.CASCADE,
         viewHeight: 0,
         viewWidth: 0,
-        mode: Modes.VIEW
+        mode: Modes.VIEW,
+        expandableBackgroundMedia: false
     };
 
     state = {
@@ -78,6 +80,7 @@ class Section extends React.Component {
                 update={this.props.update}
                 inViewRef={this.props.inViewRef}
                 editMedia={this.props.editMedia}
+                expandableBackgroundMedia={this.props.expandableBackgroundMedia}
                 editWebPage={this.props.editWebPage}
                 updateCurrentPage={this.props.updateCurrentPage}
                 remove={this.props.remove}

--- a/web/client/components/geostory/layouts/sections/Title.jsx
+++ b/web/client/components/geostory/layouts/sections/Title.jsx
@@ -46,15 +46,17 @@ export default compose(
     editMedia = () => {},
     focusedContent,
     bubblingTextEditing = () => {},
-    textEditorActiveClass = ""
+    textEditorActiveClass = "",
+    expandableBackgroundMedia = false
 }) => {
 
     const hideContent = get(focusedContent, "target.id") === contentId;
     const visibility = hideContent ?  'hidden' : 'visible';
+    const expandableBackgroundClassName = expandableBackgroundMedia && background && background.type === 'map' ? ' ms-expandable-background' : '';
     return (
         <section
             ref={inViewRef}
-            className="ms-section ms-section-title"
+            className={`ms-section ms-section-title${expandableBackgroundClassName}`}
             id={id}
         >
             <ContainerDimensions>
@@ -74,6 +76,7 @@ export default compose(
                         update={updateBackground}
                         add={add}
                         editMedia={editMedia}
+                        expandable={expandableBackgroundMedia}
                         updateSection={updateSection}
                         cover={cover}
                         remove={remove}

--- a/web/client/components/geostory/layouts/sections/__tests__/Immersive-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Immersive-test.jsx
@@ -149,4 +149,29 @@ describe('Immersive component', () => {
         expect(contentToolbar).toExist();
         testToolbarButtons(["pencil", "map-edit", "size-extra-large", "align-center", "dropper"], container);
     });
+    it('should apply expandable background class on media map', () => {
+        const CONTENTS_MAP = [{
+            id: '000',
+            type: 'column',
+            background: {
+                type: 'map'
+            },
+            contents: [{
+                type: 'text',
+                html: '<p>column</p>'
+            }]
+        }];
+        ReactDOM.render(
+            <Provider store={{
+                getState: () => {},
+                subscribe: () => {},
+                dispatch: () => {}
+            }}>
+                <Immersive mode={Modes.EDIT} expandableBackgroundMedia contents={CONTENTS_MAP} />
+            </Provider>
+            , document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.ms-section-immersive.ms-expandable-background');
+        expect(el).toExist();
+    });
 });

--- a/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/Title-test.jsx
@@ -141,4 +141,28 @@ describe('Title component', () => {
         expect(contentToolbar).toExist();
         testToolbarButtons(["pencil", "height-auto", "map-edit", "size-extra-large", "align-center", "dropper"], container);
     });
+    it('should apply expandable background class on media map', () => {
+        const VIEW_HEIGHT = 834;
+        const CONTENTS = [
+            {
+                id: '000',
+                type: "text",
+                background: {
+                    type: 'map'
+                }
+            }
+        ];
+        ReactDOM.render(
+            <Provider store={{
+                getState: () => {},
+                subscribe: () => {},
+                dispatch: () => {}
+            }}>
+                <Title contents={CONTENTS} expandableBackgroundMedia viewHeight={VIEW_HEIGHT} cover mode="edit"/>
+            </Provider>
+            , document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.ms-section-title.ms-expandable-background');
+        expect(el).toExist();
+    });
 });

--- a/web/client/components/geostory/media/Map.jsx
+++ b/web/client/components/geostory/media/Map.jsx
@@ -41,18 +41,23 @@ export default compose(
             zoomControl: false,
             interactive: true,
             mapOptions: {
-                ...mapOptions,
                 scrollWheelZoom: true,
                 interactions: {
-                    ...mapOptions.interactions,
-                    mouseWheelZoom: true
+                    mouseWheelZoom: true,
+                    dragPan: true
                 }
             }
         }
         : {
             zoomControl: false,
             interactive: false,
-            mapOptions
+            mapOptions: {
+                scrollWheelZoom: false,
+                interactions: {
+                    mouseWheelZoom: false,
+                    dragPan: false
+                }
+            }
         };
 
     const expandMapOptions = expandable ? expandedMapOptions : { mapOptions };

--- a/web/client/components/geostory/media/Map.jsx
+++ b/web/client/components/geostory/media/Map.jsx
@@ -6,13 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-import { compose, branch} from 'recompose';
-
+import { compose, branch, withState } from 'recompose';
+import { Button, Glyphicon } from 'react-bootstrap';
 
 import MapView from '../../widgets/widget/MapView'; // TODO: use a external component
 import { applyDefaults } from '../../../utils/GeoStoryUtils';
 import {defaultLayerMapPreview} from '../../../utils/MediaEditorUtils';
-
+import Portal from '../../../components/misc/Portal';
 import connectMap, {withLocalMapState, withMapEditingAndLocalMapState} from '../common/enhancers/map';
 
 export default compose(
@@ -21,40 +21,90 @@ export default compose(
         connectMap,
     ),
     withLocalMapState,
-    withMapEditingAndLocalMapState
+    withMapEditingAndLocalMapState,
+    withState('active', 'setActive', false)
 )(({
     id,
     map = {layers: [defaultLayerMapPreview]},
     fit,
     editMap = false,
-    onMapViewChanges
+    onMapViewChanges,
+    expandable = false,
+    active,
+    setActive
 }) => {
+
     const { layers = [], mapOptions = {}, ...m} = (map.data ? map.data : map);
-    return (<div
-        className={`ms-media ms-media-map ${mapOptions.zoomPosition || ""}`}
-        style={{
-            objectFit: fit
-        }}>
-        {/* BaseMap component overrides the MapView id with map's id */}
+
+    const expandedMapOptions = active
+        ? {
+            zoomControl: false,
+            interactive: true,
+            mapOptions: {
+                ...mapOptions,
+                scrollWheelZoom: true,
+                interactions: {
+                    ...mapOptions.interactions,
+                    mouseWheelZoom: true
+                }
+            }
+        }
+        : {
+            zoomControl: false,
+            interactive: false,
+            mapOptions
+        };
+
+    const expandMapOptions = expandable ? expandedMapOptions : { mapOptions };
+
+    // mouseWheelZoom is enabled only if inlineEditing is active and zoomControl too
+    const updatedMapOptions = editMap
+        ? {
+            mapOptions: {
+                ...mapOptions,
+                interactions: {
+                    ...mapOptions.interactions,
+                    mouseWheelZoom: m.zoomControl
+                }
+
+            }
+        }
+        : expandMapOptions;
+
+
+    // BaseMap component overrides the MapView id with map's id
+    const mapView = (
+        <>
         <MapView
+            // force unmount to setup correct interactions
+            key={expandable ? 'overlay' : 'block'}
             onMapViewChanges={onMapViewChanges}
             map={{
                 ...m,
                 id: `media-${id}`
             }} // if map id is passed as number, the resource id, ol throws an error
             layers={layers}
-            options={
-                // mouseWheelZoom is enabled only if inlineEditing is active and zoomControl too
-                applyDefaults(!editMap ? {mapOptions} : {
-                    mapOptions: {
-                        ...mapOptions,
-                        interactions: {
-                            ...mapOptions.interactions,
-                            mouseWheelZoom: m.zoomControl
-                        }
-
-                    }
-                })}
+            options={applyDefaults(updatedMapOptions)}
         />
+        {expandable && !editMap &&
+        <Button
+            className="ms-expand-media-button"
+            onClick={() => setActive(!active)}>
+            <Glyphicon glyph={!active ? '1-full-screen' : '1-close'}/>
+        </Button>}
+        </>
+    );
+    return (<div
+        className={`ms-media ms-media-map ${mapOptions.zoomPosition || ""}`}
+        style={{
+            objectFit: fit
+        }}>
+        {active && expandable
+            ? <Portal>
+                <div className="ms-expanded-media-container">
+                    {mapView}
+                </div>
+            </Portal>
+            : mapView}
     </div>);
 });

--- a/web/client/components/geostory/media/Map.jsx
+++ b/web/client/components/geostory/media/Map.jsx
@@ -7,13 +7,16 @@
  */
 import React from 'react';
 import { compose, branch, withState } from 'recompose';
-import { Button, Glyphicon } from 'react-bootstrap';
+import { Button as ButtonRB, Glyphicon } from 'react-bootstrap';
 
 import MapView from '../../widgets/widget/MapView'; // TODO: use a external component
 import { applyDefaults } from '../../../utils/GeoStoryUtils';
 import {defaultLayerMapPreview} from '../../../utils/MediaEditorUtils';
 import Portal from '../../../components/misc/Portal';
+import tooltip from '../../../components/misc/enhancers/tooltip';
 import connectMap, {withLocalMapState, withMapEditingAndLocalMapState} from '../common/enhancers/map';
+
+const Button = tooltip(ButtonRB);
 
 export default compose(
     branch(
@@ -94,7 +97,9 @@ export default compose(
         {expandable && !editMap &&
         <Button
             className="ms-expand-media-button"
-            onClick={() => setActive(!active)}>
+            onClick={() => setActive(!active)}
+            tooltipId={active ? 'geostory.closeFullscreenMap' : 'geostory.showFullscreenMap'}
+            tooltipPosition="left">
             <Glyphicon glyph={!active ? '1-full-screen' : '1-close'}/>
         </Button>}
         </>

--- a/web/client/components/geostory/media/__tests__/Map-test.jsx
+++ b/web/client/components/geostory/media/__tests__/Map-test.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import Map from '../Map';
+import { Provider } from 'react-redux';
+import ReactTestUtils from 'react-dom/test-utils';
+import '../../../../libs/bindings/rxjsRecompose';
+
+describe('Map component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('should render with defaults', () => {
+        const mockStore = { subscribe: () => {}, getState: () => ({}) };
+        ReactDOM.render(<Provider store={mockStore}><Map /></Provider>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const mediaMapNode = container.querySelector('.ms-media-map');
+        expect(mediaMapNode).toExist();
+    });
+    it('should show buttons to expand map', () => {
+        const mockStore = { subscribe: () => {}, getState: () => ({}) };
+        ReactDOM.render(<Provider store={mockStore}><Map expandable /></Provider>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const mediaMapNode = container.querySelector('.ms-media-map');
+        expect(mediaMapNode).toExist();
+        expect(mediaMapNode.children.length).toBe(2);
+        expect(document.body.children.length).toBe(1);
+        const expandMediaButtonNode = mediaMapNode.querySelector('.ms-expand-media-button');
+        expect(expandMediaButtonNode).toExist();
+        ReactTestUtils.Simulate.click(expandMediaButtonNode);
+        expect(mediaMapNode.children.length).toBe(0);
+        expect(document.body.children.length).toBe(2);
+        expect(document.body.children[1].getAttribute('class')).toBe('ms-expanded-media-container');
+    });
+});

--- a/web/client/components/geostory/navigation/Navigation.jsx
+++ b/web/client/components/geostory/navigation/Navigation.jsx
@@ -17,23 +17,22 @@ import { getQueryParams } from '../../../utils/URLUtils';
  * Navigation Bar for view mode of GeoStory
  * Contains the button to switch to edit mode and the navigation menu.
  * @prop {function} scrollTo handler to scroll to a particular section or id. Gets id of the HTML element as first argument and scroll options as second. See {@link https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView}
- * @prop {function} setEditing handler to set edit/view mode. Takes the `editing` flag as argument.
  * @prop {object} story the current story to navigate
  * @prop {object} currentPage contains current `sectionId`
  * @prop {number} currentPosition currentPosition indicates the position of current sections
  * @prop {number} totalItems totalItems is the total number of sections present in the story
  * @prop {object} router router object in store contains location data
+ * @prop {array} buttons array of buttons for Toolbar
  */
 export default ({
     settings,
     scrollTo = () => {},
-    setEditing = () => {},
     navigableItems = [],
     currentPage, // current page progress (current page + 1/totPages),
     totalItems = 1,
-    isEditAllowed = true,
     currentPosition = 0,
-    router
+    router,
+    buttons = []
 }) => {
     return (
         <div className="ms-geostory-navigation-bar">
@@ -48,20 +47,7 @@ export default ({
             <div className="ms-geostory-navigation-tools">
 
                 <div className="ms-geostory-navigation-toolbar">
-                    <Toolbar
-                        btnDefaultProps={{
-                            className: 'square-button-md no-border',
-                            bsStyle: 'default',
-                            tooltipPosition: 'bottom'
-                        }}
-                        buttons={[
-                            {
-                                glyph: 'pencil',
-                                visible: isEditAllowed,
-                                tooltipId: 'geostory.navigation.edit',
-                                onClick: () => setEditing(true)
-                            }
-                        ]} />
+                    <Toolbar buttons={buttons} />
                 </div>
                 {
                     router &&

--- a/web/client/components/geostory/navigation/__tests__/Navigation-test.jsx
+++ b/web/client/components/geostory/navigation/__tests__/Navigation-test.jsx
@@ -30,13 +30,16 @@ describe('GeoStory Navigation component', () => {
         const el = container.querySelector('.ms-geostory-navigation-bar');
         expect(el).toExist();
     });
-    it('Test Navigation setEditing', () => {
+    it('Test Navigation custom buttons (setEditing)', () => {
         const actions = {
             setEditing: () => {}
         };
+        const buttons = [{
+            Element: () => <button className="test-button" onClick={() => actions.setEditing(true)}></button>
+        }];
         const spySetEditing = expect.spyOn(actions, 'setEditing');
-        ReactDOM.render(<Navigation setEditing={actions.setEditing} />, document.getElementById("container"));
-        ReactTestUtils.Simulate.click(document.querySelector('.glyphicon-pencil')); // <-- trigger switch edit mode button
+        ReactDOM.render(<Navigation buttons={buttons} />, document.getElementById("container"));
+        ReactTestUtils.Simulate.click(document.querySelector('.test-button')); // <-- trigger switch edit mode button
         expect(spySetEditing).toHaveBeenCalled();
         expect(spySetEditing.calls[0].arguments[0]).toBe(true);
     });

--- a/web/client/components/map/leaflet/__tests__/Map-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Map-test.jsx
@@ -24,8 +24,23 @@ require('../plugins/WMSLayer');
 
 describe('LeafletMap', () => {
 
+    let mapStyle;
     beforeEach(() => {
         document.body.innerHTML = '<div id="container"></div>';
+        // assign size to map component to get width and height of map
+        mapStyle = document.createElement('style');
+        mapStyle.innerHTML = `
+        #container {
+            position: relative;
+            width: 500px;
+            height: 500px;
+        }
+        #container > * {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }`;
+        document.head.appendChild(mapStyle);
     });
     afterEach(() => {
         try {
@@ -38,6 +53,12 @@ describe('LeafletMap', () => {
         } catch (e) {
             // ignore
         }
+
+        if (mapStyle) {
+            document.head.removeChild(mapStyle);
+            mapStyle = undefined;
+        }
+        MapUtils.clearHooks();
     });
 
     it('creates a div for leaflet map with given id', () => {
@@ -476,7 +497,7 @@ describe('LeafletMap', () => {
             onMapViewChanges: () => {}
         };
         // fix size
-        document.querySelector('#container').setAttribute('style', "width: 200px; height: 200px");
+        document.querySelector('#container').setAttribute('style', "width: 200px; height: 160px");
         const spy = expect.spyOn(testHandlers, 'onMapViewChanges');
         const map = ReactDOM.render(<LeafletMap
             id="mymap"

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -99,22 +99,21 @@ class OpenlayersMap extends React.Component {
         register(proj4);
         // interactive flag is used only for initializations,
         // TODO manage it also when it changes status (ComponentWillReceiveProps)
-        const defaultInteractionOptions = {
-            doubleClickZoom: false,
-            dragPan: false,
-            altShiftDragRotate: false,
-            keyboard: false,
-            mouseWheelZoom: false,
-            shiftDragZoom: false,
-            pinchRotate: false,
-            pinchZoom: false
-        };
-        let interactionsOptions = !this.props.interactive
-            ? defaultInteractionOptions
-            : assign(
-                defaultInteractionOptions,
-                this.props.mapOptions.interactions
-            );
+        let interactionsOptions = assign(
+            this.props.interactive ?
+                {} :
+                {
+                    doubleClickZoom: false,
+                    dragPan: false,
+                    altShiftDragRotate: false,
+                    keyboard: false,
+                    mouseWheelZoom: false,
+                    shiftDragZoom: false,
+                    pinchRotate: false,
+                    pinchZoom: false
+                },
+            this.props.mapOptions.interactions);
+
         let interactions = defaults(assign({
             dragPan: false,
             mouseWheelZoom: false
@@ -254,7 +253,7 @@ class OpenlayersMap extends React.Component {
          * on every render. We should prevent it with something like isEqual if this becomes
          * a performance problem
          */
-        if (this.map && this.props.interactive && (this.props.mapOptions && this.props.mapOptions.interactions) !== (newProps.mapOptions && newProps.mapOptions.interactions)) {
+        if (this.map && (this.props.mapOptions && this.props.mapOptions.interactions) !== (newProps.mapOptions && newProps.mapOptions.interactions)) {
             const newInteractions = newProps.mapOptions.interactions || {};
             const mapInteractions = this.map.getInteractions().getArray();
             Object.keys(newInteractions).forEach(newInteraction => {

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -99,21 +99,22 @@ class OpenlayersMap extends React.Component {
         register(proj4);
         // interactive flag is used only for initializations,
         // TODO manage it also when it changes status (ComponentWillReceiveProps)
-        let interactionsOptions = assign(
-            this.props.interactive ?
-                {} :
-                {
-                    doubleClickZoom: false,
-                    dragPan: false,
-                    altShiftDragRotate: false,
-                    keyboard: false,
-                    mouseWheelZoom: false,
-                    shiftDragZoom: false,
-                    pinchRotate: false,
-                    pinchZoom: false
-                },
-            this.props.mapOptions.interactions);
-
+        const defaultInteractionOptions = {
+            doubleClickZoom: false,
+            dragPan: false,
+            altShiftDragRotate: false,
+            keyboard: false,
+            mouseWheelZoom: false,
+            shiftDragZoom: false,
+            pinchRotate: false,
+            pinchZoom: false
+        };
+        let interactionsOptions = !this.props.interactive
+            ? defaultInteractionOptions
+            : assign(
+                defaultInteractionOptions,
+                this.props.mapOptions.interactions
+            );
         let interactions = defaults(assign({
             dragPan: false,
             mouseWheelZoom: false
@@ -253,7 +254,7 @@ class OpenlayersMap extends React.Component {
          * on every render. We should prevent it with something like isEqual if this becomes
          * a performance problem
          */
-        if (this.map && (this.props.mapOptions && this.props.mapOptions.interactions) !== (newProps.mapOptions && newProps.mapOptions.interactions)) {
+        if (this.map && this.props.interactive && (this.props.mapOptions && this.props.mapOptions.interactions) !== (newProps.mapOptions && newProps.mapOptions.interactions)) {
             const newInteractions = newProps.mapOptions.interactions || {};
             const mapInteractions = this.map.getInteractions().getArray();
             Object.keys(newInteractions).forEach(newInteraction => {

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -265,7 +265,7 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
                 return axios.get(`configs/${id}.json`)
                     // not return anything else that data in this case
                     // to match with data/resource object structure of getResource
-                    .then(({data}) => ({data, canEdit: true}));
+                    .then(({data}) => ({ data, isStatic: true, canEdit: true }));
             }
             return getResource(id);
         })
@@ -275,7 +275,7 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
                 }
                 return true;
             })
-            .switchMap(({ data, ...resource }) => {
+            .switchMap(({ data, isStatic = false, ...resource }) => {
                 const isAdmin = isAdminUserSelector(getState());
                 const user = isLoggedIn(getState());
                 const story = isString(data) ? JSON.parse(data) : data;
@@ -283,7 +283,8 @@ export const loadGeostoryEpic = (action$, {getState = () => {}}) => action$
                     return Observable.of(loadGeostoryError({status: 403}));
                 }
                 return Observable.from([
-                    setEditing(resource && resource.canEdit || isAdmin),
+                    // initialize editing only for new or static sources
+                    setEditing(isStatic && (resource && resource.canEdit || isAdmin)),
                     geostoryLoaded(id),
                     setCurrentStory(story),
                     setResource(resource)

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -682,6 +682,7 @@
           {
             "name": "GeoStoryEditor",
             "cfg": {
+              "disablePluginIf": "{!!(state('browser') && state('browser').mobile)}",
               "containerPosition": "columns"
             }
           },

--- a/web/client/plugins/GeoStoryEditor.jsx
+++ b/web/client/plugins/GeoStoryEditor.jsx
@@ -21,7 +21,8 @@ import {
     selectedCardSelector,
     isFocusOnContentSelector,
     settingsSelector,
-    settingsChangedSelector
+    settingsChangedSelector,
+    isEditAllowedSelector
 } from '../selectors/geostory';
 import geostory from '../reducers/geostory';
 import {
@@ -39,7 +40,31 @@ import {
 import Builder from '../components/geostory/builder/Builder';
 import { Modes, scrollToContent } from '../utils/GeoStoryUtils';
 import { createPlugin } from '../utils/PluginsUtils';
+import tooltip from '../components/misc/enhancers/tooltip';
+import { Button as ButtonRB, Glyphicon } from 'react-bootstrap';
+const Button = tooltip(ButtonRB);
 
+const EditButton = connect(
+    createStructuredSelector({
+        isEditAllowed: isEditAllowedSelector
+    }),
+    { setEditingMode: setEditing }
+)(({
+    isEditAllowed,
+    setEditingMode = () => {}
+}) => {
+    return isEditAllowed
+        ? (
+            <Button
+                className="square-button-md no-border"
+                onClick={() => setEditingMode(true)}
+                tooltipId="geostory.navigation.edit"
+                tooltipPosition="bottom">
+                <Glyphicon glyph="pencil" />
+            </Button>
+        )
+        : null;
+});
 
 const GeoStoryEditor = ({
     currentPage,
@@ -123,6 +148,11 @@ export default createPlugin('GeoStoryEditor', {
             onUpdate: update
         }
     )(GeoStoryEditor),
+    containers: {
+        GeoStoryNavigation: {
+            tool: EditButton
+        }
+    },
     reducers: {
         geostory
     }

--- a/web/client/plugins/GeoStoryNavigation.jsx
+++ b/web/client/plugins/GeoStoryNavigation.jsx
@@ -11,9 +11,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { createPlugin } from '../utils/PluginsUtils';
 import { Modes, scrollToContent } from '../utils/GeoStoryUtils';
-import { setEditing } from '../actions/geostory';
 import {
-    isEditAllowedSelector,
     currentPageSelector,
     currentPositionSelector,
     modeSelector,
@@ -32,30 +30,36 @@ const GeoStoryNavigation = ({
     mode = Modes.VIEW,
     currentPage,
     currentPosition,
-    isEditAllowed,
     totalItems,
     settings,
-    setEditingMode = () => { },
     navigableItems = [],
     pathname,
-    search
-}) => (mode === Modes.VIEW ? <div
-    key="geostory-navigation"
-    className="ms-geostory-navigation"
-    style={{width: "100%", position: 'relative' }}>
-    <Navigation
-        settings={settings}
-        currentPage={currentPage}
-        currentPosition={currentPosition}
-        isEditAllowed={isEditAllowed}
-        totalItems={totalItems}
-        scrollTo={(id, options = { behavior: "smooth" }) => {
-            scrollToContent(id, options);
-        }}
-        navigableItems={navigableItems}
-        router={{ pathname, search }}
-        setEditing={setEditingMode} />
-</div> : null);
+    search,
+    items = []
+}) => {
+
+    // get all buttons from other plugins via items
+    const buttons = items
+        .filter(({ tool }) => tool)
+        .map(({ tool }) => ({ Element: tool }));
+
+    return (mode === Modes.VIEW ? <div
+        key="geostory-navigation"
+        className="ms-geostory-navigation"
+        style={{width: "100%", position: 'relative' }}>
+        <Navigation
+            settings={settings}
+            currentPage={currentPage}
+            currentPosition={currentPosition}
+            totalItems={totalItems}
+            scrollTo={(id, options = { behavior: "smooth" }) => {
+                scrollToContent(id, options);
+            }}
+            navigableItems={navigableItems}
+            router={{ pathname, search }}
+            buttons={buttons} />
+    </div> : null);
+};
 /**
  * Plugin for GeoStory top panel for navigation
  * @name GeoStoryNavigation
@@ -68,14 +72,11 @@ export default createPlugin('GeoStoryNavigation', {
             settings: settingsSelector,
             currentPage: currentPageSelector,
             currentPosition: currentPositionSelector,
-            isEditAllowed: isEditAllowedSelector,
             totalItems: totalItemsSelector,
             navigableItems: navigableItemsSelectorCreator({includeAlways: false}),
             pathname: pathnameSelector,
             search: searchSelector
-        }), {
-            setEditingMode: setEditing
-        }
+        })
     )(GeoStoryNavigation),
     reducers: {
         geostory

--- a/web/client/plugins/__tests__/Map-test.jsx
+++ b/web/client/plugins/__tests__/Map-test.jsx
@@ -14,6 +14,7 @@ import { getPluginForTest } from './pluginsTestUtils';
 
 import { INIT_MAP } from '../../actions/map';
 import { RESET_CONTROLS } from '../../actions/controls';
+import MapUtils from '../../utils/MapUtils';
 
 const map = {
     center: {
@@ -33,6 +34,7 @@ describe('Map Plugin', () => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
         setTimeout(done);
+        MapUtils.clearHooks();
     });
 
     it('creates a Map plugin with default configuration (leaflet)', () => {

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -226,24 +226,123 @@
     }
     padding: 8px;
 }
+
+.ms-sections-container-small-screen {
+    @ms-story-padding-small-screen: @square-btn-medium-size / 2 + 8px;
+    .ms-section .ms-section-background .ms-section-background-container .ms-media {
+        /* alignment of content */
+        .ms-story-align-center();
+        /* size of content */
+        width: @ms-story-size-full;
+    }
+    .ms-section-title {
+        .ms-content-text {
+            width: 100%;
+            .ms-content-body {
+                margin-left: auto;
+                margin-right: auto;
+                padding-left: @ms-story-padding-small-screen;
+                padding-right: @ms-story-padding-small-screen;
+            }
+            .ms-content-body,
+            .ms-content-body > div {
+                width: 100%;
+            }
+            .ms-content-body .ms-content-toolbar {
+                width: auto;
+            }
+        }
+    }
+    .ms-section-paragraph {
+        padding-left: @ms-story-padding-small-screen;
+        padding-right: @ms-story-padding-small-screen;
+    }
+    .ms-section-immersive {
+        .ms-content-column {
+            padding-left: @ms-story-padding-small-screen;
+            padding-right: @ms-story-padding-small-screen;
+        }
+    }
+    .ms-content {
+        /* size of content */
+        width: @ms-story-size-full;
+        /* alignment of content */
+        .ms-story-align-center();
+        &.ms-content-text {
+            .ms-content-body {
+                /* font size for all the main classes in text content */
+                p { font-size: @ms-story-font-size-base * 0.75; }
+                h1 { font-size: @ms-story-font-size-h1 * 0.75; }
+                h2 { font-size: @ms-story-font-size-h2 * 0.75; }
+                h3 { font-size: @ms-story-font-size-h3 * 0.75; }
+                h4 { font-size: @ms-story-font-size-h4 * 0.75; }
+                h5 { font-size: @ms-story-font-size-h5 * 0.75; }
+                h6 { font-size: @ms-story-font-size-h6 * 0.75; }
+            }
+        }
+    }
+    .ms-section.ms-expandable-background {
+        &.ms-section-title .ms-content-text .ms-content-body,
+        &.ms-section-immersive .ms-content-column {
+            padding-right: @square-btn-medium-size + 8px;
+        }
+    }
+}
+.ms-sections-container-medium-screen {
+    @ms-story-padding-medium-screen: @square-btn-medium-size * 1.5;
+    .ms-section .ms-section-background .ms-section-background-container {
+        /* size of content */
+        &.ms-size-full .ms-media { width: 100%; }
+        &.ms-size-large .ms-media { width: 90%; }
+        &.ms-size-medium .ms-media { width: 80%; }
+        &.ms-size-small .ms-media { width: 60%; }
+    }
+    .ms-section-title .ms-content-text .ms-content-body {
+        padding-left: @ms-story-padding-medium-screen;
+        padding-right: @ms-story-padding-medium-screen;
+    }
+    .ms-section-paragraph {
+        padding-left: @ms-story-padding-medium-screen;
+        padding-right: @ms-story-padding-medium-screen;
+    }
+    .ms-content {
+        &.ms-content-text {
+            .ms-content-body {
+                p { font-size: @ms-story-font-size-base * 0.80; }
+                h1 { font-size: @ms-story-font-size-h1 * 0.80; }
+                h2 { font-size: @ms-story-font-size-h2 * 0.80; }
+                h3 { font-size: @ms-story-font-size-h3 * 0.80; }
+                h4 { font-size: @ms-story-font-size-h4 * 0.80; }
+                h5 { font-size: @ms-story-font-size-h5 * 0.80; }
+                h6 { font-size: @ms-story-font-size-h6 * 0.80; }
+            }
+        }
+        /* size of content */
+        &.ms-size-full { width: 100%; }
+        &.ms-size-large { width: 90%; }
+        &.ms-size-medium { width: 80%; }
+        &.ms-size-small { width: 60%; }
+    }
+}
+
 .ms-cascade-story {
 
     /////////////
     // SECTIONS
     /////////////
 
-    .ms-sections {
-        /*
-        Main scrollable container of the cascade story
-        */
-        .ms-sections-container {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            overflow-y: auto;
-        }
+    /*
+    Main scrollable container of the cascade story
+    */
+    .ms-sections-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: auto;
+        &.ms-sm { .ms-sections-container-small-screen(); }
+        &.ms-md { .ms-sections-container-medium-screen(); }
     }
 
     ////////////
@@ -461,6 +560,12 @@
             .ms-content.ms-content-text.ms-dark .ms-content-body > * {
                 box-shadow: none;
             }
+            .ms-content-column {
+                .ms-content:not(.ms-content-text) {
+                    padding-top: 16px;
+                    padding-bottom: 16px;
+                }
+            }
         }
         // overrides and specific styles for immersive section layout
         &.ms-section-immersive {
@@ -474,7 +579,7 @@
             .ms-content-column {
                     display: flex; // align vertically the content
                     pointer-events: none; // pass pointer events to background (this div takes full width and height)
-                    padding: 64px 24px;
+                    padding: 64px @square-btn-medium-size + 6px;
                     padding-top: 164px;
                 &>.ms-content-body {
                     // override background of paragraph (or title) content.
@@ -581,7 +686,6 @@
                 }
 
                 .ms-text-wrapper {
-                    min-width: 200px;
                     min-height: 40px;
                 }
 
@@ -744,6 +848,7 @@
         &.ms-media-map {
             .ol-zoom {
                 top: 50px;
+                left: 6px;
             }
 
         }
@@ -825,6 +930,28 @@
         width: 100%;
         height: 100%;
     }
+    /////////////////////
+    // VIEW
+    /////////////////////
+    &.ms-view {
+        .ms-section {
+            &.ms-section-paragraph {
+                padding-top: 32px;
+                padding-bottom: 32px;
+            }
+        }
+        .ms-media.ms-media-map .ol-zoom {
+            top: 6px;
+        }
+        .ms-media.ms-media-map .leaflet-control-zoom {
+            top: 6px;
+            left: 6px;
+            margin: 0;
+        }
+        .ms-section.ms-section-immersive .ms-content-column {
+            padding-top: 64px;
+        }
+    }
 
     /////////////////////
     // LIBRARIES FIX
@@ -834,6 +961,27 @@
     .public-DraftStyleDefault-ltr {
         text-align: inherit;
     }
+}
+
+.ms-expand-media-button {
+    .square-button-md();
+    .shadow-soft();
+    .no-border();
+    position: absolute;
+    z-index: 500;
+    top: 0;
+    right: 0;
+    margin: 4px;
+}
+.ms-expanded-media-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    padding: 4px;
+    background-color: rgba(0, 0, 0, 0.25);
+    & > * {
+        background-color: @ms-story-bg;
+    } 
 }
 
 .ms-media-map.topLeft .ol-zoom.ol-unselectable.ol-control {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1928,6 +1928,8 @@
             "addWebPageContent": "Webseitenabschnitt hinzufügen",
             "emptyTitle": "Diese Geschichte ist leer",
             "emptyDescription": "Erstellen Sie eine fantastische Geostory, indem Sie neuen Inhalt hinzufügen",
+            "closeFullscreenMap": "Schließen Vollbild-Karte",
+            "showFullscreenMap": "Vollbild-Anzeige Karte",
             "contentToolbar": {
                 "contentSize": "Größe ändern",
                 "contentHeightAuto": "Passen Sie diesen Abschnitt an die Höhe des Inhalts an",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1932,6 +1932,8 @@
             "zoomToContent": "Zoom to content",
             "emptyTitle": "This story is empty",
             "emptyDescription": "Start creating an awesome geostory by adding new content",
+            "closeFullscreenMap": "Close fullscreen map",
+            "showFullscreenMap": "Show fullscreen map",
             "contentToolbar": {
                 "contentSize": "Change size",
                 "contentHeightAuto": "Make this section to adapt to the content height",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1928,6 +1928,8 @@
             "addWebPageContent": "Agregar contenido de página web",
             "emptyTitle": "Esta historia esta vacia",
             "emptyDescription": "Comience a crear una increíble geografía agregando nuevo contenido",
+            "closeFullscreenMap": "Cerrar mapa a pantalla completa",
+            "showFullscreenMap": "Ver mapa en pantalla completa",
             "contentToolbar": {
                 "contentSize": "Cambiar tamaño",
                 "contentHeightAuto": "Haga esta sección para adaptarse a la altura del contenido",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1928,6 +1928,8 @@
             "addWebPageContent": "Ajouter du contenu de page Web",
             "emptyTitle": "Cette histoire est vide",
             "emptyDescription": "Commencez à créer une géostory géniale en ajoutant du nouveau contenu",
+            "closeFullscreenMap": "Fermer carte plein écran",
+            "showFullscreenMap": "Montrer la carte en plein écran",
             "contentToolbar": {
                 "contentSize": "Changer la taille",
                 "contentHeightAuto": "Faire cette section pour s'adapter à la hauteur du contenu",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1928,6 +1928,8 @@
             "addWebPageContent": "Aggiungi contenuto alla pagina Web",
             "emptyTitle": "Questa storia è vuota",
             "emptyDescription": "Inizia a creare una fantastica storia aggiungendo dei nuovi contenuti",
+            "closeFullscreenMap": "Chiudi mappa",
+            "showFullscreenMap": "Visualizza mappa a pieno schermo",
             "contentToolbar": {
                 "contentSize": "Cambia larghezza",
                 "contentHeightAuto": "Adatta la sezione all'altezza del contenuto",

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -114,7 +114,10 @@ export const DEFAULT_MAP_OPTIONS = {
     zoomControl: true,
     style: {width: "100%", height: "100%"},
     mapOptions: {
+        // leaflet
+        scrollWheelZoom: false,
         interactions: {
+            // openlayers
             mouseWheelZoom: false,
             dragPan: true
         }

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -68,6 +68,10 @@ function executeHook(hookName, existCallback, dontExistCallback) {
     return null;
 }
 
+function clearHooks() {
+    hooks = {};
+}
+
 /**
  * @param dpi {number} dot per inch resolution
  * @return {number} dot per meter resolution
@@ -648,5 +652,6 @@ module.exports = {
     parseLayoutValue,
     prepareMapObjectToCompare,
     updateObjectFieldKey,
-    compareMapChanges
+    compareMapChanges,
+    clearHooks
 };

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -290,6 +290,7 @@ describe("GeoStory Utils", () => {
             zoomControl: true,
             style: {width: "100%", height: "100%"},
             mapOptions: {
+                scrollWheelZoom: false,
                 interactions: {
                     mouseWheelZoom: false,
                     mouseClick: false,


### PR DESCRIPTION
## Description
This PR introduces following changes:
- update of GeoStory LESS style with ms-sm and ms-md classes for small and medium screens (large is the default one with no additional classes)
- update of media map of GeoStory with a button to enable/disable fullscreen capability of the map
- update of leaflet map to correctly unmount and remove zoomControl

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Improvement

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4963

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
GeoStory is responsive also for devices with small screens

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
