### PR TITLE
Fix #5448 Edit map configuration problem with change size button

### DIFF
--- a/web/client/components/geostory/common/ToolbarDropdownButton.jsx
+++ b/web/client/components/geostory/common/ToolbarDropdownButton.jsx
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { DropdownButton as DropdownButtonRB, Glyphicon, MenuItem } from 'react-bootstrap';
 import tooltip from '../../misc/enhancers/buttonTooltip';
 import find from 'lodash/find';
@@ -39,6 +39,14 @@ export default function ToolbarDropdownButton({
     const {
         glyph: glyphOption
     } = currentOption;
+
+    // hide dropdown when disabled
+    useEffect(() => {
+        if (disabled) {
+            setOpen(false);
+        }
+    }, [ disabled ]);
+
     return (
         <DropdownButton
             noCaret

--- a/web/client/components/geostory/common/__tests__/ToolbarDropdownButton-test.jsx
+++ b/web/client/components/geostory/common/__tests__/ToolbarDropdownButton-test.jsx
@@ -10,6 +10,7 @@ import ReactDOM from 'react-dom';
 
 import expect from 'expect';
 import ToolbarDropdownButton from '../ToolbarDropdownButton';
+import { act, Simulate } from 'react-dom/test-utils';
 describe('ToolbarDropdownButton component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -24,6 +25,43 @@ describe('ToolbarDropdownButton component', () => {
         ReactDOM.render(<ToolbarDropdownButton />, document.getElementById("container"));
         const container = document.getElementById('container');
         const el = container.querySelector('.square-button-md.no-border');
-        expect(el).toExist();
+        expect(el).toBeTruthy();
+    });
+    it('should hide dropdown when disabled', () => {
+        ReactDOM.render(<ToolbarDropdownButton
+            glyph="small"
+            options={[{
+                value: 'value',
+                label: 'Label'
+            }]}
+        />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const buttonNode = container.querySelector('.square-button-md.no-border');
+        expect(buttonNode).toBeTruthy();
+        let dropdownMenuNode = container.querySelector('.dropdown.open');
+        expect(dropdownMenuNode).toBeFalsy();
+
+        // open dropdown
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+
+        dropdownMenuNode = container.querySelector('.dropdown.open');
+        expect(dropdownMenuNode).toBeTruthy();
+
+        // disabled component
+        act(() => {
+            ReactDOM.render(<ToolbarDropdownButton
+                disabled
+                glyph="small"
+                options={[{
+                    value: 'value',
+                    label: 'Label'
+                }]}
+            />, document.getElementById("container"));
+        });
+
+        dropdownMenuNode = container.querySelector('.dropdown.open');
+        expect(dropdownMenuNode).toBeFalsy();
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds a new control to ensure that dropdow of geostory tools are closed when they are disabled.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
geosolutions-it/MapStore2#5448

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
close dropdown of geostory tools when a map is in edit mode

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
