### PR TITLE
5168 BACKPORT (#5171)

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -49,6 +49,11 @@ This is the main structure:
   }],
   // flag for postponing mapstore 2 load time after theme
   "loadAfterTheme": false,
+  // if defined, WMS layer styles localization will be added
+  "localizedLayerStyles": {
+      // name of the ENV parameter variable that is needed for localization proposes
+      "name": "mapstore_language"
+  },
   // optional state initializer (it will override the one defined in appConfig.js)
   "initialState": {
       // default initial state for every mode (will override initialState imposed by plugins reducers)

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -58,7 +58,8 @@ class DefaultLayer extends React.Component {
         connectDropTarget: PropTypes.func,
         isDraggable: PropTypes.bool,
         isDragging: PropTypes.bool,
-        isOver: PropTypes.bool
+        isOver: PropTypes.bool,
+        language: PropTypes.string
     };
 
     static defaultProps = {
@@ -110,7 +111,7 @@ class DefaultLayer extends React.Component {
                     {this.props.activateLegendTool ?
                         <Row>
                             <Col xs={12}>
-                                <WMSLegend node={this.props.node} currentZoomLvl={this.props.currentZoomLvl} scales={this.props.scales} {...this.props.legendOptions} />
+                                <WMSLegend node={this.props.node} currentZoomLvl={this.props.currentZoomLvl} scales={this.props.scales} language={this.props.language} {...this.props.legendOptions} />
                             </Col>
                         </Row> : null}
                 </Grid>

--- a/web/client/components/TOC/fragments/WMSLegend.jsx
+++ b/web/client/components/TOC/fragments/WMSLegend.jsx
@@ -17,7 +17,8 @@ class WMSLegend extends React.Component {
         legendStyle: PropTypes.object,
         showOnlyIfVisible: PropTypes.bool,
         currentZoomLvl: PropTypes.number,
-        scales: PropTypes.array
+        scales: PropTypes.array,
+        language: PropTypes.string
     };
 
     static defaultProps = {
@@ -28,7 +29,7 @@ class WMSLegend extends React.Component {
     render() {
         let node = this.props.node || {};
         if (this.canShow(node) && node.type === "wms" && node.group !== "background") {
-            return <div style={this.props.legendContainerStyle}><Legend style={this.props.legendStyle} layer={node} currentZoomLvl={this.props.currentZoomLvl} scales={this.props.scales}/></div>;
+            return <div style={this.props.legendContainerStyle}><Legend style={this.props.legendStyle} layer={node} currentZoomLvl={this.props.currentZoomLvl} scales={this.props.scales} language={this.props.language}/></div>;
         }
         return null;
     }

--- a/web/client/components/TOC/fragments/__tests__/WMSLegend-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/WMSLegend-test.jsx
@@ -57,4 +57,26 @@ describe('test WMSLegend module component', () => {
         const domNode = ReactDOM.findDOMNode(comp);
         expect(domNode).toNotExist();
     });
+
+    it('tests WMSLegend component language property with value', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const language = 'example_language';
+        const comp = ReactDOM.render(<WMSLegend node={l} language={language} />, document.getElementById("container"));
+
+        const domNode = ReactDOM.findDOMNode(comp);
+        expect(domNode).toExist();
+
+        const image = domNode.getElementsByTagName('img');
+        expect(image).toExist();
+        expect(image.length).toBe(1);
+        const params = new URLSearchParams(image[0].src);
+        expect(params.get("LANGUAGE")).toBe(language);
+    });
 });

--- a/web/client/components/TOC/fragments/legend/Legend.jsx
+++ b/web/client/components/TOC/fragments/legend/Legend.jsx
@@ -16,7 +16,8 @@ class Legend extends React.Component {
         legendOptions: PropTypes.string,
         style: PropTypes.object,
         currentZoomLvl: PropTypes.number,
-        scales: PropTypes.array
+        scales: PropTypes.array,
+        language: PropTypes.string
     };
 
     static defaultProps = {
@@ -58,7 +59,8 @@ class Legend extends React.Component {
                 style: layer.style || null,
                 version: layer.version || "1.3.0",
                 SLD_VERSION: "1.1.0",
-                LEGEND_OPTIONS: props.legendOptions
+                LEGEND_OPTIONS: props.legendOptions,
+                LANGUAGE: props.language
             }, layer.legendParams || {},
             SecurityUtils.addAuthenticationToSLD(cleanParams || {}, props.layer),
             cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -50,6 +50,7 @@ module.exports = pure(({
     toggleCollapse = ( ) => { },
     editWidget = () => { },
     onLayoutChange = () => { },
+    language,
     ...actions
 } = {}) => {
     // checking if this widget appears among other dependenciesMap of other widgets (i.e. it is a parent table)
@@ -114,7 +115,8 @@ module.exports = pure(({
                 updateProperty={(...args) => updateWidgetProperty(w.id, ...args)}
                 toggleCollapse= {() => toggleCollapse(w)}
                 onDelete={() => deleteWidget(w)}
-                onEdit={() => editWidget(w)} /></div>))
+                onEdit={() => editWidget(w)}
+                language={language} /></div>))
         }
     </ResponsiveReactGridLayout>);
 });

--- a/web/client/components/widgets/widget/LegendView.jsx
+++ b/web/client/components/widgets/widget/LegendView.jsx
@@ -19,7 +19,8 @@ module.exports = ({
     currentZoomLvl,
     disableOpacitySlider = true,
     disableVisibility = true,
-    scales
+    scales,
+    language
 }) => <SideGrid
     className="compact-legend-grid"
     size="sm"
@@ -43,6 +44,7 @@ module.exports = ({
                                     node={{ ...layer }}
                                     currentZoomLvl={currentZoomLvl}
                                     scales={scales}
+                                    language={language}
                                     {...legendProps} />
                             </Col>
                         </Row>

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -13,6 +13,8 @@ const { createSelector } = require('reselect');
 const { getDashboardWidgets, dependenciesSelector, getDashboardWidgetsLayout, isWidgetSelectionActive, getEditingWidget, getWidgetsDependenciesGroups } = require('../selectors/widgets');
 const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage, selectWidget } = require('../actions/widgets');
 const { showConnectionsSelector, dashboardResource, isDashboardLoading, isBrowserMobile } = require('../selectors/dashboard');
+const { currentLocaleLanguageSelector } = require('../selectors/locale');
+const { isLocalizedLayerStylesEnabledSelector } = require('../selectors/localizedLayerStyles');
 const ContainerDimensions = require('react-container-dimensions').default;
 
 const PropTypes = require('prop-types');
@@ -29,7 +31,9 @@ const WidgetsView = compose(
             showConnectionsSelector,
             isDashboardLoading,
             isBrowserMobile,
-            (resource, widgets, layouts, dependencies, selectionActive, editingWidget, groups, showGroupColor, loading, isMobile) => ({
+            currentLocaleLanguageSelector,
+            isLocalizedLayerStylesEnabledSelector,
+            (resource, widgets, layouts, dependencies, selectionActive, editingWidget, groups, showGroupColor, loading, isMobile, currentLocaleLanguage, isLocalizedLayerStylesEnabled) => ({
                 resource,
                 loading,
                 canEdit: isMobile ? !isMobile : resource && !!resource.canEdit,
@@ -39,7 +43,8 @@ const WidgetsView = compose(
                 editingWidget,
                 widgets,
                 groups,
-                showGroupColor
+                showGroupColor,
+                language: isLocalizedLayerStylesEnabled ? currentLocaleLanguage : null
             })
         ), {
             editWidget,

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -21,10 +21,11 @@ const {zoomToExtent} = require('../actions/map');
 const {error} = require('../actions/notifications');
 const {groupsSelector, layersSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector, layerMetadataSelector, wfsDownloadSelector} = require('../selectors/layers');
 const {mapSelector, mapNameSelector} = require('../selectors/map');
-const {currentLocaleSelector} = require("../selectors/locale");
+const {currentLocaleSelector, currentLocaleLanguageSelector} = require("../selectors/locale");
 const {widgetBuilderAvailable} = require('../selectors/controls');
 const {generalInfoFormatSelector} = require("../selectors/mapInfo");
 const {userSelector} = require('../selectors/security');
+const {isLocalizedLayerStylesEnabledSelector} = require('../selectors/localizedLayerStyles');
 
 const LayersUtils = require('../utils/LayersUtils');
 const mapUtils = require('../utils/MapUtils');
@@ -78,6 +79,7 @@ const tocSelector = createSelector(
         wfsDownloadSelector,
         mapSelector,
         currentLocaleSelector,
+        currentLocaleLanguageSelector,
         selectedNodesSelector,
         layerFilterSelector,
         layersSelector,
@@ -86,8 +88,9 @@ const tocSelector = createSelector(
         widgetBuilderAvailable,
         generalInfoFormatSelector,
         isCesium,
-        userSelector
-    ], (enabled, groups, settings, layerMetadata, wfsdownload, map, currentLocale, selectedNodes, filterText, layers, mapName, catalogActive, activateWidgetTool, generalInfoFormat, isCesiumActive, user) => ({
+        userSelector,
+        isLocalizedLayerStylesEnabledSelector
+    ], (enabled, groups, settings, layerMetadata, wfsdownload, map, currentLocale, currentLocaleLanguage, selectedNodes, filterText, layers, mapName, catalogActive, activateWidgetTool, generalInfoFormat, isCesiumActive, user, isLocalizedLayerStylesEnabled) => ({
         enabled,
         groups,
         settings,
@@ -99,6 +102,7 @@ const tocSelector = createSelector(
             map && map.mapOptions && map.mapOptions.view && map.mapOptions.view.DPI || null
         ),
         currentLocale,
+        currentLocaleLanguage,
         selectedNodes,
         filterText,
         generalInfoFormat,
@@ -130,7 +134,8 @@ const tocSelector = createSelector(
         ]),
         catalogActive,
         activateWidgetTool,
-        user
+        user,
+        isLocalizedLayerStylesEnabled
     })
 );
 
@@ -199,6 +204,7 @@ class LayerTree extends React.Component {
         spatialMethodOptions: PropTypes.array,
         groupOptions: PropTypes.object,
         currentLocale: PropTypes.string,
+        currentLocaleLanguage: PropTypes.string,
         onFilter: PropTypes.func,
         filterText: PropTypes.string,
         generalInfoFormat: PropTypes.string,
@@ -219,7 +225,8 @@ class LayerTree extends React.Component {
         refreshLayerVersion: PropTypes.func,
         hideOpacityTooltip: PropTypes.bool,
         layerNodeComponent: PropTypes.func,
-        groupNodeComponent: PropTypes.func
+        groupNodeComponent: PropTypes.func,
+        isLocalizedLayerStylesEnabled: PropTypes.bool
     };
 
     static contextTypes = {
@@ -342,7 +349,9 @@ class LayerTree extends React.Component {
                 filterText={this.props.filterText}
                 onUpdateNode={this.props.updateNode}
                 hideOpacityTooltip={this.props.hideOpacityTooltip}
-            />);
+                language={this.props.isLocalizedLayerStylesEnabled ? this.props.currentLocaleLanguage : null}
+            />
+        );
     }
 
     renderTOC = () => {

--- a/web/client/selectors/__tests__/locale-test.js
+++ b/web/client/selectors/__tests__/locale-test.js
@@ -7,7 +7,7 @@
 */
 
 const expect = require('expect');
-const {currentLocaleSelector, currentMessagesSelector } = require('../locale');
+const {currentLocaleSelector, currentMessagesSelector, currentLocaleLanguageSelector} = require('../locale');
 
 const state = {
     locale: {
@@ -35,5 +35,9 @@ describe('Test locale selectors', () => {
         const currentMessages = currentMessagesSelector({});
         expect(currentMessages).toExist();
         expect(currentMessages).toEqual({});
+    });
+    it('test currentLocaleLanguageSelector', () => {
+        const currentLocaleLanguage = currentLocaleLanguageSelector(state);
+        expect(currentLocaleLanguage).toBe('en');
     });
 });

--- a/web/client/selectors/locale.js
+++ b/web/client/selectors/locale.js
@@ -6,10 +6,18 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+const {createSelector} = require('reselect');
+const {head} = require('lodash');
+
 const currentLocaleSelector = (state) => state.locale && state.locale.current || 'en-US';
 const currentMessagesSelector = (state) => state.locale && state.locale.messages || {};
 
+const currentLocaleLanguageSelector = createSelector([
+    currentLocaleSelector
+], (currentLocale) => head(currentLocale.split('-')));
+
 module.exports = {
     currentLocaleSelector,
+    currentLocaleLanguageSelector,
     currentMessagesSelector
 };


### PR DESCRIPTION
## Description
Localization added to GetLegendGraphic request using LANGUAGE param. Example:
`...&LANGUAGE=it`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5168 

**What is the new behavior?**
When *GetLegendGraphic* request occurs it should be populated with LANGUAGE param if that feature was enabled.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Backport of #5168

***During this backport conflicts were resolved as 2020.01.xx doesn't include some changes related to `readme`, `WMSLegend.jsx` and other files already merged in master and waiting for further porting. Those missing changes are not related to legend localizations and are in scope of other tasks and devs***

After conflicts were resolved changes were tested manually.