### PR TITLE
#5590: [Backport] Excluded edit button from context editor map identify tool (#5591)

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -185,7 +185,14 @@ export default class ContextCreator extends React.Component {
             "ScaleBox",
             "Toolbar",
             "MapLoading",
-            "Identify",
+            {
+                "name": "Identify",
+                "overrides": {
+                    "cfg": {
+                        showEdit: false
+                    }
+                }
+            },
             "Locate",
             "ZoomIn",
             "ZoomOut",


### PR DESCRIPTION
 [Backport of  #5591 for 2020.02.xx, issue #5590 
