### PR TITLE
Backport 2020.02.xx - #5364: Identify will not be disabled when advanced editor is closed with OK (#5404)

### DIFF
--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -316,6 +316,7 @@ function saveMapConfiguration(currentMap, currentLayers, currentGroups, currentB
         maxExtent: currentMap.maxExtent,
         projection: currentMap.projection,
         units: currentMap.units,
+        mapInfoControl: currentMap.mapInfoControl,
         zoom: currentMap.zoom,
         mapOptions: currentMap.mapOptions || {}
     };

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -157,1005 +157,821 @@ describe('Test the MapUtils', () => {
         expect(resolution2).toEqual(resolution);
     });
 
-    it('save map configuration', () => {
+    describe("saveMapConfiguration", () => {
+        it('save map configuration', () => {
 
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer001",
-                loading: true,
-                name: "layer001",
-                params: {},
-                search: {},
-                singleTile: false,
-                thumbURL: "THUMB_URL",
-                title: "layer001",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer002",
-                loading: true,
-                name: "layer002",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer002",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer003",
-                loading: true,
-                name: "layer003",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer003",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer004",
-                loading: true,
-                name: "layer004",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer004",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url",
-                origin: [100000, 100000]
-            }
-        ];
-
-        const groups = [
-            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
-                ]}
-        ];
-
-        const mapConfig = {
-            center: {x: 0, y: 0, crs: 'EPSG:4326'},
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10
-        };
-
-        const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
-        expect(saved).toEqual({
-            map: {
-                center: {crs: 'EPSG:4326', x: 0, y: 0},
-                backgrounds: [],
-                groups: [{
-                    id: 'Default',
-                    title: 'Default',
-                    expanded: true
-                }, {
-                    id: 'custom',
-                    title: 'custom',
-                    expanded: false
-                }, {
-                    id: 'custom.nested001',
-                    title: 'nested001',
-                    expanded: true
-                }],
-                layers: [{
+            const flat = [
+                {
                     allowedSRS: {},
-                    thumbURL: "THUMB_URL",
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer001",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer001",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
+                    thumbURL: "THUMB_URL",
                     title: "layer001",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer002",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer002",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer002",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer003",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer003",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer003",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer004",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer004",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer004",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: [100000, 100000],
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
-                }],
-                mapOptions: {},
+                    origin: [100000, 100000]
+                }
+            ];
+
+            const groups = [
+                {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+                    ]}
+            ];
+
+            const mapConfig = {
+                center: {x: 0, y: 0, crs: 'EPSG:4326'},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
-                text_search_config: '',
                 units: 'm',
+                mapInfoControl: true,
                 zoom: 10
-            },
-            version: 2
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
+            expect(saved).toEqual({
+                map: {
+                    center: {crs: 'EPSG:4326', x: 0, y: 0},
+                    backgrounds: [],
+                    mapInfoControl: true,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: "THUMB_URL",
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer002",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer002",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer002",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer003",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer003",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer003",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer004",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer004",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer004",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: [100000, 100000],
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    }],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10
+                },
+                version: 2
+            });
         });
-    });
 
-    it('save map configuration with backgrounds', () => {
+        it('save map configuration with backgrounds', () => {
 
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer001",
-                loading: true,
-                name: "layer001",
-                params: {},
-                search: {},
-                singleTile: false,
-                thumbURL: "THUMB_URL",
-                title: "layer001",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer002",
-                loading: true,
-                name: "layer002",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer002",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer003",
-                loading: true,
-                name: "layer003",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer003",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer004",
-                loading: true,
-                name: "layer004",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer004",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url",
-                origin: [100000, 100000]
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer005",
-                loading: true,
-                name: "layer005",
-                group: "background",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer005",
-                type: "wms",
-                url: "",
-                thumbURL: "blob:http://name.domain/id",
-                visibility: true,
-                catalogURL: "url",
-                origin: [100000, 100000]
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer006",
-                loading: true,
-                name: "layer006",
-                group: "background",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer006",
-                type: "wms",
-                url: "",
-                visibility: false,
-                catalogURL: "url",
-                origin: [100000, 100000]
-            }
-        ];
-
-        const groups = [
-            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
-                ]}
-        ];
-
-        const backgrounds = [{id: 'layer005', thumbnail: 'data'}, {id: 'layer006', thumbnail: null}];
-
-        const mapConfig = {
-            center: {x: 0, y: 0, crs: 'EPSG:4326'},
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10
-        };
-
-        const saved = saveMapConfiguration(mapConfig, flat, groups, backgrounds, '', {});
-        expect(saved).toEqual({
-            map: {
-                center: {crs: 'EPSG:4326', x: 0, y: 0},
-                backgrounds: [{id: 'layer005', thumbnail: 'data'}],
-                groups: [{
-                    id: 'Default',
-                    title: 'Default',
-                    expanded: true
-                }, {
-                    id: 'custom',
-                    title: 'custom',
-                    expanded: false
-                }, {
-                    id: 'custom.nested001',
-                    title: 'nested001',
-                    expanded: true
-                }],
-                layers: [{
+            const flat = [
+                {
                     allowedSRS: {},
-                    thumbURL: "THUMB_URL",
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer001",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer001",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
+                    thumbURL: "THUMB_URL",
                     title: "layer001",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer002",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer002",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer002",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer003",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer003",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer003",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer004",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer004",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer004",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: [100000, 100000],
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    origin: [100000, 100000]
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: "background",
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer005",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer005",
-                    opacity: undefined,
+                    group: "background",
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer005",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
+                    thumbURL: "blob:http://name.domain/id",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: [100000, 100000],
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    origin: [100000, 100000]
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: "background",
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer006",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer006",
-                    opacity: undefined,
+                    group: "background",
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer006",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: false,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: [100000, 100000],
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
-                }],
-                mapOptions: {},
+                    origin: [100000, 100000]
+                }
+            ];
+
+            const groups = [
+                {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+                    ]}
+            ];
+
+            const backgrounds = [{id: 'layer005', thumbnail: 'data'}, {id: 'layer006', thumbnail: null}];
+
+            const mapConfig = {
+                center: {x: 0, y: 0, crs: 'EPSG:4326'},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
-                text_search_config: '',
                 units: 'm',
                 zoom: 10
-            },
-            version: 2
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, backgrounds, '', {});
+            expect(saved).toEqual({
+                map: {
+                    center: {crs: 'EPSG:4326', x: 0, y: 0},
+                    backgrounds: [{id: 'layer005', thumbnail: 'data'}],
+                    mapInfoControl: undefined,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: "THUMB_URL",
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer002",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer002",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer002",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer003",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer003",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer003",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer004",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer004",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer004",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: [100000, 100000],
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: "background",
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer005",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer005",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer005",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: [100000, 100000],
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: "background",
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer006",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer006",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer006",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: false,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: [100000, 100000],
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    }],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10
+                },
+                version: 2
+            });
         });
-    });
 
-    it('save map configuration with map options', () => {
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer001",
-                loading: true,
-                name: "layer001",
-                params: {},
-                search: {},
-                singleTile: false,
-                thumbURL: "THUMB_URL",
-                title: "layer001",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url",
-                legendOptions: { legendWidth: "", legendHeight: 40}
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer002",
-                loading: true,
-                name: "layer002",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer002",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "layer003",
-                loading: true,
-                name: "layer003",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer003",
-                type: "wms",
-                url: "",
-                visibility: true,
-                catalogURL: "url",
-                tooltipOptions: "both",
-                tooltipPlacement: "right",
-                legendOptions: { legendWidth: 20, legendHeight: 40}
-            }
-        ];
-
-        const groups = [
-            { expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002'] },
-            {
-                expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{ expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003'] }
-                ]
-            }
-        ];
-
-        const mapConfig = {
-            center: { x: 0, y: 0, crs: 'EPSG:4326' },
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10,
-            mapOptions: {
-                view: {
-                    resolutions: [
-                        84666.66666666688,
-                        42333.33333333344,
-                        21166.66666666672,
-                        10583.33333333336,
-                        5291.66666666668,
-                        2645.83333333334,
-                        1322.91666666667,
-                        661.458333333335000,
-                        529.166666666668000,
-                        396.875000000001000,
-                        264.583333333334000,
-                        132.291666666667000,
-                        66.145833333333500,
-                        39.687500000000100,
-                        26.458333333333400,
-                        13.229166666666700,
-                        6.614583333333350,
-                        3.968750000000010,
-                        2.645833333333340,
-                        1.322916666666670,
-                        0.661458333333335
-                    ]
-                }
-            }
-        };
-
-        const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
-        expect(saved).toEqual({
-            map: {
-                center: { crs: 'EPSG:4326', x: 0, y: 0 },
-                backgrounds: [],
-                groups: [{
-                    id: 'Default',
-                    title: 'Default',
-                    expanded: true
-                }, {
-                    id: 'custom',
-                    title: 'custom',
-                    expanded: false
-                }, {
-                    id: 'custom.nested001',
-                    title: 'nested001',
-                    expanded: true
-                }],
-                layers: [{
+        it('save map configuration with map options', () => {
+            const flat = [
+                {
                     allowedSRS: {},
-                    thumbURL: "THUMB_URL",
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer001",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer001",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
+                    thumbURL: "THUMB_URL",
                     title: "layer001",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
                     legendOptions: { legendWidth: "", legendHeight: 40}
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer002",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer002",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer002",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer003",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer003",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer003",
-                    transparent: undefined,
                     type: "wms",
                     url: "",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
                     tooltipOptions: "both",
                     tooltipPlacement: "right",
                     legendOptions: { legendWidth: 20, legendHeight: 40}
-                }],
+                }
+            ];
+
+            const groups = [
+                { expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002'] },
+                {
+                    expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{ expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003'] }
+                    ]
+                }
+            ];
+
+            const mapConfig = {
+                center: { x: 0, y: 0, crs: 'EPSG:4326' },
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                units: 'm',
+                zoom: 10,
                 mapOptions: {
                     view: {
                         resolutions: [
@@ -1182,388 +998,491 @@ describe('Test the MapUtils', () => {
                             0.661458333333335
                         ]
                     }
+                }
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
+            expect(saved).toEqual({
+                map: {
+                    center: { crs: 'EPSG:4326', x: 0, y: 0 },
+                    backgrounds: [],
+                    mapInfoControl: undefined,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: "THUMB_URL",
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: { legendWidth: "", legendHeight: 40}
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer002",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer002",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer002",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer003",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer003",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer003",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: "both",
+                        tooltipPlacement: "right",
+                        legendOptions: { legendWidth: 20, legendHeight: 40}
+                    }],
+                    mapOptions: {
+                        view: {
+                            resolutions: [
+                                84666.66666666688,
+                                42333.33333333344,
+                                21166.66666666672,
+                                10583.33333333336,
+                                5291.66666666668,
+                                2645.83333333334,
+                                1322.91666666667,
+                                661.458333333335000,
+                                529.166666666668000,
+                                396.875000000001000,
+                                264.583333333334000,
+                                132.291666666667000,
+                                66.145833333333500,
+                                39.687500000000100,
+                                26.458333333333400,
+                                13.229166666666700,
+                                6.614583333333350,
+                                3.968750000000010,
+                                2.645833333333340,
+                                1.322916666666670,
+                                0.661458333333335
+                            ]
+                        }
+                    },
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10
                 },
-                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-                projection: 'EPSG:900913',
-                text_search_config: '',
-                units: 'm',
-                zoom: 10
-            },
-            version: 2
+                version: 2
+            });
         });
-    });
 
-    it('save map configuration with tile matrix', () => {
+        it('save map configuration with tile matrix', () => {
 
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                description: undefined,
-                dimensions: [],
-                id: "layer001",
-                loading: true,
-                name: "layer001",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer001",
-                type: "wms",
-                url: "http:url001",
-                visibility: true,
-                catalogURL: "url",
-                matrixIds: {
-                    'EPSG:4326': [{
-                        identifier: 'EPSG:4326:0'
+            const flat = [
+                {
+                    allowedSRS: {},
+                    bbox: {},
+                    description: undefined,
+                    dimensions: [],
+                    id: "layer001",
+                    loading: true,
+                    name: "layer001",
+                    params: {},
+                    search: {},
+                    singleTile: false,
+                    title: "layer001",
+                    type: "wms",
+                    url: "http:url001",
+                    visibility: true,
+                    catalogURL: "url",
+                    matrixIds: {
+                        'EPSG:4326': [{
+                            identifier: 'EPSG:4326:0'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
                     }]
                 },
-                tileMatrixSet: [{
-                    TileMatrix: [{
-                        'ows:Identifier': 'EPSG:4326:0'
-                    }],
-                    'ows:Identifier': "EPSG:4326",
-                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
-                }, {
-                    TileMatrix: [{
-                        'ows:Identifier': 'custom:0'
-                    }],
-                    'ows:Identifier': "custom",
-                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
-                }]
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                description: undefined,
-                dimensions: [],
-                id: "layer002",
-                loading: true,
-                name: "layer002",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer002",
-                type: "wms",
-                url: "http:url001",
-                visibility: true,
-                catalogURL: "url"
-            },
-            {
-                allowedSRS: {},
-                bbox: {},
-                description: undefined,
-                dimensions: [],
-                id: "layer003",
-                loading: true,
-                name: "layer003",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer003",
-                type: "wms",
-                url: "http:url001",
-                visibility: true,
-                catalogURL: "url"
-            }
-        ];
-
-        const groups = [
-            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
-                ]}
-        ];
-
-        const mapConfig = {
-            center: {x: 0, y: 0, crs: 'EPSG:4326'},
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10
-        };
-
-        const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
-        expect(saved).toEqual({
-            map: {
-                center: {crs: 'EPSG:4326', x: 0, y: 0},
-                backgrounds: [],
-                groups: [{
-                    id: 'Default',
-                    title: 'Default',
-                    expanded: true
-                }, {
-                    id: 'custom',
-                    title: 'custom',
-                    expanded: false
-                }, {
-                    id: 'custom.nested001',
-                    title: 'nested001',
-                    expanded: true
-                }],
-                layers: [{
-                    allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
-                    bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
-                    description: undefined,
-                    dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
-                    id: "layer001",
-                    matrixIds: ['EPSG:4326'],
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
-                    name: "layer001",
-                    opacity: undefined,
-                    params: {},
-                    provider: undefined,
-                    search: {},
-                    singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: true,
-                    tiled: undefined,
-                    title: "layer001",
-                    transparent: undefined,
-                    type: "wms",
-                    url: "http:url001",
-                    visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined, legendOptions: undefined
-                },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
                     description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer002",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer002",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer002",
-                    transparent: undefined,
                     type: "wms",
                     url: "http:url001",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined, legendOptions: undefined
+                    catalogURL: "url"
                 },
                 {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
                     description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer003",
-                    matrixIds: undefined,
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer003",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: undefined,
-                    tiled: undefined,
                     title: "layer003",
-                    transparent: undefined,
                     type: "wms",
                     url: "http:url001",
                     visibility: true,
-                    catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined, legendOptions: undefined
-                }],
-                mapOptions: {},
+                    catalogURL: "url"
+                }
+            ];
+
+            const groups = [
+                {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+                    ]}
+            ];
+
+            const mapConfig = {
+                center: {x: 0, y: 0, crs: 'EPSG:4326'},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
-                text_search_config: '',
                 units: 'm',
-                zoom: 10,
-                sources: {
-                    'http:url001': {
-                        tileMatrixSet: {
-                            'EPSG:4326': {
-                                TileMatrix: [{
-                                    'ows:Identifier': 'EPSG:4326:0'
-                                }],
-                                'ows:Identifier': "EPSG:4326",
-                                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                zoom: 10
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
+            expect(saved).toEqual({
+                map: {
+                    center: {crs: 'EPSG:4326', x: 0, y: 0},
+                    backgrounds: [],
+                    mapInfoControl: undefined,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: ['EPSG:4326'],
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: true,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "http:url001",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined, legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer002",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer002",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer002",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "http:url001",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined, legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer003",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer003",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer003",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "http:url001",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined, legendOptions: undefined
+                    }],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10,
+                    sources: {
+                        'http:url001': {
+                            tileMatrixSet: {
+                                'EPSG:4326': {
+                                    TileMatrix: [{
+                                        'ows:Identifier': 'EPSG:4326:0'
+                                    }],
+                                    'ows:Identifier': "EPSG:4326",
+                                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                                }
                             }
                         }
                     }
-                }
-            },
-            version: 2
+                },
+                version: 2
+            });
         });
-    });
-    it('save map configuration with annotations with geodesic lines', () => {
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                dimensions: [],
-                id: "annotations",
-                loading: true,
-                name: "annotations",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "annotations",
-                type: "vector",
-                url: "",
-                features: [{
-                    type: "FeatureCollection",
+        it('save map configuration with annotations with geodesic lines', () => {
+            const flat = [
+                {
+                    allowedSRS: {},
+                    bbox: {},
+                    dimensions: [],
+                    id: "annotations",
+                    loading: true,
+                    name: "annotations",
+                    params: {},
+                    search: {},
+                    singleTile: false,
+                    title: "annotations",
+                    type: "vector",
+                    url: "",
                     features: [{
-                        type: "Feature",
-                        geometry: {
-                            type: "MultiPoint",
-                            coordinates: [[1, 1], [2, 2]]
-                        },
-                        properties: {
-                            geometryGeodesic: {
-                                type: "LineString",
-                                coordinates: [[1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2]]
-                            },
-                            useGeodesicLines: true
-                        }
-                    }]
-                }],
-                visibility: true,
-                catalogURL: "url"
-            }
-        ];
-
-        const groups = [
-            { expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002'] },
-            {
-                expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{ expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003'] }
-                ]
-            }
-        ];
-
-        const mapConfig = {
-            center: { x: 0, y: 0, crs: 'EPSG:4326' },
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10,
-            mapOptions: {
-                view: {
-                    resolutions: [
-                        84666.66666666688,
-                        42333.33333333344,
-                        21166.66666666672,
-                        10583.33333333336,
-                        5291.66666666668,
-                        2645.83333333334,
-                        1322.91666666667,
-                        661.458333333335000,
-                        529.166666666668000,
-                        396.875000000001000,
-                        264.583333333334000,
-                        132.291666666667000,
-                        66.145833333333500,
-                        39.687500000000100,
-                        26.458333333333400,
-                        13.229166666666700,
-                        6.614583333333350,
-                        3.968750000000010,
-                        2.645833333333340,
-                        1.322916666666670,
-                        0.661458333333335
-                    ]
-                }
-            }
-        };
-
-        const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
-        expect(saved).toEqual({
-            version: 2,
-            map: {
-                center: {
-                    x: 0,
-                    y: 0,
-                    crs: 'EPSG:4326'
-                },
-                maxExtent: [ -20037508.34, -20037508.34, 20037508.34, 20037508.34 ],
-                projection: 'EPSG:900913',
-                units: 'm',
-                zoom: 10,
-                mapOptions: {
-                    view: {
-                        resolutions: [ 84666.66666666688, 42333.33333333344, 21166.66666666672, 10583.33333333336, 5291.66666666668, 2645.83333333334, 1322.91666666667, 661.458333333335, 529.166666666668, 396.875000000001, 264.583333333334, 132.291666666667, 66.1458333333335, 39.6875000000001, 26.4583333333334, 13.2291666666667, 6.61458333333335, 3.96875000000001, 2.64583333333334, 1.32291666666667, 0.661458333333335 ]
-                    }
-                },
-                backgrounds: [],
-                layers: [{
-                    id: 'annotations',
-                    features: [ {
                         type: "FeatureCollection",
                         features: [{
                             type: "Feature",
@@ -1572,349 +1491,440 @@ describe('Test the MapUtils', () => {
                                 coordinates: [[1, 1], [2, 2]]
                             },
                             properties: {
-                                geometryGeodesic: null,
+                                geometryGeodesic: {
+                                    type: "LineString",
+                                    coordinates: [[1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2], [1, 1], [2, 2]]
+                                },
                                 useGeodesicLines: true
                             }
                         }]
                     }],
-                    format: undefined,
-                    thumbURL: undefined,
-                    group: undefined,
-                    search: {},
-                    source: undefined,
-                    name: 'annotations',
-                    opacity: undefined,
-                    provider: undefined,
-                    description: undefined,
-                    styles: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
-                    title: 'annotations',
-                    transparent: undefined,
-                    tiled: undefined,
-                    type: 'vector',
-                    url: '',
-                    bbox: {},
                     visibility: true,
-                    singleTile: false,
-                    allowedSRS: {},
-                    matrixIds: undefined,
-                    tileMatrixSet: undefined,
-                    requestEncoding: undefined,
-                    dimensions: [],
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    catalogURL: 'url',
-                    capabilitiesURL: undefined,
-                    useForElevation: false,
-                    hidden: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined, legendOptions: undefined,
-                    params: {} } ],
-                groups: [ {
-                    id: 'Default', title: 'Default', expanded: true
-                }, {
-                    id: 'custom', title: 'custom', expanded: false
-                }, {
-                    id: 'custom.nested001', title: 'nested001', expanded: true
-                } ],
-                text_search_config: '' }
-        });
-    });
+                    catalogURL: "url"
+                }
+            ];
 
-    it('save map configuration with tile matrix and map info configuration', () => {
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                description: undefined,
-                dimensions: [],
-                id: "layer001",
-                loading: true,
-                name: "layer001",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer001",
-                type: "wms",
-                url: "http:url001",
-                visibility: true,
-                catalogURL: "url",
-                matrixIds: {
-                    'EPSG:4326': [{
-                        identifier: 'EPSG:4326:0'
-                    }]
-                },
-                tileMatrixSet: [{
-                    TileMatrix: [{
-                        'ows:Identifier': 'EPSG:4326:0'
-                    }],
-                    'ows:Identifier': "EPSG:4326",
-                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
-                }, {
-                    TileMatrix: [{
-                        'ows:Identifier': 'custom:0'
-                    }],
-                    'ows:Identifier': "custom",
-                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
-                }]
-            }
-        ];
-        const groups = [
-            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
-                ]}
-        ];
-        const mapConfig = {
-            center: {x: 0, y: 0, crs: 'EPSG:4326'},
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10
-        };
-        const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', { mapInfoConfiguration: {infoFormat: "text/html", showEmptyMessageGFI: false}});
-        expect(saved).toEqual({
-            map: {
-                center: {crs: 'EPSG:4326', x: 0, y: 0},
-                backgrounds: [],
-                groups: [{
-                    id: 'Default',
-                    title: 'Default',
-                    expanded: true
-                }, {
-                    id: 'custom',
-                    title: 'custom',
-                    expanded: false
-                }, {
-                    id: 'custom.nested001',
-                    title: 'nested001',
-                    expanded: true
-                }],
-                layers: [{
+            const groups = [
+                { expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002'] },
+                {
+                    expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{ expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003'] }
+                    ]
+                }
+            ];
+
+            const mapConfig = {
+                center: { x: 0, y: 0, crs: 'EPSG:4326' },
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                units: 'm',
+                zoom: 10,
+                mapOptions: {
+                    view: {
+                        resolutions: [
+                            84666.66666666688,
+                            42333.33333333344,
+                            21166.66666666672,
+                            10583.33333333336,
+                            5291.66666666668,
+                            2645.83333333334,
+                            1322.91666666667,
+                            661.458333333335000,
+                            529.166666666668000,
+                            396.875000000001000,
+                            264.583333333334000,
+                            132.291666666667000,
+                            66.145833333333500,
+                            39.687500000000100,
+                            26.458333333333400,
+                            13.229166666666700,
+                            6.614583333333350,
+                            3.968750000000010,
+                            2.645833333333340,
+                            1.322916666666670,
+                            0.661458333333335
+                        ]
+                    }
+                }
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {});
+            expect(saved).toEqual({
+                version: 2,
+                map: {
+                    center: {
+                        x: 0,
+                        y: 0,
+                        crs: 'EPSG:4326'
+                    },
+                    maxExtent: [ -20037508.34, -20037508.34, 20037508.34, 20037508.34 ],
+                    projection: 'EPSG:900913',
+                    units: 'm',
+                    zoom: 10,
+                    mapOptions: {
+                        view: {
+                            resolutions: [ 84666.66666666688, 42333.33333333344, 21166.66666666672, 10583.33333333336, 5291.66666666668, 2645.83333333334, 1322.91666666667, 661.458333333335, 529.166666666668, 396.875000000001, 264.583333333334, 132.291666666667, 66.1458333333335, 39.6875000000001, 26.4583333333334, 13.2291666666667, 6.61458333333335, 3.96875000000001, 2.64583333333334, 1.32291666666667, 0.661458333333335 ]
+                        }
+                    },
+                    mapInfoControl: undefined,
+                    backgrounds: [],
+                    layers: [{
+                        id: 'annotations',
+                        features: [ {
+                            type: "FeatureCollection",
+                            features: [{
+                                type: "Feature",
+                                geometry: {
+                                    type: "MultiPoint",
+                                    coordinates: [[1, 1], [2, 2]]
+                                },
+                                properties: {
+                                    geometryGeodesic: null,
+                                    useGeodesicLines: true
+                                }
+                            }]
+                        }],
+                        format: undefined,
+                        thumbURL: undefined,
+                        group: undefined,
+                        search: {},
+                        source: undefined,
+                        name: 'annotations',
+                        opacity: undefined,
+                        provider: undefined,
+                        description: undefined,
+                        styles: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        title: 'annotations',
+                        transparent: undefined,
+                        tiled: undefined,
+                        type: 'vector',
+                        url: '',
+                        bbox: {},
+                        visibility: true,
+                        singleTile: false,
+                        allowedSRS: {},
+                        matrixIds: undefined,
+                        tileMatrixSet: undefined,
+                        requestEncoding: undefined,
+                        dimensions: [],
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        catalogURL: 'url',
+                        capabilitiesURL: undefined,
+                        useForElevation: false,
+                        hidden: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined, legendOptions: undefined,
+                        params: {} } ],
+                    groups: [ {
+                        id: 'Default', title: 'Default', expanded: true
+                    }, {
+                        id: 'custom', title: 'custom', expanded: false
+                    }, {
+                        id: 'custom.nested001', title: 'nested001', expanded: true
+                    } ],
+                    text_search_config: '' }
+            });
+        });
+
+        it('save map configuration with tile matrix and map info configuration', () => {
+            const flat = [
+                {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
                     description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer001",
-                    matrixIds: ['EPSG:4326'],
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer001",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: true,
-                    tiled: undefined,
                     title: "layer001",
-                    transparent: undefined,
                     type: "wms",
                     url: "http:url001",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
-                }],
-                mapOptions: {},
+                    matrixIds: {
+                        'EPSG:4326': [{
+                            identifier: 'EPSG:4326:0'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                }
+            ];
+            const groups = [
+                {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+                    ]}
+            ];
+            const mapConfig = {
+                center: {x: 0, y: 0, crs: 'EPSG:4326'},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
-                text_search_config: '',
                 units: 'm',
-                zoom: 10,
-                sources: {
-                    'http:url001': {
-                        tileMatrixSet: {
-                            'EPSG:4326': {
-                                TileMatrix: [{
-                                    'ows:Identifier': 'EPSG:4326:0'
-                                }],
-                                'ows:Identifier': "EPSG:4326",
-                                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                zoom: 10
+            };
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', { mapInfoConfiguration: {infoFormat: "text/html", showEmptyMessageGFI: false}});
+            expect(saved).toEqual({
+                map: {
+                    center: {crs: 'EPSG:4326', x: 0, y: 0},
+                    backgrounds: [],
+                    mapInfoControl: undefined,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: ['EPSG:4326'],
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: true,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "http:url001",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    }],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10,
+                    sources: {
+                        'http:url001': {
+                            tileMatrixSet: {
+                                'EPSG:4326': {
+                                    TileMatrix: [{
+                                        'ows:Identifier': 'EPSG:4326:0'
+                                    }],
+                                    'ows:Identifier': "EPSG:4326",
+                                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                                }
                             }
                         }
                     }
-                }
-            },
-            mapInfoConfiguration: {
-                infoFormat: "text/html",
-                showEmptyMessageGFI: false
-            },
-            version: 2
-        });
-    });
-
-    it('save map configuration with tile matrix and map info configuration', () => {
-        const flat = [
-            {
-                allowedSRS: {},
-                bbox: {},
-                description: undefined,
-                dimensions: [],
-                id: "layer001",
-                loading: true,
-                name: "layer001",
-                params: {},
-                search: {},
-                singleTile: false,
-                title: "layer001",
-                type: "wms",
-                url: "http:url001",
-                visibility: true,
-                catalogURL: "url",
-                matrixIds: {
-                    'EPSG:4326': [{
-                        identifier: 'EPSG:4326:0'
-                    }]
                 },
-                tileMatrixSet: [{
-                    TileMatrix: [{
-                        'ows:Identifier': 'EPSG:4326:0'
-                    }],
-                    'ows:Identifier': "EPSG:4326",
-                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
-                }, {
-                    TileMatrix: [{
-                        'ows:Identifier': 'custom:0'
-                    }],
-                    'ows:Identifier': "custom",
-                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
-                }]
-            }
-        ];
-        const groups = [
-            {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-            {expanded: false, id: 'custom', name: 'custom', title: 'custom',
-                nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
-                ]}
-        ];
-        const mapConfig = {
-            center: {x: 0, y: 0, crs: 'EPSG:4326'},
-            maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
-            projection: 'EPSG:900913',
-            units: 'm',
-            zoom: 10
-        };
-        const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', { mapInfoConfiguration: {infoFormat: "text/html", showEmptyMessageGFI: false}});
-        expect(saved).toEqual({
-            map: {
-                center: {crs: 'EPSG:4326', x: 0, y: 0},
-                backgrounds: [],
-                groups: [{
-                    id: 'Default',
-                    title: 'Default',
-                    expanded: true
-                }, {
-                    id: 'custom',
-                    title: 'custom',
-                    expanded: false
-                }, {
-                    id: 'custom.nested001',
-                    title: 'nested001',
-                    expanded: true
-                }],
-                layers: [{
+                mapInfoConfiguration: {
+                    infoFormat: "text/html",
+                    showEmptyMessageGFI: false
+                },
+                version: 2
+            });
+        });
+
+        it('save map configuration with tile matrix and map info configuration', () => {
+            const flat = [
+                {
                     allowedSRS: {},
-                    thumbURL: undefined,
-                    availableStyles: undefined,
-                    layerFilter: undefined,
                     bbox: {},
-                    requestEncoding: undefined,
-                    capabilitiesURL: undefined,
                     description: undefined,
                     dimensions: [],
-                    features: undefined,
-                    queryable: undefined,
-                    featureInfo: undefined,
-                    format: undefined,
-                    group: undefined,
-                    hideLoading: false,
-                    handleClickOnLayer: false,
                     id: "layer001",
-                    matrixIds: ['EPSG:4326'],
-                    maxZoom: undefined,
-                    maxNativeZoom: undefined,
+                    loading: true,
                     name: "layer001",
-                    opacity: undefined,
                     params: {},
-                    provider: undefined,
                     search: {},
                     singleTile: false,
-                    source: undefined,
-                    style: undefined,
-                    styleName: undefined,
-                    styles: undefined,
-                    tileMatrixSet: true,
-                    tiled: undefined,
                     title: "layer001",
-                    transparent: undefined,
                     type: "wms",
                     url: "http:url001",
                     visibility: true,
                     catalogURL: "url",
-                    hidden: false,
-                    useForElevation: false,
-                    origin: undefined,
-                    thematic: undefined,
-                    tooltipOptions: undefined,
-                    tooltipPlacement: undefined,
-                    legendOptions: undefined
-                }],
-                mapOptions: {},
+                    matrixIds: {
+                        'EPSG:4326': [{
+                            identifier: 'EPSG:4326:0'
+                        }]
+                    },
+                    tileMatrixSet: [{
+                        TileMatrix: [{
+                            'ows:Identifier': 'EPSG:4326:0'
+                        }],
+                        'ows:Identifier': "EPSG:4326",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                    }, {
+                        TileMatrix: [{
+                            'ows:Identifier': 'custom:0'
+                        }],
+                        'ows:Identifier': "custom",
+                        'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::900913"
+                    }]
+                }
+            ];
+            const groups = [
+                {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+                    ]}
+            ];
+            const mapConfig = {
+                center: {x: 0, y: 0, crs: 'EPSG:4326'},
                 maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
                 projection: 'EPSG:900913',
-                text_search_config: '',
                 units: 'm',
-                zoom: 10,
-                sources: {
-                    'http:url001': {
-                        tileMatrixSet: {
-                            'EPSG:4326': {
-                                TileMatrix: [{
-                                    'ows:Identifier': 'EPSG:4326:0'
-                                }],
-                                'ows:Identifier': "EPSG:4326",
-                                'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                zoom: 10
+            };
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', { mapInfoConfiguration: {infoFormat: "text/html", showEmptyMessageGFI: false}});
+            expect(saved).toEqual({
+                map: {
+                    center: {crs: 'EPSG:4326', x: 0, y: 0},
+                    backgrounds: [],
+                    mapInfoControl: undefined,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: ['EPSG:4326'],
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: true,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "http:url001",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    }],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10,
+                    sources: {
+                        'http:url001': {
+                            tileMatrixSet: {
+                                'EPSG:4326': {
+                                    TileMatrix: [{
+                                        'ows:Identifier': 'EPSG:4326:0'
+                                    }],
+                                    'ows:Identifier': "EPSG:4326",
+                                    'ows:SupportedCRS': "urn:ogc:def:crs:EPSG::4326"
+                                }
                             }
                         }
                     }
-                }
-            },
-            mapInfoConfiguration: {
-                infoFormat: "text/html",
-                showEmptyMessageGFI: false
-            },
-            version: 2
+                },
+                mapInfoConfiguration: {
+                    infoFormat: "text/html",
+                    showEmptyMessageGFI: false
+                },
+                version: 2
+            });
         });
     });
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Backport of 
#5364: Identify will not be disabled when advanced editor is closed with OK (#5404)