### PR TITLE
5068 Triggering hover over the map of the Identify tool does not have…

### DIFF
--- a/web/client/components/map/leaflet/PopupSupport.jsx
+++ b/web/client/components/map/leaflet/PopupSupport.jsx
@@ -114,7 +114,7 @@ export default class PopupSupport extends React.Component {
             container.setAttribute("style", `max-width: ${maxWidth}px; max-height: ${maxHeight}px`);
             Utils.append(container, content);
             // Always wrap the content in a div
-            const popup = L.popup({id, autoClose: false, closeOnClick: false, autoPan, maxWidth, maxHeight, className: "ms-leaflet-popup", offset}).setContent(container);
+            const popup = L.popup({id, autoClose: false, closeOnClick: false, autoPan, autoPanPadding: L.point(70, 70), maxWidth, maxHeight, className: "ms-leaflet-popup", offset}).setContent(container);
             popup.once('remove', this.popupClose);
             component && addMutationObserver(popup, container);
 

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -38,6 +38,7 @@ import { modeSelector, getAttributeFilters } from '../selectors/featuregrid';
 import { mapSelector, projectionDefsSelector, projectionSelector, isMouseMoveIdentifyActiveSelector } from '../selectors/map';
 import { boundingMapRectSelector } from '../selectors/maplayout';
 import { floatingIdentifyDelaySelector } from '../selectors/localConfig';
+import { createControlEnabledSelector, measureSelector } from '../selectors/controls';
 import { centerToVisibleArea, isInsideVisibleArea, isPointInsideExtent, reprojectBbox, parseURN} from '../utils/CoordinatesUtils';
 
 
@@ -188,6 +189,9 @@ export default {
     onMapClick: (action$, store) =>
         action$.ofType(CLICK_ON_MAP).filter(() => {
             const {disableAlwaysOn = false} = (store.getState()).mapInfo;
+            if (isMouseMoveIdentifyActiveSelector(store.getState())) {
+                return false;
+            }
             return disableAlwaysOn || !stopFeatureInfo(store.getState() || {});
         })
             .switchMap(({point, layer}) => Rx.Observable.of(featureInfoClick(point, layer))
@@ -292,11 +296,15 @@ export default {
         action$.ofType(MOUSE_MOVE)
             .debounceTime(floatingIdentifyDelaySelector(getState()))
             .switchMap(({position, layer}) => {
-                if (!isMouseMoveIdentifyActiveSelector(getState()) || getState().mousePosition.mouseOut) {
+                const isAnnotationsEnabled = createControlEnabledSelector('annotations')(getState());
+                const isMeasureEnabled = measureSelector(getState());
+                const isMouseOut = getState().mousePosition.mouseOut;
+                const isMouseMoveIdentifyDisabled = !isMouseMoveIdentifyActiveSelector(getState());
+                if (isMouseMoveIdentifyDisabled || isAnnotationsEnabled || isMeasureEnabled || isMouseOut) {
                     return Rx.Observable.empty();
                 }
                 return Rx.Observable.of(featureInfoClick(position, layer))
-                    .merge(Rx.Observable.of(addPopup(uuid(), { component: IDENTIFY_POPUP, maxWidth: 600, position: {  coordinates: position ? position.rawPos : []}})));
+                    .merge(Rx.Observable.of(addPopup(uuid(), { component: IDENTIFY_POPUP, maxWidth: 600, position: {  coordinates: position ? position.rawPos : []}, autoPanMargin: 70, autoPan: true})));
             }),
     /**
      * Triggers remove popup on UNREGISTER_EVENT_LISTENER
@@ -313,10 +321,10 @@ export default {
                 return observable;
             }),
     /**
-     * Triggers remove popup on LOCATION_CHANGE
+     * Triggers remove popup on LOCATION_CHANGE or PURGE_MAPINFO_RESULTS
      */
     removePopupOnLocationChangeEpic: (action$, {getState}) =>
-        action$.ofType(LOCATION_CHANGE)
+        action$.ofType(LOCATION_CHANGE, PURGE_MAPINFO_RESULTS)
             .switchMap(() => {
                 let observable = Rx.Observable.empty();
                 const popups = getState().mapPopups.popups;


### PR DESCRIPTION
… to be active if the user is using the measurement/annotation tool. If the trigger hover over the map is activated, the identify marker is visible by clickung on the map. If the mouse point is too close in the menu bar, sidebar, toc, burger menu) the pop-up that opens is not completely visible.

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5068 

**What is the new behavior?**
Fixed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
