### PR TITLE
#4990 background selector edit buttons

### DIFF
--- a/web/client/plugins/BackgroundSelector.jsx
+++ b/web/client/plugins/BackgroundSelector.jsx
@@ -19,7 +19,7 @@ const {addBackground, addBackgroundProperties, confirmDeleteBackgroundModal,
 const {createSelector} = require('reselect');
 const {allBackgroundLayerSelector, backgroundControlsSelector,
     currentBackgroundSelector, tempBackgroundSelector} = require('../selectors/layers');
-const {mapSelector, mapInfoSelector, projectionSelector} = require('../selectors/map');
+const {mapSelector, mapIsEditableSelector, projectionSelector} = require('../selectors/map');
 const {modalParamsSelector, isDeletedIdSelector, backgroundListSelector,
     backgroundLayersSelector, confirmDeleteBackgroundModalSelector, allowBackgroundsDeletionSelector} = require('../selectors/backgroundselector');
 const {mapLayoutValuesSelector} = require('../selectors/maplayout');
@@ -33,7 +33,7 @@ const backgroundSelector = createSelector([
     isDeletedIdSelector,
     allBackgroundLayerSelector,
     mapSelector,
-    mapInfoSelector,
+    mapIsEditableSelector,
     backgroundLayersSelector,
     backgroundControlsSelector,
     currentBackgroundSelector,
@@ -43,14 +43,14 @@ const backgroundSelector = createSelector([
     state => state.browser && state.browser.mobile ? 'mobile' : 'desktop',
     confirmDeleteBackgroundModalSelector,
     allowBackgroundsDeletionSelector],
-(projection, modalParams, backgroundList, deletedId, backgrounds, map, mapInfo, layers, controls, currentLayer, tempLayer, style, enabledCatalog, mode, confirmDeleteBackgroundModalObj, allowDeletion) => ({
+(projection, modalParams, backgroundList, deletedId, backgrounds, map, mapIsEditable, layers, controls, currentLayer, tempLayer, style, enabledCatalog, mode, confirmDeleteBackgroundModalObj, allowDeletion) => ({
     mode,
     modalParams,
     backgroundList,
     deletedId,
     backgrounds,
     size: map && map.size || {width: 0, height: 0},
-    mapIsEditable: mapInfo && mapInfo.canEdit,
+    mapIsEditable,
     layers,
     tempLayer,
     currentLayer,

--- a/web/client/selectors/__tests__/map-test.js
+++ b/web/client/selectors/__tests__/map-test.js
@@ -17,7 +17,8 @@ const {
     mapInfoDetailsUriFromIdSelector,
     configuredRestrictedExtentSelector,
     configuredExtentCrsSelector,
-    configuredMinZoomSelector
+    configuredMinZoomSelector,
+    mapIsEditableSelector
 } = require('../map');
 const center = {x: 1, y: 1};
 let state = {
@@ -135,5 +136,13 @@ describe('Test map selectors', () => {
             }
         });
         expect(minZoom).toBe(14);
+    });
+    it('test mapIsEditableSelector for map', () => {
+        const mapIsEditable = mapIsEditableSelector({map: {present: {info: {canEdit: true}}}});
+        expect(mapIsEditable).toBe(true);
+    });
+    it('test mapIsEditableSelector for context', () => {
+        const mapIsEditable = mapIsEditableSelector({context: {resource: {canEdit: true}}});
+        expect(mapIsEditable).toBe(true);
     });
 });

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -33,6 +33,7 @@ const mapInfoSelector = state => get(mapSelector(state), "info");
 const mapInfoLoadingSelector = state => get(mapSelector(state), "loadingInfo", false);
 const mapSaveErrorsSelector = state => get(mapSelector(state), "mapSaveErrors");
 const mapInfoDetailsUriFromIdSelector = state => get(mapInfoSelector(state), "details");
+const mapIsEditableSelector = state => get(mapInfoSelector, 'mapInfo.canEdit') || get(state, 'context.resource.canEdit');
 
 // TODO: move these in selectors/localConfig.js or selectors/config.js
 const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
@@ -100,5 +101,6 @@ module.exports = {
     configuredRestrictedExtentSelector,
     mapInfoSelector,
     mapInfoLoadingSelector,
-    mapSaveErrorsSelector
+    mapSaveErrorsSelector,
+    mapIsEditableSelector
 };

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -33,7 +33,13 @@ const mapInfoSelector = state => get(mapSelector(state), "info");
 const mapInfoLoadingSelector = state => get(mapSelector(state), "loadingInfo", false);
 const mapSaveErrorsSelector = state => get(mapSelector(state), "mapSaveErrors");
 const mapInfoDetailsUriFromIdSelector = state => get(mapInfoSelector(state), "details");
-const mapIsEditableSelector = state => get(mapInfoSelector, 'mapInfo.canEdit') || get(state, 'context.resource.canEdit');
+const mapIsEditableSelector = state => {
+    const mapInfoCanEdit = get(mapInfoSelector(state), 'canEdit');
+    if (mapInfoCanEdit === undefined) {
+        return get(state, 'context.resource.canEdit');
+    }
+    return mapInfoCanEdit;
+};
 
 // TODO: move these in selectors/localConfig.js or selectors/config.js
 const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];


### PR DESCRIPTION
## Description
A fix for the Background Selector edit buttons enablement need to be provided for app contexts: buttons should appear only to authenticated users with write permissions.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
#4990 

**What is the new behavior?**
Buttons now appear only to authenticated users with write permissions.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
