### PR TITLE
Update #3269. Replace withRef with forwardRef (react-redux >= 6) to s…

### DIFF
--- a/web/client/components/plugins/PluginsContainer.jsx
+++ b/web/client/components/plugins/PluginsContainer.jsx
@@ -139,7 +139,7 @@ class PluginsContainer extends React.Component {
             .filter(this.filterLoaded)
             // renders only root plugins (children of other plugins are skipped)
             .filter(this.filterRoot)
-            .map((Plugin) => <Plugin.impl key={Plugin.id} ref={Plugin.cfg.withGlobalRef ? PluginsUtils.setRefToWrdComponent(Plugin.name) : null}
+            .map((Plugin) => <Plugin.impl key={Plugin.id} ref={Plugin.cfg.withGlobalRef ? PluginsUtils.setRefToWrappedComponent(Plugin.name) : null}
                 {...this.props.params} {...Plugin.cfg} pluginCfg={Plugin.cfg} items={Plugin.items}/>);
     };
 

--- a/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
+++ b/web/client/components/plugins/__tests__/PluginsContainer-test.jsx
@@ -12,6 +12,8 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const PluginsContainer = require('../PluginsContainer');
+const {Provider} = require('react-redux');
+const {connect} = require('react-redux');
 
 class My extends React.Component {
     render() {
@@ -53,7 +55,15 @@ const plugins = {
         name: 'no-root-plugin',
         position: 1,
         priority: 1
-    }})
+    }}),
+    WithGlobalRefPlugin: connect(
+        null,
+        null,
+        null,
+        {
+            forwardRef: true
+        }
+    )(My)
 };
 
 const pluginsCfg = {
@@ -74,6 +84,17 @@ const pluginsCfg3 = {
 };
 const pluginsCfg4 = {
     desktop: ["Container", "NoRoot"]
+};
+
+const pluginsCfgRef = {
+    desktop: [
+        {
+            'name': 'WithGlobalRef',
+            'cfg': {
+                'withGlobalRef': true
+            }
+        }
+    ]
 };
 
 describe('PluginsContainer', () => {
@@ -134,5 +155,17 @@ describe('PluginsContainer', () => {
         rendered = cmpDom.getElementsByTagName("div");
         expect(document.getElementById('no-impl-item-no-root-plugin')).toNotExist();
         expect(document.getElementById('no-root')).toExist();
+    });
+    it('checks plugin with forwardRef = true connect option', () => {
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({})
+        };
+        const app = ReactDOM.render(<Provider store={store}><PluginsContainer mode="desktop" defaultMode="desktop" params={{}}
+            plugins={plugins} pluginsConfig={pluginsCfgRef}/></Provider>, document.getElementById("container"));
+
+        expect(app).toExist();
+        expect(window.WithGlobalRefPlugin.myFunc).toExist();
     });
 });

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -430,7 +430,7 @@ export const getConfiguredPlugin = (pluginDef, loadedPlugins = {}, loaderCompone
 export const setRefToWrappedComponent = (name) => {
     return (connectedComponent) => {
         if (connectedComponent) {
-            window[`${name}Plugin`] = connectedComponent.getWrappedInstance();
+            window[`${name}Plugin`] = connectedComponent;
         }
     };
 };


### PR DESCRIPTION
…tore references to an object on a component instance

## Description
This pull request fixes the breaking changes introduced by the new version of react-redux https://github.com/reduxjs/react-redux/releases/tag/v6.0.0

The withRef option to connect has been replaced with forwardRef. If {forwardRef : true} has been passed to connect, adding a ref to the connected wrapper component will actually return the instance of the wrapped component.

View this thread for more information:
https://groups.google.com/forum/?hl=it#!topic/mapstore-developers/DcAjwl6bJXc

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
The functionality was removed due to the update of the react-redux library to version 6

**What is the new behavior?**
The functionality has been reintroduced using the new API

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
