### PR TITLE
#5471: Backport for display default legend values

### DIFF
--- a/web/client/components/TOC/fragments/settings/Display.jsx
+++ b/web/client/components/TOC/fragments/settings/Display.jsx
@@ -40,8 +40,8 @@ module.exports = class extends React.Component {
     state = {
         opacity: 100,
         legendOptions: {
-            legendWidth: "",
-            legendHeight: ""
+            legendWidth: 12,
+            legendHeight: 12
         },
         containerStyle: {overflowX: 'auto'},
         containerWidth: 0

--- a/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/Display-test.jsx
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var ReactTestUtils = require('react-dom/test-utils');
-var Display = require('../Display');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactTestUtils = require('react-dom/test-utils');
+const expect = require('expect');
 
-var expect = require('expect');
+const Display = require('../Display');
 
 describe('test Layer Properties Display module component', () => {
     beforeEach((done) => {
@@ -112,6 +112,12 @@ describe('test Layer Properties Display module component', () => {
         const comp = ReactDOM.render(<Display element={l} settings={settings} onChange={handlers.onChange}/>, document.getElementById("container"));
         expect(comp).toExist();
         const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass( comp, "control-label" );
+        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
+        const legendWidth = inputs[4];
+        const legendHeight = inputs[5];
+        // Default legend values
+        expect(legendWidth.value).toBe('12');
+        expect(legendHeight.value).toBe('12');
         expect(labels.length).toBe(6);
         expect(labels[2].innerText).toBe("layerProperties.legendOptions.title");
         expect(labels[3].innerText).toBe("layerProperties.legendOptions.legendWidth");


### PR DESCRIPTION
## Description
Display default legend width and height when legend value not present in layer property

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#5471 

**What is the new behavior?**
Default legend width and heigh values will be displayed when legend value not present in the layer property

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
