### PR TITLE
#5633 - Geodesic circles are edited accordingly from QueryPanel

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -249,7 +249,7 @@ export default class DrawSupport extends React.Component {
                         center = geometry.properties && geometry.properties.center ? reproject(geometry.properties.center, "EPSG:4326", mapCrs) : geometry.center;
                         center = [center.x, center.y];
                         feature = new Feature({
-                            geometry: this.createOLGeometry({type: "Circle", center, projection: "EPSG:3857", radius: geometry.properties && geometry.properties.radius || geometry.radius})
+                            geometry: this.createOLGeometry({type: "Circle", center, projection: "EPSG:3857", radius: geometry.properties && geometry.properties.radius || geometry.radius, options})
                         });
                     } else {
                         feature = new Feature({

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -441,6 +441,72 @@ describe('Test DrawSupport', () => {
         expect(spyChangeStatus.calls.length).toBe(1);
     });
 
+    it('tests a replace of geodesic circle feature ', () => {
+        const fakeMap = {
+            addLayer: () => {},
+            disableEventListener: () => {},
+            addInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+        const support = ReactDOM.render(
+            <DrawSupport features={[]} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        ReactDOM.render(
+            <DrawSupport
+                features={[]}
+                map={fakeMap}
+                drawStatus="start"
+                drawMethod="Circle"
+                options={{
+                    stopAfterDrawing: true,
+                    geodesic: true
+                }}
+            />, document.getElementById("container"));
+        ReactDOM.render(
+            <DrawSupport
+                features={[
+                    {
+                        type: 'Polygon',
+                        center: {
+                            x: 721565.5470120639,
+                            y: 5586683.477814646
+                        },
+                        coordinates: [
+                            721565.5470120639,
+                            5586683.477814646
+                        ],
+                        radius: 294110.99,
+                        projection: 'EPSG:3857'
+                    }
+                ]}
+                map={fakeMap}
+                drawStatus="replace"
+                drawMethod="Circle"
+                options={{
+                    geodesic: true
+                }}
+                onEndDrawing={testHandlers.onEndDrawing}
+                onChangeDrawingStatus={testHandlers.onStatusChange}
+            />, document.getElementById("container"));
+        const {geodesicCenter} = support.drawSource.getFeatures()[0].getGeometry().getProperties();
+        const isNearlyEqual = function(a, b) {
+            if (a === undefined || b === undefined) {
+                return false;
+            }
+            return a.toFixed(12) - b.toFixed(12) === 0;
+        };
+        expect(isNearlyEqual(geodesicCenter[0], 721565.5470120639)).toBeTruthy();
+        expect(isNearlyEqual(geodesicCenter[1], 5586683.477814646)).toBeTruthy();
+    });
+
+
     it('end drawing with continue', () => {
         const fakeMap = {
             addLayer: () => {},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Geodesic circles are edited accordingly from QueryPanel
The geodesic values were not passed from the "replace" status of drawsupport

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5633 
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
