### PR TITLE
Store the currently selected datetime for the timeslider inside the map configuration

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -113,6 +113,19 @@ i.e.
 !!! warning
     Actually the custom resolution values are valid for one single CRS. It's therefore suggested to avoid to add this parameter when multiple CRSs in the same map configuration are needed.
 
+## Additional map configuration options
+
+Map configuration also contains the following additional options:
+
+- `catalogServices` object describing services configuration for Catalog
+- `widgetsConfig` configuration of map widgets
+- `mapInfoConfiguration` map info configuration options
+- `dimensionData` contains map time information
+    - `currentTime` currently selected time; the beginning of a time range if offsetTime is set
+    - `offsetTime` the end of a time range
+- `timelineData` timeline options
+    - `selectedLayer` selected layer id; if not present, the first available layer with multidim-extension time information will be selected on map load
+
 ## Layers options
 
 Every layer has it's own properties. Anyway there are some options valid for every layer:

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -124,7 +124,7 @@ Map configuration also contains the following additional options:
     - `currentTime` currently selected time; the beginning of a time range if offsetTime is set
     - `offsetTime` the end of a time range
 - `timelineData` timeline options
-    - `selectedLayer` selected layer id; if not present, the first available layer with multidim-extension time information will be selected on map load
+    - `selectedLayer` selected layer id; if not present time cursor will be unlocked
 
 ## Layers options
 

--- a/web/client/actions/timeline.js
+++ b/web/client/actions/timeline.js
@@ -63,6 +63,12 @@ const ENABLE_OFFSET = "TIMELINE:ENABLE_OFFSET";
  */
 const enableOffset = enabled => ({ type: ENABLE_OFFSET, enabled});
 
+const AUTOSELECT = "TIMELINE:AUTOSELECT";
+/**
+ * Triggers autoselect setup behaviour
+ */
+const autoselect = () => ({ type: AUTOSELECT });
+
 const SET_COLLAPSED = "TIMELINE:SET_COLLAPSED";
 const setCollapsed = collapsed => ({ type: SET_COLLAPSED, collapsed});
 const SET_MAP_SYNC = 'TIMELINE:SET_MAP_SYNC';
@@ -84,6 +90,8 @@ module.exports = {
     selectLayer,
     ENABLE_OFFSET,
     enableOffset,
+    AUTOSELECT,
+    autoselect,
     SET_COLLAPSED,
     setCollapsed,
     SET_MAP_SYNC,

--- a/web/client/epics/__tests__/dimension-test.js
+++ b/web/client/epics/__tests__/dimension-test.js
@@ -53,8 +53,8 @@ describe('dimension epics', () => {
         const startActions = [configureMap(testConfig, 10)];
 
         mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
-        testEpic(updateLayerDimensionDataOnMapLoad, 4, startActions, actions => {
-            expect(actions.length).toBe(4);
+        testEpic(updateLayerDimensionDataOnMapLoad, 5, startActions, actions => {
+            expect(actions.length).toBe(5);
             expect(actions[0].type).toBe(SELECT_LAYER);
             expect(actions[0].layerId).toBe(testConfig.timelineData.selectedLayer);
             expect(actions[1].type).toBe(SET_CURRENT_TIME);
@@ -63,13 +63,30 @@ describe('dimension epics', () => {
             expect(actions[2].offsetTime).toBe(testConfig.dimensionData.offsetTime);
             expect(actions[3].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
             expect(actions[3].dimension).toBe('time');
-            expect(actions[3].layerId).toBe(testConfig.timelineData.selectedLayer);
+            expect(actions[3].layerId).toBe('timelineLayer2');
             expect(actions[3].data).toExist();
             expect(actions[3].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
             expect(actions[3].data.name).toBe('time');
+            expect(actions[4].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[4].dimension).toBe('time');
+            expect(actions[4].layerId).toBe(testConfig.timelineData.selectedLayer);
+            expect(actions[4].data).toExist();
+            expect(actions[4].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[4].data.name).toBe('time');
         }, {
             layers: {
                 flat: [{
+                    id: 'timelineLayer2',
+                    name: 'timelineLayer2',
+                    type: 'wms',
+                    dimensions: [{
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'sample/url'
+                        }
+                    }]
+                }, {
                     id: 'timelineLayer',
                     name: 'timelineLayer',
                     type: 'wms',
@@ -91,17 +108,93 @@ describe('dimension epics', () => {
         const startActions = [configureMap(testConfig, 10)];
 
         mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
-        testEpic(updateLayerDimensionDataOnMapLoad, 1, startActions, actions => {
-            expect(actions.length).toBe(1);
+        testEpic(updateLayerDimensionDataOnMapLoad, 2, startActions, actions => {
+            expect(actions.length).toBe(2);
             expect(actions[0].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
             expect(actions[0].dimension).toBe('time');
-            expect(actions[0].layerId).toBe('timelineLayer');
+            expect(actions[0].layerId).toBe('timelineLayer2');
             expect(actions[0].data).toExist();
             expect(actions[0].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
             expect(actions[0].data.name).toBe('time');
+            expect(actions[1].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[1].dimension).toBe('time');
+            expect(actions[1].layerId).toBe('timelineLayer');
+            expect(actions[1].data).toExist();
+            expect(actions[1].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[1].data.name).toBe('time');
         }, {
             layers: {
                 flat: [{
+                    id: 'timelineLayer2',
+                    name: 'timelineLayer2',
+                    type: 'wms',
+                    dimensions: [{
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'sample/url'
+                        }
+                    }]
+                }, {
+                    id: 'timelineLayer',
+                    name: 'timelineLayer',
+                    type: 'wms',
+                    dimensions: [{
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'sample/url'
+                        }
+                    }]
+                }]
+            }
+        }, done);
+    });
+    it('updateLayerDimensionDataOnMapLoad no timeline data', (done) => {
+        const testConfig = {
+            map: {},
+            dimensionData: {
+                currentTime: '1996-04-08T08:02:01.425Z',
+                offsetTime: '2016-06-07T02:17:23.197Z'
+            }
+        };
+        const startActions = [configureMap(testConfig, 10)];
+
+        mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
+        testEpic(updateLayerDimensionDataOnMapLoad, 5, startActions, actions => {
+            expect(actions.length).toBe(5);
+            expect(actions[0].type).toBe(SELECT_LAYER);
+            expect(actions[0].layerId).toBe('timelineLayer2');
+            expect(actions[1].type).toBe(SET_CURRENT_TIME);
+            expect(actions[1].time).toBe(testConfig.dimensionData.currentTime);
+            expect(actions[2].type).toBe(SET_OFFSET_TIME);
+            expect(actions[2].offsetTime).toBe(testConfig.dimensionData.offsetTime);
+            expect(actions[3].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[3].dimension).toBe('time');
+            expect(actions[3].layerId).toBe('timelineLayer2');
+            expect(actions[3].data).toExist();
+            expect(actions[3].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[3].data.name).toBe('time');
+            expect(actions[4].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[4].dimension).toBe('time');
+            expect(actions[4].layerId).toBe('timelineLayer');
+            expect(actions[4].data).toExist();
+            expect(actions[4].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[4].data.name).toBe('time');
+        }, {
+            layers: {
+                flat: [{
+                    id: 'timelineLayer2',
+                    name: 'timelineLayer2',
+                    type: 'wms',
+                    dimensions: [{
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'sample/url'
+                        }
+                    }]
+                }, {
                     id: 'timelineLayer',
                     name: 'timelineLayer',
                     type: 'wms',

--- a/web/client/epics/__tests__/dimension-test.js
+++ b/web/client/epics/__tests__/dimension-test.js
@@ -15,7 +15,8 @@ import { testEpic } from './epicTestUtils';
 import { updateLayerDimensionDataOnMapLoad } from '../dimension';
 import { configureMap } from '../../actions/config';
 import {
-    SELECT_LAYER
+    SELECT_LAYER,
+    AUTOSELECT
 } from '../../actions/timeline';
 import {
     SET_CURRENT_TIME,
@@ -108,20 +109,22 @@ describe('dimension epics', () => {
         const startActions = [configureMap(testConfig, 10)];
 
         mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
-        testEpic(updateLayerDimensionDataOnMapLoad, 2, startActions, actions => {
-            expect(actions.length).toBe(2);
+        testEpic(updateLayerDimensionDataOnMapLoad, 4, startActions, actions => {
+            expect(actions.length).toBe(4);
             expect(actions[0].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
             expect(actions[0].dimension).toBe('time');
             expect(actions[0].layerId).toBe('timelineLayer2');
             expect(actions[0].data).toExist();
             expect(actions[0].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
             expect(actions[0].data.name).toBe('time');
-            expect(actions[1].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
-            expect(actions[1].dimension).toBe('time');
-            expect(actions[1].layerId).toBe('timelineLayer');
-            expect(actions[1].data).toExist();
-            expect(actions[1].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
-            expect(actions[1].data.name).toBe('time');
+            expect(actions[1].type).toBe(AUTOSELECT);
+            expect(actions[2].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[2].dimension).toBe('time');
+            expect(actions[2].layerId).toBe('timelineLayer');
+            expect(actions[2].data).toExist();
+            expect(actions[2].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[2].data.name).toBe('time');
+            expect(actions[3].type).toBe(AUTOSELECT);
         }, {
             layers: {
                 flat: [{
@@ -161,26 +164,24 @@ describe('dimension epics', () => {
         const startActions = [configureMap(testConfig, 10)];
 
         mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
-        testEpic(updateLayerDimensionDataOnMapLoad, 5, startActions, actions => {
-            expect(actions.length).toBe(5);
-            expect(actions[0].type).toBe(SELECT_LAYER);
-            expect(actions[0].layerId).toBe('timelineLayer2');
-            expect(actions[1].type).toBe(SET_CURRENT_TIME);
-            expect(actions[1].time).toBe(testConfig.dimensionData.currentTime);
-            expect(actions[2].type).toBe(SET_OFFSET_TIME);
-            expect(actions[2].offsetTime).toBe(testConfig.dimensionData.offsetTime);
+        testEpic(updateLayerDimensionDataOnMapLoad, 4, startActions, actions => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(SET_CURRENT_TIME);
+            expect(actions[0].time).toBe(testConfig.dimensionData.currentTime);
+            expect(actions[1].type).toBe(SET_OFFSET_TIME);
+            expect(actions[1].offsetTime).toBe(testConfig.dimensionData.offsetTime);
+            expect(actions[2].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[2].dimension).toBe('time');
+            expect(actions[2].layerId).toBe('timelineLayer2');
+            expect(actions[2].data).toExist();
+            expect(actions[2].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[2].data.name).toBe('time');
             expect(actions[3].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
             expect(actions[3].dimension).toBe('time');
-            expect(actions[3].layerId).toBe('timelineLayer2');
+            expect(actions[3].layerId).toBe('timelineLayer');
             expect(actions[3].data).toExist();
             expect(actions[3].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
             expect(actions[3].data.name).toBe('time');
-            expect(actions[4].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
-            expect(actions[4].dimension).toBe('time');
-            expect(actions[4].layerId).toBe('timelineLayer');
-            expect(actions[4].data).toExist();
-            expect(actions[4].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
-            expect(actions[4].data.name).toBe('time');
         }, {
             layers: {
                 flat: [{

--- a/web/client/epics/__tests__/dimension-test.js
+++ b/web/client/epics/__tests__/dimension-test.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import axios from "../../libs/ajax";
+import MockAdapter from "axios-mock-adapter";
+
+import { testEpic } from './epicTestUtils';
+
+import { updateLayerDimensionDataOnMapLoad } from '../dimension';
+import { configureMap } from '../../actions/config';
+import {
+    SELECT_LAYER
+} from '../../actions/timeline';
+import {
+    SET_CURRENT_TIME,
+    SET_OFFSET_TIME,
+    UPDATE_LAYER_DIMENSION_DATA
+} from '../../actions/dimension';
+
+const domainsTestResponse = `<?xml version="1.0" encoding="UTF-8"?><Domains xmlns="http://demo.geo-solutions.it/share/wmts-multidim/wmts_multi_dimensional.xsd" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1">
+  <DimensionDomain>
+    <ows:Identifier>time</ows:Identifier>
+    <Domain>1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z</Domain>
+    <Size>2</Size>
+  </DimensionDomain>
+</Domains>`;
+
+describe('dimension epics', () => {
+    let mockAxios;
+    beforeEach(() => {
+        mockAxios = new MockAdapter(axios);
+    });
+    afterEach(() => {
+        mockAxios.restore();
+    });
+    it('updateLayerDimensionDataOnMapLoad', (done) => {
+        const testConfig = {
+            map: {},
+            timelineData: {
+                selectedLayer: 'timelineLayer'
+            },
+            dimensionData: {
+                currentTime: '1996-04-08T08:02:01.425Z',
+                offsetTime: '2016-06-07T02:17:23.197Z'
+            }
+        };
+        const startActions = [configureMap(testConfig, 10)];
+
+        mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
+        testEpic(updateLayerDimensionDataOnMapLoad, 4, startActions, actions => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(SELECT_LAYER);
+            expect(actions[0].layerId).toBe(testConfig.timelineData.selectedLayer);
+            expect(actions[1].type).toBe(SET_CURRENT_TIME);
+            expect(actions[1].time).toBe(testConfig.dimensionData.currentTime);
+            expect(actions[2].type).toBe(SET_OFFSET_TIME);
+            expect(actions[2].offsetTime).toBe(testConfig.dimensionData.offsetTime);
+            expect(actions[3].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[3].dimension).toBe('time');
+            expect(actions[3].layerId).toBe(testConfig.timelineData.selectedLayer);
+            expect(actions[3].data).toExist();
+            expect(actions[3].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[3].data.name).toBe('time');
+        }, {
+            layers: {
+                flat: [{
+                    id: 'timelineLayer',
+                    name: 'timelineLayer',
+                    type: 'wms',
+                    dimensions: [{
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'sample/url'
+                        }
+                    }]
+                }]
+            }
+        }, done);
+    });
+    it('updateLayerDimensionDataOnMapLoad no timeline and dimension data', (done) => {
+        const testConfig = {
+            map: {}
+        };
+        const startActions = [configureMap(testConfig, 10)];
+
+        mockAxios.onGet('/sample/url').reply(200, domainsTestResponse);
+        testEpic(updateLayerDimensionDataOnMapLoad, 1, startActions, actions => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(UPDATE_LAYER_DIMENSION_DATA);
+            expect(actions[0].dimension).toBe('time');
+            expect(actions[0].layerId).toBe('timelineLayer');
+            expect(actions[0].data).toExist();
+            expect(actions[0].data.domain).toBe('1583-01-01T00:00:00.000Z--2101-01-01T00:00:00.000Z');
+            expect(actions[0].data.name).toBe('time');
+        }, {
+            layers: {
+                flat: [{
+                    id: 'timelineLayer',
+                    name: 'timelineLayer',
+                    type: 'wms',
+                    dimensions: [{
+                        name: 'time',
+                        source: {
+                            type: 'multidim-extension',
+                            url: 'sample/url'
+                        }
+                    }]
+                }]
+            }
+        }, done);
+    });
+});

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -7,7 +7,7 @@ const {wrapStartStop} = require('../observables/epics');
 
 const { CHANGE_MAP_VIEW } = require('../actions/map');
 
-const { SELECT_TIME, RANGE_CHANGED, ENABLE_OFFSET, SET_MAP_SYNC, timeDataLoading, rangeDataLoaded, onRangeChanged, selectLayer } = require('../actions/timeline');
+const { SELECT_TIME, RANGE_CHANGED, ENABLE_OFFSET, SET_MAP_SYNC, AUTOSELECT, timeDataLoading, rangeDataLoaded, onRangeChanged, selectLayer } = require('../actions/timeline');
 const { setCurrentTime, UPDATE_LAYER_DIMENSION_DATA, setCurrentOffset } = require('../actions/dimension');
 
 const {REMOVE_NODE} = require('../actions/layers');
@@ -195,7 +195,7 @@ module.exports = {
     /**
      * Initializes the time line
      */
-    setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, UPDATE_LAYER_DIMENSION_DATA)
+    setupTimelineExistingSettings: (action$, { getState = () => { } } = {}) => action$.ofType(REMOVE_NODE, AUTOSELECT)
         .exhaustMap(() =>
             isAutoSelectEnabled(getState())
             && get(timelineLayersSelector(getState()), "[0].id")

--- a/web/client/selectors/mapsave.js
+++ b/web/client/selectors/mapsave.js
@@ -10,6 +10,8 @@ const {createStructuredSelector} = require('reselect');
 const {servicesSelector, selectedServiceSelector} = require('./catalog');
 const {getFloatingWidgets, getCollapsedState, getFloatingWidgetsLayout} = require('./widgets');
 const { mapInfoConfigurationSelector } = require('./mapInfo');
+const { currentTimeSelector, offsetTimeSelector } = require('./dimension');
+const { selectedLayerSelector } = require('./timeline');
 
 const customSaveHandlers = {};
 
@@ -31,7 +33,14 @@ const basicMapOptionsToSaveSelector = createStructuredSelector({
         layouts: getFloatingWidgetsLayout,
         collapsed: getCollapsedState
     }),
-    mapInfoConfiguration: mapInfoConfigurationSelector
+    mapInfoConfiguration: mapInfoConfigurationSelector,
+    dimensionData: createStructuredSelector({
+        currentTime: currentTimeSelector,
+        offsetTime: offsetTimeSelector
+    }),
+    timelineData: createStructuredSelector({
+        selectedLayer: selectedLayerSelector
+    })
 });
 
 const mapOptionsToSaveSelector = (state) => {

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -482,6 +482,14 @@ const mergeMapConfigs = (cfg1 = {}, cfg2 = {}) => {
                     ]
                 }), {}),
             widgets: [...get(widgetsConfig1, 'widgets', []), ...get(widgetsConfig2, 'widgets', [])]
+        },
+        timelineData: {
+            ...get(cfg1, 'timelineData', {}),
+            ...get(cfg2Fixed, 'timelineData', {})
+        },
+        dimensionData: {
+            ...get(cfg1, 'dimensionData', {}),
+            ...get(cfg2Fixed, 'dimensionData', {})
         }
     };
 };

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -2227,7 +2227,14 @@ describe('Test the MapUtils', () => {
                 projection: "EPSG:4326",
                 units: "m"
             },
-            widgetsConfig: {}
+            widgetsConfig: {},
+            timelineData: {
+                selectedLayer: 'timelineLayer1'
+            },
+            dimensionData: {
+                currentTime: '1996-04-08T08:02:01.425Z',
+                offsetTime: '2016-06-07T02:17:23.197Z'
+            }
         };
         const cfg2 = {
             catalogServices: {
@@ -2322,6 +2329,13 @@ describe('Test the MapUtils', () => {
                         group: "group2"
                     }
                 }]
+            },
+            timelineData: {
+                selectedLayer: 'timelineLayer2'
+            },
+            dimensionData: {
+                currentTime: '1997-04-08T08:02:01.425Z',
+                offsetTime: '2017-06-07T02:17:23.197Z'
             }
         };
 
@@ -2392,5 +2406,11 @@ describe('Test the MapUtils', () => {
         expect(cfg.widgetsConfig.layouts.xxs).toExist();
         expect(cfg.widgetsConfig.layouts.lg[0].i).toBe(cfg.widgetsConfig.widgets[0].id);
         expect(cfg.widgetsConfig.layouts.xxs[0].i).toBe(cfg.widgetsConfig.widgets[0].id);
+
+        expect(cfg.timelineData).toExist();
+        expect(cfg.timelineData.selectedLayer).toBe('timelineLayer2');
+        expect(cfg.dimensionData).toExist();
+        expect(cfg.dimensionData.currentTime).toBe('1997-04-08T08:02:01.425Z');
+        expect(cfg.dimensionData.offsetTime).toBe('2017-06-07T02:17:23.197Z');
     });
 });


### PR DESCRIPTION
## Description
Added saving timeline time and selected layer state to map config.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

## Issue
[support/#574](https://github.com/geosolutions-it/support/issues/574)

**What is the current behavior?**
Timeline state is not saved in map config.

**What is the new behavior?**
Timeline current time, offset time and selected layer are saved in map config.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No