### PR TITLE
#5549: Fixed infinite loop in re-open feature grid system

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1,5 +1,4 @@
 /*
-import { LOCATION_CHANGE } from 'connected-react-router';
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -105,10 +105,9 @@ const {
     featureGridUpdateGeometryFilter,
     activateTemporaryChangesEpic
 } = require('../featuregrid');
-const { hideMarkerOnIdentifyClose } = require('../identify').default;
 const { onLocationChanged } = require('connected-react-router');
 
-const {TEST_TIMEOUT, testEpic, testCombinedEpicStream, addTimeoutEpic} = require('./epicTestUtils');
+const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
 const {isEmpty, isNil} = require('lodash');
 const filterObj = {
     featureTypeName: 'TEST',
@@ -596,7 +595,7 @@ const stateWithGmlGeometry = {
     }
 };
 
-describe.only('featuregrid Epics', () => {
+describe('featuregrid Epics', () => {
 
     describe('featureGridBrowseData epic', () => {
         const LAYER = state.layers.flat[0];

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1,4 +1,5 @@
 /*
+import { LOCATION_CHANGE } from 'connected-react-router';
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -59,7 +60,7 @@ const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 const {RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl} = require('../../actions/controls');
 const {ZOOM_TO_EXTENT, clickOnMap} = require('../../actions/map');
-const { CLOSE_IDENTIFY, closeIdentify } = require('../../actions/mapInfo');
+const { CLOSE_IDENTIFY } = require('../../actions/mapInfo');
 const {CHANGE_LAYER_PROPERTIES, changeLayerParams, browseData} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
 const { TOGGLE_CONTROL } = require('../../actions/controls');
@@ -597,7 +598,7 @@ const stateWithGmlGeometry = {
     }
 };
 
-describe('featuregrid Epics', () => {
+describe.only('featuregrid Epics', () => {
 
     describe('featureGridBrowseData epic', () => {
         const LAYER = state.layers.flat[0];
@@ -1590,6 +1591,14 @@ describe('featuregrid Epics', () => {
         };
         testEpic(autoReopenFeatureGridOnFeatureInfoClose, 1, [openFeatureGrid(), featureInfoClick(), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
     });
+    it('autoReopenFeatureGridOnFeatureInfoClose: cancel ability to reopen feature grid on drawer toggle control', done => {
+        const epicResult = actions => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(TEST_TIMEOUT);
+            done();
+        };
+        testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose), 1, [openFeatureGrid(), featureInfoClick(), toggleControl('drawer'), hideMapinfoMarker(), closeFeatureGrid()], epicResult);
+    });
     it('autoReopenFeatureGridOnFeatureInfoClose flow restarts on new open feature grid ', done => {
         // This prevents event loops with other epics
         // that trigger feature info hideMarker
@@ -1603,7 +1612,6 @@ describe('featuregrid Epics', () => {
         };
         testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose), 1, [openFeatureGrid(), featureInfoClick(), openFeatureGrid(), hideMapinfoMarker(), closeFeatureGrid()], epicResult);
     });
-
     it('autoReopenFeatureGridOnFeatureInfoClose: other toggle control apart from drawer cannot cancel ability to open feature grid', done => {
         const epicResult = actions => {
             expect(actions.length).toBe(1);

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -598,7 +598,7 @@ const stateWithGmlGeometry = {
     }
 };
 
-describe.only('featuregrid Epics', () => {
+describe('featuregrid Epics', () => {
 
     describe('featureGridBrowseData epic', () => {
         const LAYER = state.layers.flat[0];

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -60,7 +60,7 @@ const {CHANGE_DRAWING_STATUS} = require('../../actions/draw');
 const {SHOW_NOTIFICATION} = require('../../actions/notifications');
 const {RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl} = require('../../actions/controls');
 const {ZOOM_TO_EXTENT, clickOnMap} = require('../../actions/map');
-const { CLOSE_IDENTIFY } = require('../../actions/mapInfo');
+const { CLOSE_IDENTIFY, closeIdentify } = require('../../actions/mapInfo');
 const {CHANGE_LAYER_PROPERTIES, changeLayerParams, browseData} = require('../../actions/layers');
 const {geometryChanged} = require('../../actions/draw');
 const { TOGGLE_CONTROL } = require('../../actions/controls');
@@ -1590,52 +1590,19 @@ describe.only('featuregrid Epics', () => {
             });
         };
         testEpic(autoReopenFeatureGridOnFeatureInfoClose, 1, [openFeatureGrid(), featureInfoClick(), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
-    });/*
-    it('autoReopenFeatureGridOnFeatureInfoClose avoiding loop', (done) => {
-
-        const actions = [];
-        const testActions = () => {
-            // expect(true).toBeFalsy();
-            expect(true).toBeTruthy();
-        };
-        const spyEpic = a$ => a$.do(a => actions.push(a)).ignoreElements();
-        const startEpic = () => Rx.Observable.of(openFeatureGrid());
-        testCombinedEpicStream([
-            spyEpic,
-            startEpic,
-            autoReopenFeatureGridOnFeatureInfoClose,
-            closeIdentifyWhenOpenFeatureGrid,
-            hideMarkerOnIdentifyClose
-        ],
-        action$ => action$.filter(({ type }) => type === LOCATION_CHANGE),
-        {
-            onNext: () => actions.push(),
-            onError: e => done(e),
-            onComplete: () => {
-                testActions();
-                done();
-            }
-        });
     });
-    */
-    it('autoReopenFeatureGridOnFeatureInfoClose avoiding loop', (done) => {
-
-        const actions = [];
-        const testActions = () => {
-            // expect(true).toBeFalsy();
-            expect(true).toBeTruthy();
-        };
-        const spyEpic = a$ => a$.do(a => actions.push(a)).ignoreElements();
-        const startEpic = () => Rx.Observable.of(openFeatureGrid());
-        testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose), 1, [openFeatureGrid(), featureInfoClick(), toggleControl('drawer'), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
-    });
-    it('autoReopenFeatureGridOnFeatureInfoClose: cancel ability to reopen feature grid on drawer toggle control', done => {
+    it('autoReopenFeatureGridOnFeatureInfoClose flow restarts on new open feature grid ', done => {
+        // This prevents event loops with other epics
+        // that trigger feature info hideMarker
         const epicResult = actions => {
             expect(actions.length).toBe(1);
-            expect(actions[0].type).toBe(TEST_TIMEOUT);
-            done();
+            actions.map((action) => {
+                if (action.type === TEST_TIMEOUT) {
+                    done();
+                }
+            });
         };
-        testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose), 1, [openFeatureGrid(), featureInfoClick(), toggleControl('drawer'), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
+        testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose), 1, [openFeatureGrid(), featureInfoClick(), openFeatureGrid(), hideMapinfoMarker(), closeFeatureGrid()], epicResult);
     });
 
     it('autoReopenFeatureGridOnFeatureInfoClose: other toggle control apart from drawer cannot cancel ability to open feature grid', done => {

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1,4 +1,5 @@
 /*
+import { LOCATION_CHANGE } from 'connected-react-router';
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -8,8 +9,10 @@
 
 const expect = require('expect');
 const assign = require('object-assign');
+const Rx = require('rxjs');
 
 const { set } = require('../../utils/ImmutableUtils');
+const { LOCATION_CHANGE } = require('connected-react-router');
 
 
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');
@@ -104,9 +107,10 @@ const {
     featureGridUpdateGeometryFilter,
     activateTemporaryChangesEpic
 } = require('../featuregrid');
+const { hideMarkerOnIdentifyClose } = require('../identify').default;
 const { onLocationChanged } = require('connected-react-router');
 
-const {TEST_TIMEOUT, testEpic, addTimeoutEpic} = require('./epicTestUtils');
+const {TEST_TIMEOUT, testEpic, testCombinedEpicStream, addTimeoutEpic} = require('./epicTestUtils');
 const {isEmpty, isNil} = require('lodash');
 const filterObj = {
     featureTypeName: 'TEST',
@@ -594,7 +598,7 @@ const stateWithGmlGeometry = {
     }
 };
 
-describe('featuregrid Epics', () => {
+describe.only('featuregrid Epics', () => {
 
     describe('featureGridBrowseData epic', () => {
         const LAYER = state.layers.flat[0];
@@ -1586,8 +1590,45 @@ describe('featuregrid Epics', () => {
             });
         };
         testEpic(autoReopenFeatureGridOnFeatureInfoClose, 1, [openFeatureGrid(), featureInfoClick(), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
-    });
+    });/*
+    it('autoReopenFeatureGridOnFeatureInfoClose avoiding loop', (done) => {
 
+        const actions = [];
+        const testActions = () => {
+            // expect(true).toBeFalsy();
+            expect(true).toBeTruthy();
+        };
+        const spyEpic = a$ => a$.do(a => actions.push(a)).ignoreElements();
+        const startEpic = () => Rx.Observable.of(openFeatureGrid());
+        testCombinedEpicStream([
+            spyEpic,
+            startEpic,
+            autoReopenFeatureGridOnFeatureInfoClose,
+            closeIdentifyWhenOpenFeatureGrid,
+            hideMarkerOnIdentifyClose
+        ],
+        action$ => action$.filter(({ type }) => type === LOCATION_CHANGE),
+        {
+            onNext: () => actions.push(),
+            onError: e => done(e),
+            onComplete: () => {
+                testActions();
+                done();
+            }
+        });
+    });
+    */
+    it('autoReopenFeatureGridOnFeatureInfoClose avoiding loop', (done) => {
+
+        const actions = [];
+        const testActions = () => {
+            // expect(true).toBeFalsy();
+            expect(true).toBeTruthy();
+        };
+        const spyEpic = a$ => a$.do(a => actions.push(a)).ignoreElements();
+        const startEpic = () => Rx.Observable.of(openFeatureGrid());
+        testEpic(addTimeoutEpic(autoReopenFeatureGridOnFeatureInfoClose), 1, [openFeatureGrid(), featureInfoClick(), toggleControl('drawer'), hideMapinfoMarker(), closeFeatureGrid()], epicResult );
+    });
     it('autoReopenFeatureGridOnFeatureInfoClose: cancel ability to reopen feature grid on drawer toggle control', done => {
         const epicResult = actions => {
             expect(actions.length).toBe(1);

--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -9,10 +9,8 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 
 const expect = require('expect');
 const assign = require('object-assign');
-const Rx = require('rxjs');
 
 const { set } = require('../../utils/ImmutableUtils');
-const { LOCATION_CHANGE } = require('connected-react-router');
 
 
 const CoordinatesUtils = require('../../utils/CoordinatesUtils');

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -688,7 +688,7 @@ module.exports = {
         action$.ofType(OPEN_FEATURE_GRID)
             // need to finalize the flow before listen the next open event to avoid
             // to catch open feature info triggered by this flow or advanced search
-            .exhaustMap(() =>
+            .switchMap(() =>
                 Rx.Observable.race(
                     action$.ofType(FEATURE_INFO_CLICK).take(1),
                     action$.ofType(CLOSE_FEATURE_GRID).take(1)


### PR DESCRIPTION
## Description
Originally epics the following epics was interacting each other creating a loop. 
```
 autoReopenFeatureGridOnFeatureInfoClose,
            closeIdentifyWhenOpenFeatureGrid,
            hideMarkerOnIdentifyClose
```
This fix `autoReopenFeatureGridOnFeatureInfoClose` to restart on every feature grid open event, so emitting hideMarker (after feature info close) does not always trigger openFeatureGrid, but it happens only once, then the full loop restarts.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5549

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
