### PR TITLE
#4739: Fix - Changing language the Tutorial doesn't work anymore

### DIFF
--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -123,7 +123,7 @@ class Tutorial extends React.Component {
         checkAction: {}
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         let defaultSteps = this.props.presetList[this.props.preset] || [];
         let checkbox = this.props.showCheckbox ? <div id="tutorial-intro-checkbox-container"><input type="checkbox" id="tutorial-intro-checkbox" className="tutorial-tooltip-intro-checkbox" onChange={this.props.actions.onDisable}/><span><I18N.Message msgId={"tutorial.checkbox"}/></span></div> : <div id="tutorial-intro-checkbox-container"/>;
         this.props.actions.onSetup('default', defaultSteps, this.props.introStyle, checkbox, this.props.defaultStep, assign({}, this.props.presetList, {default_tutorial: defaultSteps}));


### PR DESCRIPTION
## Description
Reason for solution:
The ordering of componentWillMount and componentWillUnmount is no longer guaranteed in React 16
For this reason, when the setting is opened the component is unmounted and the action in componentWillMount firing is either destroyed because of the issue (https://github.com/facebook/react/issues/12233), returning zero steps and hence tutorial is not displayed.
Also, the React team advises against the use of componentWillMount as it is unreliable. And it has a side effect so it's best to use didMount. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
Tutorial doesn't work after changing the settings 
#4739 

**What is the new behavior?**
Tutorial works even after making changes to settings.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
