### PR TITLE
Extensions section on Dev guide index

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ pages:
       - Custom dependencies: 'developer-guide/custom-dependencies.md'
       - Styling and theming: 'developer-guide/customize-theme.md'
       - Application tutorial: 'developer-guide/application-tutorial.md'
+      - Working with Extensions: 'developer-guide/extensions.md'
       - FAQ: 'developer-guide/dev-faq.md'
     - Guidelines:
       - Code Conventions: 'developer-guide/code-conventions.md'


### PR DESCRIPTION
## Description
Working with Extensions section is now  in the index of the Dev guide.

Read the Doc [link](https://mapstore.readthedocs.io/en/extensions_sections_guide/developer-guide/extensions/)

