### PR TITLE
Fix 5491 - Geostory fails when advanced editor is opened and config is missing

### DIFF
--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -321,6 +321,33 @@ describe('tutorial Epics', () => {
         });
 
     });
+    it('switchTutorialEpic selecting geostory_view_tutorial preset for story viewer page, missing presetList', (done) => {
+        const NUM_ACTIONS = 1;
+        testEpic(addTimeoutEpic(switchTutorialEpic, 50), NUM_ACTIONS, [
+            onLocationChanged({
+                pathname: '/geostory/newgeostory'
+            }),
+            initTutorial("", [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                }
+            },
+            geostory: {mode: "view"}
+        });
+
+    });
     describe("tests for switchGeostoryTutorialEpic", () => {
         beforeEach(() => {
             localStorage.setItem("mapstore.plugin.tutorial.geostory.disabled", "false");

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -57,15 +57,14 @@ const switchTutorialEpic = (action$, store) =>
                     const defaultName = id ? 'default' : action.payload && action.payload.location && action.payload.location.pathname || 'default';
                     const prevTutorialId = state.tutorial && state.tutorial.id;
                     let presetName = id + mobile + '_tutorial';
-                    if (id && id?.indexOf("geostory") !== -1) {
+                    if (id && id?.indexOf("geostory") !== -1 && !isEmpty(presetList)) {
                         // this is needed to setup correct geostory tutorial based on the current mode and page
                         if (modeSelector(state) === "edit" || id && id?.indexOf("newgeostory") !== -1) {
                             id  = "geostory";
                             presetName = `geostory_edit_tutorial`;
                             return Rx.Observable.from([
                                 setupTutorial(id, presetList[presetName], null, null, null, false)
-                            ]
-                            );
+                            ]);
                         }
                         presetName = `geostory_view_tutorial`;
                         return Rx.Observable.of(setupTutorial(id, presetList[presetName], null, null, null, true));

--- a/web/client/reducers/tutorial.js
+++ b/web/client/reducers/tutorial.js
@@ -62,7 +62,7 @@ function tutorial(state = initialState, action) {
         const isActuallyDisabled = localStorage.getItem('mapstore.plugin.tutorial.' + action.id + '.disabled') === 'true';
 
         setup.steps = setup.steps.filter((step) => {
-            return step.selector && step.selector.substring(0, 1) === '#' || step.selector.substring(0, 1) === '.';
+            return step?.selector?.substring(0, 1) === '#' || step?.selector?.substring(0, 1) === '.';
         }).map((step, index) => {
             let title = step.title ? step.title : '';
             title = step.translation ? <I18N.Message msgId = {"tutorial." + step.translation + ".title"}/> : title;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixes the bug reported in the issue, and prevents and further crahsing if config is misconfigured by not specifying a default present for tutorial in geostory

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5491

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
no longer it fails beacuse it will not configure a tutorial if presets are not present

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
