### PR TITLE
5401. fix rectangular roundvalue and step

### DIFF
--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -157,8 +157,8 @@ class GeometryDetails extends React.Component {
                     style={{minWidth: '105px', margin: 'auto'}}
                     type="number"
                     id={"queryform_bbox_" + name}
-                    step={!this.isWGS84() ? 1 : this.getStep(this.props.zoom)}
-                    defaultValue={this.roundValue(value, !this.isWGS84() ? 100 : 1000000)}
+                    step={this.getStep(this.props.zoom)}
+                    defaultValue={this.roundValue(value, 1000000)}
                     onChange={(evt) => this.onUpdateBBOX(evt.target.value, name)}/>
             </div>
         );
@@ -323,7 +323,7 @@ class GeometryDetails extends React.Component {
         for (let prop in this.extent) {
             if (prop) {
                 let coordinateInput = document.getElementById("queryform_bbox_" + prop);
-                coordinateInput.value = this.roundValue(this.extent[prop], !this.isWGS84() ? 100 : 1000000);
+                coordinateInput.value = this.roundValue(this.extent[prop], 1000000);
                 this.onUpdateBBOX(this.extent[prop], prop);
             }
         }

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -180,7 +180,7 @@ describe('GeometryDetails', () => {
             const [mainValue, decimals] = input.value.split('.');
 
             expect(mainValue.length + decimals.length <= 10 && mainValue.length + decimals.length >= 7).toBeTruthy();
-            expect(mainValue.length <= 4).toBeTruthy(); // can be ranged from 999 to -999
+            expect(mainValue.length <= 4).toBeTruthy(); // can be ranged from 180 to -180
             expect(decimals.length === 6).toBeTruthy(); // always must be 6 digits
         });
     });

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -137,10 +137,10 @@ describe('GeometryDetails', () => {
     it('creates the GeometryDetails component with BBOX selection', () => {
         let geometry = {
             extent: [
-                -1335833.8895192828,
-                5212046.6457833825,
-                -543239.115071175,
-                5785158.045300978
+                -10691400.02030417,
+                4424786.693372282,
+                -10006524.24686899,
+                5613535.357263343
             ],
             projection: "EPSG:900913",
             type: "Polygon"
@@ -172,5 +172,9 @@ describe('GeometryDetails', () => {
         let panelBodyRows = pb.getElementsByClassName('row');
         expect(panelBodyRows).toExist();
         expect(panelBodyRows.length).toBe(3);
+
+        [...panelBodyRows].forEach(row => {
+            expect(row.querySelector('input').value.length).toBe(9);
+        });
     });
 });

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -137,10 +137,10 @@ describe('GeometryDetails', () => {
     it('creates the GeometryDetails component with BBOX selection', () => {
         let geometry = {
             extent: [
-                -10691400.02030417,
-                4424786.693372282,
-                -10006524.24686899,
-                5613535.357263343
+                -12080719.446415536,
+                3035467.26726092,
+                -11112109.423985783,
+                6146760.066580733
             ],
             projection: "EPSG:900913",
             type: "Polygon"
@@ -173,8 +173,15 @@ describe('GeometryDetails', () => {
         expect(panelBodyRows).toExist();
         expect(panelBodyRows.length).toBe(3);
 
-        [...panelBodyRows].forEach(row => {
-            expect(row.querySelector('input').value.length).toBe(9);
+        const panelBodyInputs = pb.querySelectorAll('input');
+        expect(panelBodyInputs.length).toBe(4);
+
+        [...panelBodyInputs].forEach(input => {
+            const [mainValue, decimals] = input.value.split('.');
+
+            expect(mainValue.length + decimals.length <= 10 && mainValue.length + decimals.length >= 7).toBeTruthy();
+            expect(mainValue.length <= 4).toBeTruthy(); // can be ranged from 999 to -999
+            expect(decimals.length === 6).toBeTruthy(); // always must be 6 digits
         });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5401 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now rectangular spatial filter has 6-digits coordinates length. The same problem was with the step value. It was always '1' if not 'EPSG:4326'. That behavior wasn't flexible and dependable on the current 'zoom' value.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
