### PR TITLE
[Backport 2020.02.xx] #5365: GeoStory Nav Bar should disappear if empty (#5394)

### DIFF
--- a/web/client/components/geostory/navigation/Navigation.jsx
+++ b/web/client/components/geostory/navigation/Navigation.jsx
@@ -41,6 +41,26 @@ export default ({
         color,
         backgroundColor
     } = isObject(theme) && theme || {};
+
+    const {
+        isTitleEnabled,
+        isLogoEnabled,
+        isNavbarEnabled
+    } = settings || {};
+    const isToolbarEnabled = buttons.length > 0;
+    const isHomeButtonEnabled = router &&
+        router.pathname &&
+        router.search &&
+        getQueryParams(router.search).showHome === 'true' &&
+        router.pathname.includes('/geostory/shared');
+    const isNavbarVisible = isNavbarEnabled && navigableItems?.length > 0;
+
+    const isVisible = isTitleEnabled
+        || isLogoEnabled
+        || isNavbarVisible
+        || isToolbarEnabled
+        || isHomeButtonEnabled;
+
     return (
         <div
             className="ms-geostory-navigation-bar"
@@ -63,16 +83,12 @@ export default ({
                     }}
                 />
             </div>
-            <div className="ms-geostory-navigation-tools">
+            {isVisible && <div className="ms-geostory-navigation-tools">
 
                 <div className="ms-geostory-navigation-toolbar">
                     <Toolbar buttons={buttons} />
                     {
-                        router &&
-                        router.pathname &&
-                        router.search &&
-                        getQueryParams(router.search).showHome === 'true' &&
-                        router.pathname.includes('/geostory/shared') && (
+                        isHomeButtonEnabled && (
                             <Home
                                 bsStyle="default"
                                 className="square-button-md no-border"
@@ -83,7 +99,7 @@ export default ({
                     }
                 </div>
                 <div className="ms-geostory-navigation-elements">
-                    {navigableItems && navigableItems.length && settings && settings.isNavbarEnabled ?
+                    {isNavbarVisible ?
                         (<div className="ms-geostory-navigation-navigable-items">
                             <ScrollMenu
                                 items={navigableItems}
@@ -101,19 +117,19 @@ export default ({
                             />
                         </div>) : null}
                     <div className="ms-geostory-navigation-metadata">
-                        {settings && settings.isTitleEnabled &&
+                        {isTitleEnabled &&
                             <div className="ms-geostory-navigation-title">
                                 {settings.storyTitle}
                             </div>
                         }
-                        {settings && settings.isLogoEnabled &&
+                        {isLogoEnabled &&
                             <div className="ms-geostory-navigation-logo">
                                 <img src={settings.thumbnail && (settings.thumbnail.data || settings.thumbnail.url) || ""} height={32}/>
                             </div>
                         }
                     </div>
                 </div>
-            </div>
+            </div>}
         </div>
     );
 };

--- a/web/client/components/geostory/navigation/__tests__/Navigation-test.jsx
+++ b/web/client/components/geostory/navigation/__tests__/Navigation-test.jsx
@@ -62,14 +62,28 @@ describe('GeoStory Navigation component', () => {
     });
     it('should render home icon', () => {
         ReactDOM.render(<Navigation router={{ pathname: '/geostory/shared/1', search: '?showHome=true' }} />, document.getElementById('container'));
-        expect(document.querySelector('#home-button')).toExist();
+        expect(document.querySelector('#home-button')).toBeTruthy();
     });
     it('should hide home icon when showHome is false', () => {
         ReactDOM.render(<Navigation router={{ pathname: '/geostory/shared/1', search: '?showHome=false' }} />, document.getElementById('container'));
-        expect(document.querySelector('#home-button')).toBe(null);
+        expect(document.querySelector('#home-button')).toBeFalsy();
     });
     it('should hide home icon without search query', () => {
         ReactDOM.render(<Navigation router={{ pathname: '/geostory/shared/1' }} />, document.getElementById('container'));
-        expect(document.querySelector('#home-button')).toBe(null);
+        expect(document.querySelector('#home-button')).toBeFalsy();
+    });
+
+    it('should hide all navigation tools', () => {
+        ReactDOM.render(<Navigation
+            router={{ pathname: '/geostory/shared/1' }}
+            settings={{
+                isTitleEnabled: false,
+                isLogoEnabled: false,
+                isNavbarEnabled: false
+            }}
+            buttons={[]}
+            navigableItems={[]}
+        />, document.getElementById('container'));
+        expect(document.querySelector('.ms-geostory-navigation-tools')).toBeFalsy();
     });
 });

--- a/web/client/themes/default/less/geostory-navigation.less
+++ b/web/client/themes/default/less/geostory-navigation.less
@@ -32,7 +32,6 @@
 }
 
 .ms-geostory-navigation {
-    height: @square-btn-size;
     background-color: @ms-story-bg;
     .btn-default {
         .ms-geostory-navigation-btn(inherit; inherit; transparent);
@@ -57,11 +56,15 @@
             }
         }
         .ms-geostory-navigation-tools {
+            height: auto;
             align-items: center;
             display: flex;
             flex: 1;
             padding: 0 4px;
             background-color: inherit;
+            .ms-geostory-navigation-toolbar > .btn-group {
+                display: block;
+            }
             .ms-geostory-navigation-elements {
                 
                 flex: 1;
@@ -72,6 +75,7 @@
                     min-height: @square-btn-medium-size;
                     max-width: 50%;
                     background-color: inherit;
+                    margin: 4px 0;
                 }
             }
 
@@ -84,8 +88,7 @@
                 .ms-geostory-navigation-logo,
                 .ms-geostory-navigation-title {
                     white-space: nowrap;
-                    margin-left: 10px;
-                    margin-right: 10px;
+                    margin: 4px 10px;
                     align-items: center;
                 }
                 .ms-geostory-navigation-title {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR introduces new logic to hide GeoStory nav bar when tools, logo and title are disable or empty.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5365

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
