### PR TITLE
#5533 fix crash on new context due to wrong tutorial setup

### DIFF
--- a/web/client/actions/contextcreator.js
+++ b/web/client/actions/contextcreator.js
@@ -67,7 +67,11 @@ export const PLUGIN_UNINSTALLED = 'CONTEXTCREATOR:PLUGIN_UNINSTALLED';
 export const UNINSTALL_PLUGIN_ERROR = 'CONTEXTCREATOR:UNINSTALL_PLUGIN_ERROR';
 export const BACK_TO_PAGE_SHOW_CONFIRMATION = 'CONTEXTCREATOR:BACK_TO_PAGE_SHOW_CONFIRMATION';
 export const LOAD_EXTENSIONS = 'CONTEXTCREATOR:LOAD_EXTENSIONS';
-
+export const CONTEXT_TUTORIALS = {
+    "general-settings": "contextcreator_generalsettings_tutorial",
+    "configure-map": "contextcreator_configuremap_tutorial",
+    "configure-plugins": "contextcreator_configureplugins_tutorial"
+};
 /**
  * Merges initState into context creator state. Meant to be called on ContextCreator component mount
  * @param {object} initState state to merge

--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -14,7 +14,7 @@ import Stepper from '../misc/Stepper';
 import GeneralSettings from './GeneralSettingsStep';
 import ConfigurePlugins from './ConfigurePluginsStep';
 import ConfigureMap from './ConfigureMapStep';
-
+import {CONTEXT_TUTORIALS} from '../../actions/contextcreator';
 /**
  * Filters plugins and applies overrides.
  * The resulting array will filter the pluginsConfig returning only the ones present in viewerPlugins.
@@ -212,11 +212,7 @@ export default class ContextCreator extends React.Component {
         showBackToPageConfirmation: false,
         backToPageDestRoute: '/context-manager',
         backToPageConfirmationMessage: 'contextCreator.undo',
-        tutorials: {
-            "general-settings": "contextcreator_generalsettings_tutorial",
-            "configure-map": "contextcreator_configuremap_tutorial",
-            "configure-plugins": "contextcreator_configureplugins_tutorial"
-        }
+        tutorials: CONTEXT_TUTORIALS
     };
 
     componentDidMount() {

--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -348,6 +348,37 @@ describe('tutorial Epics', () => {
         });
 
     });
+    it('switchTutorialEpic loads correct tutorial for context', (done) => {
+        const NUM_ACTIONS = 1;
+        testEpic(switchTutorialEpic, NUM_ACTIONS, [
+            onLocationChanged({
+                pathname: '/context-creator/new'
+            }),
+            initTutorial("", [], {}, null, {}, {})
+        ], (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case SETUP_TUTORIAL:
+                    expect(action.id).toBe("contextcreator_generalsettings_tutorial");
+                    expect(action.steps).toEqual({context: "steps"});
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            tutorial: {
+                presetList: {
+                    "contextcreator_generalsettings_tutorial": {
+                        context: "steps"
+                    }
+                }
+            }
+        });
+    });
+
     describe("tests for switchGeostoryTutorialEpic", () => {
         beforeEach(() => {
             localStorage.setItem("mapstore.plugin.tutorial.geostory.disabled", "false");

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -13,7 +13,8 @@ const {MAPS_LIST_LOADED} = require('../actions/maps');
 const {TOGGLE_3D} = require('../actions/globeswitcher');
 const {modeSelector} = require('../selectors/geostory');
 const {CHANGE_MODE} = require('../actions/geostory');
-
+const { creationStepSelector } = require('../selectors/contextcreator');
+const { CONTEXT_TUTORIALS } = require('../actions/contextcreator');
 const findTutorialId = path => path.match(/\/(viewer)\/(\w+)\/(\d+)/) && path.replace(/\/(viewer)\/(\w+)\/(\d+)/, "$2")
     || path.match(/\/(\w+)\/(\d+)/) && path.replace(/\/(\w+)\/(\d+)/, "$1")
     || path.match(/\/(\w+)\//) && path.replace(/\/(\w+)\//, "$1");
@@ -57,6 +58,11 @@ const switchTutorialEpic = (action$, store) =>
                     const defaultName = id ? 'default' : action.payload && action.payload.location && action.payload.location.pathname || 'default';
                     const prevTutorialId = state.tutorial && state.tutorial.id;
                     let presetName = id + mobile + '_tutorial';
+                    if (defaultName.indexOf("context") !== -1) {
+                        const currentStep = creationStepSelector(state) || "general-settings";
+                        const currentPreset = CONTEXT_TUTORIALS[currentStep];
+                        return Rx.Observable.of(setupTutorial(currentPreset, presetList[currentPreset], null, null, null, prevTutorialId === (currentPreset)));
+                    }
                     if (id && id?.indexOf("geostory") !== -1 && !isEmpty(presetList)) {
                         // this is needed to setup correct geostory tutorial based on the current mode and page
                         if (modeSelector(state) === "edit" || id && id?.indexOf("newgeostory") !== -1) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fix wrong setup of tutorial for context-creator steps

The main reason it was that after entering a story and going in the context-creator 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5533
crash happen when
- open a story
- open context creator wizard

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it no longer crashes and it loads correct tutorial

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
