### PR TITLE
Fix problems with geostory tutorial

### DIFF
--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -43,6 +43,7 @@ const toolButtons = {
     editMedia: ({editMap: disabled = false, path, editMedia = () => {} }) => ({
         // using normal ToolbarButton because this has no options
         glyph: "pencil",
+        "data-button": "pencil",
         visible: true,
         disabled,
         tooltipId: "geostory.contentToolbar.editMedia",

--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -167,6 +167,7 @@ class Tutorial extends React.Component {
 
     onTour = (tour) => {
         if (this.props.steps.length > 0 && tour && tour.type) {
+            document.querySelector(tour?.step?.selector)?.scrollIntoView();
             const type = tour.type.split(':');
             if (type[0] !== 'tooltip' && type[1] === 'before'
             || tour.action === 'start'

--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -359,14 +359,16 @@ describe('tutorial Epics', () => {
         it('tests the correct tutorial setup when passing from edit to view (switchGeostoryTutorialEpic)', (done) => {
             const IS_GOING_TO_EDIT_MODE = false;
 
-            testEpic(addTimeoutEpic(switchGeostoryTutorialEpic, 50), NUM_ACTIONS, [
-                geostoryLoaded(ID_STORY),
+            testEpic(switchGeostoryTutorialEpic, NUM_ACTIONS, [
                 setEditing(IS_GOING_TO_EDIT_MODE)
             ], (actions) => {
                 expect(actions.length).toBe(NUM_ACTIONS);
                 actions.map((action) => {
                     switch (action.type) {
-                    case TEST_TIMEOUT:
+                    case SETUP_TUTORIAL:
+                        expect(action.steps).toEqual(GEOSTORY_VIEW_STEPS);
+                        expect(action.stop).toEqual(true);
+                        expect(action.id).toBe(GEOSTORY_TUTORIAL_ID);
                         break;
                     default:
                         expect(true).toBe(false);

--- a/web/client/plugins/tutorial/preset/geostory_edit_tutorial.js
+++ b/web/client/plugins/tutorial/preset/geostory_edit_tutorial.js
@@ -39,7 +39,7 @@ module.exports = [
         position: "auto"
     }, {
         translationHTML: "geostoryEditMediaEditor",
-        selector: ".ms-geostory .ms-sections-container .ms-content-toolbar > div > span > button:nth-child(1)",
+        selector: ".ms-geostory .ms-sections-container .ms-content-toolbar > div > span > button[data-button=pencil]",
         position: "bottom"
     }
 ];


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This pr improves the geostory tutorial:
- when passing to edit mode it will always trigger the tutorial
- the step of media editor checks for the pencil and it uses the first it finds
- a scroll in view has been added for each step.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5410 
#5226

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
@tdipisa it was worthless to spend more time on trying to open the tutorial automatically only once per time a story is loaded. The main reason was that the current logic behind how a story is loaded and how tutorial works made the effort to make it working properly in every cases increase too much. i opted for a simpler solution like showing tutorial every time you go from view to edit mode if the tutorial is not disabled. Also this double tutorial (one for view and one for edit) made it harder to find a more sophisticated solution