### PR TITLE
#5213: enables multiple paths, in priority order for datadir location

### DIFF
--- a/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
@@ -10,16 +10,16 @@ package it.geosolutions.mapstore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
+
 import javax.servlet.ServletContext;
-import org.apache.commons.io.IOUtils;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import it.geosolutions.mapstore.ConfigController.ResourceNotAllowedException;
 
 public class ConfigControllerTest {
@@ -67,7 +67,28 @@ public class ConfigControllerTest {
         assertEquals("{}", resource.trim());
         tempResource.delete();
     }
-    
+
+    @Test
+    public void testLoadFromManyDataDir() throws IOException {
+        File dataDir1 = TestUtils.getDataDir();
+        File dataDir2 = TestUtils.getDataDir();
+        File tempResource1 = TestUtils.copyTo(
+                ConfigControllerTest.class.getResourceAsStream("/localConfig.json"), dataDir1,
+                "localConfig.json");
+        File tempResource2 =
+                TestUtils.copyTo(ConfigControllerTest.class.getResourceAsStream("/extensions.json"),
+                        dataDir2, "extensions.json");
+        controller.setDataDir(dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath());
+        ServletContext context = Mockito.mock(ServletContext.class);
+        controller.setContext(context);
+        String resource1 = controller.loadResource("localConfig", false);
+        assertEquals("{}", resource1.trim());
+        String resource2 = controller.loadResource("extensions", false);
+        assertEquals("{}", resource2.trim());
+        tempResource1.delete();
+        tempResource2.delete();
+    }
+
     @Test
     public void testLoadAsset() throws IOException {
     	ServletContext context = Mockito.mock(ServletContext.class);

--- a/backend/src/test/java/it/geosolutions/mapstore/UploadPluginControllerTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/UploadPluginControllerTest.java
@@ -125,7 +125,30 @@ public class UploadPluginControllerTest {
         tempConfig.delete();
         tempExtensions.delete();
     }
-    
+
+    @Test
+    public void testUploadValidBundleWithMultipleDataDir() throws IOException {
+        File dataDir1 = TestUtils.getDataDir();
+        File dataDir2 = TestUtils.getDataDir();
+        controller.setDataDir(dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath());
+        ServletContext context = Mockito.mock(ServletContext.class);
+        controller.setContext(context);
+        // we load from dataDir2 (less priority)
+        File tempConfig = TestUtils.copyTo(
+                UploadPluginControllerTest.class.getResourceAsStream("/pluginsConfig.json"),
+                dataDir2, "pluginsConfig.json");
+        File tempExtensions = TestUtils.copyTo(
+                UploadPluginControllerTest.class.getResourceAsStream("/extensions.json"), dataDir2,
+                "extensions.json");
+        InputStream zipStream = UploadPluginControllerTest.class.getResourceAsStream("/plugin.zip");
+        controller.uploadPlugin(zipStream);
+        // we save to dataDir1
+        assertTrue(new File(dataDir1.getAbsolutePath() + File.separator + "dist" + File.separator
+                + "extensions" + File.separator + "My" + File.separator + "myplugin.js").exists());
+        tempConfig.delete();
+        tempExtensions.delete();
+    }
+
     @Test
     public void testUninstallPlugin() throws IOException {
         ServletContext context = Mockito.mock(ServletContext.class);

--- a/docs/developer-guide/externalized-configuration.md
+++ b/docs/developer-guide/externalized-configuration.md
@@ -49,6 +49,27 @@ java -Dgeostore-ovr=file:<path to the override file> ...
 But this is not enough. Currently usage of the datadir must be enabled for every configuration file that can be externalized.
 We will see how to enable externalization for each of them in the following sections.
 
+### Multiple data directory locations
+
+It is possible to specify more than one datadir location path, separated by commas. This can be useful if you
+need to have different places for static configuration and dynamic one.
+A dynamic configuration file is one that is updated by MapStore using the UI, while static ones can only updated manually
+by an administrator of the server. An example are uploaded extensions, and their configuration files.
+
+MapStore looks for configuration resources in these places in order:
+
+ * the first datadir.location path
+ * other datadir.location paths, if any, in order
+ * the application root folder
+
+Dynamic files will always be written by the UI in the first location in the list, so the first path is for dynamic stuff.
+
+**Example**
+
+```sh
+-Ddatadir.location=/etc/mapstore_extensions,/etc/mapstore_static_config
+```
+
 ## Externalize the proxy configuration
 
 This must be done in the WEB-INF web.xml file:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This allows to split location of static files from files that can be rewritten by MapStore itself, like uploaded extension bundles and the related configuration.

If you specify a comma delimited list of folders for datadir.location, the configuration file and assets will be searched in all the given folders, in order, the first found one is returned.
For writing purposes MapStore will always write to the first one in the list.
With this behaviour resources written by MapStore will always have priority on files preinstalled in the "static" datadir.

Example of datadir.location:

/tmp/mapstore,/var/mapstore/datadir

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5213 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
