### PR TITLE
Fix 5009 Update routing workflow of geostories between shared page and default page

### DIFF
--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -510,6 +510,116 @@ describe('Geostory Epics', () => {
                 }
             });
         });
+        it('should not change mode on story with id number, if user has permission with loadGeostoryEpic', (done) => {
+            const NUM_ACTIONS = 5;
+            mockAxios.onGet().reply(200, TEST_STORY);
+            testEpic(
+                loadGeostoryEpic,
+                NUM_ACTIONS,
+                loadGeostory(100),
+                (actions) => {
+                    try {
+                        expect(actions.length).toBe(NUM_ACTIONS);
+                        expect(actions.map(({ type }) => type)).toEqual([
+                            LOADING_GEOSTORY,
+                            GEOSTORY_LOADED,
+                            SET_CURRENT_STORY,
+                            SET_RESOURCE,
+                            LOADING_GEOSTORY
+                        ]);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                },
+                {
+                    geostory: {},
+                    security: {
+                        user: {
+                            role: "USER"
+                        }
+                    }
+                }
+            );
+        });
+        it('should change mode to VIEW on story with id number, if user has not permission and current mode is EDIT with loadGeostoryEpic', (done) => {
+            const NUM_ACTIONS = 6;
+            mockAxios.onGet().reply(200, TEST_STORY);
+            testEpic(
+                loadGeostoryEpic,
+                NUM_ACTIONS,
+                loadGeostory(100),
+                (actions) => {
+                    try {
+                        expect(actions.length).toBe(NUM_ACTIONS);
+                        expect(actions.map(({ type }) => type)).toEqual([
+                            LOADING_GEOSTORY,
+                            CHANGE_MODE,
+                            GEOSTORY_LOADED,
+                            SET_CURRENT_STORY,
+                            SET_RESOURCE,
+                            LOADING_GEOSTORY
+                        ]);
+
+                        const changeModeAction = actions[1];
+                        expect(changeModeAction.mode).toBe(Modes.VIEW);
+
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                },
+                {
+                    geostory: {
+                        mode: Modes.EDIT
+                    },
+                    security: {
+                        user: {
+                            role: "USER"
+                        }
+                    }
+                }
+            );
+        });
+        it('should change mode to VIEW on story with id number, if user has permission and current mode is EDIT with loadGeostoryEpic', (done) => {
+            const NUM_ACTIONS = 6;
+            mockAxios.onGet().reply(200, { ...TEST_STORY, ShortResource: { canEdit: true } });
+            testEpic(
+                loadGeostoryEpic,
+                NUM_ACTIONS,
+                loadGeostory(100),
+                (actions) => {
+                    try {
+                        expect(actions.length).toBe(NUM_ACTIONS);
+                        expect(actions.map(({ type }) => type)).toEqual([
+                            LOADING_GEOSTORY,
+                            CHANGE_MODE,
+                            GEOSTORY_LOADED,
+                            SET_CURRENT_STORY,
+                            SET_RESOURCE,
+                            LOADING_GEOSTORY
+                        ]);
+
+                        const changeModeAction = actions[1];
+                        expect(changeModeAction.mode).toBe(Modes.EDIT);
+
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                },
+                {
+                    geostory: {
+                        mode: Modes.EDIT
+                    },
+                    security: {
+                        user: {
+                            role: "USER"
+                        }
+                    }
+                }
+            );
+        });
     });
     it('test openMediaEditorForNewMedia, adding a media content and choosing an image already present in resources', (done) => {
         const NUM_ACTIONS = 2;

--- a/web/client/plugins/GeoStoryEditor.jsx
+++ b/web/client/plugins/GeoStoryEditor.jsx
@@ -41,6 +41,8 @@ import Builder from '../components/geostory/builder/Builder';
 import { Modes, scrollToContent } from '../utils/GeoStoryUtils';
 import { createPlugin } from '../utils/PluginsUtils';
 import tooltip from '../components/misc/enhancers/tooltip';
+import { withRouter } from 'react-router';
+import { removeQueryFromUrl } from '../utils/ShareUtils';
 import { Button as ButtonRB, Glyphicon } from 'react-bootstrap';
 const Button = tooltip(ButtonRB);
 
@@ -51,18 +53,28 @@ const EditButton = connect(
     { setEditingMode: setEditing }
 )(({
     isEditAllowed,
-    setEditingMode = () => {}
+    setEditingMode = () => {},
+    location,
+    history
 }) => {
+
+    const handleOnClick = () => {
+        setEditingMode(true);
+        const { pathname } = location;
+        if (pathname.includes('/geostory/shared')) {
+            const newUrl = removeQueryFromUrl(pathname.replace('/geostory/shared', '/geostory'));
+            history.push(newUrl);
+        }
+    };
+
     return isEditAllowed
-        ? (
-            <Button
-                className="square-button-md no-border"
-                onClick={() => setEditingMode(true)}
-                tooltipId="geostory.navigation.edit"
-                tooltipPosition="bottom">
-                <Glyphicon glyph="pencil" />
-            </Button>
-        )
+        ? <Button
+            className="square-button-md no-border"
+            onClick={handleOnClick}
+            tooltipId="geostory.navigation.edit"
+            tooltipPosition="bottom">
+            <Glyphicon glyph="pencil" />
+        </Button>
         : null;
 });
 
@@ -150,7 +162,7 @@ export default createPlugin('GeoStoryEditor', {
     )(GeoStoryEditor),
     containers: {
         GeoStoryNavigation: {
-            tool: EditButton
+            tool: withRouter(EditButton)
         }
     },
     reducers: {

--- a/web/client/selectors/__tests__/geostory-test.js
+++ b/web/client/selectors/__tests__/geostory-test.js
@@ -30,7 +30,8 @@ import {
     settingsItemsSelector,
     totalItemsSelector,
     visibleItemsSelector,
-    isMediaResourceUsed
+    isMediaResourceUsed,
+    geostoryIdSelector
 } from "../geostory";
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
 
@@ -111,6 +112,17 @@ describe('geostory selectors', () => { // TODO: check default
     it('visibleItemsSelector ', () => expect(visibleItemsSelector({ geostory: { currentStory: {settings: {checked: ["id"]}} } })).toEqual({"id": true}));
     it('settingsChangedSelector ', () => expect(settingsChangedSelector({ geostory: { currentStory: {settings: {checked: ["id"]}}, oldSettings: {checked: ["id", "otherid"]} } })).toBe(true));
     it('isMediaResourceUsed ', () => expect(isMediaResourceUsed({ geostory: { currentStory: TEST_STORY} }, "resId")).toBe(false));
-
+    it('geostoryIdSelector ', () => {
+        const GEOSTORY_ID = 'GEOSTORY_ID';
+        const state = {
+            geostory: {
+                resource: {
+                    id: GEOSTORY_ID
+                }
+            }
+        };
+        expect(geostoryIdSelector(state)).toBe(GEOSTORY_ID);
+        expect(geostoryIdSelector({})).toBe(undefined);
+    });
 
 });

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -60,7 +60,11 @@ export const resourceSelector = state => get(state, 'geostory.resource');
  * @param {object} state the application state
  */
 export const canEditSelector = state => get(resourceSelector(state), 'canEdit', false);
-
+/**
+ * Get id of current story
+ * @param {object} state the application state
+ */
+export const geostoryIdSelector = state => get(resourceSelector(state), 'id');
 /**
  * Selects the edit permission of the resource
  * @param {object} state the application state


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR remove the current redirect for shared page to default page and implement the expected behaviours described in the issue #5009

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Improvement

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5009

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see expected behaviours described in the issue #5009

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
