### PR TITLE
Fix #5447 Disable Use description as caption when the Map Configuration is open 

### DIFF
--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -103,10 +103,11 @@ const toolButtons = {
             update('loop', !loop);
         }
     }),
-    showCaption: ({ update, showCaption, caption, description }) => ({
+    showCaption: ({ editMap: disabled = false, update, showCaption, caption, description }) => ({
         glyph: 'caption',
         visible: !!(caption || description),
-        active: !!showCaption,
+        disabled,
+        active: !!(showCaption && !disabled),
         tooltipId: showCaption ? 'geostory.contentToolbar.hideCaption' : 'geostory.contentToolbar.showCaption',
         onClick: () => {
             update('showCaption', !showCaption);

--- a/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
@@ -195,6 +195,38 @@ describe('ContentToolbar component', () => {
             expect(buttons.length).toEqual(1);
             ReactTestUtils.Simulate.click(buttons[0]);
         });
+        it('showCaption', (done) => {
+            ReactDOM.render(<ContentToolbar
+                tools={["showCaption"]}
+                showCaption
+                caption="Caption"
+                update={(key, value) => {
+                    try {
+                        expect(key).toBe('showCaption');
+                        expect(value).toBe(false);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                }}
+            />, document.getElementById("container"));
+            const buttons = document.getElementsByTagName('button');
+            expect(buttons).toBeTruthy();
+            expect(buttons.length).toBe(1);
+            ReactTestUtils.Simulate.click(buttons[0]);
+        });
+        it('showCaption disabled on edit map', () => {
+            ReactDOM.render(<ContentToolbar
+                tools={["showCaption"]}
+                editMap
+                showCaption
+                caption="Caption"
+            />, document.getElementById("container"));
+            const buttons = document.getElementsByTagName('button');
+            expect(buttons).toBeTruthy();
+            expect(buttons.length).toBe(1);
+            expect(buttons[0].disabled).toBe(true);
+        });
     });
 
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR aligns the behaviour of show caption button with the others. Now when a map is in edit mode in a story the show caption is disabled.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
geosolutions-it/MapStore2#5447

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now when a map is in edit mode in a story the show caption is disabled.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
