### PR TITLE
Fix 4968 Navbar does not work on GeoStory mobile

### DIFF
--- a/web/client/components/geostory/layouts/sections/Section.jsx
+++ b/web/client/components/geostory/layouts/sections/Section.jsx
@@ -100,4 +100,4 @@ const DEFAULT_THRESHOLD = [0, 0.25, 0.5, 0.75, 1];
  * negative rootMargin allows to get the top element highlighted (trigger visibility event)
  * if it's present in the viewport after initial 100px
 */
-export default visibilityHandler({ threshold: DEFAULT_THRESHOLD, rootMargin: "-200px" })(Section);
+export default visibilityHandler({ threshold: DEFAULT_THRESHOLD, rootMargin: "-200px 0px 0px 0px" })(Section);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR removes left, bottom and right root margins on cascade story. Left and right margins were blocking the correct update of in view components of `react-intersection-observer` library.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4968

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
GeoStory navbar updates also on screen with width less than 400px

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
