### PR TITLE
Fix 5646 Number inputs are not customizable in the classification style

### DIFF
--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -73,7 +73,7 @@ const getColor = (layer, name, intervals, customRamp) => {
         : customRamp
             ? head([ customRamp, ...standardColors].filter(c => c.name === name))
             : head(standardColors.filter(c => c.name === name));
-    if (chosenColors && (!isString(chosenColors.colors) || chosenColors.colors.length >= 2)) {
+    if (chosenColors && (isString(chosenColors.colors) || chosenColors.colors.length >= 2)) {
         return {
             ramp: "custom",
             colors: chroma.scale(chosenColors.colors).colors(intervals).join(',')

--- a/web/client/api/StyleEditor.js
+++ b/web/client/api/StyleEditor.js
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import isEqual from 'lodash/isEqual';
+
+import {
+    getStyleMetadataService,
+    readClassification,
+    readRasterClassification,
+    getColor
+} from './SLDService';
+
+import axios from '../libs/ajax';
+
+/**
+ * Update rule in rules array
+ * @param {string} ruleId id of rule to update
+ * @param {array} rules array of rules
+ * @param {function} setRule must return the new rule, eg; (rule) => ({ ...rule, ...newValues })
+ * @returns {array} return new rules with updated property
+ */
+function updateRules(ruleId, rules, setRule = (rl) => rl) {
+    return rules.map((rule) => {
+        if (rule.ruleId === ruleId) {
+            return setRule(rule);
+        }
+        return rule;
+    });
+}
+
+/**
+ * API for GeoServer StyleEditor
+ *
+ * Can be used to implement @see {@link api/plugins#plugins.StyleEditor}
+ *
+ * @memberof API
+ * @name StyleEditor
+ */
+
+/**
+ * Update rules of a style for a vector layer using external SLD services
+ * @memberof API.StyleEditor
+ * @method classificationVector
+ * @param {object} values new values to update
+ * @param {object} properties current properties of the rule that needs update
+ * @param {array} rules rules of a style object
+ * @param {object} layer layer configuration object
+ * @returns {promise} return new rules with updated property and classification
+ */
+export function classificationVector({
+    values,
+    properties,
+    rules,
+    layer
+}) {
+
+    const paramsKeys = [
+        'intervals',
+        'method',
+        'reverse',
+        'attribute',
+        'ramp'
+    ];
+
+    const params = { ...properties, ...values };
+    const { ruleId } = properties;
+
+    // if ramp changes and method is custom interval
+    // we should update the color values without a new request
+    if (values.ramp !== undefined
+        && values.ramp !== properties.ramp
+        && params?.method === 'customInterval'
+        && !values.classification) {
+        const { colors: colorsString } = getColor(undefined, values.ramp, params.intervals);
+        const colors = colorsString.split(',');
+        return new Promise((resolve) =>
+            resolve(
+                updateRules(ruleId, rules, (rule) => ({
+                    ...rule,
+                    ...params,
+                    classification: params.classification.map((entry, idx) => ({
+                        ...entry,
+                        color: colors[idx]
+                    })),
+                    errorId: undefined
+                }))
+            )
+        );
+    }
+
+    const previousParams = paramsKeys.reduce((acc, key) => ({ ...acc, [key]: properties[key] }), {});
+    const currentParams = paramsKeys.reduce((acc, key) => ({ ...acc, [key]: params[key] }), {});
+    const validParameters = !paramsKeys.find(key => params[key] === undefined);
+    const needsRequest = validParameters && !isEqual(previousParams, currentParams)
+        // not request if the entries are updated manually
+        && values?.ramp !== 'custom'
+        && params?.method !== 'customInterval';
+
+    if (needsRequest) {
+        const customRamp = params.ramp === 'custom' && params.classification.length > 0
+            && {
+                name: 'custom',
+                colors: params.classification.map((entry) => entry.color)
+            };
+        const rampParams = getColor(undefined, params.ramp, params.intervals, customRamp);
+        return axios.get(getStyleMetadataService(layer, {
+            intervals: params.intervals,
+            method: params.method,
+            attribute: params.attribute,
+            reverse: params.reverse,
+            ...rampParams
+        }))
+            .then(({ data }) => {
+                return updateRules(ruleId, rules, (rule) => ({
+                    ...rule,
+                    ...values,
+                    classification: readClassification(data),
+                    errorId: undefined
+                }));
+            })
+            .catch(() => {
+                return updateRules(ruleId, rules, (rule) => ({
+                    ...rule,
+                    ...values,
+                    errorId: 'styleeditor.classificationError'
+                }));
+            });
+    }
+
+    return new Promise((resolve) =>
+        resolve(
+            updateRules(ruleId, rules, (rule) => ({
+                ...rule,
+                ...values,
+                errorId: undefined
+            }))
+        )
+    );
+}
+/**
+ * Update rules of a style for a raster layer using external SLD services
+ * @memberof API.StyleEditor
+ * @method classificationRaster
+ * @param {object} values new values to update
+ * @param {object} properties current properties of the rule that needs update
+ * @param {array} rules rules of a style object
+ * @param {object} layer layer configuration object
+ * @returns {promise} return new rules with updated property and classification
+ */
+export function classificationRaster({
+    values,
+    properties,
+    rules,
+    layer
+}) {
+
+    const paramsKeys = [
+        'intervals',
+        'continuous',
+        'method',
+        'reverse',
+        'ramp'
+    ];
+
+    const params = { ...properties, ...values};
+    const { ruleId } = properties;
+
+    const previousParams = paramsKeys.reduce((acc, key) => ({ ...acc, [key]: properties[key] }), {});
+    const currentParams = paramsKeys.reduce((acc, key) => ({ ...acc, [key]: params[key] }), {});
+    const validParameters = !paramsKeys.find(key => params[key] === undefined);
+    const needsRequest = validParameters && !isEqual(previousParams, currentParams);
+
+    if (needsRequest) {
+        const customRamp = params.ramp === 'custom' && params.classification.length > 0
+            && { name: 'custom', colors: params.classification.map((entry) => entry.color) };
+        const rampParams = getColor(undefined, params.ramp, params.intervals, customRamp);
+        return axios.get(getStyleMetadataService(layer, {
+            intervals: params.intervals,
+            continuous: params.continuous,
+            method: params.method,
+            reverse: params.reverse,
+            ...rampParams
+        }))
+            .then(({ data }) => {
+                return updateRules(ruleId, rules, (rule) => ({
+                    ...rule,
+                    ...values,
+                    classification: readRasterClassification(data),
+                    errorId: undefined
+                }));
+            })
+            .catch(() => {
+                return updateRules(ruleId, rules, (rule) => ({
+                    ...rule,
+                    ...values,
+                    errorId: 'styleeditor.classificationRasterError'
+                }));
+            });
+    }
+    return new Promise((resolve) =>
+        resolve(
+            updateRules(ruleId, rules, (rule) => ({
+                ...rule,
+                ...values,
+                errorId: undefined
+            }))
+        )
+    );
+}
+
+
+export default {
+    classificationVector,
+    classificationRaster
+};

--- a/web/client/api/__tests__/StyleEditor-test.js
+++ b/web/client/api/__tests__/StyleEditor-test.js
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {
+    classificationVector,
+    classificationRaster
+} from '../StyleEditor';
+import axios from '../../libs/ajax';
+import expect from 'expect';
+import MockAdapter from "axios-mock-adapter";
+
+let mockAxios;
+
+import CLASSIFY_VECTOR_RESPONSE from './classifyVectorResponse.json';
+import CLASSIFY_RASTER_RESPONSE from './classifyRaterResponse.json';
+
+describe('StyleEditor API', () => {
+    describe('classificationVector', () => {
+        beforeEach(done => {
+            mockAxios = new MockAdapter(axios);
+            setTimeout(done);
+        });
+        afterEach(done => {
+            mockAxios.restore();
+            setTimeout(done);
+        });
+        it('should send a classification request', (done) => {
+
+            mockAxios.onGet().reply(200, CLASSIFY_VECTOR_RESPONSE);
+
+            const values = {
+                attribute: 'ATTRIBUTE'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                ramp: 'spectral',
+                type: 'classificationVector'
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].classification).toEqual(
+                        [
+                            {
+                                title: ' >= 168839.0 AND <2211312.4',
+                                color: '#9E0142',
+                                type: 'Polygon',
+                                min: 168839,
+                                max: 2211312.4
+                            },
+                            {
+                                title: ' >= 2211312.4 AND <4253785.8',
+                                color: '#F98E52',
+                                type: 'Polygon',
+                                min: 2211312.4,
+                                max: 4253785.8
+                            },
+                            {
+                                title: ' >= 4253785.8 AND <6296259.2',
+                                color: '#FFFFBF',
+                                type: 'Polygon',
+                                min: 4253785.8,
+                                max: 6296259.2
+                            },
+                            {
+                                title: ' >= 6296259.2 AND <8338732.6',
+                                color: '#89D0A5',
+                                type: 'Polygon',
+                                min: 6296259.2,
+                                max: 8338732.6
+                            },
+                            {
+                                title: ' >= 8338732.6 AND <=1.0381206E7',
+                                color: '#5E4FA2',
+                                type: 'Polygon',
+                                min: 8338732.6,
+                                max: 10381206
+                            }
+                        ]
+                    );
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should update the rule and return errorId if service is not available', (done) => {
+
+            mockAxios.onGet().reply(404);
+
+            const values = {
+                attribute: 'NEW_ATTRIBUTE'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                ramp: 'spectral',
+                attribute: 'ATTRIBUTE',
+                type: 'classificationVector'
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].attribute).toBe('NEW_ATTRIBUTE');
+                    expect(newRules[0].errorId).toBe('styleeditor.classificationError');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should avoid request if parameters does not change', (done) => {
+
+            const values = {
+                color: '#FF0000'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                ramp: 'spectral',
+                attribute: 'ATTRIBUTE',
+                type: 'classificationVector'
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].color).toBe('#FF0000');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should avoid request when method is customInterval', (done) => {
+            const values = {
+                attribute: 'NEW_ATTRIBUTE'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'customInterval',
+                reverse: false,
+                ramp: 'spectral',
+                attribute: 'ATTRIBUTE',
+                type: 'classificationVector'
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].attribute).toBe('NEW_ATTRIBUTE');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should avoid request when new values contain custom ramp', (done) => {
+            const values = {
+                ramp: 'custom',
+                classification: [
+                    {
+                        title: ' >= 168839.0 AND <2211312.4',
+                        color: '#FF0000',
+                        type: 'Polygon',
+                        min: 168839,
+                        max: 2211312.4
+                    },
+                    {
+                        title: ' >= 2211312.4 AND <4253785.8',
+                        color: '#F98E52',
+                        type: 'Polygon',
+                        min: 2211312.4,
+                        max: 4253785.8
+                    }
+                ]
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 2,
+                method: 'equalInterval',
+                reverse: false,
+                ramp: 'spectral',
+                attribute: 'ATTRIBUTE',
+                type: 'classificationVector',
+                classification: [
+                    {
+                        title: ' >= 168839.0 AND <2211312.4',
+                        color: '#9E0142',
+                        type: 'Polygon',
+                        min: 168839,
+                        max: 2211312.4
+                    },
+                    {
+                        title: ' >= 2211312.4 AND <4253785.8',
+                        color: '#F98E52',
+                        type: 'Polygon',
+                        min: 2211312.4,
+                        max: 4253785.8
+                    }
+                ]
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].ramp).toBe('custom');
+                    expect(newRules[0].classification[0].color).toBe('#FF0000');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should avoid request while changing ramp with method set to customInterval', (done) => {
+            const values = {
+                ramp: 'greys'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 2,
+                method: 'customInterval',
+                reverse: false,
+                ramp: 'spectral',
+                attribute: 'ATTRIBUTE',
+                type: 'classificationVector',
+                classification: [
+                    {
+                        title: ' >= 168839.0 AND <2211312.4',
+                        color: '#9E0142',
+                        type: 'Polygon',
+                        min: 168839,
+                        max: 2211312.4
+                    },
+                    {
+                        title: ' >= 2211312.4 AND <4253785.8',
+                        color: '#F98E52',
+                        type: 'Polygon',
+                        min: 2211312.4,
+                        max: 4253785.8
+                    }
+                ]
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].ramp).toBe('greys');
+                    expect(newRules[0].classification[0].color).toBe('#ffffff');
+                    expect(newRules[0].classification[1].color).toBe('#000000');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+    });
+    describe('classificationRaster', () => {
+        beforeEach(done => {
+            mockAxios = new MockAdapter(axios);
+            setTimeout(done);
+        });
+
+        afterEach(done => {
+            mockAxios.restore();
+            setTimeout(done);
+        });
+        it('should send a classification request', (done) => {
+            mockAxios.onGet().reply(200, CLASSIFY_RASTER_RESPONSE);
+            const values = {
+                ramp: 'spectral'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                continuous: true,
+                type: 'classificationRaster'
+            };
+            const rules = [
+                {
+                    kind: 'Raster',
+                    opacity: 1,
+                    symbolizerKind: 'Raster',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationRaster({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].classification).toEqual(
+                        [
+                            {
+                                color: '#9E0142',
+                                opacity: 1,
+                                label: '0',
+                                quantity: 0
+                            },
+                            {
+                                color: '#F98E52',
+                                opacity: 1,
+                                label: '1789.75',
+                                quantity: 1789.75
+                            },
+                            {
+                                color: '#FFFFBF',
+                                opacity: 1,
+                                label: '3579.5',
+                                quantity: 3579.5
+                            },
+                            {
+                                color: '#89D0A5',
+                                opacity: 1,
+                                label: '5369.25',
+                                quantity: 5369.25
+                            },
+                            {
+                                color: '#5E4FA2',
+                                opacity: 1,
+                                label: '7159',
+                                quantity: 7159
+                            }
+                        ]
+                    );
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should update the rule and return errorId if service is not available', (done) => {
+            mockAxios.onGet().reply(404);
+            const values = {
+                ramp: 'greys'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                continuous: true,
+                ramp: 'spectral',
+                type: 'classificationRaster'
+            };
+            const rules = [
+                {
+                    kind: 'Raster',
+                    opacity: 1,
+                    symbolizerKind: 'Raster',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationRaster({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].errorId).toBe('styleeditor.classificationRasterError');
+                    expect(newRules[0].ramp).toBe('greys');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should avoid request if parameters does not change', (done) => {
+            const values = {
+                opacity: 0.5
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                continuous: true,
+                ramp: 'spectral',
+                type: 'classificationRaster'
+            };
+            const rules = [
+                {
+                    kind: 'Raster',
+                    opacity: 1,
+                    symbolizerKind: 'Raster',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            classificationRaster({
+                values,
+                properties,
+                rules,
+                layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].opacity).toBe(0.5);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+    });
+});

--- a/web/client/api/__tests__/classifyRaterResponse.json
+++ b/web/client/api/__tests__/classifyRaterResponse.json
@@ -1,0 +1,38 @@
+{
+    "Rules": {
+        "Rule": {
+            "RasterSymbolizer": {
+                "ColorMap": {
+                    "ColorMapEntry": [
+                        {
+                            "@color": "#9E0142",
+                            "@quantity": "0.0",
+                            "@label": "0"
+                        },
+                        {
+                            "@color": "#F98E52",
+                            "@quantity": "1789.75",
+                            "@label": "1789.75"
+                        },
+                        {
+                            "@color": "#FFFFBF",
+                            "@quantity": "3579.5",
+                            "@label": "3579.5"
+                        },
+                        {
+                            "@color": "#89D0A5",
+                            "@quantity": "5369.25",
+                            "@label": "5369.25"
+                        },
+                        {
+                            "@color": "#5E4FA2",
+                            "@quantity": "7159.0",
+                            "@label": "7159"
+                        }
+                    ]
+                },
+                "ContrastEnhancement": "null"
+            }
+        }
+    }
+}

--- a/web/client/api/__tests__/classifyVectorResponse.json
+++ b/web/client/api/__tests__/classifyVectorResponse.json
@@ -1,0 +1,126 @@
+{
+    "Rules": {
+        "Rule": [
+            {
+                "Title": " >= 168839.0 AND <2211312.4",
+                "Filter": {
+                    "And": {
+                        "PropertyIsGreaterThanOrEqualTo": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 168839
+                        },
+                        "PropertyIsLessThan": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 2211312.4
+                        }
+                    }
+                },
+                "PolygonSymbolizer": {
+                    "Fill": {
+                        "CssParameter": {
+                            "@name": "fill",
+                            "$": "#9E0142"
+                        }
+                    },
+                    "Stroke": "null"
+                }
+            },
+            {
+                "Title": " >= 2211312.4 AND <4253785.8",
+                "Filter": {
+                    "And": {
+                        "PropertyIsGreaterThanOrEqualTo": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 2211312.4
+                        },
+                        "PropertyIsLessThan": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 4253785.8
+                        }
+                    }
+                },
+                "PolygonSymbolizer": {
+                    "Fill": {
+                        "CssParameter": {
+                            "@name": "fill",
+                            "$": "#F98E52"
+                        }
+                    },
+                    "Stroke": "null"
+                }
+            },
+            {
+                "Title": " >= 4253785.8 AND <6296259.2",
+                "Filter": {
+                    "And": {
+                        "PropertyIsGreaterThanOrEqualTo": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 4253785.8
+                        },
+                        "PropertyIsLessThan": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 6296259.2
+                        }
+                    }
+                },
+                "PolygonSymbolizer": {
+                    "Fill": {
+                        "CssParameter": {
+                            "@name": "fill",
+                            "$": "#FFFFBF"
+                        }
+                    },
+                    "Stroke": "null"
+                }
+            },
+            {
+                "Title": " >= 6296259.2 AND <8338732.6",
+                "Filter": {
+                    "And": {
+                        "PropertyIsGreaterThanOrEqualTo": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 6296259.2
+                        },
+                        "PropertyIsLessThan": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 8338732.6
+                        }
+                    }
+                },
+                "PolygonSymbolizer": {
+                    "Fill": {
+                        "CssParameter": {
+                            "@name": "fill",
+                            "$": "#89D0A5"
+                        }
+                    },
+                    "Stroke": "null"
+                }
+            },
+            {
+                "Title": " >= 8338732.6 AND <=1.0381206E7",
+                "Filter": {
+                    "And": {
+                        "PropertyIsGreaterThanOrEqualTo": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 8338732.6
+                        },
+                        "PropertyIsLessThanOrEqualTo": {
+                            "PropertyName": "ATTRIBUTE",
+                            "Literal": 1.0381206E7
+                        }
+                    }
+                },
+                "PolygonSymbolizer": {
+                    "Fill": {
+                        "CssParameter": {
+                            "@name": "fill",
+                            "$": "#5E4FA2"
+                        }
+                    },
+                    "Stroke": "null"
+                }
+            }
+        ]
+    }
+}

--- a/web/client/components/style/ThemaClassesEditor.jsx
+++ b/web/client/components/style/ThemaClassesEditor.jsx
@@ -67,7 +67,7 @@ class ThemaClassesEditor extends React.Component {
                     color
                 }) : classItem;
             });
-            this.props.onUpdateClasses(newClassification);
+            this.props.onUpdateClasses(newClassification, 'color');
         }
     };
 
@@ -86,7 +86,7 @@ class ThemaClassesEditor extends React.Component {
                 }
                 return classItem;
             });
-            this.props.onUpdateClasses(newClassification, true);
+            this.props.onUpdateClasses(newClassification, 'interval');
         }
     };
 
@@ -105,7 +105,7 @@ class ThemaClassesEditor extends React.Component {
                 }
                 return classItem;
             });
-            this.props.onUpdateClasses(newClassification);
+            this.props.onUpdateClasses(newClassification, 'interval');
         }
     };
 }

--- a/web/client/components/styleeditor/ClassificationSymbolizer.jsx
+++ b/web/client/components/styleeditor/ClassificationSymbolizer.jsx
@@ -17,7 +17,7 @@ function ClassificationSymbolizer({
     params,
     kind,
     symbolizerKind,
-    classificationType = 'classification',
+    classificationType = 'classificationVector',
     attributes = [],
     onUpdate,
     onReplace,
@@ -95,7 +95,8 @@ function ClassificationSymbolizer({
                     attributes,
                     methods,
                     getColors: handleColors,
-                    bands
+                    bands,
+                    method
                 }}
                 params={mergedParams}
                 onChange={(values) => onUpdate({

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -216,7 +216,7 @@ export const fields = {
 
         useEffect(() => {
             setNewOptions(initOptions(options));
-        }, [options.length]);
+        }, [options?.length]);
 
         const SelectInput = creatable
             ? ReactSelectCreatable

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { FormGroup, FormControl as FormControlRB  } from 'react-bootstrap';
 import isObject from 'lodash/isObject';
 import omit from 'lodash/omit';
@@ -81,20 +81,31 @@ export const fields = {
             </PropertyField>
         );
     },
-    slider: ({ label, value, config = {}, onChange = () => {} }) => (
-        <PropertyField label={label}>
-            <div
-                className="mapstore-slider with-tooltip"
-                onClick={(e) => { e.stopPropagation(); }}>
-                <Slider
-                    start={[value]}
-                    tooltips={[true]}
-                    format={config.format}
-                    range={config.range || { min: 0, max: 10 }}
-                    onChange={(changedValue) => onChange(changedValue)}/>
-            </div>
-        </PropertyField>
-    ),
+    slider: ({
+        label,
+        value,
+        disabled,
+        config = {},
+        onChange = () => {}
+    }) => {
+        return (
+            <PropertyField
+                label={label}
+                disabled={disabled}>
+                <div
+                    className="mapstore-slider with-tooltip"
+                    onClick={(e) => { e.stopPropagation(); }}>
+                    <Slider
+                        start={[value]}
+                        disabled={disabled}
+                        tooltips={[true]}
+                        format={config.format}
+                        range={config.range || { min: 0, max: 10 }}
+                        onChange={(changedValue) => onChange(changedValue)}/>
+                </div>
+            </PropertyField>
+        );
+    },
     input: ({ label, value, config = {}, onChange = () => {} }) => {
         return (
             <PropertyField
@@ -109,9 +120,16 @@ export const fields = {
             </PropertyField>
         );
     },
-    toolbar: ({ label, value, onChange = () => {}, config = {} }) => (
+    toolbar: ({
+        label,
+        value,
+        onChange = () => {},
+        config = {},
+        disabled
+    }) => (
         <PropertyField
-            label={label}>
+            label={label}
+            disabled={disabled}>
             <Toolbar
                 btnDefaultProps={{
                     className: 'no-border',
@@ -121,6 +139,7 @@ export const fields = {
                     .map(({ glyph, label: optionLabel, labelId: optionLabelId, tooltipId, value: optionValue }) => ({
                         glyph,
                         tooltipId,
+                        disabled,
                         text: optionLabelId ? <Message msgId={optionLabelId} /> : optionLabel,
                         active: optionValue === value ? true : false,
                         onClick: () => onChange(value === optionValue ? undefined : optionValue)
@@ -195,6 +214,10 @@ export const fields = {
 
         const [newOptions, setNewOptions] = useState(initOptions(options));
 
+        useEffect(() => {
+            setNewOptions(initOptions(options));
+        }, [options.length]);
+
         const SelectInput = creatable
             ? ReactSelectCreatable
             : ReactSelect;
@@ -261,7 +284,11 @@ export const fields = {
             <>
             <ThemaClassesEditor
                 classification={value}
-                onUpdateClasses={(classification) => onChange(classification)}
+                onUpdateClasses={(classification, type) =>
+                    onChange({
+                        classification,
+                        type
+                    })}
             />
             </>
         );
@@ -470,7 +497,7 @@ function Fields({
     return <>
         {Object.keys(params)
             .map((keyParam) => {
-                const { type, setValue, getValue, config, label, key: keyProperty } = params[keyParam] || {};
+                const { type, setValue, getValue, isDisabled, config, label, key: keyProperty } = params[keyParam] || {};
                 const key = keyProperty || keyParam;
                 const FieldComponent = fields[type];
                 const value = setValue && setValue(properties[key], state.current.properties);
@@ -479,6 +506,7 @@ function Fields({
                     key={key}
                     label={label || key}
                     config={config}
+                    disabled={isDisabled && isDisabled(properties[key], state.current.properties)}
                     value={!isNil(value) ? value : properties[key]}
                     onChange={(values) => onChange(getValue && getValue(values, state.current.properties) || values)}/>;
             })}

--- a/web/client/components/styleeditor/PropertyField.jsx
+++ b/web/client/components/styleeditor/PropertyField.jsx
@@ -9,17 +9,18 @@
 import React from 'react';
 import Message from '../I18N/Message';
 
-function PropertyField({ children, label, tools, divider, invalid }) {
+function PropertyField({ children, label, tools, divider, invalid, disabled }) {
 
     if (divider) {
         return <div className="ms-symbolizer-field-divider"></div>;
     }
     const validationClassName = invalid ? ' ms-symbolizer-value-invalid' : '';
+    const disabledClassName = disabled ? ' ms-symbolizer-value-disabled' : '';
     return (
         <div
             className="ms-symbolizer-field">
             <div className="ms-symbolizer-label"><Message msgId={label} /></div>
-            <div className={'ms-symbolizer-value' + validationClassName}>
+            <div className={'ms-symbolizer-value' + validationClassName + disabledClassName}>
                 {children}
                 <div className="ms-symbolizer-tools">
                     {tools}

--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -55,17 +55,17 @@ const historyVisualStyleReducer = undoable(reducer, {
 const DEFAULT_STYLE = {};
 
 const updateFunc = ({
-    options,
+    values,
+    properties,
     rules,
     layer,
     styleUpdateTypes = {}
 }) => {
 
     // if there is not a correspondent type simply update the changes in the selected rule
-    const updateRules = () => {
-        const { values } = options || {};
+    const defaultUpdateRules = () => {
         return rules.map((rule) => {
-            if (rule.ruleId === options.ruleId) {
+            if (rule.ruleId === properties.ruleId) {
                 return {
                     ...rule,
                     ...values,
@@ -77,10 +77,10 @@ const updateFunc = ({
     };
 
     return new Promise((resolve) => {
-        const request = options.type && styleUpdateTypes[options.type];
+        const request = properties.type && styleUpdateTypes[properties.type];
         return request
-            ? resolve(request({ options, rules, layer, updateRules }))
-            : resolve(updateRules);
+            ? resolve(request({ values, properties, rules, layer }))
+            : resolve(defaultUpdateRules());
     });
 };
 
@@ -271,10 +271,11 @@ function VisualStyleEditor({
                 getColors
             }}
             // changes that could need an asynch update
-            onUpdate={(options) => {
+            onUpdate={({ values, ...properties }) => {
                 setUpdating(true);
                 updateFunc({
-                    options,
+                    values,
+                    properties,
                     layer,
                     rules: state.current.rules,
                     styleUpdateTypes

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -290,6 +290,7 @@ const getBlocks = (/* config = {} */) => {
         Classification: {
             kind: 'Classification',
             glyph: 'list',
+            classificationType: 'classificationVector',
             hideInputLabel: true,
             hideFilter: true,
             params: [
@@ -301,7 +302,10 @@ const getBlocks = (/* config = {} */) => {
                     }),
                     reverse: property.bool({
                         key: 'reverse',
-                        label: 'styleeditor.reverse'
+                        label: 'styleeditor.reverse',
+                        isDisabled: (value, properties) =>
+                            properties?.ramp === 'custom'
+                            || properties?.method === 'customInterval'
                     }),
                     attribute: property.select({
                         key: 'attribute',
@@ -318,11 +322,22 @@ const getBlocks = (/* config = {} */) => {
                     method: property.select({
                         key: 'method',
                         label: 'styleeditor.method',
-                        getOptions: ({ methods }) => {
-                            return methods?.map((value) => ({
+                        getOptions: ({ methods, method }) => {
+                            const options = methods?.map((value) => ({
                                 labelId: 'styleeditor.' + value,
                                 value
                             }));
+                            return [
+                                ...(method === 'customInterval'
+                                    ? [
+                                        {
+                                            labelId: 'styleeditor.' + method,
+                                            value: method
+                                        }
+                                    ]
+                                    : []),
+                                ...options
+                            ];
                         }
                     }),
                     intervals: property.intervals({
@@ -381,7 +396,7 @@ const getBlocks = (/* config = {} */) => {
         Raster: {
             kind: 'Raster',
             glyph: '1-raster',
-            classificationType: 'classification-raster',
+            classificationType: 'classificationRaster',
             hideInputLabel: false,
             hideFilter: true,
             params: [{

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -326,7 +326,7 @@ const getBlocks = (/* config = {} */) => {
                             const options = methods?.map((value) => ({
                                 labelId: 'styleeditor.' + value,
                                 value
-                            }));
+                            })) || [];
                             return [
                                 ...(method === 'customInterval'
                                     ? [

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -320,7 +320,11 @@ const property = {
             };
         }
     }),
-    bool: ({ label, key = 'label' }) => ({
+    bool: ({
+        key = 'label',
+        label,
+        isDisabled
+    }) => ({
         type: 'toolbar',
         label,
         config: {
@@ -332,13 +336,19 @@ const property = {
                 value: false
             }]
         },
+        isDisabled,
         getValue: (value) => {
             return {
                 [key]: value
             };
         }
     }),
-    intervals: ({ key = 'intervals', label = 'Intervals' }) => ({
+    intervals: ({
+        key = 'intervals',
+        label,
+        isDisabled = (value, properties) =>
+            properties?.method === 'customInterval'
+    }) => ({
         type: 'slider',
         label,
         config: {
@@ -348,6 +358,7 @@ const property = {
                 to: value => Math.round(value)
             }
         },
+        isDisabled,
         setValue: (value = 2) => {
             return parseFloat(value);
         },
@@ -383,13 +394,20 @@ const property = {
             };
         }
     }),
-    colorMap: ({ label, key = '', rampKey = '' }) => ({
+    colorMap: ({ label, key = '' }) => ({
         type: 'colorMap',
         label,
-        getValue: (value = '') => {
+        getValue: (value = {}, properties) => {
+            const {
+                classification,
+                type
+            } = value;
+            const isCustomInteval = type === 'interval' || properties.method === 'customInterval';
+            const isCustomColor = type === 'color' || properties.ramp === 'custom';
             return {
-                [key]: value,
-                ...(rampKey && { [rampKey]: 'custom' })
+                [key]: classification,
+                ...(isCustomInteval && { method: 'customInterval' }),
+                ...(isCustomColor && { ramp: 'custom' })
             };
         }
     }),

--- a/web/client/plugins/styleeditor/StyleCodeEditor.jsx
+++ b/web/client/plugins/styleeditor/StyleCodeEditor.jsx
@@ -18,17 +18,11 @@ import {
 } from '../../actions/styleeditor';
 
 import {
-    getStyleMetadataService,
-    readClassification,
-    readRasterClassification,
-    getColor,
     getColors,
     methods
 } from '../../api/SLDService';
 
 import { getEditorMode } from '../../utils/StyleEditorUtils';
-
-import axios from '../../libs/ajax';
 
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -60,116 +54,17 @@ import Loader from '../../components/misc/Loader';
 
 import { Alert, Glyphicon } from 'react-bootstrap';
 import { createShallowSelector } from '../../utils/ReselectUtils';
+import {
+    classificationVector,
+    classificationRaster
+} from '../../api/StyleEditor';
 
 const styleUpdateTypes = {
-
-    'classification': ({ options, rules, layer, updateRules }) => {
-
-        const paramsKeys = [
-            'intervals',
-            'method',
-            'reverse',
-            'attribute',
-            'ramp'
-        ];
-
-        const { values, ...others } = options || {};
-        const params = { ...others, ...values};
-        const needsRequest = !paramsKeys.find(key => params[key] === undefined);
-
-        if (needsRequest) {
-            const customRamp = params.ramp === 'custom' && params.classification.length > 0
-                && { name: 'custom', colors: params.classification.map((entry) => entry.color) };
-            return axios.get(getStyleMetadataService(layer, {
-                intervals: params.intervals,
-                method: params.method,
-                attribute: params.attribute,
-                reverse: params.reverse,
-                ...getColor(undefined, params.ramp, params.intervals, customRamp)
-            }))
-                .then(({ data }) => {
-                    const newRules = rules.map((rule) => {
-                        if (rule.ruleId === options.ruleId) {
-                            return {
-                                ...rule,
-                                ...values,
-                                [options.type]: readClassification(data),
-                                errorId: undefined
-                            };
-                        }
-                        return rule;
-                    });
-                    return newRules;
-                })
-                .catch(() => {
-                    const newRules = rules.map((rule) => {
-                        if (rule.ruleId === options.ruleId) {
-                            return {
-                                ...rule,
-                                errorId: 'styleeditor.classificationError'
-                            };
-                        }
-                        return rule;
-                    });
-                    return newRules;
-                });
-        }
-
-        return updateRules();
-    },
-    'classification-raster': ({ options, rules, layer, updateRules }) => {
-
-        const paramsKeys = [
-            'intervals',
-            'continuous',
-            'method',
-            'reverse',
-            'ramp'
-        ];
-
-        const { values, ...others } = options || {};
-        const params = { ...others, ...values};
-
-        const needsRequest = !paramsKeys.find(key => params[key] === undefined);
-        if (needsRequest) {
-            const customRamp = params.ramp === 'custom' && params.classification.length > 0
-                && { name: 'custom', colors: params.classification.map((entry) => entry.color) };
-            return axios.get(getStyleMetadataService(layer, {
-                intervals: params.intervals,
-                continuous: params.continuous,
-                method: params.method,
-                reverse: params.reverse,
-                ...getColor(undefined, params.ramp, params.intervals, customRamp)
-            }))
-                .then(({ data }) => {
-                    const newRules = rules.map((rule) => {
-                        if (rule.ruleId === options.ruleId) {
-                            return {
-                                ...rule,
-                                ...values,
-                                classification: readRasterClassification(data),
-                                errorId: undefined
-                            };
-                        }
-                        return rule;
-                    });
-                    return newRules;
-                })
-                .catch(() => {
-                    const newRules = rules.map((rule) => {
-                        if (rule.ruleId === options.ruleId) {
-                            return {
-                                ...rule,
-                                errorId: 'styleeditor.classificationRasterError'
-                            };
-                        }
-                        return rule;
-                    });
-                    return newRules;
-                });
-        }
-        return updateRules();
-    }
+    'classificationVector': classificationVector,
+    'classificationRaster': classificationRaster,
+    // support previous type
+    'classification': classificationVector,
+    'classification-raster': classificationRaster
 };
 
 function getAttributes(hintProperties, geometryType) {

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -427,6 +427,9 @@ Ported to CodeMirror by Peter Kroon
         &.ms-symbolizer-value-invalid {
             outline: 1px solid @ms2-color-danger;
         }
+        &.ms-symbolizer-value-disabled {
+            opacity: 0.4;
+        }
     }
 }
 

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2064,7 +2064,8 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Classification",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+            "customInterval": "Custom Interval"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2076,7 +2076,8 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Classification",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+            "customInterval": "Custom Interval"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2065,7 +2065,8 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Clasificación",
-            "ruleRaster": "Ráster"
+            "ruleRaster": "Ráster",
+            "customInterval": "Custom Interval"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2066,7 +2066,8 @@
             "blueChannel": "Blue channel",
             "grayChannel": "Channel",
             "ruleClassification": "Classification",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+            "customInterval": "Custom Interval"
         },
         "playback": {
             "settings": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2065,7 +2065,8 @@
             "blueChannel": "Canale blue",
             "grayChannel": "Canale",
             "ruleClassification": "Classificazione",
-            "ruleRaster": "Raster"
+            "ruleRaster": "Raster",
+            "customInterval": "Custom Interval"
         },
         "playback": {
             "settings": {

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -280,6 +280,7 @@ export function parseJSONStyle(style) {
                             ['>=', rule.attribute, entry.min],
                             [lessThan, rule.attribute, entry.max]
                         ],
+                        ...(rule.scaleDenominator && { scaleDenominator: rule.scaleDenominator }),
                         symbolizers: [
                             {
                                 ...omit(rule, [
@@ -311,6 +312,7 @@ export function parseJSONStyle(style) {
                 };
                 return {
                     name: rule.name || '',
+                    ...(rule.scaleDenominator && { scaleDenominator: rule.scaleDenominator }),
                     symbolizers: [
                         {
                             ...omit(rule, [
@@ -349,12 +351,12 @@ export function formatJSONStyle(style) {
                 ...rule,
                 ruleId: uuidv1(),
                 filter: rule.filter && filterArrayToFilterObject(rule.filter),
-                symbolizers: rule.symbolizers.map((symbolizer) => {
+                symbolizers: rule.symbolizers && rule.symbolizers.map((symbolizer) => {
                     return {
                         ...symbolizer,
                         symbolizerId: uuidv1()
                     };
-                })
+                }) || []
             };
         })
     };

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -369,5 +369,81 @@ describe('StyleEditorUtils test', () => {
         expect(formattedJSONStyle.rules[0].filter.groupFields).toBeTruthy();
         expect(formattedJSONStyle.rules[0].filter.filterFields).toBeTruthy();
     });
+    it('test parseJSONStyle read scale denominator filters for rule kind Classification', () => {
+        const scaleDenominator = {
+            min: 100,
+            max: 50000
+        };
+        const style = {
+            name: 'Style',
+            rules: [ {
+                scaleDenominator,
+
+                kind: 'Classification',
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                ramp: 'spectral',
+                type: 'classificationVector',
+
+                symbolizerKind: 'Fill',
+                color: '#dddddd',
+                fillOpacity: 1,
+                outlineColor: '#777777',
+                outlineWidth: 1,
+
+                classification: [
+                    {
+                        title: ' >= 168839.0 AND <2211312.4',
+                        color: '#9E0142',
+                        type: 'Polygon',
+                        min: 168839,
+                        max: 2211312.4
+                    },
+                    {
+                        title: ' >= 2211312.4 AND <4253785.8',
+                        color: '#F98E52',
+                        type: 'Polygon',
+                        min: 2211312.4,
+                        max: 4253785.8
+                    }
+                ]
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(2);
+        expect(formattedJSONStyle.rules[0].scaleDenominator).toEqual(scaleDenominator);
+        expect(formattedJSONStyle.rules[1].scaleDenominator).toEqual(scaleDenominator);
+    });
+    it('test parseJSONStyle read scale denominator filters for rule kind Raster', () => {
+        const scaleDenominator = {
+            min: 100,
+            max: 50000
+        };
+        const style = {
+            name: 'Style',
+            rules: [ {
+                scaleDenominator,
+
+                kind: 'Raster',
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                continuous: true,
+                ramp: 'spectral',
+                type: 'classificationRaster',
+
+                opacity: 1,
+                symbolizerKind: 'Raster'
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(1);
+        expect(formattedJSONStyle.rules[0].scaleDenominator).toEqual(scaleDenominator);
+    });
 
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR updates the workflow for classification of vector styles to customize number and color ramp.
These are the update:
- externalize classifiaction functions in a new file to test them
- improve classifications avoiding unnecessary request in particular when the method is custom or the ramp is custom
- when a user change a number the method is set to custom interval
- when a user change a color is set to 
- disabled unnecessary inputs fileds:
  - if method is `customInterval` reverse order and intervals are disabled
  - if method is `custom` reverse order and intervals are disabled 
- fix scale denominator in classification rules

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5646

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Update classification request workflow and fixed some UI behaviours in Classification and Classifiaction Raster rules of visual style editor

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

It needed a GeoServer with sldservice extension to be properly test this bug