### PR TITLE
#5638 Circle steps now uses the right number of decimals

### DIFF
--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -168,7 +168,7 @@ class GeometryDetails extends React.Component {
             <FormControl
                 type="number"
                 id={"queryform_circle_" + name}
-                defaultValue={this.roundValue(value, !this.isWGS84() || name === 'radius' ? 100 : 1000000)}
+                defaultValue={this.roundValue(value, name === 'radius' ? 100 : 1000000)}
                 step={this.getStepCircle(this.props.zoom, name)}
                 onChange={(evt) => this.onUpdateCircle(evt.target.value, name)}/>
         );

--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -164,11 +164,13 @@ class GeometryDetails extends React.Component {
         );
     };
     renderCircleField = (value, name) => {
+        // radius should have 2 decimals if uom of projections is meter (EPSG:3857)
+        // all other cases it must have at least 6 decimals because coords are converted to EPSG:4326
         return (
             <FormControl
                 type="number"
                 id={"queryform_circle_" + name}
-                defaultValue={this.roundValue(value, name === 'radius' ? 100 : 1000000)}
+                defaultValue={this.roundValue(value, name === 'radius' && !this.isWGS84() ? 100 : 1000000)}
                 step={this.getStepCircle(this.props.zoom, name)}
                 onChange={(evt) => this.onUpdateCircle(evt.target.value, name)}/>
         );

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -31,8 +31,8 @@ describe('GeometryDetails', () => {
         let geometry = {
             center: {
                 srs: "EPSG:900913",
-                x: -1761074.344349588,
-                y: 5852757.632510748
+                x: -1764074.344349588,
+                y: 5854757.632510748
             },
             projection: "EPSG:900913",
             radius: 836584.05,
@@ -66,6 +66,13 @@ describe('GeometryDetails', () => {
         let panelBodyRows = pb.getElementsByClassName('row');
         expect(panelBodyRows).toExist();
         expect(panelBodyRows.length).toBe(3);
+
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(3);
+        // checking number of decimals
+        expect(inputs[0].value.substring(inputs[0].value.indexOf(".") + 1).length).toBe(6); // "-15.846949"
+        expect(inputs[1].value.substring(inputs[1].value.indexOf(".") + 1).length).toBe(6); // "46.462377"
+        expect(inputs[2].value.substring(inputs[2].value.indexOf(".") + 1).length).toBe(2); // "6114748.17"
 
         expect(pb.childNodes.length).toBe(1);
     });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Circle steps were using the rounded value present in the UI and this was inconsistent with the real value of the center.
Since step can be at most 0.00001 I propose to use always 5 decimals to avoid this situation.

Btw the value in the geometry details is always in 4326

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5638

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
steps updates values correctly
![correct behaviour](https://user-images.githubusercontent.com/11991428/87404511-868bfa00-c5be-11ea-8320-ef64d31c1b24.gif)



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
