### PR TITLE
#5504-add-support-default-options-identify-plugin

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var expect = require('expect');
-var {
+import expect from 'expect';
+import {
     CHANGE_MAPINFO_STATE,
     NEW_MAPINFO_REQUEST,
     PURGE_MAPINFO_RESULTS,
@@ -31,8 +31,9 @@ var {
     TOGGLE_SHOW_COORD_EDITOR, toggleShowCoordinateEditor,
     CHANGE_FORMAT, changeFormat,
     CHANGE_PAGE, changePage,
-    TOGGLE_HIGHLIGHT_FEATURE, toggleHighlightFeature
-} = require('../mapInfo');
+    TOGGLE_HIGHLIGHT_FEATURE, toggleHighlightFeature,
+    SET_DEFAULT_IDENTIFY, setDefaultIdentify
+} from '../mapInfo';
 
 describe('Test correctness of the map actions', () => {
 
@@ -151,5 +152,17 @@ describe('Test correctness of the map actions', () => {
         expect(retVal.type).toBe(CHANGE_PAGE);
         expect(changePage().index).toBeFalsy();
         expect(changePage(1).index).toBe(1);
+    });
+    it('setDefaultIdentify', () => {
+        const defaultConfig = {
+            enabled: true,
+            defaultConfiguration: {
+                infoFormat: 'test'
+            }
+        };
+        const retVal = setDefaultIdentify(defaultConfig);
+        expect(retVal).toExist();
+        expect(retVal.type).toBe(SET_DEFAULT_IDENTIFY);
+        expect(retVal.cfg).toBe(defaultConfig);
     });
 });

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -35,7 +35,7 @@ const SET_CURRENT_EDIT_FEATURE_QUERY = 'IDENTIFY:CURRENT_EDIT_FEATURE_QUERY';
 
 const TOGGLE_EMPTY_MESSAGE_GFI = "IDENTIFY:TOGGLE_EMPTY_MESSAGE_GFI";
 const toggleEmptyMessageGFI = () => ({type: TOGGLE_EMPTY_MESSAGE_GFI});
-
+const SET_DEFAULT_IDENTIFY = "SET_DEFAULT_IDENTIFY";
 /**
  * Private
  * @return a LOAD_FEATURE_INFO action with the response data to a wms GetFeatureInfo
@@ -267,6 +267,17 @@ const setCurrentEditFeatureQuery = (query) => ({
     query
 });
 
+/**
+ * sets default properties for enabled, disabledAlwaysOn, configuration from config
+ * @prop {object} cfg
+*/
+function setDefaultIdentify(cfg) {
+    return {
+        type: SET_DEFAULT_IDENTIFY,
+        cfg
+    };
+}
+
 module.exports = {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
@@ -312,5 +323,6 @@ module.exports = {
     featureInfoClick,
     UPDATE_FEATURE_INFO_CLICK_POINT, updateFeatureInfoClickPoint,
     EDIT_LAYER_FEATURES, editLayerFeatures,
-    SET_CURRENT_EDIT_FEATURE_QUERY, setCurrentEditFeatureQuery
+    SET_CURRENT_EDIT_FEATURE_QUERY, setCurrentEditFeatureQuery,
+    SET_DEFAULT_IDENTIFY, setDefaultIdentify
 };

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -8,7 +8,8 @@
 
 const React = require('react');
 const {Row, Col} = require('react-bootstrap');
-const {get} = require('lodash');
+const {get, isNil} = require('lodash');
+const PropTypes = require('prop-types');
 const Toolbar = require('../../misc/toolbar/Toolbar');
 const Message = require('../../I18N/Message');
 const DockablePanel = require('../../misc/panels/DockablePanel');
@@ -28,160 +29,215 @@ const {responseValidForEdit} = require('../../../utils/IdentifyUtils');
  * @prop {function} getToolButtons must return an array of object representing the toolbar buttons, eg (props) => [{ glyph: 'info-sign', tooltip: 'hello!'}]
  * @prop {function} getNavigationButtons must return an array of navigation buttons, eg (props) => [{ glyph: 'info-sign', tooltip: 'hello!'}]
  */
-module.exports = props => {
-    const {
-        enabled,
-        requests = [],
-        onClose,
-        responses = [],
-        index,
-        viewerOptions = {},
-        format,
-        dock = true,
-        position,
-        size,
-        fluid,
-        validResponses = [],
-        viewer = () => null,
-        getToolButtons = () => [],
-        getNavigationButtons = () => [],
-        showFullscreen,
-        reverseGeocodeData = {},
-        point,
-        dockStyle = {},
-        draggable,
-        setIndex,
-        warning,
-        clearWarning,
-        zIndex,
-        showEmptyMessageGFI,
-        showEdit,
-        isEditingAllowed,
-        onEdit = () => {},
+class IdentifyContainer extends React.Component {
+    static propTypes = {
+        enabled: PropTypes.bool,
+        requests: PropTypes.array,
+        onClose: PropTypes.func,
+        responses: PropTypes.array,
+        index: PropTypes.number,
+        viewerOptions: PropTypes.object,
+        format: PropTypes.string,
+        dock: PropTypes.bool,
+        position: PropTypes.string,
+        size: PropTypes.number,
+        fluid: PropTypes.bool,
+        validResponses: PropTypes.array,
+        viewer: PropTypes.func,
+        getToolButtons: PropTypes.func,
+        getNavigationButtons: PropTypes.func,
+        showFullscreen: PropTypes.bool,
+        reverseGeocodeData: PropTypes.object,
+        point: PropTypes.object,
+        dockStyle: PropTypes.object,
+        draggable: PropTypes.bool,
+        setIndex: PropTypes.func,
+        warning: PropTypes.string,
+        clearWarning: PropTypes.func,
+        zIndex: PropTypes.number,
+        showEmptyMessageGFI: PropTypes.bool,
+        showEdit: PropTypes.bool,
+        isEditingAllowed: PropTypes.bool,
+        onEdit: PropTypes.func,
+        enabledCoordEditorButton: PropTypes.bool,
+        showCoordinateEditor: PropTypes.bool,
+        onSubmitClickPoint: PropTypes.func,
+        onChangeFormat: PropTypes.func,
+        formatCoord: PropTypes.string,
+        setDefaultIdentify: PropTypes.func,
+        defaultConfiguration: PropTypes.object,
+        disabledAlwaysOn: PropTypes.bool
+    };
+
+    static defaultProps = {
+        enabled: false,
+        disabledAlwaysOn: false,
+        requests: [],
+        onClose: () => {},
+        responses: [],
+        index: 0,
+        viewerOptions: {},
+        format: 'text/plain',
+        dock: true,
+        position: 'right',
+        size: 660,
+        fluid: false,
+        validResponses: [],
+        viewer: () => null,
+        getToolButtons: () => [],
+        getNavigationButtons: () => [],
+        showFullscreen: false,
+        reverseGeocodeData: {},
+        point: {},
+        dockStyle: {},
+        draggable: true,
+        setIndex: () => {},
+        warning: "",
+        clearWarning: () => {},
+        zIndex: 1050,
+        showEmptyMessageGFI: false,
+        showEdit: false,
+        isEditingAllowed: false,
+        onEdit: () => {},
         // coord editor props
-        enabledCoordEditorButton,
-        showCoordinateEditor,
-        onSubmitClickPoint,
-        onChangeFormat,
-        formatCoord
-    } = props;
+        enabledCoordEditorButton: true,
+        showCoordinateEditor: false,
+        onSubmitClickPoint: () => {},
+        onChangeFormat: () => {},
+        formatCoord: "decimal",
+        setDefaultIdentify: () => {},
+        defaultConfiguration: {}
+    };
 
-    const latlng = point && point.latlng || null;
+    componentDidMount() {
+        const { enabled, disabledAlwaysOn } = this.props;
+        this.props.setDefaultIdentify({
+            enabled: (isNil(enabled) && true) || enabled,
+            ...(!isNil(this.props.disabledAlwaysOn) && {disabledAlwaysOn: disabledAlwaysOn}),
+            defaultConfiguration: {...this.props.defaultConfiguration}
+        });
+    }
 
-    const targetResponse = validResponses[index];
-    const {layer} = targetResponse || {};
+    render() {
+        const latlng = this.props.point && this.props.point.latlng || null;
 
-    let lngCorrected = null;
-    if (latlng) {
+        const targetResponse = this.props.validResponses[this.props.index];
+        const {layer} = targetResponse || {};
+
+        let lngCorrected = null;
+        if (latlng) {
         /* lngCorrected is the converted longitude in order to have the value between
          * the range (-180 / +180).
          * Precision has to be >= than the coordinate editor precision
          * especially in the case of aeronautical degree edito which is 12
-        */
-        lngCorrected = latlng && Math.round(latlng.lng * 100000000000000000) / 100000000000000000;
-        /* the following formula apply the converion */
-        lngCorrected = lngCorrected - 360 * Math.floor(lngCorrected / 360 + 0.5);
-    }
-    const Viewer = viewer;
-    // TODO: put all the header (Toolbar, navigation, coordinate editor) outside the container
-    const toolButtons = getToolButtons({
-        ...props,
-        lngCorrected,
-        validResponses,
-        latlng,
-        showEdit: showEdit && isEditingAllowed && !!targetResponse && responseValidForEdit(targetResponse),
-        onEdit: onEdit.bind(null, layer && {
-            id: layer.id,
-            name: layer.name,
-            url: get(layer, 'search.url')
-        })
-    });
-    const missingResponses = requests.length - responses.length;
-    const revGeocodeDisplayName = reverseGeocodeData.error ? <Message msgId="identifyRevGeocodeError"/> : reverseGeocodeData.display_name;
-    return (
-        <div id="identify-container" className={enabled && requests.length !== 0 ? "identify-active" : ""}>
-            <DockablePanel
-                bsStyle="primary"
-                glyph="map-marker"
-                title={!viewerOptions.header ? validResponses[index] && validResponses[index].layerMetadata && validResponses[index].layerMetadata.title || '' : <Message msgId="identifyTitle" />}
-                open={enabled && requests.length !== 0}
-                size={size}
-                fluid={fluid}
-                position={position}
-                draggable={draggable}
-                onClose={onClose}
-                dock={dock}
-                style={dockStyle}
-                showFullscreen={showFullscreen}
-                zIndex={zIndex}
-                header={[
-                    <Coordinate
-                        key="coordinate-editor"
-                        formatCoord={formatCoord}
-                        enabledCoordEditorButton={enabledCoordEditorButton}
-                        onSubmit={onSubmitClickPoint}
-                        onChangeFormat={onChangeFormat}
-                        edit={showCoordinateEditor}
-                        coordinate={{
-                            lat: latlng && latlng.lat,
-                            lon: lngCorrected
-                        }}
-                    />,
-                    <GeocodeViewer latlng={latlng} revGeocodeDisplayName={revGeocodeDisplayName} {...props}/>,
-                    <Row key="button-row" className="text-center" style={{position: 'relative'}}>
-                        <Col key="tools" xs={12}>
-                            <Toolbar
-                                btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
-                                buttons={toolButtons}
-                                transitionProps={null
+       */
+            lngCorrected = latlng && Math.round(latlng.lng * 100000000000000000) / 100000000000000000;
+            /* the following formula apply the converion*/
+            lngCorrected = lngCorrected - 360 * Math.floor(lngCorrected / 360 + 0.5);
+        }
+        const Viewer = this.props.viewer;
+        // TODO: put all the header (Toolbar, navigation, coordinate editor) outside the container
+        const toolButtons = this.props.getToolButtons({
+            ...this.props,
+            lngCorrected,
+            latlng,
+            showEdit: this.props.showEdit && this.props.isEditingAllowed && !!targetResponse && responseValidForEdit(targetResponse),
+            onEdit: this.props.onEdit.bind(null, layer && {
+                id: layer.id,
+                name: layer.name,
+                url: get(layer, 'search.url')
+            })
+        });
+        const missingResponses = this.props.requests.length - this.props.responses.length;
+        const revGeocodeDisplayName = this.props.reverseGeocodeData.error ? <Message msgId="identifyRevGeocodeError"/> : this.props.reverseGeocodeData.display_name;
+
+        return (
+            <div id="identify-container" className={this.props.enabled && this.props.requests.length !== 0 ? "identify-active" : ""}>
+                <DockablePanel
+                    bsStyle="primary"
+                    glyph="map-marker"
+                    title={!this.props.viewerOptions.header ? this.props.validResponses[this.props.index] && this.props.validResponses[this.props.index].layerMetadata && this.props.validResponses[this.props.index].layerMetadata.title || '' : <Message msgId="identifyTitle" />}
+                    open={this.props.enabled && this.props.requests.length !== 0}
+                    size={this.props.size}
+                    fluid={this.props.fluid}
+                    position={this.props.position}
+                    draggable={this.props.draggable}
+                    onClose={this.props.onClose}
+                    dock={this.props.dock}
+                    style={this.props.dockStyle}
+                    showFullscreen={this.props.showFullscreen}
+                    zIndex={this.props.zIndex}
+                    header={[
+                        <Coordinate
+                            key="coordinate-editor"
+                            formatCoord={this.props.formatCoord}
+                            enabledCoordEditorButton={this.props.enabledCoordEditorButton}
+                            onSubmit={this.props.onSubmitClickPoint}
+                            onChangeFormat={this.props.onChangeFormat}
+                            edit={this.props.showCoordinateEditor}
+                            coordinate={{
+                                lat: latlng && latlng.lat,
+                                lon: lngCorrected
+                            }}
+                        />,
+                        <GeocodeViewer latlng={latlng} revGeocodeDisplayName={revGeocodeDisplayName} {...this.props}/>,
+                        <Row key="button-row" className="text-center" style={{position: 'relative'}}>
+                            <Col key="tools" xs={12}>
+                                <Toolbar
+                                    btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
+                                    buttons={toolButtons}
+                                    transitionProps={null
                                     /* transitions was causing a bad rendering of toolbar present in the identify panel
                                          * for this reason they ahve been disabled
                                         */
-                                }/>
-                        </Col>
-                        <div key="navigation" style={{
-                            zIndex: 1,
-                            position: "absolute",
-                            right: 0,
-                            top: 0,
-                            margin: "0 10px"
-                        }}>
-                            <Toolbar
-                                btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
-                                buttons={getNavigationButtons(props)}
-                                transitionProps={null /* same here */}
-                            />
+                                    }/>
+                            </Col>
+                            <div key="navigation" style={{
+                                zIndex: 1,
+                                position: "absolute",
+                                right: 0,
+                                top: 0,
+                                margin: "0 10px"
+                            }}>
+                                <Toolbar
+                                    btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
+                                    buttons={this.props.getNavigationButtons(this.props)}
+                                    transitionProps={null /* same here */}
+                                />
+                            </div>
+                        </Row>
+                    ].filter(headRow => headRow)}>
+                    <Viewer
+                        index={this.props.index}
+                        setIndex={this.props.setIndex}
+                        format={this.props.format}
+                        missingResponses={missingResponses}
+                        responses={this.props.responses}
+                        showEmptyMessageGFI={this.props.showEmptyMessageGFI}
+                        {...this.props.viewerOptions}/>
+                </DockablePanel>
+                <Portal>
+                    <ResizableModal
+                        fade
+                        title={<Message msgId="warning"/>}
+                        size="xs"
+                        show={this.props.warning}
+                        onClose={this.props.clearWarning}
+                        buttons={[{
+                            text: <Message msgId="close"/>,
+                            onClick: this.props.clearWarning,
+                            bsStyle: 'primary'
+                        }]}>
+                        <div className="ms-alert" style={{padding: 15}}>
+                            <div className="ms-alert-center text-center">
+                                <Message msgId="identifyNoQueryableLayers"/>
+                            </div>
                         </div>
-                    </Row>
-                ].filter(headRow => headRow)}>
-                <Viewer
-                    index={index}
-                    setIndex={setIndex}
-                    format={format}
-                    missingResponses={missingResponses}
-                    responses={responses}
-                    showEmptyMessageGFI={showEmptyMessageGFI}
-                    {...viewerOptions}/>
-            </DockablePanel>
-            <Portal>
-                <ResizableModal
-                    fade
-                    title={<Message msgId="warning"/>}
-                    size="xs"
-                    show={warning}
-                    onClose={clearWarning}
-                    buttons={[{
-                        text: <Message msgId="close"/>,
-                        onClick: clearWarning,
-                        bsStyle: 'primary'
-                    }]}>
-                    <div className="ms-alert" style={{padding: 15}}>
-                        <div className="ms-alert-center text-center">
-                            <Message msgId="identifyNoQueryableLayers"/>
-                        </div>
-                    </div>
-                </ResizableModal>
-            </Portal>
-        </div>
-    );
-};
+                    </ResizableModal>
+                </Portal>
+            </div>
+        );
+    }
+}
+
+module.exports = IdentifyContainer;

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -129,7 +129,7 @@ describe("test IdentifyContainer", () => {
             isEditingAllowed
             getToolButtons={funcs.getToolButtons}
             index={0}
-            requests={{}}
+            requests={[{}]}
             validResponses={[{format: 'PROPERTIES', layer: {search: {url: 'search_url'}}}]}
             responses={[{format: 'PROPERTIES', layer: {search: {url: 'search_url'}}}]}/>, document.getElementById("container"));
         expect(getToolButtonsSpy).toHaveBeenCalled();
@@ -148,7 +148,7 @@ describe("test IdentifyContainer", () => {
             isEditingAllowed
             getToolButtons={funcs.getToolButtons}
             index={0}
-            requests={{}}
+            requests={[{}]}
             validResponses={[{format: 'TEMPLATE', layer: {search: {url: 'search_url'}}}]}
             responses={[{format: 'TEMPLATE', layer: {search: {url: 'search_url'}}}]}/>, document.getElementById("container"));
         expect(getToolButtonsSpy).toHaveBeenCalled();

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -10,6 +10,7 @@ const {Glyphicon} = require('react-bootstrap');
 const {connect} = require('react-redux');
 const { createSelector, createStructuredSelector} = require('reselect');
 const assign = require('object-assign');
+const {isNil} = require('lodash');
 const {mapSelector, isMouseMoveIdentifyActiveSelector} = require('../selectors/map');
 const {layersSelector} = require('../selectors/layers');
 const { mapTypeSelector, isCesium } = require('../selectors/maptype');
@@ -18,7 +19,8 @@ const { generalInfoFormatSelector, clickPointSelector, indexSelector, responsesS
 const { isEditingAllowedSelector } = require('../selectors/featuregrid');
 
 
-const { hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults, updateFeatureInfoClickPoint, changeFormat, toggleShowCoordinateEditor, changePage, toggleHighlightFeature, editLayerFeatures} = require('../actions/mapInfo');
+const { hideMapinfoMarker, showMapinfoRevGeocode, hideMapinfoRevGeocode, clearWarning, toggleMapInfoState, changeMapInfoFormat, updateCenterToMarker, closeIdentify, purgeMapInfoResults, updateFeatureInfoClickPoint, changeFormat, toggleShowCoordinateEditor, changePage, toggleHighlightFeature, editLayerFeatures,
+    setDefaultIdentify} = require('../actions/mapInfo');
 const { changeMousePointer, zoomToExtent, registerEventListener, unRegisterEventListener} = require('../actions/map');
 
 
@@ -38,7 +40,7 @@ const Message = require('./locale/Message');
 require('./identify/identify.css');
 
 const selector = createStructuredSelector({
-    enabled: (state) => state.mapInfo && state.mapInfo.enabled || state.controls && state.controls.info && state.controls.info.enabled || false,
+    enabled: (state) => state.mapInfo && state.mapInfo.enabled || state.controls && state.controls.info && state.controls.info.enabled,
     responses: responsesSelector,
     validResponses: validResponsesSelector,
     requests: (state) => state.mapInfo && state.mapInfo.requests || [],
@@ -194,12 +196,25 @@ const IdentifyPlugin = compose(
         showRevGeocode: showMapinfoRevGeocode,
         hideRevGeocode: hideMapinfoRevGeocode,
         onEnableCenterToMarker: updateCenterToMarker.bind(null, 'enabled'),
-        onEdit: editLayerFeatures
+        onEdit: editLayerFeatures,
+        setDefaultIdentify: setDefaultIdentify
     }, (stateProps, dispatchProps, ownProps) => ({
         ...ownProps,
         ...stateProps,
         ...dispatchProps,
-        enabled: stateProps.enabled && (stateProps.isCesium || !ownProps.showInMapPopup) && !stateProps.floatingIdentifyEnabled
+        enabled: (
+            isNil(ownProps.enabled)
+            && isNil((stateProps.enabled && (stateProps.isCesium || !ownProps.showInMapPopup) && !stateProps.floatingIdentifyEnabled))
+            && true
+        )
+        || (
+            isNil(ownProps.enabled)
+            && (stateProps.enabled
+            && (stateProps.isCesium
+            || !ownProps.showInMapPopup)
+            && !stateProps.floatingIdentifyEnabled)
+        )
+        || ownProps.enabled
     })),
     // highlight support
     compose(

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -6,11 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-const mapInfo = require('../mapInfo');
-const { featureInfoClick, toggleEmptyMessageGFI, toggleShowCoordinateEditor, changeFormat, changePage, toggleHighlightFeature} = require('../../actions/mapInfo');
-const { MAP_CONFIG_LOADED } = require('../../actions/config');
-const assign = require('object-assign');
+import expect from 'expect';
+import assign from 'object-assign';
+import mapInfo from '../mapInfo';
+import {
+    featureInfoClick,
+    toggleEmptyMessageGFI,
+    toggleShowCoordinateEditor,
+    changeFormat,
+    changePage,
+    toggleHighlightFeature,
+    setDefaultIdentify
+} from '../../actions/mapInfo';
+import { MAP_CONFIG_LOADED } from '../../actions/config';
 
 require('babel-polyfill');
 
@@ -815,5 +823,19 @@ describe('Test the mapInfo reducer', () => {
         const action = toggleHighlightFeature(true);
         const state = mapInfo(undefined, action);
         expect(state.highlight).toBe(true);
+    });
+    it('setDefaultIdentify', () => {
+        const defaultConfig = {
+            enabled: true,
+            disabledAlwaysOn: true,
+            defaultConfiguration: {
+                infoFormat: 'test'
+            }
+        };
+        const action = setDefaultIdentify(defaultConfig);
+        const state = mapInfo(undefined, action);
+        expect(state.enabled).toBe(true);
+        expect(state.disabledAlwaysOn).toBe(true);
+        expect(state.configuration.infoFormat).toBe('test');
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -5,6 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const {isNil} = require('lodash');
 
 const {
     ERROR_FEATURE_INFO,
@@ -29,7 +30,8 @@ const {
     TOGGLE_EMPTY_MESSAGE_GFI,
     CHANGE_FORMAT,
     TOGGLE_SHOW_COORD_EDITOR,
-    SET_CURRENT_EDIT_FEATURE_QUERY
+    SET_CURRENT_EDIT_FEATURE_QUERY,
+    SET_DEFAULT_IDENTIFY
 } = require('../actions/mapInfo');
 const {
     MAP_CONFIG_LOADED
@@ -55,7 +57,6 @@ function receiveResponse(state, action, type) {
     return state;
 }
 const initState = {
-    enabled: true,
     configuration: {}
 };
 
@@ -344,7 +345,10 @@ function mapInfo(state = initState, action) {
     case MAP_CONFIG_LOADED: {
         return {
             ...state,
-            configuration: action.config.mapInfoConfiguration || state.configuration || {}
+            configuration: {
+                ...state.configuration,
+                ...action.config.mapInfoConfiguration
+            }
         };
     }
     case CHANGE_FORMAT: {
@@ -363,6 +367,18 @@ function mapInfo(state = initState, action) {
         return {
             ...state,
             currentEditFeatureQuery: action.query
+        };
+    }
+    case SET_DEFAULT_IDENTIFY: {
+        const { cfg } = action;
+        return {
+            ...state,
+            ...(!isNil(cfg.enabled) && {enabled: cfg.enabled}),
+            ...(!isNil(cfg.disabledAlwaysOn) && {disabledAlwaysOn: cfg.disabledAlwaysOn}),
+            configuration: {
+                ...state.configuration,
+                ...cfg.defaultConfiguration
+            }
         };
     }
     default:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5504 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Default options are configured from the plugin configuration. If a plugin is presented in localConfig, it is enabled by default.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
