### PR TITLE
[2020.02.xx] Printing engine not included by default in the build (new profiles for maven) (#5375)

### DIFF
--- a/docs/developer-guide/building-and-deploying.md
+++ b/docs/developer-guide/building-and-deploying.md
@@ -110,3 +110,18 @@ In particular:
 * build for travis
 
 `npm run travis`
+
+## Including the printing engine in your build
+
+The [MapStore printing engine](https://github.com/geosolutions-it/mapfish-print/wiki) is not included in official builds by default.
+
+To build your own version of MapStore with the printing module included, you can enable the
+**printing** profile:
+
+`./build.sh [version_identifier] -Pprinting`
+
+It is also possible to build only the printing extension as a zip (to be unzipped on your deployed MapStore). To do that:
+
+`mvn clean install -Pprintingbundle`
+
+The zip bundle will be in printing/target/mapstore-printing.zip.

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,17 @@
 
     </profile>
     <profile>
+        <id>printingbundle</id>
+        <activation>
+        <property>
+          <name>printingbundle</name>
+        </property>
+      </activation>
+      <modules>
+        <module>printing</module>
+      </modules>
+    </profile>
+    <profile>
       <id>release</id>
       <activation>
         <property>
@@ -44,6 +55,7 @@
         <module>backend</module>
         <module>web</module>
         <module>release</module>
+        <module>printing</module>
       </modules>
     </profile>
   </profiles>

--- a/printing/assembly/mapstore-printing.xml
+++ b/printing/assembly/mapstore-printing.xml
@@ -1,0 +1,21 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>/WEB-INF</outputDirectory>
+            <directory>${project.build.directory}/mapstore-printing/WEB-INF</directory>
+            <includes>
+                <include>**/*.xml</include>
+                <include>**/print-lib*.jar</include>
+                <include>**/mapfish-geo-lib*.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/printing/pom.xml
+++ b/printing/pom.xml
@@ -1,0 +1,151 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>it.geosolutions.mapstore</groupId>
+  <artifactId>mapstore-print</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>MapStore 2 - Printing extension bundle</name>
+  <url>http://www.geo-solutions.it</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <mapstore2.version>DEV</mapstore2.version>
+  </properties>
+
+  <dependencies>
+    <!-- mapfish-print -->
+    <dependency>
+        <groupId>org.mapfish.print</groupId>
+        <artifactId>print-lib</artifactId>
+        <version>geosolutions-2.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>org.mapfish.geo</groupId>
+        <artifactId>mapfish-geo-lib</artifactId>
+        <version>1.2.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>mapstore-printing</finalName>
+    <plugins>
+        <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/mapstore-printing/WEB-INF/lib</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+                <execution>
+                    <id>application-context</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>copy-resources</goal>
+                    </goals>
+                    <configuration>
+                        <outputDirectory>${basedir}/target/mapstore-printing/WEB-INF/classes</outputDirectory>
+                        <encoding>UTF-8</encoding>
+                        <resources>
+                            <resource>
+                                <directory>${basedir}/../web/src/printing</directory>
+                            </resource>
+                        </resources>
+                    </configuration>
+                </execution>
+
+            </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+            <execution>
+                <id>create-distribution</id>
+                <phase>package</phase>
+                <goals>
+                <goal>single</goal>
+                </goals>
+                <configuration>
+                <finalName>mapstore-printing</finalName>
+                <appendAssemblyId>false</appendAssemblyId>
+                <descriptors>
+                    <descriptor>assembly/mapstore-printing.xml</descriptor>
+                </descriptors>
+                </configuration>
+            </execution>
+            </executions>
+        </plugin>
+    </plugins>
+  </build>
+    <repositories>
+        <!-- GeoSolutions -->
+        <repository>
+            <id>geosolutions</id>
+            <name>GeoSolutions Repository</name>
+            <url>https://maven.geo-solutions.it</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+
+        <!-- Apache -->
+        <repository>
+            <id>maven2-repository.dev.java.net</id>
+            <name>Java.net Repository for Maven</name>
+            <url>http://download.java.net/maven/2/</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <!-- JBoss -->
+        <repository>
+            <id>jboss-repo</id>
+            <name>JBoss Maven2 Repository</name>
+            <url>http://repository.jboss.com/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <!-- Spring -->
+        <repository>
+            <id>spring-release</id>
+            <name>Spring Portfolio Release Repository</name>
+            <url>http://maven.springframework.org/release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-external</id>
+            <name>Spring Portfolio External Repository</name>
+            <url>http://maven.springframework.org/external</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>osgeo</id>
+            <name>Open Source Geospatial Foundation Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>

--- a/project/custom/templates/web/src/main/webapp/WEB-INF/web.xml
+++ b/project/custom/templates/web/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,7 @@
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
             classpath*:applicationContext.xml
+            classpath*:applicationContext-print.xml
         </param-value>
 	</context-param>
     <display-name>__PROJECTDESCRIPTION__ - Web App</display-name>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -39,12 +39,7 @@
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
-    <!-- mapfish-print -->
-    <dependency>
-      <groupId>org.mapfish.print</groupId>
-      <artifactId>print-lib</artifactId>
-      <version>geosolutions-2.0-SNAPSHOT</version>
-    </dependency>
+
 
     <dependency>
       <groupId>org.geotools</groupId>
@@ -60,11 +55,6 @@
       <groupId>com.vividsolutions</groupId>
       <artifactId>jts</artifactId>
       <version>1.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mapfish.geo</groupId>
-      <artifactId>mapfish-geo-lib</artifactId>
-      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>javax.media</groupId>
@@ -431,6 +421,50 @@
         </plugin>
     </plugins>
   </build>
+    <profiles>
+        <profile>
+            <id>printing</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.coderplus.maven.plugins</groupId>
+                        <artifactId>copy-rename-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>rename-context</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                <overWrite>true</overWrite>
+                                <sourceFile>src/printing/applicationContext-print.xml</sourceFile>
+                                <destinationFile>target/__PROJECTNAME__/WEB-INF/classes/applicationContext-print.xml</destinationFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <!-- mapfish-print -->
+                <dependency>
+                    <groupId>org.mapfish.print</groupId>
+                    <artifactId>print-lib</artifactId>
+                    <version>geosolutions-2.0-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.mapfish.geo</groupId>
+                    <artifactId>mapfish-geo-lib</artifactId>
+                    <version>1.2.0</version>
+                </dependency>
+            </dependencies>
+            </profile>
+    </profiles>
 
 	<repositories>
         <!-- GeoSolutions -->

--- a/project/standard/templates/web/src/main/resources/applicationContext.xml
+++ b/project/standard/templates/web/src/main/resources/applicationContext.xml
@@ -16,9 +16,6 @@
 
     <context:annotation-config />
 
-    <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
-	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
-    
     <bean id="geostoreInitializer" class="it.geosolutions.geostore.init.GeoStoreInit" lazy-init="false">
         <!-- Site specific initialization. Please specify a path in the ovr file-->
         <!--<property name="userListInitFile"><null/></property>-->
@@ -29,76 +26,6 @@
         <!-- Site specific initialization. Please specify a path in the ovr file-->
         <property name="userGroupListInitFile" value="classpath:sample_groups.xml" />
         <!-- The default password encoder -->
-        <property name="passwordEncoder" ref="${passwordEncoderUsed}"></property>	
-        
-        
+        <property name="passwordEncoder" ref="${passwordEncoderUsed}"></property>
     </bean>
-      
-      <!-- Define MapReaderFactories -->
-    <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
-    <bean id="wms-MapReaderFactory" class="org.mapfish.print.map.readers.WMSMapReader$Factory"/>
-    <bean id="mapServer-MapReaderFactory" class="org.mapfish.print.map.readers.MapServerMapReader$Factory"/>
-    <bean id="tileCache-MapReaderFactory" class="org.mapfish.print.map.readers.TileCacheMapReader$Factory"/>
-    <bean id="osm-MapReaderFactory" class="org.mapfish.print.map.readers.OsmMapReader$Factory"/>
-    <bean id="xyz-MapReaderFactory" class="org.mapfish.print.map.readers.XyzMapReader$Factory"/>
-    <bean id="tms-MapReaderFactory" class="org.mapfish.print.map.readers.TmsMapReader$Factory"/>
-    <bean id="vector-MapReaderFactory" class="org.mapfish.print.map.readers.VectorMapReader$Factory"/>
-    <bean id="image-MapReaderFactory" class="org.mapfish.print.map.readers.ImageMapReader$Factory"/>
-    <bean id="tiledGoogle-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapTileReader$Factory"/>
-    <bean id="google-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapReader$Factory"/>
-    <bean id="kaMapCache-ReaderFactory" class="org.mapfish.print.map.readers.KaMapCacheMapReader$Factory"/>
-    <bean id="kaMap-ReaderFactory" class="org.mapfish.print.map.readers.KaMapMapReader$Factory"/>
-    <bean id="wmts-ReaderFactory" class="org.mapfish.print.map.readers.WMTSMapReader$Factory"/>
-    
-    <!-- Define output factories -->
-    <bean id="outputFactory" class="org.mapfish.print.output.OutputFactory">
-        <property name="formatFactories">
-            <list>
-                <!-- Uncomment to use image magick for image output -->
-                <!-- <ref bean="imageMagickOutput" />  -->
-                <ref bean="fileCachingJaiMosaicOutputFactory" />
-                <ref bean="inMemoryJaiMosaicOutputFactory" />
-                <ref bean="pdfOutputFactory" />
-            </list>
-        </property>
-    </bean>
-    <bean id="imageMagickOutput" class="org.mapfish.print.output.NativeProcessOutputFactory">
-        <!-- the path and command of the process to use for converting the pdf to another format.
-             The normal configuration is for imagemagick  -->
-        <property name="cmd">
-            <value>/usr/local/convert</value>
-        </property>
-        <!-- The arguments to use when running an imagemagick process -->
-        <property name="cmdArgs">
-            <list>
-                <value>-density</value>
-                <value>@@dpi@@</value>
-                <value>-append</value>
-                <value>@@sourceFile@@</value>
-                <value>@@targetFile@@</value>
-            </list>
-        </property>
-        <!-- Formats supported by the converter -->
-        <property name="formats">
-            <list>
-                <value>jpg</value>
-                <value>png</value>
-                <value>tif</value>
-                <value>tiff</value>
-                <value>gif</value>
-                <value>bmp</value>
-            </list>
-        </property>
-        <!-- The number of concurrent processes to run.  Extra processes will wait their turn  -->
-        <constructor-arg>
-            <value>10</value>
-        </constructor-arg>
-        <!-- the length of time to wait for a process to be available before giving up -->
-        <property name="timeoutSeconds">
-            <value>30</value>
-        </property>
-    </bean>
-    <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
-    <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
-    <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
 </beans>

--- a/project/standard/templates/web/src/main/webapp/WEB-INF/web.xml
+++ b/project/standard/templates/web/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,7 @@
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
             classpath*:applicationContext.xml
+            classpath*:applicationContext-print.xml
         </param-value>
 	</context-param>
     <display-name>__PROJECTDESCRIPTION__ - Web App</display-name>

--- a/project/standard/templates/web/src/printing/applicationContext-print.xml
+++ b/project/standard/templates/web/src/printing/applicationContext-print.xml
@@ -1,0 +1,89 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+
+	   xmlns:cxf="http://cxf.apache.org/core"
+	   xmlns:jaxws="http://cxf.apache.org/jaxws"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs"
+
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+            http://cxf.apache.org/jaxws                     http://cxf.apache.org/schemas/jaxws.xsd
+            http://cxf.apache.org/jaxrs                     http://cxf.apache.org/schemas/jaxrs.xsd
+            http://cxf.apache.org/core                      http://cxf.apache.org/schemas/core.xsd
+            http://www.springframework.org/schema/context   http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+       default-autowire="byName">
+
+    <context:annotation-config />
+
+    <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
+	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+
+      <!-- Define MapReaderFactories -->
+    <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
+    <bean id="wms-MapReaderFactory" class="org.mapfish.print.map.readers.WMSMapReader$Factory"/>
+    <bean id="mapServer-MapReaderFactory" class="org.mapfish.print.map.readers.MapServerMapReader$Factory"/>
+    <bean id="tileCache-MapReaderFactory" class="org.mapfish.print.map.readers.TileCacheMapReader$Factory"/>
+    <bean id="osm-MapReaderFactory" class="org.mapfish.print.map.readers.OsmMapReader$Factory"/>
+    <bean id="xyz-MapReaderFactory" class="org.mapfish.print.map.readers.XyzMapReader$Factory"/>
+    <bean id="tms-MapReaderFactory" class="org.mapfish.print.map.readers.TmsMapReader$Factory"/>
+    <bean id="vector-MapReaderFactory" class="org.mapfish.print.map.readers.VectorMapReader$Factory"/>
+    <bean id="image-MapReaderFactory" class="org.mapfish.print.map.readers.ImageMapReader$Factory"/>
+    <bean id="tiledGoogle-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapTileReader$Factory"/>
+    <bean id="google-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapReader$Factory"/>
+    <bean id="kaMapCache-ReaderFactory" class="org.mapfish.print.map.readers.KaMapCacheMapReader$Factory"/>
+    <bean id="kaMap-ReaderFactory" class="org.mapfish.print.map.readers.KaMapMapReader$Factory"/>
+    <bean id="wmts-ReaderFactory" class="org.mapfish.print.map.readers.WMTSMapReader$Factory"/>
+
+    <!-- Define output factories -->
+    <bean id="outputFactory" class="org.mapfish.print.output.OutputFactory">
+        <property name="formatFactories">
+            <list>
+                <!-- Uncomment to use image magick for image output -->
+                <!-- <ref bean="imageMagickOutput" />  -->
+                <ref bean="fileCachingJaiMosaicOutputFactory" />
+                <ref bean="inMemoryJaiMosaicOutputFactory" />
+                <ref bean="pdfOutputFactory" />
+            </list>
+        </property>
+    </bean>
+    <bean id="imageMagickOutput" class="org.mapfish.print.output.NativeProcessOutputFactory">
+        <!-- the path and command of the process to use for converting the pdf to another format.
+             The normal configuration is for imagemagick  -->
+        <property name="cmd">
+            <value>/usr/local/convert</value>
+        </property>
+        <!-- The arguments to use when running an imagemagick process -->
+        <property name="cmdArgs">
+            <list>
+                <value>-density</value>
+                <value>@@dpi@@</value>
+                <value>-append</value>
+                <value>@@sourceFile@@</value>
+                <value>@@targetFile@@</value>
+            </list>
+        </property>
+        <!-- Formats supported by the converter -->
+        <property name="formats">
+            <list>
+                <value>jpg</value>
+                <value>png</value>
+                <value>tif</value>
+                <value>tiff</value>
+                <value>gif</value>
+                <value>bmp</value>
+            </list>
+        </property>
+        <!-- The number of concurrent processes to run.  Extra processes will wait their turn  -->
+        <constructor-arg>
+            <value>10</value>
+        </constructor-arg>
+        <!-- the length of time to wait for a process to be available before giving up -->
+        <property name="timeoutSeconds">
+            <value>30</value>
+        </property>
+    </bean>
+    <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
+    <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
+    <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+</beans>

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -49,7 +49,9 @@
       {"name": "router", "path": "router.location.pathname"},
       {"name": "browser", "path": "browser"},
       {"name": "geostorymode", "path": "geostory.mode"},
-      {"name": "featuregridmode", "path": "featuregrid.mode"}],
+      {"name": "featuregridmode", "path": "featuregrid.mode"},
+      {"name": "printEnabled", "path": "print.capabilities"}
+    ],
     "userSessions": {
       "enabled": true
     },

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -464,7 +464,7 @@ module.exports = {
         enabler: (state) => state.print && state.print.enabled || state.toolbar && state.toolbar.active === 'print'
     },
     {
-        disablePluginIf: "{state('mapType') === 'cesium'}",
+        disablePluginIf: "{state('mapType') === 'cesium' || !state('printEnabled')}",
         Toolbar: {
             name: 'print',
             position: 7,

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -37,12 +37,6 @@
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
-    <!-- mapfish-print -->
-    <dependency>
-      <groupId>org.mapfish.print</groupId>
-      <artifactId>print-lib</artifactId>
-      <version>geosolutions-2.0-SNAPSHOT</version>
-    </dependency>
 
     <dependency>
       <groupId>org.geotools</groupId>
@@ -58,11 +52,6 @@
       <groupId>com.vividsolutions</groupId>
       <artifactId>jts</artifactId>
       <version>1.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mapfish.geo</groupId>
-      <artifactId>mapfish-geo-lib</artifactId>
-      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>javax.media</groupId>
@@ -411,6 +400,48 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>printing</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>rename-context</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                        <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                        <overWrite>true</overWrite>
+                        <sourceFile>src/printing/applicationContext-print.xml</sourceFile>
+                        <destinationFile>target/mapstore/WEB-INF/classes/applicationContext-print.xml</destinationFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+       </build>
+       <dependencies>
+        <!-- mapfish-print -->
+        <dependency>
+            <groupId>org.mapfish.print</groupId>
+            <artifactId>print-lib</artifactId>
+            <version>geosolutions-2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapfish.geo</groupId>
+            <artifactId>mapfish-geo-lib</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+       </dependencies>
+    </profile>
     <profile>
         <id>serveronly</id>
         <properties>

--- a/web/src/main/resources/applicationContext.xml
+++ b/web/src/main/resources/applicationContext.xml
@@ -16,9 +16,6 @@
 
     <context:annotation-config />
 
-    <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
-	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
-    
     <bean id="geostoreInitializer" class="it.geosolutions.geostore.init.GeoStoreInit" lazy-init="false">
         <!-- Site specific initialization. Please specify a path in the ovr file-->
         <!--<property name="userListInitFile"><null/></property>-->
@@ -29,76 +26,6 @@
         <!-- Site specific initialization. Please specify a path in the ovr file-->
         <property name="userGroupListInitFile" value="classpath:sample_groups.xml" />
         <!-- The default password encoder -->
-        <property name="passwordEncoder" ref="${passwordEncoderUsed}"></property>	
-        
-        
+        <property name="passwordEncoder" ref="${passwordEncoderUsed}"></property>
     </bean>
-      
-      <!-- Define MapReaderFactories -->
-    <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
-    <bean id="wms-MapReaderFactory" class="org.mapfish.print.map.readers.WMSMapReader$Factory"/>
-    <bean id="mapServer-MapReaderFactory" class="org.mapfish.print.map.readers.MapServerMapReader$Factory"/>
-    <bean id="tileCache-MapReaderFactory" class="org.mapfish.print.map.readers.TileCacheMapReader$Factory"/>
-    <bean id="osm-MapReaderFactory" class="org.mapfish.print.map.readers.OsmMapReader$Factory"/>
-    <bean id="xyz-MapReaderFactory" class="org.mapfish.print.map.readers.XyzMapReader$Factory"/>
-    <bean id="tms-MapReaderFactory" class="org.mapfish.print.map.readers.TmsMapReader$Factory"/>
-    <bean id="vector-MapReaderFactory" class="org.mapfish.print.map.readers.VectorMapReader$Factory"/>
-    <bean id="image-MapReaderFactory" class="org.mapfish.print.map.readers.ImageMapReader$Factory"/>
-    <bean id="tiledGoogle-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapTileReader$Factory"/>
-    <bean id="google-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapReader$Factory"/>
-    <bean id="kaMapCache-ReaderFactory" class="org.mapfish.print.map.readers.KaMapCacheMapReader$Factory"/>
-    <bean id="kaMap-ReaderFactory" class="org.mapfish.print.map.readers.KaMapMapReader$Factory"/>
-    <bean id="wmts-ReaderFactory" class="org.mapfish.print.map.readers.WMTSMapReader$Factory"/>
-    
-    <!-- Define output factories -->
-    <bean id="outputFactory" class="org.mapfish.print.output.OutputFactory">
-        <property name="formatFactories">
-            <list>
-                <!-- Uncomment to use image magick for image output -->
-                <!-- <ref bean="imageMagickOutput" />  -->
-                <ref bean="fileCachingJaiMosaicOutputFactory" />
-                <ref bean="inMemoryJaiMosaicOutputFactory" />
-                <ref bean="pdfOutputFactory" />
-            </list>
-        </property>
-    </bean>
-    <bean id="imageMagickOutput" class="org.mapfish.print.output.NativeProcessOutputFactory">
-        <!-- the path and command of the process to use for converting the pdf to another format.
-             The normal configuration is for imagemagick  -->
-        <property name="cmd">
-            <value>/usr/local/convert</value>
-        </property>
-        <!-- The arguments to use when running an imagemagick process -->
-        <property name="cmdArgs">
-            <list>
-                <value>-density</value>
-                <value>@@dpi@@</value>
-                <value>-append</value>
-                <value>@@sourceFile@@</value>
-                <value>@@targetFile@@</value>
-            </list>
-        </property>
-        <!-- Formats supported by the converter -->
-        <property name="formats">
-            <list>
-                <value>jpg</value>
-                <value>png</value>
-                <value>tif</value>
-                <value>tiff</value>
-                <value>gif</value>
-                <value>bmp</value>
-            </list>
-        </property>
-        <!-- The number of concurrent processes to run.  Extra processes will wait their turn  -->
-        <constructor-arg>
-            <value>10</value>
-        </constructor-arg>
-        <!-- the length of time to wait for a process to be available before giving up -->
-        <property name="timeoutSeconds">
-            <value>30</value>
-        </property>
-    </bean>
-    <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
-    <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
-    <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
 </beans>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,7 @@
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
             classpath*:applicationContext.xml
+            classpath*:applicationContext-print.xml
         </param-value>
 	</context-param>
 
@@ -76,7 +77,7 @@
         <servlet-name>dispatcher</servlet-name>
         <url-pattern>/rest/config/*</url-pattern>
     </servlet-mapping>
-    
+
 	<!-- CXF Servlet -->
 	<servlet>
 		<servlet-name>CXFServlet</servlet-name>
@@ -112,7 +113,7 @@
       <servlet-name>mapfish.print</servlet-name>
       <url-pattern>/pdf/*</url-pattern>
     </servlet-mapping>
-    
+
 	<!-- Default page to serve -->
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>

--- a/web/src/printing/applicationContext-print.xml
+++ b/web/src/printing/applicationContext-print.xml
@@ -1,0 +1,89 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+
+	   xmlns:cxf="http://cxf.apache.org/core"
+	   xmlns:jaxws="http://cxf.apache.org/jaxws"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs"
+
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+            http://cxf.apache.org/jaxws                     http://cxf.apache.org/schemas/jaxws.xsd
+            http://cxf.apache.org/jaxrs                     http://cxf.apache.org/schemas/jaxrs.xsd
+            http://cxf.apache.org/core                      http://cxf.apache.org/schemas/core.xsd
+            http://www.springframework.org/schema/context   http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+       default-autowire="byName">
+
+    <context:annotation-config />
+
+    <bean id="mapPrinter" class="org.mapfish.print.MapPrinter" scope="prototype"></bean>
+	<bean id="configFactory" class="org.mapfish.print.config.ConfigFactory"></bean>
+
+      <!-- Define MapReaderFactories -->
+    <bean id="mapReaderFactoryFinder" class="org.mapfish.print.map.readers.MapReaderFactoryFinder"/>
+    <bean id="wms-MapReaderFactory" class="org.mapfish.print.map.readers.WMSMapReader$Factory"/>
+    <bean id="mapServer-MapReaderFactory" class="org.mapfish.print.map.readers.MapServerMapReader$Factory"/>
+    <bean id="tileCache-MapReaderFactory" class="org.mapfish.print.map.readers.TileCacheMapReader$Factory"/>
+    <bean id="osm-MapReaderFactory" class="org.mapfish.print.map.readers.OsmMapReader$Factory"/>
+    <bean id="xyz-MapReaderFactory" class="org.mapfish.print.map.readers.XyzMapReader$Factory"/>
+    <bean id="tms-MapReaderFactory" class="org.mapfish.print.map.readers.TmsMapReader$Factory"/>
+    <bean id="vector-MapReaderFactory" class="org.mapfish.print.map.readers.VectorMapReader$Factory"/>
+    <bean id="image-MapReaderFactory" class="org.mapfish.print.map.readers.ImageMapReader$Factory"/>
+    <bean id="tiledGoogle-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapTileReader$Factory"/>
+    <bean id="google-MapReaderFactory" class="org.mapfish.print.map.readers.google.GoogleMapReader$Factory"/>
+    <bean id="kaMapCache-ReaderFactory" class="org.mapfish.print.map.readers.KaMapCacheMapReader$Factory"/>
+    <bean id="kaMap-ReaderFactory" class="org.mapfish.print.map.readers.KaMapMapReader$Factory"/>
+    <bean id="wmts-ReaderFactory" class="org.mapfish.print.map.readers.WMTSMapReader$Factory"/>
+
+    <!-- Define output factories -->
+    <bean id="outputFactory" class="org.mapfish.print.output.OutputFactory">
+        <property name="formatFactories">
+            <list>
+                <!-- Uncomment to use image magick for image output -->
+                <!-- <ref bean="imageMagickOutput" />  -->
+                <ref bean="fileCachingJaiMosaicOutputFactory" />
+                <ref bean="inMemoryJaiMosaicOutputFactory" />
+                <ref bean="pdfOutputFactory" />
+            </list>
+        </property>
+    </bean>
+    <bean id="imageMagickOutput" class="org.mapfish.print.output.NativeProcessOutputFactory">
+        <!-- the path and command of the process to use for converting the pdf to another format.
+             The normal configuration is for imagemagick  -->
+        <property name="cmd">
+            <value>/usr/local/convert</value>
+        </property>
+        <!-- The arguments to use when running an imagemagick process -->
+        <property name="cmdArgs">
+            <list>
+                <value>-density</value>
+                <value>@@dpi@@</value>
+                <value>-append</value>
+                <value>@@sourceFile@@</value>
+                <value>@@targetFile@@</value>
+            </list>
+        </property>
+        <!-- Formats supported by the converter -->
+        <property name="formats">
+            <list>
+                <value>jpg</value>
+                <value>png</value>
+                <value>tif</value>
+                <value>tiff</value>
+                <value>gif</value>
+                <value>bmp</value>
+            </list>
+        </property>
+        <!-- The number of concurrent processes to run.  Extra processes will wait their turn  -->
+        <constructor-arg>
+            <value>10</value>
+        </constructor-arg>
+        <!-- the length of time to wait for a process to be available before giving up -->
+        <property name="timeoutSeconds">
+            <value>30</value>
+        </property>
+    </bean>
+    <bean id="fileCachingJaiMosaicOutputFactory" class="org.mapfish.print.output.FileCachingJaiMosaicOutputFactory"/>
+    <bean id="inMemoryJaiMosaicOutputFactory" class="org.mapfish.print.output.InMemoryJaiMosaicOutputFactory"/>
+    <bean id="pdfOutputFactory" class="org.mapfish.print.output.PdfOutputFactory"/>
+</beans>


### PR DESCRIPTION
Backports the following commits to 2020.02.xx:
 - Printing engine not included by default in the build (new profiles for maven) (#5375)