### PR TITLE
Fix 5649 Error on style editor toggle causes recursive requests

### DIFF
--- a/web/client/epics/__tests__/styleeditor-test.js
+++ b/web/client/epics/__tests__/styleeditor-test.js
@@ -206,6 +206,58 @@ describe('Test styleeditor epics', () => {
             state);
 
     });
+    it('test toggleStyleEditorEpic enabled to true with global error', (done) => {
+
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        id: 'layerId',
+                        name: 'layerName',
+                        url: '/geoserver/'
+                    }
+                ],
+                selected: [
+                    'layerId'
+                ]
+            },
+            styleeditor: {
+                error: {
+                    global: {
+                        status: 401
+                    }
+                }
+            }
+        };
+        const NUMBER_OF_ACTIONS = 1;
+
+        const results = (actions) => {
+            expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+            try {
+                actions.map((action) => {
+                    switch (action.type) {
+                    case SHOW_NOTIFICATION:
+                        expect(action.title).toBe('styleeditor.initErrorTitle');
+                        expect(action.level).toBe('error');
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+
+        testEpic(
+            toggleStyleEditorEpic,
+            NUMBER_OF_ACTIONS,
+            toggleStyleEditor(undefined, true),
+            results,
+            state);
+
+    });
     it('test updateLayerOnStatusChangeEpic status template', (done) => {
 
         const state = {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2064,7 +2064,10 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Classification",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+
+            "initErrorTitle": "Verbindungsfehler",
+            "initErrorMessage": "Es ist nicht möglich, eine Verbindung zum Stileditor herzustellen"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2076,7 +2076,10 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Classification",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+
+            "initErrorTitle": "Connection error",
+            "initErrorMessage": "It's not possible to connect to the style editor service"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2065,7 +2065,10 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Clasificación",
-            "ruleRaster": "Ráster"
+            "ruleRaster": "Ráster",
+
+            "initErrorTitle": "Error de conexión",
+            "initErrorMessage": "No es posible conectarse al servicio del editor de estilos"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2066,7 +2066,10 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Classification",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+
+            "initErrorTitle": "Erreur de connexion",
+            "initErrorMessage": "Il n'est pas possible de se connecter au service d'éditeur de style"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2065,7 +2065,10 @@
             "blueChannel": "Canale blue",
             "grayChannel": "Canale",
             "ruleClassification": "Classificazione",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+
+            "initErrorTitle": "Errore di connessione al servizio",
+            "initErrorMessage": "Non è possibile connettersi al servizio dell'editor di stili"
         },
         "playback": {
             "settings": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds a control to stop the style editor initialization in case of error from rest or get capabilities request.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5649 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
