### PR TITLE
Fixed issue with FeatureInfo on WFS

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -22,6 +22,7 @@ const GET_VECTOR_INFO = 'GET_VECTOR_INFO';
 const NO_QUERYABLE_LAYERS = 'NO_QUERYABLE_LAYERS';
 const CLEAR_WARNING = 'CLEAR_WARNING';
 const FEATURE_INFO_CLICK = 'FEATURE_INFO_CLICK';
+const UPDATE_FEATURE_INFO_CLICK_POINT  = 'IDENTIFY:UPDATE_FEATURE_INFO_CLICK_POINT';
 const TOGGLE_HIGHLIGHT_FEATURE = "IDENTIFY:TOGGLE_HIGHLIGHT_FEATURE";
 const TOGGLE_MAPINFO_STATE = 'TOGGLE_MAPINFO_STATE';
 const UPDATE_CENTER_TO_MARKER = 'UPDATE_CENTER_TO_MARKER';
@@ -208,6 +209,13 @@ function featureInfoClick(point, layer, filterNameList = [], overrideParams = {}
     };
 }
 
+function updateFeatureInfoClickPoint(point) {
+    return {
+        type: UPDATE_FEATURE_INFO_CLICK_POINT,
+        point
+    };
+}
+
 function toggleHighlightFeature(enabled) {
     return {
         type: TOGGLE_HIGHLIGHT_FEATURE,
@@ -302,6 +310,7 @@ module.exports = {
     toggleMapInfoState,
     updateCenterToMarker,
     featureInfoClick,
+    UPDATE_FEATURE_INFO_CLICK_POINT, updateFeatureInfoClickPoint,
     EDIT_LAYER_FEATURES, editLayerFeatures,
     SET_CURRENT_EDIT_FEATURE_QUERY, setCurrentEditFeatureQuery
 };

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -9,11 +9,11 @@
 const expect = require('expect');
 
 const { ZOOM_TO_POINT, clickOnMap, CHANGE_MAP_VIEW } = require('../../actions/map');
-const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, SET_CURRENT_EDIT_FEATURE_QUERY, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature, editLayerFeatures } = require('../../actions/mapInfo');
-const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh, closeFeatureInfoOnCatalogOpenEpic, identifyEditLayerFeaturesEpic, hideMarkerOnIdentifyClose } = require('../identify').default;
+const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, SET_CURRENT_EDIT_FEATURE_QUERY, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature, editLayerFeatures,updateFeatureInfoClickPoint } = require('../../actions/mapInfo');
+const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh, closeFeatureInfoOnCatalogOpenEpic, identifyEditLayerFeaturesEpic, hideMarkerOnIdentifyClose, onUpdateFeatureInfoClickPoint } = require('../identify').default;
 const { CLOSE_ANNOTATIONS } = require('../../actions/annotations');
 const { testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
-const { registerHook } = require('../../utils/MapUtils');
+const { registerHook, GET_COORDINATES_FROM_PIXEL_HOOK, GET_PIXEL_FROM_COORDINATES_HOOK } = require('../../utils/MapUtils');
 const { setControlProperties } = require('../../actions/controls');
 const { BROWSE_DATA } = require('../../actions/layers');
 
@@ -610,6 +610,54 @@ describe('identify Epics', () => {
                 }
             }
         });
+
+    });
+    it('onMapClick generates geometricFilter', done => {
+        const cleanUp = () => {
+            registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, undefined);
+            registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, undefined);
+        };
+        registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, ([x, y]) => {
+            expect(x).toBe(0);
+            expect(y).toBe(5); // 5 is the radius
+            return [0, 5];
+
+        });
+        registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, ([x, y]) => {
+            return [0, 0];
+        });
+
+        testEpic(onMapClick, 1, [clickOnMap({ latlng: { lat: 0, lng: 0 } })], ([action]) => {
+            if (action.type === FEATURE_INFO_CLICK) {
+                expect(action.point).toBeTruthy();
+                expect(action.point.geometricFilter).toBeTruthy();
+                const geometry = action.point.geometricFilter.value.geometry;
+                // due to mock data coordinates of the extent should be ,ore or less -5 + 5, not check the coordinates of the circle to avoid float issues with test
+                expect(Math.round(geometry.extent[0])).toEqual(-5);
+                expect(Math.round(geometry.extent[1])).toEqual(-5);
+                expect(Math.round(geometry.extent[2])).toEqual(5);
+                expect(Math.round(geometry.extent[3])).toEqual(5);
+                cleanUp();
+                done();
+            }
+        }, {
+            mapInfo: {
+                enabled: true,
+                disableAlwaysOn: false
+            },
+            context: {
+                currentContext: {
+                    plugins: {
+                        desktop: [{ name: "Identify" }]
+                    }
+                }
+            },
+            map: {
+                present: {
+                    projection: 'EPSG:3857'
+                }
+            }
+        });
     });
 
     it('closeFeatureAndAnnotationEditing closes annotations', (done) => {
@@ -745,5 +793,45 @@ describe('identify Epics', () => {
             expect(actions.length).toBe(1);
             expect(actions[0].type).toBe(HIDE_MAPINFO_MARKER);
         }, {}, done);
+    });
+    it('onUpdateFeatureInfoClickPoint', done => {
+        const cleanUp = () => {
+            registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, undefined);
+            registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, undefined);
+        };
+        registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, ([x, y]) => {
+            expect(x).toBe(0);
+            expect(y).toBe(5);
+            return [0, 5];
+
+        });
+        registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, ([x, y]) => {
+            expect(x).toBe(0);
+            expect(y).toBe(0);
+            return [0, 0];
+        });
+        const LAYER_NAME = "This is one sample additional argument of featureInfoClick that have to be replicated";
+        const PROJECTION = 'EPSG:4326';
+        testEpic(onUpdateFeatureInfoClickPoint, 1, [
+            featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 }}, LAYER_NAME),
+            updateFeatureInfoClickPoint({latlng: {lat: 0, lng: 0}})
+        ], ([{point, layer}]) => {
+            expect(point.latlng.lat).toEqual(0);
+            expect(point.latlng.lng).toEqual(0);
+            expect(point.geometricFilter.type).toEqual('geometry');
+            expect(point.geometricFilter.value.operation).toEqual("INTERSECTS");
+            expect(point.geometricFilter.value.geometry.center).toEqual([0, 0]); // some checks to verify that a circle is created
+            expect(point.geometricFilter.value.geometry.projection).toEqual(PROJECTION); // some checks to verify that a circle is created
+            expect(point.geometricFilter.value.geometry.extent).toEqual([-5, -5, 5, 5]); // not check the coordinate to avoid issue with float, but the extent should be this accordingly with the mock data
+            expect(layer).toBe(LAYER_NAME);
+            cleanUp();
+            done();
+        }, {
+            map: {
+                present: {
+                    projection: PROJECTION
+                }
+            }
+        });
     });
 });

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -541,6 +541,8 @@ describe('identify Epics', () => {
     });
 
     it('onMapClick triggers featureinfo when selected', done => {
+        registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, undefined);
+        registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, undefined);
         testEpic(onMapClick, 1, [clickOnMap({latlng: {lat: 8, lng: 8}})], ([action]) => {
             expect(action.type === FEATURE_INFO_CLICK);
             done();
@@ -557,6 +559,8 @@ describe('identify Epics', () => {
         });
     });
     it('onMapClick do not trigger when mapinfo is not enabled', done => {
+        registerHook(GET_COORDINATES_FROM_PIXEL_HOOK, undefined);
+        registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, undefined);
         testEpic(addTimeoutEpic(onMapClick, 10), 1, [clickOnMap()], ([action]) => {
             if (action.type === TEST_TIMEOUT) {
                 done();

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -9,7 +9,7 @@
 const expect = require('expect');
 
 const { ZOOM_TO_POINT, clickOnMap, CHANGE_MAP_VIEW } = require('../../actions/map');
-const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, SET_CURRENT_EDIT_FEATURE_QUERY, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature, editLayerFeatures,updateFeatureInfoClickPoint } = require('../../actions/mapInfo');
+const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, SET_CURRENT_EDIT_FEATURE_QUERY, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature, editLayerFeatures, updateFeatureInfoClickPoint } = require('../../actions/mapInfo');
 const { getFeatureInfoOnFeatureInfoClick, zoomToVisibleAreaEpic, onMapClick, closeFeatureAndAnnotationEditing, handleMapInfoMarker, featureInfoClickOnHighligh, closeFeatureInfoOnCatalogOpenEpic, identifyEditLayerFeaturesEpic, hideMarkerOnIdentifyClose, onUpdateFeatureInfoClickPoint } = require('../identify').default;
 const { CLOSE_ANNOTATIONS } = require('../../actions/annotations');
 const { testEpic, TEST_TIMEOUT, addTimeoutEpic } = require('./epicTestUtils');
@@ -623,7 +623,7 @@ describe('identify Epics', () => {
             return [0, 5];
 
         });
-        registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, ([x, y]) => {
+        registerHook(GET_PIXEL_FROM_COORDINATES_HOOK, () => {
             return [0, 0];
         });
 

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -16,6 +16,7 @@ import {
     LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, GET_VECTOR_INFO,
     FEATURE_INFO_CLICK, CLOSE_IDENTIFY, TOGGLE_HIGHLIGHT_FEATURE,
     PURGE_MAPINFO_RESULTS, EDIT_LAYER_FEATURES,
+    UPDATE_FEATURE_INFO_CLICK_POINT,
     featureInfoClick, updateCenterToMarker, purgeMapInfoResults,
     exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo,
     noQueryableLayers, newMapInfoRequest, getVectorInfo,
@@ -47,7 +48,7 @@ import { floatingIdentifyDelaySelector } from '../selectors/localConfig';
 import { createControlEnabledSelector, measureSelector } from '../selectors/controls';
 import { localizedLayerStylesEnvSelector } from '../selectors/localizedLayerStyles';
 
-import {getBbox, getCurrentResolution, parseLayoutValue, getHook, GET_COORDINATES_FROM_PIXEL_HOOK} from '../utils/MapUtils';
+import {getBbox, getCurrentResolution, parseLayoutValue, getHook, GET_COORDINATES_FROM_PIXEL_HOOK, GET_PIXEL_FROM_COORDINATES_HOOK} from '../utils/MapUtils';
 import MapInfoUtils from '../utils/MapInfoUtils';
 import { IDENTIFY_POPUP } from '../components/map/popups';
 
@@ -57,6 +58,58 @@ const gridGeometryQuickFilter = state => get(find(getAttributeFilters(state), f 
 const stopFeatureInfo = state => stopGetFeatureInfoSelector(state) || isFeatureGridOpen(state) && (gridEditingSelector(state) || gridGeometryQuickFilter(state));
 
 import {getFeatureInfo} from '../api/identify';
+
+/**
+ * Recalculates pixel and geometric filter to allow also GFI emulation for WFS.
+ * This information is used also to switch to edit bode from GFI applying the same filter
+ * @param {object} point the point clicked, emitted by featureInfoClick action
+ * @param {string} projection map projection
+ */
+const updatePointWithGeometricFilter = (point, projection) => {
+    // calculate a query for edit
+    const lng = get(point, 'latlng.lng');
+    const lat = get(point, 'latlng.lat');
+    // update pixel if changed
+    const pos = reproject([lng, lat], 'EPSG:4326', projection);
+    const getPixel = getHook(GET_PIXEL_FROM_COORDINATES_HOOK);
+    let pixel;
+    if (getPixel) {
+        const [x, y] = getPixel([pos.x, pos.y]);
+        pixel = { x, y };
+    } else {
+        pixel = point.pixel;
+    }
+    const hook = getHook(GET_COORDINATES_FROM_PIXEL_HOOK);
+    const radius = calculateCircleRadiusFromPixel(
+        hook,
+        pixel,
+        pos,
+        5
+    );
+    // emulation of feature info filter to query WFS services (edit and/or WFS layer)
+    // TODO: evaluate to do this calculation at map level, so we can use this filter also in popups
+    const geometricFilter = {
+        type: 'geometry',
+        enabled: true,
+        value: {
+            geometry: {
+                center: [pos.x, pos.y],
+                coordinates: calculateCircleCoordinates(pos, radius, 12),
+                extent: [pos.x - radius, pos.y - radius, pos.x + radius, pos.y + radius],
+                projection,
+                radius,
+                type: "Polygon"
+            },
+            method: "Circle",
+            operation: "INTERSECTS"
+        }
+    };
+    return {
+        ...point,
+        pixel,
+        geometricFilter
+    };
+};
 
 /**
  * Epics for Identify and map info
@@ -170,43 +223,29 @@ export default {
             return disableAlwaysOn || !stopFeatureInfo(store.getState() || {});
         })
             .switchMap(({point, layer}) => {
-                // calculate a query for edit
-                const lng = get(point, 'latlng.lng');
-                const lat = get(point, 'latlng.lat');
                 const projection = projectionSelector(store.getState());
-                const pos = reproject([lng, lat], 'EPSG:4326', projection);
-                const hook = getHook(GET_COORDINATES_FROM_PIXEL_HOOK);
-                const radius = calculateCircleRadiusFromPixel(
-                    hook,
-                    get(point, 'pixel'),
-                    pos,
-                    3
-                );
-                // emulation of feature info filter to query WFS services (edit and/or WFS layer)
-                // TODO: evaluate to do this calculation at map level, so we can use this filter also in popups
-                const geometricFilter = {
-                    type: 'geometry',
-                    enabled: true,
-                    value: {
-                        geometry: {
-                            center: [pos.x, pos.y],
-                            coordinates: calculateCircleCoordinates(pos, radius, 12),
-                            extent: [pos.x - radius, pos.y - radius, pos.x + radius, pos.y + radius],
-                            projection,
-                            radius,
-                            type: "Polygon"
-                        },
-                        method: "Circle",
-                        operation: "INTERSECTS"
-                    }
-                };
-
-                return Rx.Observable.of(featureInfoClick({ ...point, geometricFilter}, layer))
+                return Rx.Observable.of(featureInfoClick(updatePointWithGeometricFilter(point, projection), layer))
                     .merge(Rx.Observable.of(addPopup(uuid(),
                         { component: IDENTIFY_POPUP, maxWidth: 600, position: {  coordinates: point ? point.rawPos : []}}))
                         .filter(() => isMapPopup(store.getState()))
                     );
             }),
+    /**
+     * Reacts to an update of FeatureInfo coordinates recalculating geometry filter from the map and re-trigger the feature info.
+     */
+    onUpdateFeatureInfoClickPoint: (action$, {getState = () => {}} = {}) =>
+        action$.ofType(UPDATE_FEATURE_INFO_CLICK_POINT)
+            .map(({ point }) => {
+                const projection = projectionSelector(getState());
+                return {
+                    point: updatePointWithGeometricFilter(point, projection)
+                };
+            })
+            // recover old parameters of last featureInfoClick and re-trigger the action
+            .withLatestFrom(action$.ofType(FEATURE_INFO_CLICK), ({point}, lastAction) => ({
+                ...lastAction,
+                point
+            })),
     /**
      * triggers click again when highlight feature is enabled, to download the feature.
      */

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -61,7 +61,7 @@ import {getFeatureInfo} from '../api/identify';
 
 /**
  * Recalculates pixel and geometric filter to allow also GFI emulation for WFS.
- * This information is used also to switch to edit bode from GFI applying the same filter
+ * This information is used also to switch to edit mode (feature grid) from GFI applying the same filter
  * @param {object} point the point clicked, emitted by featureInfoClick action
  * @param {string} projection map projection
  */

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -87,7 +87,6 @@ const updatePointWithGeometricFilter = (point, projection) => {
         5
     );
     // emulation of feature info filter to query WFS services (edit and/or WFS layer)
-    // TODO: evaluate to do this calculation at map level, so we can use this filter also in popups
     const geometricFilter = {
         type: 'geometry',
         enabled: true,

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -18,7 +18,7 @@ const { generalInfoFormatSelector, clickPointSelector, indexSelector, responsesS
 const { isEditingAllowedSelector } = require('../selectors/featuregrid');
 
 
-const { hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults, featureInfoClick, changeFormat, toggleShowCoordinateEditor, changePage, toggleHighlightFeature, editLayerFeatures} = require('../actions/mapInfo');
+const { hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults, updateFeatureInfoClickPoint, changeFormat, toggleShowCoordinateEditor, changePage, toggleHighlightFeature, editLayerFeatures} = require('../actions/mapInfo');
 const { changeMousePointer, zoomToExtent, registerEventListener, unRegisterEventListener} = require('../actions/map');
 
 
@@ -185,7 +185,7 @@ const IdentifyPlugin = compose(
     connect(selector, {
         purgeResults: purgeMapInfoResults,
         closeIdentify,
-        onSubmitClickPoint: featureInfoClick,
+        onSubmitClickPoint: updateFeatureInfoClickPoint,
         onToggleShowCoordinateEditor: toggleShowCoordinateEditor,
         onChangeFormat: changeFormat,
         changeMousePointer,


### PR DESCRIPTION
## Description
Fix issue reported in this comment

https://github.com/geosolutions-it/MapStore2/issues/5220#issuecomment-627388964

The problem was caused by the Identify coordinate editor that triggered directly `FEATURE_INFO_CLICK`, without recalculating the geometric fitler (the geometric filter is an emulation of featureinfo query created as a circlular spatial filter of 5 px radius on the map, using mapUtils hooks)
I solved creating another action dedicated to feature info point update and an epic that recalculates the geometricFilter and triggers the last `FEATURE_INFO_CLICK` action, as it happens on map click.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5220 

**What is the current behavior?**
See comment https://github.com/geosolutions-it/MapStore2/issues/5220#issuecomment-627388964


**What is the new behavior?**
Now pixel and geometric filter that emulates WFS FeatureInfo is updated when lat/lon are updated.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
