### PR TITLE
Fix 5326 Improve add group action to support override of options

### DIFF
--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -341,7 +341,7 @@ describe('Test correctness of the layers actions', () => {
         const action = addGroup(options.id, undefined, options);
         expect(action.type).toBe(ADD_GROUP);
         expect(action.group).toBe(options.id);
-        expect(action.parent).toNotExist();
-        expect(action.options).toBe(options);
+        expect(action.parent).toBeFalsy();
+        expect(action.options).toEqual(options);
     });
 });

--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -331,4 +331,17 @@ describe('Test correctness of the layers actions', () => {
         expect(action.group).toBe('newgroup');
         expect(action.parent).toBe('group1.group2');
     });
+
+    it('add group with options', () => {
+        const options = {
+            id: 'uuid',
+            title: 'My title',
+            expanded: true
+        };
+        const action = addGroup(options.id, undefined, options);
+        expect(action.type).toBe(ADD_GROUP);
+        expect(action.group).toBe(options.id);
+        expect(action.parent).toNotExist();
+        expect(action.options).toBe(options);
+    });
 });

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -183,7 +183,14 @@ function addLayer(layer, foreground = true) {
         foreground
     };
 }
-
+/**
+ * Add a new group
+ * @memberof actions.layers
+ * @function
+ * @param {string} group title of group
+ * @param {string} parent parent group described with dot notation (eg parent.nested )
+ * @param {object} options override all option of a group while adding it
+ */
 function addGroup(group, parent, options) {
     return {
         type: ADD_GROUP,

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -189,7 +189,7 @@ function addLayer(layer, foreground = true) {
  * @function
  * @param {string} group title of group
  * @param {string} parent parent group described with dot notation (eg parent.nested )
- * @param {object} options override all option of a group while adding it
+ * @param {object} options Additional properties to assign to the group. They will override the default ones.
  */
 function addGroup(group, parent, options) {
     return {

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -184,11 +184,12 @@ function addLayer(layer, foreground = true) {
     };
 }
 
-function addGroup(group, parent) {
+function addGroup(group, parent, options) {
     return {
         type: ADD_GROUP,
         group,
-        parent
+        parent,
+        options
     };
 }
 

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -883,6 +883,30 @@ describe('Test the layers reducer', () => {
         expect(newgroup1.id).toNotBe(newgroup2.id);
     });
 
+    it('use controlled options on add group', () => {
+        const options = {
+            id: 'uniq_id',
+            title: 'Group Title',
+            name: 'uniq_id'
+        };
+        const state = layers(
+            {
+                groups: [{
+                    id: 'group1',
+                    nodes: []
+                }]
+            },
+            addGroup(options.title, 'group1', options)
+        );
+        expect(state).toExist();
+        expect(state.groups.length).toBe(1);
+        expect(state.groups[0].nodes.length).toBe(1);
+        const newNode = state.groups[0].nodes[0];
+        expect(newNode.id).toBe(options.id);
+        expect(newNode.title).toBe(options.title);
+        expect(newNode.name).toBe(options.name);
+    });
+
     it('move groups when two are with the same title', () => {
         const action = moveNode('groupid1.groupid2', 'Default', 0);
         const state = layers({

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -343,7 +343,8 @@ function layers(state = { flat: [] }, action) {
             title: action.group,
             name: id,
             nodes: [],
-            expanded: true
+            expanded: true,
+            ...action.options
         }, action.parent);
         return assign({}, state, {
             groups: newGroups


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds a new parameter to `addGroup` action called `options`.
The `options` parameter will override generated option of group.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Other... Please describe: Improvement of existing action

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5326

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
