### PR TITLE
Fix 5439 Mobile - Interactivity of background maps problem

### DIFF
--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -1186,8 +1186,11 @@
     height: 100%;
     padding: 4px;
     background-color: rgba(0, 0, 0, 0.25);
-    & > * {
+    & > *:not(button) {
         background-color: @ms-story-bg;
+        position: relative;
+        width: 100%;
+        height: 100%;
     }
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds a missing CSS style to the map in story when they are in full size mode on mobile devices.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
geosolutions-it/MapStore2#5439

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Map are visible when in full screen in story on mobile device

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
