### PR TITLE
Fix 5397 Map info data wrongly requested for static map configurations

### DIFF
--- a/web/client/config.json
+++ b/web/client/config.json
@@ -1,22 +1,29 @@
 {
-	"map": {
-		"projection": "EPSG:900913",
-		"units": "m",
-		"center": {"x": 1250000.000000, "y": 5370000.000000, "crs": "EPSG:900913"},
-    "zoom":5,
-		"maxExtent": [
-			-20037508.34, -20037508.34,
-			20037508.34, 20037508.34
-		],
-		"layers": [
-			{
-				"type": "osm",
-				"title": "Open Street Map",
-				"name": "mapnik",
-        "source": "osm",
-				"group": "background",
-        "visibility": true
-			}
-		]
-	}
+    "version": 2,
+    "map": {
+        "projection": "EPSG:900913",
+        "units": "m",
+        "center": {
+            "x": 1250000.000000,
+            "y": 5370000.000000,
+            "crs": "EPSG:900913"
+        },
+        "zoom": 5,
+        "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+        ],
+        "layers": [
+            {
+                "type": "osm",
+                "title": "Open Street Map",
+                "name": "mapnik",
+                "source": "osm",
+                "group": "background",
+                "visibility": true
+            }
+        ]
+    }
 }

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -214,6 +214,19 @@ describe('config epics', () => {
                 }
             });
         });
+        it('load existing configuration file with alphanumeric mapId', (done) => {
+            mockAxios.onGet("/base/web/client/test-resources/testConfig.json").reply(() => ([ 200, {} ]));
+            const checkActions = ([a]) => {
+                expect(a).toBeTruthy();
+                expect(a.type).toBe(MAP_CONFIG_LOADED);
+                done();
+            };
+            testEpic(loadMapConfigAndConfigureMap,
+                1,
+                [loadMapConfig('base/web/client/test-resources/testConfig.json', 'testConfig')],
+                checkActions
+            );
+        });
     });
 
     describe('loadMapInfo', () => {

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -7,7 +7,7 @@
  */
 import { Observable } from 'rxjs';
 import axios from '../libs/ajax';
-import { get, merge } from 'lodash';
+import { get, merge, isNaN } from 'lodash';
 import {
     LOAD_NEW_MAP,
     LOAD_MAP_CONFIG,
@@ -61,6 +61,10 @@ const mapFlowWithOverride = (configName, mapId, config, mapInfo, state, override
     // certain epics always function correctly
     // i.e. FeedbackMask disables correctly after load
     // TODO: investigate the root causes of the problem and come up with a better solution, if possible
+
+    // mapstore recognizes alphanumeric map id as static json
+    // avoid map info requests if the configuration is static 
+    const isNumberId = !isNaN(parseFloat(mapId));
     return (
         config ?
             Observable.of({data: merge({}, config, overrideConfig), staticConfig: true}).delay(100) :
@@ -77,7 +81,7 @@ const mapFlowWithOverride = (configName, mapId, config, mapInfo, state, override
                     return Observable.of(configureError({messageId: `map.errors.loading.projectionError`, errorMessageParams: {projection}}, mapId));
                 }
                 const mapConfig = merge({}, response.data, overrideConfig);
-                return mapId ? Observable.of(
+                return isNumberId ? Observable.of(
                     configureMap(mapConfig, mapId),
                     mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId),
                     ...(response.staticConfig ? [] : [saveMapConfig(response.data)])
@@ -91,7 +95,7 @@ const mapFlowWithOverride = (configName, mapId, config, mapInfo, state, override
             try {
                 const data = JSON.parse(response.data);
                 const mapConfig = merge({}, data, overrideConfig);
-                return mapId ? Observable.of(configureMap(mapConfig, mapId), mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId)) :
+                return isNumberId ? Observable.of(configureMap(mapConfig, mapId), mapInfo ? mapInfoLoaded(mapInfo) : loadMapInfo(mapId)) :
                     Observable.of(
                         configureMap(mapConfig, mapId),
                         ...(mapInfo ? [mapInfoLoaded(mapInfo)] : []),

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -63,7 +63,7 @@ const mapFlowWithOverride = (configName, mapId, config, mapInfo, state, override
     // TODO: investigate the root causes of the problem and come up with a better solution, if possible
 
     // mapstore recognizes alphanumeric map id as static json
-    // avoid map info requests if the configuration is static 
+    // avoid map info requests if the configuration is static
     const isNumberId = !isNaN(parseFloat(mapId));
     return (
         config ?


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds a control for alphanumeric ids in the config epics for map config request to avoid additional map info request for static map.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5397

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No additional request when the mapId is alphanumeric (static configuration)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
