### PR TITLE
4962 Allow the user to visualize the layer legend corresponding t…

### DIFF
--- a/web/client/components/TOC/fragments/WMSLegend.jsx
+++ b/web/client/components/TOC/fragments/WMSLegend.jsx
@@ -17,18 +17,31 @@ class WMSLegend extends React.Component {
         legendStyle: PropTypes.object,
         showOnlyIfVisible: PropTypes.bool,
         currentZoomLvl: PropTypes.number,
-        scales: PropTypes.array
+        scales: PropTypes.array,
+        WMSLegendOptions: PropTypes.string,
+        scaleDependent: PropTypes.bool
     };
 
     static defaultProps = {
         legendContainerStyle: {},
-        showOnlyIfVisible: false
+        showOnlyIfVisible: false,
+        scaleDependent: true
     };
 
     render() {
         let node = this.props.node || {};
         if (this.canShow(node) && node.type === "wms" && node.group !== "background") {
-            return <div style={this.props.legendContainerStyle}><Legend style={this.props.legendStyle} layer={node} currentZoomLvl={this.props.currentZoomLvl} scales={this.props.scales}/></div>;
+            return (
+                <div style={this.props.legendContainerStyle}>
+                    <Legend
+                        style={this.props.legendStyle}
+                        layer={node}
+                        currentZoomLvl={this.props.currentZoomLvl}
+                        scales={this.props.scales}
+                        legendOptions={this.props.WMSLegendOptions}
+                        scaleDependent={this.props.scaleDependent}/>
+                </div>
+            );
         }
         return null;
     }

--- a/web/client/components/TOC/fragments/legend/Legend.jsx
+++ b/web/client/components/TOC/fragments/legend/Legend.jsx
@@ -16,14 +16,16 @@ class Legend extends React.Component {
         legendOptions: PropTypes.string,
         style: PropTypes.object,
         currentZoomLvl: PropTypes.number,
-        scales: PropTypes.array
+        scales: PropTypes.array,
+        scaleDependent: PropTypes.bool
     };
 
     static defaultProps = {
         legendHeigth: 12,
         legendWidth: 12,
-        legendOptions: "forceLabels:on;fontSize:10",
-        style: {maxWidth: "100%"}
+        legendOptions: "forceLabels:on;fontSize:30",
+        style: {maxWidth: "100%"},
+        scaleDependent: true
     };
     state = {
         error: false
@@ -62,7 +64,7 @@ class Legend extends React.Component {
             }, layer.legendParams || {},
             SecurityUtils.addAuthenticationToSLD(cleanParams || {}, props.layer),
             cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},
-            props.scales && props.currentZoomLvl ? {SCALE: Math.round(props.scales[props.currentZoomLvl])} : {});
+            props.scales && props.currentZoomLvl && props.scaleDependent ? {SCALE: Math.round(props.scales[props.currentZoomLvl])} : {});
             SecurityUtils.addAuthenticationParameter(url, query);
 
             return urlUtil.format({

--- a/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
+++ b/web/client/components/TOC/fragments/legend/__tests__/Legend-test.jsx
@@ -122,4 +122,37 @@ describe("test the Layer legend", () => {
                 done();
             });
     });
+    it('test legend scaleDependent and legendOptions default props', () => {
+        const layer = {
+            "type": "wms",
+            "url": "http://test2/reflector/open/service",
+            "visibility": true,
+            "title": "test layer 3 (no group)",
+            "name": "layer3",
+            "format": "image/png"
+        };
+        const legendComponent = ReactDOM.render(<Legend layer={layer} />, document.getElementById("container"));
+        expect(legendComponent.props.legendOptions).toBe('forceLabels:on;fontSize:30');
+        expect(legendComponent.props.scaleDependent).toBe(true);
+    });
+    it('test legend scaleDependent and legendOptions custom props', () => {
+        const layer = {
+            "type": "wms",
+            "url": "http://test2/reflector/open/service",
+            "visibility": true,
+            "title": "test layer 3 (no group)",
+            "name": "layer3",
+            "format": "image/png"
+        };
+        const legendOptionsCustom = 'forceLabels:on;fontSize:50';
+        const scaleDependentCustom = false;
+        const legendComponent = ReactDOM.render(
+            <Legend
+                layer={layer}
+                legendOptions={legendOptionsCustom}
+                scaleDependent={scaleDependentCustom}/>,
+            document.getElementById("container"));
+        expect(legendComponent.props.legendOptions).toBe(legendOptionsCustom);
+        expect(legendComponent.props.scaleDependent).toBe(scaleDependentCustom);
+    });
 });

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -346,7 +346,13 @@
             }, {
                 "name": "TOC",
                 "cfg": {
-                    "activateMetedataTool": false
+                    "activateMetedataTool": false,
+                    "layerOptions": {
+                      "legendOptions": {
+                        "WMSLegendOptions": "forceLabels:on;fontSize:30",
+                        "scaleDependent": true
+                      }
+                    }
                 }
             },
             "FilterLayer",

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -638,6 +638,24 @@ const checkPluginsEnhancer = branch(
  *   }
  *  }
  * ```
+ * Another legendOptions entry can be `WMSLegendOptions` it is styling prop for the wms legend.
+ * example:
+ * ```
+ * "layerOptions": {
+ *  "legendOptions": {
+ *   "WMSLegendOptions": "forceLabels:on;fontSize:30"
+ *  }
+ * }
+ * ```
+ * Another one legendOptions entry is `scaleDependent`, this option activates / deactivates scale dependency.
+ * example:
+ * ```
+ * "layerOptions": {
+ *  "legendOptions": {
+ *   "scaleDependent": true
+ *  }
+ * }
+ * ```
  * Another layerOptions entry can be `indicators`. `indicators` is an array of icons to add to the TOC. They must satisfy a condition to be shown in the TOC.
  * For the moment only indicators of type `dimension` are supported.
  * example :


### PR DESCRIPTION
…o the assigned style and scale dependence.

## Description
Allow the user to visualize the layer legend corresponding to the assigned style and scale dependence.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#4962  

**What is the new behavior?**
 The user can visualize the layer legend corresponding to the assigned style and scale dependence.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
