### PR TITLE
#4954: added machinery for user session loading

### DIFF
--- a/web/client/actions/__tests__/config-test.js
+++ b/web/client/actions/__tests__/config-test.js
@@ -11,11 +11,14 @@ const { configureError, loadMapConfig, loadMapInfo, configureMap, MAP_CONFIG_LOA
 
 describe('Test configuration related actions', () => {
     it('loadMapConfig', () => {
-        const retVal = loadMapConfig("test", 1);
+        const retVal = loadMapConfig("test", 1, {}, {}, {});
         expect(retVal).toExist();
         expect(retVal.type).toBe(LOAD_MAP_CONFIG);
         expect(retVal.configName).toBe("test");
         expect(retVal.mapId).toBe(1);
+        expect(retVal.config).toExist();
+        expect(retVal.mapInfo).toExist();
+        expect(retVal.overrideConfig).toExist();
     });
 
     it('configureMap', () => {

--- a/web/client/actions/__tests__/usersession-test.js
+++ b/web/client/actions/__tests__/usersession-test.js
@@ -7,8 +7,8 @@
  */
 
 import expect from 'expect';
-import {SAVE_USER_SESSION, USER_SESSION_SAVED, USER_SESSION_LOADING,
-    saveUserSession, userSessionSaved, loading} from "../usersession";
+import {SAVE_USER_SESSION, USER_SESSION_SAVED, LOAD_USER_SESSION, USER_SESSION_LOADED, USER_SESSION_LOADING,
+    saveUserSession, userSessionSaved, loadUserSession, userSessionLoaded, loading} from "../usersession";
 
 describe('Test correctness of the usersession actions', () => {
 
@@ -29,5 +29,17 @@ describe('Test correctness of the usersession actions', () => {
         expect(action.type).toBe(USER_SESSION_LOADING);
         expect(action.name).toBe("loading");
         expect(action.value).toBe(true);
+    });
+    it('load user session', () => {
+        const action = loadUserSession();
+        expect(action.type).toBe(LOAD_USER_SESSION);
+    });
+    it('user session loaded', () => {
+        const action = userSessionLoaded(1, {
+            attribute: "myvalue"
+        });
+        expect(action.type).toBe(USER_SESSION_LOADED);
+        expect(action.id).toBe(1);
+        expect(action.session.attribute).toBe("myvalue");
     });
 });

--- a/web/client/actions/config.js
+++ b/web/client/actions/config.js
@@ -56,14 +56,16 @@ function loadNewMap(configName, contextId) {
  * @param {number} mapId resource id of the map on a server
  * @param {object} config full config, overrides configName if not null or undefined
  * @param {object} mapInfo map info override
+ * @param {object} overrideConfig config override
  */
-function loadMapConfig(configName, mapId, config, mapInfo) {
+function loadMapConfig(configName, mapId, config, mapInfo, overrideConfig) {
     return {
         type: LOAD_MAP_CONFIG,
         configName,
         mapId,
         config,
-        mapInfo
+        mapInfo,
+        overrideConfig
     };
 }
 function mapInfoLoaded(info, mapId) {

--- a/web/client/actions/usersession.js
+++ b/web/client/actions/usersession.js
@@ -7,10 +7,15 @@
  */
 
 export const SAVE_USER_SESSION = "USER_SESSION:SAVE";
+export const LOAD_USER_SESSION = "USER_SESSION:LOAD";
 export const USER_SESSION_SAVED = "USER_SESSION:SAVED";
+export const USER_SESSION_LOADED = "USER_SESSION:LOADED";
 export const USER_SESSION_LOADING = "USER_SESSION:LOADING";
+
 export const saveUserSession = () => ({type: SAVE_USER_SESSION});
 export const userSessionSaved = (id, session) => ({type: USER_SESSION_SAVED, id, session});
+export const loadUserSession = () => ({type: LOAD_USER_SESSION});
+export const userSessionLoaded = (id, session) => ({type: USER_SESSION_LOADED, id, session});
 
 export const loading = (value, name = "loading") => ({
     type: USER_SESSION_LOADING,

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -132,6 +132,20 @@ describe('config epics', () => {
                 done();
             });
         });
+        it('load a context with new map with override', (done) => {
+            mockAxios.onGet("/new.json").reply(() => ([ 200, {} ]));
+            const NUM_ACTIONS = 1;
+            testEpic(loadMapConfigAndConfigureMap, NUM_ACTIONS, loadMapConfig('new.json', null, { version: 2}, undefined, {myproperty: "myvalue"}), (actions) => {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                const [a] = actions;
+                expect(a).toExist();
+                expect(a.type).toBe(MAP_CONFIG_LOADED);
+                expect(a.config).toExist();
+                expect(a.config.version).toBe(2);
+                expect(a.config.myproperty).toBe("myvalue");
+                done();
+            });
+        });
         it('load new map as ADMIN', (done) => {
             const NUM_ACTIONS = 1;
             mockAxios.onGet("/new.json").reply(() => ([ 200, {} ]));

--- a/web/client/epics/__tests__/usersession-test.js
+++ b/web/client/epics/__tests__/usersession-test.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { testEpic } from './epicTestUtils';
-import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator } from "../usersession";
-import { saveUserSession, USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION } from "../../actions/usersession";
+import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator } from "../usersession";
+import { saveUserSession, loadUserSession,
+    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED } from "../../actions/usersession";
 import { SHOW_NOTIFICATION } from "../../actions/notifications";
 import expect from "expect";
 
@@ -48,7 +49,7 @@ describe('usersession Epics', () => {
             expect(actions[1].session.sample2).toBe("sample2");
         }, initialState, done);
     });
-    it('user session name is taken from idSelector', (done) => {
+    it('user session name is taken from idSelector during save', (done) => {
         mockAxios.onPost().reply(200, "1");
         mockAxios.onGet().reply(200, {});
         testEpic(saveUserSessionEpicCreator(idSelector, sessionSelector), 2, saveUserSession(), (actions) => {
@@ -57,7 +58,7 @@ describe('usersession Epics', () => {
             expect(mockAxios.history.post[0].data).toContain("id.myuser");
         }, initialState, done);
     });
-    it('user session is indexed by username', (done) => {
+    it('user session is indexed by username during save', (done) => {
         mockAxios.onPost().reply(200, "1");
         mockAxios.onGet().reply(200, {});
         testEpic(saveUserSessionEpicCreator(idSelector, sessionSelector), 2, saveUserSession(), (actions) => {
@@ -104,5 +105,14 @@ describe('usersession Epics', () => {
         setTimeout(() => {
             store.dispatch({ type: 'STOP' });
         }, 100);
+    });
+    it('user session name is taken from idSelector when loading', (done) => {
+        mockAxios.onGet().reply(200, {});
+        testEpic(loadUserSessionEpicCreator(idSelector), 2, loadUserSession(), (actions) => {
+            expect(actions[0].type).toBe(USER_SESSION_LOADING);
+            expect(actions[1].type).toBe(USER_SESSION_LOADED);
+            expect(mockAxios.history.get[0].url).toContain("id.myuser");
+            expect(mockAxios.history.get[1].url).toContain("id.myuser");
+        }, initialState, done);
     });
 });

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -7,7 +7,7 @@
  */
 import { Observable } from 'rxjs';
 import axios from '../libs/ajax';
-import { get } from 'lodash';
+import { get, merge } from 'lodash';
 import {
     LOAD_NEW_MAP,
     LOAD_MAP_CONFIG,
@@ -40,12 +40,12 @@ export const loadNewMapEpic = (action$) =>
 
 export const loadMapConfigAndConfigureMap = (action$, store) =>
     action$.ofType(LOAD_MAP_CONFIG)
-        .switchMap(({configName, mapId, config, mapInfo}) =>
+        .switchMap(({configName, mapId, config, mapInfo, overrideConfig = {}}) =>
             // delay here is to postpone map load to ensure that
             // certain epics always function correctly
             // i.e. FeedbackMask disables correctly after load
             // TODO: investigate the root causes of the problem and come up with a better solution, if possible
-            (config ? Observable.of({data: config}).delay(100) : Observable.defer(() => axios.get(configName)))
+            (config ? Observable.of({data: merge(config, overrideConfig)}).delay(100) : Observable.defer(() => axios.get(configName)))
                 .switchMap(response => {
                     // added !config in order to avoid showing login modal when a new.json mapConfig is used in a public context
                     if (configName === "new.json" && !config && !isLoggedIn(store.getState())) {
@@ -57,13 +57,15 @@ export const loadMapConfigAndConfigureMap = (action$, store) =>
                         if (projectionDefs.concat([{code: "EPSG:4326"}, {code: "EPSG:3857"}, {code: "EPSG:900913"}]).filter(({code}) => code === projection).length === 0) {
                             return Observable.of(configureError({messageId: `map.errors.loading.projectionError`, errorMessageParams: {projection}}, mapId));
                         }
-                        return mapId ? Observable.of(configureMap(response.data, mapId), mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId)) :
-                            Observable.of(configureMap(response.data, mapId), ...(mapInfo ? [mapInfoLoaded(mapInfo)] : []));
+                        const mapConfig = merge(response.data, overrideConfig);
+                        return mapId ? Observable.of(configureMap(mapConfig, mapId), mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId)) :
+                            Observable.of(configureMap(mapConfig, mapId), ...(mapInfo ? [mapInfoLoaded(mapInfo)] : []));
                     }
                     try {
                         const data = JSON.parse(response.data);
-                        return mapId ? Observable.of(configureMap(data, mapId), mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId)) :
-                            Observable.of(configureMap(data, mapId), ...(mapInfo ? [mapInfoLoaded(mapInfo)] : []));
+                        const mapConfig = merge(data, overrideConfig);
+                        return mapId ? Observable.of(configureMap(mapConfig, mapId), mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId)) :
+                            Observable.of(configureMap(mapConfig, mapId), ...(mapInfo ? [mapInfoLoaded(mapInfo)] : []));
                     } catch (e) {
                         return Observable.of(configureError('Configuration file broken (' + configName + '): ' + e.message, mapId));
                     }

--- a/web/client/reducers/__tests__/usersession-test.js
+++ b/web/client/reducers/__tests__/usersession-test.js
@@ -8,12 +8,18 @@
 import expect from 'expect';
 
 import usersession from '../usersession';
-import {USER_SESSION_SAVED, USER_SESSION_LOADING} from "../../actions/usersession";
+import {USER_SESSION_SAVED, USER_SESSION_LOADED, USER_SESSION_LOADING} from "../../actions/usersession";
 
 // saveUserSession, userSessionSaved, loading
 describe('Test the usersession reducer', () => {
     it('user session saved', () => {
         const state = usersession({}, { type: USER_SESSION_SAVED, id: 1, session: {attribute: "mysession"} });
+        expect(state.session).toExist();
+        expect(state.id).toBe(1);
+        expect(state.session.attribute).toBe("mysession");
+    });
+    it('user session loaded', () => {
+        const state = usersession({}, { type: USER_SESSION_LOADED, id: 1, session: {attribute: "mysession"} });
         expect(state.session).toExist();
         expect(state.id).toBe(1);
         expect(state.session.attribute).toBe("mysession");

--- a/web/client/reducers/usersession.js
+++ b/web/client/reducers/usersession.js
@@ -5,11 +5,17 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { USER_SESSION_SAVED, USER_SESSION_LOADING } from "../actions/usersession";
+import { USER_SESSION_SAVED, USER_SESSION_LOADING, USER_SESSION_LOADED } from "../actions/usersession";
 
 export default (state = {}, action) => {
     switch (action.type) {
     case USER_SESSION_SAVED:
+        return {
+            ...state,
+            id: action.id,
+            session: action.session
+        };
+    case USER_SESSION_LOADED:
         return {
             ...state,
             id: action.id,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Basic stuff for user session loading (actions, reducers and an epic creator).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#4954 
