### PR TITLE
[2020.02.xx] Fix #5447 Disable Use description as caption when the Map Configuration is open (#5451)

### DIFF
--- a/web/client/components/geostory/contents/ContentToolbar.jsx
+++ b/web/client/components/geostory/contents/ContentToolbar.jsx
@@ -103,10 +103,11 @@ const toolButtons = {
             update('loop', !loop);
         }
     }),
-    showCaption: ({ update, showCaption, caption, description }) => ({
+    showCaption: ({ editMap: disabled = false, update, showCaption, caption, description }) => ({
         glyph: 'caption',
         visible: !!(caption || description),
-        active: !!showCaption,
+        disabled,
+        active: !!(showCaption && !disabled),
         tooltipId: showCaption ? 'geostory.contentToolbar.hideCaption' : 'geostory.contentToolbar.showCaption',
         onClick: () => {
             update('showCaption', !showCaption);

--- a/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/ContentToolbar-test.jsx
@@ -195,6 +195,38 @@ describe('ContentToolbar component', () => {
             expect(buttons.length).toEqual(1);
             ReactTestUtils.Simulate.click(buttons[0]);
         });
+        it('showCaption', (done) => {
+            ReactDOM.render(<ContentToolbar
+                tools={["showCaption"]}
+                showCaption
+                caption="Caption"
+                update={(key, value) => {
+                    try {
+                        expect(key).toBe('showCaption');
+                        expect(value).toBe(false);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                }}
+            />, document.getElementById("container"));
+            const buttons = document.getElementsByTagName('button');
+            expect(buttons).toBeTruthy();
+            expect(buttons.length).toBe(1);
+            ReactTestUtils.Simulate.click(buttons[0]);
+        });
+        it('showCaption disabled on edit map', () => {
+            ReactDOM.render(<ContentToolbar
+                tools={["showCaption"]}
+                editMap
+                showCaption
+                caption="Caption"
+            />, document.getElementById("container"));
+            const buttons = document.getElementsByTagName('button');
+            expect(buttons).toBeTruthy();
+            expect(buttons.length).toBe(1);
+            expect(buttons[0].disabled).toBe(true);
+        });
     });
 
 });


### PR DESCRIPTION
Backports the following commits to 2020.02.xx:
 - #5447 disable caption button of story if map is in edit mode (#5451)