### PR TITLE
#4954: added explicit actions for user session saving handling (start…

### DIFF
--- a/web/client/actions/__tests__/usersession-test.js
+++ b/web/client/actions/__tests__/usersession-test.js
@@ -8,9 +8,9 @@
 
 import expect from 'expect';
 import {SAVE_USER_SESSION, USER_SESSION_SAVED, LOAD_USER_SESSION, USER_SESSION_LOADED, USER_SESSION_LOADING,
-    REMOVE_USER_SESSION, USER_SESSION_REMOVED, SAVE_MAP_CONFIG,
+    REMOVE_USER_SESSION, USER_SESSION_REMOVED, SAVE_MAP_CONFIG, USER_SESSION_START_SAVING, USER_SESSION_STOP_SAVING,
     saveUserSession, userSessionSaved, loadUserSession, userSessionLoaded, loading,
-    removeUserSession, userSessionRemoved, saveMapConfig} from "../usersession";
+    removeUserSession, userSessionRemoved, saveMapConfig, userSessionStartSaving, userSessionStopSaving} from "../usersession";
 
 describe('Test correctness of the usersession actions', () => {
 
@@ -52,6 +52,14 @@ describe('Test correctness of the usersession actions', () => {
     it('user session removed', () => {
         const action = userSessionRemoved();
         expect(action.type).toBe(USER_SESSION_REMOVED);
+    });
+    it('user session start saving', () => {
+        const action = userSessionStartSaving();
+        expect(action.type).toBe(USER_SESSION_START_SAVING);
+    });
+    it('user session stop saving', () => {
+        const action = userSessionStopSaving();
+        expect(action.type).toBe(USER_SESSION_STOP_SAVING);
     });
     it('save map config', () => {
         const action = saveMapConfig({});

--- a/web/client/actions/usersession.js
+++ b/web/client/actions/usersession.js
@@ -14,6 +14,8 @@ export const USER_SESSION_REMOVED = "USER_SESSION:REMOVED";
 export const USER_SESSION_LOADED = "USER_SESSION:LOADED";
 export const USER_SESSION_LOADING = "USER_SESSION:LOADING";
 export const SAVE_MAP_CONFIG = "USER_SESSION:ORIGINAL_CONFIG";
+export const USER_SESSION_START_SAVING = "USER_SESSION:START_SAVING";
+export const USER_SESSION_STOP_SAVING = "USER_SESSION:STOP_SAVING";
 
 export const saveUserSession = () => ({type: SAVE_USER_SESSION});
 export const userSessionSaved = (id, session) => ({type: USER_SESSION_SAVED, id, session});
@@ -21,6 +23,8 @@ export const loadUserSession = (name = "") => ({type: LOAD_USER_SESSION, name});
 export const userSessionLoaded = (id, session) => ({type: USER_SESSION_LOADED, id, session});
 export const removeUserSession = () => ({type: REMOVE_USER_SESSION});
 export const userSessionRemoved = () => ({type: USER_SESSION_REMOVED});
+export const userSessionStartSaving = () => ({type: USER_SESSION_START_SAVING});
+export const userSessionStopSaving = () => ({type: USER_SESSION_STOP_SAVING});
 export const saveMapConfig = (config) => ({type: SAVE_MAP_CONFIG, config});
 export const loading = (value, name = "loading") => ({
     type: USER_SESSION_LOADING,


### PR DESCRIPTION
…, stop)

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Added a couple of actions to explicitly start and stop user session saving.
These can be used by more complex workflows to start session at map / context loading.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:
