### PR TITLE
Update PluginsContainer.jsx

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -89,21 +89,20 @@ class PluginsContainer extends React.Component {
         this.loadPlugins(this.props.pluginsState, this.props);
     }
 
-    UNSAFE_componentWillReceiveProps(newProps) {
-        this.loadPlugins(newProps.pluginsState, newProps);
-    }
-
     shouldComponentUpdate(nextProps, nextState) {
-        return nextProps.pluginsConfig !== this.props.pluginsConfig
-            || nextProps.plugins !== this.props.plugins
+        return !isEqual(nextProps.pluginsConfig, this.props.pluginsConfig)
+            || !isEqual(nextProps.plugins, this.props.plugins)
             || nextProps.params !== this.props.params
             || nextProps.mode !== this.props.mode
-            || nextProps.monitoredState !== this.props.monitoredState
+            || !isEqual(nextProps.monitoredState, this.props.monitoredState)
             || nextProps.className !== this.props.className
             || nextProps.style !== this.props.style
             || nextProps.defaultMode !== this.props.defaultMode
             || !isEqual(nextProps.pluginsState, this.props.pluginsState)
             || !isEqual(nextState.loadedPlugins, this.state.loadedPlugins);
+    }
+    UNSAFE_componentWillUpdate(newProps) {
+        this.loadPlugins(newProps.pluginsState, newProps);
     }
 
     getState = (path, newProps) => {


### PR DESCRIPTION
## Description
Instead of using componentWillReceiveProps (that is applied everytime) we should use componentWillUpdate that is applied only if shouldComponentUpdate returns true (at least until rewrite this with hooks). 
This seems to speed up performances a lot. If it doesn't affect too much the dynamic plugin load system, i should propose this changes.

What do you thinj @mbarto 

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
