### PR TITLE
#5334: Fixed issue with Timeline rendering on missing playback plugin

### DIFF
--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -16,7 +16,7 @@ const { offsetEnabledSelector, currentTimeSelector } = require('../selectors/dim
 const { currentTimeRangeSelector, isVisible, rangeSelector, timelineLayersSelector, isMapSync } = require('../selectors/timeline');
 const { mapLayoutValuesSelector } = require('../selectors/maplayout');
 
-const { withState, compose, branch, renderNothing, withStateHandlers, withProps, defaultProps } = require('recompose');
+const { withState, compose, branch, renderNothing, withStateHandlers, withProps, defaultProps, setDisplayName } = require('recompose');
 const withResizeSpy = require('../components/misc/enhancers/withResizeSpy');
 
 const { selectTime, enableOffset, onRangeChanged, setMapSync } = require('../actions/timeline');
@@ -126,7 +126,8 @@ const TimelinePlugin = compose(
             }
         ),
         // effective hide
-        branch(({ hide }) => hide, renderNothing)
+        branch(({ hide }) => hide, renderNothing),
+        setDisplayName("TimelinePlugin")
     )
 )(
     ({
@@ -266,11 +267,11 @@ const TimelinePlugin = compose(
 
                             }
                         ]} />
-                    <Playback
+                    {Playback && <Playback
                         {...playbackItem}
                         settingsStyle={{
                             right: (collapsed || compactToolbar) ? 40 : 'unset'
-                        }}/>
+                        }}/>}
                 </div>
 
                 <Button

--- a/web/client/plugins/__tests__/Timeline-test.jsx
+++ b/web/client/plugins/__tests__/Timeline-test.jsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TimelinePlugin from '../Timeline';
+import { getPluginForTest } from './pluginsTestUtils';
+
+
+import MapUtils from '../../utils/MapUtils';
+
+const SAMPLE_STATE = {
+    timeline: {
+        selectedLayer: "TEST_LAYER",
+        range: {
+            start: "2000-01-01T00:00:00.000Z",
+            end: "2020-12-31T00:00:00.000Z"
+        }
+    },
+    layers: {
+        flat: [{
+            id: 'TEST_LAYER',
+            name: 'TEST_LAYER',
+            type: 'wms',
+            url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+            dimensions: [
+                {
+                    source: {
+                        type: 'multidim-extension',
+                        // this forces to load fixed values from the test file, ignoring parameters
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                    },
+                    name: 'time'
+                }
+            ],
+            params: {
+                time: '2000-06-08T00:00:00.000Z'
+            }
+        }]
+    }
+};
+
+describe('Timeline Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+        MapUtils.clearHooks();
+    });
+
+
+    describe('render Plugin', () => {
+        it('do not render when state missing', () => {
+            const { Plugin } = getPluginForTest(TimelinePlugin, {});
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.querySelector('.timeline-plugin')).toBeFalsy();
+        });
+        it('render with minimal state', () => {
+            const { Plugin} = getPluginForTest(TimelinePlugin, SAMPLE_STATE);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.querySelector('.timeline-plugin')).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
## Description
When playback item was not present, the timeline fails. This because of the disablePluginIf present in playback but not in Timeline. I fixed the problem, adding a test to ensure the correct rendering of the plugin in any case.

Anyway, for cohherence, I also disabled Timeline plugin, as well as playback, under the same condtions. 

Maybe in the future we can leave the timeline visible when the edit mode is active.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5334

**What is the new behavior?**
Error is not present anymore. Timeline is not rendered during edit mode.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
