### PR TITLE
#5083 Columns/paragraph media (map and web-page) size height changes

### DIFF
--- a/web/client/components/geostory/contents/Column.jsx
+++ b/web/client/components/geostory/contents/Column.jsx
@@ -22,6 +22,13 @@ const ColumnContent = compose(
  * Column is a like a Paragraph section, but as content.
  * has (sub) contents to render like a page.
  */
+
+const size = (pullRight) => ({
+    id: 'size',
+    filterOptions: ({ value }) => value !== 'full',
+    pullRight
+});
+
 export default ({
     viewWidth,
     viewHeight,
@@ -53,10 +60,10 @@ export default ({
         }}
         tools={{
             [ContentTypes.TEXT]: ['remove'],
-            [MediaTypes.IMAGE]: ['editMedia', 'size', 'align', 'remove'],
-            [MediaTypes.MAP]: ['editMedia', 'editMap', 'remove'],
+            [MediaTypes.IMAGE]: ['editMedia', size(), 'align', 'remove'],
+            [MediaTypes.MAP]: ['editMedia', 'editMap', size(true), 'remove'],
             [MediaTypes.VIDEO]: ['editMedia', 'remove'], // TODO change this list for video
-            [ContentTypes.WEBPAGE]: ['editURL', 'size', 'align', 'remove']
+            [ContentTypes.WEBPAGE]: ['editURL', size(true), 'remove']
         }}
         addButtons={[{
             glyph: 'sheet',

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -80,13 +80,25 @@ const toolButtons = {
 
 /**
  * Toolbar to update properties of content,
- * @prop {array} tools list of tool's names to display in the edit toolbar, available tools `size`, `align` and `theme`
+ * @prop {array} tools list of tool's names or object ({ id: 'toolName' }) to display in the edit toolbar, available tools `size`, `align` and `theme`
  * @prop {string} size one of `small`, `medium`, `large` and `full`
  * @prop {string} align one of `left`, `center` and `right`
  * @prop {string} theme one of `bright`, `bright-text`, `dark` and `dark-text`
  * @prop {string} fit one of `contain` and `cover`
  * @prop {function} update handler for select properties events, parameters (key, value)
  * @example
+ *
+ * // tools prop with string
+ * function Content({ children }) {
+ *  return <div className="test-toolbar"><ContentToolbar tools={[ 'size' ]}/>{children}</div>;
+ * }
+ *
+ * // tools prop with object entry to override default props
+ * function Content({ children }) {
+ *  const size = { id: 'size', pullRight: true }; // override pullRight props of size dropdown
+ *  return <div className="test-toolbar"><ContentToolbar tools={[ size ]}/>{children}</div>;
+ * }
+ *
  */
 export default function ContentToolbar({
     tools = [],

--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -100,8 +100,8 @@ export default function ContentToolbar({
                     noTooltipWhenDisabled: true
                 }}
                 buttons={tools
-                    .filter((id) => toolButtons[id])
-                    .map(id => toolButtons[id](props))}/>
+                    .filter((tool) => tool?.id && toolButtons[tool.id] || toolButtons[tool])
+                    .map(tool => tool?.id && toolButtons[tool.id]({ ...props, ...tool }) || toolButtons[tool](props))}/>
         </div>
     );
 }

--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -22,13 +22,13 @@ const BUTTON_CLASSES = 'square-button-md no-border';
  * these components have been created because it was causing an excessive re-rendering
  */
 
-export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {} }) =>
+export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {}, filterOptions, pullRight }) =>
     (<ToolbarDropdownButton
         value={size}
         noTooltipWhenDisabled
         disabled={disabled}
         glyph="resize-horizontal"
-        pullRight={(align === "right" || size === "full" || size === "large") && !sectionType}
+        pullRight={pullRight || (align === "right" || size === "full" || size === "large") && !sectionType}
         tooltipId="geostory.contentToolbar.contentSize"
         options={[{
             value: 'small',
@@ -46,7 +46,7 @@ export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType
             value: 'full',
             glyph: 'size-extra-large',
             label: <Message msgId="geostory.contentToolbar.fullSizeLabel"/>
-        }]}
+        }].filter((option) => !filterOptions || filterOptions(option))}
         onSelect={(selected) => update('size', selected)}/>
     );
 

--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -22,6 +22,13 @@ const BUTTON_CLASSES = 'square-button-md no-border';
  * these components have been created because it was causing an excessive re-rendering
  */
 
+/**
+ * Size dropdown
+ * @prop {string} size one of `small`, `medium`, `large` and `full`
+ * @prop {string} align one of `left`, `center` and `right`
+ * @prop {function} filterOptions filter dropdown options by value (eg `({ value }) => value !== 'full'` to exclude `full` option)
+ * @prop {function} pullRight pull dropdown right
+ */
 export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {}, filterOptions, pullRight }) =>
     (<ToolbarDropdownButton
         value={size}

--- a/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
@@ -98,6 +98,18 @@ describe('ContentToolbar component', () => {
         expect(buttons.length).toEqual(1);
         ReactTestUtils.Simulate.click(buttons[0]);
     });
+    it('should accept object tool', () => {
+        const filterOptions = ({ value }) => value !== 'full';
+        ReactDOM.render(<ContentToolbar
+            tools={[{ id: 'size', filterOptions }]}
+        />, document.getElementById('container'));
+        const buttons = document.getElementsByTagName('button');
+        expect(buttons).toBeTruthy();
+        expect(buttons.length).toEqual(1);
+        ReactTestUtils.Simulate.click(buttons[0]);
+        const menuItems = document.querySelectorAll('.dropdown-menu > li');
+        expect(menuItems.length).toBe(3);
+    });
     describe('tools', () => {
         // TODO: align, theme, size...
         it(`align`, (done) => {

--- a/web/client/components/geostory/layouts/Cascade.jsx
+++ b/web/client/components/geostory/layouts/Cascade.jsx
@@ -107,7 +107,7 @@ const Cascade = ({
     isContentFocused = false,
     getSize = defaultGetSize,
     theme = {}
-}) => (<BorderLayout  className={`ms-cascade-story ms-${mode}`} bodyClassName={`ms2-border-layout-body ${isContentFocused ? 'no-overflow' : ''}`}>
+}) => (<BorderLayout  className={`ms-cascade-story ms-${mode}`}>
     <ContainerDimensions
         sections={sections}
         add={add}>
@@ -119,7 +119,10 @@ const Cascade = ({
             return (<div
                 id="ms-sections-container"
                 className={`ms-sections-container${sizeClassName}`}
-                style={storyTheme}>
+                style={{
+                    ...storyTheme,
+                    ...isContentFocused && { overflow: 'hidden' }
+                }}>
                 {
                     sections.map(({ contents = [], id: sectionId, type: sectionType, cover }) => {
                         return (

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -20,6 +20,11 @@
 @ms-story-size-large: 85%;
 @ms-story-size-medium: 60%;
 @ms-story-size-small: 40%;
+
+@ms-story-size-height-large: 800px;
+@ms-story-size-height-medium: 575px;
+@ms-story-size-height-small: 350px;
+
 .ms-story-align-center { margin-left: auto; margin-right: auto; }
 /* mixin for align*/
 .ms-story-align-left { margin-left: 0; margin-right: auto; }
@@ -599,11 +604,13 @@
                         width: 100%;
                     }
                 }
-                .ms-media-map {
+                .ms-content.ms-content-webPage,
+                .ms-content.ms-content-map {
+                    width: 100%;
                     height: 350px;
-                    & > div {
-                        position: relative;
-                    }
+                    &.ms-size-large { height: @ms-story-size-height-large; }
+                    &.ms-size-medium { height: @ms-story-size-height-medium; }
+                    &.ms-size-small { height: @ms-story-size-height-small; }
                 }
             }
         }
@@ -680,18 +687,19 @@
                     right: 16px;
                 }
                 .ms-media-map {
-                    height: 350px;
-                    & > div {
-                        position: relative;
-                    }
                     .ms-expand-media-button {
                         margin: 0;
                         top: 20px;
                         right: 20px;
                     }
                 }
+                .ms-content.ms-content-webPage,
                 .ms-content.ms-content-map {
                     width: 100%;
+                    height: 350px;
+                    &.ms-size-large { height: @ms-story-size-height-large; }
+                    &.ms-size-medium { height: @ms-story-size-height-medium; }
+                    &.ms-size-small { height: @ms-story-size-height-small; }
                 }
             }
         }
@@ -708,11 +716,52 @@
         we need to restore the possibility to interact with the content body
         using `pointer-events: auto;`
         */
-
-        .ms-webpage-wrapper > iframe {
-            border: none;
+        .ms-content-webPage {
+            position: relative;
             width: 100%;
-            min-height: 100%;
+            height: 100%;
+            .ms-content-body,
+            .ms-visibility-container,
+            .ms-webpage-wrapper,
+            .ms-webpage-wrapper > iframe {
+                position: relative;
+                width: 100%;
+                height: 100%;
+            }
+            .ms-webpage-wrapper > iframe {
+                border: none;
+            }
+            .ms-content-body {
+                display: flex;
+                flex-direction: column;
+            }
+            .ms-visibility-container {
+                flex: 1;
+            }
+        }
+
+        .ms-content-map {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            .ms-content-body,
+            .ms-visibility-container,
+            .ms-media-map,
+            .ms-media-map > div  {
+                position: relative;
+                width: 100%;
+                height: 100%;
+            }
+            .ms-content-body {
+                display: flex;
+                flex-direction: column;
+            }
+            .ms-visibility-container {
+                flex: 1;
+            }
+            canvas {
+                position: absolute;
+            }
         }
 
         .ms-content-body > * {
@@ -836,6 +885,10 @@
                     padding: 16px;
                 }
             }
+            code {
+                color: inherit;
+                background: #f1f1f1;
+            }
         }
 
         /* size of content */
@@ -850,6 +903,9 @@
         &.ms-align-right { .ms-story-align-right(); }
     }
 
+    .ms-content-column {
+        .ms-content.ms-size-large { width: @ms-story-size-full; }
+    }
 
     //////////
     // MEDIA

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -33,9 +33,6 @@
 .ms-story-color-contrast { color: contrast(@ms-story-bg); }
 .ms-story-color-no-contrast { color: @ms-story-bg; }
 
-
-.no-overflow {overflow: hidden !important;}
-
 /* TEXT EDITOR TODO: externalize */
 @import '~draft-js-inline-toolbar-plugin/lib/plugin.css';
 @import '~react-draft-wysiwyg/dist/react-draft-wysiwyg.css';

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -314,6 +314,15 @@ export const getDefaultSectionTemplate = (type, localize = v => v) => {
             align: 'center'
         };
     }
+    case ContentTypes.MEDIA: {
+        return {
+            id: uuid(),
+            type,
+            title: localize("geostory.builder.defaults.titleUnknown"),
+            size: 'large',
+            align: 'center'
+        };
+    }
     default:
         return {
             id: uuid(),

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -289,6 +289,13 @@ describe("GeoStory Utils", () => {
             expect(data.id).toExist();
             expect(data.type).toBe(ContentTypes.TEXT);
         });
+        it("ContentTypes.MEDIA", () => {
+            const data = getDefaultSectionTemplate(ContentTypes.MEDIA);
+            expect(data.id).toBeTruthy();
+            expect(data.type).toBe(ContentTypes.MEDIA);
+            expect(data.size).toBe('large');
+            expect(data.align).toBe('center');
+        });
     });
     it('test applyDefaults', () => {
         const res = applyDefaults();


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR improves size selection of media map and webpage contents of paragraph and immersive section (Column)

![media-heigth](https://user-images.githubusercontent.com/19175505/78025015-99edbf00-7359-11ea-8a6c-6c8f4a73f9c0.gif)

It fixes also a regression on map editor about stop scrolling while a map is focused.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5083

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Map and webpage contens adjust size vertically instead of horizontally inside columns.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
