### PR TITLE
Add support for disablePermission

### DIFF
--- a/web/client/components/resources/modals/Save.jsx
+++ b/web/client/components/resources/modals/Save.jsx
@@ -76,6 +76,7 @@ class SaveModal extends React.Component {
         onFileDrop: PropTypes.func,
         onFileDropClear: PropTypes.func,
         metadataChanged: PropTypes.func,
+        disablePermission: PropTypes.bool,
         availablePermissions: PropTypes.arrayOf(PropTypes.string),
         availableGroups: PropTypes.arrayOf(PropTypes.object),
         user: PropTypes.object,
@@ -105,6 +106,7 @@ class SaveModal extends React.Component {
         onUpdate: ()=> {},
         onUpdateLinkedResource: () => {},
         onSave: ()=> {},
+        disablePermission: false,
         availablePermissions: ["canRead", "canWrite"],
         availableGroups: [],
         canSave: true,
@@ -123,7 +125,7 @@ class SaveModal extends React.Component {
      * @return the modal for unsaved changes
     */
     render() {
-        const canEditPermission = canEditResourcePermission(this.props.user, this.props.resource);
+        const canEditPermission = !this.props.disablePermission && canEditResourcePermission(this.props.user, this.props.resource);
 
         return (<Portal key="saveDialog">
             {<ResizableModal

--- a/web/client/components/resources/modals/enhancers/__tests__/handlePermission-test.jsx
+++ b/web/client/components/resources/modals/enhancers/__tests__/handlePermission-test.jsx
@@ -61,11 +61,20 @@ describe('handlePermission enhancer', () => {
         };
 
         const Sink = handlePermission(DUMMY_API)(createSink(props => {
+            expect(props.onUpdateRules).toBeTruthy(); // check that the handler is present
             if (props.rules && props.rules.length > 0) {
                 expect(props.rules.length).toBe(1);
                 done();
             }
         }));
         ReactDOM.render(<Sink resource={{id: 1}} />, document.getElementById("container"));
+    });
+    it('test disablePermission', (done) => {
+            const Sink = handlePermission()(createSink( props => {
+                expect(props).toExist();
+                expect(props.onUpdateRules).toBeFalsy(); // check that the enhancer is not applied at all (verifying one of the properties added by it)
+                done();
+            }));
+            ReactDOM.render(<Sink disablePermission />, document.getElementById("container"));
     });
 });

--- a/web/client/components/resources/modals/enhancers/__tests__/handlePermission-test.jsx
+++ b/web/client/components/resources/modals/enhancers/__tests__/handlePermission-test.jsx
@@ -70,11 +70,11 @@ describe('handlePermission enhancer', () => {
         ReactDOM.render(<Sink resource={{id: 1}} />, document.getElementById("container"));
     });
     it('test disablePermission', (done) => {
-            const Sink = handlePermission()(createSink( props => {
-                expect(props).toExist();
-                expect(props.onUpdateRules).toBeFalsy(); // check that the enhancer is not applied at all (verifying one of the properties added by it)
-                done();
-            }));
-            ReactDOM.render(<Sink disablePermission />, document.getElementById("container"));
+        const Sink = handlePermission()(createSink( props => {
+            expect(props).toExist();
+            expect(props.onUpdateRules).toBeFalsy(); // check that the enhancer is not applied at all (verifying one of the properties added by it)
+            done();
+        }));
+        ReactDOM.render(<Sink disablePermission />, document.getElementById("container"));
     });
 });

--- a/web/client/components/resources/modals/enhancers/handlePermission.jsx
+++ b/web/client/components/resources/modals/enhancers/handlePermission.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const Rx = require('rxjs');
-const { mapPropsStream, compose, withStateHandlers } = require('recompose');
+const { mapPropsStream, compose, branch, withStateHandlers } = require('recompose');
 const GeoStoreDAO = require('../../../../api/GeoStoreDAO');
 
 /**
@@ -68,9 +68,12 @@ const manageLocalPermissionChanges = withStateHandlers(
     }
 );
 
-module.exports = ( API = GeoStoreDAO ) => compose(
-    retrieveGroups(API),
-    retrievePermission(API),
-    manageLocalPermissionChanges
+module.exports = ( API = GeoStoreDAO ) => branch(
+    ({ disablePermission }) => !disablePermission,
+    compose(
+        retrieveGroups(API),
+        retrievePermission(API),
+        manageLocalPermissionChanges
+    )
 );
 

--- a/web/client/plugins/Save.jsx
+++ b/web/client/plugins/Save.jsx
@@ -20,6 +20,12 @@ import SaveBaseDialog from './maps/MapSave';
 
 const showMapSaveSelector = state => state.controls && state.controls.mapSave && state.controls.mapSave.enabled;
 
+/**
+ * Plugin for Save Map.Allows to re-save an existing map (using the persistence API). Note: creation of new Map is implemented by plugins.SaveAs
+ * @prop {boolean} [cfg.disablePermission=false] disable the permission selector in the tool. Can be used in context when permissions are not needed (resources are private only/using plugin with another API)
+ * @name Save
+ * @memberof plugins
+ */
 export default createPlugin('Save', {
     component: compose(
         connect(createSelector(

--- a/web/client/plugins/SaveAs.jsx
+++ b/web/client/plugins/SaveAs.jsx
@@ -21,6 +21,12 @@ import SaveBaseDialog from './maps/MapSave';
 
 const showMapSaveAsSelector = state => state.controls && state.controls.mapSaveAs && state.controls.mapSaveAs.enabled;
 
+/**
+ * Plugin for Create/Clone a Map. Saves the map as a new Resource (using the persistence API).
+ * @prop {boolean} [cfg.disablePermission=false] disable the permission selector in the tool. Can be used in context when permissions are not needed (resources are private only/using plugin with another API)
+ * @name SaveAs
+ * @memberof plugins
+ */
 export default createPlugin('SaveAs', {
     component: compose(
         connect(createSelector(

--- a/web/client/plugins/__tests__/Save-test.jsx
+++ b/web/client/plugins/__tests__/Save-test.jsx
@@ -52,7 +52,21 @@ describe('MapSave Plugins (MapSave, MapSaveAs)', () => {
             const storeState = stateMocker(DUMMY_ACTION, toggleControl('mapSave', 'enabled'));
             const { Plugin } = getPluginForTest(MapSave, storeState);
             ReactDOM.render(<Plugin />, document.getElementById("container"));
-            expect(document.getElementsByClassName('modal-fixed').length).toBe(1);
+            expect(document.querySelector('.modal-fixed')).toBeTruthy();
+            // permission table present by default
+            expect(document.querySelector('.permissions-table')).toBeTruthy();
+        });
+        describe('integrations', () => {
+            it('disablePermission options hides the permission (compatibility with system that do not use GeoStore)', () => {
+                const storeState = stateMocker(DUMMY_ACTION, toggleControl('mapSave', 'enabled'));
+                const { Plugin } = getPluginForTest(MapSave, storeState);
+                ReactDOM.render(<Plugin disablePermission />, document.getElementById("container"));
+                expect(document.querySelector('.modal-fixed')).toBeTruthy();
+                expect(document.querySelector('.permissions-table')).toBeFalsy();
+                ReactDOM.render(<Plugin />, document.getElementById("container"));
+                expect(document.querySelector('.modal-fixed')).toBeTruthy();
+                expect(document.querySelector('.permissions-table')).toBeTruthy();
+            });
         });
     });
 

--- a/web/client/plugins/__tests__/SaveAs-test.jsx
+++ b/web/client/plugins/__tests__/SaveAs-test.jsx
@@ -58,5 +58,17 @@ describe('MapSave Plugins (MapSave, MapSaveAs)', () => {
             ReactDOM.render(<Plugin />, document.getElementById("container"));
             expect(document.getElementsByClassName('modal-fixed').length).toBe(1);
         });
+        describe('integrations', () => {
+            it('disablePermission options hides the permission (compatibility with system that do not use GeoStore)', () => {
+                const storeState = stateMocker(DUMMY_ACTION, toggleControl('mapSaveAs', 'enabled'));
+                const { Plugin } = getPluginForTest(MapSaveAs, storeState);
+                ReactDOM.render(<Plugin disablePermission />, document.getElementById("container"));
+                expect(document.querySelector('.modal-fixed')).toBeTruthy();
+                expect(document.querySelector('.permissions-table')).toBeFalsy();
+                ReactDOM.render(<Plugin />, document.getElementById("container"));
+                expect(document.querySelector('.modal-fixed')).toBeTruthy();
+                expect(document.querySelector('.permissions-table')).toBeTruthy();
+            });
+        });
     });
 });


### PR DESCRIPTION
## Description
This issue allows to remove by configuration the permissions from the "Edit properties" window.
See https://github.com/geosolutions-it/geonode-mapstore-client-issues/issues/184

This possibility is needed for GeoNode integration.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
MapStore new save dialog's permissions editor can not be disabled

**What is the new behavior?**
MapStore new save dialog's permissions editor can be disabled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
