### PR TITLE
#5582 - Fix scroll made by tutorial inside map viewer

### DIFF
--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -46,35 +46,36 @@ const defaultIntroStyle = {
 
 class Tutorial extends React.Component {
     static propTypes = {
-        toggle: PropTypes.bool,
-        status: PropTypes.string,
-        preset: PropTypes.string,
-        presetList: PropTypes.object,
+        actions: PropTypes.object,
+        allowClicksThruHole: PropTypes.bool,
+        autoStart: PropTypes.bool,
+        defaultStep: PropTypes.object,
+        disableOverlay: PropTypes.bool,
+        holePadding: PropTypes.number,
         intro: PropTypes.bool,
         introPosition: PropTypes.number,
-        showCheckbox: PropTypes.bool,
-        defaultStep: PropTypes.object,
         introStyle: PropTypes.object,
-        tourAction: PropTypes.string,
-        stepIndex: PropTypes.number,
-        steps: PropTypes.array,
-        run: PropTypes.bool,
-        autoStart: PropTypes.bool,
         keyboardNavigation: PropTypes.bool,
+        preset: PropTypes.string,
+        presetList: PropTypes.object,
+        run: PropTypes.bool,
         resizeDebounce: PropTypes.bool,
         resizeDebounceDelay: PropTypes.number,
-        holePadding: PropTypes.number,
+        scrollIntoViewOptions: PropTypes.bool,
         scrollOffset: PropTypes.number,
-        scrollToSteps: PropTypes.bool,
         scrollToFirstStep: PropTypes.bool,
+        scrollToSteps: PropTypes.bool,
         showBackButton: PropTypes.bool,
+        showCheckbox: PropTypes.bool,
         showOverlay: PropTypes.bool,
-        allowClicksThruHole: PropTypes.bool,
         showSkipButton: PropTypes.bool,
         showStepsProgress: PropTypes.bool,
+        status: PropTypes.string,
+        steps: PropTypes.array,
+        stepIndex: PropTypes.number,
+        toggle: PropTypes.bool,
         tooltipOffset: PropTypes.number,
-        disableOverlay: PropTypes.bool,
-        actions: PropTypes.object
+        tourAction: PropTypes.string
     };
 
     static defaultProps = {
@@ -117,6 +118,9 @@ class Tutorial extends React.Component {
             onDisable: () => {},
             onReset: () => {},
             onClose: () => {}
+        },
+        scrollIntoViewOptions: {
+            block: "end"
         }
     };
 
@@ -167,7 +171,7 @@ class Tutorial extends React.Component {
 
     onTour = (tour) => {
         if (this.props.steps.length > 0 && tour && tour.type) {
-            document.querySelector(tour?.step?.selector)?.scrollIntoView({block: "end"});
+            document.querySelector(tour?.step?.selector)?.scrollIntoView(this.props.scrollIntoViewOptions);
             const type = tour.type.split(':');
             if (type[0] !== 'tooltip' && type[1] === 'before'
             || tour.action === 'start'

--- a/web/client/components/tutorial/Tutorial.jsx
+++ b/web/client/components/tutorial/Tutorial.jsx
@@ -167,7 +167,7 @@ class Tutorial extends React.Component {
 
     onTour = (tour) => {
         if (this.props.steps.length > 0 && tour && tour.type) {
-            document.querySelector(tour?.step?.selector)?.scrollIntoView();
+            document.querySelector(tour?.step?.selector)?.scrollIntoView({block: "end"});
             const type = tour.type.split(':');
             if (type[0] !== 'tooltip' && type[1] === 'before'
             || tour.action === 'start'

--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -23,6 +23,7 @@ const epics = require('../epics/tutorial');
  * @prop {string} cfg.preset overrides the default_tutorial with another from the preset folder
  * @prop {object} cfg.presetList overrides preset list of MapStore2
  * @prop {boolean} cfg.showCheckbox shows/hides checkbox to disable tutorial next autostart
+ * @prop {object} cfg.scrollIntoViewOptions options applied to Element.scrollIntoView, {"block": "end"}
  * @prop {number} cfg.scrollOffset changes the scroll offset
  * @memberof plugins
  * @class Tutorial


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixes the scroll made by tutorial in the map viewer
i've checked other tutorials and seems not affect with this kind of problem

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5582

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The tutorial has a scrollintoView effect for each step.
by configuring how to position vertically we can avoid the issue

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
