### PR TITLE
#5280 - fix tooltip for identify in geostory maps

### DIFF
--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2143,7 +2143,7 @@
                     "navbar": "Navigationsleiste",
                     "showNavbar": "Navigationsleiste anzeigen",
                     "theme": "Thema",
-                    "templateTooltip":"Mit dem erweiterten Karteneditor kann eine benutzerdefinierte Vorlage für jede Ebene konfiguriert werden (siehe Stiftsymbol).Weitere Informationen finden Sie in der <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>Bedienungsanleitung</a>"
+                    "templateTooltip":"Mit dem erweiterten Karteneditor kann eine benutzerdefinierte Vorlage für jede Ebene konfiguriert werden (siehe Stiftsymbol).Weitere Informationen finden Sie in der <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>Bedienungsanleitung</a>. Wenn für eine Ebene ein benutzerdefiniertes Info-Format definiert ist, wird dieses anstelle dieses allgemeineren Formats verwendet"
                 }
             },
             "errors": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2143,7 +2143,7 @@
                     "navbar": "Navigationsleiste",
                     "showNavbar": "Navigationsleiste anzeigen",
                     "theme": "Thema",
-                    "templateTooltip":"Mit dem erweiterten Karteneditor kann eine benutzerdefinierte Vorlage für jede Ebene konfiguriert werden (siehe Stiftsymbol).Weitere Informationen finden Sie in der <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>Bedienungsanleitung</a>. Wenn für eine Ebene ein benutzerdefiniertes Info-Format definiert ist, wird dieses anstelle dieses allgemeineren Formats verwendet"
+                    "templateTooltip":"Mit dieser Einstellung können Sie die Identifizierungsfunktion auf der Karte aktivieren, indem Sie ein generisches Format für alle Ebenen definieren. Mit dem erweiterten Karteneditor (Stiftsymbol) kann für jede Ebene ein anderes Format konfiguriert werden. Weitere Informationen finden Sie im <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'> Benutzerhandbuch </a>. Wenn ein Layer sein eigenes Identifizierungsformat definiert hat, wird er anstelle des auf Kartenebene festgelegten generischen Formats verwendet."
                 }
             },
             "errors": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2147,7 +2147,7 @@
                     "navbar" : "Navigation bar",
                     "showNavbar" : "Show navbar",
                     "theme": "Theme",
-                    "templateTooltip":"It is possible to configure a custom template for each layer using the advanced map editor (see pencil icon). For more info check the <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>user guide</a>. If a layer has a custom info_format defined it will be used instead of this more general one"
+                    "templateTooltip":"This setting allows you to enable the Identify function on the map by defining a generic format for all the layers. It is possible to configure a different format for each single layer using the advanced map editor (pencil icon). For more information, see the <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'> user guide </a>. If a layer has defined its own Identify format, it will be used instead of the generic one set at the map level."
                 }
             },
             "errors": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2147,7 +2147,7 @@
                     "navbar" : "Navigation bar",
                     "showNavbar" : "Show navbar",
                     "theme": "Theme",
-                    "templateTooltip":"It is possible to configure a custom template for each layer using the advanced map editor (see pencil icon). For more info check the <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>user guide</a>"
+                    "templateTooltip":"It is possible to configure a custom template for each layer using the advanced map editor (see pencil icon). For more info check the <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>user guide</a>. If a layer has a custom info_format defined it will be used instead of this more general one"
                 }
             },
             "errors": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2144,7 +2144,7 @@
                     "navbar": "Barra de navegación",
                     "showNavbar": "Mostrar barra de navegación",
                     "theme": "Tema",
-                    "templateTooltip":"Es posible configurar una plantilla personalizada para cada capa utilizando el editor de mapas avanzado (ver icono de lápiz). Para más información consulte la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guía del usuario</a>. Si una capa tiene un formato de información personalizado definido, se usará en lugar de este más general"
+                    "templateTooltip":"Esta configuración le permite habilitar la función Identificar en el mapa definiendo un formato genérico para todas las capas. Es posible configurar un formato diferente para cada nivel usando el editor de mapas avanzado (icono de lápiz). Para obtener más información, consulte la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'> guía del usuario </a>. Si una capa ha definido su propio formato de identificación, se utilizará en lugar del genérico establecido en el nivel del mapa."
                 }
             },
             "errors": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2144,7 +2144,7 @@
                     "navbar": "Barra de navegación",
                     "showNavbar": "Mostrar barra de navegación",
                     "theme": "Tema",
-                    "templateTooltip":"Es posible configurar una plantilla personalizada para cada capa utilizando el editor de mapas avanzado (ver icono de lápiz). Para más información consulte la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guía del usuario</a>"
+                    "templateTooltip":"Es posible configurar una plantilla personalizada para cada capa utilizando el editor de mapas avanzado (ver icono de lápiz). Para más información consulte la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guía del usuario</a>. Si una capa tiene un formato de información personalizado definido, se usará en lugar de este más general"
                 }
             },
             "errors": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2145,7 +2145,7 @@
                     "navbar": "Barre de navigation",
                     "showNavbar": "Afficher la barre de navigation",
                     "theme": "Thème",
-                    "templateTooltip":"Il est possible de configurer un modèle personnalisé pour chaque couche à l'aide de l'éditeur de carte avancé (voir l'icône crayon). Pour plus d'informations, consultez le <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guide de l'utilisateur</a>"
+                    "templateTooltip":"Il est possible de configurer un modèle personnalisé pour chaque couche à l'aide de l'éditeur de carte avancé (voir l'icône crayon). Pour plus d'informations, consultez le <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guide de l'utilisateur</a>. Si un calque a un info_format personnalisé défini, il sera utilisé à la place de celui-ci plus général"
                 }
             },
             "errors": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2145,7 +2145,7 @@
                     "navbar": "Barre de navigation",
                     "showNavbar": "Afficher la barre de navigation",
                     "theme": "Thème",
-                    "templateTooltip":"Il est possible de configurer un modèle personnalisé pour chaque couche à l'aide de l'éditeur de carte avancé (voir l'icône crayon). Pour plus d'informations, consultez le <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guide de l'utilisateur</a>. Si un calque a un info_format personnalisé défini, il sera utilisé à la place de celui-ci plus général"
+                    "templateTooltip":"Ce paramètre vous permet d'activer la fonction Identifier sur la carte en définissant un format générique pour toutes les couches. Il est possible de configurer un format différent pour chaque niveau à l'aide de l'éditeur de carte avancé (icône crayon). Pour plus d'informations, consultez le <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'> guide de l'utilisateur </a>. Si une couche a défini son propre format d'identification, elle sera utilisée à la place du format générique défini au niveau de la carte."
                 }
             },
             "errors": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2144,7 +2144,7 @@
                     "navbar": "Barra di navigazione",
                     "showNavbar": "Mostra barra di navigazione",
                     "theme": "Tema",
-                    "templateTooltip":"E' possibile configurare un modello custom per ogni livello usando l'edito di mappa avanzato (vedi icona matita). Per maggiori informazioni vedi la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guida utente</a>. Se un layer ha definito un suo info_format, esso verrà usato al posto di quello più generale"
+                    "templateTooltip":"Questa impostazione consente di abilitare la funzione di Identify sulla mappa definendo un formato generico per tutti i layer. E' possibile configurare un formato differente per ogni singolo livello usando l'editor di mappa avanzato (icona matita). Per maggiori informazioni si consulti la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guida utente</a>. Se un layer ha definito il proprio formato di Identify, questo esso verrà usato al posto di quello generico impostato a livello di mappa."
                 }
             },
             "errors": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2144,7 +2144,7 @@
                     "navbar": "Barra di navigazione",
                     "showNavbar": "Mostra barra di navigazione",
                     "theme": "Tema",
-                    "templateTooltip":"E' possibile configurare un modello custom per ogni livello usando l'edito di mappa avanzato (vedi icona matita). Per maggiori informazioni vedi la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guida utente</a>"
+                    "templateTooltip":"E' possibile configurare un modello custom per ogni livello usando l'edito di mappa avanzato (vedi icona matita). Per maggiori informazioni vedi la <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'>guida utente</a>. Se un layer ha definito un suo info_format, esso verrà usato al posto di quello più generale"
                 }
             },
             "errors": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Improved tooltip for identify section in inline editor of maps explaining that custom info_format wins over general one

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: changes to translations

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5280

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
a different tooltip explains that custom info format wins over the general one

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
