### PR TITLE
#5290: Improved custom editors documentation. 

### DIFF
--- a/build/docma-config.json
+++ b/build/docma-config.json
@@ -111,6 +111,7 @@
             "web/client/components/notifications/NotificationContainer.jsx",
             "web/client/components/buttons/ToggleButton.jsx",
             "web/client/components/data/featuregrid/FeatureGrid.jsx",
+            "web/client/components/data/featuregrid/editors/index.jsdoc",
             "web/client/components/data/featuregrid/editors/customEditors.jsx",
             "web/client/components/data/featuregrid/editors/DropDownEditor.jsx",
             "web/client/components/data/featuregrid/editors/FormatEditor.jsx",

--- a/docma-template/js/app.js
+++ b/docma-template/js/app.js
@@ -248,9 +248,12 @@
     docma.on('render', function (currentRoute) {
 
         // CUSTOMIZATION: workaround to fix hash links that was not working anymore
-        var old = window.location.hash;
-        window.location.hash = "";
-        window.location.hash = old;
+        setTimeout(function() {
+            var old = window.location.hash;
+            window.location.hash = "";
+            window.location.hash = old;
+        }, 200);
+
         // end of workaround
 
         $('[data-toggle="tooltip"]').tooltip({

--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -18,6 +18,7 @@ const {isValidValueForPropertyName, isProperty} = require('../../../utils/Featur
  * A component that gets the describeFeatureType and the features to display
  * attributes
  * @class
+ * @name FeatureGrid
  * @memberof components.data.featuregrid
  * @prop {geojson[]} features array of geojson features
  * @prop {object} describeFeatureType the describeFeatureType in json format

--- a/web/client/components/data/featuregrid/editors/AttributeEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/AttributeEditor.jsx
@@ -1,6 +1,13 @@
 const PropTypes = require('prop-types');
 const { editors } = require('react-data-grid');
 
+/**
+ * Base Class of attribute editor for FeatureGrid
+ *
+ * @name AttributeEditor
+ * @memberof components.data.featuregrid.editors
+ * @type {Object}
+ */
 class AttributeEditor extends editors.SimpleTextEditor {
     static propTypes = {
         onTemporaryChanges: PropTypes.func

--- a/web/client/components/data/featuregrid/editors/AutocompleteEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/AutocompleteEditor.jsx
@@ -12,6 +12,13 @@ const {AutocompleteCombobox} = require('../../../misc/AutocompleteCombobox');
 const {getParsedUrl} = require('../../../../utils/ConfigUtils');
 const {createPagedUniqueAutompleteStream} = require('../../../../observables/autocomplete');
 
+/**
+ * Editor for FeatureGrid, used for strings with auto-complete
+ *
+ * @name AutocompleteEditor
+ * @memberof components.data.featuregrid.editors
+ * @type {Object}
+ */
 class AutocompleteEditor extends AttributeEditor {
     static propTypes = {
         column: PropTypes.object,

--- a/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/DropDownEditor.jsx
@@ -14,9 +14,10 @@ const {head} = require('lodash');
 const assign = require('object-assign');
 
 /**
+ * Editor that provides a DropDown menu of a list of elements passed.
  * @memberof components.data.featuregrid.editors
- * @name DropDownEditor
  * @class
+ * @name DropDownEditor
  * @prop {string[]} editorProps.values list of valid values
  */
 class DropDownEditor extends AttributeEditor {

--- a/web/client/components/data/featuregrid/editors/FormatEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/FormatEditor.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
+ * Editor of the FeatureGrid that uses a regex passed as prop to validate the input.
  * @memberof components.data.featuregrid.editors
  * @name FormatEditor
  * @class

--- a/web/client/components/data/featuregrid/editors/NumberEditor.jsx
+++ b/web/client/components/data/featuregrid/editors/NumberEditor.jsx
@@ -16,6 +16,7 @@ const parsers = {
 };
 
 /**
+ * Editor of the FeatureGrid, that allows to insert a number, limited by `minValue` and `maxValue`
  * @memberof components.data.featuregrid.editors
  * @name NumberEditor
  * @class

--- a/web/client/components/data/featuregrid/editors/customEditors.jsx
+++ b/web/client/components/data/featuregrid/editors/customEditors.jsx
@@ -23,14 +23,14 @@ const FormatEditor = require('./FormatEditor').default;
  *
  * Currently custom editors available by default are:
  *
- * * DropDownEditor - editor that allows to choose a value from a preconfigured values list
- * * NumberEditor - editor that supports numeric data, setting min/max bounds on a value
- * * FormatEditor - editor that checks if data matches a particular regular expression
+ * * {@link #components.data.featuregrid.editors.DropDownEditor | DropDownEditor} - editor that allows to choose a value from a preconfigured values list
+ * * {@link #components.data.featuregrid.editors.NumberEditor | NumberEditor} - editor that supports numeric data, setting min/max bounds on a value
+ * * {@link #components.data.featuregrid.editors.FormatEditor | FormatEditor} - editor that checks if data matches a particular regular expression
  *
  * Each editor has a specific section in framework documentation with available properties.
  *
- * @name Editors
- * @memberof components.data.featuregrid
+ * @name customEditors
+ * @memberof components.data.featuregrid.editors
  * @type {Object}
  */
 const Editors = {

--- a/web/client/components/data/featuregrid/editors/index.jsdoc
+++ b/web/client/components/data/featuregrid/editors/index.jsdoc
@@ -1,0 +1,6 @@
+/**
+ * Available Attribute Editors for FeatureGrid.
+ * Here you can find the default editors for the various data types and the {@link #components.data.featuregrid.editors.customEditors | Custom Editors} that can be used to force editing constraints to certain attributes.
+ * @name editors
+ * @memberof components.data.featuregrid
+ */

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -48,7 +48,7 @@ const Dock = connect(createSelector(
   * @prop {object} cfg.customEditorsOptions Set of options used to connect the custom editors to the featuregrid. It contains a set of
   * `rules`.
   * Each rule in the `rules` array contains:
-  * - `editor`: the string name of the editor. For more information about custom editors and their specific props (`editorProps`), see {@link api/framework#components.data.featuregrid.Editors}
+  * - `editor`: the string name of the editor. For more information about custom editors and their specific props (`editorProps`), see {@link api/framework#components.data.featuregrid.editors.customEditors}
   * - `regex`: An object with 2 regular expression, `attribute` and `typeName` that have to match with the specific attribute name and feature type name.
   * - `editorProps`: the properties to pass to the specific editor.
   * Example:
@@ -73,7 +73,6 @@ const Dock = connect(createSelector(
   *    }]
   *}
   * ```
-  * For more information about custom editors, see {@link api/framework#components.data.featuregrid.Editors}
   * @prop {object} cfg.editingAllowedRoles array of user roles allowed to enter in edit mode
   * @prop {boolean} cfg.virtualScroll default true. Activates virtualScroll. When false the grid uses normal pagination
   * @prop {number} cfg.maxStoredPages default 5. In virtual Scroll mode determines the size of the loaded pages cache


### PR DESCRIPTION
Fixed interlink issue with docma (clicking on links from plugins to framework didn't work on the first click. 
see #5290