### PR TITLE
issue 5280 - geostory settings improvements

### DIFF
--- a/web/client/components/geostory/common/map/Controls.jsx
+++ b/web/client/components/geostory/common/map/Controls.jsx
@@ -86,6 +86,7 @@ export const Controls = ({
             />
             {options.mapInfoControl && <FeatureInfoFormatSelector
                 disabled={!options.mapInfoControl}
+                popoverMessage="geostory.builder.settings.templateTooltip"
                 infoFormat={options.mapOptions && options.mapOptions.mapInfoFormat || "application/json"}
                 onInfoFormatChange={(format) => onChangeMap("mapOptions.mapInfoFormat", format)}
                 selectProps={{

--- a/web/client/components/misc/FeatureInfoFormatSelector.jsx
+++ b/web/client/components/misc/FeatureInfoFormatSelector.jsx
@@ -11,12 +11,15 @@ import PropTypes from 'prop-types';
 import MapInfoUtils from '../../utils/MapInfoUtils';
 import Select from "react-select";
 import { FormGroup, ControlLabel } from 'react-bootstrap';
+import ControlledPopover from '../widgets/widget/ControlledPopover';
+import HTML from '../I18N/HTML';
 
 function FeatureInfoFormatSelector({
     id,
     label,
     infoFormat,
     availableInfoFormat,
+    popoverMessage,
     disabled,
     onInfoFormatChange,
     selectProps
@@ -38,6 +41,8 @@ function FeatureInfoFormatSelector({
     }));
 
     const select = (
+        <>
+        &nbsp;  {popoverMessage && <ControlledPopover text={<HTML msgId={popoverMessage} />} /> }
         <Select
             { ...selectProps }
             id={id}
@@ -46,7 +51,7 @@ function FeatureInfoFormatSelector({
             disabled={disabled}
             options={options}
             onChange={(selected) => onInfoFormatChange(selected?.value)}
-        />
+        /></>
     );
 
     return label
@@ -64,6 +69,7 @@ FeatureInfoFormatSelector.propTypes = {
     label: PropTypes.oneOfType([PropTypes.func, PropTypes.string, PropTypes.object]),
     availableInfoFormat: PropTypes.object,
     infoFormat: PropTypes.string,
+    popoverMessage: PropTypes.string,
     onInfoFormatChange: PropTypes.func,
     disabled: PropTypes.bool,
     selectProps: PropTypes.object
@@ -73,6 +79,7 @@ FeatureInfoFormatSelector.defaultProps = {
     id: "mapstore-feature-format-selector",
     availableInfoFormat: MapInfoUtils.getAvailableInfoFormat(),
     infoFormat: MapInfoUtils.getDefaultInfoFormatValue(),
+    popoverMessage: "",
     onInfoFormatChange: function() {},
     selectProps: {}
 };

--- a/web/client/components/widgets/widget/ControlledPopover.jsx
+++ b/web/client/components/widgets/widget/ControlledPopover.jsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useState, useRef} from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import {
+    Popover,
+    Glyphicon,
+    Button
+} from 'react-bootstrap';
+
+import Overlay from '../../misc/Overlay';
+/**
+ * ControlledPopover. A component that renders a icon with a Popover
+ * it uses:
+ * - mouseEnter on glyph to open
+ * - click to close
+ * it supports fixed text with clickable link
+ * @prop {string} title the title of popover
+ * @prop {string|function} text the text of popover (can be a component, like I18N.HTML)
+ * @prop {string} glyph glyph id for the icon
+ * @prop {number} left left prop of popover
+ * @prop {number} right right prop of popover
+ * @prop {string} placement position of popover
+ */
+const ControlledPopover = ({
+    text,
+    placement,
+    bsStyle,
+    left,
+    top,
+    title,
+    glyph,
+    id
+}) => {
+    const trigger = useRef();
+    const [show, setShow] = useState(false);
+    return (
+        <span className="mapstore-info-popover">
+            <Glyphicon
+                onMouseEnter={() => {
+                    setShow(true);
+                }}
+                ref={(popover) => {
+                    trigger.current = popover;
+                }}
+                className={`text-${bsStyle}`}
+                glyph={glyph} />
+            <Overlay placement={placement} show={show} target={() => ReactDOM.findDOMNode(trigger.current)}>
+                <Popover
+                    id={id}
+                    placement={placement}
+                    positionLeft={left}
+                    positionTop={top}
+                    title={title}>
+                    <div style={{display: "flex"}}>
+                        <div>{text}</div>
+                        <Button className="no-border" style={{alignSelf: "flex-start"}} onClick={() => {
+                            setShow(false);
+                        }}><Glyphicon glyph="1-close"/></Button>
+
+                    </div>
+                </Popover>
+            </Overlay>
+        </span>
+    );
+};
+
+ControlledPopover.propTypes = {
+    id: PropTypes.string,
+    title: PropTypes.string,
+    text: PropTypes.string,
+    glyph: PropTypes.string,
+    bsStyle: PropTypes.string,
+    placement: PropTypes.string,
+    left: PropTypes.number,
+    top: PropTypes.number,
+    trigger: PropTypes.oneOfType([PropTypes.array, PropTypes.bool])
+};
+
+ControlledPopover.defaultProps = {
+    id: '',
+    title: '',
+    text: '',
+    placement: 'right',
+    left: 200,
+    top: 50,
+    glyph: "question-sign",
+    bsStyle: 'info'
+};
+
+export default ControlledPopover;

--- a/web/client/components/widgets/widget/ControlledPopover.jsx
+++ b/web/client/components/widgets/widget/ControlledPopover.jsx
@@ -7,7 +7,6 @@
  */
 
 import React, {useState, useRef} from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import {
     Popover,
@@ -52,7 +51,7 @@ const ControlledPopover = ({
                 }}
                 className={`text-${bsStyle}`}
                 glyph={glyph} />
-            <Overlay placement={placement} show={show} target={() => ReactDOM.findDOMNode(trigger.current)}>
+            <Overlay placement={placement} show={show} target={() => trigger.current}>
                 <Popover
                     id={id}
                     placement={placement}

--- a/web/client/components/widgets/widget/ControlledPopover.jsx
+++ b/web/client/components/widgets/widget/ControlledPopover.jsx
@@ -41,7 +41,7 @@ const ControlledPopover = ({
     const trigger = useRef();
     const [show, setShow] = useState(false);
     return (
-        <span className="mapstore-info-popover">
+        <span className="mapstore-info-popover" onMouseLeave={() => setShow(false)}>
             <Glyphicon
                 onMouseEnter={() => {
                     setShow(true);
@@ -59,11 +59,7 @@ const ControlledPopover = ({
                     positionTop={top}
                     title={title}>
                     <div style={{display: "flex"}}>
-                        <div>{text}</div>
-                        <Button className="no-border" style={{alignSelf: "flex-start"}} onClick={() => {
-                            setShow(false);
-                        }}><Glyphicon glyph="1-close"/></Button>
-
+                        {text}
                     </div>
                 </Popover>
             </Overlay>

--- a/web/client/components/widgets/widget/ControlledPopover.jsx
+++ b/web/client/components/widgets/widget/ControlledPopover.jsx
@@ -10,8 +10,7 @@ import React, {useState, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {
     Popover,
-    Glyphicon,
-    Button
+    Glyphicon
 } from 'react-bootstrap';
 
 import Overlay from '../../misc/Overlay';

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2118,7 +2118,8 @@
                     "autoplayIntervalPlaceholder": "Aktivieren Sie das Autoplay-Intervall",
                     "navbar": "Navigationsleiste",
                     "showNavbar": "Navigationsleiste anzeigen",
-                    "theme": "Thema"
+                    "theme": "Thema",
+                    "templateTooltip":"Mit dem erweiterten Karteneditor kann eine benutzerdefinierte Vorlage für jede Ebene konfiguriert werden (siehe Stiftsymbol).Weitere Informationen finden Sie in der <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>Bedienungsanleitung</a>"
                 }
             },
             "errors": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2123,7 +2123,8 @@
                     "autoplayIntervalPlaceholder" : "Enable autoplay interval",
                     "navbar" : "Navigation bar",
                     "showNavbar" : "Show navbar",
-                    "theme": "Theme"
+                    "theme": "Theme",
+                    "templateTooltip":"It is possible to configure a custom template for each layer using the advanced map editor (see pencil icon). For more info check the <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>user guide</a>"
                 }
             },
             "errors": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2119,7 +2119,8 @@
                     "autoplayIntervalPlaceholder": "Habilitar intervalo de reproducción automática",
                     "navbar": "Barra de navegación",
                     "showNavbar": "Mostrar barra de navegación",
-                    "theme": "Tema"
+                    "theme": "Tema",
+                    "templateTooltip":"Es posible configurar una plantilla personalizada para cada capa utilizando el editor de mapas avanzado (ver icono de lápiz). Para más información consulte la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guía del usuario</a>"
                 }
             },
             "errors": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2118,7 +2118,8 @@
                     "autoplayIntervalPlaceholder": "Activer l'intervalle de lecture automatique",
                     "navbar": "Barre de navigation",
                     "showNavbar": "Afficher la barre de navigation",
-                    "theme": "Thème"
+                    "theme": "Thème",
+                    "templateTooltip":"Il est possible de configurer un modèle personnalisé pour chaque couche à l'aide de l'éditeur de carte avancé (voir l'icône crayon). Pour plus d'informations, consultez le <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guide de l'utilisateur</a>"
                 }
             },
             "errors": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2113,14 +2113,14 @@
                     "title": "Titolo",
                     "titlePlaceholder": "Inserisci titolo",
                     "logo": "Logo",
-                    "logoPlaceholder": "Inserisci sorgente del logo (formato immagine)",
                     "autoplay": "Autoplay",
                     "enableAutoplay": "Abilita Autoplay",
                     "autoplayInterval": "Intervallo dell'autoplay (secondi)",
                     "autoplayIntervalPlaceholder": "Abilita l'intervallo dell'autoplay",
                     "navbar": "Barra di navigazione",
                     "showNavbar": "Mostra barra di navigazione",
-                    "theme": "Tema"
+                    "theme": "Tema",
+                    "templateTooltip":"E' possibile configurare un modello custom per ogni livello usando l'edito di mappa avanzato (vedi icona matita). Per maggiori informazioni vedi la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guida utente</a>"
                 }
             },
             "errors": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This pr introduces a popover for identify functionality in geostory inline map editor panel.

![166 template custom settings geostory](https://user-images.githubusercontent.com/11991428/81923371-dc9fe980-95dd-11ea-8cd1-2deb3a9fc3c5.gif)

The text in the gif is little outdated, but the important thing is that we needed a popover that would stay opened because of the clickable link

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5280

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see previous gif

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
