### PR TITLE
Fix problem with info_format defined at layer level in Geostory

### DIFF
--- a/web/client/components/geostory/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/geostory/common/enhancers/withIdentifyPopup.jsx
@@ -55,9 +55,9 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                         point,
                         currentLocale: "en-US"});
                     const basePath = url;
-                    const requestParams = request;
+                    const queryParams = request;
                     const appParams = filterRequestParams(layer, includeOptions, excludeParams);
-                    const param = { ...appParams, ...requestParams };
+                    const param = { ...appParams, ...queryParams };
                     const reqId = uuidv1();
                     return getFeatureInfo(basePath, param, layer)
                         .map((response) =>
@@ -65,13 +65,13 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                                 ? ({
                                     reqId,
                                     exceptions: response.data.exceptions,
-                                    requestParams,
+                                    queryParams,
                                     layerMetadata: metadata
                                 })
                                 : ({
                                     data: response.data,
                                     reqId: reqId,
-                                    requestParams,
+                                    queryParams,
                                     layerMetadata: {
                                         ...metadata,
                                         features: response.features,
@@ -82,7 +82,7 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                         .catch((e) => ({
                             error: e.data || e.statusText || e.status,
                             reqId,
-                            requestParams,
+                            queryParams,
                             layerMetadata: metadata
                         }))
                         .startWith(({
@@ -95,9 +95,9 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                         const {reqId, request} = action;
                         return {requests: requests.concat({ reqId, request }), responses, validResponses};
                     }
-                    const {data, requestParams, layerMetadata} = action;
+                    const {data, queryParams, layerMetadata} = action; // TODO DEBUG THIS queryParams Action
                     const validator = getValidator(mapInfoFormat);
-                    const newResponses = responses.concat({response: data, requestParams, layerMetadata});
+                    const newResponses = responses.concat({response: data, queryParams, layerMetadata});
                     const newValidResponses = validator.getValidResponses(newResponses);
                     return {requests, validResponses: newValidResponses, responses: newResponses};
                 }, {requests: [], responses: [], validResponses: []});

--- a/web/client/components/geostory/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/geostory/common/enhancers/withIdentifyPopup.jsx
@@ -95,7 +95,7 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                         const {reqId, request} = action;
                         return {requests: requests.concat({ reqId, request }), responses, validResponses};
                     }
-                    const {data, queryParams, layerMetadata} = action; // TODO DEBUG THIS queryParams Action
+                    const {data, queryParams, layerMetadata} = action;
                     const validator = getValidator(mapInfoFormat);
                     const newResponses = responses.concat({response: data, queryParams, layerMetadata});
                     const newValidResponses = validator.getValidResponses(newResponses);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The problem was that the utilities in mapInfoUtils was using queryParams property to do validation but another property was being passed.

This pr fixes that in the enhancer so the other components and utilities works as expected

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5280

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
 Info formate defined at layer level in geostory works correctly by fetching results when they should do it

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
