### PR TITLE
fix changeGroupPropery on expanded

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/handleNodePropertyChanges-test.jsx
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/handleNodePropertyChanges-test.jsx
@@ -80,6 +80,25 @@ describe('handleNodePropertyChanges enhancer', () => {
         expect(spyCallbacks.calls[0].arguments[1]).toBe(true);
     });
 
+    it('Test handleNodePropertyChange onChangeGroupProperty Expanded calls if groups is not array and it has no id', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyCallbacks = expect.spyOn(actions, 'onChange');
+        const Sink = handleNodePropertyChanges(createSink(props => {
+            expect(props).toExist();
+            props.changeGroupProperty("GGG", "expanded", true);
+        }));
+        ReactDOM.render(<Sink
+            map={{ groups: { name: 'GGG' }, layers: [{ id: "LAYER", group: "GGG", options: {} }] }}
+            onChange={actions.onChange} />, document.getElementById("container"));
+
+        expect(spyCallbacks.calls.length).toBe(2);
+        expect(spyCallbacks.calls[0].arguments[0]).toBe("map.groups[1].id");
+        expect(spyCallbacks.calls[0].arguments[1]).toEqual("GGG");
+        expect(spyCallbacks.calls[1].arguments[0]).toBe("map.groups[1].expanded");
+        expect(spyCallbacks.calls[1].arguments[1]).toBe(true);
+    });
     it('Test handleNodePropertyChange onChangeGroupProperty Expanded calls if groups is not array', () => {
         const actions = {
             onChange: () => {}
@@ -93,13 +112,9 @@ describe('handleNodePropertyChanges enhancer', () => {
             map={{ groups: { id: 'GGG' }, layers: [{ id: "LAYER", group: "GGG", options: {} }] }}
             onChange={actions.onChange} />, document.getElementById("container"));
 
-        expect(spyCallbacks.calls.length).toBe(3);
-        expect(spyCallbacks.calls[0].arguments[0]).toBe("map.groups");
-        expect(spyCallbacks.calls[0].arguments[1]).toEqual([]);
-        expect(spyCallbacks.calls[1].arguments[0]).toBe("map.groups[0].expanded");
-        expect(spyCallbacks.calls[1].arguments[1]).toBe(true);
-        expect(spyCallbacks.calls[2].arguments[0]).toBe("map.groups[0].id");
-        expect(spyCallbacks.calls[2].arguments[1]).toBe('GGG');
+        expect(spyCallbacks.calls.length).toBe(1);
+        expect(spyCallbacks.calls[0].arguments[0]).toBe("map.groups[0].expanded");
+        expect(spyCallbacks.calls[0].arguments[1]).toBe(true);
     });
 
     it('Test handleNodePropertyChange onChangeGroupProperty Expanded calls if id is not present in groups', () => {

--- a/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/handleNodePropertyChanges-test.jsx
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/__tests__/handleNodePropertyChanges-test.jsx
@@ -62,4 +62,63 @@ describe('handleNodePropertyChanges enhancer', () => {
         expect(spyCallbacks.calls[4].arguments[0]).toBe("map[b]");
         expect(spyCallbacks.calls[4].arguments[1]).toBe("b");
     });
+
+    it('Test handleNodePropertyChange onChangeGroupProperty Expanded calls', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyCallbacks = expect.spyOn(actions, 'onChange');
+        const Sink = handleNodePropertyChanges(createSink(props => {
+            expect(props).toExist();
+            props.changeGroupProperty("GGG", "expanded", true);
+        }));
+        ReactDOM.render(<Sink
+            map={{ groups: [{id: "GGG", expanded: false}], layers: [{ id: "LAYER", group: "GGG", options: {} }] }}
+            onChange={actions.onChange} />, document.getElementById("container"));
+        expect(spyCallbacks.calls.length).toBe(1);
+        expect(spyCallbacks.calls[0].arguments[0]).toBe("map.groups[0].expanded");
+        expect(spyCallbacks.calls[0].arguments[1]).toBe(true);
+    });
+
+    it('Test handleNodePropertyChange onChangeGroupProperty Expanded calls if groups is not array', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyCallbacks = expect.spyOn(actions, 'onChange');
+        const Sink = handleNodePropertyChanges(createSink(props => {
+            expect(props).toExist();
+            props.changeGroupProperty("GGG", "expanded", true);
+        }));
+        ReactDOM.render(<Sink
+            map={{ groups: { id: 'GGG' }, layers: [{ id: "LAYER", group: "GGG", options: {} }] }}
+            onChange={actions.onChange} />, document.getElementById("container"));
+
+        expect(spyCallbacks.calls.length).toBe(3);
+        expect(spyCallbacks.calls[0].arguments[0]).toBe("map.groups");
+        expect(spyCallbacks.calls[0].arguments[1]).toEqual([]);
+        expect(spyCallbacks.calls[1].arguments[0]).toBe("map.groups[0].expanded");
+        expect(spyCallbacks.calls[1].arguments[1]).toBe(true);
+        expect(spyCallbacks.calls[2].arguments[0]).toBe("map.groups[0].id");
+        expect(spyCallbacks.calls[2].arguments[1]).toBe('GGG');
+    });
+
+    it('Test handleNodePropertyChange onChangeGroupProperty Expanded calls if id is not present in groups', () => {
+        const actions = {
+            onChange: () => {}
+        };
+        const spyCallbacks = expect.spyOn(actions, 'onChange');
+        const Sink = handleNodePropertyChanges(createSink(props => {
+            expect(props).toExist();
+            props.changeGroupProperty("GGG", "expanded", true);
+        }));
+        ReactDOM.render(<Sink
+            map={{ groups: [], layers: [{ id: "LAYER", group: "GGG", options: {} }] }}
+            onChange={actions.onChange} />, document.getElementById("container"));
+
+        expect(spyCallbacks.calls.length).toBe(2);
+        expect(spyCallbacks.calls[0].arguments[0]).toBe("map.groups[0].id");
+        expect(spyCallbacks.calls[0].arguments[1]).toBe('GGG');
+        expect(spyCallbacks.calls[1].arguments[0]).toBe("map.groups[0].expanded");
+        expect(spyCallbacks.calls[1].arguments[1]).toBe(true);
+    });
 });

--- a/web/client/components/widgets/builder/wizard/map/enhancers/handleNodePropertyChanges.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/handleNodePropertyChanges.js
@@ -8,7 +8,7 @@
 // handle property changes
 const { withHandlers } = require('recompose');
 const {belongsToGroup} = require('../../../../../../utils/LayersUtils');
-const { findIndex, isArray } = require('lodash');
+const { findIndex, castArray } = require('lodash');
 /**
  * Add to the TOC or the Node editor some handlers for TOC nodes
  * add to the wrapped component the following methods:
@@ -51,23 +51,16 @@ module.exports = withHandlers({
             (id, key, value) => {
 
                 const EXPANDED = 'expanded';
-                const index = findIndex(map.groups || [], {
-                    id
-                });
+                const groups = map.groups ? castArray(map.groups) : [];
+                const groupIndex = findIndex(groups, (group) => id === group.id);
+                // if no group is found, then we add a new group
+                let correctGroupIndex = groupIndex === -1 ? groups.length : groupIndex;
 
-                if (key === EXPANDED) {
-                    if (!isArray(map.groups)) {
-                        onChange(`map.groups`, []);
-                        onChange(`map.groups[${index === -1 ? 0 : index}].${key}`, value);
-                        onChange(`map.groups[${index === -1 ? 0 : index}].id`, id);
-                    } else {
-                        (!map.groups[index === -1 ? map.groups.length : index]
-                        || (map.groups[index === -1 ? map.groups.length : index] && !map.groups[index === -1 ? 0 : index].id)
-                        )
-                        && onChange(`map.groups[${index === -1 ? map.groups.length : index}].id`, id);
-                        onChange(`map.groups[${index === -1 ? map.groups.length : index}].${key}`, value);
-                    }
-                } else onChange(`map.groups[${index}].${key}`, value);
+                if (key === EXPANDED && !groups?.[correctGroupIndex]?.id) {
+                    // add id if missing
+                    onChange(`map.groups[${correctGroupIndex}].id`, id);
+                }
+                onChange(`map.groups[${correctGroupIndex}].${key}`, value);
             },
     updateMapEntries: ({ onChange = () => { } }) => (obj = {}) => Object.keys(obj).map(k => onChange(`map[${k}]`, obj[k]))
 });

--- a/web/client/components/widgets/builder/wizard/map/enhancers/handleNodePropertyChanges.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/handleNodePropertyChanges.js
@@ -8,7 +8,7 @@
 // handle property changes
 const { withHandlers } = require('recompose');
 const {belongsToGroup} = require('../../../../../../utils/LayersUtils');
-const { findIndex } = require('lodash');
+const { findIndex, isArray } = require('lodash');
 /**
  * Add to the TOC or the Node editor some handlers for TOC nodes
  * add to the wrapped component the following methods:
@@ -56,7 +56,7 @@ module.exports = withHandlers({
                 });
 
                 if (key === EXPANDED) {
-                    if (!Array.isArray(map.groups)) {
+                    if (!isArray(map.groups)) {
                         onChange(`map.groups`, []);
                         onChange(`map.groups[${index === -1 ? 0 : index}].${key}`, value);
                         onChange(`map.groups[${index === -1 ? 0 : index}].id`, id);

--- a/web/client/components/widgets/builder/wizard/map/enhancers/handleNodePropertyChanges.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/handleNodePropertyChanges.js
@@ -49,10 +49,25 @@ module.exports = withHandlers({
     changeGroupProperty:
         ({ onChange = () => { }, map = [] }) =>
             (id, key, value) => {
+
+                const EXPANDED = 'expanded';
                 const index = findIndex(map.groups || [], {
                     id
                 });
-                onChange(`map.groups[${index}].${key}`, value);
+
+                if (key === EXPANDED) {
+                    if (!Array.isArray(map.groups)) {
+                        onChange(`map.groups`, []);
+                        onChange(`map.groups[${index === -1 ? 0 : index}].${key}`, value);
+                        onChange(`map.groups[${index === -1 ? 0 : index}].id`, id);
+                    } else {
+                        (!map.groups[index === -1 ? map.groups.length : index]
+                        || (map.groups[index === -1 ? map.groups.length : index] && !map.groups[index === -1 ? 0 : index].id)
+                        )
+                        && onChange(`map.groups[${index === -1 ? map.groups.length : index}].id`, id);
+                        onChange(`map.groups[${index === -1 ? map.groups.length : index}].${key}`, value);
+                    }
+                } else onChange(`map.groups[${index}].${key}`, value);
             },
     updateMapEntries: ({ onChange = () => { } }) => (obj = {}) => Object.keys(obj).map(k => onChange(`map[${k}]`, obj[k]))
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4709 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
On expanded change:
- converts groups to array.
- adds id if not present
- adds group item if groups array is empty
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
