### PR TITLE
#5641: Thematic layer not added when the layer is not wfs

### DIFF
--- a/web/client/plugins/ThematicLayer.jsx
+++ b/web/client/plugins/ThematicLayer.jsx
@@ -131,6 +131,9 @@ module.exports = {
         TOCItemsSettings: {
             priority: 1,
             name: 'ThematicLayer',
+            selector: (props) => {
+                return props?.element?.search;
+            },
             container: "TOCItemSettings",
             target: "style"
         }

--- a/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
+++ b/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
@@ -23,6 +23,43 @@ describe('TOCItemsSettings - getStyleTabPlugin', () => {
         };
         expect(getStyleTabPlugin(DEFAULT_TEST_PARAMS)).toEqual({});
     });
+    it('getStyleTabPlugin gets thematic plugin if present and the layer is wfs', () => {
+        const DEFAULT_TEST_PARAMS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                search: {
+                    type: "wfs",
+                    url: "something"
+                }
+            },
+            items: [{
+                target: 'style',
+                name: 'ThematicLayer',
+                selector: (props) => {
+                    return props?.element?.search;
+                }
+            }]
+        };
+        const toolbar = getStyleTabPlugin(DEFAULT_TEST_PARAMS).toolbar;
+        expect(toolbar).toBeTruthy();
+        expect(toolbar.length).toBe(2);
+    });
+    it('getStyleTabPlugin exclude thematic plugin if layer is not', () => {
+        const DEFAULT_TEST_PARAMS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                type: "asd"
+            },
+            items: [{
+                target: 'style',
+                name: 'ThematicLayer',
+                selector: (props) => {
+                    return props?.element?.search;
+                }
+            }]
+        };
+        expect(getStyleTabPlugin(DEFAULT_TEST_PARAMS)).toEqual({});
+    });
     it('defaultSettingsTabs', () => {
         {
             const items = defaultSettingsTabs(BASE_STYLE_TEST_DATA);

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -144,7 +144,7 @@ export const getStyleTabPlugin = ({ settings, items = [], loadedPlugins, onToggl
     // get Higher priority plugin that satisfies requirements.
     const candidatePluginItems =
             sortBy(filter([...items], { target: 'style' }), ["priority"]) // find out plugins with target panel 'style' and sort by priority
-                .filter(({selector}) => selector ? selector(props) : true); // filter out items that do not have the correct requirements.
+                .filter(({selector}) => selector ? selector({...props, element}) : true); // filter out items that do not have the correct requirements.
     // TODO: to complete externalization of these items, we need to
     // move handlers, Component creation and configuration on the plugins, delegating also action dispatch.
     const thematicPlugin = head(filter(candidatePluginItems, {name: "ThematicLayer"}));


### PR DESCRIPTION
## Description
This PR updates the selector for thematic layers in order to exclude layers that are not vector

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5641

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
