### PR TITLE
Fix maps getMapsResourcesByCategoryEpic epic wrapper

### DIFF
--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -12,7 +12,7 @@ const configureMockStore = require('redux-mock-store').default;
 const {createEpicMiddleware, combineEpics } = require('redux-observable');
 const {CALL_HISTORY_METHOD} = require('connected-react-router');
 const {
-    saveDetails, SET_DETAILS_CHANGED, MAPS_LIST_LOADING, MAPS_LIST_LOADED,
+    saveDetails, SET_DETAILS_CHANGED, MAPS_LIST_LOADING, MAPS_LIST_LOADED, MAPS_LIST_LOAD_ERROR,
     CLOSE_DETAILS_PANEL, closeDetailsPanel, loadMaps, MAPS_GET_MAP_RESOURCES_BY_CATEGORY,
     openDetailsPanel, UPDATE_DETAILS, DETAILS_LOADED, getMapResourcesByCategory,
     MAP_DELETING, MAP_DELETED, deleteMap, mapDeleted, TOGGLE_DETAILS_SHEET,
@@ -653,6 +653,25 @@ describe('Get Map Resource By Category Epic', () => {
             });
         }))
     );
+    it('test getMapsResourcesByCategoryEpic with an error', (done) => {
+        const mock = new MockAdapter(axios);
+        mock.onPost().reply(404);
+        testEpic(addTimeoutEpic(getMapsResourcesByCategoryEpic), 3, getMapResourcesByCategory('MAP', 'test', {
+            baseUrl,
+            params: { start: 0, limit: 12 }
+        }), actions => {
+            expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[0].value).toBe(true);
+            expect(actions[0].name).toBe('loadingMaps');
+            expect(actions[1].type).toBe(MAPS_LIST_LOAD_ERROR);
+            expect(actions[2].type).toBe(LOADING);
+            expect(actions[2].value).toBe(false);
+            expect(actions[2].name).toBe('loadingMaps');
+            mock.restore();
+            done();
+        });
+    });
 });
 const Persistence = require("../../api/persistence");
 const Rx = require("rxjs");

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -299,7 +299,7 @@ const getMapsResourcesByCategoryEpic = (action$, store) =>
                 .let(wrapStartStop(
                     loading(true, 'loadingMaps'),
                     loading(false, 'loadingMaps'),
-                    e => loadError(e)
+                    e => Rx.Observable.of(loadError(e))
                 ));
         });
 


### PR DESCRIPTION
## Description
Fix maps getMapsResourcesByCategoryEpic epic wrapper.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No