### PR TITLE
#5115 Fix to version identification issue for timeline mapSync

### DIFF
--- a/web/client/test-resources/wmts/DescribeDomains1.1.xml
+++ b/web/client/test-resources/wmts/DescribeDomains1.1.xml
@@ -1,0 +1,21 @@
+<Domains xmlns="http://demo.geo-solutions.it/share/wmts-multidim/wmts_multi_dimensional.xsd"
+    xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1">
+    <SpaceDomain>
+        <BoundingBox CRS="EPSG:4326" maxx="179.875" maxy="89.9375" minx="-180.125" miny="-90.125"/>
+    </SpaceDomain>
+    <DimensionDomain>
+        <ows:Identifier>elevation</ows:Identifier>
+        <Domain>0.0,200.0,400.0,600.0,800.0,1000.0</Domain>
+        <Size>6</Size>
+    </DimensionDomain>
+    <DimensionDomain>
+        <ows:Identifier>REFERENCE_TIME</ows:Identifier>
+        <Domain>2016-02-23T00:00:00.000Z,2016-02-24T00:00:00.000Z</Domain>
+        <Size>2</Size>
+    </DimensionDomain>
+    <DimensionDomain>
+        <ows:Identifier>time</ows:Identifier>
+        <Domain>2016-02-23T03:00:00.000Z,2016-02-23T06:00:00.000Z</Domain>
+        <Size>2</Size>
+    </DimensionDomain>
+</Domains>

--- a/web/client/utils/TimeUtils.js
+++ b/web/client/utils/TimeUtils.js
@@ -234,7 +234,7 @@ const getDateTimeFormat = (locale, type) => {
  */
 const domainsToDimensionsObject = ({ Domains = {} } = {}, url) => {
     let dimensions = castArray(Domains.DimensionDomain || []).concat();
-    let version = Domains['@version'];
+    let version = Domains['@version'] || Domains.version;
     const bbox = get(Domains, 'SpaceDomain.BoundingBox');
     if (bbox) {
         dimensions.push({

--- a/web/client/utils/__tests__/TimeUtils-test.js
+++ b/web/client/utils/__tests__/TimeUtils-test.js
@@ -10,8 +10,10 @@ const {
     getDateTimeFormat,
     getUTCTimePart,
     getUTCDatePart,
-    roundResolution
+    roundResolution,
+    domainsToDimensionsObject
 } = require('../TimeUtils');
+import { describeDomains } from '../../api/MultiDim';
 
 describe('TimeUtils', () => {
     it('roundResolution', () => {
@@ -53,6 +55,26 @@ describe('TimeUtils', () => {
         // date-time
         expect(getDateTimeFormat("en-US", "date-time")).toBe("MM/DD/YYYY HH:mm:SS");
         expect(getDateTimeFormat("it-IT", "date-time")).toBe("DD/MM/YYYY HH:mm:SS");
+    });
+    it('domainsToDimensionsObject', done => {
+        describeDomains('base/web/client/test-resources/wmts/DescribeDomains.xml', "test:layer")
+            .subscribe(result => {
+                const dimensions = domainsToDimensionsObject(result);
+                dimensions.map( ({source}) => expect(source.version).toBeFalsy());
+            },
+            e => done(e),
+            () => done()
+            );
+    });
+    it('domainsToDimensionsObject 1.1', done => {
+        describeDomains('base/web/client/test-resources/wmts/DescribeDomains1.1.xml', "test:layer")
+            .subscribe(result => {
+                const dimensions = domainsToDimensionsObject(result);
+                dimensions.map(({ source }) => expect(source.version).toBe("1.1"));
+            },
+            e => done(e),
+            () => done()
+            );
     });
 
 });


### PR DESCRIPTION
## Description
This PR should solve the problems with layers using projections not defined in mapstore and mapsync.
The old version was checking `@version` from the json created from the XML, but instead it should be "version" (probably a typo).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5115 

**What is the new behavior?**
Timeline correctly recognize the service. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


