### PR TITLE
[2020.02.xx] #3688: json-patch format overrides support for dynamically loaded configuration files (#5266)

### DIFF
--- a/backend/src/main/java/it/geosolutions/mapstore/UploadPluginController.java
+++ b/backend/src/main/java/it/geosolutions/mapstore/UploadPluginController.java
@@ -46,9 +46,9 @@ import it.geosolutions.mapstore.utils.ResourceUtils;
  *  - extensions.registry: json file where uploaded extensions are registered (default: extensions.json)
  *  - context.plugins.config: json file where context creator plugins are configured (default: pluginsConfig.json)
  *  - context.plugins.savepatch: uses json-patch format for the context creator plugins configuration (default: true)
- *  
+ *
  *  When a datadir is available, the pluginsConfig.json original file is not touched, a pluginsConfig.json.patch file is
- *  used, in json-patch format to list only the uploaded extensions.  
+ *  used, in json-patch format to list only the uploaded extensions.
  */
 @Controller
 public class UploadPluginController {
@@ -57,13 +57,13 @@ public class UploadPluginController {
     @Value("${extensions.registry:extensions.json}") private String extensionsConfig = "extensions.json";
     @Value("${context.plugins.config:pluginsConfig.json}") private String pluginsConfig = "pluginsConfig.json";
     @Value("${context.plugins.savepatch:true}") private Boolean pluginsConfigAsPatch = true;
-    
+
     private ObjectMapper jsonMapper = new ObjectMapper();
     private JsonNodeFactory jsonNodeFactory = new JsonNodeFactory(false);
-    
+
     @Autowired
     ServletContext context;
-    
+
     /**
      * Stores and uploaded plugin zip bundle.
      * The zip bundle must be POSTed as the body of the request.
@@ -126,7 +126,7 @@ public class UploadPluginController {
                 moveAsset(tempFile, assetPath);
             }
         }
-       
+
         zip.close();
         if (plugin == null) {
             throw new IOException("Invalid bundle: index.json missing");
@@ -138,7 +138,7 @@ public class UploadPluginController {
         // we use patch files only if we have a datadir
         return pluginsConfigAsPatch && canUseDataDir();
     }
-    
+
     private boolean canUseDataDir() {
         return dataDir.isEmpty() ? false
             : Stream.of(dataDir.split(",")).filter(new Predicate<String>() {
@@ -147,12 +147,12 @@ public class UploadPluginController {
                     return !folder.trim().isEmpty() && new File(folder).exists();
                 }
             }).count() > 0;
-        
+
     }
 
     /**
      * Removes an installed plugin extension.
-     * 
+     *
      * @param pluginName name of the extension to be removed
      */
     @Secured({"ROLE_ADMIN"})
@@ -267,7 +267,7 @@ public class UploadPluginController {
             int remove = -1;
             for (int count = 0; count < plugins.size(); count++) {
                 JsonNode node = plugins.get(count);
-                if (json.get("name").asText().equals(node.get("name").asText())) {
+                if (json.get("name").asText().equals(node.get("value").get("name").asText())) {
                     remove = count;
                 }
             }
@@ -278,12 +278,12 @@ public class UploadPluginController {
             storeJSONConfig(config, pluginsConfig);
         }
     }
-	
+
     private void addPluginConfigurationAsPatch(JsonNode json) throws IOException {
         ArrayNode config = null;
         String configPath = pluginsConfig + ".patch";
         Optional<File> pluginsConfigFile = findResource(configPath);
-        
+
         if (pluginsConfigFile.isPresent()) {
             try (FileInputStream input = new FileInputStream(pluginsConfigFile.get())) {
                 config = (ArrayNode)readJSON(input);
@@ -304,7 +304,7 @@ public class UploadPluginController {
             if (remove >= 0) {
                 config.remove(remove);
             }
-            
+
             ObjectNode plugin = new ObjectNode(jsonNodeFactory);
             plugin.put("op", "add");
             plugin.put("path", "/plugins/-");
@@ -326,7 +326,7 @@ public class UploadPluginController {
         	throw new FileNotFoundException(pluginsConfig);
         }
     }
-    
+
     private ArrayNode getPluginsConfigurationPatch() throws IOException {
         Optional<File> pluginsConfigFile = findResource(pluginsConfig + ".patch");
         if (pluginsConfigFile.isPresent()) {
@@ -342,7 +342,7 @@ public class UploadPluginController {
             throws FileNotFoundException, IOException {
         ResourceUtils.storeJSONConfig(getWriteStorage(), context, config, configName);
     }
-    
+
     private void addExtension(String pluginName, String pluginBundle, String translations)
             throws FileNotFoundException, IOException {
         ObjectNode config = null;
@@ -370,7 +370,7 @@ public class UploadPluginController {
             storeJSONConfig(config, extensionsConfig);
         }
     }
-    
+
     private ObjectNode getExtensionConfig() throws IOException {
         Optional<File> extensionsConfigFile = findResource(extensionsConfig);
         if (extensionsConfigFile.isPresent()) {
@@ -405,10 +405,10 @@ public class UploadPluginController {
     public void setDataDir(String dataDir) {
         this.dataDir = dataDir;
     }
-    
+
     public void setContext(ServletContext context) {
         this.context = context;
     }
-    
-    
+
+
 }

--- a/backend/src/test/java/it/geosolutions/mapstore/UploadPluginControllerTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/UploadPluginControllerTest.java
@@ -24,13 +24,13 @@ import org.mockito.stubbing.Answer;
 
 public class UploadPluginControllerTest {
     UploadPluginController controller;
-    
+
     @Before
     public void setUp() {
         controller = new UploadPluginController();
         controller.setPluginsConfigAsPatch(false);
     }
-    
+
     @Test
     public void testUploadValidBundle() throws IOException {
         ServletContext context = Mockito.mock(ServletContext.class);
@@ -47,34 +47,7 @@ public class UploadPluginControllerTest {
                 String path = (String)invocation.getArguments()[0];
                 return tempDist.getAbsolutePath()  + File.separator + path.substring("dist/extensions/".length());
             }
-            
-        });
-        InputStream zipStream = UploadPluginControllerTest.class.getResourceAsStream("/plugin.zip");
-        String result = controller.uploadPlugin(zipStream);
-        assertEquals("{\"name\":\"My\",\"dependencies\":[\"Toolbar\"],\"extension\":true}", result);
-        String extensions = TestUtils.getContent(tempExtensions);
-        assertEquals("{\"MyPlugin\":{\"bundle\":\"dist/extensions/My/myplugin.js\",\"translations\":\"dist/extensions/My/translations\"}}", extensions);
-        tempConfig.delete();
-        tempExtensions.delete();
-    }
-    
-    @Test
-    public void testUploadValidBundleReplace() throws IOException {
-        ServletContext context = Mockito.mock(ServletContext.class);
-        controller.setContext(context);
-        File tempConfig = TestUtils.copyToTemp(ConfigControllerTest.class.getResourceAsStream("/pluginsConfigWithPlugin.json"));
-        Mockito.when(context.getRealPath(Mockito.endsWith("pluginsConfig.json"))).thenReturn(tempConfig.getAbsolutePath());
-        File tempExtensions = TestUtils.copyToTemp(ConfigControllerTest.class.getResourceAsStream("/extensionsWithPlugin.json"));
-        File tempDist = TestUtils.getDataDir();
-        Mockito.when(context.getRealPath(Mockito.contains("extensions.json"))).thenReturn(tempExtensions.getAbsolutePath());
-        Mockito.when(context.getRealPath(Mockito.contains("dist/extensions/"))).thenAnswer(new Answer<String>() {
 
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                String path = (String)invocation.getArguments()[0];
-                return tempDist.getAbsolutePath()  + File.separator + path.substring("dist/extensions/".length());
-            }
-            
         });
         InputStream zipStream = UploadPluginControllerTest.class.getResourceAsStream("/plugin.zip");
         String result = controller.uploadPlugin(zipStream);
@@ -84,7 +57,7 @@ public class UploadPluginControllerTest {
         tempConfig.delete();
         tempExtensions.delete();
     }
-    
+
     @Test
     public void testUploadValidBundleUsingPatch() throws IOException {
         controller.setPluginsConfigAsPatch(true);
@@ -105,7 +78,7 @@ public class UploadPluginControllerTest {
                 String path = (String)invocation.getArguments()[0];
                 return tempDist.getAbsolutePath()  + File.separator + path.substring("dist/extensions/".length());
             }
-            
+
         });
         InputStream zipStream = UploadPluginControllerTest.class.getResourceAsStream("/plugin.zip");
         String result = controller.uploadPlugin(zipStream);
@@ -115,7 +88,7 @@ public class UploadPluginControllerTest {
         tempConfig.delete();
         tempExtensions.delete();
     }
-    
+
     @Test
     public void testCustomBundlesPath() throws IOException {
         ServletContext context = Mockito.mock(ServletContext.class);
@@ -133,7 +106,7 @@ public class UploadPluginControllerTest {
                 String path = (String)invocation.getArguments()[0];
                 return tempDist.getAbsolutePath() + File.separator + path.substring("custom/".length());
             }
-            
+
         });
         InputStream zipStream = UploadPluginControllerTest.class.getResourceAsStream("/plugin.zip");
         controller.uploadPlugin(zipStream);
@@ -141,7 +114,7 @@ public class UploadPluginControllerTest {
         tempConfig.delete();
         tempExtensions.delete();
     }
-    
+
     @Test
     public void testUploadInvalidBundle() throws IOException {
         ServletContext context = Mockito.mock(ServletContext.class);
@@ -158,7 +131,7 @@ public class UploadPluginControllerTest {
                 String path = (String)invocation.getArguments()[0];
                 return tempDist.getAbsolutePath()  + File.separator + path.substring("dist/extensions/".length());
             }
-            
+
         });
         InputStream zipStream = UploadPluginControllerTest.class.getResourceAsStream("/invalid.zip");
         try {
@@ -167,9 +140,9 @@ public class UploadPluginControllerTest {
         } catch(IOException e) {
             assertNotNull(e);
         }
-        
+
     }
-    
+
     @Test
     public void testUploadValidBundleWithDataDir() throws IOException {
     	File dataDir = TestUtils.getDataDir();
@@ -224,7 +197,7 @@ public class UploadPluginControllerTest {
                 String path = (String)invocation.getArguments()[0];
                 return tempDist.getAbsolutePath()  + File.separator + path.substring("dist/extensions/".length());
             }
-            
+
         });
         File pluginFolder = new File(tempDist.getAbsolutePath() + File.separator + "My");
         pluginFolder.mkdirs();
@@ -240,7 +213,7 @@ public class UploadPluginControllerTest {
         tempConfig.delete();
         tempExtensions.delete();
     }
-    
+
     @Test
     public void testUninstallPluginWithPatch() throws IOException {
         controller.setPluginsConfigAsPatch(true);


### PR DESCRIPTION
Backports the following commits to 2020.02.xx:
 - #3688: json-patch format overrides support for dynamically loaded configuration files (#5266)