### PR TITLE
Fix 5616 Color picker does not update the target container node

### DIFF
--- a/web/client/components/style/ColorPicker.jsx
+++ b/web/client/components/style/ColorPicker.jsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import isFunction from 'lodash/isFunction';
 import { SketchPicker } from 'react-color';
 import tinycolor from 'tinycolor2';
 import { createPortal } from 'react-dom';
@@ -21,7 +22,7 @@ import { getConfigProp } from '../../utils/ConfigUtils';
  * @prop {function} line show swatch for line style
  * @prop {bool} disabled disable swatch and picker
  * @prop {object} pickerProps props for picker component
- * @prop {node} containerNode container node target for picker overlay
+ * @prop {node|function} containerNode container node target for picker overlay or a function that return the target node
  * @prop {function} onOpen detect when color picker is open
  * @prop {string} placement preferred placement of picker, one of 'top', 'right', 'bottom' or 'left'
  */
@@ -33,7 +34,7 @@ function ColorPicker({
     line,
     disabled,
     pickerProps,
-    containerNode,
+    containerNode: containerNodeProp,
     onOpen,
     placement
 }) {
@@ -54,6 +55,9 @@ function ColorPicker({
     const [displayColorPicker, setDisplayColorPicker] = useState();
 
     const valueString = tinycolor(value).toString();
+
+    const containerNode = isFunction(containerNodeProp) ? containerNodeProp() : containerNodeProp;
+
     useEffect(() => {
         const colorString = color && tinycolor(color).toString();
         if (colorString && valueString
@@ -371,7 +375,7 @@ ColorPicker.propTypes = {
     line: PropTypes.bool,
     disabled: PropTypes.bool,
     pickerProps: PropTypes.object,
-    containerNode: PropTypes.node,
+    containerNode: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
     onOpen: PropTypes.function,
     placement: PropTypes.string
 };
@@ -382,7 +386,7 @@ ColorPicker.defaultProps = {
     onChangeColor: () => {},
     pickerProps: {},
     onOpen: () => {},
-    containerNode: document.querySelector('.' + (getConfigProp('themePrefix') || 'ms2') + " > div") || document.body
+    containerNode: () => document.querySelector('.' + (getConfigProp('themePrefix') || 'ms2') + " > div") || document.body
 };
 
 export default ColorPicker;

--- a/web/client/components/style/__tests__/ColorPiker-test.jsx
+++ b/web/client/components/style/__tests__/ColorPiker-test.jsx
@@ -310,4 +310,42 @@ describe("Test the ColorPicker style component", () => {
         expect(pickerArrow).toBeTruthy();
         expect(pickerArrow.style.transform).toBe(`translate(-50%, -50%) rotateZ(${ARROW_ROTATION}deg) translateX(50%)`);
     });
+
+    it('should use container node as function', () => {
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}
+                >
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: '50%',
+                            left: '50%'
+                        }}>
+                        <ColorPicker
+                            placement="left"
+                            containerNode={() => document.querySelector('#test-overlay-target')}
+                        />
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const colorPickerNode = document.querySelector('.ms-color-picker');
+        expect(colorPickerNode).toBeTruthy();
+        const swatchNode = colorPickerNode.querySelector('.ms-color-picker-swatch');
+        expect(swatchNode).toBeTruthy();
+        act(() => {
+            Simulate.click(swatchNode);
+        });
+        const colorPickerOverlaynode = document.querySelector('.ms-color-picker-overlay');
+        expect(colorPickerOverlaynode).toBeTruthy();
+        expect(colorPickerOverlaynode.parentNode.getAttribute('id')).toBe('test-overlay-target');
+    });
 });

--- a/web/client/components/styleeditor/FilterBuilder.jsx
+++ b/web/client/components/styleeditor/FilterBuilder.jsx
@@ -157,13 +157,15 @@ export function FilterBuilderPopover({
     value,
     hide,
     attributes,
-    onChange
+    onChange,
+    placement = 'right'
 }) {
     if (hide || !attributes || attributes.length === 0) {
         return null;
     }
     return (
         <Popover
+            placement={placement}
             content={
                 <FilterBuilder
                     filterObj={value}

--- a/web/client/components/styleeditor/Popover.jsx
+++ b/web/client/components/styleeditor/Popover.jsx
@@ -1,7 +1,15 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
 
 import React, { useState, useEffect, useRef, useCallback, cloneElement } from 'react';
 import { createPortal } from 'react-dom';
 import { getConfigProp } from '../../utils/ConfigUtils';
+import isFunction from 'lodash/isFunction';
 
 /**
  * Popover used for style components.
@@ -10,14 +18,14 @@ import { getConfigProp } from '../../utils/ConfigUtils';
  * @memberof components.styleeditor
  * @name ControlledPopover
  * @class
- * @prop {object} containerNode values of the style
+ * @prop {node|function} containerNode container node target for picker overlay or a function that return the target node
  * @prop {object} placement position of popover, one of center, left, right, top, bottom
  * @prop {node} content content of floating popover
  * @prop {boolean} open open/close content
  * @prop {function} onOpen triggered when child is clicked
  */
 export function ControlledPopover({
-    containerNode = document.querySelector('.' + (getConfigProp('themePrefix') || 'ms2') + " > div") || document.body,
+    containerNode: containerNodeProp = () => document.querySelector('.' + (getConfigProp('themePrefix') || 'ms2') + " > div") || document.body,
     placement,
     content,
     children,
@@ -26,6 +34,7 @@ export function ControlledPopover({
 }) {
 
     const margin = 10;
+    const containerNode = isFunction(containerNodeProp) ? containerNodeProp() : containerNodeProp;
 
     const defaultStyle = useRef({
         picker: {

--- a/web/client/components/styleeditor/Popover.jsx
+++ b/web/client/components/styleeditor/Popover.jsx
@@ -307,6 +307,7 @@ export function ControlledPopover({
                         {content}
                     </div>
                     <div
+                        className="ms-popover-arrow"
                         style={{
                             position: 'absolute',
                             borderTop: `${margin - 1}px solid transparent`,

--- a/web/client/components/styleeditor/ScaleDenominator.jsx
+++ b/web/client/components/styleeditor/ScaleDenominator.jsx
@@ -59,7 +59,7 @@ function ScaleInput({
 function ScaleDenominator({
     value,
     zoom,
-    scales: propScales,
+    scales: propScales = [],
     onChange
 }) {
 
@@ -130,17 +130,19 @@ function ScaleDenominator({
 }
 
 export function ScaleDenominatorPopover({
-    value,
-    scales,
+    value = {},
+    scales = [],
     zoom,
     hide,
-    onChange
+    onChange,
+    placement = 'right'
 }) {
     if (hide) {
         return null;
     }
     return (
         <Popover
+            placement={placement}
             content={
                 <ScaleDenominator
                     value={value}

--- a/web/client/components/styleeditor/__tests__/Popover-test.jsx
+++ b/web/client/components/styleeditor/__tests__/Popover-test.jsx
@@ -1,0 +1,299 @@
+
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Popover from '../Popover';
+import { Simulate, act } from 'react-dom/test-utils';
+
+describe("Popover style component", () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div><div id="test-overlay-target" style="transform:translate(0,0);position:fixed;left:0;top:0;width:1920px;height:1080px;"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('should render popover in a different container', () => {
+        ReactDOM.render(
+            <div className="test-popover-container">
+                <Popover
+                    containerNode={document.body}
+                    content={<div className="test-content"></div>}
+                >
+                    <button className="test-button"></button>
+                </Popover>
+            </div>
+            , document.getElementById("container"));
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        Simulate.click(buttonNode);
+
+        const testContainer = document.querySelector('.test-popover-container');
+
+        let overlayNode = testContainer.querySelector('.ms-popover-overlay');
+        expect(overlayNode).toBeFalsy();
+
+        overlayNode = document.querySelector('body > .ms-popover-overlay');
+        expect(overlayNode).toBeTruthy();
+    });
+
+    it('should be placed on top', () => {
+        const ARROW_ROTATION = 270;
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            left: '50%',
+                            bottom: 0
+                        }}>
+                        <Popover
+                            containerNode={document.getElementById("test-overlay-target")}
+                            content={<div className="test-content">Content</div>}
+                        >
+                            <button className="test-button">Button</button>
+                        </Popover>
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+        const popoverArrow = document.querySelector('.ms-popover-arrow');
+        expect(popoverArrow).toBeTruthy();
+        expect(popoverArrow.style.transform).toBe(`translate(-50%, -50%) rotateZ(${ARROW_ROTATION}deg) translateX(50%)`);
+    });
+
+    it('should be placed on right', () => {
+        const ARROW_ROTATION = 0;
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: '50%',
+                            left: 0
+                        }}>
+                        <Popover
+                            containerNode={document.getElementById("test-overlay-target")}
+                            content={<div className="test-content">Content</div>}
+                        >
+                            <button className="test-button">Button</button>
+                        </Popover>
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+        const popoverArrow = document.querySelector('.ms-popover-arrow');
+        expect(popoverArrow).toBeTruthy();
+        expect(popoverArrow.style.transform).toBe(`translate(-50%, -50%) rotateZ(${ARROW_ROTATION}deg) translateX(50%)`);
+    });
+    it('should be placed on bottom', () => {
+        const ARROW_ROTATION = 90;
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            left: '50%',
+                            top: 0
+                        }}>
+                        <Popover
+                            containerNode={document.getElementById("test-overlay-target")}
+                            content={<div className="test-content">Content</div>}
+                        >
+                            <button className="test-button">Button</button>
+                        </Popover>
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+        const popoverArrow = document.querySelector('.ms-popover-arrow');
+        expect(popoverArrow).toBeTruthy();
+        expect(popoverArrow.style.transform).toBe(`translate(-50%, -50%) rotateZ(${ARROW_ROTATION}deg) translateX(50%)`);
+    });
+    it('should be placed on left', () => {
+        const ARROW_ROTATION = 180;
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: '50%',
+                            right: 0
+                        }}>
+                        <Popover
+                            containerNode={document.getElementById("test-overlay-target")}
+                            content={<div className="test-content">Content</div>}
+                        >
+                            <button className="test-button">Button</button>
+                        </Popover>
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+        const popoverArrow = document.querySelector('.ms-popover-arrow');
+        expect(popoverArrow).toBeTruthy();
+        expect(popoverArrow.style.transform).toBe(`translate(-50%, -50%) rotateZ(${ARROW_ROTATION}deg) translateX(50%)`);
+    });
+    it('should be placed on center (not found available position)', () => {
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0
+                        }}>
+                        <Popover
+                            containerNode={document.getElementById("test-overlay-target")}
+                            content={<div className="test-content">Content</div>}
+                        >
+                            <button className="test-button">Button</button>
+                        </Popover>
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+        const popoverArrow = document.querySelector('.ms-popover-arrow');
+        expect(popoverArrow).toBeTruthy();
+        expect(popoverArrow.style.opacity).toBe('0');
+    });
+
+    it('should use declared placement', () => {
+        const ARROW_ROTATION = 180;
+        act(() => {
+            ReactDOM.render(
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: 1920,
+                        height: 1080
+                    }}>
+                    <div
+                        style={{
+                            position: 'absolute',
+                            top: '50%',
+                            left: '50%'
+                        }}>
+                        <Popover
+                            placement="left"
+                            containerNode={document.getElementById("test-overlay-target")}
+                            content={<div className="test-content">Content</div>}
+                        >
+                            <button className="test-button">Button</button>
+                        </Popover>
+                    </div>
+                </div>
+                , document.getElementById("container"));
+        });
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        act(() => {
+            Simulate.click(buttonNode);
+        });
+        const popoverArrow = document.querySelector('.ms-popover-arrow');
+        expect(popoverArrow).toBeTruthy();
+        expect(popoverArrow.style.transform).toBe(`translate(-50%, -50%) rotateZ(${ARROW_ROTATION}deg) translateX(50%)`);
+    });
+
+    it('should use container node as function', () => {
+        ReactDOM.render(
+            <div className="test-popover-container">
+                <Popover
+                    format="hex"
+                    containerNode={() => document.getElementById("test-overlay-target")}
+                    content={<div className="test-content"></div>}
+                >
+                    <button className="test-button"></button>
+                </Popover>
+            </div>
+            , document.getElementById("container"));
+        const buttonNode = document.querySelector('.test-button');
+        expect(buttonNode).toBeTruthy();
+        Simulate.click(buttonNode);
+
+        const testContainer = document.querySelector('.test-popover-container');
+
+        let overlayNode = testContainer.querySelector('.ms-popover-overlay');
+        expect(overlayNode).toBeFalsy();
+
+        overlayNode = document.querySelector('#test-overlay-target > .ms-popover-overlay');
+        expect(overlayNode).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR improve container node props for style popover adding the possibility to use function that return node target. Currently it was declared in defaultProps so it was created once during the application lifecicle.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5616

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Color selector is mounted on the correct target so it is visible to the user.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
