### PR TITLE
#5017 The advanced options for the Share tool must be availables by de…

### DIFF
--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -86,7 +86,9 @@ class SharePanel extends React.Component {
     };
 
     state = {
-        eventKey: 1
+        eventKey: 1,
+        showAdvanced: true,
+        bboxEnabled: true
     };
 
     UNSAFE_componentWillMount() {
@@ -115,7 +117,7 @@ class SharePanel extends React.Component {
     getShareUrl = () => {
         const { settings, advancedSettings } = this.props;
         let shareUrl = getSharedGeostoryUrl(removeQueryFromUrl(this.props.shareUrl));
-        if (settings.bboxEnabled && advancedSettings && advancedSettings.bbox && this.state.bbox) shareUrl = `${shareUrl}?bbox=${this.state.bbox}`;
+        if (this.state.bboxEnabled && advancedSettings && advancedSettings.bbox && this.state.bbox) shareUrl = `${shareUrl}?bbox=${this.state.bbox}`;
         if (settings.showHome && advancedSettings && advancedSettings.homeButton) shareUrl = `${shareUrl}?showHome=true`;
         return shareUrl;
     };
@@ -180,12 +182,8 @@ class SharePanel extends React.Component {
                 expanded={this.state.showAdvanced}
                 onSwitch={() => this.setState({ showAdvanced: !this.state.showAdvanced })}>
                 {this.props.advancedSettings.bbox && <Checkbox
-                    checked={this.props.settings.bboxEnabled ? true : false}
-                    onChange={() =>
-                        this.props.onUpdateSettings({
-                            ...this.props.settings,
-                            bboxEnabled: !this.props.settings.bboxEnabled
-                        })}>
+                    checked={this.state.bboxEnabled}
+                    onChange={() => this.setState({ bboxEnabled: !this.state.bboxEnabled })}>
                     <Message msgId="share.addBboxParam" />
                 </Checkbox>}
                 {this.props.advancedSettings.homeButton && <Checkbox

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -87,8 +87,7 @@ class SharePanel extends React.Component {
 
     state = {
         eventKey: 1,
-        showAdvanced: true,
-        bboxEnabled: true
+        showAdvanced: true
     };
 
     UNSAFE_componentWillMount() {
@@ -117,7 +116,7 @@ class SharePanel extends React.Component {
     getShareUrl = () => {
         const { settings, advancedSettings } = this.props;
         let shareUrl = getSharedGeostoryUrl(removeQueryFromUrl(this.props.shareUrl));
-        if (this.state.bboxEnabled && advancedSettings && advancedSettings.bbox && this.state.bbox) shareUrl = `${shareUrl}?bbox=${this.state.bbox}`;
+        if (settings.bboxEnabled && advancedSettings && advancedSettings.bbox && this.state.bbox) shareUrl = `${shareUrl}?bbox=${this.state.bbox}`;
         if (settings.showHome && advancedSettings && advancedSettings.homeButton) shareUrl = `${shareUrl}?showHome=true`;
         return shareUrl;
     };
@@ -182,8 +181,12 @@ class SharePanel extends React.Component {
                 expanded={this.state.showAdvanced}
                 onSwitch={() => this.setState({ showAdvanced: !this.state.showAdvanced })}>
                 {this.props.advancedSettings.bbox && <Checkbox
-                    checked={this.state.bboxEnabled}
-                    onChange={() => this.setState({ bboxEnabled: !this.state.bboxEnabled })}>
+                    checked={this.props.settings.bboxEnabled ? true : false}
+                    onChange={() =>
+                        this.props.onUpdateSettings({
+                            ...this.props.settings,
+                            bboxEnabled: !this.props.settings.bboxEnabled
+                        })}>
                     <Message msgId="share.addBboxParam" />
                 </Checkbox>}
                 {this.props.advancedSettings.homeButton && <Checkbox

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -81,7 +81,10 @@ const Share = connect(createSelector([
     embedOptions: {
         showTOCToggle: !context
     },
-    settings
+    settings,
+    advancedSettings: {
+        bbox: true
+    }
 })), {
     onClose: toggleControl.bind(null, 'share', null),
     onUpdateSettings: setControlProperty.bind(null, 'share', 'settings')

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -204,7 +204,7 @@ describe('Share Plugin', () => {
         }, 1000);
     });
 
-    it('test Share plugin advanced options is active by default and add bbox param checkbox is checked, EPSG:4326', (done) => {
+    it('test Share plugin advanced options is active by default and add bbox param checkbox is unchecked, EPSG:4326', (done) => {
         try {
             const controls = {
                 share: {
@@ -225,12 +225,6 @@ describe('Share Plugin', () => {
             const { Plugin } = getPluginForTest(SharePlugin, { controls, map });
             ReactDOM.render(<Plugin />, document.getElementById("container"));
             setTimeout(() => {
-                const inputLink = document.querySelector('input[type=\'text\']');
-                expect(inputLink).toExist();
-                const shareUrl = inputLink.value;
-                const splitUrl = shareUrl.split('?');
-                const query = splitUrl[splitUrl.length - 1];
-                expect(query).toBe('bbox=9,45,10,46');
                 const sharePanelDialog = document.getElementById('share-panel-dialog');
                 expect(sharePanelDialog).toExist();
                 const switchButton = sharePanelDialog.querySelector('.mapstore-switch-btn input[type=\'checkbox\']');
@@ -238,7 +232,7 @@ describe('Share Plugin', () => {
                 expect(switchButton.checked).toBe(true);
                 const bboxCheckbox = sharePanelDialog.querySelector('.panel-body .checkbox input[type=\'checkbox\']');
                 expect(bboxCheckbox).toExist();
-                expect(bboxCheckbox.checked).toBe(true);
+                expect(bboxCheckbox.checked).toBe(false);
                 done();
             }, 500);
         } catch (e) {

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -204,4 +204,46 @@ describe('Share Plugin', () => {
         }, 1000);
     });
 
+    it('test Share plugin advanced options is active by default and add bbox param checkbox is checked, EPSG:4326', (done) => {
+        try {
+            const controls = {
+                share: {
+                    enabled: true
+                }
+            };
+            const map = {
+                bbox: {
+                    bounds: {
+                        minx: 9,
+                        miny: 45,
+                        maxx: 10,
+                        maxy: 46
+                    },
+                    crs: 'EPSG:4326'
+                }
+            };
+            const { Plugin } = getPluginForTest(SharePlugin, { controls, map });
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            setTimeout(() => {
+                const inputLink = document.querySelector('input[type=\'text\']');
+                expect(inputLink).toExist();
+                const shareUrl = inputLink.value;
+                const splitUrl = shareUrl.split('?');
+                const query = splitUrl[splitUrl.length - 1];
+                expect(query).toBe('bbox=9,45,10,46');
+                const sharePanelDialog = document.getElementById('share-panel-dialog');
+                expect(sharePanelDialog).toExist();
+                const switchButton = sharePanelDialog.querySelector('.mapstore-switch-btn input[type=\'checkbox\']');
+                expect(switchButton).toExist();
+                expect(switchButton.checked).toBe(true);
+                const bboxCheckbox = sharePanelDialog.querySelector('.panel-body .checkbox input[type=\'checkbox\']');
+                expect(bboxCheckbox).toExist();
+                expect(bboxCheckbox.checked).toBe(true);
+                done();
+            }, 500);
+        } catch (e) {
+            done(e);
+        }
+    });
+
 });


### PR DESCRIPTION
…fault for both context and map resources. Add a test to cover new behavior.

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#5017 

**What is the new behavior?**
The advanced options for the Share tool are available by default for both context and map resources.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
