### PR TITLE
Add DXF format support from server

### DIFF
--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -25,7 +25,8 @@ const {getLayerWFSCapabilities} = require('../observables/wfs');
 
 const DOWNLOAD_FORMATS_LOOKUP = {
 	        "gml3": "GML3.1",
-	        "GML2": "GML2",
+            "GML2": "GML2",
+            "DXF-ZIP": "DXF-ZIP",
 	        "application/vnd.google-earth.kml+xml": "KML",
 	        "OGR-CSV": "OGR-CSV",
 	        "OGR-FileGDB": "OGR-GeoDatabase",

--- a/web/client/epics/wfsdownload.js
+++ b/web/client/epics/wfsdownload.js
@@ -24,21 +24,21 @@ const {getLayerWFSCapabilities} = require('../observables/wfs');
 
 
 const DOWNLOAD_FORMATS_LOOKUP = {
-	        "gml3": "GML3.1",
-            "GML2": "GML2",
-            "DXF-ZIP": "DXF-ZIP",
-	        "application/vnd.google-earth.kml+xml": "KML",
-	        "OGR-CSV": "OGR-CSV",
-	        "OGR-FileGDB": "OGR-GeoDatabase",
-	        "OGR-GPKG": "OGR-GeoPackage",
-	        "OGR-KML": "OGR-KML",
-	        "OGR-MIF": "OGR-MIF",
-	        "OGR-TAB": "OGR-TAB",
-	        "SHAPE-ZIP": "Shapefile",
-	        "gml32": "GML3.2",
-	        "application/json": "GeoJSON",
-	        "csv": "CSV",
-	        "application/x-gpkg": "GeoPackage"
+    "gml3": "GML3.1",
+    "GML2": "GML2",
+    "DXF-ZIP": "DXF-ZIP",
+    "application/vnd.google-earth.kml+xml": "KML",
+    "OGR-CSV": "OGR-CSV",
+    "OGR-FileGDB": "OGR-GeoDatabase",
+    "OGR-GPKG": "OGR-GeoPackage",
+    "OGR-KML": "OGR-KML",
+    "OGR-MIF": "OGR-MIF",
+    "OGR-TAB": "OGR-TAB",
+    "SHAPE-ZIP": "Shapefile",
+    "gml32": "GML3.2",
+    "application/json": "GeoJSON",
+    "csv": "CSV",
+    "application/x-gpkg": "GeoPackage"
 };
 
 const hasOutputFormat = (data) => {


### PR DESCRIPTION
## Description
This PR add DXF to the list of formats compatible with mapstore for download (actual support allow DXF only if formats are configured in MapStore's plugin configruation, as a list). 


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5479

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
