### PR TITLE
add font size to geostory editor

### DIFF
--- a/web/client/components/geostory/contents/enhancers/editableText.jsx
+++ b/web/client/components/geostory/contents/enhancers/editableText.jsx
@@ -74,7 +74,7 @@ export default compose(
                 toolbarStyle,
                 toolbar: {
                     // [here](https://jpuri.github.io/react-draft-wysiwyg/#/docs) you can find some examples (hard to find them in the official draft-js doc)
-                    options: ['fontFamily', 'blockType', 'inline', 'textAlign', 'colorPicker', 'list', 'link', 'remove'],
+                    options: ['fontFamily', 'blockType', 'fontSize', 'inline', 'textAlign', 'colorPicker', 'list', 'link', 'remove'],
                     fontFamily: {
                         options: ['inherit', 'Arial', 'Georgia', 'Impact', 'Tahoma', 'Times New Roman', 'Verdana'],
                         className: undefined,
@@ -100,6 +100,9 @@ export default compose(
                         className: undefined,
                         component: undefined,
                         dropdownClassName: undefined
+                    },
+                    fontSize: {
+                        defaultFontSize: 24
                     },
                     inline: {
                         options: ['bold', 'italic', 'underline', 'strikethrough', 'monospace'],

--- a/web/client/components/geostory/contents/enhancers/editableText.jsx
+++ b/web/client/components/geostory/contents/enhancers/editableText.jsx
@@ -101,9 +101,6 @@ export default compose(
                         component: undefined,
                         dropdownClassName: undefined
                     },
-                    fontSize: {
-                        defaultFontSize: 24
-                    },
                     inline: {
                         options: ['bold', 'italic', 'underline', 'strikethrough', 'monospace'],
                         bold: { className: `${className}-toolbar-btn` },

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -44,6 +44,11 @@
 @import '~draft-js-inline-toolbar-plugin/lib/plugin.css';
 @import '~react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 
+
+// needed to assure the fontsize numbers to be correctly displayed (2 sided digits )
+.rdw-fontsize-dropdown {
+    min-width: 50px !important;
+}
 /* mixin for position sticky */
 .ms-position-sticky {
     position: -webkit-sticky;
@@ -536,7 +541,7 @@
                     z-index: 2;
                     .shadow-soft();
                 }
-                
+
                 /*
                 content body needs to be aligned accordingly with the alignment of container,
                 this is needed in particular for size equal to large and short titles
@@ -944,7 +949,9 @@
                     h4 span { font-size: @ms-story-font-size-h4; }
                     h5 span { font-size: @ms-story-font-size-h5; }
                     h6 span { font-size: @ms-story-font-size-h6; }
-
+                    span > span {
+                        font-size: inherit;
+                    }
                     /*
                     headers and paragraph tags have a div children with `margin: 1em 0;`
                     this style increases the size of the text container and it's different from the plain html
@@ -1181,7 +1188,7 @@
     background-color: rgba(0, 0, 0, 0.25);
     & > * {
         background-color: @ms-story-bg;
-    } 
+    }
 }
 
 .ms-custom-theme-picker-field {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
added fontsize to text editor in geostory

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5406

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
now you can customize the font inside the text editor

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
