### PR TITLE
5054 Feature Attribute Form - Identify tool.

### DIFF
--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -33,7 +33,7 @@ import { stopGetFeatureInfoSelector, identifyOptionsSelector,
     clickPointSelector, clickLayerSelector,
     isMapPopup, isHighlightEnabledSelector,
     itemIdSelector, overrideParamsSelector, filterNameListSelector } from '../selectors/mapInfo';
-import { centerToMarkerSelector, queryableLayersSelector } from '../selectors/layers';
+import { centerToMarkerSelector, queryableLayersSelector, queryableSelectedLayersSelector } from '../selectors/layers';
 import { modeSelector } from '../selectors/featuregrid';
 import { mapSelector, projectionDefsSelector, projectionSelector } from '../selectors/map';
 import { boundingMapRectSelector } from '../selectors/maplayout';
@@ -96,7 +96,11 @@ export default {
     getFeatureInfoOnFeatureInfoClick: (action$, { getState = () => { } }) =>
         action$.ofType(FEATURE_INFO_CLICK)
             .switchMap(({ point, filterNameList = [], overrideParams = {} }) => {
-                const queryableLayers = queryableLayersSelector(getState());
+                let queryableLayers = queryableLayersSelector(getState());
+                const queryableSelectedLayers = queryableSelectedLayersSelector(getState());
+                if (queryableSelectedLayers.length) {
+                    queryableLayers = queryableSelectedLayers;
+                }
                 if (queryableLayers.length === 0) {
                     return Rx.Observable.of(purgeMapInfoResults(), noQueryableLayers());
                 }

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -11,7 +11,7 @@ const {
     getLayerFromName, getLayerFromId, layersSelector, layerSelectorWithMarkers, groupsSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector,
     layerMetadataSelector, wfsDownloadSelector, backgroundControlsSelector,
     currentBackgroundSelector, tempBackgroundSelector, centerToMarkerSelector,
-    getLayersWithDimension, elementSelector
+    getLayersWithDimension, elementSelector, queryableSelectedLayersSelector
 } = require('../layers');
 
 describe('Test layers selectors', () => {
@@ -723,5 +723,54 @@ describe('Test layers selectors', () => {
             "group": "first.second.third"
         };
         expect(elementSelector(state)).toEqual(element);
+    });
+    it('test queryableSelectedLayersSelector', () => {
+        const queryableSelectedLayers = [
+            {
+                type: 'wms',
+                visibility: true,
+                id: 'mapstore:states__7'
+            },
+            {
+                type: 'wms',
+                visibility: true,
+                id: 'mapstore:Types__6'
+            },
+            {
+                type: 'wms',
+                visibility: true,
+                id: 'mapstore:Meteorite_Landings_from_NASA_Open_Data_Portal__5'
+            }
+        ];
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'mapnik__0',
+                        group: 'background',
+                        type: 'osm',
+                        visibility: true
+                    },
+                    {
+                        id: 'Night2012__1',
+                        group: 'background',
+                        type: 'tileprovider',
+                        visibility: false
+                    },
+                    {
+                        type: 'wms',
+                        visibility: true,
+                        id: 'mapstore:DE_USNG_UTM18__8'
+                    },
+                    ...queryableSelectedLayers
+                ],
+                selected: [
+                    'mapstore:states__7',
+                    'mapstore:Types__6',
+                    'mapstore:Meteorite_Landings_from_NASA_Open_Data_Portal__5'
+                ]
+            }
+        };
+        expect(queryableSelectedLayersSelector(state)).toEqual(queryableSelectedLayers);
     });
 });

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -141,6 +141,12 @@ const queryableLayersSelector = state => layersSelector(state).filter(defaultQue
  * @return {boolean} true if selected layer has error
  */
 const selectedLayerLoadingErrorSelector = state => (getSelectedLayer(state) || {}).loadingError === 'Error';
+/**
+ * Return queriable selected layers
+ * @param {object} state the state
+ * @return {array} the queriable selected layers
+ */
+const queryableSelectedLayersSelector = state => getSelectedLayers(state).filter(defaultQueryableFilter);
 
 module.exports = {
     getLayerFromName,
@@ -165,5 +171,6 @@ module.exports = {
     tempBackgroundSelector,
     centerToMarkerSelector,
     elementSelector,
-    selectedLayerLoadingErrorSelector
+    selectedLayerLoadingErrorSelector,
+    queryableSelectedLayersSelector
 };


### PR DESCRIPTION
## Description
- If no layer is selected in TOC, the Identify request will be performed for all layers in the map as it is now
- If one or more layers are selected in the TOC, the Identify request will be performed as usual but only for the selected layers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#5054 

**What is the new behavior?**
- If no layer is selected in TOC, the Identify request will be performed for all layers in the map as it is now
- If one or more layers are selected in the TOC, the Identify request will be performed as usual but only for the selected layers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
