### PR TITLE
Fix #5532 Group manager card has layout problem

### DIFF
--- a/web/client/components/manager/users/GroupCard.jsx
+++ b/web/client/components/manager/users/GroupCard.jsx
@@ -23,6 +23,8 @@ class GroupCard extends React.Component {
         // props
         style: PropTypes.object,
         group: PropTypes.object,
+        titleStyle: PropTypes.object,
+        headerStyle: PropTypes.object,
         innerItemStyle: PropTypes.object,
         avatarStyle: PropTypes.object,
         nameStyle: PropTypes.object,
@@ -36,21 +38,27 @@ class GroupCard extends React.Component {
             backgroundPosition: "center",
             backgroundRepeat: "repeat-x"
         },
-        innerItemStyle: {
-            marginTop: "35px",
-            marginLeft: "9px"
+        titleStyle: {
+            display: "flex"
         },
+        headerStyle: {
+            flexGrow: 1,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+            width: 0
+        },
+        innerItemStyle: {},
         avatarStyle: {
             margin: "10px"
         },
         nameStyle: {
-            position: "absolute",
-            left: "80px",
-            top: "30px",
-            width: "75%",
             borderBottom: "1px solid #ddd",
             fontSize: 18,
-            fontWeight: "bold"
+            fontWeight: "bold",
+            overflow: "auto",
+            wordWrap: "break-word",
+            minHeight: "1.5em"
         }
     };
 
@@ -72,7 +80,7 @@ class GroupCard extends React.Component {
     renderDescription = () => {
         return (<div className="group-thumb-description" style={this.props.innerItemStyle}>
             <div><strong><Message msgId="usergroups.description" /></strong></div>
-            <div>{this.props.group.description ? this.props.group.description : <Message msgId="usergroups.noDescriptionAvailable" />}</div>
+            <div className="group-thumb-description-content">{this.props.group.description ? this.props.group.description : <Message msgId="usergroups.noDescriptionAvailable" />}</div>
         </div>);
     };
 
@@ -80,15 +88,21 @@ class GroupCard extends React.Component {
         return (<div key="name" style={this.props.nameStyle}>{this.props.group.groupName}</div>);
     };
 
+    renderHeader = () => {
+        return <div style={this.props.headerStyle}>{this.props.group.groupName}</div>;
+    }
+
     render() {
         return (
-            <GridCard className="group-thumb" style={this.props.style} header={this.props.group.groupName}
+            <GridCard className="group-thumb" style={this.props.style} titleStyle={this.props.titleStyle} header={this.renderHeader()}
                 actions={this.props.actions}
             >
                 <div className="user-data-container">
                     {this.renderAvatar()}
-                    {this.renderName()}
-                    {this.renderDescription()}
+                    <div className="user-card-info-container">
+                        {this.renderName()}
+                        {this.renderDescription()}
+                    </div>
                 </div>
                 {this.renderStatus()}
             </GridCard>

--- a/web/client/components/manager/users/UserCard.jsx
+++ b/web/client/components/manager/users/UserCard.jsx
@@ -22,6 +22,8 @@ class UserCard extends React.Component {
         // props
         style: PropTypes.object,
         user: PropTypes.object,
+        titleStyle: PropTypes.object,
+        headerStyle: PropTypes.object,
         innerItemStyle: PropTypes.object,
         avatarStyle: PropTypes.object,
         nameStyle: PropTypes.object,
@@ -35,24 +37,27 @@ class UserCard extends React.Component {
             backgroundPosition: "center",
             backgroundRepeat: "repeat-x"
         },
-        innerItemStyle: {
-            position: "relative",
-            marginTop: "35px",
-            marginLeft: "10px",
-            marginRight: "10px",
-            maxHeight: "85px"
+        titleStyle: {
+            display: "flex"
         },
+        headerStyle: {
+            flexGrow: 1,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+            width: 0
+        },
+        innerItemStyle: {},
         avatarStyle: {
             margin: "10px"
         },
         nameStyle: {
-            position: "absolute",
-            left: "80px",
-            top: "30px",
-            width: "75%",
             borderBottom: "1px solid #ddd",
             fontSize: 18,
-            fontWeight: "bold"
+            fontWeight: "bold",
+            overflow: "auto",
+            wordWrap: "break-word",
+            minHeight: "1.5em"
         }
     };
 
@@ -91,16 +96,24 @@ class UserCard extends React.Component {
         return (<div key="name" style={this.props.nameStyle}>{this.props.user.name}</div>);
     };
 
+    renderHeader = () => {
+        return <div style={this.props.headerStyle}>{this.props.user.name}</div>;
+    }
+
     render() {
         return (
-            <GridCard className="user-thumb" style={this.props.style} header={this.props.user.name}
+            <GridCard className="user-thumb" style={this.props.style} titleStyle={this.props.titleStyle} header={this.renderHeader()}
                 actions={this.props.actions}
             >
                 <div className="user-data-container">
                     {this.renderAvatar()}
-                    {this.renderName()}
-                    {this.renderRole()}
-                    {this.renderGroups()}
+                    <div className="user-card-info-container">
+                        {this.renderName()}
+                        <div className="user-card-rolegroups-container">
+                            {this.renderRole()}
+                            {this.renderGroups()}
+                        </div>
+                    </div>
                 </div>
                 {this.renderStatus()}
             </GridCard>

--- a/web/client/components/manager/users/__tests__/GroupCard-test.jsx
+++ b/web/client/components/manager/users/__tests__/GroupCard-test.jsx
@@ -51,8 +51,8 @@ describe("Test GroupCard Component", () => {
         let comp = ReactDOM.render(
             <GroupCard group={group1} />, document.getElementById("container"));
         expect(comp).toExist();
-        let items = document.querySelectorAll('#container .gridcard .user-data-container > div');
-        let renderName = items[1];
+        let items = document.querySelectorAll('#container .gridcard .user-data-container .user-card-info-container > div');
+        let renderName = items[0];
         expect(renderName.innerHTML).toBe(group1.groupName);
     });
 });

--- a/web/client/components/manager/users/__tests__/UserCard-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserCard-test.jsx
@@ -73,8 +73,8 @@ describe("Test UserCard Component", () => {
         let comp = ReactDOM.render(
             <UserCard user={enabledUser} />, document.getElementById("container"));
         expect(comp).toExist();
-        let items = document.querySelectorAll('#container .gridcard .user-data-container > div');
-        let renderName = items[1];
+        let items = document.querySelectorAll('#container .gridcard .user-data-container .user-card-info-container > div');
+        let renderName = items[0];
         expect(renderName.innerHTML).toBe(enabledUser.name);
     });
 });

--- a/web/client/components/manager/users/style/usercard.css
+++ b/web/client/components/manager/users/style/usercard.css
@@ -1,7 +1,7 @@
 .user-thumb, .group-thumb {
     max-width: 100%;
     overflow: hidden;
-    height: 180px;
+    height: 200px;
     font-size: 12px;
     cursor: auto;
 }
@@ -15,20 +15,36 @@
 .user-data-container {
     display: flex;
     width: 100%;
+    height: 132px;
+}
+.user-card-info-container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding: 5px 10px 0 10px;
+    width: 0;
+}
+.user-card-rolegroups-container {
+    display: flex;
+    min-height: 72px;
+    padding-top: 3px;
 }
 .user-thumb .role-containter{
     width: 50px;
+    margin-right: 20px
 }
 .user-thumb .avatar-containter{
     width: 50px;
 }
 .user-thumb  .groups-container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
     white-space: nowrap;
     overflow: hidden;
 }
 .user-thumb  .groups-container .groups-list{
     width: 100%;
-    max-height: 100px;
     overflow-y: auto;
     overflow-x: hidden;
 }
@@ -38,16 +54,14 @@
     text-overflow: ellipsis;
 }
 .group-thumb .group-thumb-description {
-    /* ellipsis for description */
-    display: block; /* Fallback for non-webkit */
-    display: -webkit-box;
-    magin: 0 auto;
-    height: 75px; /* font-size * webkit-line-clamp + padding */
     font-size: 12px;
-    -webkit-line-clamp: 5;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
     text-align: justify;
-    /* end ellipsis for description */
-    }
+    min-height: 72px;
+    display: flex;
+    flex-direction: column;
+    padding-top: 3px;
+}
+.group-thumb .group-thumb-description .group-thumb-description-content {
+    overflow: auto;
+    word-wrap: break-word;
+}

--- a/web/client/components/misc/GridCard.jsx
+++ b/web/client/components/misc/GridCard.jsx
@@ -14,6 +14,7 @@ require('./style/gridcard.css');
 class GridCard extends React.Component {
     static propTypes = {
         style: PropTypes.object,
+        titleStyle: PropTypes.object,
         className: PropTypes.string,
         header: PropTypes.node,
         actions: PropTypes.array,
@@ -45,7 +46,7 @@ class GridCard extends React.Component {
             style={this.props.style}
             className={"gridcard" + (this.props.className ? " " + this.props.className : "")}
             onClick={this.props.onClick}>
-            <div className="gridcard-title bg-primary">{this.props.header}</div>
+            <div style={this.props.titleStyle} className="gridcard-title bg-primary">{this.props.header}</div>
             {this.props.children}
             {this.renderActions()}
         </div>)


### PR DESCRIPTION
# Description
Addresses overflow layout problems with UserCard and GridCard in account manager.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5532 

**What is the current behavior?**
#5532 

**What is the new behavior?**
Group and user card titles display two lines without overflowing, otherwise scrollbar is shown. Description in group card can also be overflown with scrollbar functionality. User card group list correctly overflows. Grid card titles overflow with ellipsis.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No