### PR TITLE
#5312: Support for WMTS with not sorted matrix sets

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -798,7 +798,138 @@ describe('Leaflet layer', () => {
 
         expect(layer.layer.wmsParams['ms2-authkey']).toBe("########-####-$$$$-####-###########");
     });
-
+    it('tile matrix set and ids must be sorted to match each other', () => {
+        const tileMatrix = [{
+            "ows:Identifier": "0",
+            "ScaleDenominator": "17471320.75089746",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "1",
+            "MatrixHeight": "1"
+        },
+        {
+            "ows:Identifier": "2",
+            "ScaleDenominator": "4367830.187724365",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "4",
+            "MatrixHeight": "4"
+        },
+        {
+            "ows:Identifier": "1",
+            "ScaleDenominator": "8735660.37544873",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "2",
+            "MatrixHeight": "2"
+        },
+        {
+            "ows:Identifier": "3",
+            "ScaleDenominator": "2183915.0938621825",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "8",
+            "MatrixHeight": "8"
+        }];
+        const options = {
+            type: 'wmts',
+            visibility: false,
+            name: 'nurc:Arc_Sample',
+            group: 'Meteo',
+            format: 'image/png',
+            requestEncoding: "RESTful",
+            tileMatrixSet: [
+                {
+                    'ows:Identifier': 'EPSG:3857',
+                    'ows:SupportedCRS': 'urn:ogc:def:crs:EPSG::3857',
+                    TileMatrix: tileMatrix
+                }
+            ],
+            url: 'http://sample.server/geoserver/gwc/service/wmts'
+        };
+        const layer = ReactDOM.render(<LeafLetLayer
+            type="wmts"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+        const sortedTileMatrix = [...tileMatrix].sort((a, b) => Number(b.ScaleDenominator) - Number(a.ScaleDenominator));
+        sortedTileMatrix.map((v, i) => expect("EPSG:3857:" + v["ows:Identifier"]).toEqual(layer.layer.matrixIds[i].identifier));
+        layer.layer.matrixSet.map((v, i) => expect(v["ows:Identifier"]).toEqual(sortedTileMatrix[i]["ows:Identifier"]));
+    });
+    it('limited Ids array should provide the same number resolutions, sizes (that have to match), even with wrong sorting...', () => {
+        const tileMatrix = [{
+            "ows:Identifier": "0",
+            "ScaleDenominator": "17471320.75089746",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "1",
+            "MatrixHeight": "1"
+        },
+        {
+            "ows:Identifier": "2",
+            "ScaleDenominator": "4367830.187724365",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "4",
+            "MatrixHeight": "4"
+        },
+        {
+            "ows:Identifier": "1",
+            "ScaleDenominator": "8735660.37544873",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "2",
+            "MatrixHeight": "2"
+        },
+        {
+            "ows:Identifier": "3",
+            "ScaleDenominator": "2183915.0938621825",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "8",
+            "MatrixHeight": "8"
+        }];
+        const options = {
+            type: 'wmts',
+            visibility: false,
+            name: 'nurc:Arc_Sample',
+            group: 'Meteo',
+            format: 'image/png',
+            requestEncoding: "RESTful",
+            matrixIds: {
+                'EPSG:3857': [{
+                    identifier: '0'
+                }, {
+                    identifier: '1'
+                }]
+            },
+            tileMatrixSet: [
+                {
+                    'ows:Identifier': 'EPSG:3857',
+                    'ows:SupportedCRS': 'urn:ogc:def:crs:EPSG::3857',
+                    TileMatrix: tileMatrix
+                }
+            ],
+            url: 'http://sample.server/geoserver/gwc/service/wmts'
+        };
+        const layer = ReactDOM.render(<LeafLetLayer
+            type="wmts"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+        const sortedTileMatrix = [...tileMatrix].sort((a, b) => Number(b.ScaleDenominator) - Number(a.ScaleDenominator));
+        // they should have the same order and be a sub set
+        layer.layer.matrixIds.map((v, i) => expect(v.identifier).toEqual(sortedTileMatrix[i]["ows:Identifier"]));
+        layer.layer.matrixSet.map((v, i) => expect(v["ows:Identifier"]).toEqual(sortedTileMatrix[i]["ows:Identifier"]));
+    });
     it('test wmts security token', () => {
         const options = {
             type: 'wmts',

--- a/web/client/components/map/leaflet/plugins/WMTSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMTSLayer.js
@@ -13,7 +13,7 @@ import assign from 'object-assign';
 import SecurityUtils from '../../../../utils/SecurityUtils';
 import WMTSUtils from '../../../../utils/WMTSUtils';
 import WMTS from '../../../../utils/leaflet/WMTS';
-import { isArray, isObject, head } from 'lodash';
+import { isArray } from 'lodash';
 import { isVectorFormat } from '../../../../utils/VectorTileUtils';
 
 L.tileLayer.wmts = function(urls, options, matrixOptions) {
@@ -42,10 +42,6 @@ function getWMSURLs(urls) {
     return urls.map((url) => url.split("\?")[0]);
 }
 
-function getMatrixIds(matrix, srs) {
-    return isObject(matrix) && matrix[srs] || matrix;
-}
-
 const createLayer = options => {
     const urls = getWMSURLs(isArray(options.url) ? options.url : [options.url]);
     const queryParameters = wmtsToLeafletOptions(options) || {};
@@ -58,7 +54,7 @@ const createLayer = options => {
         originX: options.originX || -20037508.3428,
         ignoreErrors: options.ignoreErrors || false,
         // TODO: use matrix IDs sorted from getTileMatrix
-        matrixIds: options.matrixIds && getMatrixIds(options.matrixIds, queryParameters.tileMatrixSet || srs) || null,
+        matrixIds: matrixIds,
         matrixSet: tileMatrixSet
     });
 };

--- a/web/client/components/map/leaflet/plugins/WMTSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMTSLayer.js
@@ -51,13 +51,15 @@ const createLayer = options => {
     const queryParameters = wmtsToLeafletOptions(options) || {};
     urls.forEach(url => SecurityUtils.addAuthenticationParameter(url, queryParameters, options.securityToken));
     const srs = CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS);
+    const { tileMatrixSet, matrixIds } = WMTSUtils.getTileMatrix(options, srs);
     return L.tileLayer.wmts(urls, queryParameters, {
         tileMatrixPrefix: options.tileMatrixPrefix || queryParameters.tileMatrixSet + ':' || srs + ':',
         originY: options.originY || 20037508.3428,
         originX: options.originX || -20037508.3428,
         ignoreErrors: options.ignoreErrors || false,
+        // TODO: use matrix IDs sorted from getTileMatrix
         matrixIds: options.matrixIds && getMatrixIds(options.matrixIds, queryParameters.tileMatrixSet || srs) || null,
-        matrixSet: head(options.tileMatrixSet.filter(t => t['ows:Identifier'] === queryParameters.tileMatrixSet)) || null
+        matrixSet: tileMatrixSet
     });
 };
 

--- a/web/client/components/map/openlayers/plugins/WMTSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMTSLayer.js
@@ -11,7 +11,6 @@ import Layers from '../../../../utils/openlayers/Layers';
 import castArray from 'lodash/castArray';
 import head from 'lodash/head';
 import last from 'lodash/last';
-import sortBy from 'lodash/sortBy';
 
 
 import SecurityUtils from '../../../../utils/SecurityUtils';
@@ -53,7 +52,7 @@ const createLayer = options => {
     const projection = get(srs);
     const metersPerUnit = projection.getMetersPerUnit();
     const { tileMatrixSetName, tileMatrixSet, matrixIds } = WMTSUtils.getTileMatrix(options, srs);
-    const scales = tileMatrixSet && tileMatrixSet.TileMatrix.map(t => Number(t.ScaleDenominator));
+    const scales = tileMatrixSet && tileMatrixSet?.TileMatrix.map(t => Number(t.ScaleDenominator));
     const mapResolutions = MapUtils.getResolutions();
     /*
      * WMTS assumes a DPI 90.7 instead of 96 as documented in the WMTSCapabilities document:
@@ -125,7 +124,7 @@ const createLayer = options => {
             origins,
             origin: !origins ? [20037508.3428, -20037508.3428] : undefined, // Either origin or origins must be configured, never both.
             resolutions,
-            matrixIds: WMTSUtils.limitMatrix(matrixIds || WMTSUtils.getDefaultMatrixId(options), resolutions.length),
+            matrixIds: WMTSUtils.limitMatrix((matrixIds || WMTSUtils.getDefaultMatrixId(options) || []).map((el) => el.identifier), resolutions.length),
             sizes,
             extent,
             tileSizes,

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -19,7 +19,7 @@ describe('Test the WMTSUtils', () => {
             }]
         }, 'EPSG:4326');
         expect(ids.length).toBe(1);
-        expect(ids[0]).toBe('EPSG:4326');
+        expect(ids[0].identifier).toBe('EPSG:4326');
     });
 
     it('get matrix ids with array', () => {
@@ -27,7 +27,7 @@ describe('Test the WMTSUtils', () => {
             identifier: 'EPSG:4326'
         }], 'EPSG:4326');
         expect(ids.length).toBe(1);
-        expect(ids[0]).toBe('EPSG:4326');
+        expect(ids[0].identifier).toBe('EPSG:4326');
     });
 
     it('wmts kvp', (done) => {


### PR DESCRIPTION
## Description
Matrix set in
https://wxs.ign.fr/choisirgeoportail/geoportail/wmts  
are not sorted by ScaleDenominator. 
This causes issues in openlayers because resolutions (calculated from that valuses) must be in order. Fixing this order required to fix the order of other derived information, so I had to restructure it a little to provide all values always in the same order.

Moreover other layers from this server (i.e. altitude) has a limited set of tileMatrixIds. These layers was not working too, because filtering ids caused misalignment between the sizes, origins and so on. 
In Leaflet too, these layers had problems because of the same misalignment and sorting reasons. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5312 

**What is the new behavior?**
The layer from the server are now visible

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information