### PR TITLE
#5291: Workaround to make hash links working

### DIFF
--- a/docma-template/js/app.js
+++ b/docma-template/js/app.js
@@ -247,6 +247,12 @@
 
     docma.on('render', function (currentRoute) {
 
+        // CUSTOMIZATION: workaround to fix hash links that was not working anymore
+        var old = window.location.hash;
+        window.location.hash = "";
+        window.location.hash = old;
+        // end of workaround
+
         $('[data-toggle="tooltip"]').tooltip({
             container: 'body',
             placement: 'bottom'


### PR DESCRIPTION
## Description
Adding workaround to restore internal linking by hash that was not working anymore. 

I added only a workaround because we need to update doc tools at all in the future, so doing a clean maintainable fix could be unuseful due to future changes.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5291

**What is the new behavior?**
Now links in docma work

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->
