### PR TITLE
#5644 Fixed elevation activation regression

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -9,7 +9,6 @@
 const PropTypes = require('prop-types');
 const React = require('react');
 const {connect} = require('../utils/PluginsUtils');
-const {createSelector} = require('reselect');
 
 const {loadFont} = require('../utils/AgentUtils');
 
@@ -411,60 +410,9 @@ class MapPlugin extends React.Component {
         plugins = require('./map/index')(props.mapType, props.actions);
     };
 }
+const selector = require('./map/selector').default;
 
-const {mapSelector, projectionDefsSelector} = require('../selectors/map');
-const { mapTypeSelector, isOpenlayers } = require('../selectors/maptype');
-const {layerSelectorWithMarkers} = require('../selectors/layers');
-const {highlighedFeatures} = require('../selectors/highlight');
-const {securityTokenSelector} = require('../selectors/security');
-const {currentLocaleLanguageSelector} = require('../selectors/locale');
-const {
-    isLocalizedLayerStylesEnabledSelector,
-    localizedLayerStylesNameSelector
-} = require('../selectors/localizedLayerStyles');
 
-const selector = createSelector(
-    [
-        projectionDefsSelector,
-        mapSelector,
-        mapTypeSelector,
-        layerSelectorWithMarkers,
-        highlighedFeatures,
-        (state) => state.mapInitialConfig && state.mapInitialConfig.loadingError && state.mapInitialConfig.loadingError.data,
-        securityTokenSelector,
-        (state) => state.mousePosition && state.mousePosition.enabled,
-        isOpenlayers,
-        isLocalizedLayerStylesEnabledSelector,
-        localizedLayerStylesNameSelector,
-        currentLocaleLanguageSelector
-    ], (
-        projectionDefs,
-        map,
-        mapType,
-        layers,
-        features,
-        loadingError,
-        securityToken,
-        elevationEnabled,
-        shouldLoadFont,
-        isLocalizedLayerStylesEnabled,
-        localizedLayerStylesName,
-        currentLocaleLanguage
-    ) => ({
-        projectionDefs,
-        map,
-        mapType,
-        layers,
-        features,
-        loadingError,
-        securityToken,
-        elevationEnabled,
-        shouldLoadFont,
-        isLocalizedLayerStylesEnabled,
-        localizedLayerStylesName,
-        currentLocaleLanguage
-    })
-);
 module.exports = {
     MapPlugin: connect(selector, {
         onFontError: errorLoadingFont,

--- a/web/client/plugins/map/__tests__/selector-test.jsx
+++ b/web/client/plugins/map/__tests__/selector-test.jsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+
+import { createStateMocker } from '../../../reducers/__tests__/reducersTestUtils';
+
+import selector from '../selector';
+import map from '../../../reducers/map';
+import layers from '../../../reducers/layers';
+import additionallayers from '../../../reducers/additionallayers';
+
+import { registerEventListener } from '../../../actions/map';
+
+const stateMocker = createStateMocker({ map, layers, additionallayers});
+describe('Map plugin state to pros selector', () => {
+    describe('elevationEnabled', () => {
+        it('elevation is active when mouseposition is listening to map', () => {
+            const elevationEnabledState = selector(stateMocker(registerEventListener('mousemove', 'mouseposition')));
+            expect(elevationEnabledState.elevationEnabled).toBeTruthy();
+        });
+        it('elevation is not active when other is listening to map', () => {
+            const elevationEnabledState = selector(stateMocker(registerEventListener('mousemove', 'otherTool')));
+            expect(elevationEnabledState.elevationEnabled).toBeFalsy();
+        });
+    });
+});

--- a/web/client/plugins/map/selector.js
+++ b/web/client/plugins/map/selector.js
@@ -1,0 +1,27 @@
+import { createStructuredSelector } from 'reselect';
+
+import { mapSelector, projectionDefsSelector, isMouseMoveCoordinatesActiveSelector } from '../../selectors/map';
+import { mapTypeSelector, isOpenlayers } from '../../selectors/maptype';
+import { layerSelectorWithMarkers } from '../../selectors/layers';
+import { highlighedFeatures } from '../../selectors/highlight';
+import { securityTokenSelector } from '../../selectors/security';
+import { currentLocaleLanguageSelector } from '../../selectors/locale';
+import { isLocalizedLayerStylesEnabledSelector, localizedLayerStylesNameSelector } from '../../selectors/localizedLayerStyles';
+
+/**
+ * Map state to props selector for Map plugin
+ */
+export default createStructuredSelector({
+    projectionDefs: projectionDefsSelector,
+    map: mapSelector,
+    mapType: mapTypeSelector,
+    layers: layerSelectorWithMarkers,
+    features: highlighedFeatures,
+    loadingError: state => state.mapInitialConfig && state.mapInitialConfig.loadingError && state.mapInitialConfig.loadingError.data,
+    securityToken: securityTokenSelector,
+    elevationEnabled: isMouseMoveCoordinatesActiveSelector,
+    shouldLoadFont: isOpenlayers,
+    isLocalizedLayerStylesEnabled: isLocalizedLayerStylesEnabledSelector,
+    localizedLayerStylesName: localizedLayerStylesNameSelector,
+    currentLocaleLanguage: currentLocaleLanguageSelector
+});

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -92,7 +92,7 @@ const mapVersionSelector = (state) => state.map && state.map.present && state.ma
  */
 const mapNameSelector = (state) => state.map && state.map.present && state.map.present.info && state.map.present.info.name || '';
 
-const mouseMoveListenerSelector = (state) => get(state, 'map.present.eventListeners.mousemove', []);
+const mouseMoveListenerSelector = (state) => get(mapSelector(state), 'eventListeners.mousemove', []);
 
 const isMouseMoveActiveSelector = (state) => !!mouseMoveListenerSelector(state).length;
 


### PR DESCRIPTION
## Description
Recent changes to mousePosition needed to support popup on mouse hover changes the state where the mousePosition tool is enabled. 

The `mousePosition` selector was manually written in map plugin to support enable/disable elevation layer on activation.

Otherwise simply replacing the local with the the shared selector solves the problem, like this
```diff
diff --git a/web/client/plugins/Map.jsx b/web/client/plugins/Map.jsx
index c8668f55..0419d408 100644
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -412,7 +412,7 @@ class MapPlugin extends React.Component {
     };
 }
 
-const {mapSelector, projectionDefsSelector} = require('../selectors/map');
+const { mapSelector, projectionDefsSelector, isMouseMoveCoordinatesActiveSelector} = require('../selectors/map');
 const { mapTypeSelector, isOpenlayers } = require('../selectors/maptype');
 const {layerSelectorWithMarkers} = require('../selectors/layers');
 const {highlighedFeatures} = require('../selectors/highlight');
@@ -432,7 +432,7 @@ const selector = createSelector(
         highlighedFeatures,
         (state) => state.mapInitialConfig && state.mapInitialConfig.loadingError && state.mapInitialConfig.loadingError.data,
         securityTokenSelector,
-        (state) => state.mousePosition && state.mousePosition.enabled,
+        isMouseMoveCoordinatesActiveSelector,
         isOpenlayers,
         isLocalizedLayerStylesEnabledSelector,
         localizedLayerStylesNameSelector,
```
Notes: In order to create a unit test I had to move the plugins `mapStateToProps` outside the plugin (moved in plugins/map/selector.js. because it is proper of the plugin). I also fixed the current selector to support mapSelector, instead of duplicated (and wrong) `map.present`



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5644

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
