### PR TITLE
Fix 5308 Web Page section size 

### DIFF
--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -28,6 +28,10 @@
 @ms-story-size-height-medium: 575px;
 @ms-story-size-height-small: 350px;
 
+@ms-web-page-size-height-large: 1080px;
+@ms-web-page-size-height-medium: 900px;
+@ms-web-page-size-height-small: 720px;
+
 .ms-story-align-center { margin-left: auto; margin-right: auto; }
 /* mixin for align*/
 .ms-story-align-left { margin-left: 0; margin-right: auto; }
@@ -605,13 +609,19 @@
                         width: 100%;
                     }
                 }
-                .ms-content.ms-content-webPage,
                 .ms-content.ms-content-map {
                     width: 100%;
                     height: 350px;
                     &.ms-size-large { height: @ms-story-size-height-large; }
                     &.ms-size-medium { height: @ms-story-size-height-medium; }
                     &.ms-size-small { height: @ms-story-size-height-small; }
+                }
+                .ms-content.ms-content-webPage {
+                    width: 100%;
+                    height: @ms-web-page-size-height-small;
+                    &.ms-size-large { height: @ms-web-page-size-height-large; }
+                    &.ms-size-medium { height: @ms-web-page-size-height-medium; }
+                    &.ms-size-small { height: @ms-web-page-size-height-small; }
                 }
                 .ms-content.ms-content-video {
                     width: 100%;
@@ -697,13 +707,20 @@
                         right: 20px;
                     }
                 }
-                .ms-content.ms-content-webPage,
                 .ms-content.ms-content-map {
                     width: 100%;
                     height: 350px;
                     &.ms-size-large { height: @ms-story-size-height-large; }
                     &.ms-size-medium { height: @ms-story-size-height-medium; }
                     &.ms-size-small { height: @ms-story-size-height-small; }
+                }
+
+                .ms-content.ms-content-webPage {
+                    width: 100%;
+                    height: @ms-web-page-size-height-small;
+                    &.ms-size-large { height: @ms-web-page-size-height-large; }
+                    &.ms-size-medium { height: @ms-web-page-size-height-medium; }
+                    &.ms-size-small { height: @ms-web-page-size-height-small; }
                 }
 
                 .ms-content.ms-content-video {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR updates sizes of web page contents in stories

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Style update

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5308

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Sizes of web page are:
- small 720px
![image](https://user-images.githubusercontent.com/19175505/82672519-be229980-9c40-11ea-84c1-7b7aca6f0b7d.png)

- medium 900px
![image](https://user-images.githubusercontent.com/19175505/82672569-cda1e280-9c40-11ea-8d66-b36e8972dc8d.png)

- large 1080px
![image](https://user-images.githubusercontent.com/19175505/82672613-d98da480-9c40-11ea-831b-a441db0c6e3d.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
