### PR TITLE
#5309: Confirmation dialog for GeoStory pending changes

### DIFF
--- a/web/client/actions/geostory.js
+++ b/web/client/actions/geostory.js
@@ -38,6 +38,7 @@ export const UPDATE = "GEOSTORY:UPDATE";
 export const UPDATE_SETTING = "GEOSTORY:UPDATE_SETTING";
 export const UPDATE_CURRENT_PAGE = "GEOSTORY:UPDATE_CURRENT_PAGE";
 export const REMOVE_RESOURCE = "GEOSTORY:REMOVE_RESOURCE";
+export const SET_PENDING_CHANGES = "GEOSTORY:SET_PENDING_CHANGES";
 
 /**
  * Adds an entry to current story. The entry can be a section, a content or anything to append in an array (even sub-content)
@@ -227,3 +228,8 @@ export const editWebPage = ({ path }, owner = 'GEOSTORY') => ({ type: EDIT_WEBPA
  * Removes a resource in the current story
  */
 export const removeResource = ( id, mediaType) => ({type: REMOVE_RESOURCE, id, mediaType});
+
+/**
+ * Sets pending changes
+ */
+export const setPendingChanges = value => ({type: SET_PENDING_CHANGES, value});

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -24,7 +24,6 @@ const INIT_MAP = 'INIT_MAP';
 const RESIZE_MAP = 'RESIZE_MAP';
 const CHANGE_MAP_LIMITS = 'CHANGE_MAP_LIMITS';
 const SET_MAP_RESOLUTIONS = 'SET_MAP_RESOLUTIONS';
-const CHECK_MAP_CHANGES = 'CHECK_MAP_CHANGES';
 const REGISTER_EVENT_LISTENER = 'REGISTER_EVENT_LISTENER';
 const UNREGISTER_EVENT_LISTENER = 'UNREGISTER_EVENT_LISTENER';
 const MOUSE_MOVE = 'MOUSE_MOVE';
@@ -185,12 +184,6 @@ function setMapResolutions(resolutions) {
     };
 }
 
-const checkMapChanges = (action, source) => ({
-    type: CHECK_MAP_CHANGES,
-    action,
-    source
-});
-
 /**
  * Add a tool to the list of event listeners for the map plugin.
  * This can help to trigger actions only if some tool is effectively listen. Useful for
@@ -253,7 +246,6 @@ module.exports = {
     RESIZE_MAP,
     CHANGE_MAP_LIMITS,
     SET_MAP_RESOLUTIONS,
-    CHECK_MAP_CHANGES,
     REGISTER_EVENT_LISTENER,
     UNREGISTER_EVENT_LISTENER,
     MOUSE_MOVE,
@@ -275,7 +267,6 @@ module.exports = {
     resizeMap,
     changeMapLimits,
     setMapResolutions,
-    checkMapChanges,
     registerEventListener,
     unRegisterEventListener,
     mouseMove,

--- a/web/client/actions/pendingChanges.js
+++ b/web/client/actions/pendingChanges.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const CHECK_PENDING_CHANGES = 'SAVE:CHECK_PENDING_CHANGES';
+
+/**
+ * Action that triggers a check to the current content (if it has changes).
+ * @param {object} action the action to trigger if there are no changes
+ * @param {string} source the source object that invoked this call
+ */
+export const checkPendingChanges = (action, source) => ({
+    type: CHECK_PENDING_CHANGES,
+    action,
+    source
+});

--- a/web/client/epics/__tests__/map-test.js
+++ b/web/client/epics/__tests__/map-test.js
@@ -7,11 +7,8 @@
  */
 
 const expect = require('expect');
-const { set } = require('../../utils/ImmutableUtils');
-const { LOCATION_CHANGE } = require('connected-react-router');
 
-
-const { resetLimitsOnInit, zoomToExtentEpic, checkMapPermissions, compareMapChanges, redirectUnauthorizedUserOnNewMap} = require('../map');
+const { resetLimitsOnInit, zoomToExtentEpic, checkMapPermissions, redirectUnauthorizedUserOnNewMap} = require('../map');
 const { CHANGE_MAP_LIMITS, changeMapCrs } = require('../../actions/map');
 
 const { LOAD_MAP_INFO, configureMap, configureError} = require('../../actions/config');
@@ -21,13 +18,11 @@ const MapUtils = require('../../utils/MapUtils');
 
 const {
     CHANGE_MAP_VIEW,
-    zoomToExtent,
-    checkMapChanges
+    zoomToExtent
 } = require('../../actions/map');
 
 
-const { LOGIN_SUCCESS, logout } = require('../../actions/security');
-const {SET_CONTROL_PROPERTY} = require('../../actions/controls');
+const { LOGIN_SUCCESS } = require('../../actions/security');
 
 const LAYOUT_STATE = {
     layout: {
@@ -248,167 +243,6 @@ describe('map epics', () => {
             expect(minZoom).toBe(2);
             done();
         }, state);
-    });
-    describe('compareMapChanges', () => {
-        const SAME_MAP_STATE = {
-            map: {
-                present: {
-                    mapId: '1',
-                    info: {
-                        canEdit: true
-                    }
-                }
-            },
-            feedbackMask: {
-                currentPage: 'viewer'
-            },
-            layers: [
-                {
-                    allowedSRS: {},
-                    bbox: {},
-                    dimensions: [],
-                    id: "layer001",
-                    loading: true,
-                    name: "layer001",
-                    params: {},
-                    search: {},
-                    singleTile: false,
-                    thumbURL: "THUMB_URL",
-                    title: "layer001",
-                    type: "wms",
-                    url: "",
-                    visibility: true,
-                    catalogURL: "url"
-                }
-            ],
-            backgroundSelector: {
-                backgrounds: [
-                    { id: 'layer005', thumbnail: 'data' },
-                    { id: 'layer006', thumbnail: null }
-                ]
-            },
-            mapConfigRawData: {
-                "version": 2,
-                "map": {
-                    "mapOptions": {},
-                    "layers": [
-                        {
-                            "id": "layer001",
-                            "thumbURL": "THUMB_URL",
-                            "search": {},
-                            "name": "layer001",
-                            "title": "layer001",
-                            "type": "wms",
-                            "url": "",
-                            "bbox": {},
-                            "visibility": true,
-                            "singleTile": false,
-                            "allowedSRS": {},
-                            "dimensions": [],
-                            "hideLoading": false,
-                            "handleClickOnLayer": false,
-                            "catalogURL": "url",
-                            "useForElevation": false,
-                            "hidden": false,
-                            "params": {}
-                        }
-                    ],
-                    "groups": [],
-                    "backgrounds": [
-                        {
-                            "id": "layer005",
-                            "thumbnail": "data"
-                        }
-                    ]
-                },
-                "catalogServices": {},
-                "widgetsConfig": {},
-                "mapInfoConfiguration": {}
-            }
-        };
-        const CHANGED_MAP_STATE = set("map.present.zoom", 10, SAME_MAP_STATE);
-        const NOT_EDITABLE_STATE = set("map.present.info.canEdit", false, SAME_MAP_STATE);
-        it('shouldn\'t do anything if current view is different than map', (done) => {
-            const state = {
-                feedbackMask: {
-                    currentPage: ''
-                }
-            };
-
-            const epicResponse = (actions) => {
-                expect(actions.length).toBe(1);
-                expect(actions[0].type).toBe(TEST_TIMEOUT);
-                done();
-            };
-
-            testEpic(addTimeoutEpic(compareMapChanges, 10), 1, checkMapChanges(), epicResponse, state);
-        });
-        it('shouldn\'t do anything if map not editable', (done) => {
-            const epicResponse = (actions) => {
-                expect(actions.length).toBe(1);
-                expect(actions[0].type).toBe(TEST_TIMEOUT);
-                done();
-            };
-            testEpic(addTimeoutEpic(compareMapChanges, 10), 1, checkMapChanges(), epicResponse, NOT_EDITABLE_STATE);
-        });
-        it('shouldn\'t do anything if map is same', (done) => {
-            const epicResponse = (actions) => {
-                expect(actions.length).toBe(1);
-                expect(actions[0].type).toBe(TEST_TIMEOUT);
-                done();
-            };
-
-            testEpic(addTimeoutEpic(compareMapChanges, 10), 1, checkMapChanges(), epicResponse, SAME_MAP_STATE);
-        });
-
-        it('should show confirm prompt if anything changed', (done) => {
-
-            const epicResponse = (actions) => {
-                expect(actions.length).toBe(2);
-                expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[0].property).toBe('enabled');
-                expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[1].property).toBe('source');
-                done();
-            };
-            testEpic(compareMapChanges, 2, checkMapChanges(), epicResponse, CHANGED_MAP_STATE);
-        });
-        it('On logout the controls should be reset', (done) => {
-
-            const epicResponse = (actions) => {
-                expect(actions.length).toBe(4);
-                expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[0].property).toBe('enabled');
-                expect(actions[0].value).toBe(true);
-                expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[1].property).toBe('source');
-                expect(actions[2].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[2].property).toBe('enabled');
-                expect(actions[2].value).toBe(false);
-                expect(actions[3].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[3].property).toBe('source');
-                done();
-            };
-            testEpic(compareMapChanges, 4, [checkMapChanges(), logout()], epicResponse, CHANGED_MAP_STATE);
-        });
-        it('On location change the controls should be reset', (done) => {
-
-            const epicResponse = (actions) => {
-                expect(actions.length).toBe(4);
-                expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[0].property).toBe('enabled');
-                expect(actions[0].value).toBe(true);
-                expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[1].property).toBe('source');
-                expect(actions[2].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[2].property).toBe('enabled');
-                expect(actions[2].value).toBe(false);
-                expect(actions[3].type).toBe(SET_CONTROL_PROPERTY);
-                expect(actions[3].property).toBe('source');
-                done();
-            };
-            testEpic(compareMapChanges, 4, [checkMapChanges(), {type: LOCATION_CHANGE}], epicResponse, CHANGED_MAP_STATE);
-        });
     });
 
     describe('redirectUnauthorizedUserOnNewMap', () => {

--- a/web/client/epics/__tests__/pendingChanges-test.js
+++ b/web/client/epics/__tests__/pendingChanges-test.js
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import { checkPendingChanges } from '../../actions/pendingChanges';
+import { SET_CONTROL_PROPERTY } from '../../actions/controls';
+import { comparePendingChanges } from '../pendingChanges';
+import { LOCATION_CHANGE } from 'connected-react-router';
+import {logout} from '../../actions/security';
+
+import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
+import { set } from '../../utils/ImmutableUtils';
+
+describe('comparePendingChanges', () => {
+    const SAME_MAP_STATE = {
+        map: {
+            present: {
+                mapId: '1',
+                info: {
+                    canEdit: true
+                }
+            }
+        },
+        feedbackMask: {
+            currentPage: 'viewer'
+        },
+        layers: [
+            {
+                allowedSRS: {},
+                bbox: {},
+                dimensions: [],
+                id: "layer001",
+                loading: true,
+                name: "layer001",
+                params: {},
+                search: {},
+                singleTile: false,
+                thumbURL: "THUMB_URL",
+                title: "layer001",
+                type: "wms",
+                url: "",
+                visibility: true,
+                catalogURL: "url"
+            }
+        ],
+        backgroundSelector: {
+            backgrounds: [
+                { id: 'layer005', thumbnail: 'data' },
+                { id: 'layer006', thumbnail: null }
+            ]
+        },
+        mapConfigRawData: {
+            "version": 2,
+            "map": {
+                "mapOptions": {},
+                "layers": [
+                    {
+                        "id": "layer001",
+                        "thumbURL": "THUMB_URL",
+                        "search": {},
+                        "name": "layer001",
+                        "title": "layer001",
+                        "type": "wms",
+                        "url": "",
+                        "bbox": {},
+                        "visibility": true,
+                        "singleTile": false,
+                        "allowedSRS": {},
+                        "dimensions": [],
+                        "hideLoading": false,
+                        "handleClickOnLayer": false,
+                        "catalogURL": "url",
+                        "useForElevation": false,
+                        "hidden": false,
+                        "params": {}
+                    }
+                ],
+                "groups": [],
+                "backgrounds": [
+                    {
+                        "id": "layer005",
+                        "thumbnail": "data"
+                    }
+                ]
+            },
+            "catalogServices": {},
+            "widgetsConfig": {},
+            "mapInfoConfiguration": {}
+        }
+    };
+    const CHANGED_MAP_STATE = set("map.present.zoom", 10, SAME_MAP_STATE);
+    const NOT_EDITABLE_STATE = set("map.present.info.canEdit", false, SAME_MAP_STATE);
+    it('shouldn\'t do anything if current view is different than map', (done) => {
+        const state = {
+            feedbackMask: {
+                currentPage: ''
+            }
+        };
+
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(TEST_TIMEOUT);
+            done();
+        };
+
+        testEpic(addTimeoutEpic(comparePendingChanges, 10), 1, checkPendingChanges(), epicResponse, state);
+    });
+    it('shouldn\'t do anything if map not editable', (done) => {
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(TEST_TIMEOUT);
+            done();
+        };
+        testEpic(addTimeoutEpic(comparePendingChanges, 10), 1, checkPendingChanges(), epicResponse, NOT_EDITABLE_STATE);
+    });
+    it('shouldn\'t do anything if map is same', (done) => {
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(TEST_TIMEOUT);
+            done();
+        };
+
+        testEpic(addTimeoutEpic(comparePendingChanges, 10), 1, checkPendingChanges(), epicResponse, SAME_MAP_STATE);
+    });
+
+    it('should show confirm prompt if anything changed on map', (done) => {
+
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(2);
+            expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[0].property).toBe('enabled');
+            expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[1].property).toBe('source');
+            done();
+        };
+        testEpic(comparePendingChanges, 2, checkPendingChanges(), epicResponse, CHANGED_MAP_STATE);
+    });
+    it('should show confirm prompt if anything changed on geostory', (done) => {
+
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(2);
+            expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[0].property).toBe('enabled');
+            expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[1].property).toBe('source');
+            done();
+        };
+        testEpic(comparePendingChanges, 2, checkPendingChanges(), epicResponse, {
+            ...SAME_MAP_STATE,
+            geostory: {pendingChanges: true},
+            feedbackMask: {
+                currentPage: 'geostory'
+            }
+        });
+    });
+    it('On logout the controls should be reset', (done) => {
+
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[0].property).toBe('enabled');
+            expect(actions[0].value).toBe(true);
+            expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[1].property).toBe('source');
+            expect(actions[2].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[2].property).toBe('enabled');
+            expect(actions[2].value).toBe(false);
+            expect(actions[3].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[3].property).toBe('source');
+            done();
+        };
+        testEpic(comparePendingChanges, 4, [checkPendingChanges(), logout()], epicResponse, CHANGED_MAP_STATE);
+    });
+    it('On location change the controls should be reset', (done) => {
+
+        const epicResponse = (actions) => {
+            expect(actions.length).toBe(4);
+            expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[0].property).toBe('enabled');
+            expect(actions[0].value).toBe(true);
+            expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[1].property).toBe('source');
+            expect(actions[2].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[2].property).toBe('enabled');
+            expect(actions[2].value).toBe(false);
+            expect(actions[3].type).toBe(SET_CONTROL_PROPERTY);
+            expect(actions[3].property).toBe('source');
+            done();
+        };
+        testEpic(comparePendingChanges, 4, [checkPendingChanges(), { type: LOCATION_CHANGE }], epicResponse, CHANGED_MAP_STATE);
+    });
+});

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -14,7 +14,6 @@ import {push} from 'connected-react-router';
 import Api from '../api/GeoStoreDAO';
 
 import ConfigUtils from '../utils/ConfigUtils';
-import MapUtils from '../utils/MapUtils';
 
 import {SAVE_CONTEXT, SAVE_TEMPLATE, LOAD_CONTEXT, LOAD_TEMPLATE, DELETE_TEMPLATE, EDIT_TEMPLATE, SHOW_DIALOG, SET_CREATION_STEP, MAP_VIEWER_LOAD,
     MAP_VIEWER_RELOAD, CHANGE_ATTRIBUTE, ENABLE_MANDATORY_PLUGINS, ENABLE_PLUGINS, DISABLE_PLUGINS, SAVE_PLUGIN_CFG,
@@ -35,11 +34,8 @@ import {isLoggedIn} from '../selectors/security';
 import {show, error} from '../actions/notifications';
 import {changePreset} from '../actions/tutorial';
 import {initMap} from '../actions/map';
-import {mapSelector} from '../selectors/map';
-import {layersSelector, groupsSelector} from '../selectors/layers';
-import {backgroundListSelector} from '../selectors/backgroundselector';
-import {textSearchConfigSelector} from '../selectors/searchconfig';
-import {mapOptionsToSaveSelector} from '../selectors/mapsave';
+
+import {mapSaveSelector} from '../selectors/mapsave';
 import {loadMapConfig} from '../actions/config';
 import {createResource, createCategory, updateResource, deleteResource, getResource} from '../api/persistence';
 import getPluginsConfig from '../observables/config/getPluginsConfig';
@@ -83,18 +79,10 @@ export const saveContextResource = (action$, store) => action$
     .ofType(SAVE_CONTEXT)
     .exhaustMap(({destLocation}) => {
         const state = store.getState();
+        const mapConfig = mapSaveSelector(state);
+        const plugins = pluginsSelector(state);
         const context = newContextSelector(state);
         const resource = resourceSelector(state);
-        const map = mapSelector(state);
-        const layers = layersSelector(state);
-        const groups = groupsSelector(state);
-        const backgrounds = backgroundListSelector(state);
-        const textSearchConfig = textSearchConfigSelector(state);
-        const additionalOptions = mapOptionsToSaveSelector(state);
-        const plugins = pluginsSelector(state);
-
-        const mapConfig = MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, additionalOptions);
-
         const pluginsArray = flattenPluginTree(plugins).filter(plugin => plugin.enabled);
         const unselectablePlugins = makePlugins(pluginsArray.filter(plugin => !plugin.isUserPlugin));
         const userPlugins = makePlugins(pluginsArray.filter(plugin => plugin.isUserPlugin));

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -437,7 +437,6 @@ export const handlePendingGeoStoryChanges = action$ =>
         Observable.merge(
             // when load an existing geostory
             action$.ofType(LOAD_GEOSTORY).switchMap(() => action$.ofType(SET_RESOURCE))
-            // TODO: add ... or load new geostory
         ).switchMap( () =>
             // listen to modification events
             action$.ofType(

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -27,10 +27,13 @@ const {
 
 import {
     ADD,
+    ADD_RESOURCE,
     LOAD_GEOSTORY,
+    SET_RESOURCE,
     MOVE,
     REMOVE,
     SAVE,
+    SAVED,
     addResource,
     add,
     geostoryLoaded,
@@ -46,11 +49,14 @@ import {
     storySaved,
     update,
     setFocusOnContent,
+    setPendingChanges,
     UPDATE,
     CHANGE_MODE,
     SET_WEBPAGE_URL,
     EDIT_WEBPAGE,
-    UPDATE_CURRENT_PAGE
+    EDIT_RESOURCE,
+    UPDATE_CURRENT_PAGE,
+    UPDATE_SETTING
 } from '../actions/geostory';
 import { setControlProperty } from '../actions/controls';
 
@@ -424,6 +430,38 @@ export const closeShareOnGeostoryChangeMode = action$ =>
     action$.ofType(CHANGE_MODE)
         .switchMap(() => Observable.of(setControlProperty('share', 'enabled', false)));
 
+/**
+ * Handles changes on GeoStory to show the pending changes prompt
+ */
+export const handlePendingGeoStoryChanges = action$ =>
+        Observable.merge(
+            // when load an existing geostory
+            action$.ofType(LOAD_GEOSTORY).switchMap(() => action$.ofType(SET_RESOURCE))
+            // TODO: add ... or load new geostory
+        ).switchMap( () =>
+            // listen to modification events
+            action$.ofType(
+                    ADD,
+                    UPDATE,
+                    REMOVE,
+                    ADD_RESOURCE,
+                    EDIT_RESOURCE,
+                    UPDATE_SETTING
+                )
+                // TODO: compare to exclude no-ops (e.g. update by click)
+                .take(1)
+                .switchMap( () =>
+                    // set the flag for pending changes
+                    Observable.of(setPendingChanges(true)).concat(
+                        // and reset it when one of these actions is performed.
+                        action$.ofType(
+                            SAVED, LOCATION_CHANGE, LOGOUT
+                        )
+                        .take(1)
+                            .switchMap(() => Observable.of(setPendingChanges(false)))
+                    )
+            )
+    );
 /**
  * Handle the scroll of section preview in the sidebar
  * @memberof epics.mediaEditor

--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -8,15 +8,12 @@
 
 const Rx = require('rxjs');
 const {changeLayerProperties} = require('../actions/layers');
-const { LOCATION_CHANGE } = require('connected-react-router');
-
 
 const {
     CREATION_ERROR_LAYER,
     INIT_MAP,
     ZOOM_TO_EXTENT,
     CHANGE_MAP_CRS,
-    CHECK_MAP_CHANGES,
     changeMapView,
     changeMapLimits
 } = require('../actions/map');
@@ -24,7 +21,7 @@ const {configuredExtentCrsSelector, configuredRestrictedExtentSelector, configur
 
 
 const { loadMapInfo} = require('../actions/config');
-const {LOGIN_SUCCESS, LOGOUT} = require('../actions/security');
+const {LOGIN_SUCCESS} = require('../actions/security');
 
 const {currentBackgroundLayerSelector, allBackgroundLayerSelector, getLayerFromId} = require('../selectors/layers');
 const {mapTypeSelector} = require('../selectors/maptype');
@@ -43,14 +40,9 @@ const {clearWarning: clearMapInfoWarning} = require('../actions/mapInfo');
 const {removeAllAdditionalLayers} = require('../actions/additionallayers');
 const { head, isArray, isObject, mapValues } = require('lodash');
 
-const {layersSelector, groupsSelector} = require('../selectors/layers');
-const {backgroundListSelector} = require('../selectors/backgroundselector');
-const {mapOptionsToSaveSelector} = require('../selectors/mapsave');
-const {feedbackMaskSelector} = require('../selectors/feedbackmask');
 const { isLoggedIn } = require('../selectors/security');
 const {pathnameSelector} = require('../selectors/router');
 const { push } = require('connected-react-router');
-const textSearchConfigSelector = state => state.searchconfig && state.searchconfig.textSearchConfig;
 
 const handleCreationBackgroundError = (action$, store) =>
     action$.ofType(CREATION_ERROR_LAYER)
@@ -230,54 +222,6 @@ const checkMapPermissions = (action$, {getState = () => {} }) =>
             return loadMapInfo(mapId);
         });
 
-/**
- * When CHECK_MAP_CHANGES is triggered, checks current status of the map for temporary changes
- * If any, triggers to show confirm message.
- * Otherwise, if any, triggers the action passed in CHECK_MAP_CHANGES action.
- * TODO: move this out of map epics (confirm modals are now rendered by home and login plugins)
- * they should be externalized in a separated plug-in (or in Save plugin).
- */
-const compareMapChanges = (action$, { getState = () => {} }) =>
-    action$
-        .ofType(CHECK_MAP_CHANGES)
-        .switchMap(({ action, source }) => {
-            const state = getState();
-            const currentMap = mapSelector(state) || {};
-            const { canEdit } = currentMap.info || {};
-            const { currentPage } = feedbackMaskSelector(state);
-            const { mapConfigRawData } = state;
-            // TODO: Find out a better way to check
-            // if we are in the map. Maybe is a good idea to
-            // monitor map changes and save "dirty" in a flag,
-            // that will be reset on Save plugin(s) unmount.
-            if ((currentPage) !== 'viewer' || (!canEdit && currentMap.mapId)) {
-                return action ? Rx.Observable.of(action) : Rx.Observable.empty();
-            }
-            const updatedMap = MapUtils.saveMapConfiguration(
-                currentMap,
-                layersSelector(state),
-                groupsSelector(state),
-                backgroundListSelector(state),
-                textSearchConfigSelector(state),
-                mapOptionsToSaveSelector(state)
-            );
-            const isEqual = MapUtils.compareMapChanges(mapConfigRawData, updatedMap);
-            if (!isEqual) {
-                return Rx.Observable.of(
-                    setControlProperty('unsavedMap', 'enabled', true, false),
-                    setControlProperty('unsavedMap', 'source', source, false)
-                ).merge(
-                    // reset on location change
-                    action$.ofType(LOCATION_CHANGE, LOGOUT).take(1).switchMap(() =>
-                        Rx.Observable.of(
-                            setControlProperty('unsavedMap', 'enabled', false),
-                            setControlProperty('unsavedMap', 'source', undefined)
-                        )
-                    ));
-            }
-            return action ? Rx.Observable.of(action) : Rx.Observable.empty();
-        });
-
 const redirectUnauthorizedUserOnNewMap = (action$, { getState = () => {}}) =>
     action$.ofType(MAP_CONFIG_LOAD_ERROR)
         .filter((action) => action.error && action.error.status === 403 && pathnameSelector(getState()).indexOf("new") !== -1)
@@ -291,6 +235,5 @@ module.exports = {
     resetMapOnInit,
     resetLimitsOnInit,
     zoomToExtentEpic,
-    compareMapChanges,
     redirectUnauthorizedUserOnNewMap
 };

--- a/web/client/epics/pendingChanges.js
+++ b/web/client/epics/pendingChanges.js
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 import Rx from 'rxjs';
 import { setControlProperty } from '../actions/controls';
 import { mapHasPendingChangesSelector } from '../selectors/mapsave';

--- a/web/client/epics/pendingChanges.js
+++ b/web/client/epics/pendingChanges.js
@@ -1,0 +1,43 @@
+import Rx from 'rxjs';
+import { setControlProperty } from '../actions/controls';
+import { mapHasPendingChangesSelector } from '../selectors/mapsave';
+import { hasPendingChanges as storyHasPendingChanges } from '../selectors/geostory';
+
+import { feedbackMaskSelector } from '../selectors/feedbackmask';
+
+import { LOGOUT } from '../actions/security';
+import { CHECK_PENDING_CHANGES } from '../actions/pendingChanges';
+import { LOCATION_CHANGE } from 'connected-react-router';
+
+
+/**
+ * When CHECK_PENDING_CHANGES is triggered, checks current status of the resource to check if it has pending changes to save.
+ * If any, triggers to show confirm message.
+ * Otherwise, if any, triggers the action passed in CHECK_PENDING_CHANGES action.
+ */
+export const comparePendingChanges = (action$, { getState = () => { } }) =>
+    action$
+        .ofType(CHECK_PENDING_CHANGES)
+        .switchMap(({ action, source }) => {
+            const state = getState();
+
+            const { currentPage } = feedbackMaskSelector(state);
+
+            // TODO: avoid to specify the check and the reset event here, provide them externally to generalize this support.
+            const isMapToSave = currentPage === 'viewer' && mapHasPendingChangesSelector(state);
+            const isStoryToSave = currentPage === 'geostory' && storyHasPendingChanges(state);
+            if (isMapToSave || isStoryToSave) {
+                return Rx.Observable.of(
+                    setControlProperty('unsavedMap', 'enabled', true),
+                    setControlProperty('unsavedMap', 'source', source, false)
+                ).merge(
+                    // reset on location change
+                    action$.ofType(LOCATION_CHANGE, LOGOUT).take(1).switchMap(() =>
+                        Rx.Observable.of(
+                            setControlProperty('unsavedMap', 'enabled', false),
+                            setControlProperty('unsavedMap', 'source', undefined)
+                        )
+                    ));
+            }
+            return action ? Rx.Observable.of(action) : Rx.Observable.empty();
+        });

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -277,7 +277,7 @@
             },
             "FeedbackMask"
         ],
-        "desktop": [ "Details", "Snapshot",
+        "desktop": [ "Details",
           {
             "name": "Map",
             "cfg": {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -277,7 +277,7 @@
             },
             "FeedbackMask"
         ],
-        "desktop": [ "Details",
+        "desktop": [ "Details", "Snapshot",
           {
             "name": "Map",
             "cfg": {

--- a/web/client/plugins/Home.jsx
+++ b/web/client/plugins/Home.jsx
@@ -11,6 +11,8 @@ const React = require('react');
 const assign = require('object-assign');
 
 const {goToPage} = require('../actions/router');
+const { comparePendingChanges } = require('../epics/pendingChanges');
+
 
 const Message = require('./locale/Message');
 
@@ -19,7 +21,7 @@ const {Glyphicon} = require('react-bootstrap');
 const Home = require('../components/home/Home');
 
 const {connect} = require('react-redux');
-const {checkMapChanges} = require('../actions/map');
+const { checkPendingChanges } = require('../actions/pendingChanges');
 const {setControlProperty} = require('../actions/controls');
 const {unsavedMapSelector, unsavedMapSourceSelector} = require('../selectors/controls');
 const {feedbackMaskSelector} = require('../selectors/feedbackmask');
@@ -27,7 +29,7 @@ const ConfigUtils = require('../utils/ConfigUtils');
 
 const checkUnsavedMapChanges = (action) => {
     return dispatch => {
-        dispatch(checkMapChanges(action, 'gohome'));
+        dispatch(checkPendingChanges(action, 'gohome'));
     };
 };
 
@@ -35,7 +37,8 @@ const HomeConnected = connect((state) => ({
     renderUnsavedMapChangesDialog: ConfigUtils.getConfigProp('unsavedMapChangesDialog'),
     displayUnsavedDialog: unsavedMapSelector(state)
         && unsavedMapSourceSelector(state) === 'gohome'
-        && feedbackMaskSelector(state).currentPage === 'viewer'
+        && (feedbackMaskSelector(state).currentPage === 'viewer'
+        || feedbackMaskSelector(state).currentPage === 'geostory')
 }), {
     onCheckMapChanges: checkUnsavedMapChanges,
     onCloseUnsavedDialog: setControlProperty.bind(null, 'unsavedMap', 'enabled', false)
@@ -68,5 +71,6 @@ module.exports = {
             priority: 3
         }
     }),
-    reducers: {}
+    reducers: {},
+    epics: { comparePendingChanges }
 };

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -10,6 +10,8 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const assign = require('object-assign');
 const {UserDetails, PasswordReset, UserMenu, Login, LoginNav } = require('./login/index');
+const epics = require('../epics/login');
+const { comparePendingChanges } = require('../epics/pendingChanges');
 
 require('./login/login.css');
 
@@ -63,5 +65,8 @@ module.exports = {
         }
     }),
     reducers: {security: require('../reducers/security')},
-    epics: require('../epics/login')
+    epics: {
+        ...epics,
+        comparePendingChanges
+    }
 };

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -9,7 +9,7 @@ const React = require('react');
 const {connect} = require('../../utils/PluginsUtils');
 const {login, loginFail, logoutWithReload, changePassword, resetError, logout} = require('../../actions/security');
 const {setControlProperty} = require('../../actions/controls');
-const {checkMapChanges} = require('../../actions/map');
+const { checkPendingChanges } = require('../../actions/pendingChanges');
 const {Glyphicon} = require('react-bootstrap');
 const {unsavedMapSelector, unsavedMapSourceSelector} = require('../../selectors/controls');
 const ConfigUtils = require('../../utils/ConfigUtils');
@@ -24,7 +24,7 @@ const closeLogin = () => {
 
 const checkUnsavedMapChanges = (action) => {
     return dispatch => {
-        dispatch(checkMapChanges(action, 'logout'));
+        dispatch(checkPendingChanges(action, 'logout'));
     };
 };
 

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -27,7 +27,8 @@ import {
     update,
     updateCurrentPage,
     updateSetting,
-    removeResource
+    removeResource,
+    setPendingChanges
 } from '../../actions/geostory';
 import geostory from '../../reducers/geostory';
 import {
@@ -47,7 +48,8 @@ import {
     resourcesSelector,
     sectionAtIndexSelectorCreator,
     sectionsSelector,
-    settingsSelector
+    settingsSelector,
+    hasPendingChanges
 } from '../../selectors/geostory';
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
 import TEST_STORY_1 from "../../test-resources/geostory/story_state.json";
@@ -409,5 +411,10 @@ describe('geostory reducer', () => {
         expect(contC).toExist();
         expect(contC.resourceId).toNotExist();
         expect(contC.map).toNotExist();
+    });
+    it('setPendingChanges', () => {
+        expect(hasPendingChanges( { geostory: geostory(undefined, setCurrentStory(TEST_STORY)) } )).toBeFalsy();
+        expect(hasPendingChanges( { geostory: geostory(undefined, setPendingChanges(true)) } )).toBeTruthy();
+        expect(hasPendingChanges( { geostory: geostory(undefined, setPendingChanges(false)) } )).toBeFalsy();
     });
 });

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -31,7 +31,8 @@ import {
     UPDATE,
     UPDATE_CURRENT_PAGE,
     UPDATE_SETTING,
-    REMOVE_RESOURCE
+    REMOVE_RESOURCE,
+    SET_PENDING_CHANGES
 } from '../actions/geostory';
 
 
@@ -321,6 +322,9 @@ export default (state = INITIAL_STATE, action) => {
         const {status, target, selector = "", hideContent = false, path} = action;
         const focusedContent = status ? {target, selector, hideContent, path} : undefined;
         return set(`focusedContent`, focusedContent, state);
+    }
+    case SET_PENDING_CHANGES: {
+        return set(`pendingChanges`, action.value, state);
     }
     default:
         return state;

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -275,3 +275,5 @@ export const isMediaResourceUsed = (state, resId) => !!find(sectionsSelector(sta
  * @param {object} state application state
  */
 export const isSharedStory = (state = {}) => pathnameSelector(state).includes("geostory/shared");
+
+export const hasPendingChanges = (state = {}) => state?.geostory?.pendingChanges;

--- a/web/client/selectors/mapsave.js
+++ b/web/client/selectors/mapsave.js
@@ -5,13 +5,17 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+const MapUtils = require('../utils/MapUtils');
+const {mapSelector} = require('./map');
 const {createStructuredSelector} = require('reselect');
 const {servicesSelector, selectedServiceSelector} = require('./catalog');
 const {getFloatingWidgets, getCollapsedState, getFloatingWidgetsLayout} = require('./widgets');
 const { mapInfoConfigurationSelector } = require('./mapInfo');
 const { currentTimeSelector, offsetTimeSelector } = require('./dimension');
 const { selectedLayerSelector } = require('./timeline');
+const { layersSelector, groupsSelector } = require('../selectors/layers');
+const { backgroundListSelector } = require('../selectors/backgroundselector');
+const { textSearchConfigSelector } = require('./searchconfig');
 
 const customSaveHandlers = {};
 
@@ -53,4 +57,32 @@ const mapOptionsToSaveSelector = (state) => {
     return { ...basicMapOptionsToSaveSelector(state), ...customState};
 };
 
-module.exports = {mapOptionsToSaveSelector, registerCustomSaveHandler};
+/**
+ * Selector that returns the current mapConfig to save.
+ * @param {object} state the application state
+ * @return the map to save
+ */
+const mapSaveSelector = state => {
+    const map = mapSelector(state);
+    const layers = layersSelector(state);
+    const groups = groupsSelector(state);
+    const backgrounds = backgroundListSelector(state);
+    const textSearchConfig = textSearchConfigSelector(state);
+    const additionalOptions = mapOptionsToSaveSelector(state);
+    return MapUtils.saveMapConfiguration(map, layers, groups, backgrounds, textSearchConfig, additionalOptions);
+};
+/**
+ * Selector to identify pending changes.
+ * TODO: reuse if possible with `mapSaveSelector` (actually they differs a little)
+ * @param {object} state
+ * @returns {boolean} true if there are pending changes to save.
+ */
+const mapHasPendingChangesSelector = state => {
+    const updatedMap = mapSaveSelector(state);
+    const currentMap = mapSelector(state) || {};
+    const { canEdit } = currentMap.info || {};
+    const { mapConfigRawData } = state;
+    return (canEdit || !currentMap.mapId) && !MapUtils.compareMapChanges(mapConfigRawData, updatedMap);
+};
+
+module.exports = { mapSaveSelector, mapOptionsToSaveSelector, mapHasPendingChangesSelector, registerCustomSaveHandler};


### PR DESCRIPTION
## Description

This PR reuses, isolates (and generalize a little) the existing logic for pending changes check used for map to extend it for geotsory.
I didn't modified the existing logic for maps (only reorganized) to avoid regessions on the pending release.

Now if the user modifies the story and don't save, a prompt is shown clicking on home button or trying to log out.

**Note**: the only issue I wasn't able to delete (it should require more work on update condition checks) is when user clicks on some text in edit mode to edit, but do not modify it. In this case the prompt is shown anyway. 
Anyway I think this could be acceptable at this stage adn/or can be resolved as a separated task. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5309

**What is the new behavior?**
Now if some pending changes 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
