### PR TITLE
Allow switch to edit directly from identify tool fix

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -16,7 +16,7 @@ const GeocodeViewer = require('./GeocodeViewer');
 const ResizableModal = require('../../misc/ResizableModal');
 const Portal = require('../../misc/Portal');
 const Coordinate = require('./coordinates/Coordinate');
-const {getFormatForResponse, responseValidForEdit} = require('../../../utils/IdentifyUtils');
+const {responseValidForEdit} = require('../../../utils/IdentifyUtils');
 /**
  * Component for rendering Identify Container inside a Dockable container
  * @memberof components.data.identify
@@ -87,8 +87,7 @@ module.exports = props => {
         lngCorrected,
         validResponses,
         latlng,
-        showEdit: showEdit && isEditingAllowed && !!responses[index] && responseValidForEdit(responses[index]) &&
-            getFormatForResponse(responses[index], props) !== 'application/json',
+        showEdit: showEdit && isEditingAllowed && !!responses[index] && responseValidForEdit(responses[index]),
         onEdit: onEdit.bind(null, layer && {
             id: layer.id,
             name: layer.name,

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -116,4 +116,40 @@ describe("test IdentifyContainer", () => {
         expect(sidePanel.length).toBe(1);
         expect(sidePanel[0].children[0].style.zIndex).toBe('7777');
     });
+
+    it('test edit button with PROPERTIES response', () => {
+        const funcs = {
+            getToolButtons: () => {}
+        };
+
+        const getToolButtonsSpy = expect.spyOn(funcs, 'getToolButtons');
+        ReactDOM.render(<IdentifyContainer
+            enabled
+            showEdit
+            isEditingAllowed
+            getToolButtons={funcs.getToolButtons}
+            index={0}
+            requests={{}}
+            responses={[{format: 'PROPERTIES', layer: {search: {url: 'search_url'}}}]}/>, document.getElementById("container"));
+        expect(getToolButtonsSpy).toHaveBeenCalled();
+        expect(getToolButtonsSpy.calls[0].arguments[0].showEdit).toBe(true);
+    });
+
+    it('test edit button with TEMPLATE response', () => {
+        const funcs = {
+            getToolButtons: () => {}
+        };
+
+        const getToolButtonsSpy = expect.spyOn(funcs, 'getToolButtons');
+        ReactDOM.render(<IdentifyContainer
+            enabled
+            showEdit
+            isEditingAllowed
+            getToolButtons={funcs.getToolButtons}
+            index={0}
+            requests={{}}
+            responses={[{format: 'TEMPLATE', layer: {search: {url: 'search_url'}}}]}/>, document.getElementById("container"));
+        expect(getToolButtonsSpy).toHaveBeenCalled();
+        expect(getToolButtonsSpy.calls[0].arguments[0].showEdit).toBe(true);
+    });
 });


### PR DESCRIPTION
## Description
Removed a condition to not show edit button if format is application/json.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#5185 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No