### PR TITLE
[2020.02.xx] #5346: include security reducer in JS API (#5456)

### DIFF
--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -182,6 +182,7 @@ const MapStore2 = {
         const actionTrigger = generateActionTrigger(options.startAction || "CHANGE_MAP_VIEW");
         triggerAction = actionTrigger.trigger;
         const appStore = require('../stores/StandardStore').bind(null, initialState || {}, {
+            security: require('../reducers/security'),
             version: require('../reducers/version')
         }, {
             jsAPIEpic: actionTrigger.epic,


### PR DESCRIPTION
Backports the following commits to 2020.02.xx:
 - #5346: include security reducer in JS API (#5456)