### PR TITLE
#4882: Fix - Unsaved modal appearing for saved changes

### DIFF
--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -18,7 +18,7 @@ const {
     MAP_DELETING, MAP_DELETED, deleteMap, mapDeleted, TOGGLE_DETAILS_SHEET,
     saveMapResource, MAP_CREATED, SAVING_MAP, MAP_UPDATING, MAPS_LOAD_MAP, LOADING, LOAD_CONTEXTS
 } = require('../../actions/maps');
-const { mapInfoLoaded, MAP_SAVED, LOAD_MAP_INFO } = require('../../actions/config');
+const { mapInfoLoaded, MAP_SAVED, LOAD_MAP_INFO, MAP_CONFIG_LOADED } = require('../../actions/config');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 const {TOGGLE_CONTROL, SET_CONTROL_PROPERTY} = require('../../actions/controls');
 const {RESET_CURRENT_MAP, editMap} = require('../../actions/currentMap');
@@ -717,6 +717,7 @@ describe('Create and update flow using persistence api', () => {
                 case MAP_SAVED:
                 case SHOW_NOTIFICATION:
                 case LOAD_MAP_INFO:
+                case MAP_CONFIG_LOADED:
                     break;
                 default:
                     expect(true).toBe(false);
@@ -735,6 +736,7 @@ describe('Create and update flow using persistence api', () => {
                 case MAP_SAVED:
                 case SHOW_NOTIFICATION:
                 case LOAD_MAP_INFO:
+                case MAP_CONFIG_LOADED:
                     break;
                 default:
                     expect(true).toBe(false);

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -708,8 +708,8 @@ describe('Create and update flow using persistence api', () => {
         });
     });
     it('test update flow ', done => {
-        testEpic(addTimeoutEpic(mapSaveMapResourceEpic), 5, saveMapResource( {id: 10}), actions => {
-            expect(actions.length).toBe(5);
+        testEpic(addTimeoutEpic(mapSaveMapResourceEpic), 6, saveMapResource( {id: 10}), actions => {
+            expect(actions.length).toBe(6);
             actions.map((action) => {
                 switch (action.type) {
                 case MAP_UPDATING:
@@ -727,8 +727,8 @@ describe('Create and update flow using persistence api', () => {
         });
     });
     it('test create with a null attribute', done => {
-        testEpic(addTimeoutEpic(mapSaveMapResourceEpic), 5, saveMapResource({id: 10, attributes: {context: null}}), actions => {
-            expect(actions.length).toBe(5);
+        testEpic(addTimeoutEpic(mapSaveMapResourceEpic), 6, saveMapResource({id: 10, attributes: {context: null}}), actions => {
+            expect(actions.length).toBe(6);
             actions.map((action) => {
                 switch (action.type) {
                 case MAP_UPDATING:

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -12,7 +12,7 @@ const assign = require('object-assign');
 const {push} = require('connected-react-router');
 const {basicError, basicSuccess} = require('../utils/NotificationUtils');
 const GeoStoreApi = require('../api/GeoStoreDAO');
-const { MAP_INFO_LOADED, MAP_SAVED, mapSaveError, mapSaved, loadMapInfo } = require('../actions/config');
+const { MAP_INFO_LOADED, MAP_SAVED, mapSaveError, mapSaved, loadMapInfo, configureMap } = require('../actions/config');
 const {get, isNil, isArray, isEqual, find, pick, omit, keys, zip} = require('lodash');
 const {
     SAVE_DETAILS, SAVE_RESOURCE_DETAILS, MAPS_GET_MAP_RESOURCES_BY_CATEGORY,
@@ -504,6 +504,7 @@ const mapSaveMapResourceEpic = (action$, store) =>
                     }))) : Rx.Observable.of([])).switchMap(() =>
                     Rx.Observable.from([
                         ...(resource.id ? [loadMapInfo(rid)] : []),
+                        ...(resource.id ? [configureMap(resource.data, rid)] : []),
                         resource.id ? toggleControl('mapSave') : toggleControl('mapSaveAs'),
                         mapSaved(),
                         ...(!resource.id ? [


### PR DESCRIPTION
## Description
Map data comparison happens with the updated map and mapconfigdata which is updated only during the initial load. Hence, modified mapSaveResource to update mapconfigData state with the updated resource whenever the map is modified and saved.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

##Issue

**What is the current behavior?**
#4882 

**What is the new behavior?**
Unsaved changes modal will not appear when all the changes done to map is saved before navigating to Home

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
