### PR TITLE
Fix missing version and correct url in homepage for maps

### DIFF
--- a/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
+++ b/web/client/components/resources/enhancers/__tests__/withShareTool-test.js
@@ -102,6 +102,35 @@ describe('withShareTool enhancer', () => {
             // verify the embedOptions.showTOCToggle has effect on "show TOC" checkbox hiding it
             expect(showTOC).toNotExist();
         });
+        it('tests correct shareApiUrl when share api is visible)', () => {
+            const VERSION = "VERSION";
+            const Sink = addSharePanel(createSink(() => { }));
+            ReactDOM.render(<Sink
+                showShareModal
+                shareApi
+                version={VERSION}
+                editedResource={{}}
+                getShareUrl={() => FAKE_RESOURCE_PATH}
+            />, document.getElementById("container"));
+            const sharePanel = document.querySelector('#sharePanel-tabs');
+            expect(sharePanel).toExist('Share panel doesn\'t exist');
+            document.getElementById('sharePanel-tabs-tab-3').click();
+            // check if the showTOC is enabled by deafult
+            let showTOC = document.querySelector('#sharePanel-tabs .input-link-tools input[type=checkbox]');
+            expect(showTOC).toExist();
+            ReactDOM.render(<Sink
+                showShareModal
+                shareApi
+                version={VERSION}
+                editedResource={{}}
+                getShareUrl={() => FAKE_RESOURCE_PATH}
+            />, document.getElementById("container"));
+            document.getElementById('sharePanel-tabs-tab-3').click();
+            const codeAPI = document.querySelectorAll("code")[1];
+            const code = codeAPI.innerText;
+            const index = code.indexOf("dist/ms2-api.js?VERSION");
+            expect(index).toBeGreaterThan(-1);
+        });
     });
 
 });

--- a/web/client/components/resources/enhancers/withShareTool.jsx
+++ b/web/client/components/resources/enhancers/withShareTool.jsx
@@ -14,7 +14,7 @@ import ShareUtils from '../../../utils/ShareUtils';
 import {isString} from 'lodash';
 
 export const addSharePanel = Component => props => {
-    const { showShareModal, onShowShareModal, shareModalSettings, setShareModalSettings, editedResource, setEditedResource, shareOptions = {}, getLocationObject = () => window.location, ...other } = props;
+    const { showShareModal, onShowShareModal, shareModalSettings, setShareModalSettings, editedResource, setEditedResource, shareOptions = {}, getLocationObject = () => window.location, version, ...other } = props;
     const { getShareUrl = () => { }, shareApi = false } = other;
     const options = editedResource && typeof shareOptions === 'function' ? shareOptions(editedResource) : shareOptions;
     const shareUrlResult = editedResource ? getShareUrl(editedResource) : '';
@@ -37,7 +37,8 @@ export const addSharePanel = Component => props => {
             settings={shareModalSettings}
             shareUrl={fullUrl}
             showAPI={showAPI}
-            shareApiUrl={shareApi ? ShareUtils.getApiUrl(fullUrl) : ''}
+            version={version}
+            shareApiUrl={showAPI ? ShareUtils.getApiUrl(fullUrl) : ''}
             shareConfigUrl={ShareUtils.getConfigUrl(fullUrl, ConfigUtils.getConfigProp('geoStoreUrl'))}
             onClose={() => onShowShareModal(false)}
             onUpdateSettings={setShareModalSettings}

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -20,6 +20,7 @@ const Message = require("../components/I18N/Message");
 const maptypeEpics = require('../epics/maptype');
 const mapsEpics = require('../epics/maps');
 const {userRoleSelector} = require('../selectors/security');
+const {versionSelector} = require('../selectors/version');
 const {mapTypeSelector} = require('../selectors/maptype');
 const {resourceSelector, searchTextSelector, isFeaturedMapsEnabled} = require('../selectors/featuredmaps');
 const {loadPage, updateItemsLifecycle} = require('../components/maps/enhancers/featuredMaps');
@@ -45,6 +46,7 @@ class FeaturedMaps extends React.Component {
         className: PropTypes.string,
         previousItems: PropTypes.array,
         enableFeaturedMaps: PropTypes.func,
+        version: PropTypes.string,
         showAPIShare: PropTypes.bool
     };
 
@@ -88,6 +90,7 @@ class FeaturedMaps extends React.Component {
                 title={<h3><Message msgId="manager.featuredMaps" /></h3>}
                 maps={items}
                 colProps={this.props.colProps}
+                version={this.props.version}
                 viewerUrl={(res) => this.context.router.history.push('/' + this.makeShareUrl(res).url)}
                 getShareUrl={this.makeShareUrl}
                 shareOptions={this.getShareOptions} // TODO: share options depending on the content type
@@ -126,15 +129,17 @@ const featuredMapsPluginSelector = createSelector([
     state => state.browser && state.browser.mobile,
     searchTextSelector,
     resourceSelector,
-    isFeaturedMapsEnabled
-], (mapType, role, isMobile, searchText, resource, isFeaturedEnabled) => ({
+    isFeaturedMapsEnabled,
+    versionSelector
+], (mapType, role, isMobile, searchText, resource, isFeaturedEnabled, version) => ({
     mapType,
     role,
     permission: role === 'ADMIN',
     pagination: isMobile ? 'virtual-scroll-horizontal' : 'show-more',
     searchText,
     resource,
-    isFeaturedEnabled
+    isFeaturedEnabled,
+    version
 }));
 
 const updateFeaturedMapsStream = mapPropsStream(props$ =>

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -17,6 +17,7 @@ const maptypeEpics = require('../epics/maptype');
 const mapsEpics = require('../epics/maps');
 const {mapTypeSelector} = require('../selectors/maptype');
 const {userRoleSelector} = require('../selectors/security');
+const {versionSelector} = require('../selectors/version');
 const { totalCountSelector } = require('../selectors/maps');
 const { isFeaturedMapsEnabled } = require('../selectors/featuredmaps');
 const emptyState = require('../components/misc/enhancers/emptyState');
@@ -78,6 +79,7 @@ class Maps extends React.Component {
         searchText: PropTypes.string,
         mapsOptions: PropTypes.object,
         colProps: PropTypes.object,
+        version: PropTypes.string,
         fluid: PropTypes.bool,
         showAPIShare: PropTypes.bool
     };
@@ -120,6 +122,7 @@ class Maps extends React.Component {
             }}
             getShareUrl={(map) => map.contextName ? `context/${map.contextName}/${map.id}` : `viewer/${this.props.mapType}/${map.id}`}
             shareApi={this.props.showAPIShare}
+            version={this.props.version}
             bottom={<PaginationToolbar />}
             metadataModal={MetadataModal}
         />);
@@ -132,10 +135,12 @@ const mapsPluginSelector = createSelector([
     state => state.maps && state.maps.results ? state.maps.results : [],
     state => state.maps && state.maps.loading,
     isFeaturedMapsEnabled,
-    userRoleSelector
-], (mapType, searchText, maps, loading, featuredEnabled, role) => ({
+    userRoleSelector,
+    versionSelector
+], (mapType, searchText, maps, loading, featuredEnabled, role, version) => ({
     mapType,
     searchText,
+    version,
     maps: maps.map(map => ({...map, featuredEnabled: featuredEnabled && role === 'ADMIN'})),
     loading
 }));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
There was inconsistency between the share api section shown and the url fetched in that case.

Also added version to the share tool allowing it to be used in the home page map cards

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5502

the base used in the shareAPI component was not correct

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
now the url is correct and version has been added too

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

In my opinion the share plugin and enhancer etc needs some refactor to better organize the code