### PR TITLE
Add console log for errors triggered by UI

### DIFF
--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -66,7 +66,13 @@ class StandardRouter extends React.Component {
                     {this.props.themeLoaded ? (<Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
                         <ConnectedRouter history={history}>
                             <div className="error-container">
-                                <ErrorBoundary FallbackComponent={ ErrorBoundaryFallbackComponent}>
+                                <ErrorBoundary
+                                    onError={e => {
+                                        /* eslint-disable no-console */
+                                        console.log(e);
+                                        /* eslint-enable no-console */
+                                    }}
+                                    FallbackComponent={ ErrorBoundaryFallbackComponent}>
                                     {this.renderPages()}
                                 </ErrorBoundary>
                             </div>

--- a/web/client/components/app/StandardRouter.jsx
+++ b/web/client/components/app/StandardRouter.jsx
@@ -69,7 +69,7 @@ class StandardRouter extends React.Component {
                                 <ErrorBoundary
                                     onError={e => {
                                         /* eslint-disable no-console */
-                                        console.log(e);
+                                        console.error(e);
                                         /* eslint-enable no-console */
                                     }}
                                     FallbackComponent={ ErrorBoundaryFallbackComponent}>
@@ -92,7 +92,13 @@ class StandardRouter extends React.Component {
                 <Localized messages={this.props.locale.messages} locale={this.props.locale.current} loadingError={this.props.locale.localeError}>
                     <ConnectedRouter history={history}>
                         <div className="error-container">
-                            <ErrorBoundary FallbackComponent={ ErrorBoundaryFallbackComponent}>
+                            <ErrorBoundary
+                                onError={e => {
+                                    /* eslint-disable no-console */
+                                    console.error(e);
+                                    /* eslint-enable no-console */
+                                }}
+                                FallbackComponent={ ErrorBoundaryFallbackComponent}>
                                 {this.renderPages()}
                             </ErrorBoundary>
                         </div>


### PR DESCRIPTION
## Description
Added a console log for error triggered by error boundary (reporting old changes).

Correct me if I'm wrong @MV88 , now if I have an error I can not see the log and/or the link in the console anymore. (Didn't check at all). This PR help developer to directly have a link to the failing code.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: error logging improvement

