### PR TITLE
#5363: Video thumbnail refresh

### DIFF
--- a/web/client/components/maps/forms/__tests__/Thumbnail-test.jsx
+++ b/web/client/components/maps/forms/__tests__/Thumbnail-test.jsx
@@ -225,7 +225,7 @@ describe('This test for Thumbnail', () => {
         />, document.getElementById("container"));
         expect(thumbnailItem).toBeTruthy();
 
-        const removeNode = document.querySelector('.dropzone-remove');
+        const removeNode = document.querySelector('.btn');
         expect(removeNode).toBeTruthy();
         TestUtils.Simulate.click(removeNode);
     });

--- a/web/client/components/mediaEditor/video/VideoForm.jsx
+++ b/web/client/components/mediaEditor/video/VideoForm.jsx
@@ -68,14 +68,12 @@ const VideoThumbnail = ({
         };
     }, []);
 
-    const [loading, setLoading] = useState(false);
     const [errors, setErrors] = useState();
     // try to automatically create a thumbnail from video source
     // when thumbnail is missing
     const [createThumbnail, setCreateThumbnail] = useState(!thumbnail);
     useEffect(() => {
-        if (src && !loading && createThumbnail) {
-            setLoading(true);
+        if (src && createThumbnail) {
             setErrors(undefined);
             getVideoThumbnail(src, {
                 width: 640,
@@ -85,19 +83,16 @@ const VideoThumbnail = ({
             }).then((response) => {
                 if (mounted.current) {
                     onUpdate(response);
-                    setLoading(false);
                     setCreateThumbnail(false);
                 }
             }).catch(() => {
                 if (mounted.current) {
-                    setLoading(false);
                     setCreateThumbnail(false);
                     setErrors([ 'CREATE' ]);
                 }
             });
         }
-    }, [ src, loading, createThumbnail ]);
-
+    }, [ src, createThumbnail ]);
 
     return (
         <>
@@ -109,36 +104,34 @@ const VideoThumbnail = ({
                 type: 'image/jpeg',
                 quality: 0.5
             }}
-            loading={loading}
+            loading={createThumbnail}
             message={<Message msgId="mediaEditor.mediaPicker.thumbnail"/>}
             onUpdate={(newImageData) => {
                 onUpdate(newImageData);
                 setErrors(undefined);
             }}
             onError={(err) => setErrors(err)}
-            toolbar={
-                <Toolbar
-                    buttons={[
-                        {
-                            glyph: 'refresh',
-                            visible: !thumbnail,
-                            onClick: (event) => {
-                                event.stopPropagation();
-                                setCreateThumbnail(true);
-                            }
-                        },
-                        {
-                            glyph: 'trash',
-                            visible: !!thumbnail,
-                            onClick: (event) => {
-                                event.stopPropagation();
-                                onUpdate(undefined);
-                                setErrors(undefined);
-                            }
-                        }
-                    ]}
-                />
-            }
+            toolbarButtons={[
+                {
+                    glyph: 'refresh',
+                    tooltipId: 'mediaEditor.mediaPicker.createVideoThumbnail',
+                    visible: !thumbnail,
+                    onClick: (event) => {
+                        event.stopPropagation();
+                        setCreateThumbnail(true);
+                    }
+                },
+                {
+                    glyph: 'trash',
+                    tooltipId: 'removeThumbnail',
+                    visible: !!thumbnail,
+                    onClick: (event) => {
+                        event.stopPropagation();
+                        onUpdate(undefined);
+                        setErrors(undefined);
+                    }
+                }
+            ]}
         />
         {errors && errors.length > 0 &&
         <Alert bsStyle="danger" className="text-center">

--- a/web/client/components/mediaEditor/video/VideoForm.jsx
+++ b/web/client/components/mediaEditor/video/VideoForm.jsx
@@ -69,12 +69,14 @@ const VideoThumbnail = ({
     }, []);
 
     const [errors, setErrors] = useState();
+    const [loading, setLoading] = useState();
     // try to automatically create a thumbnail from video source
     // when thumbnail is missing
     const [createThumbnail, setCreateThumbnail] = useState(!thumbnail);
     useEffect(() => {
         if (src && createThumbnail) {
             setErrors(undefined);
+            setLoading(true);
             getVideoThumbnail(src, {
                 width: 640,
                 height: 360,
@@ -84,11 +86,13 @@ const VideoThumbnail = ({
                 if (mounted.current) {
                     onUpdate(response);
                     setCreateThumbnail(false);
+                    setLoading(false);
                 }
             }).catch(() => {
                 if (mounted.current) {
                     setCreateThumbnail(false);
                     setErrors([ 'CREATE' ]);
+                    setLoading(false);
                 }
             });
         }
@@ -104,7 +108,7 @@ const VideoThumbnail = ({
                 type: 'image/jpeg',
                 quality: 0.5
             }}
-            loading={createThumbnail}
+            loading={loading}
             message={<Message msgId="mediaEditor.mediaPicker.thumbnail"/>}
             onUpdate={(newImageData) => {
                 onUpdate(newImageData);

--- a/web/client/components/mediaEditor/video/__tests__/VideoForm-test.jsx
+++ b/web/client/components/mediaEditor/video/__tests__/VideoForm-test.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
 import VideoForm from '../VideoForm';
+import { Simulate, act } from 'react-dom/test-utils';
 
 describe('VideoForm component', () => {
     beforeEach((done) => {
@@ -21,8 +22,15 @@ describe('VideoForm component', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
-    it('should render with empty preview', () => {
-        ReactDOM.render(<VideoForm/>, document.getElementById("container"));
+    it('should render with thumbnail', () => {
+        ReactDOM.render(<VideoForm
+            editing
+            selectedItem={ {
+                data: {
+                    thumbnail: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII='
+                }
+            }}
+        />, document.getElementById("container"));
         const container = document.getElementById('container');
         const inputsNodes = container.querySelectorAll('input');
         expect(inputsNodes.length).toBe(5);
@@ -42,5 +50,31 @@ describe('VideoForm component', () => {
                 'mediaEditor.mediaPicker.descriptionPlaceholder',
                 'mediaEditor.mediaPicker.creditsPlaceholder'
             ]);
+    });
+
+    it('should render refresh button to create thumbnail from video source', () => {
+        ReactDOM.render(<VideoForm
+            editing
+            selectedItem={ {
+                data: {
+                    thumbnail: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII='
+                }
+            }}
+        />, document.getElementById("container"));
+        const container = document.getElementById('container');
+
+        const thumbnailNode = container.querySelector('.ms-thumbnail');
+        expect(thumbnailNode).toBeTruthy();
+
+        const removeButtonNode = thumbnailNode.querySelector('.btn');
+        expect(removeButtonNode.querySelector('.glyphicon-trash')).toBeTruthy();
+
+        act(() => {
+            Simulate.click(removeButtonNode);
+        });
+
+        const refreshButtonNode = thumbnailNode.querySelector('.btn');
+        expect(refreshButtonNode.querySelector('.glyphicon-refresh')).toBeTruthy();
+
     });
 });

--- a/web/client/components/misc/Thumbnail.jsx
+++ b/web/client/components/misc/Thumbnail.jsx
@@ -7,10 +7,10 @@
  */
 
 import React, { forwardRef, useState, useRef, useEffect } from 'react';
-import { Glyphicon } from 'react-bootstrap';
 import Dropzone from 'react-dropzone';
 import Loader from './Loader';
 import { createBase64Thumbnail } from '../../utils/ThumbnailUtils';
+import Toolbar from './toolbar/Toolbar';
 
 const getThumbnail = (files, options) => {
     return new Promise((resolve) => {
@@ -48,9 +48,10 @@ const getThumbnail = (files, options) => {
  * @prop {array} supportedImageTypes array of images supported mime types
  * @prop {options} thumbnailOptions options to scale the thumbnail to fit a specific size
  * @prop {object} dropZoneProps props for dropzone component
- * @prop {function} onUpdate
- * @prop {function} onError
- * @prop {function} onRemove
+ * @prop {function} onUpdate return updated data after add/drop an image
+ * @prop {function} onError return errors after add/drop an image
+ * @prop {function} onRemove callback on removing thumbnail
+ * @prop {array} toolbarButtons array of buttons objects (see Toolbar)
  */
 const Thumbnail = forwardRef(({
     className = 'ms-thumbnail',
@@ -60,6 +61,7 @@ const Thumbnail = forwardRef(({
     error,
     thumbnail,
     removeGlyph = 'trash',
+    removeTooltipId = 'removeThumbnail',
     style = {},
     maxFileSize = 500000,
     supportedImageTypes = ['image/png', 'image/jpeg', 'image/jpg'],
@@ -72,7 +74,7 @@ const Thumbnail = forwardRef(({
     onUpdate = () => {},
     onError = () => {},
     onRemove,
-    toolbar
+    toolbarButtons
 }, ref) => {
 
     const mounted = useRef();
@@ -125,6 +127,24 @@ const Thumbnail = forwardRef(({
         );
     }
 
+    const toolbar = (
+        <Toolbar
+            btnDefaultProps={{
+                className: 'square-button-md no-border'
+            }}
+            buttons={toolbarButtons
+                ? toolbarButtons
+                : [
+                    {
+                        glyph: removeGlyph,
+                        visible: !!(onRemove && thumbnail),
+                        tooltipId: removeTooltipId,
+                        onClick: handleRemove
+                    }
+                ]}
+        />
+    );
+
     return (
         <div
             className={`dropzone-thumbnail-container${className ? ` ${className}` : ''}`}
@@ -155,11 +175,7 @@ const Thumbnail = forwardRef(({
                                 }}
                             />
                             <div className="dropzone-content-image-added">{message}</div>
-                            {toolbar
-                                ? toolbar
-                                : onRemove && <div className="dropzone-remove" onClick={handleRemove}>
-                                    <Glyphicon glyph={removeGlyph} />
-                                </div>}
+                            {toolbar}
                         </div>
                     )
                     : (

--- a/web/client/components/misc/Thumbnail.jsx
+++ b/web/client/components/misc/Thumbnail.jsx
@@ -71,7 +71,8 @@ const Thumbnail = forwardRef(({
     },
     onUpdate = () => {},
     onError = () => {},
-    onRemove
+    onRemove,
+    toolbar
 }, ref) => {
 
     const mounted = useRef();
@@ -154,14 +155,17 @@ const Thumbnail = forwardRef(({
                                 }}
                             />
                             <div className="dropzone-content-image-added">{message}</div>
-                            {onRemove && <div className="dropzone-remove" onClick={handleRemove}>
-                                <Glyphicon glyph={removeGlyph} />
-                            </div>}
+                            {toolbar
+                                ? toolbar
+                                : onRemove && <div className="dropzone-remove" onClick={handleRemove}>
+                                    <Glyphicon glyph={removeGlyph} />
+                                </div>}
                         </div>
                     )
                     : (
                         <div className="dropzone-content-image">
                             {message}
+                            {toolbar}
                             {error && <div className="dropzone-errors">
                                 {error}
                             </div>}

--- a/web/client/components/misc/__tests__/Thumbnail-test.jsx
+++ b/web/client/components/misc/__tests__/Thumbnail-test.jsx
@@ -84,7 +84,7 @@ describe('Thumbnail component', () => {
         const container = document.getElementById('container');
         expect(container.querySelector('.ms-thumbnail-dropzone')).toBeTruthy();
 
-        const removeNode = document.querySelector('.dropzone-remove');
+        const removeNode = document.querySelector('.btn');
         expect(removeNode).toBeTruthy();
         Simulate.click(removeNode);
         const loadingNode = document.querySelector('.ms-loading');

--- a/web/client/components/resources/forms/__tests__/Thumbnail-test.jsx
+++ b/web/client/components/resources/forms/__tests__/Thumbnail-test.jsx
@@ -28,20 +28,20 @@ describe('This test for Thumbnail', () => {
     // test DEFAULTS
     it('creates the component with defaults, loading=true', () => {
         const thumbnailItem = ReactDOM.render(<Thumbnail loading/>, document.getElementById("container"));
-        expect(thumbnailItem).toExist();
+        expect(thumbnailItem).toBeTruthy();
 
         const thumbnailItemDom = ReactDOM.findDOMNode(thumbnailItem);
-        expect(thumbnailItemDom).toExist();
+        expect(thumbnailItemDom).toBeTruthy();
 
-        expect(thumbnailItemDom.className).toBe('btn btn-info');
+        expect(thumbnailItemDom.className).toBe('dropzone-thumbnail-container ms-loading');
     });
 
     it('creates the component with defaults, loading=false', () => {
         const thumbnailItem = ReactDOM.render(<Thumbnail loading={false} map={{saving: false}}/>, document.getElementById("container"));
-        expect(thumbnailItem).toExist();
+        expect(thumbnailItem).toBeTruthy();
 
         const thumbnailItemDom = ReactDOM.findDOMNode(thumbnailItem);
-        expect(thumbnailItemDom).toExist();
+        expect(thumbnailItemDom).toBeTruthy();
 
         expect(thumbnailItemDom.className).toBe('dropzone-thumbnail-container');
     });
@@ -55,25 +55,25 @@ describe('This test for Thumbnail', () => {
             errors: []
         };
         const thumbnailItem = ReactDOM.render(<Thumbnail map={map}/>, document.getElementById("container"));
-        expect(thumbnailItem).toExist();
+        expect(thumbnailItem).toBeTruthy();
 
         const thumbnailItemDom = ReactDOM.findDOMNode(thumbnailItem);
-        expect(thumbnailItemDom).toExist();
+        expect(thumbnailItemDom).toBeTruthy();
 
         const content = TestUtils.findRenderedDOMComponentWithClass(thumbnailItem, 'dropzone-content-image');
-        expect(content).toExist();
+        expect(content).toBeTruthy();
     });
 
     it('creates the component with a thumbnail', () => {
         let thumbnail = "http://localhost:8081/%2Fgeostore%2Frest%2Fdata%2F2214%2Fraw%3Fdecode%3Ddatauri";
         const thumbnailItem = ReactDOM.render(<Thumbnail thumbnail={thumbnail}/>, document.getElementById("container"));
-        expect(thumbnailItem).toExist();
+        expect(thumbnailItem).toBeTruthy();
 
         const thumbnailItemDom = ReactDOM.findDOMNode(thumbnailItem);
-        expect(thumbnailItemDom).toExist();
+        expect(thumbnailItemDom).toBeTruthy();
 
         const content = TestUtils.findRenderedDOMComponentWithClass(thumbnailItem, 'dropzone-content-image-added');
-        expect(content).toExist();
+        expect(content).toBeTruthy();
     });
 
 });

--- a/web/client/themes/default/less/dropzone.less
+++ b/web/client/themes/default/less/dropzone.less
@@ -207,4 +207,29 @@
 		align-items: center;
 		justify-content: center;
 	}
+
+	.btn-group {
+		position: absolute;
+		right: 0;
+		top: 0;
+		padding: 4px;
+
+		.btn {
+			.shadow-soft;
+		}
+	}
+}
+
+/* buttons in map thumbnails */
+.dropzone-thumbnail-container {
+	.btn-group {
+		position: absolute;
+		right: 0;
+		top: 0;
+		padding: 4px;
+		z-index: 2;
+		.btn {
+			.shadow-soft;
+		}
+	}
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -50,6 +50,7 @@
         },
         "showEmptyMessageGFI": "Nachricht mit leeren Ergebnissen anzeigen",
         "remove": "Löschen",
+        "removeThumbnail": "Miniaturbild entfernen",
         "layerProperties": {
             "windowTitle": "Ebenen Eigenschaften",
             "title": "Titel",
@@ -2224,7 +2225,9 @@
                 "trash": "Remove resource",
                 "videoUrl": "Video URL",
                 "videoUrlPlaceholder": "Geben Sie eine Video-URL ein",
-                "thumbnail": "Miniaturbild hinzufügen (maximale Größe 500 KB)"
+                "thumbnail": "Miniaturbild hinzufügen (maximale Größe 500 KB)",
+                "createVideoThumbnail": "Erstellen Sie eine Miniaturansicht aus einer Videoquelle",
+                "thumbnailCreateError": "Es ist nicht möglich, ein Miniaturbild aus der aktuellen Videoquelle zu erstellen. Klicken oder löschen Sie ein Bild in der Miniaturansicht, um es manuell hochzuladen"
             },
             "mediaform": {
                 "confirmExitTitle": "Schließen Media Form",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -50,6 +50,7 @@
         },
         "showEmptyMessageGFI": "Show empty results message in GetFeatureInfo panel",
         "remove": "Delete",
+        "removeThumbnail": "Remove thumbnail",
         "layerProperties": {
             "windowTitle": "Layer Properties",
             "title": "Title",
@@ -2228,7 +2229,9 @@
                 "trash": "Remove resource",
                 "videoUrl": "Video URL",
                 "videoUrlPlaceholder": "Enter a video url",
-                "thumbnail": "Add thumbnail (maximum size 500kb)"
+                "thumbnail": "Add thumbnail (maximum size 500kb)",
+                "createVideoThumbnail": "Create a thumbnail from video source",
+                "thumbnailCreateError": "It's not possible to create a thumbnail from the current video source. Click or drop an image in the thumbnail input to upload it manually"
             },
             "mediaform": {
                 "confirmExitTitle": "Close Media Form",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -50,6 +50,7 @@
         },
         "showEmptyMessageGFI": "Mostrar mensaje de resultados vacío en el panel de GFI",
         "remove": "Borrar",
+        "removeThumbnail": "Eliminar miniatura",
         "layerProperties": {
             "windowTitle": "Propiedades de la capa",
             "title": "Título",
@@ -2225,7 +2226,9 @@
                 "trash": "Eliminar recurso",
                 "videoUrl": "URL de video",
                 "videoUrlPlaceholder": "Ingrese una url de video",
-                "thumbnail": "Añadir miniatura (tamaño máximo 500kb)"
+                "thumbnail": "Añadir miniatura (tamaño máximo 500kb)",
+                "createVideoThumbnail": "Crea una miniatura de la fuente de video",
+                "thumbnailCreateError": "No es posible crear una miniatura desde la fuente de video actual. Haga clic o suelte una imagen en la entrada en miniatura para cargarla manualmente"
             },
             "mediaform": {
                 "confirmExitTitle": "Cerrar el Media Form",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -50,6 +50,7 @@
         },
         "showEmptyMessageGFI": "Afficher un message de résultat vide dans le panneau GetFeatureInfo",
         "remove": "Supprimer",
+        "removeThumbnail": "Supprimer la miniature",
         "layerProperties": {
             "windowTitle": "Propriétés de la couche",
             "title": "Titre",
@@ -2225,7 +2226,9 @@
                 "trash": "Supprimer la ressource",
                 "videoUrl": "URL de la vidéo",
                 "videoUrlPlaceholder": "Entrez une URL d'une vidéo",
-                "thumbnail": "Ajouter une vignette (taille maximale 500 Kb)"
+                "thumbnail": "Ajouter une vignette (taille maximale 500 Kb)",
+                "createVideoThumbnail": "Créer une miniature à partir de la source vidéo",
+                "thumbnailCreateError": "Il n'est pas possible de créer une miniature à partir de la source vidéo actuelle. Cliquez ou déposez une image dans la vignette pour la télécharger manuellement"
             },
             "mediaform": {
                 "confirmExitTitle": "Fermer le formulaire de médias",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -50,6 +50,7 @@
         },
         "showEmptyMessageGFI": "Mostra il messaggio: Nessuna feature per gli altri layer",
         "remove": "Rimuovi",
+        "removeThumbnail": "Rimuovi anteprima",
         "layerProperties": {
             "windowTitle": "Proprietà del livello",
             "title": "Titolo",
@@ -2225,7 +2226,9 @@
                 "trash": "Elimina la risorsa",
                 "videoUrl": "Video URL",
                 "videoUrlPlaceholder": "Inserisci video url",
-                "thumbnail": "Aggiungi thumbnail (dimensione massima 500kb)"
+                "thumbnail": "Aggiungi thumbnail (dimensione massima 500kb)",
+                "createVideoThumbnail": "Crea un'anteprima dalla risorsa video",
+                "thumbnailCreateError": "Non è possibile creare un'anteprima dalla risorsa video. Clicca o rilascia un'immagine nel input dell'anteprima per caricarne una manualmente"
             },
             "mediaform": {
                 "confirmExitTitle": "Chiudi Media From",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR introduces following changes:
- introduce of toolbar in thumbnail component to support additional buttons
- update all thumbnail component with the same styles
- add refresh button in video thumbnail
![vido-refresh-thumbnail](https://user-images.githubusercontent.com/19175505/83631145-53a51e00-a59d-11ea-82e3-02e42cf588cb.gif)

- add error message if thumbanil can't be created
![image](https://user-images.githubusercontent.com/19175505/83631591-43854280-a58d-11ea-921c-ab20a9506152.png)


All the thumbnails need to be tested because of the changes on buttons:

- map resource card (homepage)
- dashboard resource card (homepage)
- story resource card (homepage)
- logo global settings (geostory page)
- video thumbnail media editor (geostory page)
- map thumbnail media editor (geostory page)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5363

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
