### PR TITLE
#5108: allow app epics to override standard ones

### DIFF
--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -55,7 +55,7 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
         layers: () => {return null; },
         router: storeOpts.noRouter ? undefined : connectRouter(history)
     });
-    const rootEpic = persistEpic(combineEpics(plugins, {...appEpics, ...standardEpics}));
+    const rootEpic = persistEpic(combineEpics(plugins, {...standardEpics, ...appEpics}));
     const optsState = storeOpts.initialState || {defaultState: {}, mobile: {}};
     const defaultState = assign({}, initialState.defaultState, optsState.defaultState);
     const mobileOverride = assign({}, initialState.mobile, optsState.mobile);

--- a/web/client/stores/__tests__/StandardStore-test.js
+++ b/web/client/stores/__tests__/StandardStore-test.js
@@ -9,6 +9,8 @@
 import expect from 'expect';
 
 import createStore from "../StandardStore";
+import { Observable } from 'rxjs';
+import {LOAD_MAP_CONFIG} from "../../actions/config";
 
 
 describe('Test StandardStore', () => {
@@ -19,5 +21,23 @@ describe('Test StandardStore', () => {
     it('addActionListener is not available if storeOpts notify is false', () => {
         const store = createStore({}, {}, {}, {}, /* storeOpts */{ notify: false });
         expect(store.addActionListener).toNotExist();
+    });
+    it('appEpics override standard epics', (done) => {
+
+        const store = createStore({}, {}, {
+            loadMapConfigAndConfigureMap: ($action) =>
+                $action.ofType(LOAD_MAP_CONFIG).switchMap(() => Observable.of({type: "PONG"}))
+        });
+        let actions = 0;
+        store.addActionListener((action) => {
+            actions++;
+            if (actions === 2) {
+                expect(action.type).toBe("PONG");
+                done();
+            }
+        });
+        store.dispatch({
+            type: LOAD_MAP_CONFIG
+        });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Allow app epics to override standard ones

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#5108 
