### PR TITLE
#4712: Fix -Share tool button missing in the Options menu

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -635,6 +635,14 @@
                 "className": "navbar shadow navbar-home"
             }
         }, "Login", "Language", "NavMenu", "DashboardSave", "DashboardSaveAs", "Attribution", "Home", {
+          "name": "Share",
+          "cfg": {
+            "advancedSettings": {
+              "bbox": false
+            }
+          }
+        },
+          {
           "name": "DashboardEditor",
           "cfg": {
             "catalog": {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -637,9 +637,8 @@
         }, "Login", "Language", "NavMenu", "DashboardSave", "DashboardSaveAs", "Attribution", "Home", {
           "name": "Share",
           "cfg": {
-            "advancedSettings": {
-              "bbox": false
-            }
+            "embedPanel": false,
+            "advancedSettings": false
           }
         },
           {

--- a/web/client/selectors/__tests__/localConfig-test.js
+++ b/web/client/selectors/__tests__/localConfig-test.js
@@ -17,6 +17,8 @@ import localConfig from '../../reducers/localConfig';
 import {
     localConfigLoaded
 } from '../../actions/localConfig';
+import LOCAL_CONFIG from '../../localConfig';
+import {filter, includes} from 'lodash';
 
 
 const stateMocker = createStateMocker({localConfig});
@@ -39,5 +41,12 @@ describe('localConfig selectors', () => {
         expect(pluginsSelectorCreator('desktop')(stateMocker(localConfigLoaded(TEST_CONFIG)))).toBe(TEST_CONFIG.plugins.desktop);
     });
 
+    it('pluginSelectorCreator for dashboard', ()=>{
+        const loadedConfig = (pluginsSelectorCreator('dashboard')(stateMocker(localConfigLoaded(LOCAL_CONFIG))));
+        expect(loadedConfig).toEqual(LOCAL_CONFIG.plugins.dashboard);
+        expect(includes(loadedConfig, 'DashboardSave')).toBe(true);
+        expect(includes(loadedConfig, 'DashboardSaveAs')).toBe(true);
+        expect(filter(loadedConfig, { "name": "Share"})[0]).toContain({ "name": "Share"});
+    });
 
 });

--- a/web/client/selectors/__tests__/localConfig-test.js
+++ b/web/client/selectors/__tests__/localConfig-test.js
@@ -43,10 +43,11 @@ describe('localConfig selectors', () => {
 
     it('pluginSelectorCreator for dashboard', ()=>{
         const loadedConfig = (pluginsSelectorCreator('dashboard')(stateMocker(localConfigLoaded(LOCAL_CONFIG))));
-        expect(loadedConfig).toEqual(LOCAL_CONFIG.plugins.dashboard);
         expect(includes(loadedConfig, 'DashboardSave')).toBe(true);
         expect(includes(loadedConfig, 'DashboardSaveAs')).toBe(true);
         expect(filter(loadedConfig, { "name": "Share"})[0]).toContain({ "name": "Share"});
+        expect(filter(loadedConfig, { "name": "Share"})[0].cfg).toContain({ "embedPanel": false});
+        expect(filter(loadedConfig, { "name": "Share"})[0].cfg).toContain({ "advancedSettings": false});
     });
 
 });


### PR DESCRIPTION
## Description
Added share option to the config file for enabling share button in dashboard.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#4712 

**What is the new behavior?**
Share button will be displayed in Dashboard

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

