### PR TITLE
C125-164: Import annotation layer via Map menu

### DIFF
--- a/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
+++ b/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
@@ -19,7 +19,8 @@ const {
     getGpxFile,
     getGeoJsonFile,
     getMapFile,
-    getUnsupportedMapFile
+    getUnsupportedMapFile,
+    getAnnotationGeoJsonFile
 } = require('./testData');
 
 const rxjsConfig = require('recompose/rxjsObservableConfig').default;
@@ -129,6 +130,24 @@ describe('processFiles enhancer', () => {
             expect(props).toExist();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
+                done();
+            }
+        }));
+        ReactDOM.render(<Sink />, document.getElementById("container"));
+    });
+    it('processFiles read annotation geojson', (done) => {
+        const Sink = compose(
+            processFiles,
+            mapPropsStream(props$ => props$.merge(
+                props$
+                    .take(1)
+                    .switchMap(({ onDrop = () => { } }) => getAnnotationGeoJsonFile().map((file) => onDrop([file]))).ignoreElements()))
+        )(createSink(props => {
+            expect(props).toExist();
+            if (props.files) {
+                expect(props.files.layers.length).toBe(1);
+                expect(props.files.layers[0].name).toBe("Annotations");
+                expect(props.files.layers[0].features).toExist();
                 done();
             }
         }));

--- a/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
+++ b/web/client/components/import/dragZone/enhancers/__tests__/processFiles-test.jsx
@@ -38,7 +38,7 @@ describe('processFiles enhancer', () => {
     });
     it('processFiles rendering with defaults', (done) => {
         const Sink = processFiles(createSink( props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             done();
         }));
         ReactDOM.render(<Sink />, document.getElementById("container"));
@@ -48,7 +48,7 @@ describe('processFiles enhancer', () => {
             processFiles,
             mapPropsStream(props$ => props$.merge(props$.take(1).do(({ onDrop = () => { } }) => onDrop(["ABC"])).ignoreElements()))
         )(createSink( props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.error) {
                 done();
             }
@@ -63,7 +63,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getShapeFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 done();
@@ -79,7 +79,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getKmzFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 done();
@@ -95,7 +95,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getGpxFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 done();
@@ -111,7 +111,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getKmlFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 done();
@@ -127,7 +127,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getGeoJsonFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 done();
@@ -143,11 +143,11 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getAnnotationGeoJsonFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 expect(props.files.layers[0].name).toBe("Annotations");
-                expect(props.files.layers[0].features).toExist();
+                expect(props.files.layers[0].features).toBeTruthy();
                 done();
             }
         }));
@@ -161,7 +161,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getGeoJsonFile("file.geojson").map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(1);
                 done();
@@ -177,7 +177,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getMapFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.files) {
                 expect(props.files.layers.length).toBe(0);
                 expect(props.files.maps.length).toBe(1);
@@ -194,7 +194,7 @@ describe('processFiles enhancer', () => {
                     .take(1)
                     .switchMap(({ onDrop = () => { } }) => getUnsupportedMapFile().map((file) => onDrop([file]))).ignoreElements()))
         )(createSink(props => {
-            expect(props).toExist();
+            expect(props).toBeTruthy();
             if (props.error) {
                 done();
             }

--- a/web/client/components/import/dragZone/enhancers/__tests__/testData.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/testData.js
@@ -8,15 +8,16 @@ const GPX_FILE_URL = require('file-loader!../../../../../test-resources/caput-mu
 const KMZ_FILE_URL = require('file-loader!../../../../../test-resources/caput-mundi/caput-mundi.kmz');
 const KML_FILE_URL = require('file-loader!../../../../../test-resources/caput-mundi/caput-mundi.kml');
 const GEO_JSON_FILE_URL = require('file-loader!../../../../../test-resources/caput-mundi/caput-mundi.geojson');
+const ANNOTATION_GEO_JSON_FILE_URL = require('file-loader!../../../../../test-resources/caput-mundi/caput-mundi.config');
 const MAP_FILE = require('file-loader!../../../../../test-resources/map.config');
 const UNSUPPORTED_MAP_FILE = require('file-loader!../../../../../test-resources/unsupportedMap.config');
 const getFile = (url, fileName = "file") =>
     Rx.Observable.defer( () => axios.get(url, {
         responseType: 'arraybuffer'
     }))
-        .map( res =>
-            new File([new Blob([res.data], {type: res.headers['response-type']})], fileName)
-        );
+        .map( res => {
+            return new File([new Blob([res.data], {type: res.headers['response-type']})], fileName);
+        });
 
 module.exports = {
     // PDF_FILE: new File(b64toBlob('UEsDBAoAAAAAACGPaktDvrfoAQAAAAEAAAAKAAAAc2FtcGxlLnR4dGFQSwECPwAKAAAAAAAhj2pLQ7636AEAAAABAAAACgAkAAAAAAAAACAAAAAAAAAAc2FtcGxlLnR4dAoAIAAAAAAAAQAYAGILh+1EWtMBy3f86URa0wHLd/zpRFrTAVBLBQYAAAAAAQABAFwAAAApAAAAAAA=', 'application/pdf'), "file.pdf"),
@@ -25,6 +26,7 @@ module.exports = {
     getKmlFile: () => getFile(KML_FILE_URL, "file.kml"),
     getKmzFile: () => getFile(KMZ_FILE_URL, "file.kmz"),
     getGeoJsonFile: (name = "file.json") => getFile(GEO_JSON_FILE_URL, name),
+    getAnnotationGeoJsonFile: () => getFile(ANNOTATION_GEO_JSON_FILE_URL, "file.json"),
     getMapFile: () => getFile(MAP_FILE, "map.json"),
     getUnsupportedMapFile: () => getFile(UNSUPPORTED_MAP_FILE, "unsupportedMap.json")
 };

--- a/web/client/components/import/dragZone/enhancers/__tests__/testData.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/testData.js
@@ -26,7 +26,7 @@ module.exports = {
     getKmlFile: () => getFile(KML_FILE_URL, "file.kml"),
     getKmzFile: () => getFile(KMZ_FILE_URL, "file.kmz"),
     getGeoJsonFile: (name = "file.json") => getFile(GEO_JSON_FILE_URL, name),
-    getAnnotationGeoJsonFile: () => getFile(ANNOTATION_GEO_JSON_FILE_URL, "file.json"),
+    getAnnotationGeoJsonFile: () => getFile(ANNOTATION_GEO_JSON_FILE_URL, "annotation.json"),
     getMapFile: () => getFile(MAP_FILE, "map.json"),
     getUnsupportedMapFile: () => getFile(UNSUPPORTED_MAP_FILE, "unsupportedMap.json")
 };

--- a/web/client/components/import/dragZone/enhancers/__tests__/useFiles-test.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/useFiles-test.js
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require('react');
+const ReactDOM = require('react-dom');
+const {createSink} = require('recompose');
+const expect = require('expect');
+const useFiles = require('../useFiles');
+
+describe('useFiles enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('useFiles rendering with map', (done) => {
+
+        const actions = {
+            loadMap: (conf, mapId, zoomToExtent, ) => {
+                expect(conf).toExist();
+                expect(conf.map).toExist();
+                expect(conf.map.bbox).toExist();
+                expect(conf.map.center).toExist();
+                expect(conf.map.zoom).toExist();
+                expect(mapId).toBe(null);
+                expect(zoomToExtent).toBe(false);
+                done();
+            },
+            onClose: () => {},
+            loadAnnotations: () => {},
+            setLayers: () => {}
+        };
+        const spyOnClose = expect.spyOn(actions, 'onClose');
+        const spyLoadAnnotations = expect.spyOn(actions, 'loadAnnotations');
+        const spySetLayers = expect.spyOn(actions, 'setLayers');
+
+        const sink = createSink( props => {
+            expect(props).toExist();
+            expect(props.maps).toExist();
+            expect(props.useFiles).toExist();
+            props.useFiles({maps: props.maps});
+        });
+        const EnhancedSink = useFiles(sink);
+        ReactDOM.render(<EnhancedSink maps={[ {map: {zoom: 4, center: { x: 1, y: 1 }, bbox: { x: 1, y: 1 }, maxExtent: "TEST"}} ]}
+            loadAnnotations={actions.loadAnnotations} setLayers={actions.setLayers} loadMap={actions.loadMap} onClose={actions.onClose} currentMap={{zoom: 4, center: { x: 1, y: 1 }}} />, document.getElementById("container"));
+        expect(spyOnClose).toHaveBeenCalled();
+        expect(spyLoadAnnotations).toNotHaveBeenCalled();
+        expect(spySetLayers).toNotHaveBeenCalled();
+    });
+    it('useFiles rendering with layer', (done) => {
+
+        const actions = {
+            setLayers: (layers) => {
+                expect(layers).toExist();
+                expect(layers.length).toBe(1);
+                expect(layers[0].features).toExist();
+                done();
+            },
+            onClose: () => {},
+            loadAnnotations: () => {},
+            loadMap: () => {}
+        };
+        const spyOnClose = expect.spyOn(actions, 'onClose');
+        const spyLoadAnnotations = expect.spyOn(actions, 'loadAnnotations');
+        const spyLoadMap = expect.spyOn(actions, 'loadMap');
+
+        const sink = createSink( props => {
+            expect(props).toExist();
+            expect(props.layers).toExist();
+            expect(props.useFiles).toExist();
+            props.useFiles({layers: props.layers});
+        });
+        const EnhancedSink = useFiles(sink);
+        ReactDOM.render(<EnhancedSink layers={[{type: 'vector', name: "FileName", hideLoading: true, features: []}]}
+            setLayers={actions.setLayers} onClose={actions.onClose} />, document.getElementById("container"));
+        expect(spyOnClose).toNotHaveBeenCalled();
+        expect(spyLoadAnnotations).toNotHaveBeenCalled();
+        expect(spyLoadMap).toNotHaveBeenCalled();
+    });
+    it('useFiles rendering with new annotation layer', (done) => {
+
+        const actions = {
+            loadAnnotations: (layers, override) => {
+                expect(layers).toExist();
+                expect(override).toBe(false);
+                done();
+            },
+            onClose: () => {},
+            setLayers: () => {},
+            loadMap: () => {}
+        };
+        const spyOnClose = expect.spyOn(actions, 'onClose');
+        const spySetLayers = expect.spyOn(actions, 'setLayers');
+        const spyLoadMap = expect.spyOn(actions, 'loadMap');
+
+        const sink = createSink( props => {
+            expect(props).toExist();
+            expect(props.layers).toExist();
+            expect(props.useFiles).toExist();
+            props.useFiles({layers: props.layers});
+        });
+        const EnhancedSink = useFiles(sink);
+        ReactDOM.render(<EnhancedSink layers={[{name: 'Annotations', features: []}]}
+            loadAnnotations={actions.loadAnnotations} setLayers={actions.setLayers} onClose={actions.onClose} annotationsLayer={false}  />, document.getElementById("container"));
+        expect(spyOnClose).toHaveBeenCalled();
+        expect(spySetLayers).toNotHaveBeenCalled();
+        expect(spyLoadMap).toNotHaveBeenCalled();
+    });
+    it('useFiles rendering with existing annotation layer', (done) => {
+
+        const actions = {
+            loadAnnotations: () => {},
+            onClose: () => {},
+            setLayers: (layers) => {
+                expect(layers).toExist();
+                expect(layers.length).toBe(1);
+                expect(layers[0].features).toExist();
+                expect(layers[0].name).toBe("Annotations");
+                done();
+            },
+            loadMap: () => {}
+        };
+        const spyOnClose = expect.spyOn(actions, 'onClose');
+        const spyLoadAnnotations = expect.spyOn(actions, 'loadAnnotations');
+        const spyLoadMap = expect.spyOn(actions, 'loadMap');
+
+        const sink = createSink( props => {
+            expect(props).toExist();
+            expect(props.layers).toExist();
+            expect(props.useFiles).toExist();
+            props.useFiles({layers: props.layers});
+        });
+        const EnhancedSink = useFiles(sink);
+        ReactDOM.render(<EnhancedSink layers={[{name: 'Annotations', features: []}]}
+            setLayers={actions.setLayers} loadAnnotations={actions.loadAnnotations} onClose={actions.onClose} annotationsLayer  />, document.getElementById("container"));
+        expect(spyOnClose).toNotHaveBeenCalled();
+        expect(spyLoadAnnotations).toNotHaveBeenCalled();
+        expect(spyLoadMap).toNotHaveBeenCalled();
+    });
+});

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -11,6 +11,7 @@ const { get, some, every } = require('lodash');
 const FileUtils = require('../../../../utils/FileUtils');
 const LayersUtils = require('../../../../utils/LayersUtils');
 const ConfigUtils = require('../../../../utils/ConfigUtils');
+const {isAnnotation} = require('../../../../utils/AnnotationsUtils');
 
 const JSZip = require('jszip');
 
@@ -107,7 +108,6 @@ const readFile = (onWarnings) => (file) => {
 };
 
 const isGeoJSON = json => json && json.features && json.features.length !== 0;
-const isAnnotation = json => json && json.type && json.type === "ms2-annotations";
 const isMap = json => json && json.version && json.map;
 
 /**
@@ -131,7 +131,7 @@ module.exports = compose(
                                     jsonObjects.filter(json => isGeoJSON(json))
                                         .map(json => (isAnnotation(json) ?
                                             // annotation GeoJSON to layers
-                                            { name: "Annotations", features: json && json.features, filename: json.filename} :
+                                            { name: "Annotations", features: json?.features || [], filename: json.filename} :
                                             // other GeoJSON to layers
                                             {...LayersUtils.geoJSONToLayer(json), filename: json.filename}))
                                 ),

--- a/web/client/components/import/dragZone/enhancers/processFiles.jsx
+++ b/web/client/components/import/dragZone/enhancers/processFiles.jsx
@@ -107,6 +107,7 @@ const readFile = (onWarnings) => (file) => {
 };
 
 const isGeoJSON = json => json && json.features && json.features.length !== 0;
+const isAnnotation = json => json && json.type && json.type === "ms2-annotations";
 const isMap = json => json && json.version && json.map;
 
 /**
@@ -128,7 +129,11 @@ module.exports = compose(
                             layers: (result.layers || [])
                                 .concat(
                                     jsonObjects.filter(json => isGeoJSON(json))
-                                        .map(json => ({...LayersUtils.geoJSONToLayer(json), filename: json.filename}))
+                                        .map(json => (isAnnotation(json) ?
+                                            // annotation GeoJSON to layers
+                                            { name: "Annotations", features: json && json.features, filename: json.filename} :
+                                            // other GeoJSON to layers
+                                            {...LayersUtils.geoJSONToLayer(json), filename: json.filename}))
                                 ),
                             maps: (result.maps || [])
                                 .concat(

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -2,9 +2,9 @@
 const {compose, mapPropsStream, withHandlers} = require('recompose');
 
 /**
- * Enhancers for the component to process map and layer object from the processed file
- * Recognizes the object is a map or a layer
- * Then respective action of loading a map or a layer is performed and throws warning if any
+ * Enhancer for processing map configuration and layers object
+ * Recognizes if the file dropped is a map or a layer
+ * Then a related action for loading a map or a layer is performed and throws warning if any error occurs
  */
 module.exports = compose(
     withHandlers({

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -1,6 +1,11 @@
 
 const {compose, mapPropsStream, withHandlers} = require('recompose');
 
+/**
+ * Enhancers for the component to process map and layer object from the processed file
+ * Recognizes the object is a map or a layer
+ * Then respective action of loading a map or a layer is performed and throws warning if any
+ */
 module.exports = compose(
     withHandlers({
         useFiles: ({ currentMap, loadMap = () => { }, onClose = () => { }, setLayers = () => { },

--- a/web/client/components/import/dragZone/enhancers/useFiles.js
+++ b/web/client/components/import/dragZone/enhancers/useFiles.js
@@ -3,7 +3,8 @@ const {compose, mapPropsStream, withHandlers} = require('recompose');
 
 module.exports = compose(
     withHandlers({
-        useFiles: ({ currentMap, loadMap = () => { }, onClose = () => { }, setLayers = () => { } }) =>
+        useFiles: ({ currentMap, loadMap = () => { }, onClose = () => { }, setLayers = () => { },
+            annotationsLayer, loadAnnotations = () => {} }) =>
             ({ layers = [], maps = [] }, warnings) => {
                 const map = maps[0]; // only 1 map is allowed
                 if (map) {
@@ -17,13 +18,15 @@ module.exports = compose(
                             center: map.map.center || center
                         }
                     }, null, !map.map.zoom && (map.map.bbox || {bounds: map.map.maxExtent}));
+                    onClose(); // close if loaded the map
                 }
                 if (layers.length > 0) {
-                    setLayers(layers, warnings); // TODO: warnings
-                } else {
-                    // close if loaded only the map
-                    if (map) {
-                        onClose();
+                    const isAnnotation = layers && layers[0].name === "Annotations";
+                    if (!annotationsLayer && isAnnotation) {
+                        loadAnnotations(layers[0].features, false);
+                        onClose(); // close if loaded a new annotation layer
+                    } else {
+                        setLayers(layers, warnings); // TODO: warnings
                     }
                 }
             }

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -11,6 +11,7 @@ const React = require('react');
 
 const Message = require('../../I18N/Message');
 const LocaleUtils = require('../../../utils/LocaleUtils');
+const {isAnnotation} = require('../../../utils/AnnotationsUtils');
 let { toVectorStyle } = require('../../../utils/StyleUtils');
 const { Grid, Row, Col, Button, Alert, ButtonToolbar} = require('react-bootstrap');
 
@@ -150,7 +151,7 @@ class StylePanel extends React.Component {
                     {this.state.useDefaultStyle ? null : this.props.stylers[this.getGeomType(this.props.selected)]}
                 </Row>
                 <Row key="options">
-                    {this.props.selected && this.props.selected.name === "Annotations" ?
+                    {isAnnotation(this.props.selected) ?
                         this.annotationOptions()
                         :
                         <>
@@ -192,10 +193,10 @@ class StylePanel extends React.Component {
         if (!this.state.useDefaultStyle) {
             styledLayer = toVectorStyle(styledLayer, this.props.shapeStyle);
         }
-        const isAnnotation = styledLayer.name === "Annotations";
-        Promise.resolve(isAnnotation ? this.props.loadAnnotations(styledLayer.features, this.state.overrideAnnotation) :
+        const isAnnotationLayer = isAnnotation(styledLayer);
+        Promise.resolve(isAnnotationLayer ? this.props.loadAnnotations(styledLayer.features, this.state.overrideAnnotation) :
             this.props.addLayer( styledLayer )).then(() => {
-            if (!isAnnotation) {
+            if (!isAnnotationLayer) {
                 let bbox = [];
                 if (this.props.layers[0].bbox && this.props.bbox) {
                     bbox = [
@@ -211,12 +212,12 @@ class StylePanel extends React.Component {
                 }
             }
             this.props.onSuccess(this.props.layers.length > 1
-                ? isAnnotation ? "Annotation" : this.props.layers[0].name + LocaleUtils.getMessageById(this.context.messages, "shapefile.success")
+                ? isAnnotationLayer ? "Annotation" : this.props.layers[0].name + LocaleUtils.getMessageById(this.context.messages, "shapefile.success")
                 : undefined);
 
             this.props.onLayerAdded(this.props.selected);
         }).catch(e => {
-            this.props.onError({ type: "error", name: isAnnotation ? "Annotation" : this.props.layers[0].name, error: e, message: 'shapefile.error.genericLoadError'});
+            this.props.onError({ type: "error", name: isAnnotationLayer ? "Annotation" : this.props.layers[0].name, error: e, message: 'shapefile.error.genericLoadError'});
         });
     };
 

--- a/web/client/components/import/style/__tests__/StylePanel-test.jsx
+++ b/web/client/components/import/style/__tests__/StylePanel-test.jsx
@@ -15,6 +15,9 @@ const MY_JSON = require('../../../../test-resources/wfs/museam.json');
 const L1 = { name: "L1", features: MY_JSON.features };
 const L2 = { name: "L2" };
 const W1 = { name: "TEST", "message": "M1" };
+const Annotations = {name: "Annotations", features: [{type: "FeatureCollection", properties: {title: "Annotation 1"},
+    features: [{type: "Feature", properties: {title: "Name1"},
+        geometry: {type: "Point", coordinates: [12.481312562873996, 41.89790148509894]}}]}]};
 
 describe('StylePanel component', () => {
     beforeEach((done) => {
@@ -33,6 +36,54 @@ describe('StylePanel component', () => {
         const checkBoxes = [].slice.call(container.querySelectorAll('input[type=checkbox]'));
         expect(checkBoxes.length).toBe(2);
         expect(checkBoxes.filter(e => e.checked).length).toBe(1);
+    });
+    it('StylePanel rendering with annotation layers', () => {
+        ReactDOM.render(<StylePanel layers={[Annotations]} selected={Annotations} stylers={{"Point": <div></div>}}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container.querySelector('h4')).toExist();
+        const radioButtons = [].slice.call(container.querySelectorAll('input[type=radio]'));
+        const labels = [].slice.call(container.querySelectorAll('label'));
+        expect(radioButtons.length).toBe(2);
+        expect(radioButtons.filter(e => e.checked).length).toBe(1);
+        expect(labels[0].innerText).toContain("merge");
+        expect(radioButtons[0].checked).toBe(true);
+        expect(radioButtons[1].checked).toBe(false);
+        expect(labels[1].innerText).toContain("replace");
+    });
+    it('Test StylePanel for loadAnnotations to have been called on FINISH button click', (done) => {
+        const actions = {
+            onSuccess: () => {},
+            loadAnnotations: () => {}
+        };
+        const onSuccessCallBack = expect.spyOn(actions, 'onSuccess');
+        const loadAnnotationsCallBack = expect.spyOn(actions, 'loadAnnotations');
+
+        const onLayerAdded = () => {
+            expect(loadAnnotationsCallBack).toHaveBeenCalled();
+            expect(onSuccessCallBack).toHaveBeenCalled();
+            done();
+        };
+
+        const cmp = ReactDOM.render(
+            <StylePanel shapeStyle={{marker: true}} errors={[W1]} layers={[Annotations]} selected={Annotations} stylers={{ "Point": <div></div> }}
+                loadAnnotations={actions.loadAnnotations}
+                onLayerAdded={onLayerAdded}
+                onSuccess={actions.onSuccess} />, document.getElementById("container"));
+        expect(cmp).toExist();
+        let btn = document.querySelectorAll('button')[2];
+
+        // Merge annotation layer (by default)
+        ReactTestUtils.Simulate.click(btn); // <-- trigger event callback
+        expect(loadAnnotationsCallBack.calls[0].arguments[0]).toExist();
+        expect(loadAnnotationsCallBack.calls[0].arguments[1]).toBe(false);
+
+        // Replace annotation layer
+        const radioBtn = document.querySelectorAll('input[type=radio]')[1];
+        ReactTestUtils.Simulate.change(radioBtn); // Click replace annotation layer
+        expect(radioBtn.checked).toBe(true);
+        ReactTestUtils.Simulate.click(btn);
+        expect(loadAnnotationsCallBack.calls[1].arguments[0]).toExist();
+        expect(loadAnnotationsCallBack.calls[1].arguments[1]).toBe(true);
     });
     it('StylePanel rendering with errors', () => {
         ReactDOM.render(<StylePanel errors={[W1]} layers={[L1, L2]} selected={L1} stylers={{ "Point": <div></div> }} />, document.getElementById("container"));

--- a/web/client/components/mapcontrols/annotations/SelectAnnotationsFile.jsx
+++ b/web/client/components/mapcontrols/annotations/SelectAnnotationsFile.jsx
@@ -18,6 +18,7 @@ const Message = require('../../I18N/Message');
 const ResizableModal = require('../../misc/ResizableModal');
 
 const FileUtils = require('../../../utils/FileUtils');
+const {ANNOTATION_TYPE} = require('../../../utils/AnnotationsUtils');
 const {Promise} = require('es6-promise');
 
 class SelectAnnotationsFile extends React.Component {
@@ -86,7 +87,7 @@ class SelectAnnotationsFile extends React.Component {
                 this.setState(() => ({error: null}));
             }
             // Get only features
-            const annotations = contents.filter(({geoJSON, errors = []}) => errors.length === 0 || geoJSON.type === 'ms2-annotations').reduce((acc, {geoJSON}) => acc.concat(geoJSON.features || geoJSON), []);
+            const annotations = contents.filter(({geoJSON, errors = []}) => errors.length === 0 || geoJSON.type === ANNOTATION_TYPE).reduce((acc, {geoJSON}) => acc.concat(geoJSON.features || geoJSON), []);
             if (annotations.length === 0) {
                 throw new Error();
             }

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -13,6 +13,7 @@ const {TOGGLE_CONTROL, toggleControl, setControlProperty} = require('../actions/
 const {addLayer, updateNode, changeLayerProperties, removeLayer} = require('../actions/layers');
 const {set} = require('../utils/ImmutableUtils');
 const {reprojectGeoJson} = require('../utils/CoordinatesUtils');
+const {ANNOTATION_TYPE} = require('../utils/AnnotationsUtils');
 const {error} = require('../actions/notifications');
 const {closeFeatureGrid} = require('../actions/featuregrid');
 const {isFeatureGridOpen} = require('../selectors/featuregrid');
@@ -470,7 +471,7 @@ module.exports = (viewer) => ({
             try {
                 const annotations = annotation && [annotation] || (annotationsLayerSelector(getState())).features;
                 const mapName = mapNameSelector(getState());
-                saveAs(new Blob([JSON.stringify({features: annotations, type: "ms2-annotations"})], {type: "application/json;charset=utf-8"}), `${ mapName.length > 0 && mapName || "Annotations"}.json`);
+                saveAs(new Blob([JSON.stringify({features: annotations, type: ANNOTATION_TYPE})], {type: "application/json;charset=utf-8"}), `${ mapName.length > 0 && mapName || "Annotations"}.json`);
                 return Rx.Observable.empty();
             } catch (e) {
                 return Rx.Observable.of(error({

--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -14,6 +14,8 @@ const Message = require('./locale/Message');
 const { onError, setLoading, setLayers, onSelectLayer, onLayerAdded, onLayerSkipped, updateBBox, onSuccess} = require('../actions/mapimport');
 const {zoomToExtent} = require('../actions/map');
 const {addLayer} = require('../actions/layers');
+const {loadAnnotations} = require('../actions/annotations');
+const {annotationsLayerSelector} = require('../selectors/annotations');
 const {toggleControl} = require('../actions/controls');
 
 const assign = require('object-assign');
@@ -47,7 +49,8 @@ module.exports = {
                     success: state.mapimport && state.mapimport.success || null,
                     errors: state.mapimport && state.mapimport.errors || null,
                     shapeStyle: state.style || {},
-                    mapType: mapTypeSelector(state)
+                    mapType: mapTypeSelector(state),
+                    annotationsLayer: annotationsLayerSelector(state)
                 }
             ), {
                 setLayers,
@@ -57,6 +60,7 @@ module.exports = {
                 onError,
                 onSuccess,
                 addLayer,
+                loadAnnotations,
                 onZoomSelected: zoomToExtent,
                 updateBBox,
                 setLoading,

--- a/web/client/test-resources/caput-mundi/caput-mundi.config
+++ b/web/client/test-resources/caput-mundi/caput-mundi.config
@@ -1,0 +1,4 @@
+{"type":"ms2-annotations",
+  "features":[{"type":"FeatureCollection","properties":{"title":"Annotation 1"},
+  "features":[{"type":"Feature","properties":{"NAME":"Rome"},"geometry":{"type":"Point","coordinates":[12.481312562873995,41.897901485098942]}}]}
+]}

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1172,6 +1172,8 @@
             },
             "add": "Hinzufügen",
             "cancel": "Abbrechen",
+            "merge": "Mit der vorhandenen Annotationsebene zusammenführen",
+            "replace": "Ersetzen Sie die vorhandene Anmerkungsebene",
             "success": " erfolgreich importiert",
             "next": "Nächster",
             "skip": "springen",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1185,7 +1185,7 @@
                 "dropZone": {
                     "heading": "<p> <h4> Legen Sie hier Ihre Kartenkontexte oder Vektordateien ab </h4> <small> oder </small> </p>",
                     "selectFiles": "Dateien auswählen...",
-                    "infoSupported": "<p> <small> Unterstützte Kartenkontextdateien: MapStore Legacy-Format, WMC. Unterstützte Vektor-Layer-Dateien: Shapefiles müssen in Zip-Archiven, KML / KMZ, GPX oder GeoJSON </small> </p> vorliegen",
+                    "infoSupported": "<p> <small> Unterstützte Kartenkontextdateien: MapStore Legacy-Format, WMC. Unterstützte Vektor-Layer-Dateien: Shapefiles müssen in Zip-Archiven, KML / KMZ, GPX, GeoJSON oder Annotations </small> </p> vorliegen",
                     "note": "<p> <small> <i> <strong> Hinweis </strong>: Die aktuelle Map wird bei der Verwendung von Kartenkontextdateien überschrieben </i> </small> </p>"
                 },
                 "errors": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1170,6 +1170,8 @@
                 "genericLoadError": "Cannot load the vector file on map",
                 "missingPrj": "Missing projection info (.prj), coordinate system is  supposed to be EPSG:4326"
             },
+            "merge": "Merge with the existing annotation layer",
+            "replace": "Replace the existing annotation layer",
             "add": "Add",
             "cancel": "Cancel",
             "success": " correctly imported",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1185,7 +1185,7 @@
             "dropZone": {
                 "heading": "<p><h4>Drop your map context or vector files here</h4><small>or</small></p>",
                 "selectFiles": "Select files...",
-                "infoSupported": "<p><small>Supported map context files: MapStore legacy format, WMC<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON or GPX</small></p>",
+                "infoSupported": "<p><small>Supported map context files: MapStore legacy format, WMC<br />Supported vector layer files: shapefiles (must be contained in zip archives), KML/KMZ, GeoJSON, Annotations or GPX</small></p>",
                 "note": "<p><small><i><strong>note</strong>: current map will be overridden in case of map context files</i></small></p>"
             },
             "errors": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1185,7 +1185,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Suelta contextos de mapas o archivos vectoriales aquí </h4> <small> o </small> </p>",
                 "selectFiles": "Selecciona archivos...",
-                "infoSupported": "<p> <small> Archivos de contexto de mapas admitidos: formato heredado MapStore, WMC<br /> Archivos de capa vectorial soportados: shapefiles (deben estar en archivos comprimidos), KML / KMZ, GPX o GeoJSON </small> </p>",
+                "infoSupported": "<p> <small> Archivos de contexto de mapas admitidos: formato heredado MapStore, WMC<br /> Archivos de capa vectorial soportados: shapefiles (deben estar en archivos comprimidos), KML / KMZ, GPX, GeoJSON o Annotations </small> </p>",
                 "note": "<p> <small> <i> <strong> nota </strong>: el mapa actual se sobrescribe en el caso de nuevos contextos de mapa </i> </small> </p>"
             },
             "errors": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1172,6 +1172,8 @@
             },
             "add": "Añadir",
             "cancel": "Cancelar",
+            "merge": "Fusionar con la capa de anotación existente",
+            "replace": "Reemplazar la capa de anotación existente",
             "success": " Importación correcta",
             "next": "Siguiente",
             "skip": "Saltar",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1185,7 +1185,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Déposez votre contextes cartographiques ou vos fichiers vectoriels ici </h4> <small> ou </small> </p>",
                 "selectFiles": "Sélectionnez des fichiers...",
-                "infoSupported": "<p><small>Fichiers de contextes pris en charge : format hérité MapStore, WMC<br />Fichiers vectoriels pris en charge : fichier de formes (doivent être contenus dans des archives zip), KML/KMZ, GeoJSON ou GPX</small></p>",
+                "infoSupported": "<p><small>Fichiers de contextes pris en charge : format hérité MapStore, WMC<br />Fichiers vectoriels pris en charge : fichier de formes (doivent être contenus dans des archives zip), KML/KMZ, GeoJSON, Annotations ou GPX</small></p>",
                 "note": "<p><small><i><strong> note </strong>: la carte actuelle sera remplacée dans le cas des fichiers de contextes cartographiques</i></small></p>"
             },
             "errors": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1172,6 +1172,8 @@
             },
             "add": "Ajouter",
             "cancel": "Annuler",
+            "merge": "Fusionner avec la couche d'annotation existante",
+            "replace": "Remplacer le calque d'annotation existant",
             "success": " importé correctement",
             "next": "Suivant",
             "skip": "Passer",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1185,7 +1185,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Rilascia qui i contesti di mappa o i file vettoriali </h4> <small> o </small> </p>",
                 "selectFiles": "Seleziona i file...",
-                "infoSupported": "<p> <small> File di contesti di mappa supportati: formato legacy di MapStore, WMC<br /> File di livello vettoriale supportati: shapefile (devono essere contenuti in archivi zip), KML / KMZ, GPX, GeoJSON o Annotations </small> </p>",
+                "infoSupported": "<p> <small> File di contesti di mappa supportati: formato legacy di MapStore, WMC<br /> File di livello vettoriale supportati: shapefile (devono essere contenuti in archivi zip), KML / KMZ, GPX, GeoJSON o Annotazioni </small> </p>",
                 "note": "<p> <small> <i> <strong> nota </strong>: la mappa corrente verrà sovrascritta in caso di nuovi contesti di mappa </i> </small> </p>"
             },
             "errors": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1185,7 +1185,7 @@
             "dropZone": {
                 "heading": "<p> <h4> Rilascia qui i contesti di mappa o i file vettoriali </h4> <small> o </small> </p>",
                 "selectFiles": "Seleziona i file...",
-                "infoSupported": "<p> <small> File di contesti di mappa supportati: formato legacy di MapStore, WMC<br /> File di livello vettoriale supportati: shapefile (devono essere contenuti in archivi zip), KML / KMZ, GPX o GeoJSON </small> </p>",
+                "infoSupported": "<p> <small> File di contesti di mappa supportati: formato legacy di MapStore, WMC<br /> File di livello vettoriale supportati: shapefile (devono essere contenuti in archivi zip), KML / KMZ, GPX, GeoJSON o Annotations </small> </p>",
                 "note": "<p> <small> <i> <strong> nota </strong>: la mappa corrente verrà sovrascritta in caso di nuovi contesti di mappa </i> </small> </p>"
             },
             "errors": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1172,6 +1172,8 @@
             },
             "add": "Importa",
             "cancel": "Annulla",
+            "merge": "Unisci con il livello di annotazione esistente",
+            "replace": "Sostituisci il livello di annotazione esistente",
             "success": " correttamente importato",
             "next": "Avanti",
             "skip": "Salta",

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -72,6 +72,8 @@ const DEFAULT_ANNOTATIONS_STYLES = {
     "MultiPolygon": STYLE_POLYGON
 };
 
+const ANNOTATION_TYPE = "ms2-annotations";
+
 /**
  * return two styles object for start and end point.
  * usually added to a LineString
@@ -199,6 +201,10 @@ const annStyleToOlStyle = (type, tempStyle, label = "") => {
 };
 
 const AnnotationsUtils = {
+    /**
+     * The constant for annotation type
+     */
+    ANNOTATION_TYPE,
     /**
      * function used to convert a geojson into a internal model.
      * if it finds some textValues in the properties it will return this as Text
@@ -582,7 +588,14 @@ const AnnotationsUtils = {
         const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
         return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
     },
-    getDashArrayFromStyle
+    getDashArrayFromStyle,
+    /**
+     * utility to check if the GeoJSON has the annotation model structure i.e. {"type": "ms2-annotations", "features": [list of FeatureCollection]}
+     * or the imported annotation object's name is of "Annotations"
+     * @param {object} json GeoJSON/plain object
+     * @returns {boolean} if the GeoJSON passes is a ms2-annotation or if the name property of the object passed is Annotations
+     */
+    isAnnotation: (json) => json?.type === ANNOTATION_TYPE || json?.name === "Annotations"
 };
 
 module.exports = AnnotationsUtils;

--- a/web/client/utils/StyleUtils.js
+++ b/web/client/utils/StyleUtils.js
@@ -18,7 +18,7 @@ const getColor = function(color) {
     return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`;
 };
 const getGeomType = function(layer) {
-    return layer.features && layer.features[0] ? layer.features[0].geometry.type : undefined;
+    return layer.features && layer.features[0] ? layer.features[0].geometry && layer.features[0].geometry.type : undefined;
 };
 //
 const DUMMY_COLOR = {r: 255, g: 0, b: 0, a: 1}; // This style should never be applied, is only a default for tests and to prevent failures


### PR DESCRIPTION
## Description
Allow annotation layer to be imported via Map Menu while maintaining compatibility to import via Annotations

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#5498
Annotation can only be imported from import option in annotations windows

**What is the new behavior?**
To import annotations in the general import tool

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
https://github.com/geosolutions-it/austrocontrol-C125/issues/164#issuecomment-633268641