### PR TITLE
#5567 - fix translations of geostory

### DIFF
--- a/web/client/components/mediaEditor/MediaEditor.jsx
+++ b/web/client/components/mediaEditor/MediaEditor.jsx
@@ -78,7 +78,7 @@ export default ({
                     disabled={saveState && saveState.addingMedia}
                     noResultsText="mediaEditor.mediaPicker.noResults"
                     placeholder="mediaEditor.mediaPicker.selectService"
-                    options={services.map(s => ({label: s.name, value: s.id}))}
+                    options={services.map(s => ({label: <Message msgId={s.name}/>, value: s.id}))}
                     onChange={setMediaService}
                     value={selectedService}
                     clearable={false}

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -58,7 +58,7 @@ export const DEFAULT_STATE = {
                 type: SourceTypes.GEOSTORY // determines the type related to the API
             },
             geostoreMap: {
-                name: "Geostore Dev",
+                name: "geostory.geostoreMap", // id for Message comp
                 type: SourceTypes.GEOSTORE,
                 baseURL: "rest/geostore/",
                 category: "MAP"

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2067,6 +2067,7 @@
             "selectworkspace": "Sie müssen den Arbeitsbereich auswählen, um erweiterte Optionen zu aktivieren."
         },
         "geostory": {
+            "geostoreMap": "MapStore-Karten",
             "loadingSpinner": "Story wird geladen",
             "addTitleSection": "Titelabschnitt hinzufügen",
             "addParagraphSection": "Absatzabschnitt hinzufügen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2071,6 +2071,7 @@
             "selectworkspace": "You need to select the workspace to enable advanced options"
         },
         "geostory": {
+            "geostoreMap": "MapStore Maps",
             "loadingSpinner": "Loading Story",
             "addTitleSection": "Add Title Section",
             "addParagraphSection": "Add Paragraph Section",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2068,6 +2068,7 @@
             "selectworkspace": "Debe seleccionar el espacio de trabajo para habilitar opciones avanzadas."
         },
         "geostory": {
+            "geostoreMap": "Mapas de MapStore",
             "loadingSpinner": "Cargando Historia",
             "addTitleSection": "Agregar sección de título",
             "addParagraphSection": "Agregar sección de párrafo",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2069,6 +2069,7 @@
             "selectworkspace": "Vous devez sélectionner l'espace de travail pour activer les options avancées"
         },
         "geostory": {
+            "geostoreMap": "Cartes de MapStore",
             "loadingSpinner": "Chargement de story",
             "addTitleSection": "Ajouter une section de titre",
             "addParagraphSection": "Ajouter une section de paragraphe",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2068,6 +2068,7 @@
             "selectworkspace": "È necessario selezionare lo spazio di lavoro per abilitare le opzioni avanzate."
         },
         "geostory": {
+            "geostoreMap": "Mappe di MapStore",
             "loadingSpinner": "Caricamento Storia",
             "addTitleSection": "Aggiungi sezione titolo",
             "addParagraphSection": "Aggiungi sezione paragrafo",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Changed the name of geostore maps

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: translations changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5567 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
now it uses translations or the name passed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
