### PR TITLE
issue 5225 - Fix the bug related to apply button in mediaEditor

### DIFF
--- a/web/client/plugins/mediaEditor/MediaModal.jsx
+++ b/web/client/plugins/mediaEditor/MediaModal.jsx
@@ -84,7 +84,7 @@ const MediaModal = ({
                     {
                         text: <Message msgId="mediaEditor.apply"/>,
                         bsSize: 'sm',
-                        disabled: adding || editing,
+                        disabled: adding || editing || !selectedItem,
                         onClick: () => chooseMedia(selectedItem)
                     }
                 ]}>

--- a/web/client/plugins/mediaEditor/__tests__/MediaModal-test.jsx
+++ b/web/client/plugins/mediaEditor/__tests__/MediaModal-test.jsx
@@ -11,14 +11,14 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import {Provider} from 'react-redux';
 import MediaModal from '../MediaModal';
-// TODO: it fails on travis and not locally
-describe.skip('MediaModal component', () => {
+
+describe('MediaModal component', () => {
     beforeEach((done) => {
-        document.body.innerHTML = '<div id="container"></div>';
+        document.body.innerHTML = '<div><div id="myContainer"></div></div>';
         setTimeout(done);
     });
     afterEach((done) => {
-        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        ReactDOM.unmountComponentAtNode(document.getElementById("myContainer"));
         document.body.innerHTML = '';
         setTimeout(done);
     });
@@ -26,10 +26,44 @@ describe.skip('MediaModal component', () => {
         ReactDOM.render(
             <Provider store={{subscribe: () => {}, getState: () => ({mediaEditor: {open: true}})}}>
                 <MediaModal open/>
-            </Provider>, document.getElementById("container"));
-        const container = document.getElementById('container');
-        expect(container.querySelector('.modal-fixed')).toNotExist();
+            </Provider>, document.getElementById("myContainer")
+        );
+        const myContainer = document.getElementById("myContainer");
+        expect(myContainer.querySelector('.modal-fixed')).toNotExist();
         expect(document.querySelector('.modal-fixed')).toExist();
+
+    });
+    describe('tests disabled state of apply button', () => {
+        it('when no item is selected', () => {
+            ReactDOM.render(
+                <Provider store={{subscribe: () => {}, getState: () => ({mediaEditor: {open: true}})}}>
+                    <MediaModal open selectedItem={null}/>
+                </Provider>, document.getElementById("myContainer"));
+            const buttons = document.querySelectorAll("button");
+            expect(buttons.length).toBe(3);
+            const applyBtn = buttons[2];
+            expect(applyBtn.disabled).toBe(true);
+        });
+        it('when is adding a new resource', () => {
+            ReactDOM.render(
+                <Provider store={{subscribe: () => {}, getState: () => ({mediaEditor: {open: true}})}}>
+                    <MediaModal open adding/>
+                </Provider>, document.getElementById("myContainer"));
+            const buttons = document.querySelectorAll("button");
+            expect(buttons.length).toBe(3);
+            const applyBtn = buttons[2];
+            expect(applyBtn.disabled).toBe(true);
+        });
+        it('when is editing a resource', () => {
+            ReactDOM.render(
+                <Provider store={{subscribe: () => {}, getState: () => ({mediaEditor: {open: true}})}}>
+                    <MediaModal open editing/>
+                </Provider>, document.getElementById("myContainer"));
+            const buttons = document.querySelectorAll("button");
+            expect(buttons.length).toBe(3);
+            const applyBtn = buttons[2];
+            expect(applyBtn.disabled).toBe(true);
+        });
     });
 });
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Now apply button in media editor is disabled if no item has been selected.

**Note**
Also this pr fixes a problem with <Portal> in tests.
Basically it was not rendering outside my div because the body had a custom class which means that portal was returning the first div inside body, therefore the modal was not being rendered outisde. a fix was to add another div around the modal or to remove the "custom" className from the body tag. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5225 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
changed behavior of apply button in order to avoid the crash

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
