### PR TITLE
Adds popup support and mapInfo popup viewer

### DIFF
--- a/web/client/actions/__tests__/mapPopups-test.js
+++ b/web/client/actions/__tests__/mapPopups-test.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import * as POPUP from '../mapPopups';
+
+
+describe('test map popups action creators', () => {
+    it('addPopup', () => {
+        const action = POPUP.addPopup("id", {content: "options"}, true);
+        expect(action.type).toEqual(POPUP.ADD_MAP_POPUP);
+        expect(action.id).toBe("id");
+        expect(action.single).toBeTruthy();
+        expect(action.popup.content).toBe("options");
+    });
+    it('removePopup', () => {
+        const action = POPUP.removePopup("id");
+        expect(action.type).toEqual(POPUP.REMOVE_MAP_POPUP);
+        expect(action.id).toBe("id");
+    });
+    it('cleanPopup', () => {
+        const action = POPUP.cleanPopups();
+        expect(action.type).toEqual(POPUP.CLEAN_MAP_POPUPS);
+    });
+});
+

--- a/web/client/actions/mapPopups.js
+++ b/web/client/actions/mapPopups.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+
+export const ADD_MAP_POPUP = 'MAP:ADD_POPUP';
+export const REMOVE_MAP_POPUP = 'MAP:REMOVE_POPUP';
+export const CLEAN_MAP_POPUPS = 'MAP:CLEAN_POPUPS';
+
+export const addPopup = (id, options, single = true) => ({
+    type: ADD_MAP_POPUP,
+    id,
+    popup: { id, ...options},
+    single
+});
+
+export const removePopup = (id) => ({
+    type: REMOVE_MAP_POPUP,
+    id
+});
+
+export const cleanPopups = () => ({
+    type: CLEAN_MAP_POPUPS
+});

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -58,11 +58,13 @@ module.exports = props => {
         showCoordinateEditor,
         onChangeClickPoint,
         onChangeFormat,
-        formatCoord
+        formatCoord,
+        showInMapPopup,
+        isCesium
     } = props;
 
     const latlng = point && point.latlng || null;
-
+    const isEnabled = enabled && (isCesium || !showInMapPopup);
     let lngCorrected = null;
     if (latlng) {
         /* lngCorrected is the converted longitude in order to have the value between
@@ -80,12 +82,12 @@ module.exports = props => {
     const missingResponses = requests.length - responses.length;
     const revGeocodeDisplayName = reverseGeocodeData.error ? <Message msgId="identifyRevGeocodeError"/> : reverseGeocodeData.display_name;
     return (
-        <div id="identify-container" className={enabled && requests.length !== 0 ? "identify-active" : ""}>
+        <div id="identify-container" className={isEnabled && requests.length !== 0 ? "identify-active" : ""}>
             <DockablePanel
                 bsStyle="primary"
                 glyph="map-marker"
                 title={!viewerOptions.header ? validResponses[index] && validResponses[index].layerMetadata && validResponses[index].layerMetadata.title || '' : <Message msgId="identifyTitle" />}
-                open={enabled && requests.length !== 0}
+                open={isEnabled && requests.length !== 0}
                 size={size}
                 fluid={fluid}
                 position={position}

--- a/web/client/components/data/identify/PopupViewer.jsx
+++ b/web/client/components/data/identify/PopupViewer.jsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import loadingState from '../../misc/enhancers/loadingState';
+import {defaultViewerHandlers, defaultViewerDefaultProps} from './enhancers/defaultViewer';
+import { compose, defaultProps} from 'recompose';
+import {connect} from 'react-redux';
+import { createSelector} from 'reselect';
+import {indexSelector, responsesSelector, showEmptyMessageGFISelector, generalInfoFormatSelector, validResponsesSelector} from '../../../selectors/mapInfo';
+import {changePage} from '../../../actions/mapInfo';
+import Viewer from './DefaultViewer';
+import {isArray} from 'lodash';
+import SwipeHeader from './SwipeHeader';
+
+/**
+ * Container that render only the selected result
+ */
+const Container = ({index, children}) => (<React.Fragment>{isArray(children) && children[index] || children}</React.Fragment>);
+
+/*
+ * Enhancer to enable set index only if Component has not header in viewerOptions props
+ */
+const identifyIndex = compose(
+    connect(
+        createSelector(indexSelector, (index) => ({ index })),
+        {
+            setIndex: changePage
+        }
+    ),
+    defaultProps({
+        index: 0,
+        responses: []
+    })
+)
+;
+const selector = createSelector([
+    responsesSelector,
+    validResponsesSelector,
+    (state) => state.mapInfo && state.mapInfo.requests || [],
+    generalInfoFormatSelector,
+    showEmptyMessageGFISelector],
+(responses, validResponses, requests, format, showEmptyMessageGFI) => ({
+    responses,
+    validResponses,
+    requests,
+    format,
+    showEmptyMessageGFI,
+    missingResponses: (requests || []).length - (responses || []).length
+}));
+
+
+export  default compose(
+    connect(selector),
+    defaultProps({
+        responses: [],
+        container: Container,
+        header: SwipeHeader
+    }),
+    identifyIndex,
+    defaultViewerDefaultProps,
+    defaultViewerHandlers,
+    loadingState(({responses}) => responses.length === 0)
+)(Viewer);

--- a/web/client/components/geostory/media/Map.jsx
+++ b/web/client/components/geostory/media/Map.jsx
@@ -9,11 +9,12 @@ import React from 'react';
 import { compose, branch} from 'recompose';
 
 
-import MapView from '../../widgets/widget/MapView'; // TODO: use a external component
+import MapView from '../common/MapView'; // TODO: use a external component
 import { applyDefaults } from '../../../utils/GeoStoryUtils';
 import {defaultLayerMapPreview} from '../../../utils/MediaEditorUtils';
 
 import connectMap, {withLocalMapState, withMapEditingAndLocalMapState} from '../common/enhancers/map';
+
 
 export default compose(
     branch(
@@ -27,7 +28,8 @@ export default compose(
     map = {layers: [defaultLayerMapPreview]},
     fit,
     editMap = false,
-    onMapViewChanges
+    onMapViewChanges,
+    eventHandlers
 }) => {
     const { layers = [], mapOptions = {}, ...m} = (map.data ? map.data : map);
     return (<div
@@ -38,11 +40,13 @@ export default compose(
         {/* BaseMap component overrides the MapView id with map's id */}
         <MapView
             onMapViewChanges={onMapViewChanges}
+            eventHandlers={eventHandlers}
             map={{
                 ...m,
                 id: `media-${id}`
             }} // if map id is passed as number, the resource id, ol throws an error
             layers={layers}
+            tools={["popup"]}
             options={
                 // mouseWheelZoom is enabled only if inlineEditing is active and zoomControl too
                 applyDefaults(!editMap ? {mapOptions} : {

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -137,6 +137,7 @@ class LeafletMap extends React.Component {
                         lng: event.latlng.lng,
                         z: this.elevationLayer && this.elevationLayer.getElevation(event.latlng, event.containerPoint) || undefined
                     },
+                    rawPos: [event.latlng.lat, event.latlng.lng],
                     modifiers: {
                         alt: event.originalEvent.altKey,
                         ctrl: event.originalEvent.ctrlKey,

--- a/web/client/components/map/leaflet/PopupSupport.jsx
+++ b/web/client/components/map/leaflet/PopupSupport.jsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import L from 'leaflet';
+import * as Utils from '../../../utils/PopupUtils';
+
+
+// It adds a mutation observer to popup's container
+// When react render inside it, the observer call an update on leaflet popup
+// adjusting the popup size.
+const addMutationObserver = (popup, container) => {
+    let observer = new MutationObserver(() => {
+        popup.update();
+    });
+    popup.once('remove', () => {
+        observer && observer.disconnect();
+        observer = null;
+    });
+    observer.observe(container, {attributes: true, childList: true, subtree: true });
+};
+
+export default class PopupSupport extends React.Component {
+    static propTypes = {
+        map: PropTypes.object,
+        popups: PropTypes.arrayOf(PropTypes.object),
+        onPopupClose: PropTypes.func
+    }
+
+    static defaultProps = {
+        popups: [],
+        onPopupClose: () => {}
+    }
+    componentDidMount() {
+        if (this.props.map) {
+            this.props.map.on('resize', this.updatePopup);
+        }
+    }
+    shouldComponentUpdate({popups}) {
+        return popups !== this.props.popups;
+    }
+    componentWillUnmount() {
+        if (this.props.map) {
+            this.props.map.off('resize', this.updatePopup);
+        }
+    }
+    renderPopups() {
+        return  this.preparePopups()
+            .filter(({component}) => !!component)
+            .map(({popup, props = {}, compStyle, component: PopupContent, id}) => {
+                const context = popup.getContent();
+                const El = React.isValidElement(PopupContent) && PopupContent || <PopupContent style={compStyle} {...props}/>;
+                return context ? ReactDOM.createPortal(El, context, id) : null;
+            });
+    }
+    render() {
+        return <div>{this.renderPopups()}</div>;
+    }
+    updatePopup = () => {
+        (this._popups || []).map(({popup}) => popup.update());
+    }
+    popupClose = ({target: {options: {id} = {}} = {}} = {}) => {
+        if (id) {
+            this.props.onPopupClose(id);
+        }
+    }
+    preparePopups = () => {
+        const {popups = [], map} = this.props;
+        const size = this.props.map.getSize();
+        // Clean old popups without throwing event
+        (this._popups || []).forEach(({popup}) => {
+            popup.off('remove', this.popupClose);
+            popup && this.props.map.removeLayer(popup);
+        });
+        // Create popups
+        this._popups = popups.map(( options = {}) => {
+            const { id, position: { coordinates }, component, content, className,
+                maxWidth = size.x * 0.9,
+                maxHeight = size.y * 0.5,
+                autoPan = true,
+                offset = [0, 7]} = options;
+            const container = Utils.createContainer(id, className);
+            container.setAttribute("style", `max-width: ${maxWidth}px; max-height: ${maxHeight}px`);
+            Utils.append(container, content);
+            // Always wrap the content in a div
+            const popup = L.popup({id, autoClose: false, closeOnClick: false, autoPan, maxWidth, maxHeight, className: "ms-leaflet-popup", offset}).setContent(container);
+            popup.once('remove', this.popupClose);
+            component && addMutationObserver(popup, container);
+
+            popup.setLatLng(coordinates);
+            map.addLayer(popup); // This is needed to mange multiple popup
+            const compStyle = {maxWidth: maxWidth - 30, maxHeight: maxHeight - 20};
+
+            return {popup, compStyle, ...options};
+        });
+        return this._popups;
+    }
+}

--- a/web/client/components/map/leaflet/__tests__/PopupSupport-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/PopupSupport-test.jsx
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+
+import L from 'leaflet';
+import PopupSupport from '../PopupSupport';
+
+const popupExists = () => {
+    const popup = document.querySelector('.leaflet-popup-content');
+    expect(popup).toExist();
+    return popup;
+};
+
+describe('Leaflet PopupSupport', () => {
+    let psNode;
+    let map;
+
+
+    const renderPopups = (props = {}) => {
+        return ReactDOM.render(
+            <PopupSupport
+                map={props.map || map}
+                {...props}
+            />,
+            psNode
+        );
+    };
+
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="map" style="heigth: 100px; width: 100px"></div><div id="ps"></div>';
+        psNode = document.getElementById('ps');
+        map = L.map("map", {
+            center: [25, 25],
+            zoom: 13
+        });
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(psNode);
+        document.body.innerHTML = '';
+        psNode = undefined;
+        setTimeout(done);
+    });
+
+    it('should render', () => {
+        const component = renderPopups();
+        expect(component).toExist();
+    });
+    it('should attach popup with a text content to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                content: "popup text content",
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        const popup = popupExists();
+        expect(popup.querySelector('#test-map-popup')).toExist();
+    });
+    it('should attach popup with a html content to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                content: '<div id="innerHtml">popup text content</div>',
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        const popup = popupExists();
+        expect(popup.querySelector('#innerHtml')).toExist();
+    });
+    it('should attach popup with a component to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                component: () => (<div style={{width: 300, height: 100}} >popup content text</div>),
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        const popup = popupExists();
+        expect(popup.querySelector('#test-map-popup')).toExist();
+    });
+    it('should attach popup with a component instance to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                component: <div style={{width: 300, height: 100}} >popup content text</div>,
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            }
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        const popup = popupExists();
+        expect(popup.querySelector('#test-map-popup')).toExist();
+    });
+    it('should attach popups text, html, component', () => {
+        const popups = [
+            {
+                id: 'test-text',
+                content: "popup text content",
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            },
+            {
+                id: 'test-html',
+                content: '<div id="innerHtml">popup text content</div>',
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            },
+            {
+                id: 'test-component',
+                component: () => (<div style={{width: 300, height: 100}} >popup content text</div>),
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        const poups = document.querySelectorAll('.leaflet-popup-content');
+        expect(poups).toExist();
+        expect(poups.length).toBe(3);
+        expect(poups[0].querySelector('#test-text-map-popup')).toExist();
+        expect(poups[1].querySelector('#test-html-map-popup')).toExist();
+        expect(poups[2].querySelector('#test-component-map-popup')).toExist();
+    });
+    it('should close an open popups and call the right action', (done) => {
+        const popups = [
+            {
+                id: 'test-text',
+                content: "popup text content",
+                position: { coordinates: {lat: 0, lng: 0} },
+                autoPan: false
+            }
+        ];
+        const onPopupClose = (id) => {
+            expect(id).toBe(popups[0].id);
+            done();
+        };
+        const component = renderPopups({ popups, onPopupClose});
+        expect(component).toExist();
+        const close = document.querySelector('.leaflet-popup-close-button');
+        close.click();
+    });
+});
+

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -210,6 +210,7 @@ class OpenlayersMap extends React.Component {
                             lng: tLng,
                             z: getElevation && getElevation(pos, event.pixel) || undefined
                         },
+                        rawPos: event.coordinate.slice(),
                         modifiers: {
                             alt: event.originalEvent.altKey,
                             ctrl: event.originalEvent.ctrlKey,

--- a/web/client/components/map/openlayers/PopupSupport.jsx
+++ b/web/client/components/map/openlayers/PopupSupport.jsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { Overlay } from 'ol';
+import * as Utils from '../../../utils/PopupUtils';
+
+
+const addMutationObserver = (popup, container) => {
+    let observer = new MutationObserver(() => {
+        popup.getMap().render();
+        popup.setElement(popup.getElement());
+    });
+    observer.observe(container, {attributes: true, childList: true, subtree: true });
+    return observer;
+};
+
+
+export default class PopupSupport extends React.Component {
+
+    static propTypes = {
+        map: PropTypes.object,
+        popups: PropTypes.arrayOf(PropTypes.object),
+        onPopupClose: PropTypes.func
+    }
+
+    static defaultProps = {
+        popups: [],
+        onPopupClose: () => {}
+    }
+    shouldComponentUpdate({popups}) {
+        return popups !== this.props.popups;
+    }
+    onPopupClose = (id) => {
+        this.props.onPopupClose(id);
+    }
+    renderPopups = () => {
+        return this.preparePopups().map(({ popup, id, component: PopupContent, content, props, compStyle, containerStyle}) => {
+            const context = popup.getElement();
+            let El;
+            if (!!PopupContent) {
+                El = React.isValidElement(PopupContent) && PopupContent || <PopupContent style={compStyle} {...props}/>;
+            } else if (content) {
+                El = Utils.isHTML(content) ? <div dangerouslySetInnerHTML={{__html: content}}/> : content;
+            }
+            return context && ReactDOM.createPortal(
+                <div className="map-popup-ol" key={id} onMouseUp={this.convertToClick}>
+                    <div className="ol-popup-content-wrapper" >
+                        <div className="ol-popup-content" style={containerStyle}>
+                            {El}
+                        </div>
+                    </div>
+                    <div className="ol-popup-closer" onClick={() => this.onPopupClose(id)}>x</div>
+                </div>,
+                context
+            );
+        });
+    }
+    render() {
+        return <div>{this.renderPopups()}</div>;
+    }
+    update = () => {
+        (this._popups || []).map(({popup}) => {
+            popup.setElement(popup.getElement());
+        });
+    }
+    convertToClick = (e) => {
+        const evt = new MouseEvent('click', { bubbles: true });
+        evt.stopPropagation = () => {};
+        e.target.dispatchEvent(evt);
+    }
+
+    preparePopups = () => {
+        const {popups = [], map} = this.props;
+        const size = map.getSize();
+        (this._popups || []).forEach(({popup, observer}) => {
+            !!observer && observer.disconnect();
+            !!popup && map.removeOverlay(popup);
+        });
+        this._popups = popups.map((options) => {
+            const { id, position: { coordinates }, className,
+                maxWidth = Math.round(size[0] * 0.9),
+                maxHeight = Math.round(size[1] * 0.5),
+                autoPan = true,
+                autoPanMargin = 20,
+                offset = [0, 0],
+                autoPanAnimation = {
+                    duration: 200
+                }} = options;
+
+            const container = Utils.createContainer(id, className);
+            const popup = new Overlay({
+                id,
+                element: container,
+                autoPan,
+                offset,
+                autoPanMargin,
+                autoPanAnimation,
+                positioning: 'bottom-center',
+                className: 'ol-overlay-container ol-unselectable',
+                position: coordinates
+            });
+            map.addOverlay(popup);
+            const observer = addMutationObserver(popup, container);
+            const containerStyle = {maxWidth, maxHeight: maxHeight};
+            const compStyle = {maxWidth: maxWidth - 30, maxHeight: maxHeight - 20};
+            return {popup, observer, compStyle, containerStyle, ...options};
+        });
+        return this._popups;
+    }
+}

--- a/web/client/components/map/openlayers/__tests__/PopupSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/PopupSupport-test.jsx
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+
+import { Map, View } from 'ol';
+import PopupSupport from '../PopupSupport';
+
+describe('Openlayers PopupSupport', () => {
+    const viewOptions = {
+        projection: 'EPSG:3857',
+        center: [0, 0],
+        zoom: 5
+    };
+    let psNode;
+    let map;
+
+    const renderPopups = (props = {}) => {
+        return ReactDOM.render(
+            <PopupSupport
+                map={props.map || map}
+                {...props}
+            />,
+            psNode
+        );
+    };
+
+    const getOverlaysNum = (olMap) => {
+        return olMap.getOverlays().getLength();
+    };
+
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="map" style="heigth: 100px; width: 100px"></div><div id="ps"></div>';
+        psNode = document.getElementById('ps');
+        map = new Map({
+            layers: [],
+            target: "map",
+            view: new View(viewOptions)
+        });
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(psNode);
+        document.body.innerHTML = '';
+        psNode = undefined;
+        map.setTarget(null);
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render', () => {
+        const component = renderPopups();
+        expect(component).toExist();
+    });
+    it('should attach popup with a text content to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                content: "popup text content",
+                position: { coordinates: [0, 0]},
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        expect(getOverlaysNum(map)).toBe(1);
+        expect(document.querySelector('#test-map-popup')).toExist();
+    });
+    it('should attach popup with a html content to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                content: '<div id="innerHtml">popup text content</div>',
+                position: { coordinates: [0, 0] },
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        expect(getOverlaysNum(map)).toBe(1);
+        expect(document.querySelector('#innerHtml')).toExist();
+    });
+    it('should attach popup with a component to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                component: () => (<div style={{width: 300, height: 100}} >popup content text</div>),
+                position: { coordinates: [0, 0]},
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        expect(getOverlaysNum(map)).toBe(1);
+        expect(document.querySelector('#test-map-popup')).toExist();
+    });
+    it('should attach popup with a component instance to map', () => {
+        const popups = [
+            {
+                id: 'test',
+                component: <div style={{width: 300, height: 100}} >popup content text</div>,
+                position: { coordinates: [0, 0]},
+                autoPan: false
+            }
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        expect(getOverlaysNum(map)).toBe(1);
+        expect(document.querySelector('#test-map-popup')).toExist();
+    });
+    it('should attach popups text, html, component', () => {
+        const popups = [
+            {
+                id: 'test-text',
+                content: "popup text content",
+                position: { coordinates: [0, 0] },
+                autoPan: false
+            },
+            {
+                id: 'test-html',
+                content: '<div id="innerHtml">popup text content</div>',
+                position: { coordinates: [0, 0] },
+                autoPan: false
+            },
+            {
+                id: 'test-component',
+                component: () => (<div style={{width: 300, height: 100}} >popup content text</div>),
+                position: { coordinates: [0, 0] },
+                autoPan: false
+            }
+
+        ];
+        const component = renderPopups({ popups });
+        expect(component).toExist();
+        expect(getOverlaysNum(map)).toBe(3);
+
+        expect(document.querySelector('#test-text-map-popup')).toExist();
+        expect(document.querySelector('#test-html-map-popup')).toExist();
+        expect(document.querySelector('#test-component-map-popup')).toExist();
+    });
+
+});
+

--- a/web/client/components/map/plugins/leaflet.js
+++ b/web/client/components/map/plugins/leaflet.js
@@ -16,6 +16,7 @@ module.exports = () => {
         MeasurementSupport: require('../leaflet/MeasurementSupport'),
         Overview: require('../leaflet/Overview'),
         ScaleBar: require('../leaflet/ScaleBar'),
-        DrawSupport: require('../leaflet/DrawSupport')
+        DrawSupport: require('../leaflet/DrawSupport'),
+        PopupSupport: require('../leaflet/PopupSupport').default
     };
 };

--- a/web/client/components/map/plugins/openlayers.js
+++ b/web/client/components/map/plugins/openlayers.js
@@ -16,7 +16,8 @@ module.exports = () => {
         MeasurementSupport: require('../openlayers/MeasurementSupport').default,
         Overview: require('../openlayers/Overview').default,
         ScaleBar: require('../openlayers/ScaleBar').default,
-        DrawSupport: require('../openlayers/DrawSupport').default
+        DrawSupport: require('../openlayers/DrawSupport').default,
+        PopupSupport: require('../openlayers/PopupSupport').default
     };
 };
 

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -10,7 +10,7 @@ const expect = require('expect');
 
 const { ZOOM_TO_POINT, clickOnMap } = require('../../actions/map');
 const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature } = require('../../actions/mapInfo');
-const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh, closeFeatureInfoOnCatalogOpenEpic } = require('../identify');
+const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh, closeFeatureInfoOnCatalogOpenEpic } = require('../identify').default;
 const { CLOSE_ANNOTATIONS } = require('../../actions/annotations');
 const { testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
 const { registerHook } = require('../../utils/MapUtils');

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -13,7 +13,7 @@ const assign = require('object-assign');
 
 const {mapSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
-const { mapTypeSelector } = require('../selectors/maptype');
+const { mapTypeSelector, isCesium } = require('../selectors/maptype');
 
 const { generalInfoFormatSelector, clickPointSelector, indexSelector, responsesSelector, validResponsesSelector, showEmptyMessageGFISelector, isHighlightEnabledSelector, currentFeatureSelector, currentFeatureCrsSelector } = require('../selectors/mapInfo');
 
@@ -53,7 +53,8 @@ const selector = createStructuredSelector({
     dockStyle: state => mapLayoutValuesSelector(state, {height: true}),
     formatCoord: (state) => state.mapInfo && state.mapInfo.formatCoord,
     showCoordinateEditor: (state) => state.mapInfo && state.mapInfo.showCoordinateEditor,
-    showEmptyMessageGFI: state => showEmptyMessageGFISelector(state)
+    showEmptyMessageGFI: state => showEmptyMessageGFISelector(state),
+    isCesium
 });
 // result panel
 
@@ -242,5 +243,5 @@ module.exports = {
         }
     }),
     reducers: {mapInfo: require('../reducers/mapInfo')},
-    epics: require('../epics/identify')
+    epics: require('../epics/identify').default
 };

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -210,7 +210,7 @@ class MapPlugin extends React.Component {
         zoomControl: false,
         mapLoadingMessage: "map.loading",
         loadingSpinner: true,
-        tools: ["measurement", "locate", "scalebar", "draw", "highlight"],
+        tools: ["measurement", "locate", "scalebar", "draw", "highlight", "popup"],
         options: {},
         mapOptions: {},
         fonts: ['FontAwesome'],

--- a/web/client/plugins/map/index.js
+++ b/web/client/plugins/map/index.js
@@ -7,8 +7,10 @@
 */
 
 const React = require('react');
+const {createSelector} = require('reselect');
 
 const {creationError, changeMapView, clickOnMap} = require('../../actions/map');
+const {removePopup} = require('../../actions/mapPopups');
 const {layerLoading, layerLoad, layerError} = require('../../actions/layers');
 const {changeMousePosition} = require('../../actions/mousePosition');
 const {changeMeasurementState, changeGeometry, resetGeometry, updateMeasures} = require('../../actions/measurement');
@@ -93,6 +95,16 @@ module.exports = (mapType, actions) => {
     require('../../components/map/' + mapType + '/plugins/index');
     const LLayer = connect(null, {onWarning: warning})( components.Layer || Empty);
 
+    const EMPTY_POPUPS = [];
+    const PopupSupport = connect(
+        createSelector(
+            (state) => state.mapPopups && state.mapPopups.popups || EMPTY_POPUPS,
+            (popups) => ({
+                popups
+            })), {
+            onPopupClose: removePopup
+        }
+    )(components.PopupSupport || Empty);
     return {
         Map: LMap,
         Layer: LLayer,
@@ -104,7 +116,8 @@ module.exports = (mapType, actions) => {
             scalebar: components.ScaleBar || Empty,
             draw: DrawSupport,
             highlight: HighlightSupport,
-            selection: SelectionSupport
+            selection: SelectionSupport,
+            popup: PopupSupport
         }
     };
 };

--- a/web/client/plugins/map/leaflet/index.js
+++ b/web/client/plugins/map/leaflet/index.js
@@ -15,5 +15,6 @@ module.exports = {
     Overview: require('../../../components/map/leaflet/Overview'),
     ScaleBar: require('../../../components/map/leaflet/ScaleBar'),
     DrawSupport: require('../../../components/map/leaflet/DrawSupport'),
-    HighlightFeatureSupport: require('../../../components/map/leaflet/HighlightFeatureSupport')
+    HighlightFeatureSupport: require('../../../components/map/leaflet/HighlightFeatureSupport'),
+    PopupSupport: require('../../../components/map/leaflet/PopupSupport').default
 };

--- a/web/client/plugins/map/openlayers/index.js
+++ b/web/client/plugins/map/openlayers/index.js
@@ -20,5 +20,6 @@ module.exports = {
     ScaleBar: require('../../../components/map/openlayers/ScaleBar').default,
     DrawSupport: require('../../../components/map/openlayers/DrawSupport').default,
     HighlightFeatureSupport: require('../../../components/map/openlayers/HighlightFeatureSupport').default,
-    SelectionSupport: require('../../../components/map/openlayers/SelectionSupport').default
+    SelectionSupport: require('../../../components/map/openlayers/SelectionSupport').default,
+    PopupSupport: require('../../../components/map/openlayers/PopupSupport').default
 };

--- a/web/client/product/main.jsx
+++ b/web/client/product/main.jsx
@@ -58,6 +58,7 @@ module.exports = (config = {}, pluginsDef, overrideConfig = cfg => cfg) => {
                 maps: require('../reducers/maps'),
                 maplayout: require('../reducers/maplayout'),
                 version: require('../reducers/version'),
+                mapPopups: require('../reducers/mapPopups').default,
                 ...appReducers
             },
             baseEpics || {

--- a/web/client/reducers/__tests__/mapPopups-test.js
+++ b/web/client/reducers/__tests__/mapPopups-test.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import * as ACTIONS from '../../actions/mapPopups';
+
+import reducer from '../mapPopups';
+
+const initialState = {popups: []};
+describe('mapPopups reducer', () => {
+    it('ADD POPUP ', () => {
+        const state = reducer(initialState, ACTIONS.addPopup("id", {}, true));
+        expect(state.popups).toExist();
+        expect(state.popups.length).toBe(1);
+        expect(state.popups[0].id).toBe("id");
+    });
+    it('REMOVE POPUP ', () => {
+        let state = reducer(initialState, ACTIONS.addPopup("id", {}, true));
+        expect(state.popups).toExist();
+        expect(state.popups.length).toBe(1);
+        expect(state.popups[0].id).toBe("id");
+        state = reducer(state, ACTIONS.removePopup("id"));
+        expect(state.popups).toExist();
+        expect(state.popups.length).toBe(0);
+    });
+    it('REMOVE POPUP ', () => {
+        let state = reducer(initialState, ACTIONS.addPopup("id", {}, false));
+        state = reducer(state, ACTIONS.addPopup("id-2", {}, false));
+        expect(state.popups).toExist();
+        expect(state.popups.length).toBe(2);
+        state = reducer(state, ACTIONS.cleanPopups());
+        expect(state.popups).toExist();
+        expect(state.popups.length).toBe(0);
+    });
+
+});

--- a/web/client/reducers/mapPopups.js
+++ b/web/client/reducers/mapPopups.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {ADD_MAP_POPUP, REMOVE_MAP_POPUP, CLEAN_MAP_POPUPS} from '../actions/mapPopups';
+import {arrayDelete} from '../utils/ImmutableUtils';
+
+const initialState = {popups: []};
+export default function(state = initialState, action) {
+    switch (action.type) {
+    case ADD_MAP_POPUP: {
+        const {popup, single} = action;
+        return {...state, popups: single && [popup] || (state.popups || []).concat([popup])};
+    }
+    case REMOVE_MAP_POPUP: {
+        const {id} = action;
+        return arrayDelete("popups", {id}, state);
+    }
+    case CLEAN_MAP_POPUPS: {
+        return {...state, popups: []};
+    }
+    default:
+        return state;
+    }
+}

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -14,7 +14,9 @@ const { mapSelector } = require('./map');
 const { isPluginInContext } = require('./context');
 const { currentLocaleSelector } = require('./locale');
 const MapInfoUtils = require('../utils/MapInfoUtils');
+const {isCesium} = require('./maptype');
 
+const {pluginsSelectorCreator} = require('./localConfig');
 /**
  * selects mapinfo state
  * @name mapinfo
@@ -22,6 +24,13 @@ const MapInfoUtils = require('../utils/MapInfoUtils');
  * @static
  */
 
+const isMapPopup =  createSelector(
+    (state) => pluginsSelectorCreator("desktop")(state) || {},
+    isCesium,
+    (plugins, cesium) => {
+        return !cesium && !!((Object.values(plugins).filter(({name}) => name === "Identify").pop() || {}).cfg || {}).showInMapPopup;
+    }
+);
 /**
   * Get mapinfo requests from state
   * @function
@@ -33,7 +42,8 @@ const mapInfoRequestsSelector = state => get(state, "mapInfo.requests") || [];
 const isMapInfoOpen = createSelector(
     mapInfoRequestsSelector,
     isPluginInContext('Identify'),
-    (mapInfoRequests, isIdentifyInContext) => !!mapInfoRequests && mapInfoRequests.length > 0 && isIdentifyInContext
+    isMapPopup,
+    (mapInfoRequests, isIdentifyInContext, showInMapPopup) => !showInMapPopup && !!mapInfoRequests && mapInfoRequests.length > 0 && isIdentifyInContext
 );
 
 /**
@@ -198,5 +208,6 @@ module.exports = {
     isHighlightEnabledSelector,
     itemIdSelector,
     overrideParamsSelector,
-    filterNameListSelector
+    filterNameListSelector,
+    isMapPopup
 };

--- a/web/client/themes/default/less/map-popup.less
+++ b/web/client/themes/default/less/map-popup.less
@@ -1,0 +1,105 @@
+.map-popup-ol {
+  margin-bottom: 15px ;
+  text-align: left;
+  > .ol-popup-content-wrapper {
+    padding: 1px;
+    background: white;
+    color: #333;
+    box-shadow: 0 3px 3px rgba(0,0,0,0.1);
+    border-radius: 12px;
+    > .ol-popup-content {
+      position: relative;
+      background-color: white;      
+      margin: 20px 20px;
+    }
+  }
+  * {
+    user-select: text !important;
+  }
+}
+
+.map-popup-ol:after, .map-popup-ol:before {
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+  bottom: -11px;
+}
+.map-popup-ol:after {
+  border-top-color: white;
+  border-width: 13px;
+  left: 50%;
+  margin-left: -13px;
+}
+.map-popup-ol:before {
+  border-top-color: #ccc;
+  border-width: 13px;
+  left: 50%;
+  margin-left: -13px;
+}
+
+.ol-popup-closer {
+  text-decoration: none;
+  position: absolute;
+  top: -4px;
+  right: 2px;
+  padding-right: 4px;
+  color: #078aa3;
+  font-size: x-large;
+}
+
+
+.ms-leaflet-popup {
+  
+  .leaflet-popup-content-wrapper{
+    overflow: hidden;
+  }
+  a.leaflet-popup-close-button {
+    color: #078aa3;
+    font-size: x-large;
+    top: 0px;
+    right: 0;
+    padding: 4px 3px 0 0;
+    font-family:"Helvetica Neue", Arial, Helvetica, sans-serif;
+    font-weight: normal;
+  }
+  a.leaflet-popup-close-button:hover {
+    color: #056172;
+  }
+}
+
+.ms-map-popup {
+  overflow: auto;
+  .mapstore-identify-viewer {
+    min-width: 100px;
+    min-height: 100px;
+    max-height: inherit;
+    max-width: inherit;
+    overflow: hidden;
+   
+    .panel {
+          -webkit-box-shadow: none;
+          box-shadow: none;
+          margin-bottom: 0px;
+          overflow: auto;
+      .panel-heading {
+      .panel-title {
+        > span{
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+      }    
+      }
+        }
+
+    }
+    
+  
+  .loader-container {
+    min-width: 50px;
+    min-height: 50px;
+  }
+}

--- a/web/client/themes/default/ms2-theme.less
+++ b/web/client/themes/default/ms2-theme.less
@@ -66,3 +66,4 @@
 @import "./less/backgroundSelector.less";
 @import "./less/map-editor.less";
 @import "./less/user-extensions.less";
+@import "./less/map-popup.less";

--- a/web/client/utils/PopupUtils.js
+++ b/web/client/utils/PopupUtils.js
@@ -1,0 +1,31 @@
+import uuid from "uuid";
+export const createContainer = ( id = uuid(), className = "ms-map-popup") => {
+    const c = document.createElement('div');
+    c.setAttribute("id", id + "-map-popup");
+    c.setAttribute("class", className);
+    return c;
+};
+export const createOLContainer = ( id = uuid(), className = "ms-map-popup") => {
+    const c = document.createElement('div');
+    c.setAttribute("id", id + "-map-popup");
+    c.setAttribute("class", className);
+    return c;
+};
+export const isHTML = (text = "") =>  text.startsWith("<");
+// Append a node element a text ar an HTML string
+export const append = (container, content) => {
+    if (!content) {
+        return container;
+    }
+    if (content instanceof Node) {
+        const docFrag = document.createDocumentFragment();
+        docFrag.appendChild(content);
+        container.appendChild(docFrag);
+    } else if (isHTML(content)) {
+        container.innerHTML = content;
+    } else {
+        container.append(document.createTextNode(String(content)));
+    }
+    return container;
+};
+export const getPopupCoordinates = ({lat, lng} = {}, flip = false) => flip && [lng, lat] || [lat, lng];


### PR DESCRIPTION
## Description
Adds popup support to Ol and leaflet. To ad a popup just create one with an appPopup action,
passing point coordinates and a content (text or html) or a component (React component or element)
To show the mapInfo response in a popup just add "showInMapPopup": true in identify cfg


**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4910 
also refero to this pull for geosolutions-it/mapstore2-c039#52
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4910 

**What is the new behavior?**
#4910 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
