### PR TITLE
Map templates handling enhancements

### DIFF
--- a/web/client/actions/contextcreator.js
+++ b/web/client/actions/contextcreator.js
@@ -125,10 +125,11 @@ export const setSelectedTemplates = (ids) => ({
  * @param {string} fileName file name to display
  * @param {any} data template data
  */
-export const setParsedTemplate = (fileName, data) => ({
+export const setParsedTemplate = (fileName, data, format) => ({
     type: SET_PARSED_TEMPLATE,
     fileName,
-    data
+    data,
+    format
 });
 
 /**

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -351,6 +351,7 @@ const configurePluginsStep = ({
                 onSelect={items => setSelectedPlugins(pickIds(ignoreMandatory(items)))}
                 onTransfer={(items, direction) => (direction === 'right' ? onEnablePlugins : onDisablePlugins)(pickIds(ignoreMandatory(items)))}/>
             <ResizableModal
+                loading={loading && loadFlags.templateDataLoading}
                 showFullscreen
                 title={<Message msgId="contextCreator.configureTemplates.title"/>}
                 show={showDialog.mapTemplatesConfig}

--- a/web/client/components/maptemplates/MapTemplatesPanel.jsx
+++ b/web/client/components/maptemplates/MapTemplatesPanel.jsx
@@ -17,6 +17,7 @@ import BaseFilter from '../misc/Filter';
 import ConfirmDialog from '../misc/ConfirmDialog';
 import emptyState from '../misc/enhancers/emptyState';
 import localizedProps from '../misc/enhancers/localizedProps';
+import FileFormatUtils from '../../utils/FileFormatUtils';
 
 const Filter = localizedProps('filterPlaceholder')(BaseFilter);
 
@@ -77,8 +78,13 @@ export default ({
         preview:
             <div className="map-templates-preview">
                 {template.thumbnail && template.thumbnail !== 'NODATA' ?
-                    <img src={template.thumbnail}/> :
+                    <img src={decodeURIComponent(template.thumbnail)}/> :
                     <Glyphicon glyph="1-map"/>}
+            </div>,
+        infoExtra:
+            template.format && <div className="map-templates-formaticon">
+                <Glyphicon glyph={FileFormatUtils.formatToGlyph[template.format]}/>
+                <span>{FileFormatUtils.formatToText[template.format]}</span>
             </div>,
         tools: <Toolbar
             btnDefaultProps={{

--- a/web/client/components/misc/cardgrids/SideCard.jsx
+++ b/web/client/components/misc/cardgrids/SideCard.jsx
@@ -18,6 +18,7 @@ const Loader = require('../Loader');
  * @class
  * @prop {node}         body            add a node to the bottom of card
  * @prop {node|string}  caption         text for caption
+ * @prop {node}         infoExtra       add a node under info
  * @prop {string}       className       custom class
  * @prop {node|string}  description     text for description
  * @prop {bool}         fullText        add full-text className
@@ -37,6 +38,7 @@ const Loader = require('../Loader');
 module.exports = ({
     body,
     caption,
+    infoExtra,
     className = '',
     description,
     fullText,
@@ -72,24 +74,29 @@ module.exports = ({
             </div>}
             <div className="mapstore-side-card-container">
                 <div className="mapstore-side-card-inner">
-                    <div className="mapstore-side-card-info">
-                        {title && <div className="mapstore-side-card-title">
-                            <span>{title}</span>
-                        </div>}
-                        {description && <div className="mapstore-side-card-desc">
-                            <span>{description}</span>
-                        </div>}
-                        {caption && <div className="mapstore-side-card-caption">
-                            <span>{caption}</span>
-                        </div>}
+                    <div className="mapstore-side-card-left-container">
+                        <div className="mapstore-side-card-info">
+                            {title && <div className="mapstore-side-card-title">
+                                <span>{title}</span>
+                            </div>}
+                            {description && <div className="mapstore-side-card-desc">
+                                <span>{description}</span>
+                            </div>}
+                            {caption && <div className="mapstore-side-card-caption">
+                                <span>{caption}</span>
+                            </div>}
+                        </div>
+                        {infoExtra}
                     </div>
-                    <div className="mapstore-side-card-tool text-center" style={styleTools}>
-                        {tools}
+                    <div className="mapstore-side-card-right-container">
+                        <div className="mapstore-side-card-tool text-center" style={styleTools}>
+                            {tools}
+                        </div>
+                        {size !== 'sm' && <div className="mapstore-side-card-loading">
+                            <Loader className="mapstore-side-card-loader" size={12} hidden={!loading}/>
+                        </div>}
                     </div>
                 </div>
-                {size !== 'sm' && <div className="mapstore-side-card-loading">
-                    <Loader className="mapstore-side-card-loader" size={12} hidden={!loading}/>
-                </div>}
             </div>
         </div>
         {body && <div className="ms-body">

--- a/web/client/components/misc/cardgrids/__tests__/SideCard-test.jsx
+++ b/web/client/components/misc/cardgrids/__tests__/SideCard-test.jsx
@@ -130,4 +130,20 @@ describe('SideCard component', () => {
         expect(descClassName).toExist();
         expect(previewClassName).toExist();
     });
+    it('SideCard with infoExtra', () => {
+        ReactDOM.render(<SideCard caption="caption" description="desc" title="title" infoExtra={<div className="side-card-test-infoextra"/>}/>,
+            document.getElementById("container"));
+        const container = document.getElementById('container');
+        let body = container.querySelector('.ms-body');
+        let titleClassName = container.querySelector('.mapstore-side-card-title');
+        let descClassName = container.querySelector('.mapstore-side-card-desc');
+
+        const sideCardLeftContainer = container.getElementsByClassName('mapstore-side-card-left-container')[0];
+        expect(sideCardLeftContainer).toExist();
+        let infoExtraClassName = sideCardLeftContainer.querySelector('.side-card-test-infoextra');
+        expect(body).toNotExist();
+        expect(titleClassName).toExist();
+        expect(descClassName).toExist();
+        expect(infoExtraClassName).toExist();
+    });
 });

--- a/web/client/components/resources/modals/enhancers/handleResourceData.jsx
+++ b/web/client/components/resources/modals/enhancers/handleResourceData.jsx
@@ -85,7 +85,7 @@ module.exports = compose(
     }),
     // manage save handler
     withHandlers({
-        onSave: ({onSave = () => {}, category = "DASHBOARD", data, additionalAttributes, linkedResources}) => resource => onSave({
+        onSave: ({onSave = () => {}, category = "DASHBOARD", data, additionalAttributes = {}, linkedResources}) => resource => onSave({
             category,
             linkedResources,
             data,

--- a/web/client/components/resources/modals/enhancers/handleResourceData.jsx
+++ b/web/client/components/resources/modals/enhancers/handleResourceData.jsx
@@ -85,11 +85,15 @@ module.exports = compose(
     }),
     // manage save handler
     withHandlers({
-        onSave: ({onSave = () => {}, category = "DASHBOARD", data, linkedResources}) => resource => onSave({
+        onSave: ({onSave = () => {}, category = "DASHBOARD", data, additionalAttributes, linkedResources}) => resource => onSave({
             category,
             linkedResources,
             data,
-            ...resource
+            ...resource,
+            attributes: {
+                ...resource.attributes,
+                ...additionalAttributes
+            }
         })
     })
 );

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -17,7 +17,8 @@ import {
     uninstallPluginEpic,
     saveTemplateEpic,
     saveContextResource,
-    checkIfContextExists
+    checkIfContextExists,
+    editTemplateEpic
 } from '../contextcreator';
 import {
     editPlugin,
@@ -28,6 +29,8 @@ import {
     uploadPlugin,
     uninstallPlugin,
     saveTemplate,
+    saveNewContext,
+    editTemplate,
     SET_EDITED_PLUGIN,
     SET_EDITED_CFG,
     SET_CFG_ERROR,
@@ -42,9 +45,11 @@ import {
     SHOW_DIALOG,
     IS_VALID_CONTEXT_NAME,
     CONTEXT_NAME_CHECKED,
-    saveNewContext,
     LOAD_EXTENSIONS,
-    CONTEXT_SAVED
+    CONTEXT_SAVED,
+    SET_EDITED_TEMPLATE,
+    SET_PARSED_TEMPLATE,
+    SET_FILE_DROP_STATUS
 } from '../../actions/contextcreator';
 import {
     SHOW_NOTIFICATION
@@ -853,7 +858,6 @@ describe('contextcreator epics', () => {
             }
         }, done);
     });
-
     it('saveContextResource saves a context', (done) => {
         mockAxios.onPost().reply(200, "1");
         mockAxios.onGet().reply(200, {});
@@ -873,6 +877,53 @@ describe('contextcreator epics', () => {
                 }
             },
             map: {}
+        }, done);
+    });
+    it('editTemplateEpic with id', (done) => {
+        mockAxios.onGet().reply(200, 'data');
+        const startActions = [editTemplate(1)];
+        testEpic(editTemplateEpic, 6, startActions, actions => {
+            expect(actions.length).toBe(6);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[1].type).toBe(SET_EDITED_TEMPLATE);
+            expect(actions[1].id).toBe(1);
+            expect(actions[2].type).toBe(SET_PARSED_TEMPLATE);
+            expect(actions[2].data).toBe('data');
+            expect(actions[2].format).toBe('json');
+            expect(actions[3].type).toBe(SET_FILE_DROP_STATUS);
+            expect(actions[3].status).toBe('accepted');
+            expect(actions[4].type).toBe(SHOW_DIALOG);
+            expect(actions[4].dialogName).toBe('uploadTemplate');
+            expect(actions[4].show).toBe(true);
+            expect(actions[5].type).toBe(LOADING);
+        }, {
+            contextcreator: {
+                newContext: {
+                    templates: [{
+                        id: 1,
+                        format: 'json'
+                    }]
+                }
+            }
+        }, done);
+    });
+    it('editTemplateEpic without id', (done) => {
+        const startActions = [editTemplate()];
+        testEpic(editTemplateEpic, 4, startActions, actions => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[1].type).toBe(SET_EDITED_TEMPLATE);
+            expect(actions[1].id).toNotExist();
+            expect(actions[2].type).toBe(SHOW_DIALOG);
+            expect(actions[2].dialogName).toBe('uploadTemplate');
+            expect(actions[2].show).toBe(true);
+            expect(actions[3].type).toBe(LOADING);
+        }, {
+            contextcreator: {
+                newContext: {
+                    templates: []
+                }
+            }
         }, done);
     });
 });

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -248,7 +248,7 @@ export const editTemplateEpic = (action$, store) => action$
     .ofType(EDIT_TEMPLATE)
     .switchMap(({id}) => {
         const state = store.getState();
-        const template = get(newContextSelector(state), 'templates', []).map(t => t.id === id);
+        const template = find(get(newContextSelector(state), 'templates', []), t => t.id === id) || {};
 
         return (id ? Rx.Observable.defer(() => Api.getData(id)) : Rx.Observable.of(null))
             .switchMap(data => Rx.Observable.of(

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -22,11 +22,11 @@ import {SAVE_CONTEXT, SAVE_TEMPLATE, LOAD_CONTEXT, LOAD_TEMPLATE, DELETE_TEMPLAT
     startResourceLoad, loadFinished, loadTemplate, showDialog, setFileDropStatus, updateTemplate, isValidContextName,
     contextNameChecked, setCreationStep, contextLoadError, loading, mapViewerLoad, mapViewerLoaded, setEditedPlugin,
     setEditedCfg, setParsedCfg, validateEditedCfg, setValidationStatus, savePluginCfg, enableMandatoryPlugins,
-    enablePlugins, disablePlugins, setCfgError, changePluginsKey, changeTemplatesKey, setEditedTemplate, setTemplates, pluginUploaded,
-    pluginUploading, pluginUninstalled, pluginUninstalling, loadExtensions} from '../actions/contextcreator';
+    enablePlugins, disablePlugins, setCfgError, changePluginsKey, changeTemplatesKey, setEditedTemplate, setTemplates, setParsedTemplate,
+    pluginUploaded, pluginUploading, pluginUninstalled, pluginUninstalling, loadExtensions} from '../actions/contextcreator';
 import {newContextSelector, resourceSelector, creationStepSelector, mapConfigSelector, mapViewerLoadedSelector, contextNameCheckedSelector,
     editedPluginSelector, editedCfgSelector, validationStatusSelector, parsedCfgSelector, cfgErrorSelector,
-    pluginsSelector, initialEnabledPluginsSelector} from '../selectors/contextcreator';
+    pluginsSelector, initialEnabledPluginsSelector, editedTemplateSelector} from '../selectors/contextcreator';
 import {CONTEXTS_LIST_LOADED} from '../actions/contextmanager';
 import {wrapStartStop} from '../observables/epics';
 import {isLoggedIn} from '../selectors/security';
@@ -38,7 +38,7 @@ import {backgroundListSelector} from '../selectors/backgroundselector';
 import {textSearchConfigSelector} from '../selectors/searchconfig';
 import {mapOptionsToSaveSelector} from '../selectors/mapsave';
 import {loadMapConfig} from '../actions/config';
-import {createResource, createCategory, updateResource, deleteResource, getResource, getResources} from '../api/persistence';
+import {createResource, createCategory, updateResource, deleteResource, getResource} from '../api/persistence';
 import getPluginsConfig from '../observables/config/getPluginsConfig';
 import { upload, uninstall } from '../api/plugins';
 
@@ -48,6 +48,15 @@ const saveContextErrorStatusToMessage = (status) => {
         return 'contextCreator.saveErrorNotification.conflict';
     default:
         return 'contextCreator.saveErrorNotification.defaultMessage';
+    }
+};
+
+const loadTemplateErrorStatusToMessage = (status) => {
+    switch (status) {
+    case 403:
+        return 'contextCreator.loadTemplateErrorNotification.forbidden';
+    default:
+        return 'contextCreator.loadTemplateErrorNotification.defaultMessage';
     }
 };
 
@@ -190,10 +199,19 @@ export const saveTemplateEpic = (action$) => action$
 export const loadTemplateEpic = (action$) => action$
     .ofType(LOAD_TEMPLATE)
     .switchMap(({id}) => getResource(id, {includeAttributes: true, withData: false, withPermissions: false})
-        .switchMap(resource => Rx.Observable.of(updateTemplate({
-            ...resource,
-            thumbnail: get(resource, 'attributes.thumbnail')
-        })))
+        .switchMap(resource => {
+            const thumbnail = get(resource, 'attributes.thumbnail');
+            const format = get(resource, 'attributes.format');
+            return Rx.Observable.of(updateTemplate({
+                ...resource,
+                attributes: {
+                    ...(thumbnail ? {thumbnail: decodeURIComponent(thumbnail)} : {}),
+                    ...(format ? {format} : {})
+                },
+                ...(thumbnail ? {thumbnail: decodeURIComponent(thumbnail)} : {}),
+                ...(format ? {format} : {})
+            }));
+        })
         .let(wrapStartStop(
             loading(true, 'templateLoading'),
             loading(false, 'templateLoading')
@@ -226,9 +244,29 @@ export const deleteTemplateEpic = (action$, store) => action$
  * Trigger template metadata editor
  * @param {observable} action$ manages `EDIT_TEMPLATE`
  */
-export const editTemplateEpic = (action$) => action$
+export const editTemplateEpic = (action$, store) => action$
     .ofType(EDIT_TEMPLATE)
-    .switchMap(({id}) => Rx.Observable.of(setEditedTemplate(id), showDialog('uploadTemplate', true)));
+    .switchMap(({id}) => {
+        const state = store.getState();
+        const template = get(newContextSelector(state), 'templates', []).map(t => t.id === id);
+
+        return (id ? Rx.Observable.defer(() => Api.getData(id)) : Rx.Observable.of(null))
+            .switchMap(data => Rx.Observable.of(
+                setEditedTemplate(id),
+                ...(id ? [setParsedTemplate('Template Data', data, template.format), setFileDropStatus('accepted')] : []),
+                showDialog('uploadTemplate', true)
+            ))
+            .let(wrapStartStop(
+                loading(true, "templateDataLoading"),
+                loading(false, "templateDataLoading"),
+                ({status}) => Rx.Observable.of(error({
+                    title: "notification.error",
+                    message: loadTemplateErrorStatusToMessage(status),
+                    position: "tc",
+                    autoDismiss: 5
+                }))
+            ));
+    });
 
 /**
  * Reset stuff when dialog is shown
@@ -239,10 +277,11 @@ export const resetOnShowDialog = (action$, store) => action$
     .flatMap(({dialogName, show: showDialogBool}) => {
         const state = store.getState();
         const context = newContextSelector(state) || {};
+        const editedTemplateId = editedTemplateSelector(state);
         const templates = context.templates || [];
 
         return showDialogBool ?
-            Rx.Observable.of(...(dialogName === 'uploadTemplate' ? [setFileDropStatus()] : []),
+            Rx.Observable.of(...(dialogName === 'uploadTemplate' && !editedTemplateId ? [setFileDropStatus(), setParsedTemplate()] : []),
                 ...(dialogName === 'mapTemplatesConfig' ? [changeTemplatesKey(templates.map(template => template.id), 'selected', false)] : [])) :
             Rx.Observable.empty();
     });
@@ -258,15 +297,13 @@ export const contextCreatorLoadContext = (action$, store) => action$
     .switchMap(({id, pluginsConfig}) => Rx.Observable.of(startResourceLoad()).concat(
         Rx.Observable.forkJoin(
             Rx.Observable.defer(() => getPluginsConfig(pluginsConfig)),
-            getResources({
-                category: 'TEMPLATE',
-                options: {
-                    params: {
-                        start: 0,
-                        limit: 10000
-                    }
+            Rx.Observable.defer(() => Api.getResourcesByCategory('TEMPLATE', '*', {
+                params: {
+                    start: 0,
+                    limit: 10000,
+                    includeAttributes: true
                 }
-            }).map(response => response.totalCount === 1 ? [response.results] : values(response.results)),
+            })).map(response => response.totalCount === 1 ? [response.results] : values(response.results)),
             id === 'new' ? Rx.Observable.of(null) : getResource(id)
         ).switchMap(([config, templates, resource]) =>
             Rx.Observable.of(setResource(resource, config, templates))

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -200,9 +200,11 @@ export default (state = {}, action) => {
             set('newContext', {
                 templates: (action.allTemplates || []).map(template => ({
                     ...template,
-                    attributes: template.thumbnail ? {
-                        thumbnail: template.thumbnail
-                    } : undefined,
+                    ...(template.thumbnail ? {thumbnail: decodeURIComponent(template.thumbnail)} : {}),
+                    attributes: {
+                        ...(template.thumbnail ? {thumbnail: decodeURIComponent(template.thumbnail)} : {}),
+                        ...(template.format ? {format: template.format} : {})
+                    },
                     enabled: templates.reduce((result, cur) => result || cur.id === template.id, false),
                     selected: false
                 })),
@@ -244,7 +246,7 @@ export default (state = {}, action) => {
         })), state);
     }
     case SET_PARSED_TEMPLATE: {
-        return set('parsedTemplate', {fileName: action.fileName, data: action.data}, state);
+        return set('parsedTemplate', {fileName: action.fileName, data: action.data, format: action.format}, state);
     }
     case SET_FILE_DROP_STATUS: {
         return set('fileDropStatus', action.status, state);
@@ -299,9 +301,7 @@ export default (state = {}, action) => {
             set(`newContext.${action.key}`, action.value, state);
     }
     case SHOW_DIALOG: {
-        return set('parsedTemplate', undefined,
-            set(`showDialog.${action.dialogName}`, action.show,
-                set(`showDialog.${action.dialogName}Payload`, action.payload, state)));
+        return set(`showDialog.${action.dialogName}`, action.show, set(`showDialog.${action.dialogName}Payload`, action.payload, state));
     }
     case LOADING: {
         // anyway sets loading to true

--- a/web/client/themes/default/less/context-creator.less
+++ b/web/client/themes/default/less/context-creator.less
@@ -130,6 +130,18 @@
                 color: white;
             }
         }
+
+        .configure-map-templates-formaticon {
+            display: flex;
+            padding-left: 8px;
+            line-height: 30px;
+            margin-bottom: 10px;
+
+            .glyphicon {
+                font-size: 24px;
+                margin-right: 2px;
+            }
+        }
     }
 }
 

--- a/web/client/themes/default/less/context-creator.less
+++ b/web/client/themes/default/less/context-creator.less
@@ -136,9 +136,10 @@
             padding-left: 8px;
             line-height: 30px;
             margin-bottom: 10px;
+            font-size: 11px;
 
             .glyphicon {
-                font-size: 24px;
+                font-size: 22px;
                 margin-right: 2px;
             }
         }

--- a/web/client/themes/default/less/maptemplates.less
+++ b/web/client/themes/default/less/maptemplates.less
@@ -18,6 +18,18 @@
 
 }
 
+.map-templates-formaticon {
+    display: flex;
+    padding-left: 8px;
+    line-height: 30px;
+    margin-bottom: 10px;
+
+    .glyphicon {
+        font-size: 24px;
+        margin-right: 2px;
+    }
+}
+
 .map-templates-favourites {
     padding-bottom: 8px;
 

--- a/web/client/themes/default/less/maptemplates.less
+++ b/web/client/themes/default/less/maptemplates.less
@@ -23,9 +23,10 @@
     padding-left: 8px;
     line-height: 30px;
     margin-bottom: 10px;
+    font-size: 11px;
 
     .glyphicon {
-        font-size: 24px;
+        font-size: 22px;
         margin-right: 2px;
     }
 }

--- a/web/client/themes/default/less/sidegrid.less
+++ b/web/client/themes/default/less/sidegrid.less
@@ -88,8 +88,7 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
-        padding: 8px 16px 8px 8px;
-        width: 100px;
+        padding: 8px 16px 0 8px;
         & > div {
             display: flex;
             margin-bottom: 0;
@@ -100,7 +99,8 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 overflow: hidden;
-                width: 100%;
+                width: 100px;
+                flex-grow: 1;
             }
 
         }
@@ -115,6 +115,7 @@
             font-size: @font-size-small;
             margin-bottom: 10px;
             border-bottom: 1px solid @ms2-color-shade-lighter;
+            display: flex;
             span div {
                 text-overflow: ellipsis;
                 overflow: hidden;
@@ -129,9 +130,19 @@
         width: auto;
         display: flex;
         width: auto;
+        height: 100%;
         > * {
             margin: auto 10px 15px;
         }
+    }
+    .mapstore-side-card-left-container {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+    }
+    .mapstore-side-card-right-container {
+        display: flex;
+        flex-direction: column;
     }
 
     &.selected {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2451,6 +2451,10 @@
                 "defaultMessage": "Unbekannter Fehler",
                 "categoryError": "Das Erstellen der fehlenden Kategorie \"{categoryName}\" ist fehlgeschlagen"
             },
+            "loadTemplateErrorNotification": {
+                "forbidden": "Konnte nicht auf die Vorlagendaten zugreifen, dem Benutzer fehlen die erforderlichen Berechtigungen!",
+                "defaultMessage": "Ein unerwarteter Fehler ist aufgetreten"
+            },
             "contextNameErrorNotification": {
                 "title": "Falscher Kontextname",
                 "unknownError": "Ein unerwarteter Fehler ist aufgetreten"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2454,6 +2454,10 @@
                 "defaultMessage": "Unknown error",
                 "categoryError": "Creating missing category \"{categoryName}\" failed"
             },
+            "loadTemplateErrorNotification": {
+                "forbidden": "Couldn't access the template data, the user lacks necessary permissions!",
+                "defaultMessage": "Unexpected error occured"
+            },
             "contextNameErrorNotification": {
                 "title": "Bad context name",
                 "unknownError": "Unexpected error occurred"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2450,6 +2450,10 @@
                 "defaultMessage": "Error desconocido",
                 "categoryError": "Error al crear la categoría faltante \"{categoryName}\""
             },
+            "loadTemplateErrorNotification": {
+                "forbidden": "No se pudo acceder a los datos de la plantilla, ¡el usuario carece de los permisos necesarios!",
+                "defaultMessage": "Ocurrió un error inesperado"
+            },
             "contextNameErrorNotification": {
                 "title": "Nombre de contexto incorrecto",
                 "unknownError": "Ocurrió un error inesperado"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2450,6 +2450,10 @@
                 "defaultMessage": "Erreur inconnue",
                 "categoryError": "La création de la catégorie manquante \"{categoryName}\" a échoué"
             },
+            "loadTemplateErrorNotification": {
+                "forbidden": "Impossible d'accéder aux données du modèle, l'utilisateur n'a pas les autorisations nécessaires!",
+                "defaultMessage": "Une erreur inattendue s'est produite"
+            },
             "contextNameErrorNotification": {
                 "title": "Nom de contexte incorrect",
                 "unknownError": "Une erreur inattendue s'est produite"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2451,6 +2451,10 @@
                 "defaultMessage": "Errore sconosciuto",
                 "categoryError": "Creazione della categoria mancante \"{categoryName}\" non riuscita"
             },
+            "loadTemplateErrorNotification": {
+                "forbidden": "Impossibile accedere ai dati del modello, l'utente non dispone delle autorizzazioni necessarie!",
+                "defaultMessage": "Si è verificato un errore imprevisto"
+            },
             "contextNameErrorNotification": {
                 "title": "Nome di contesto errato",
                 "unknownError": "Si è verificato un errore imprevisto"

--- a/web/client/utils/FileFormatUtils.js
+++ b/web/client/utils/FileFormatUtils.js
@@ -5,6 +5,17 @@ const getFormatByName = (outF) => {
     return extension ? {outputFormat: outF, extension: extension.toLowerCase()} : undefined;
 
 };
+
+const formatToGlyph = {
+    json: 'ext-json',
+    wmc: 'ext-wmc'
+};
+
+const formatToText = {
+    json: 'JSON',
+    wmc: 'WMC'
+};
+
 const formats = [{
     outputFormat: "shape-zip",
     extension: "zip"
@@ -70,5 +81,7 @@ const formats = [{
 
 module.exports = {
     formats,
+    formatToGlyph,
+    formatToText,
     getByOutputFormat: (outF) => head(formats.filter(format => format.outputFormat === outF)) || getFormatByName(outF)
 };


### PR DESCRIPTION
## Description
* An ability to replace map template data in context creator added
* Map templates now can have displayed formats

Format display depends on whether the template has a format attribute. If the template has no format upon saving in context creator, it will try to determine one and save it, so to ensure that all
templates, that don't have a format information at the moment need to be just resaved by editing them in context creator and just clicking Save.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

## Issue
#5064 
#5065 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No