### PR TITLE
5184: indentify tool localized

### DIFF
--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -55,7 +55,7 @@ function wmsToOpenlayersOptions(options) {
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         TILED: options.singleTile ? false : (!isNil(options.tiled) ? options.tiled : true),
         VERSION: options.version || "1.3.0",
-        ENV: options.env && options.env.length ? generateEnvString(options.env) : ''
+        ENV: generateEnvString(options.env)
     }, assign(
         {},
         (options._v_ ? {_v_: options._v_} : {}),

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -43,6 +43,7 @@ import { boundingMapRectSelector } from '../selectors/maplayout';
 import { centerToVisibleArea, isInsideVisibleArea, isPointInsideExtent, reprojectBbox, parseURN, calculateCircleCoordinates } from '../utils/CoordinatesUtils';
 import { floatingIdentifyDelaySelector } from '../selectors/localConfig';
 import { createControlEnabledSelector, measureSelector } from '../selectors/controls';
+import { localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
 
 import {getBbox, getCurrentResolution, parseLayoutValue} from '../utils/MapUtils';
 import MapInfoUtils from '../utils/MapInfoUtils';
@@ -122,7 +123,8 @@ export default {
                     return filterNameList.length ? (filterNameList.filter(name => name.indexOf(l.name) !== -1).length > 0) : true;
                 })))
                     .mergeMap(layer => {
-                        let { url, request, metadata } = MapInfoUtils.buildIdentifyRequest(layer, identifyOptionsSelector(getState()));
+                        let env = localizedLayerStylesEnvSelector(getState());
+                        let { url, request, metadata } = MapInfoUtils.buildIdentifyRequest(layer, {...identifyOptionsSelector(getState()), env});
                         // request override
                         if (itemIdSelector(getState()) && overrideParamsSelector(getState())) {
                             request = {...request, ...overrideParamsSelector(getState())[layer.name]};

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -32,7 +32,7 @@ const {head} = require('lodash');
 
 const {scalesSelector} = require('../selectors/map');
 const {currentLocaleSelector, currentLocaleLanguageSelector} = require('../selectors/locale');
-const {isLocalizedLayerStylesEnabledSelector, localizedLayerStylesNameSelector} = require('../selectors/localizedLayerStyles');
+const {isLocalizedLayerStylesEnabledSelector, localizedLayerStylesEnvSelector} = require('../selectors/localizedLayerStyles');
 const {mapTypeSelector} = require('../selectors/maptype');
 
 const Message = require('../components/I18N/Message');
@@ -150,7 +150,7 @@ module.exports = {
                         currentLocaleLanguage: PropTypes.string,
                         overrideOptions: PropTypes.object,
                         isLocalizedLayerStylesEnabled: PropTypes.bool,
-                        localizedLayerStylesName: PropTypes.string
+                        localizedLayerStylesEnv: PropTypes.object
                     };
 
                     static contextTypes = {
@@ -277,7 +277,6 @@ module.exports = {
                         const layout = this.getLayout();
                         const layoutName = this.props.getLayoutName(this.props.printSpec);
                         const mapSize = this.getMapSize(layout);
-                        const env = this.generateEnv();
                         return (
                             <Grid fluid role="body">
                                 {this.renderError()}
@@ -311,7 +310,7 @@ module.exports = {
                                             layoutSize={layout && layout.map || {width: 10, height: 10}}
                                             resolutions={MapUtils.getResolutions()}
                                             useFixedScales={this.props.useFixedScales}
-                                            env={env}
+                                            env={this.props.localizedLayerStylesEnv}
                                             {...this.props.mapPreviewOptions}
                                         />
                                         {this.isBackgroundIgnored() ? <DefaultBackgroundOption label={LocaleUtils.getMessageById(this.context.messages, "print.defaultBackground")}/> : null}
@@ -353,17 +352,6 @@ module.exports = {
                             return this.renderBody();
                         }
                         return null;
-                    }
-
-                    generateEnv = () => {
-                        const env = [];
-                        if (this.props.isLocalizedLayerStylesEnabled) {
-                            env.push({
-                                name: this.props.localizedLayerStylesName,
-                                value: this.props.currentLocaleLanguage
-                            });
-                        }
-                        return env;
                     }
 
                     isAllowed = (layer) => {
@@ -411,7 +399,7 @@ module.exports = {
                     print = () => {
                         let printSpec = this.props.printSpec;
                         if (this.props.isLocalizedLayerStylesEnabled) {
-                            printSpec = {...printSpec, env: this.generateEnv(), language: this.props.currentLocaleLanguage};
+                            printSpec = {...printSpec, env: this.props.localizedLayerStylesEnv, language: this.props.currentLocaleLanguage};
                         }
                         const spec = this.props.getPrintSpecification(printSpec);
                         this.props.setPage(0);
@@ -434,8 +422,8 @@ module.exports = {
                     currentLocaleLanguageSelector,
                     mapTypeSelector,
                     isLocalizedLayerStylesEnabledSelector,
-                    localizedLayerStylesNameSelector
-                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, scales, usePreview, currentLocale, currentLocaleLanguage, mapType, isLocalizedLayerStylesEnabled, localizedLayerStylesName) => ({
+                    localizedLayerStylesEnvSelector
+                ], (open, capabilities, printSpec, pdfUrl, error, map, layers, scales, usePreview, currentLocale, currentLocaleLanguage, mapType, isLocalizedLayerStylesEnabled, localizedLayerStylesEnv) => ({
                     open,
                     capabilities,
                     printSpec,
@@ -449,7 +437,7 @@ module.exports = {
                     currentLocaleLanguage,
                     mapType,
                     isLocalizedLayerStylesEnabled,
-                    localizedLayerStylesName
+                    localizedLayerStylesEnv
                 }));
 
                 const PrintPlugin = connect(selector, {

--- a/web/client/selectors/__tests__/localizedLayerStyles-test.js
+++ b/web/client/selectors/__tests__/localizedLayerStyles-test.js
@@ -7,7 +7,8 @@
 */
 
 const expect = require('expect');
-const {localizedLayerStylesNameSelector} = require('../localizedLayerStyles');
+const {localizedLayerStylesNameSelector, localizedLayerStylesEnvSelector} = require('../localizedLayerStyles');
+const {currentLocaleLanguageSelector} = require('../locale');
 
 describe('Test localizedLayerStyles', () => {
     it('test localizedLayerStylesNameSelector default', () => {
@@ -21,5 +22,20 @@ describe('Test localizedLayerStyles', () => {
         const localizedLayerStyles = localizedLayerStylesNameSelector({localConfig: {localizedLayerStyles: {name}}});
 
         expect(localizedLayerStyles).toBe(name);
+    });
+
+    it('test localizedLayerStylesEnvSelector default', () => {
+        const env = localizedLayerStylesEnvSelector({});
+
+        expect(env).toEqual([]);
+    });
+
+    it('test localizedLayerStylesEnvSelector', () => {
+        const name = 'example';
+        const store = {localConfig: {localizedLayerStyles: {name}}};
+        const env = localizedLayerStylesEnvSelector(store);
+        const language = currentLocaleLanguageSelector(store);
+
+        expect(env).toEqual([ {name, value: language} ]);
     });
 });

--- a/web/client/selectors/localizedLayerStyles.js
+++ b/web/client/selectors/localizedLayerStyles.js
@@ -7,6 +7,9 @@
 */
 
 const {has, get} = require('lodash');
+const {createSelector} = require('reselect');
+
+const {currentLocaleLanguageSelector} = require('./locale');
 
 /**
  * selects localizedLayerStyles state
@@ -31,7 +34,30 @@ const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig
  */
 const localizedLayerStylesNameSelector = (state) => get(state, 'localConfig.localizedLayerStyles.name', 'mapstore_language');
 
+/**
+ * generates localizedLayerStyles env object
+ * @memberof selectors.localizedLayerStyles
+ * @param  {object} state the state
+ * @return {object} object that represents ENV param
+ */
+const localizedLayerStylesEnvSelector = createSelector(
+    isLocalizedLayerStylesEnabledSelector,
+    localizedLayerStylesNameSelector,
+    currentLocaleLanguageSelector,
+    (isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage) => {
+        const env = [];
+        if (isLocalizedLayerStylesEnabled) {
+            env.push({
+                name: localizedLayerStylesName,
+                value: currentLocaleLanguage
+            });
+        }
+        return env;
+    }
+);
+
 module.exports = {
     isLocalizedLayerStylesEnabledSelector,
-    localizedLayerStylesNameSelector
+    localizedLayerStylesNameSelector,
+    localizedLayerStylesEnvSelector
 };

--- a/web/client/utils/LayerLocalizationUtils.js
+++ b/web/client/utils/LayerLocalizationUtils.js
@@ -19,7 +19,12 @@
  * @return {string} the string presentation of env param
  * @memberof utils.LayerLocalizationUtils
  */
-const generateEnvString = (env) => env.map(({ name, value }) => `${name}:${value}`).join(';');
+const generateEnvString = (env = []) => {
+    if (env.length) {
+        return env.map(({ name, value }) => `${name}:${value}`).join(';');
+    }
+    return '';
+};
 
 export {
     generateEnvString

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -205,7 +205,7 @@ const PrintUtils = {
                     "TILED": true,
                     "EXCEPTIONS": "application/vnd.ogc.se_inimage",
                     "scaleMethod": "accurate",
-                    "ENV": spec.env && spec.env.length ? generateEnvString(spec.env) : ''
+                    "ENV": generateEnvString(spec.env)
                 }, layer.baseParams || {}, layer.params || {}, {
                     ...optionsToVendorParams({
                         layerFilter: layer.layerFilter,

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -9,8 +9,9 @@
 const MapUtils = require('../MapUtils');
 const CoordinatesUtils = require('../CoordinatesUtils');
 const {getLayerUrl} = require('../LayersUtils');
-const {isObject, head} = require('lodash');
+const {isObject} = require('lodash');
 const { optionsToVendorParams } = require('../VendorParamsUtils');
+const { generateEnvString } = require('../LayerLocalizationUtils');
 
 const SecurityUtils = require('../SecurityUtils');
 const assign = require('object-assign');
@@ -24,7 +25,7 @@ module.exports = {
      * @param {string} viewer
      * @return {object} an object with `request`, containing request paarams, `metadata` with some info about the layer and the request, and `url` to send the request to.
      */
-    buildRequest: (layer, { sizeBBox, map = {}, point, currentLocale, params: defaultParams, maxItems = 10} = {}, infoFormat, viewer, featureInfo) => {
+    buildRequest: (layer, { sizeBBox, map = {}, point, currentLocale, params: defaultParams, maxItems = 10, env } = {}, infoFormat, viewer, featureInfo) => {
         /* In order to create a valid feature info request
          * we create a bbox of 101x101 pixel that wrap the point.
          * center point is re-projected then is built a box of 101x101pixel around it
@@ -45,8 +46,7 @@ module.exports = {
             queryLayers = layer.queryLayers.join(",");
         }
 
-        const locale = currentLocale ? head(currentLocale.split('-')) : null;
-        const ENV = locale ? 'locale:' + locale : '';
+        const ENV = generateEnvString(env);
         const params = optionsToVendorParams({
             layerFilter: layer.layerFilter,
             filterObj: layer.filterObj,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
ENV parameter added to the GetFeatureInfo. It has same values as ENV param added to GetMap request (defined by the localConfig and application language).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5184 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
If localized layer styles were enabled and described through localConfig  GetFeatureInfo request should be accompanied by ENV param (example `ENV: mapstore_language:en`).

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
