### PR TITLE
fix identify issue on geostory map

### DIFF
--- a/web/client/components/map/openlayers/PopupSupport.jsx
+++ b/web/client/components/map/openlayers/PopupSupport.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { Overlay } from 'ol';
 import isString from 'lodash/isString';
 import * as Utils from '../../../utils/PopupUtils';
+
 import popupsComponents from '../popups';
 
 const addMutationObserver = (popup, container, options = {}) => {
@@ -109,7 +110,7 @@ export default class PopupSupport extends React.Component {
             const { id, position: { coordinates }, className,
                 maxWidth: maxWidthOption = maxMapWidth,
                 maxHeight: maxHeightOption = maxMapHeight,
-                autoPan = true,
+                autoPan = false,
                 autoPanMargin = margin,
                 offset = [0, 0],
                 autoPanAnimation = {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This pr fixes the problem of identify popups and chagne of map view under a particular series of steps

[this](https://dev.mapstore2.geo-solutions.it/mapstore/#/geostory/24839) map has been created for better replicate the issue and for testing it 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5257 

**What is the new behavior?**
<!-- Describe here the new behavior based on your changes -->
It no longer happen the that GFI on another map is not displayed correctly (with the map that do not change the view)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

One note for the mapStore Team:
@offtherailz  @mbarto @allyoucanmap @tdipisa @kappu72 @vlt1 
Although the fix is just one line of code, the investigation time required was high due the multiple components involved and due to the lack of action creator used.
