### PR TITLE
#5432: Remove schemaLocation from Query

### DIFF
--- a/web/client/components/widgets/enhancers/dependenciesToExtent.js
+++ b/web/client/components/widgets/enhancers/dependenciesToExtent.js
@@ -53,6 +53,14 @@ module.exports = compose(
                         }
                         const featureTypeName = dependencies && dependencies.layer && dependencies.layer.name;
                         if (!isEmpty(filterObjCollection)) {
+                            // remove xsi:schemaLocation for performance improvements.
+                            filterObjCollection = {
+                                ...filterObjCollection,
+                                options: {
+                                    ...(filterObjCollection.options || {}),
+                                    noSchemaLocation: true
+                                }
+                            };
                             const wfsGetFeature = FilterUtils.toOGCFilter(featureTypeName, filterObjCollection, "1.1.0");
                             return wpsBounds(getWpsUrl(dependencies.layer), {wfsGetFeature })
                                 .switchMap(response => {

--- a/web/client/utils/FilterUtils.jsx
+++ b/web/client/utils/FilterUtils.jsx
@@ -535,8 +535,8 @@ const FilterUtils = {
                     'xmlns:wfs="http://www.opengis.net/wfs" ' +
                     'xmlns:ogc="http://www.opengis.net/ogc" ' +
                     'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
-                    'xsi:schemaLocation="http://www.opengis.net/wfs ' +
-                        'http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd">';
+                    (options.noSchemaLocation ? "" : 'xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd"') +
+                '>';
             break;
         case "1.1.0":
             getFeature += pagination && pagination.maxFeatures ? 'maxFeatures="' + pagination.maxFeatures + '" ' : "";
@@ -548,8 +548,8 @@ const FilterUtils = {
                     'xmlns:wfs="http://www.opengis.net/wfs" ' +
                     'xmlns:ogc="http://www.opengis.net/ogc" ' +
                     'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
-                    'xsi:schemaLocation="http://www.opengis.net/wfs ' +
-                        'http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">';
+                    (options.noSchemaLocation ? "" : 'xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"') +
+                    '>';
             break;
         default: // default is wfs 2.0
             getFeature += pagination && pagination.maxFeatures ? 'count="' + pagination.maxFeatures + '" ' : "";
@@ -561,10 +561,11 @@ const FilterUtils = {
                     'xmlns:fes="http://www.opengis.net/fes/2.0" ' +
                     'xmlns:gml="http://www.opengis.net/gml/3.2" ' +
                     'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
-                    'xsi:schemaLocation="http://www.opengis.net/wfs/2.0 ' +
+                    (options.noSchemaLocation ? "" : ('xsi:schemaLocation="http://www.opengis.net/wfs/2.0 ' +
                         'http://schemas.opengis.net/wfs/2.0/wfs.xsd ' +
                         'http://www.opengis.net/gml/3.2 ' +
-                        'http://schemas.opengis.net/gml/3.2.1/gml.xsd">';
+                        'http://schemas.opengis.net/gml/3.2.1/gml.xsd"')) +
+                    '>';
         }
 
         return getFeature;

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -606,6 +606,14 @@ describe('FilterUtils', () => {
         expect(base.indexOf('viewParams="a:b"') > 0).toBeTruthy();
         expect(FilterUtils.getGetFeatureBase(version, null, false, "application/json", { cql_filter: "a:b" }).indexOf('viewParams="a:b"') > 0).toBeFalsy();
     });
+    it('getGetFeatureBase excludes xsi:schemaLocation when option noSchemaLocation=true', () => {
+        const version = "2.0";
+        // use noSchemaLocation
+        const base = FilterUtils.getGetFeatureBase(version, null, false, "application/json", { noSchemaLocation: true });
+        expect(base.indexOf('xsi:schemaLocation=') >= 0).toBeFalsy();
+        // default includes
+        expect(FilterUtils.getGetFeatureBase(version, null, false, "application/json", {}).indexOf('xsi:schemaLocation=') > 0).toBeTruthy();
+    });
     it('Check for undefined or null values for string and number and list in ogc filter', () => {
         let filterObj = {
             filterFields: [{


### PR DESCRIPTION
## Description
Removing from WPS gs:getBounds nested query the schemaLocation attribute, the request speeds up a lot. It doesn't seems to cause problems in the dashboard context.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5432
geosolutions-it/MapStore2-c028#151

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5432

**What is the new behavior?**
The response and the zoom is fast now.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
