### PR TITLE
remove geostory from localconfig of stable branch 2020.01.xx

### DIFF
--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -573,7 +573,8 @@
         "maps": ["HomeDescription", "Fork", "MapSearch", {
           "name": "CreateNewMap",
           "cfg": {
-            "showNewGeostory": false
+            "showNewGeostory": false,
+            "showNewContext": false
           }
         }, "FeaturedMaps", "ContentTabs",
 
@@ -643,45 +644,6 @@
                 "containerPosition": "header"
             }
         }],
-        "geostory": [
-          {
-            "name": "OmniBar",
-            "cfg": {
-              "containerPosition": "header",
-              "className": "navbar shadow navbar-home"
-            }
-          },
-          "Login",
-          "BurgerMenu",
-          "Language",
-          "NavMenu",
-          "Attribution",
-          "Home",
-          "GeoStory",
-          "GeoStorySave",
-          "GeoStorySaveAs",
-          "MapEditor",
-          "MediaEditor",
-          {
-            "name": "GeoStoryEditor",
-            "cfg": {
-              "containerPosition": "columns"
-            }
-          },
-          {
-            "name": "GeoStoryNavigation",
-            "cfg": {
-              "containerPosition": "header"
-            }
-          },
-          "Notifications",
-          {
-            "name": "FeedbackMask",
-            "cfg": {
-              "containerPosition": "header"
-            }
-          }
-        ],
         "manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"]
     }
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
removing geostory from config

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: config config changess

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
no geostory stuff will be shown (it happened to me with c162 project)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
