### PR TITLE
5462. add env to baseMap. add layer styles override from localconfig

### DIFF
--- a/web/client/components/map/BaseMap.jsx
+++ b/web/client/components/map/BaseMap.jsx
@@ -41,7 +41,8 @@ class BaseMap extends React.Component {
         projectionDefs: PropTypes.array,
         plugins: PropTypes.any,
         tools: PropTypes.array,
-        getLayerProps: PropTypes.func
+        getLayerProps: PropTypes.func,
+        env: PropTypes.array
     };
 
     static defaultProps = {
@@ -57,7 +58,8 @@ class BaseMap extends React.Component {
             onMouseMove: () => {},
             onLayerLoading: () => {},
             onLayerError: () => {}
-        }
+        },
+        env: []
     };
 
     getTool = (tool) => {
@@ -87,6 +89,7 @@ class BaseMap extends React.Component {
                     position={index}
                     key={layer.id || layer.name}
                     options={layer}
+                    env={layer.localizedLayerStyles ? this.props.env : []}
                 >
                     {this.renderLayerContent(layer, projection)}
                 </Layer>

--- a/web/client/components/widgets/builder/wizard/MapWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/MapWizard.jsx
@@ -22,7 +22,8 @@ module.exports = ({
     editorData = {},
     editNode,
     setEditNode = () => {},
-    closeNodeEditor = () => {}
+    closeNodeEditor = () => {},
+    isLocalizedLayerStylesEnabled
 } = {}) => (
     <Wizard
         step={step}
@@ -36,6 +37,7 @@ module.exports = ({
             onNodeSelect={onNodeSelect}
             selectedNodes={selectedNodes}
             onChange={onChange}
+            isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled}
             preview={<Preview
                 onChange={onChange}
                 layers={editorData.map && editorData.map.layers}

--- a/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapOptions.jsx
@@ -37,7 +37,7 @@ const EditorTitle = compose(
 )(StepHeader);
 
 
-module.exports = ({ preview, map = {}, onChange = () => { }, selectedNodes = [], onNodeSelect = () => { }, editNode, closeNodeEditor = () => { } }) => (<div>
+module.exports = ({ preview, map = {}, onChange = () => { }, selectedNodes = [], onNodeSelect = () => { }, editNode, closeNodeEditor = () => { }, isLocalizedLayerStylesEnabled }) => (<div>
     <StepHeader title={<Message msgId={`widgets.builder.wizard.configureMapOptions`} />} />
     <div key="sample" style={{marginTop: 10}}>
         <StepHeader title={<Message msgId={`widgets.builder.wizard.preview`} />} />
@@ -51,7 +51,8 @@ module.exports = ({ preview, map = {}, onChange = () => { }, selectedNodes = [],
                 closeNodeEditor={closeNodeEditor}
                 editNode={editNode}
                 map={map}
-                onChange={onChange} />
+                onChange={onChange}
+                isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled} />
         ] : [<StepHeader title={<Message msgId={`layers`} />} />, <TOC
             selectedNodes={selectedNodes}
             onSelect={onNodeSelect}

--- a/web/client/components/widgets/builder/wizard/map/NodeEditor.jsx
+++ b/web/client/components/widgets/builder/wizard/map/NodeEditor.jsx
@@ -18,6 +18,7 @@ const NavItem = tooltip(BSNavItem);
  */
 module.exports = ({
     settings, element = {}, tabs = [], activeTab, width, groups,
+    isLocalizedLayerStylesEnabled,
     setActiveTab = () => { }, onUpdateParams = () => { }, onRetrieveLayerData = () => { }, realtimeUpdate, ...props} = {}) =>
     (<Row key="ms-toc-settings-navbar" className="ms-row-tab">
         <Col xs={12}>
@@ -44,6 +45,7 @@ module.exports = ({
                     nodeType={settings.nodeType}
                     settings={settings}
                     retrieveLayerData={onRetrieveLayerData}
+                    isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled}
                     onChange={(key, value) => isObject(key) ? onUpdateParams(key, realtimeUpdate) : onUpdateParams({ [key]: value }, realtimeUpdate)} />
             ))}</Col>
     </Row>);

--- a/web/client/components/widgets/view/WidgetsView.jsx
+++ b/web/client/components/widgets/view/WidgetsView.jsx
@@ -51,6 +51,7 @@ module.exports = pure(({
     editWidget = () => { },
     onLayoutChange = () => { },
     language,
+    env,
     ...actions
 } = {}) => {
     // checking if this widget appears among other dependenciesMap of other widgets (i.e. it is a parent table)
@@ -116,7 +117,8 @@ module.exports = pure(({
                 toggleCollapse= {() => toggleCollapse(w)}
                 onDelete={() => deleteWidget(w)}
                 onEdit={() => editWidget(w)}
-                language={language} /></div>))
+                language={language}
+                env={env} /></div>))
         }
     </ResponsiveReactGridLayout>);
 });

--- a/web/client/components/widgets/widget/MapWidget.jsx
+++ b/web/client/components/widgets/widget/MapWidget.jsx
@@ -27,7 +27,8 @@ module.exports = ({
     confirmDelete = false,
     loading = false,
     onDelete = () => {},
-    headerStyle
+    headerStyle,
+    env
 } = {}) =>
     (<WidgetContainer id={`widget-text-${id}`} title={title} confirmDelete={confirmDelete} onDelete={onDelete} toggleDeleteConfirm={toggleDeleteConfirm} headerStyle={headerStyle}
         icons={icons}
@@ -47,6 +48,7 @@ module.exports = ({
                 hookRegister={hookRegister}
                 layers={map && map.layers}
                 options={{ style: { margin: 10, height: 'calc(100% - 20px)' }}}
+                env={env}
             />
         </BorderLayout>
 

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -14,7 +14,7 @@ const { getDashboardWidgets, dependenciesSelector, getDashboardWidgetsLayout, is
 const { editWidget, updateWidgetProperty, deleteWidget, changeLayout, exportCSV, exportImage, selectWidget } = require('../actions/widgets');
 const { showConnectionsSelector, dashboardResource, isDashboardLoading, isBrowserMobile } = require('../selectors/dashboard');
 const { currentLocaleLanguageSelector } = require('../selectors/locale');
-const { isLocalizedLayerStylesEnabledSelector } = require('../selectors/localizedLayerStyles');
+const { isLocalizedLayerStylesEnabledSelector, localizedLayerStylesEnvSelector } = require('../selectors/localizedLayerStyles');
 const ContainerDimensions = require('react-container-dimensions').default;
 
 const PropTypes = require('prop-types');
@@ -33,7 +33,9 @@ const WidgetsView = compose(
             isBrowserMobile,
             currentLocaleLanguageSelector,
             isLocalizedLayerStylesEnabledSelector,
-            (resource, widgets, layouts, dependencies, selectionActive, editingWidget, groups, showGroupColor, loading, isMobile, currentLocaleLanguage, isLocalizedLayerStylesEnabled) => ({
+            localizedLayerStylesEnvSelector,
+            (resource, widgets, layouts, dependencies, selectionActive, editingWidget, groups, showGroupColor, loading, isMobile, currentLocaleLanguage, isLocalizedLayerStylesEnabled,
+                env) => ({
                 resource,
                 loading,
                 canEdit: isMobile ? !isMobile : resource && !!resource.canEdit,
@@ -44,7 +46,8 @@ const WidgetsView = compose(
                 widgets,
                 groups,
                 showGroupColor,
-                language: isLocalizedLayerStylesEnabled ? currentLocaleLanguage : null
+                language: isLocalizedLayerStylesEnabled ? currentLocaleLanguage : null,
+                env
             })
         ), {
             editWidget,

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -15,7 +15,7 @@ const PropTypes = require('prop-types');
 const { isDashboardEditing } = require('../selectors/dashboard');
 const { dashboardHasWidgets, getWidgetsDependenciesGroups } = require('../selectors/widgets');
 const { showConnectionsSelector, isDashboardLoading, buttonCanEdit } = require('../selectors/dashboard');
-const { dashboardSelector } = require('./widgetbuilder/commons');
+const { dashboardSelector, dashboardsSelectorIsLocalizedLayerStylesEnabled } = require('./widgetbuilder/commons');
 
 const { createWidget, toggleConnection } = require('../actions/widgets');
 const { triggerShowConnections } = require('../actions/dashboard');
@@ -26,6 +26,7 @@ const LoadingSpinner = require('../components/misc/LoadingSpinner');
 const Builder =
     compose(
         connect(dashboardSelector, { toggleConnection, triggerShowConnections }),
+        connect(dashboardsSelectorIsLocalizedLayerStylesEnabled),
         withProps(({ availableDependencies = [] }) => ({
             availableDependencies: availableDependencies.filter(d => d !== "map")
         })),

--- a/web/client/plugins/widgetbuilder/MapBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/MapBuilder.jsx
@@ -87,7 +87,7 @@ module.exports = mapBuilder(({
     enabled, onClose = () => {},
     toggleLayerSelector = () => {},
     editorData = {},
-    editNode, setEditNode, closeNodeEditor, selectedGroups = [], exitButton, selectedLayers = [], selectedNodes, onNodeSelect = () => {},
+    editNode, setEditNode, closeNodeEditor, isLocalizedLayerStylesEnabled, selectedGroups = [], exitButton, selectedLayers = [], selectedNodes, onNodeSelect = () => {},
     availableDependencies = [], toggleConnection = () => {}
 } = {}) =>
     (<BorderLayout
@@ -109,5 +109,6 @@ module.exports = mapBuilder(({
             editNode={editNode}
             closeNodeEditor={closeNodeEditor}
             onNodeSelect={onNodeSelect}
+            isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled}
             selectedNodes={selectedNodes}/> : null}
     </BorderLayout>));

--- a/web/client/plugins/widgetbuilder/commons.js
+++ b/web/client/plugins/widgetbuilder/commons.js
@@ -6,7 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 const {createSelector} = require('reselect');
+const {isNil} = require('lodash');
 const { getEditingWidget, dependenciesSelector, getEditorSettings, getWidgetLayer, getFloatingWidgets, availableDependenciesForEditingWidgetSelector} = require('../../selectors/widgets');
+const { isLocalizedLayerStylesEnabledDashboardsSelector } = require('../../selectors/localizedLayerStyles');
 const { showConnectionsSelector } = require('../../selectors/dashboard');
 
 const wizardStateToProps = ( stateProps = {}, dispatchProps = {}, ownProps = {}) => ({
@@ -45,10 +47,18 @@ const dashboardSelector = createSelector(
         ...dependencyConnectProps
     }));
 
+const dashboardsSelectorIsLocalizedLayerStylesEnabled =   createSelector(
+    isLocalizedLayerStylesEnabledDashboardsSelector,
+    (isLocalizedLayerStylesEnabled) => ({
+        isLocalizedLayerStylesEnabled: !isNil(isLocalizedLayerStylesEnabled)
+    })
+);
+
 module.exports = {
     getWidgetLayer,
     availableDependenciesForEditingWidgetSelector,
     dashboardSelector,
+    dashboardsSelectorIsLocalizedLayerStylesEnabled,
     wizardStateToProps,
     wizardSelector
 };

--- a/web/client/plugins/widgetbuilder/enhancers/manageLayers.js
+++ b/web/client/plugins/widgetbuilder/enhancers/manageLayers.js
@@ -22,7 +22,9 @@ module.exports = compose(
         setLayers: layers => onEditorChange('map.layers', layers)
     }),
     withHandlers({
-        addLayer: ({ layers = [], setLayers = () => { } }) => layer => setLayers([...layers, normalizeLayer(layer)]),
+        addLayer: ({ layers = [], setLayers = () => { }, catalog}) => layer => catalog.localizedLayerStyles ?
+            setLayers([...layers, normalizeLayer({...layer, localizedLayerStyles: catalog.localizedLayerStyles})])
+            : setLayers([...layers, normalizeLayer(layer)]),
         removeLayersById: ({ layers = [], setLayers = () => { } }) => (ids = []) => setLayers(layers.filter(l => !find(castArray(ids), id => id === l.id)))
     })
 );

--- a/web/client/selectors/__tests__/localizedLayerStyles-test.js
+++ b/web/client/selectors/__tests__/localizedLayerStyles-test.js
@@ -10,6 +10,7 @@ const expect = require('expect');
 
 const {
     isLocalizedLayerStylesEnabledSelector,
+    isLocalizedLayerStylesEnabledDashboardsSelector,
     localizedLayerStylesNameSelector,
     localizedLayerStylesEnvSelector
 } = require('../localizedLayerStyles');
@@ -20,6 +21,16 @@ const givenState = {
     localConfig: {
         localizedLayerStyles: {
             name: givenName
+        },
+        plugins: {
+            dashboard: [{
+                name: "DashboardEditor",
+                cfg: {
+                    catalog: {
+                        localizedLayerStyles: true
+                    }
+                }
+            }]
         }
     }
 };
@@ -44,6 +55,16 @@ describe('Test localizedLayerStyles', () => {
         expect(isLocalizedLayerStylesEnabled).toBe(false);
 
         isLocalizedLayerStylesEnabled = isLocalizedLayerStylesEnabledSelector(givenState);
+        expect(isLocalizedLayerStylesEnabled).toBe(true);
+    });
+
+    it('test isLocalizedLayerStylesEnabledDashboardsSelector', () => {
+        let isLocalizedLayerStylesEnabled;
+
+        isLocalizedLayerStylesEnabled = isLocalizedLayerStylesEnabledDashboardsSelector({});
+        expect(isLocalizedLayerStylesEnabled).toBe(false);
+
+        isLocalizedLayerStylesEnabled = isLocalizedLayerStylesEnabledDashboardsSelector(givenState);
         expect(isLocalizedLayerStylesEnabled).toBe(true);
     });
 

--- a/web/client/selectors/localizedLayerStyles.js
+++ b/web/client/selectors/localizedLayerStyles.js
@@ -6,7 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {has, get} = require('lodash');
+const {has, get, find} = require('lodash');
 const {createSelector} = require('reselect');
 
 const {currentLocaleLanguageSelector} = require('./locale');
@@ -34,8 +34,8 @@ const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig
  */
 const isLocalizedLayerStylesEnabledDashboardsSelector = (state) => {
     const dashboardPlugins = get(state, "localConfig.plugins.dashboard", []);
-    const dashboardEditorPlugin = dashboardPlugins.find(item => item.name === 'DashboardEditor') || {};
-    return get(dashboardEditorPlugin, "cfg.catalog.localizedLayerStyles", false); // get of lodash
+    const dashboardEditorPlugin = find(dashboardPlugins, item => item.name === 'DashboardEditor') || {};
+    return get(dashboardEditorPlugin, "cfg.catalog.localizedLayerStyles", false);
 };
 
 /**

--- a/web/client/selectors/localizedLayerStyles.js
+++ b/web/client/selectors/localizedLayerStyles.js
@@ -6,7 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {has, get, isArray} = require('lodash');
+const {has, get} = require('lodash');
 const {createSelector} = require('reselect');
 
 const {currentLocaleLanguageSelector} = require('./locale');
@@ -33,8 +33,9 @@ const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig
  * @return {boolean} boolean if the localizedLayerStyles property is defined
  */
 const isLocalizedLayerStylesEnabledDashboardsSelector = (state) => {
-    return isArray(state?.localConfig?.plugins?.dashboard)
-    && state.localConfig.plugins.dashboard.find(item => item.name === 'DashboardEditor').cfg.catalog.localizedLayerStyles;
+    const dashboardPlugins = get(state, "localConfig.plugins.dashboard", []);
+    const dashboardEditorPlugin = dashboardPlugins.find(item => item.name === 'DashboardEditor') || {};
+    return get(dashboardEditorPlugin, "cfg.catalog.localizedLayerStyles", false); // get of lodash
 };
 
 /**

--- a/web/client/selectors/localizedLayerStyles.js
+++ b/web/client/selectors/localizedLayerStyles.js
@@ -6,7 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {has, get} = require('lodash');
+const {has, get, isArray} = require('lodash');
 const {createSelector} = require('reselect');
 
 const {currentLocaleLanguageSelector} = require('./locale');
@@ -25,6 +25,17 @@ const {currentLocaleLanguageSelector} = require('./locale');
  * @return {boolean} true if the localizedLayerStyles property is defined
  */
 const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig.localizedLayerStyles');
+
+/**
+ * selects localizedLayerStyles value from state
+ * @memberof selectors.localizedLayerStyles
+ * @param  {object} state the state
+ * @return {boolean} boolean if the localizedLayerStyles property is defined
+ */
+const isLocalizedLayerStylesEnabledDashboardsSelector = (state) => {
+    return isArray(state?.localConfig?.plugins?.dashboard)
+    && state.localConfig.plugins.dashboard.find(item => item.name === 'DashboardEditor').cfg.catalog.localizedLayerStyles;
+};
 
 /**
  * selects localizedLayerStyles name from state
@@ -59,5 +70,6 @@ const localizedLayerStylesEnvSelector = createSelector(
 module.exports = {
     isLocalizedLayerStylesEnabledSelector,
     localizedLayerStylesNameSelector,
-    localizedLayerStylesEnvSelector
+    localizedLayerStylesEnvSelector,
+    isLocalizedLayerStylesEnabledDashboardsSelector
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5462 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Add env param to BaseMap if layer has localizedLayerStyles.
If in localConfig->DashboardEditor->cfg->Catalog presents "localizedLayerStyles":
 - In layer settings presents "Enable localized style" checkbox.
 - On layer adding to map widget adds "localizedLayerStyles" value
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
