### PR TITLE
#5178: fixed printing of measurement layers

### DIFF
--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -43,6 +43,7 @@ export const addAsLayerEpic = (action$) =>
                 addLayer({
                     type: 'vector',
                     id: uuidv1(),
+                    isAnnotation: true,
                     name: 'Measurements',
                     hideLoading: true,
                     features: [layerFeature],

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -28,6 +28,10 @@ const getGeomType = function(layer) {
     return layer.features && layer.features[0] && layer.features[0].geometry ? layer.features[0].geometry.type :
         layer.features && layer.features[0].features && layer.features[0].style && layer.features[0].style.type ? layer.features[0].style.type : undefined;
 };
+
+const isAnnotationLayer = (layer) => {
+    return layer.id === "annotations" || layer.isAnnotation;
+};
 /**
  * Utilities for Print
  * @memberof utils
@@ -302,7 +306,7 @@ const PrintUtils = {
                 },
                 geoJson: CoordinatesUtils.reprojectGeoJson({
                     type: "FeatureCollection",
-                    features: layer.id === "annotations" && AnnotationsUtils.annotationsToPrint(layer.features) ||
+                    features: isAnnotationLayer(layer) && AnnotationsUtils.annotationsToPrint(layer.features) ||
                                     layer.features.map( f => ({...f, properties: {...f.properties, ms_style: f && f.geometry && f.geometry.type && f.geometry.type.replace("Multi", "") || 1}}))
                 },
                 "EPSG:4326",

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -93,6 +93,38 @@ const featurePoint = {
     },
     "id": 0
 };
+
+const featureLine = {
+    "type": "Feature",
+    "geometry": {
+        "type": "LineString",
+        "coordinates": [
+            -112.50042920000001,
+            42.22829164089942,
+            -113.50042920000001,
+            42.22829164089942,
+            -114.50042920000001,
+            42.22829164089942
+        ]
+    },
+    "properties": {
+        "serial_num": "12C324776"
+    },
+    "id": 0
+};
+
+const featureCollection = {
+    "type": "FeatureCollection",
+    "features": [featureLine],
+    "style": {
+        "weight": 3,
+        "radius": 10,
+        "opacity": 1,
+        "fillOpacity": 0.1,
+        "color": "rgb(0, 0, 255)",
+        "fillColor": "rgb(0, 0, 255)"
+    }
+};
 const vectorLayer = {
     "type": "vector",
     "visibility": true,
@@ -101,6 +133,25 @@ const vectorLayer = {
     "name": "web2014all_mv",
     "hideLoading": true,
     "features": [ featurePoint ],
+    "style": {
+        "weight": 3,
+        "radius": 10,
+        "opacity": 1,
+        "fillOpacity": 0.1,
+        "color": "rgb(0, 0, 255)",
+        "fillColor": "rgb(0, 0, 255)"
+    }
+};
+
+var annotationsVectorLayer = {
+    "type": "vector",
+    "visibility": true,
+    "group": "Local shape",
+    "id": "web2014all_mv__14",
+    "name": "web2014all_mv",
+    "hideLoading": true,
+    "isAnnotation": true,
+    "features": [ featureCollection ],
     "style": {
         "weight": 3,
         "radius": 10,
@@ -220,6 +271,12 @@ describe('PrintUtils', () => {
         expect(specs).toExist();
         expect(specs.length).toBe(1);
         expect(specs[0].geoJson.features[0].geometry.coordinates[0], mapFishVectorLayer).toBe(mapFishVectorLayer.geoJson.features[0].geometry.coordinates[0]);
+    });
+    it('vector layer from annotations are preprocessed for printing', () => {
+        const specs = PrintUtils.getMapfishLayersSpecification([annotationsVectorLayer], {projection: "EPSG:3857"}, 'map');
+        expect(specs).toExist();
+        expect(specs.length).toBe(1);
+        expect(specs[0].geoJson.features[0].properties.ms_style.strokeColor).toBe("rgb(0, 0, 255)");
     });
     it('wms layer generation for legend', () => {
         const specs = PrintUtils.getMapfishLayersSpecification([layer], {projection: "EPSG:3857"}, 'legend');


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Measurement should be preprocessed for printing like annotations, so we need to identify them as such, and apply the same preprocessing.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#5178 
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5178 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
