### PR TITLE
4977 Documentation extension. Add the logic to get configured url ins…

### DIFF
--- a/build/docma-config.json
+++ b/build/docma-config.json
@@ -219,6 +219,7 @@
                 "web/client/plugins/FullScreen.jsx",
                 "web/client/plugins/GlobeViewSwitcher.jsx",
                 "web/client/plugins/GoFull.jsx",
+                "web/client/plugins/HelpLink.jsx",
                 "web/client/plugins/Identify.jsx",
                 "web/client/plugins/Locate.jsx",
                 "web/client/plugins/Login.jsx",

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -295,7 +295,17 @@
                 }
               }
             }
-          }, "AutoMapUpdate", "HelpLink", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
+          },
+          "AutoMapUpdate",
+          {
+            "name": "HelpLink",
+            "cfg": {
+              "defaultOptions": {
+                "docsUrl": "https://mapstore.readthedocs.io/en/latest/"
+              }
+            }
+          },
+          "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
             {
               "name": "Share",
               "cfg": {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -295,17 +295,7 @@
                 }
               }
             }
-          },
-          "AutoMapUpdate",
-          {
-            "name": "HelpLink",
-            "cfg": {
-              "defaultOptions": {
-                "docsUrl": "https://mapstore.readthedocs.io/en/latest/"
-              }
-            }
-          },
-          "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
+          }, "AutoMapUpdate", "HelpLink", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
             {
               "name": "Share",
               "cfg": {

--- a/web/client/plugins/HelpLink.jsx
+++ b/web/client/plugins/HelpLink.jsx
@@ -10,6 +10,7 @@ const React = require('react');
 
 const assign = require('object-assign');
 const {Glyphicon} = require('react-bootstrap');
+const {get} = require('lodash');
 
 const Message = require('../components/I18N/Message');
 
@@ -25,7 +26,10 @@ module.exports = {
             text: <Message msgId="docs"/>,
             icon: <Glyphicon glyph="question-sign"/>,
             action: () => ({type: ''}),
-            selector: () => ({href: 'https://mapstore.readthedocs.io/en/latest/', target: 'blank'}),
+            selector: (state, ownProps) => {
+                const docsUrl = get(ownProps, 'defaultOptions.docsUrl', 'https://mapstore.readthedocs.io/en/latest/');
+                return {href: docsUrl, target: 'blank'};
+            },
             priority: 2,
             doNotHide: true
         }

--- a/web/client/plugins/HelpLink.jsx
+++ b/web/client/plugins/HelpLink.jsx
@@ -6,20 +6,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
+import React from 'react';
+import {Glyphicon} from 'react-bootstrap';
+import {get} from 'lodash';
 
-const assign = require('object-assign');
-const {Glyphicon} = require('react-bootstrap');
-const {get} = require('lodash');
+import { createPlugin } from '../utils/PluginsUtils';
+import Message from '../components/I18N/Message';
+import help from '../reducers/help';
 
-const Message = require('../components/I18N/Message');
+/**
+ *  HelpLink is a plugin that navigates the user to the online documentation.
+ *  It gets displayed into the BurgerMenu plugin.
+ *  @name HelpLink
+ *  @memberof plugins
+ *  @class
+ *  @prop {string} docsUrl default https://mapstore.readthedocs.io/en/latest/. Link to the online documentation.
+ *  @example
+ *  // If you, as an admin, want to specify the link to the docs when creating or editing a context, you can configure the HelpLink plugin, as shown below:
+ *  {
+ *    "docsUrl": "https://your-path"
+ *  }
+ */
 
-module.exports = {
-    HelpLinkPlugin: assign(class extends React.Component {
-        render() {
-            return null;
-        }
-    }, {
+export default createPlugin('HelpLink', {
+    component: () => null,
+    reducers: { help },
+    containers: {
         BurgerMenu: {
             name: 'helplink',
             position: 1100,
@@ -27,12 +39,12 @@ module.exports = {
             icon: <Glyphicon glyph="question-sign"/>,
             action: () => ({type: ''}),
             selector: (state, ownProps) => {
-                const docsUrl = get(ownProps, 'defaultOptions.docsUrl', 'https://mapstore.readthedocs.io/en/latest/');
+                const docsUrl = get(ownProps, 'docsUrl', 'https://mapstore.readthedocs.io/en/latest/');
                 return {href: docsUrl, target: 'blank'};
             },
             priority: 2,
             doNotHide: true
         }
-    }),
-    reducers: {help: require('../reducers/help')}
-};
+    }
+});
+

--- a/web/client/plugins/__tests__/HelpLink-test.jsx
+++ b/web/client/plugins/__tests__/HelpLink-test.jsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { getPluginForTest } from './pluginsTestUtils';
+import HelpLinkPlugin from '../HelpLink';
+
+describe('HelpLink Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('HelpLink plugin with default documentations url', () => {
+        const { Plugin, containers } = getPluginForTest(HelpLinkPlugin);
+        expect(Object.keys(containers)).toContain('BurgerMenu');
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(containers.BurgerMenu.selector()).toEqual({ href: 'https://mapstore.readthedocs.io/en/latest/', target: 'blank' });
+    });
+
+    it('HelpLink plugin with custom documentations url', () => {
+        const { Plugin, containers } = getPluginForTest(HelpLinkPlugin);
+        expect(Object.keys(containers)).toContain('BurgerMenu');
+        ReactDOM.render(<Plugin />, document.getElementById("container"));
+        expect(containers.BurgerMenu.selector(null, {docsUrl: 'https://google.com'})).toEqual({ href: 'https://google.com', target: 'blank' });
+    });
+});

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -61,7 +61,7 @@ module.exports = {
         GoFull: require('../plugins/GoFull'),
         GridContainerPlugin: require('../plugins/GridContainer'),
         GroupManagerPlugin: require('../plugins/manager/GroupManager'),
-        HelpLinkPlugin: require('../plugins/HelpLink'),
+        HelpLinkPlugin: require('../plugins/HelpLink').default,
         HelpPlugin: require('../plugins/Help'),
         HomePlugin: require('../plugins/Home'),
         IdentifyPlugin: require('../plugins/Identify'),


### PR DESCRIPTION
…ide the HelpLink plugin.

## Description
An extension must be provided to reach the online documentation related to the viewer and its installed extensions.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#4977 

**What is the new behavior?**
Now it's possible to configure the documentation link making changes in the localConfig file or when creating the new context (or editing existing):
![image](https://user-images.githubusercontent.com/61145641/76087963-42fa0180-5fc8-11ea-815c-4386938f9cad.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
