### PR TITLE
#5518 Add missing user to provide group list in map templates

### DIFF
--- a/web/client/components/contextcreator/ConfigureMapTemplates.jsx
+++ b/web/client/components/contextcreator/ConfigureMapTemplates.jsx
@@ -92,6 +92,7 @@ const onTemplateDrop = (setParsedTemplate, setFileDropStatus, onError, files) =>
 };
 
 export default ({
+    user,
     loading,
     loadFlags,
     mapTemplates = [],
@@ -173,6 +174,7 @@ export default ({
             onSelect={items => setSelectedTemplates(pickIds(items))}
             onTransfer={(items, direction) => changeTemplatesKey(pickIds(items), 'enabled', direction === 'right')}/>
         <SaveDialog
+            user={user}
             loading={loading && (loadFlags.templateSaving || loadFlags.templateLoading)}
             resource={editedTemplate}
             clickOutEnabled={false}

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -241,6 +241,7 @@ const renderUploadModal = ({
 };
 
 const configurePluginsStep = ({
+    user,
     loading,
     loadFlags,
     allPlugins = [],
@@ -401,6 +402,7 @@ const configurePluginsStep = ({
                 size="lg"
                 onClose={() => onShowDialog('mapTemplatesConfig', false)}>
                 <ConfigureMapTemplates
+                    user={user}
                     loading={loading}
                     loadFlags={loadFlags}
                     mapTemplates={mapTemplates}

--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -75,6 +75,7 @@ export const pluginsFilterOverride = (pluginsConfigs, viewerPlugins) => {
 
 export default class ContextCreator extends React.Component {
     static propTypes = {
+        user: PropTypes.object,
         loading: PropTypes.bool,
         loadFlags: PropTypes.object,
         isValidContextName: PropTypes.bool,
@@ -288,6 +289,7 @@ export default class ContextCreator extends React.Component {
                         !this.props.isCfgValidated,
                     component:
                         <ConfigurePlugins
+                            user={this.props.user}
                             loading={this.props.loading}
                             loadFlags={this.props.loadFlags}
                             tutorialMode={this.props.tutorialStatus === 'run'}

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -28,6 +28,40 @@ import { userSelector } from '../selectors/security';
 
 import ContextCreator from '../components/contextcreator/ContextCreator';
 
+export const contextCreatorSelector = createStructuredSelector({
+    user: userSelector,
+    curStepId: creationStepSelector,
+    tutorialStatus: state => tutorialSelector(state)?.status,
+    tutorialStep: tutorialStepSelector,
+    newContext: newContextSelector,
+    resource: resourceSelector,
+    allAvailablePlugins: pluginsSelector,
+    editedPlugin: editedPluginSelector,
+    editedCfg: editedCfgSelector,
+    isCfgValidated: validationStatusSelector,
+    cfgError: cfgErrorSelector,
+    parsedTemplate: parsedTemplateSelector,
+    editedTemplate: editedTemplateSelector,
+    fileDropStatus: fileDropStatusSelector,
+    availablePluginsFilterText: availablePluginsFilterTextSelector,
+    enabledPluginsFilterText: enabledPluginsFilterTextSelector,
+    availableTemplatesFilterText: availableTemplatesFilterTextSelector,
+    enabledTemplatesFilterText: enabledTemplatesFilterTextSelector,
+    mapType: mapTypeSelector,
+    showReloadConfirm: reloadConfirmSelector,
+    showDialog: showDialogSelector,
+    loading: isLoadingSelector,
+    loadFlags: loadFlagsSelector,
+    isValidContextName: isValidContextNameSelector,
+    contextNameChecked: contextNameCheckedSelector,
+    uploadEnabled: state => state.contextcreator && state.contextcreator.uploadPluginEnabled,
+    uploading: state => state.contextcreator && state.contextcreator.uploadingPlugin,
+    uploadResult: state => state.contextcreator && state.contextcreator.uploadResult,
+    pluginsToUpload: state => state.contextcreator?.pluginsToUpload,
+    pluginsConfig: () => ConfigUtils.getConfigProp('plugins'),
+    showBackToPageConfirmation: showBackToPageConfirmationSelector
+});
+
 /**
  * Plugin for creation of Contexts.
  * @memberof plugins
@@ -36,39 +70,7 @@ import ContextCreator from '../components/contextcreator/ContextCreator';
  * @prop {string} cfg.saveDestLocation router path when the application is redirected when a context is saved
  */
 export default createPlugin('ContextCreator', {
-    component: connect(createStructuredSelector({
-        user: userSelector,
-        curStepId: creationStepSelector,
-        tutorialStatus: state => tutorialSelector(state)?.status,
-        tutorialStep: tutorialStepSelector,
-        newContext: newContextSelector,
-        resource: resourceSelector,
-        allAvailablePlugins: pluginsSelector,
-        editedPlugin: editedPluginSelector,
-        editedCfg: editedCfgSelector,
-        isCfgValidated: validationStatusSelector,
-        cfgError: cfgErrorSelector,
-        parsedTemplate: parsedTemplateSelector,
-        editedTemplate: editedTemplateSelector,
-        fileDropStatus: fileDropStatusSelector,
-        availablePluginsFilterText: availablePluginsFilterTextSelector,
-        enabledPluginsFilterText: enabledPluginsFilterTextSelector,
-        availableTemplatesFilterText: availableTemplatesFilterTextSelector,
-        enabledTemplatesFilterText: enabledTemplatesFilterTextSelector,
-        mapType: mapTypeSelector,
-        showReloadConfirm: reloadConfirmSelector,
-        showDialog: showDialogSelector,
-        loading: isLoadingSelector,
-        loadFlags: loadFlagsSelector,
-        isValidContextName: isValidContextNameSelector,
-        contextNameChecked: contextNameCheckedSelector,
-        uploadEnabled: state => state.contextcreator && state.contextcreator.uploadPluginEnabled,
-        uploading: state => state.contextcreator && state.contextcreator.uploadingPlugin,
-        uploadResult: state => state.contextcreator && state.contextcreator.uploadResult,
-        pluginsToUpload: state => state.contextcreator?.pluginsToUpload,
-        pluginsConfig: () => ConfigUtils.getConfigProp('plugins'),
-        showBackToPageConfirmation: showBackToPageConfirmationSelector
-    }), {
+    component: connect(contextCreatorSelector, {
         onFilterAvailablePlugins: setFilterText.bind(null, 'availablePlugins'),
         onFilterEnabledPlugins: setFilterText.bind(null, 'enabledPlugins'),
         onFilterAvailableTemplates: setFilterText.bind(null, 'availableTemplates'),

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -24,6 +24,8 @@ import {init, setCreationStep, changeAttribute, saveNewContext, saveTemplate, ma
     addPluginToUpload, removePluginToUpload, showBackToPageConfirmation, showTutorial} from '../actions/contextcreator';
 import contextcreator from '../reducers/contextcreator';
 import * as epics from '../epics/contextcreator';
+import { userSelector } from '../selectors/security';
+
 import ContextCreator from '../components/contextcreator/ContextCreator';
 
 /**
@@ -35,6 +37,7 @@ import ContextCreator from '../components/contextcreator/ContextCreator';
  */
 export default createPlugin('ContextCreator', {
     component: connect(createStructuredSelector({
+        user: userSelector,
         curStepId: creationStepSelector,
         tutorialStatus: state => tutorialSelector(state)?.status,
         tutorialStep: tutorialStepSelector,

--- a/web/client/plugins/__tests__/ContextCreator-test.jsx
+++ b/web/client/plugins/__tests__/ContextCreator-test.jsx
@@ -14,7 +14,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import expect from 'expect';
 import { getPluginForTest } from './pluginsTestUtils';
-import ContextCreator from '../ContextCreator';
+import ContextCreator, { contextCreatorSelector } from '../ContextCreator';
 
 describe('ContextCreator plugin', () => {
     beforeEach((done) => {
@@ -70,5 +70,34 @@ describe('ContextCreator plugin', () => {
         // check customization of destination path
         expect(actions.length).toBeGreaterThanOrEqualTo(1);
         expect(actions[1].destLocation).toBe("MY_DESTINATION");
+    });
+});
+describe('contextCreatorSelector', () => {
+    const ADMIN_LOGGED_STATE = {
+        security: {
+            user: {
+                attribute: [
+                ],
+                enabled: true,
+                groups: {
+                    group: [
+                        {
+                            description: 'description',
+                            enabled: true,
+                            groupName: 'everyone',
+                            id: 479
+                        }
+                    ]
+                },
+                id: 3,
+                name: 'admin',
+                role: 'ADMIN'
+            }
+        }
+    };
+    // MapTemplates
+    it('user is passed as prop to provide role and so API to use to SaveModal', () => {
+        const props = contextCreatorSelector(ADMIN_LOGGED_STATE);
+        expect(props.user).toBe(ADMIN_LOGGED_STATE.security.user);
     });
 });


### PR DESCRIPTION
## Description
Save modal provides groups where to assign permissions depending on the current user. 
 - If the current user is an ADMIN, then it gets the list of all groups.
 - If the current user is a USER (or no user), then it gets the list of the groups of the user.

This fix provides the user to the save modal nested in the context creator. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
