### PR TITLE
#5186 BACKPORT (#5196)

### DIFF
--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -42,6 +42,7 @@ export const CHANGE_TITLE = 'CATALOG:CHANGE_TITLE';
 export const CHANGE_TEXT = 'CATALOG:CHANGE_TEXT';
 export const CHANGE_TYPE = 'CATALOG:CHANGE_TYPE';
 export const CHANGE_AUTOLOAD = 'CATALOG:CHANGE_AUTOLOAD';
+export const CHANGE_LOCALIZED_LAYER_STYLES = 'CATALOG:CHANGE_LOCALIZED_LAYER_STYLES';
 export const CHANGE_SERVICE_FORMAT = 'CATALOG:CHANGE_SERVICE_FORMAT';
 export const FOCUS_SERVICES_LIST = 'CATALOG:FOCUS_SERVICES_LIST';
 export const CHANGE_URL = 'CATALOG:CHANGE_URL';
@@ -150,6 +151,12 @@ export function changeAutoload(autoload) {
     return {
         type: CHANGE_AUTOLOAD,
         autoload
+    };
+}
+export function changeLocalizedLayerStyles(localizedLayerStyles) {
+    return {
+        type: CHANGE_LOCALIZED_LAYER_STYLES,
+        localizedLayerStyles
     };
 }
 export function changeServiceFormat(format) {

--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -34,6 +34,7 @@ const TOCItemSettings = (props, context) => {
         className = '',
         activeTab = 'general',
         currentLocale = 'en-US',
+        currentLocaleLanguage = 'en',
         width = 500,
         groups = [],
         element = {},
@@ -53,7 +54,8 @@ const TOCItemSettings = (props, context) => {
         showFullscreen,
         draggable,
         position = 'left',
-        tabsConfig = {}
+        tabsConfig = {},
+        isLocalizedLayerStylesEnabled = false
     } = props;
 
     const tabs = getTabs(props, context);
@@ -131,7 +133,9 @@ const TOCItemSettings = (props, context) => {
                         nodeType={settings.nodeType}
                         settings={settings}
                         retrieveLayerData={onRetrieveLayerData}
-                        onChange={(key, value) => isObject(key) ? onUpdateParams(key, realtimeUpdate) : onUpdateParams({[key]: value}, realtimeUpdate)}/>
+                        onChange={(key, value) => isObject(key) ? onUpdateParams(key, realtimeUpdate) : onUpdateParams({[key]: value}, realtimeUpdate)}
+                        isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled}
+                        currentLocaleLanguage={currentLocaleLanguage}/>
                 ))}
             </DockablePanel>
             <Portal>

--- a/web/client/components/TOC/fragments/__tests__/WMSLegend-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/WMSLegend-test.jsx
@@ -65,7 +65,8 @@ describe('test WMSLegend module component', () => {
             visibility: true,
             storeIndex: 9,
             type: 'wms',
-            url: 'fakeurl'
+            url: 'fakeurl',
+            localizedLayerStyles: true
         };
         const language = 'example_language';
         const comp = ReactDOM.render(<WMSLegend node={l} language={language} />, document.getElementById("container"));

--- a/web/client/components/TOC/fragments/legend/Legend.jsx
+++ b/web/client/components/TOC/fragments/legend/Legend.jsx
@@ -59,9 +59,9 @@ class Legend extends React.Component {
                 style: layer.style || null,
                 version: layer.version || "1.3.0",
                 SLD_VERSION: "1.1.0",
-                LEGEND_OPTIONS: props.legendOptions,
-                LANGUAGE: props.language
+                LEGEND_OPTIONS: props.legendOptions
             }, layer.legendParams || {},
+            props.language && layer.localizedLayerStyles ? {LANGUAGE: props.language} : {},
             SecurityUtils.addAuthenticationToSLD(cleanParams || {}, props.layer),
             cleanParams && cleanParams.SLD_BODY ? {SLD_BODY: cleanParams.SLD_BODY} : {},
             props.scales && props.currentZoomLvl ? {SCALE: Math.round(props.scales[props.currentZoomLvl])} : {});

--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -12,6 +12,7 @@ const {DropdownList} = require('react-widgets');
 const Message = require('../../../I18N/Message');
 const {Grid, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox} = require('react-bootstrap');
 const {clamp, isNil} = require('lodash');
+const InfoPopover = require('../../../widgets/widget/InfoPopover');
 
 require('react-widgets/lib/less/react-widgets.less');
 
@@ -21,7 +22,8 @@ module.exports = class extends React.Component {
         element: PropTypes.object,
         formats: PropTypes.array,
         settings: PropTypes.object,
-        onChange: PropTypes.func
+        onChange: PropTypes.func,
+        isLocalizedLayerStylesEnabled: PropTypes.bool
     };
 
     static defaultProps = {
@@ -97,6 +99,13 @@ module.exports = class extends React.Component {
                                 onChange={(e) => this.props.onChange("singleTile", e.target.checked)}>
                                 <Message msgId="layerProperties.singleTile"/>
                             </Checkbox>
+                            {(this.props.isLocalizedLayerStylesEnabled && (
+                                <Checkbox key="localizedLayerStyles" value="localizedLayerStyles"
+                                    data-qa="display-lacalized-layer-styles-option"
+                                    checked={this.props.element && (this.props.element.localizedLayerStyles !== undefined ? this.props.element.localizedLayerStyles : false )}
+                                    onChange={(e) => this.props.onChange("localizedLayerStyles", e.target.checked)}>
+                                    <Message msgId="layerProperties.enableLocalizedLayerStyles.label" />&nbsp;<InfoPopover text={<Message msgId="layerProperties.enableLocalizedLayerStyles.tooltip" />} />
+                                </Checkbox>))}
                         </FormGroup>
                     </Col>
                 </Row>}

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -77,4 +77,21 @@ describe('test Layer Properties Display module component', () => {
         expect(spy.calls.length).toBe(1);
     });
 
+    it('tests Display component for wms with localized layer styles enabled', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: {opacity: 0.7}
+        };
+        ReactDOM.render(<Display isLocalizedLayerStylesEnabled element={l} settings={settings}/>, document.getElementById("container"));
+        const isLocalizedLayerStylesOption = document.querySelector('[data-qa="display-lacalized-layer-styles-option"]');
+        expect(isLocalizedLayerStylesOption).toExist();
+    });
+
 });

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -21,6 +21,7 @@ const OverlayTrigger = require('../misc/OverlayTrigger');
 const RecordGrid = require("./RecordGrid");
 const SwitchPanel = require("../misc/switch/SwitchPanel");
 const Loader = require('../misc/Loader');
+const InfoPopover = require('../widgets/widget/InfoPopover');
 
 require('react-select/dist/react-select.css');
 require('react-quill/dist/quill.snow.css');
@@ -44,6 +45,7 @@ class Catalog extends React.Component {
         newService: PropTypes.object,
         onAddService: PropTypes.func,
         onChangeAutoload: PropTypes.func,
+        onChangeLocalizedLayerStyles: PropTypes.func,
         onChangeCatalogMode: PropTypes.func,
         onChangeServiceFormat: PropTypes.func,
         onChangeMetadataTemplate: PropTypes.func,
@@ -85,7 +87,8 @@ class Catalog extends React.Component {
         onUpdateThumbnail: PropTypes.func,
         clearModal: PropTypes.func,
         formatOptions: PropTypes.array,
-        layerBaseConfig: PropTypes.object
+        layerBaseConfig: PropTypes.object,
+        isLocalizedLayerStylesEnabled: PropTypes.bool
     };
 
     static contextTypes = {
@@ -112,6 +115,7 @@ class Catalog extends React.Component {
         },
         onAddService: () => {},
         onChangeAutoload: () => {},
+        onChangeLocalizedLayerStyles: () => {},
         onChangeCatalogMode: () => {},
         onChangeFormat: () => {},
         onChangeMetadataTemplate: () => {},
@@ -156,7 +160,8 @@ class Catalog extends React.Component {
             value: 'image/gif'
         }],
         layerBaseConfig: {},
-        crs: "EPSG:3857"
+        crs: "EPSG:3857",
+        isLocalizedLayerStylesEnabled: false
     };
 
     state = {
@@ -309,6 +314,7 @@ class Catalog extends React.Component {
                 onAdd={() => {
                     this.search({services: this.props.services, selectedService: this.props.selectedService});
                 }}
+                localizedLayerStyles={this.props.services[this.props.selectedService] && this.props.services[this.props.selectedService].localizedLayerStyles}
             />
         </div>);
     };
@@ -479,6 +485,17 @@ class Catalog extends React.Component {
                                         </Checkbox>
                                     </Col>
                                 </FormGroup>
+                                {(this.props.isLocalizedLayerStylesEnabled && !isNil(this.props.newService.type) ? this.props.newService.type === "wms" : false) && (
+                                    <FormGroup controlId="localized-styles" key="localized-styles">
+                                        <Col xs={12}>
+                                            <Checkbox
+                                                onChange={(e) => this.props.onChangeLocalizedLayerStyles(e.target.checked)}
+                                                checked={!isNil(this.props.newService.localizedLayerStyles) ? this.props.newService.localizedLayerStyles : false}>
+                                                <Message msgId="catalog.enableLocalizedLayerStyles.label" />&nbsp;<InfoPopover text={<Message msgId="catalog.enableLocalizedLayerStyles.tooltip" />} />
+                                            </Checkbox>
+                                        </Col>
+                                    </FormGroup>
+                                )}
                                 {(!isNil(this.props.newService.type) ? this.props.newService.type === "csw" : false) && (<FormGroup controlId="metadata-template" key="metadata-template" className="metadata-template-editor">
                                     <Col xs={12}>
                                         <Checkbox

--- a/web/client/components/catalog/RecordGrid.jsx
+++ b/web/client/components/catalog/RecordGrid.jsx
@@ -42,7 +42,8 @@ class RecordGrid extends React.Component {
         showTemplate: PropTypes.bool,
         defaultFormat: PropTypes.string,
         formatOptions: PropTypes.array,
-        layerBaseConfig: PropTypes.object
+        layerBaseConfig: PropTypes.object,
+        localizedLayerStyles: PropTypes.bool
     };
 
     static defaultProps = {
@@ -90,6 +91,7 @@ class RecordGrid extends React.Component {
                     defaultFormat={this.props.defaultFormat}
                     formatOptions={this.props.formatOptions}
                     layerBaseConfig={this.props.layerBaseConfig}
+                    localizedLayerStyles={this.props.localizedLayerStyles}
                 />
             </Col>
         );

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -67,7 +67,8 @@ class RecordItem extends React.Component {
         clearModal: PropTypes.func,
         showTemplate: PropTypes.bool,
         defaultFormat: PropTypes.string,
-        formatOptions: PropTypes.array
+        formatOptions: PropTypes.array,
+        localizedLayerStyles: PropTypes.bool
     };
 
     static defaultProps = {
@@ -326,7 +327,7 @@ class RecordItem extends React.Component {
             ...(type === 'wms' ? {catalogURL: this.props.catalogType === 'csw' && this.props.catalogURL ?
                 this.props.catalogURL + "?request=GetRecordById&service=CSW&version=2.0.2&elementSetName=full&id=" +
                 this.props.record.identifier : null, format: this.props.defaultFormat} : {format: this.props.defaultFormat})
-        }, this.props.layerBaseConfig);
+        }, this.props.layerBaseConfig, this.props.localizedLayerStyles);
     }
 
     addLayer = (layer) => {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -54,12 +54,14 @@ function wmsToOpenlayersOptions(options) {
         SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         TILED: options.singleTile ? false : (!isNil(options.tiled) ? options.tiled : true),
-        VERSION: options.version || "1.3.0",
-        ENV: options.env && options.env.length ? generateEnvString(options.env) : ''
+        VERSION: options.version || "1.3.0"
     }, assign(
         {},
         (options._v_ ? {_v_: options._v_} : {}),
-        (params || {})
+        (params || {}),
+        (options.localizedLayerStyles &&
+            options.env && options.env.length &&
+            options.group !== 'background' ? {ENV: generateEnvString(options.env) } : {})
     ));
     return SecurityUtils.addAuthenticationToSLD(result, options);
 }
@@ -215,6 +217,7 @@ const mustCreateNewLayer = (oldOptions, newOptions) => {
         || oldOptions.credits !== newOptions.credits && !newOptions.credits
         || isVectorFormat(oldOptions.format) !== isVectorFormat(newOptions.format)
         || isVectorFormat(oldOptions.format) && isVectorFormat(newOptions.format) && oldOptions.format !== newOptions.format
+        || oldOptions.localizedLayerStyles !== newOptions.localizedLayerStyles
     );
 };
 

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -15,7 +15,7 @@ const {Glyphicon, Panel} = require('react-bootstrap');
 const ContainerDimensions = require('react-container-dimensions').default;
 const {changeLayerProperties} = require('../actions/layers');
 const {addService, deleteService, textSearch, changeCatalogFormat, changeCatalogMode,
-    changeUrl, changeTitle, changeAutoload, changeType, changeServiceFormat, changeSelectedService,
+    changeUrl, changeTitle, changeAutoload, changeLocalizedLayerStyles, changeType, changeServiceFormat, changeSelectedService,
     addLayer, addLayerError, focusServicesList, changeText,
     changeMetadataTemplate, toggleAdvancedSettings, toggleThumbnail, toggleTemplate, catalogClose} = require("../actions/catalog");
 const {zoomToExtent} = require("../actions/map");
@@ -30,6 +30,7 @@ const {resultSelector, serviceListOpenSelector, newServiceSelector,
     searchTextSelector, groupSelector, pageSizeSelector, loadingSelector
 } = require("../selectors/catalog");
 const {projectionSelector} = require('../selectors/map');
+const {isLocalizedLayerStylesEnabledSelector} = require('../selectors/localizedLayerStyles');
 
 const {mapLayoutValuesSelector} = require('../selectors/maplayout');
 const {metadataSourceSelector, modalParamsSelector} = require('../selectors/backgroundselector');
@@ -105,6 +106,7 @@ class MetadataExplorerComponent extends React.Component {
         style: PropTypes.object,
         dockProps: PropTypes.object,
         zoomToLayer: PropTypes.bool,
+        isLocalizedLayerStylesEnabled: PropTypes.bool,
 
         // side panel properties
         width: PropTypes.number,
@@ -194,8 +196,9 @@ const metadataExplorerSelector = createSelector([
     state => mapLayoutValuesSelector(state, {height: true}),
     searchTextSelector,
     groupSelector,
-    metadataSourceSelector
-], (searchOptions, formats, result, loadingError, selectedService, mode, services, servicesWithBackgrounds, layerError, active, dockStyle, searchText, group, source) => ({
+    metadataSourceSelector,
+    isLocalizedLayerStylesEnabledSelector
+], (searchOptions, formats, result, loadingError, selectedService, mode, services, servicesWithBackgrounds, layerError, active, dockStyle, searchText, group, source, isLocalizedLayerStylesEnabled) => ({
     searchOptions,
     formats,
     result,
@@ -207,7 +210,8 @@ const metadataExplorerSelector = createSelector([
     dockStyle,
     searchText,
     group,
-    source
+    source,
+    isLocalizedLayerStylesEnabled
 }));
 
 const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
@@ -223,6 +227,7 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     onChangeMetadataTemplate: changeMetadataTemplate,
     onChangeText: changeText,
     onChangeAutoload: changeAutoload,
+    onChangeLocalizedLayerStyles: changeLocalizedLayerStyles,
     onChangeSelectedService: changeSelectedService,
     onChangeCatalogMode: changeCatalogMode,
     onAddService: addService,

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -18,32 +18,37 @@ const LayersUtils = require('../utils/LayersUtils');
 const { initialSettingsSelector, originalSettingsSelector, activeTabSettingsSelector } = require('../selectors/controls');
 const {layerSettingSelector, layersSelector, groupsSelector, elementSelector} = require('../selectors/layers');
 const {mapLayoutValuesSelector} = require('../selectors/maplayout');
-const {currentLocaleSelector} = require('../selectors/locale');
+const {currentLocaleSelector, currentLocaleLanguageSelector} = require('../selectors/locale');
 const {isAdminUserSelector} = require('../selectors/security');
 const {setControlProperty} = require('../actions/controls');
 const {toggleStyleEditor} = require('../actions/styleeditor');
+const {isLocalizedLayerStylesEnabledSelector} = require('../selectors/localizedLayerStyles');
 
 const tocItemsSettingsSelector = createSelector([
     layerSettingSelector,
     layersSelector,
     groupsSelector,
     currentLocaleSelector,
+    currentLocaleLanguageSelector,
     state => mapLayoutValuesSelector(state, {height: true}),
     isAdminUserSelector,
     initialSettingsSelector,
     originalSettingsSelector,
     activeTabSettingsSelector,
-    elementSelector
-], (settings, layers, groups, currentLocale, dockStyle, isAdmin, initialSettings, originalSettings, activeTab, element) => ({
+    elementSelector,
+    isLocalizedLayerStylesEnabledSelector
+], (settings, layers, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, initialSettings, originalSettings, activeTab, element, isLocalizedLayerStylesEnabled) => ({
     settings,
     element,
     groups,
     currentLocale,
+    currentLocaleLanguage,
     dockStyle,
     isAdmin,
     initialSettings,
     originalSettings,
-    activeTab
+    activeTab,
+    isLocalizedLayerStylesEnabled
 }));
 
 /**

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -17,6 +17,7 @@ const {
     CHANGE_TITLE,
     CHANGE_TEXT,
     CHANGE_AUTOLOAD,
+    CHANGE_LOCALIZED_LAYER_STYLES,
     CHANGE_TYPE,
     CHANGE_URL,
     CHANGE_SERVICE_FORMAT,
@@ -130,6 +131,8 @@ function catalog(state = {
         return set("newService.url", action.url, state);
     case CHANGE_AUTOLOAD:
         return set("newService.autoload", action.autoload, state);
+    case CHANGE_LOCALIZED_LAYER_STYLES:
+        return set("newService.localizedLayerStyles", action.localizedLayerStyles, state);
     case CHANGE_SERVICE_FORMAT:
         return set("newService.format", action.format, state);
     case CHANGE_TYPE: {

--- a/web/client/selectors/__tests__/localizedLayerStyles-test.js
+++ b/web/client/selectors/__tests__/localizedLayerStyles-test.js
@@ -7,7 +7,22 @@
 */
 
 const expect = require('expect');
-const {localizedLayerStylesNameSelector} = require('../localizedLayerStyles');
+
+const {
+    isLocalizedLayerStylesEnabledSelector,
+    localizedLayerStylesNameSelector,
+    localizedLayerStylesEnvSelector
+} = require('../localizedLayerStyles');
+const {currentLocaleLanguageSelector} = require('../locale');
+
+const givenName = 'example';
+const givenState = {
+    localConfig: {
+        localizedLayerStyles: {
+            name: givenName
+        }
+    }
+};
 
 describe('Test localizedLayerStyles', () => {
     it('test localizedLayerStylesNameSelector default', () => {
@@ -17,9 +32,34 @@ describe('Test localizedLayerStyles', () => {
     });
 
     it('test localizedLayerStylesNameSelector', () => {
-        const name = 'example';
-        const localizedLayerStyles = localizedLayerStylesNameSelector({localConfig: {localizedLayerStyles: {name}}});
+        const localizedLayerStyles = localizedLayerStylesNameSelector(givenState);
 
-        expect(localizedLayerStyles).toBe(name);
+        expect(localizedLayerStyles).toBe(givenName);
+    });
+
+    it('test isLocalizedLayerStylesEnabledSelector', () => {
+        let isLocalizedLayerStylesEnabled;
+
+        isLocalizedLayerStylesEnabled = isLocalizedLayerStylesEnabledSelector({});
+        expect(isLocalizedLayerStylesEnabled).toBe(false);
+
+        isLocalizedLayerStylesEnabled = isLocalizedLayerStylesEnabledSelector(givenState);
+        expect(isLocalizedLayerStylesEnabled).toBe(true);
+    });
+
+    it('test localizedLayerStylesEnvSelector default', () => {
+        const env = localizedLayerStylesEnvSelector({});
+
+        expect(env).toEqual([]);
+    });
+
+    it('test localizedLayerStylesEnvSelector', () => {
+        const env = localizedLayerStylesEnvSelector(givenState);
+        const language = currentLocaleLanguageSelector(givenState);
+
+        expect(env).toEqual([{
+            name: givenName,
+            value: language
+        }]);
     });
 });

--- a/web/client/selectors/localizedLayerStyles.js
+++ b/web/client/selectors/localizedLayerStyles.js
@@ -7,6 +7,9 @@
 */
 
 const {has, get} = require('lodash');
+const {createSelector} = require('reselect');
+
+const {currentLocaleLanguageSelector} = require('./locale');
 
 /**
  * selects localizedLayerStyles state
@@ -31,7 +34,30 @@ const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig
  */
 const localizedLayerStylesNameSelector = (state) => get(state, 'localConfig.localizedLayerStyles.name', 'mapstore_language');
 
+/**
+ * generates localizedLayerStyles env object
+ * @memberof selectors.localizedLayerStyles
+ * @param  {object} state the state
+ * @return {object} object that represents ENV param
+ */
+const localizedLayerStylesEnvSelector = createSelector(
+    isLocalizedLayerStylesEnabledSelector,
+    localizedLayerStylesNameSelector,
+    currentLocaleLanguageSelector,
+    (isLocalizedLayerStylesEnabled, localizedLayerStylesName, currentLocaleLanguage) => {
+        const env = [];
+        if (isLocalizedLayerStylesEnabled) {
+            env.push({
+                name: localizedLayerStylesName,
+                value: currentLocaleLanguage
+            });
+        }
+        return env;
+    }
+);
+
 module.exports = {
     isLocalizedLayerStylesEnabledSelector,
-    localizedLayerStylesNameSelector
+    localizedLayerStylesNameSelector,
+    localizedLayerStylesEnvSelector
 };

--- a/web/client/translations/data.de-DE
+++ b/web/client/translations/data.de-DE
@@ -106,6 +106,10 @@
                 "right": "Recht",
                 "bottom": "Bottom",
                 "top": "Oben"
+            },
+            "enableLocalizedLayerStyles": {
+                "label": "Schakel gelokaliseerde stijl in",
+                "tooltip": "Opmerking: deze parameter vereist specifieke configuraties op GeoServer"
             }
         },
         "longitude": "Länge",
@@ -1181,7 +1185,11 @@
                 "serviceDeletedCorrectly": "Der Service wurde korrekt gelöscht",
                 "errorServiceUrl": "Service nicht verfügbar. Bitte überprüfen Sie die angegebene URL"
             },
-            "backgroundAlreadyAdded": "Zur Hintergrundauswahl hinzugefügt"
+            "backgroundAlreadyAdded": "Zur Hintergrundauswahl hinzugefügt",
+            "enableLocalizedLayerStyles": {
+                "label": "Schakel gelokaliseerde stijlen in",
+                "tooltip": "Opmerking: deze parameter vereist specifieke configuraties op GeoServer"
+            }
         },
         "uploader": {
             "filename": "Datei Name",

--- a/web/client/translations/data.en-US
+++ b/web/client/translations/data.en-US
@@ -106,6 +106,10 @@
                 "right": "Right",
                 "bottom": "Bottom",
                 "top": "Top"
+            },
+            "enableLocalizedLayerStyles": {
+                "label": "Enable localized style",
+                "tooltip": "Note: This parameter requires specific configurations on GeoServer"
             }
         },
         "longitude": "Longitude",
@@ -1182,7 +1186,11 @@
                 "serviceDeletedCorrectly": "The service was deleted correctly",
                 "errorServiceUrl": "Service not available. Please, check the provided url"
             },
-            "backgroundAlreadyAdded": "Added to background selector"
+            "backgroundAlreadyAdded": "Added to background selector",
+            "enableLocalizedLayerStyles": {
+                "label": "Enable localized styles",
+                "tooltip": "Note: This parameter requires specific configurations on GeoServer"
+            }
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/translations/data.es-ES
+++ b/web/client/translations/data.es-ES
@@ -106,7 +106,11 @@
                 "top": "Cima"
             },
             "templateFormatInfoAlertExample": "La identificación de la característica es ${ properties }",
-            "templatePreview": "Vista previa de la plantilla"
+            "templatePreview": "Vista previa de la plantilla",
+            "enableLocalizedLayerStyles": {
+                "label": "Habilitar estilo localizado",
+                "tooltip": "Nota: este parámetro requiere configuraciones específicas en GeoServer"
+            }
         },
         "longitude": "Longitud",
         "latitude": "Latitud",
@@ -1181,7 +1185,11 @@
                 "serviceDeletedCorrectly": "El servicio se ha eliminado correctamente",
                 "errorServiceUrl": "Servicio no disponible. Por favor, compruebe la url proporcionada"
             },
-            "backgroundAlreadyAdded": "Agregado al selector de fondo"
+            "backgroundAlreadyAdded": "Agregado al selector de fondo",
+            "enableLocalizedLayerStyles": {
+                "label": "Habilitar estilos localizados",
+                "tooltip": "Nota: este parámetro requiere configuraciones específicas en GeoServer"
+            }
         },
         "uploader": {
             "filename": "Nombre del fichero",

--- a/web/client/translations/data.fr-FR
+++ b/web/client/translations/data.fr-FR
@@ -106,6 +106,10 @@
                 "right": "Droite",
                 "bottom": "Bottom",
                 "top": "Haut"
+            },
+            "enableLocalizedLayerStyles": {
+                "label": "Activer le style localisé",
+                "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"
             }
         },
         "longitude": "Longitude",
@@ -1181,7 +1185,11 @@
                 "serviceDeletedCorrectly": "Le service a été correctement effacé",
                 "errorServiceUrl": "Service non disponible. Veuillez vérifier l'URL fournie"
             },
-            "backgroundAlreadyAdded": "Ajouté au sélecteur de fond"
+            "backgroundAlreadyAdded": "Ajouté au sélecteur de fond",
+            "enableLocalizedLayerStyles": {
+                "label": "Activer les styles localisés",
+                "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"
+            }
         },
         "uploader": {
             "filename": "Nom du fichier",

--- a/web/client/translations/data.it-IT
+++ b/web/client/translations/data.it-IT
@@ -106,6 +106,10 @@
                 "right": "Destra",
                 "bottom": "Sotto",
                 "top": "Sopra"
+            },
+            "enableLocalizedLayerStyles": {
+                "label": "Abilita stile localizzato",
+                "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"
             }
         },
         "longitude": "Longitudine",
@@ -1181,7 +1185,11 @@
                 "serviceDeletedCorrectly": "Il servizio è stato eliminato correttamente",
                 "errorServiceUrl": "Servizio non disponibile. Verifica l'url inserito."
             },
-            "backgroundAlreadyAdded": "Aggiunto al selettore di sfondo"
+            "backgroundAlreadyAdded": "Aggiunto al selettore di sfondo",
+            "enableLocalizedLayerStyles": {
+                "label": "Abilita stili di livello localizzati",
+                "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"
+            }
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -7,7 +7,7 @@
  */
 
 const assign = require('object-assign');
-const {head, isArray, isString, castArray, isObject, sortBy, uniq, includes} = require('lodash');
+const {head, isArray, isString, castArray, isObject, sortBy, uniq, includes, isNil} = require('lodash');
 const urlUtil = require('url');
 const CoordinatesUtils = require('./CoordinatesUtils');
 const ConfigUtils = require('./ConfigUtils');
@@ -416,7 +416,7 @@ const CatalogUtils = {
      *  - `removeParameters` if you didn't provided an `url` option and you want to use record's one, you can remove some params (typically authkey params) using this.
      *  - `url`, if you already have the correct service URL (typically when you want to use you URL already stripped from some parameters, e.g. authkey params)
      */
-    recordToLayer: (record, type = "wms", {removeParams = [], format, catalogURL, url} = {}, baseConfig = {}) => {
+    recordToLayer: (record, type = "wms", {removeParams = [], format, catalogURL, url} = {}, baseConfig = {}, localizedLayerStyles) => {
         if (!record || !record.references) {
             // we don't have a valid record so no buttons to add
             return null;
@@ -476,7 +476,8 @@ const CatalogUtils = {
             params: params,
             allowedSRS: allowedSRS,
             catalogURL,
-            ...baseConfig
+            ...baseConfig,
+            localizedLayerStyles: !isNil(localizedLayerStyles) ? localizedLayerStyles : undefined
         };
     },
     getCatalogRecords: (format, records, options, locales) => {

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -492,7 +492,8 @@ const LayersUtils = {
             tooltipPlacement: layer.tooltipPlacement
         },
         layer.params ? { params: layer.params } : {},
-        layer.credits ? { credits: layer.credits } : {});
+        layer.credits ? { credits: layer.credits } : {},
+        layer.localizedLayerStyles ? { localizedLayerStyles: layer.localizedLayerStyles } : {});
     },
     /**
     * default initial constant regex rule for searching for a /geoserver/ string in a url


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
We need to add possibility to setup localized layer styles param for each WMS layer separately. To achieve that relative settings need to be added to Catalog tool and TOC Item Settings.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5186 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
If localized layer styles param was enabled through localConfig in Catalog tool user will be able to enable/disable ENV param by default when new layers are added. Even after that user is able to customize ENV param usage through display settings of certain WMS layer.
_Also ENV param was removed from background layers as bugfix._

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
This is BACKPORT of #5186 .

***NOTE: some customizations were made as MetadataExplorer plugin in master differs a lot from version of that plugin presented in 2020.01.xx revision***