### PR TITLE
5175: print tool localization added

### DIFF
--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -36,10 +36,7 @@ import VectorTileLayer from 'ol/layer/VectorTile';
 
 import { isVectorFormat } from '../../../../utils/VectorTileUtils';
 import { OL_VECTOR_FORMATS, applyStyle } from '../../../../utils/openlayers/VectorTileUtils';
-
-function getWMSEnvParam(env) {
-    return env.map(({ name, value }) => `${name}:${value}`).join(';');
-}
+import { generateEnvString } from '../../../../utils/LayerLocalizationUtils';
 
 /**
     @param {object} options of the layer
@@ -58,7 +55,7 @@ function wmsToOpenlayersOptions(options) {
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         TILED: options.singleTile ? false : (!isNil(options.tiled) ? options.tiled : true),
         VERSION: options.version || "1.3.0",
-        ENV: options.env && options.env.length ? getWMSEnvParam(options.env) : ''
+        ENV: options.env && options.env.length ? generateEnvString(options.env) : ''
     }, assign(
         {},
         (options._v_ ? {_v_: options._v_} : {}),

--- a/web/client/components/print/MapPreview.jsx
+++ b/web/client/components/print/MapPreview.jsx
@@ -37,7 +37,8 @@ class MapPreview extends React.Component {
         printRatio: PropTypes.number,
         layout: PropTypes.string,
         layoutSize: PropTypes.object,
-        useFixedScales: PropTypes.bool
+        useFixedScales: PropTypes.bool,
+        env: PropTypes.object
     };
 
     static defaultProps = {
@@ -136,7 +137,9 @@ class MapPreview extends React.Component {
             >
                 {this.props.layers.map((layer, index) =>
                     (<Layer key={layer.id || layer.name} position={index} type={layer.type}
-                        options={assign({}, this.adjustResolution(layer), {srs: projection})}>
+                        options={assign({}, this.adjustResolution(layer), {srs: projection})}
+                        env={this.props.env}
+                    >
                         {this.renderLayerContent(layer, projection)}
                     </Layer>)
 

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -204,7 +204,7 @@ class MapPlugin extends React.Component {
         elevationEnabled: PropTypes.bool,
         isLocalizedLayerStylesEnabled: PropTypes.bool,
         localizedLayerStylesName: PropTypes.string,
-        currentLocale: PropTypes.string
+        currentLocaleLanguage: PropTypes.string
     };
 
     static defaultProps = {
@@ -312,7 +312,7 @@ class MapPlugin extends React.Component {
         if (this.props.isLocalizedLayerStylesEnabled) {
             env.push({
                 name: this.props.localizedLayerStylesName,
-                value: this.props.currentLocale
+                value: this.props.currentLocaleLanguage
             });
         }
 
@@ -374,7 +374,8 @@ class MapPlugin extends React.Component {
                     {...this.props.map}
                     mapOptions={assign({}, mapOptions, this.getMapOptions())}
                     zoomControl={this.props.zoomControl}
-                    onResolutionsChange={this.props.onResolutionsChange}>
+                    onResolutionsChange={this.props.onResolutionsChange}
+                >
                     {this.renderLayers()}
                     {this.renderSupportTools()}
                 </plugins.Map>
@@ -411,13 +412,12 @@ class MapPlugin extends React.Component {
     };
 }
 
-const {head} = require('lodash');
 const {mapSelector, projectionDefsSelector} = require('../selectors/map');
 const { mapTypeSelector, isOpenlayers } = require('../selectors/maptype');
 const {layerSelectorWithMarkers} = require('../selectors/layers');
 const {highlighedFeatures} = require('../selectors/highlight');
 const {securityTokenSelector} = require('../selectors/security');
-const {currentLocaleSelector} = require('../selectors/locale');
+const {currentLocaleLanguageSelector} = require('../selectors/locale');
 const {
     isLocalizedLayerStylesEnabledSelector,
     localizedLayerStylesNameSelector
@@ -436,7 +436,7 @@ const selector = createSelector(
         isOpenlayers,
         isLocalizedLayerStylesEnabledSelector,
         localizedLayerStylesNameSelector,
-        (state) => head(currentLocaleSelector(state).split('-'))
+        currentLocaleLanguageSelector
     ], (
         projectionDefs,
         map,
@@ -449,7 +449,7 @@ const selector = createSelector(
         shouldLoadFont,
         isLocalizedLayerStylesEnabled,
         localizedLayerStylesName,
-        currentLocale
+        currentLocaleLanguage
     ) => ({
         projectionDefs,
         map,
@@ -462,7 +462,7 @@ const selector = createSelector(
         shouldLoadFont,
         isLocalizedLayerStylesEnabled,
         localizedLayerStylesName,
-        currentLocale
+        currentLocaleLanguage
     })
 );
 module.exports = {

--- a/web/client/utils/LayerLocalizationUtils.js
+++ b/web/client/utils/LayerLocalizationUtils.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Utility functions for layers localization
+ * @memberof utils
+ * @static
+ * @name LayerLocalizationUtils
+ */
+
+/**
+ * The generateEnvString function converts ENV array into the string.
+ * @param  {array} env the array that represents the sequence of name/values pairs defined by localConfig
+ * @return {string} the string presentation of env param
+ * @memberof utils.LayerLocalizationUtils
+ */
+const generateEnvString = (env) => env.map(({ name, value }) => `${name}:${value}`).join(';');
+
+export {
+    generateEnvString
+};

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -12,6 +12,7 @@ const MapUtils = require('./MapUtils');
 const {optionsToVendorParams} = require('./VendorParamsUtils');
 const AnnotationsUtils = require("./AnnotationsUtils");
 const {colorToHexStr} = require("./ColorUtils");
+const {generateEnvString} = require('./LayerLocalizationUtils');
 
 const {isArray} = require('lodash');
 
@@ -187,7 +188,7 @@ const PrintUtils = {
     },
     specCreators: {
         wms: {
-            map: (layer) => ({
+            map: (layer, spec) => ({
                 "baseURL": PrintUtils.normalizeUrl(layer.url) + '?',
                 "opacity": layer.opacity || 1.0,
                 "singleTile": false,
@@ -203,7 +204,8 @@ const PrintUtils = {
                     "TRANSPARENT": true,
                     "TILED": true,
                     "EXCEPTIONS": "application/vnd.ogc.se_inimage",
-                    "scaleMethod": "accurate"
+                    "scaleMethod": "accurate",
+                    "ENV": spec.env && spec.env.length ? generateEnvString(spec.env) : ''
                 }, layer.baseParams || {}, layer.params || {}, {
                     ...optionsToVendorParams({
                         layerFilter: layer.layerFilter,
@@ -225,6 +227,7 @@ const PrintUtils = {
                                     SERVICE: "WMS",
                                     REQUEST: "GetLegendGraphic",
                                     LAYER: layer.name,
+                                    LANGUAGE: spec.language || '',
                                     STYLE: layer.style || '',
                                     SCALE: spec.scale,
                                     height: spec.iconSize,

--- a/web/client/utils/__tests__/LayerLocalizationUtils-test.js
+++ b/web/client/utils/__tests__/LayerLocalizationUtils-test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const expect = require('expect');
+
+const {generateEnvString} = require('../LayerLocalizationUtils');
+
+const envMock = [
+    {
+        name: 'name_one',
+        value: 'value_one'
+    },
+    {
+        name: 'name_two',
+        value: 'value_two'
+    }
+];
+
+describe('LayerLocalizationUtils', () => {
+    it('generateEnvString returns expected string value', () => {
+        expect(generateEnvString(envMock)).toBe('name_one:value_one;name_two:value_two');
+    });
+});


### PR DESCRIPTION
## Description
Localization added to the printing tool. JSON post request body now contains ENV and LANGUAGE params,

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5175 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When `mapstore.geo-solutions.it/mapstore/pdf/create.json` request occurs it should be populated with LANGUAGE and ENV params for legends and layers if that feature was enabled.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
