### PR TITLE
#5312: [Backport] Support for WMTS with not sorted matrix sets (#5328)

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -798,7 +798,138 @@ describe('Leaflet layer', () => {
 
         expect(layer.layer.wmsParams['ms2-authkey']).toBe("########-####-$$$$-####-###########");
     });
-
+    it('tile matrix set and ids must be sorted to match each other', () => {
+        const tileMatrix = [{
+            "ows:Identifier": "0",
+            "ScaleDenominator": "17471320.75089746",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "1",
+            "MatrixHeight": "1"
+        },
+        {
+            "ows:Identifier": "2",
+            "ScaleDenominator": "4367830.187724365",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "4",
+            "MatrixHeight": "4"
+        },
+        {
+            "ows:Identifier": "1",
+            "ScaleDenominator": "8735660.37544873",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "2",
+            "MatrixHeight": "2"
+        },
+        {
+            "ows:Identifier": "3",
+            "ScaleDenominator": "2183915.0938621825",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "8",
+            "MatrixHeight": "8"
+        }];
+        const options = {
+            type: 'wmts',
+            visibility: false,
+            name: 'nurc:Arc_Sample',
+            group: 'Meteo',
+            format: 'image/png',
+            requestEncoding: "RESTful",
+            tileMatrixSet: [
+                {
+                    'ows:Identifier': 'EPSG:3857',
+                    'ows:SupportedCRS': 'urn:ogc:def:crs:EPSG::3857',
+                    TileMatrix: tileMatrix
+                }
+            ],
+            url: 'http://sample.server/geoserver/gwc/service/wmts'
+        };
+        const layer = ReactDOM.render(<LeafLetLayer
+            type="wmts"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+        const sortedTileMatrix = [...tileMatrix].sort((a, b) => Number(b.ScaleDenominator) - Number(a.ScaleDenominator));
+        sortedTileMatrix.map((v, i) => expect("EPSG:3857:" + v["ows:Identifier"]).toEqual(layer.layer.matrixIds[i].identifier));
+        layer.layer.matrixSet.map((v, i) => expect(v["ows:Identifier"]).toEqual(sortedTileMatrix[i]["ows:Identifier"]));
+    });
+    it('limited Ids array should provide the same number resolutions, sizes (that have to match), even with wrong sorting...', () => {
+        const tileMatrix = [{
+            "ows:Identifier": "0",
+            "ScaleDenominator": "17471320.75089746",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "1",
+            "MatrixHeight": "1"
+        },
+        {
+            "ows:Identifier": "2",
+            "ScaleDenominator": "4367830.187724365",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "4",
+            "MatrixHeight": "4"
+        },
+        {
+            "ows:Identifier": "1",
+            "ScaleDenominator": "8735660.37544873",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "2",
+            "MatrixHeight": "2"
+        },
+        {
+            "ows:Identifier": "3",
+            "ScaleDenominator": "2183915.0938621825",
+            "TopLeftCorner": "-46133.17 6301219.54",
+            "TileWidth": "256",
+            "TileHeight": "256",
+            "MatrixWidth": "8",
+            "MatrixHeight": "8"
+        }];
+        const options = {
+            type: 'wmts',
+            visibility: false,
+            name: 'nurc:Arc_Sample',
+            group: 'Meteo',
+            format: 'image/png',
+            requestEncoding: "RESTful",
+            matrixIds: {
+                'EPSG:3857': [{
+                    identifier: '0'
+                }, {
+                    identifier: '1'
+                }]
+            },
+            tileMatrixSet: [
+                {
+                    'ows:Identifier': 'EPSG:3857',
+                    'ows:SupportedCRS': 'urn:ogc:def:crs:EPSG::3857',
+                    TileMatrix: tileMatrix
+                }
+            ],
+            url: 'http://sample.server/geoserver/gwc/service/wmts'
+        };
+        const layer = ReactDOM.render(<LeafLetLayer
+            type="wmts"
+            options={options}
+            map={map}
+        />, document.getElementById("container"));
+        const sortedTileMatrix = [...tileMatrix].sort((a, b) => Number(b.ScaleDenominator) - Number(a.ScaleDenominator));
+        // they should have the same order and be a sub set
+        layer.layer.matrixIds.map((v, i) => expect(v.identifier).toEqual(sortedTileMatrix[i]["ows:Identifier"]));
+        layer.layer.matrixSet.map((v, i) => expect(v["ows:Identifier"]).toEqual(sortedTileMatrix[i]["ows:Identifier"]));
+    });
     it('test wmts security token', () => {
         const options = {
             type: 'wmts',

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -8,7 +8,7 @@
 
 
 const CoordinatesUtils = require('./CoordinatesUtils');
-const {isString, isArray, isObject, head, castArray, slice } = require('lodash');
+const { isString, isArray, isObject, head, castArray, slice, sortBy } = require('lodash');
 
 const WMTSUtils = {
     getDefaultMatrixId: (options) => {
@@ -20,7 +20,7 @@ const WMTSUtils = {
         return matrixIds;
     },
     getMatrixIds: (matrix, srs) => {
-        return ((isObject(matrix) && isArray(matrix[srs]) && matrix[srs]) || (isArray(matrix) && matrix) || []).map((el) => el.identifier);
+        return ((isObject(matrix) && isArray(matrix[srs]) && matrix[srs]) || (isArray(matrix) && matrix) || []);
     },
     limitMatrix: (matrix, len) => {
         if (matrix.length > len) {
@@ -107,7 +107,53 @@ const WMTSUtils = {
     /**
      * gets the first format available in the list
      */
-    getDefaultFormat: layer => head(castArray(layer.Format))
+    getDefaultFormat: layer => head(castArray(layer.Format)),
+    /**
+     * This avoid https://openlayers.org/en/v5.3.0/doc/errors/#17 in case the scale tilematrix
+     * is not naturally sorted by scale denominator.
+     * for instance https://wxs.ign.fr/choisirgeoportail/geoportail/wmts
+     */
+    sortTileMatrix: (tileMatrixSet, ids)  => {
+        if (!tileMatrixSet) {
+            return tileMatrixSet;
+        }
+        return {
+            ...tileMatrixSet,
+            TileMatrix:
+                // sort by scale denominator, decendent
+                sortBy(tileMatrixSet?.TileMatrix
+                    .map(t => ({ ...t, ScaleDenominator: Number(t.ScaleDenominator) })), "ScaleDenominator"
+                )
+                    .reverse()
+                    // return only the Ids allowed to match array indexes
+                    .filter(t => ids ? ids.map(({ identifier } = {}) => identifier).indexOf(t["ows:Identifier"]) >= 0 : true)
+        };
+    },
+    /**
+     * Parse layer options to get back the tile matrix sub-set that can be used.
+     * This allows to have matrixIds and tileMatrixSet correctly sorted and filtered to match
+     */
+    getTileMatrix: (options, srs) => {
+        const tileMatrixSetName = WMTSUtils.getTileMatrixSet(options.tileMatrixSet, srs, options.allowedSRS, options.matrixIds);
+        const ids = options.matrixIds && WMTSUtils.getMatrixIds(options.matrixIds, tileMatrixSetName || srs);
+        const tileMatrixSet = WMTSUtils.sortTileMatrix(
+            head(options.tileMatrixSet.filter(tM => tM['ows:Identifier'] === tileMatrixSetName)),
+            ids);
+        // identifiers are in the same order of scales and resolutions
+
+        const identifiers = tileMatrixSet?.TileMatrix.map?.(t => t["ows:Identifier"]);
+        // use same order of matrixIds in TileMatrix, if present.
+        const matrixIds = identifiers && ids
+            ? ids.sort((a, b) => {
+                return identifiers.indexOf(a.identifier) - identifiers.indexOf(b.identifier);
+            })
+            : ids;
+        return {
+            matrixIds,
+            tileMatrixSetName,
+            tileMatrixSet: tileMatrixSet
+        };
+    }
 };
 
 

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -19,7 +19,7 @@ describe('Test the WMTSUtils', () => {
             }]
         }, 'EPSG:4326');
         expect(ids.length).toBe(1);
-        expect(ids[0]).toBe('EPSG:4326');
+        expect(ids[0].identifier).toBe('EPSG:4326');
     });
 
     it('get matrix ids with array', () => {
@@ -27,7 +27,7 @@ describe('Test the WMTSUtils', () => {
             identifier: 'EPSG:4326'
         }], 'EPSG:4326');
         expect(ids.length).toBe(1);
-        expect(ids[0]).toBe('EPSG:4326');
+        expect(ids[0].identifier).toBe('EPSG:4326');
     });
 
     it('wmts kvp', (done) => {


### PR DESCRIPTION
Backport #5312 for 2020.02.xx, pr #5328 