### PR TITLE
Backport 2020.02.xx - #5491 Geostory fails when advanced editor is opened and config is missing #5492

### DIFF
--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -321,6 +321,33 @@ describe('tutorial Epics', () => {
         });
 
     });
+    it('switchTutorialEpic selecting geostory_view_tutorial preset for story viewer page, missing presetList', (done) => {
+        const NUM_ACTIONS = 1;
+        testEpic(addTimeoutEpic(switchTutorialEpic, 50), NUM_ACTIONS, [
+            onLocationChanged({
+                pathname: '/geostory/newgeostory'
+            }),
+            initTutorial("", [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                }
+            },
+            geostory: {mode: "view"}
+        });
+
+    });
     describe("tests for switchGeostoryTutorialEpic", () => {
         beforeEach(() => {
             localStorage.setItem("mapstore.plugin.tutorial.geostory.disabled", "false");

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -57,15 +57,14 @@ const switchTutorialEpic = (action$, store) =>
                     const defaultName = id ? 'default' : action.payload && action.payload.location && action.payload.location.pathname || 'default';
                     const prevTutorialId = state.tutorial && state.tutorial.id;
                     let presetName = id + mobile + '_tutorial';
-                    if (id && id?.indexOf("geostory") !== -1) {
+                    if (id && id?.indexOf("geostory") !== -1 && !isEmpty(presetList)) {
                         // this is needed to setup correct geostory tutorial based on the current mode and page
                         if (modeSelector(state) === "edit" || id && id?.indexOf("newgeostory") !== -1) {
                             id  = "geostory";
                             presetName = `geostory_edit_tutorial`;
                             return Rx.Observable.from([
                                 setupTutorial(id, presetList[presetName], null, null, null, false)
-                            ]
-                            );
+                            ]);
                         }
                         presetName = `geostory_view_tutorial`;
                         return Rx.Observable.of(setupTutorial(id, presetList[presetName], null, null, null, true));

--- a/web/client/reducers/tutorial.js
+++ b/web/client/reducers/tutorial.js
@@ -62,7 +62,7 @@ function tutorial(state = initialState, action) {
         const isActuallyDisabled = localStorage.getItem('mapstore.plugin.tutorial.' + action.id + '.disabled') === 'true';
 
         setup.steps = setup.steps.filter((step) => {
-            return step.selector && step.selector.substring(0, 1) === '#' || step.selector.substring(0, 1) === '.';
+            return step?.selector?.substring(0, 1) === '#' || step?.selector?.substring(0, 1) === '.';
         }).map((step, index) => {
             let title = step.title ? step.title : '';
             title = step.translation ? <I18N.Message msgId = {"tutorial." + step.translation + ".title"}/> : title;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Backport 2020.02.xx - #5491 Geostory fails when advanced editor is opened and config is missing #5492