### PR TITLE
#5321: Allow to reload context and user session after logout. 

### DIFF
--- a/web/client/epics/__tests__/context-test.js
+++ b/web/client/epics/__tests__/context-test.js
@@ -257,6 +257,20 @@ describe('context epics', () => {
                 done();
             });
         });
+        // this could not be needed because logged in users has usually more access privileges to a resource than a
+        // not logged user. Anyway, this allows to reload eventually also the user session
+        it('reload when loaded, then the user logout and re-login (this if you have user session to reload)', done => {
+            const actions = [loadContext({ mapId, contextName }), loadFinished(), logout(), loginSuccess()];
+            testEpic(handleLoginLogoutContextReload, 2, actions, ([logoutReload, loginReload]) => {
+                expect(logoutReload.type).toBe(LOAD_CONTEXT);
+                expect(logoutReload.mapId).toBe(mapId);
+                expect(logoutReload.contextName).toBe(contextName);
+                expect(loginReload.type).toBe(LOAD_CONTEXT);
+                expect(loginReload.mapId).toBe(mapId);
+                expect(loginReload.contextName).toBe(contextName);
+                done();
+            });
+        });
     });
 
 });

--- a/web/client/epics/__tests__/context-test.js
+++ b/web/client/epics/__tests__/context-test.js
@@ -259,8 +259,8 @@ describe('context epics', () => {
         });
         // this could not be needed because logged in users has usually more access privileges to a resource than a
         // not logged user. Anyway, this allows to reload eventually also the user session
-        it('reload when loaded, then the user logout and re-login (this if you have user session to reload)', done => {
-            const actions = [loadContext({ mapId, contextName }), loadFinished(), logout(), loginSuccess()];
+        it('reload when loaded, then the user logout and re-login ', done => {
+            const actions = [loadContext({ mapId, contextName }), loadFinished(), logout(), loadContext({ mapId, contextName }), loadFinished(), loginSuccess()];
             testEpic(handleLoginLogoutContextReload, 2, actions, ([logoutReload, loginReload]) => {
                 expect(logoutReload.type).toBe(LOAD_CONTEXT);
                 expect(logoutReload.mapId).toBe(mapId);

--- a/web/client/epics/__tests__/epicTestUtils.js
+++ b/web/client/epics/__tests__/epicTestUtils.js
@@ -7,7 +7,7 @@ module.exports = {
     /**
      * Utility to test an epic
      * @param  {function}   epic       the epic to test
-     * @param  {number}   count      the number of actions to wait (note, the stream)
+     * @param  {number|function}   count      the number of actions to wait. If a function, it represents a check to do on the next action to stop.
      * @param  {object|object[]}   action     the action(s) to trigger
      * @param  {function} callback   The check function, called after `count` actions received
      * @param  {Object|function}   [state={}] the state or a function that return it

--- a/web/client/epics/__tests__/usersession-test.js
+++ b/web/client/epics/__tests__/usersession-test.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { testEpic } from './epicTestUtils';
-import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator } from "../usersession";
+import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator, stopSaveSessionEpic } from "../usersession";
 import { saveUserSession, loadUserSession,
-    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED } from "../../actions/usersession";
+    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED, USER_SESSION_START_SAVING, USER_SESSION_STOP_SAVING, userSessionStartSaving, userSessionStopSaving } from "../../actions/usersession";
 import expect from "expect";
 import {Providers} from  "../../api/usersession";
 import {Observable} from "rxjs";
@@ -67,34 +67,43 @@ describe('usersession Epics', () => {
         }, initialState, done);
     });
     it('start and stop user session save', (done) => {
-        const store = testEpic(autoSaveSessionEpicCreator(10, () => ({type: 'END'}), 'START', 'STOP', 10, ), (action) => action.type !== "END", {type: 'START'}, (actions) => {
-            expect(actions[0].type).toBe(SAVE_USER_SESSION);
-            expect(actions[actions.length - 1].type).toBe("EPIC_COMPLETED");
-        }, initialState, done, true);
+        const store = testEpic(
+            autoSaveSessionEpicCreator(10, () => ({type: 'END'})),
+            (action) => action.type !== "END",
+            userSessionStartSaving(), (actions) => {
+                expect(actions[0].type).toBe(SAVE_USER_SESSION);
+                expect(actions[actions.length - 1].type).toBe("EPIC_COMPLETED");
+            }, initialState, done, true);
         setTimeout(() => {
-            store.dispatch({ type: 'STOP' });
+            store.dispatch(userSessionStopSaving());
         }, 100);
     });
     it('disable autoSave do not allow session saving', (done) => {
-        const store = testEpic(autoSaveSessionEpicCreator(10, () => ({ type: 'END' }), 'START', 'STOP', 10), (action) => action.type !== "END", { type: 'START' }, (actions) => {
-            expect(actions[0].type).toBe("EPIC_COMPLETED");
-        }, { ...initialState, usersession: { autoSave: false } }, done, true);
+        const store = testEpic(
+            autoSaveSessionEpicCreator(10, () => ({ type: 'END' })),
+            (action) => action.type !== "END", [userSessionStartSaving(), userSessionStopSaving()],
+            (actions) => {
+                expect(actions[0].type).toBe("EPIC_COMPLETED");
+            }, { ...initialState, usersession: { autoSave: false } }, done, true);
         setTimeout(() => {
             store.dispatch({ type: 'STOP' });
         }, 100);
     });
     it('start, stop and restart user session save', (done) => {
         let count = 0;
-        const store = testEpic(autoSaveSessionEpicCreator(10, () => ({type: 'END' + (count++)}), 'START', 'STOP'), (action) => action.type !== "END1", {type: 'START'}, (actions) => {
-            expect(actions[0].type).toBe(SAVE_USER_SESSION);
-            expect(actions[actions.length - 1].type).toBe("EPIC_COMPLETED");
-        }, initialState, done, true);
+        const store = testEpic(
+            autoSaveSessionEpicCreator(10, () => ({type: 'END' + (count++)})),
+            (action) => action.type !== "END1",
+            userSessionStartSaving(), (actions) => {
+                expect(actions[0].type).toBe(SAVE_USER_SESSION);
+                expect(actions[actions.length - 1].type).toBe("EPIC_COMPLETED");
+            }, initialState, done, true);
         setTimeout(() => {
-            store.dispatch({ type: 'STOP' });
+            store.dispatch(userSessionStopSaving());
             setTimeout(() => {
-                store.dispatch({ type: 'START' });
+                store.dispatch(userSessionStartSaving());
                 setTimeout(() => {
-                    store.dispatch({ type: 'STOP' });
+                    store.dispatch(userSessionStopSaving());
                 }, 100);
             }, 50);
         }, 100);
@@ -107,4 +116,5 @@ describe('usersession Epics', () => {
             expect(actions[1].session).toExist();
         }, initialState, done);
     });
+
 });

--- a/web/client/epics/__tests__/usersession-test.js
+++ b/web/client/epics/__tests__/usersession-test.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { testEpic } from './epicTestUtils';
-import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator, stopSaveSessionEpic } from "../usersession";
+import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator } from "../usersession";
 import { saveUserSession, loadUserSession,
-    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED, USER_SESSION_START_SAVING, USER_SESSION_STOP_SAVING, userSessionStartSaving, userSessionStopSaving } from "../../actions/usersession";
+    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED, userSessionStartSaving, userSessionStopSaving } from "../../actions/usersession";
 import expect from "expect";
 import {Providers} from  "../../api/usersession";
 import {Observable} from "rxjs";

--- a/web/client/epics/context.js
+++ b/web/client/epics/context.js
@@ -180,22 +180,13 @@ export const setMapTypeOnContextChange = action$ => action$
  * This allows to correctly reload the context (and the eventual user session map and context changes)
  * @param {observable} action$ stream of actions
  */
-export const handleLoginLogoutContextReload = action$ => {
-    return Observable.merge(
-        // After a login event if
-        Observable.merge(
-            // the was a forbidden error (access denied to the given context, then login)
-            action$.ofType(CONTEXT_LOAD_ERROR)
-                .filter(({ error }) => error.status === 403),
-            //  or in case of context successfully loaded, then logout and re-login
-            action$.ofType(LOAD_CONTEXT)
-                .switchMap(() => action$.ofType(LOGOUT))
-        ).switchMap( () =>  action$.ofType(LOGIN_SUCCESS).take(1).takeUntil(action$.ofType(LOCATION_CHANGE))), // ...wait for login success
-        // Or if context was loaded and the user logs-out
-        action$.ofType(LOAD_FINISHED)
-            .switchMap(() => action$.ofType(LOGOUT).take(1).takeUntil(action$.ofType(LOCATION_CHANGE))) // ...and then the user logged out
-    // then reload the last context and map
-    ).withLatestFrom(
-        action$.ofType(LOAD_CONTEXT)
-    ).switchMap(([, args]) => Observable.of(loadContext(args)));
-};
+export const handleLoginLogoutContextReload = action$ =>
+    // If the was a forbidden error (access denied to the given context)
+    action$.ofType(CONTEXT_LOAD_ERROR).filter(({ error }) => error.status === 403)
+        //  or in case of context successfully loaded
+        .merge(action$.ofType(LOAD_FINISHED))
+        // on login-logout event
+        .switchMap(() => action$.ofType(LOGIN_SUCCESS, LOGOUT).take(1).takeUntil(action$.ofType(LOCATION_CHANGE)))
+        // re-trigger the last context load event to re-load context and map ()
+        .withLatestFrom(action$.ofType(LOAD_CONTEXT))
+        .switchMap(([, args]) => Observable.of(loadContext(args)));

--- a/web/client/epics/context.js
+++ b/web/client/epics/context.js
@@ -175,16 +175,23 @@ export const setMapTypeOnContextChange = action$ => action$
     .switchMap(({context}) => Observable.of(changeMapType(context && context.mapType || 'openlayers')));
 
 /**
- * Handles the reload of the context and map.
+ * Handles the reload of the context and map. This have to be triggered
+ * When access conditions change due to login/logout events.
+ * This allows to correctly reload the context (and the eventual user session map and context changes)
  * @param {observable} action$ stream of actions
  */
 export const handleLoginLogoutContextReload = action$ => {
     return Observable.merge(
-        // in case of forbidden error...
-        action$.ofType(CONTEXT_LOAD_ERROR)
-            .filter(({ error }) => error.status === 403)
-            .switchMap( () =>  action$.ofType(LOGIN_SUCCESS).take(1).takeUntil(action$.ofType(LOCATION_CHANGE))), // ...wait for login success
-        // Or if context was loaded
+        // After a login event if
+        Observable.merge(
+            // the was a forbidden error (access denied to the given context, then login)
+            action$.ofType(CONTEXT_LOAD_ERROR)
+                .filter(({ error }) => error.status === 403),
+            //  or in case of context successfully loaded, then logout and re-login
+            action$.ofType(LOAD_CONTEXT)
+                .switchMap(() => action$.ofType(LOGOUT))
+        ).switchMap( () =>  action$.ofType(LOGIN_SUCCESS).take(1).takeUntil(action$.ofType(LOCATION_CHANGE))), // ...wait for login success
+        // Or if context was loaded and the user logs-out
         action$.ofType(LOAD_FINISHED)
             .switchMap(() => action$.ofType(LOGOUT).take(1).takeUntil(action$.ofType(LOCATION_CHANGE))) // ...and then the user logged out
     // then reload the last context and map


### PR DESCRIPTION
## Description
This PR is for #5321 and #5322. The context was not reloaded on logout/and login (only on re-login due to an error. or logout. Adding this new reload condition looks to trigger the context and map load flow, so restore also the user session.

Moreover I solved also a small issue due to an unstopped auto session saving on logout. In this context I did also a general clean up on parameters that doesn't look to be needed anymore. (startAction, stopAction for session).
@mbarto what do you think? I don't see custom start/stop action used anymore in georchestra, so I should remove this additional complexity.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5321 

**What is the new behavior?**
Now logout and re-login reloads the current context.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
