### PR TITLE
Fix empty list for image

### DIFF
--- a/web/client/components/mediaEditor/image/ImageList.jsx
+++ b/web/client/components/mediaEditor/image/ImageList.jsx
@@ -12,6 +12,7 @@ import withLocal from "../../misc/enhancers/localizedProps";
 import Filter from '../../misc/Filter';
 import SideGrid from '../../misc/cardgrids/SideGrid';
 import { filterResources } from '../../../utils/GeoStoryUtils';
+import HTML from '../../I18N/HTML';
 
 const FilterLocalized = withLocal('filterPlaceholder')(Filter);
 
@@ -28,18 +29,24 @@ export default withFilter(({
             filterPlaceholder="mediaEditor.mediaPicker.imageFilter"
             filterText={filterText}
             onFilter={onFilter}/>
-        <SideGrid
-            items={filterResources(resources, filterText).map(({ id, data = {}}) => ({
-                preview: <div
-                    style={{
-                        background: `url("${data.src}")`,
-                        backgroundSize: 'cover',
-                        height: "100%",
-                        overflow: 'hidden'
-                    }} />,
-                title: data.title,
-                onClick: () => selectItem(id),
-                selected: selectedItem && selectedItem.id && id === selectedItem.id,
-                description: data.description
-            }))} />
+        {
+            resources.length > 0 && (
+                <SideGrid
+                    items={filterResources(resources, filterText).map(({ id, data = {}}) => ({
+                        preview: <div
+                            style={{
+                                background: `url("${data.src}")`,
+                                backgroundSize: 'cover',
+                                height: "100%",
+                                overflow: 'hidden'
+                            }} />,
+                        title: data.title,
+                        onClick: () => selectItem(id),
+                        selected: selectedItem && selectedItem.id && id === selectedItem.id,
+                        description: data.description
+                    }))} />) || (
+                <div className="msEmptyListMessage">
+                    <HTML msgId="mediaEditor.imageList.emptyList"/>
+                </div>)
+        }
     </div>));

--- a/web/client/components/mediaEditor/image/__tests__/ImageList-test.jsx
+++ b/web/client/components/mediaEditor/image/__tests__/ImageList-test.jsx
@@ -22,8 +22,21 @@ describe('ImageList component', () => {
         setTimeout(done);
     });
     it('ImageList rendering with defaults', () => {
-        ReactDOM.render(<ImageList />, document.getElementById("container"));
+        ReactDOM.render(<ImageList/>, document.getElementById("container"));
         const container = document.getElementById('container');
-        expect(container.querySelector('.ms-imageList')).toExist();
+        expect(container.querySelector('.ms-imageList')).toBeTruthy();
+        expect(container.querySelector('.msEmptyListMessage')).toBeTruthy();
+    });
+    it('does not renders empty list message', () => {
+        ReactDOM.render(<ImageList resources={[
+            {
+                id: "test",
+                data: {}
+            }
+        ]} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container.querySelector('.ms-imageList')).toBeTruthy();
+        expect(container.querySelector('.msEmptyListMessage')).toBeFalsy();
+
     });
 });

--- a/web/client/components/mediaEditor/map/MapList.jsx
+++ b/web/client/components/mediaEditor/map/MapList.jsx
@@ -9,7 +9,7 @@ import React from "react";
 import {compose, withProps, withHandlers, mapPropsStream} from 'recompose';
 
 import MapCatalogComp from '../../maps/MapCatalog';
-import Message from '../../I18N/Message';
+import HTML from '../../I18N/HTML';
 import mapCatalog from '../../maps/enhancers/mapCatalog';
 import handleMapSelect from '../../widgets/builder/wizard/map/enhancers/handleMapSelect';
 import Filter from '../../misc/Filter';
@@ -91,7 +91,7 @@ const MapList = ({
                     }))}
                 />) || (
                 <div className="msEmptyListMessage">
-                    <Message msgId="mediaEditor.mapList.emptyList"/>
+                    <HTML msgId="mediaEditor.mapList.emptyList"/>
                 </div>)
             }
         </div>);

--- a/web/client/components/mediaEditor/video/VideoList.jsx
+++ b/web/client/components/mediaEditor/video/VideoList.jsx
@@ -10,7 +10,7 @@ import React from "react";
 import withFilter from '../enhancers/withFilter';
 import withLocal from "../../misc/enhancers/localizedProps";
 import Filter from '../../misc/Filter';
-import Message from '../../I18N/Message';
+import HTML from '../../I18N/HTML';
 import SideGrid from '../../misc/cardgrids/SideGrid';
 import { filterResources } from '../../../utils/GeoStoryUtils';
 const Icon = require('../../misc/FitIcon');
@@ -51,6 +51,6 @@ export default withFilter(({
                     description: data.description
                 }))} />
             : <div className="msEmptyListMessage">
-                <Message msgId="mediaEditor.videoList.emptyList"/>
+                <HTML msgId="mediaEditor.videoList.emptyList"/>
             </div>}
     </div>));

--- a/web/client/configs/newgeostory.json
+++ b/web/client/configs/newgeostory.json
@@ -1,16 +1,6 @@
 {
   "type": "cascade",
-  "resources": [{
-    "id": "3025f52e-8d57-48df-9a56-8e21ac252282",
-    "type": "image",
-    "data": {
-      "src": "https://images.unsplash.com/photo-1566305828756-cacc74d3dd20?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60",
-      "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-      "credits": "Lorem Ipsum and Internation Spatial Agency",
-      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-      "altText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    }
-  }],
+  "resources": [],
   "settings": {
     "theme": {
       "general": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2243,11 +2243,14 @@
                 "confirmRemoveResource": "Möchten Sie diese Medienressource aus der Story entfernen?",
                 "confirmRemoveUsedResource": "Diese Ressource wird auch aus allen Abschnitten / Inhalten entfernt, in denen sie verwendet wird und sie bleiben leer. Möchten Sie es aus der Geschichte entfernen?"
             },
+            "imageList": {
+                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Bild hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> hier <a/>"
+            },
             "mapList": {
-                "emptyList": "Klicken Sie auf die Plus-Schaltfläche, um eine Karte zu erstellen oder einen anderen Kartendienst auszuwählen."
+                "emptyList": "Klicken Sie auf die Plus-Schaltfläche, um eine Karte zu erstellen oder einen anderen Kartendienst auszuwählen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> hier <a/>"
             },
             "videoList": {
-                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Video hinzuzufügen"
+                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Video hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> hier <a/>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2244,13 +2244,13 @@
                 "confirmRemoveUsedResource": "Diese Ressource wird auch aus allen Abschnitten / Inhalten entfernt, in denen sie verwendet wird und sie bleiben leer. Möchten Sie es aus der Geschichte entfernen?"
             },
             "imageList": {
-                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Bild hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> hier <a/>"
+                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Bild hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> hier </a>"
             },
             "mapList": {
-                "emptyList": "Klicken Sie auf die Plus-Schaltfläche, um eine Karte zu erstellen oder einen anderen Kartendienst auszuwählen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> hier <a/>"
+                "emptyList": "Klicken Sie auf die Plus-Schaltfläche, um eine Karte zu erstellen oder einen anderen Kartendienst auszuwählen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> hier </a>"
             },
             "videoList": {
-                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Video hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> hier <a/>"
+                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Video hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> hier </a>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2247,11 +2247,14 @@
                 "confirmRemoveResource": "Do you want to remove this media resource from the story?",
                 "confirmRemoveUsedResource": "This resource will also be removed from all the sections/contents where It's used leaving them empty. Do you want to remove It from the story?"
             },
+            "imageList": {
+                "emptyList": "Click on the plus button to add a new image. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>here<a/>"
+            },
             "mapList": {
-                "emptyList": "Click on the plus button to create a map or select a different map service."
+                "emptyList": "Click on the plus button to create a map or select a different map service. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>here<a/>"
             },
             "videoList": {
-                "emptyList": "Click on the plus button to add a new video"
+                "emptyList": "Click on the plus button to add a new video. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>here<a/>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2248,13 +2248,13 @@
                 "confirmRemoveUsedResource": "This resource will also be removed from all the sections/contents where It's used leaving them empty. Do you want to remove It from the story?"
             },
             "imageList": {
-                "emptyList": "Click on the plus button to add a new image. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>here<a/>"
+                "emptyList": "Click on the plus button to add a new image. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>here</a>"
             },
             "mapList": {
-                "emptyList": "Click on the plus button to create a map or select a different map service. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>here<a/>"
+                "emptyList": "Click on the plus button to create a map or select a different map service. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>here</a>"
             },
             "videoList": {
-                "emptyList": "Click on the plus button to add a new video. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>here<a/>"
+                "emptyList": "Click on the plus button to add a new video. See the user guide <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>here</a>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2244,11 +2244,14 @@
                 "confirmRemoveResource": "¿Desea eliminar este recurso de medios de la historia?",
                 "confirmRemoveUsedResource": "Este recurso también se eliminará de todas las secciones / contenidos donde se usa dejándolos vacíos. ¿Quieres eliminarlo de la historia?"
             },
+            "imageList": {
+                "emptyList": "Haga clic en el botón más para agregar una nueva imagen. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> aquí <a/>"
+            },
             "mapList": {
-                "emptyList": "Haga clic en el botón más para crear un mapa o seleccione un servicio de mapas diferente."
+                "emptyList": "Haga clic en el botón más para crear un mapa o seleccione un servicio de mapas diferente. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> aquí <a/>"
             },
             "videoList": {
-                "emptyList": "Haga clic en el botón más para agregar un nuevo video"
+                "emptyList": "Haga clic en el botón más para agregar un nuevo video. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> aquí <a/>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2245,13 +2245,13 @@
                 "confirmRemoveUsedResource": "Este recurso también se eliminará de todas las secciones / contenidos donde se usa dejándolos vacíos. ¿Quieres eliminarlo de la historia?"
             },
             "imageList": {
-                "emptyList": "Haga clic en el botón más para agregar una nueva imagen. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> aquí <a/>"
+                "emptyList": "Haga clic en el botón más para agregar una nueva imagen. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> aquí </a>"
             },
             "mapList": {
-                "emptyList": "Haga clic en el botón más para crear un mapa o seleccione un servicio de mapas diferente. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> aquí <a/>"
+                "emptyList": "Haga clic en el botón más para crear un mapa o seleccione un servicio de mapas diferente. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> aquí </a>"
             },
             "videoList": {
-                "emptyList": "Haga clic en el botón más para agregar un nuevo video. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> aquí <a/>"
+                "emptyList": "Haga clic en el botón más para agregar un nuevo video. Consulte la guía del usuario <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> aquí </a>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2244,11 +2244,14 @@
                 "confirmRemoveResource": "Voulez-vous supprimer cette ressource multimédia de la story ?",
                 "confirmRemoveUsedResource": "Cette ressource sera également supprimée de toutes les sections / contenus où elle est utilisée les laissant vides. Voulez-vous la supprimer de la story ?"
             },
+            "imageList": {
+                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle image. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> ici <a/>"
+            },
             "mapList": {
-                "emptyList": "Cliquez sur le bouton plus pour créer une carte ou sélectionnez un autre service de carte."
+                "emptyList": "Cliquez sur le bouton plus pour créer une carte ou sélectionnez un autre service de carte. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> ici <a/>"
             },
             "videoList": {
-                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle vidéo"
+                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle vidéo. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> ici <a/>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2245,13 +2245,13 @@
                 "confirmRemoveUsedResource": "Cette ressource sera également supprimée de toutes les sections / contenus où elle est utilisée les laissant vides. Voulez-vous la supprimer de la story ?"
             },
             "imageList": {
-                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle image. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> ici <a/>"
+                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle image. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> ici </a>"
             },
             "mapList": {
-                "emptyList": "Cliquez sur le bouton plus pour créer une carte ou sélectionnez un autre service de carte. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> ici <a/>"
+                "emptyList": "Cliquez sur le bouton plus pour créer une carte ou sélectionnez un autre service de carte. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> ici </a>"
             },
             "videoList": {
-                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle vidéo. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> ici <a/>"
+                "emptyList": "Cliquez sur le bouton plus pour ajouter une nouvelle vidéo. Voir le guide de l'utilisateur <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> ici </a>"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2251,7 +2251,7 @@
                 "emptyList": "Premere il pulsante più per creare una mappa o selezionare un altro servizio di mappe. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>questa</a> guida"
             },
             "videoList": {
-                "emptyList": "Premere il pulsante più per aggiungere un nuovo video. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>questa<a/> guida"
+                "emptyList": "Premere il pulsante più per aggiungere un nuovo video. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>questa</a> guida"
             }
         },
         "backgroundDialog": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2248,7 +2248,7 @@
                 "emptyList": "Premere il pulsante più per aggiungere una nuova immagine. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>questa</a> guida"
             },
             "mapList": {
-                "emptyList": "Premere il pulsante più per creare una mappa o selezionare un altro servizio di mappe. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>questa<a/> guida"
+                "emptyList": "Premere il pulsante più per creare una mappa o selezionare un altro servizio di mappe. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>questa</a> guida"
             },
             "videoList": {
                 "emptyList": "Premere il pulsante più per aggiungere un nuovo video. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>questa<a/> guida"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2245,7 +2245,7 @@
                 "confirmRemoveUsedResource": "Questa risorsa sarà rimossa anche da tutte le sezioni/contenuti che rimarrano vuoti. La vuoi rimuovere dalla storia?"
             },
             "imageList": {
-                "emptyList": "Premere il pulsante più per aggiungere una nuova immagine. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>questa<a/> guida"
+                "emptyList": "Premere il pulsante più per aggiungere una nuova immagine. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>questa</a> guida"
             },
             "mapList": {
                 "emptyList": "Premere il pulsante più per creare una mappa o selezionare un altro servizio di mappe. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>questa<a/> guida"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2244,11 +2244,14 @@
                 "confirmRemoveResource": "Vuoi rimuovere questa risorsa multimediale dalla storia?",
                 "confirmRemoveUsedResource": "Questa risorsa sarà rimossa anche da tutte le sezioni/contenuti che rimarrano vuoti. La vuoi rimuovere dalla storia?"
             },
+            "imageList": {
+                "emptyList": "Premere il pulsante più per aggiungere una nuova immagine. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/>questa<a/> guida"
+            },
             "mapList": {
-                "emptyList": "Premere il pulsante più per creare una mappa o selezionare un altro servizio di mappe."
+                "emptyList": "Premere il pulsante più per creare una mappa o selezionare un altro servizio di mappe. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/>questa<a/> guida"
             },
             "videoList": {
-                "emptyList": "Premere il pulsante più per aggiungere un nuovo video"
+                "emptyList": "Premere il pulsante più per aggiungere un nuovo video. Per maggiori informazioni consulta <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/>questa<a/> guida"
             }
         },
         "backgroundDialog": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
- [ ] Added a message of empty list of images in media editor.
- [ ] added link to user guide for the three tabs (images, maps, videos)
- [ ] removed default image for new geostory config

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5310

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
A message appear if not images are in the media editore image list

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
