### PR TITLE
#5674. Add documentation to configure local environment with Tomcat

### DIFF
--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -121,7 +121,7 @@ devServer: {
 * You have to run npm start to run mapstore client on port 8081, that is now connected to the local test back-end
 
 ### Using local backend and setting up tomcat server
-* Download a tomcat standalone [here](https://tomcat.apache.org/download-90.cgi) and extract to a folder of your choice
+* Download a tomcat standalone [here](https://mapstore.readthedocs.io/en/latest/developer-guide/requirements/) and extract to a folder of your choice
 * To generate a war file that will be deployed on your tomcat server, go to the root of the Mapstore project that was git cloned and run `./build.sh`. This might take some time but at the end a war file named `mapstore.war` will be generated into the `web/target` folder.
 * Copy the `mapstore.war` and then head back to your tomcat folder. Look for a `webapps` folder and paste the `mapstore.war` file there.
 * For Unix systems, to start tomcat server, go to the terminal `cd` into the root of your tomcat extracted folder and run `./bin/startup.sh`

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -121,7 +121,9 @@ devServer: {
 * You have to run npm start to run mapstore client on port 8081, that is now connected to the local test back-end
 
 ### Running local backend in tomcat 
-* Download a tomcat standalone [here](https://mapstore.readthedocs.io/en/latest/developer-guide/requirements/) and extract to a folder of your choice
+If you prefer, or if you have some problems with `mvn jetty:run-war`, you can run MapStore back-end in a tomcat instance instead of using Jetty. 
+To do so, you can :
+* download a tomcat standalone [here](https://mapstore.readthedocs.io/en/latest/developer-guide/requirements/) and extract to a folder of your choice
 * To generate a war file that will be deployed on your tomcat server, go to the root of the Mapstore project that was git cloned and run `./build.sh`. This might take some time but at the end a war file named `mapstore.war` will be generated into the `web/target` folder.
 * Copy the `mapstore.war` and then head back to your tomcat folder. Look for a `webapps` folder and paste the `mapstore.war` file there.
 * To start tomcat server, go to the terminal, `cd` into the root of your tomcat extracted folder and run `./bin/startup.sh` ( unix systems) or `./bin/startup.bat` (Windows). The server will start on port `8080` and Mapstore will be running at `http://localhost:8080/mapstore`. For development purposes we're only interested in the backend that was started on the tomcat server along with Mapstore.

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -120,6 +120,35 @@ devServer: {
 
 * You have to run npm start to run mapstore client on port 8081, that is now connected to the local test back-end
 
+### Using local backend and setting up tomcat server
+* Download a tomcat standalone [here](https://tomcat.apache.org/download-90.cgi) and extract to a folder of your choice
+* To generate a war file that will be deployed on your tomcat server, go to the root of the Mapstore project that was git cloned and run `./build.sh`. This might take some time but at the end a war file named `mapstore.war` will be generated into the `web/target` folder.
+* Copy the `mapstore.war` and then head back to your tomcat folder. Look for a `webapps` folder and paste the `mapstore.war` file there.
+* For Unix systems, to start tomcat server, go to the terminal `cd` into the root of your tomcat extracted folder and run `./bin/startup.sh`
+* The server will start on port `8080` and Mapstore will be running at `http://localhost:8080/mapstore`
+* But for development purposes, we're interested in the backend that was started on the tomcat server along with Mapstore.
+* To point our development server when we eventually start it using `npm start` we need to make the following change to `build/buildConfig.js`
+
+```javascript
+devServer: {
+        proxy: {
+            '/rest/': {
+                target: "http://localhost:8080/mapstore"
+            },
+            '/proxy': {
+                target: "http://localhost:8080/mapstore",
+                secure: false
+            },
+            '/docs': { // this can be used when you run npm run doctest
+                target: "http://localhost:8081",
+                pathRewrite: { '/docs': '/mapstore/docs' }
+            }
+        }
+    },
+    // ...
+```
+* Finally, run the development server using `npm start`. The backend will now be pointed to the one tomcat is running.
+
 You can even run geostore and http-proxy separately and debug them with your own IDE. See the documentation about them in their own repositories.
 
 if you want to change the default port for mapstore back-end you have to edit `pom.xml` in the root of the project:

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -120,7 +120,7 @@ devServer: {
 
 * You have to run npm start to run mapstore client on port 8081, that is now connected to the local test back-end
 
-### Using local backend and setting up tomcat server
+### Running local backend in tomcat 
 * Download a tomcat standalone [here](https://mapstore.readthedocs.io/en/latest/developer-guide/requirements/) and extract to a folder of your choice
 * To generate a war file that will be deployed on your tomcat server, go to the root of the Mapstore project that was git cloned and run `./build.sh`. This might take some time but at the end a war file named `mapstore.war` will be generated into the `web/target` folder.
 * Copy the `mapstore.war` and then head back to your tomcat folder. Look for a `webapps` folder and paste the `mapstore.war` file there.

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -124,9 +124,7 @@ devServer: {
 * Download a tomcat standalone [here](https://mapstore.readthedocs.io/en/latest/developer-guide/requirements/) and extract to a folder of your choice
 * To generate a war file that will be deployed on your tomcat server, go to the root of the Mapstore project that was git cloned and run `./build.sh`. This might take some time but at the end a war file named `mapstore.war` will be generated into the `web/target` folder.
 * Copy the `mapstore.war` and then head back to your tomcat folder. Look for a `webapps` folder and paste the `mapstore.war` file there.
-* For Unix systems, to start tomcat server, go to the terminal `cd` into the root of your tomcat extracted folder and run `./bin/startup.sh`
-* The server will start on port `8080` and Mapstore will be running at `http://localhost:8080/mapstore`
-* But for development purposes, we're interested in the backend that was started on the tomcat server along with Mapstore.
+* To start tomcat server, go to the terminal, `cd` into the root of your tomcat extracted folder and run `./bin/startup.sh` ( unix systems) or `./bin/startup.bat` (Windows). The server will start on port `8080` and Mapstore will be running at `http://localhost:8080/mapstore`. For development purposes we're only interested in the backend that was started on the tomcat server along with Mapstore.
 * To point our development server when we eventually start it using `npm start` we need to make the following change to `build/buildConfig.js`
 
 ```javascript


### PR DESCRIPTION
## Description
Adds documentation for how to configure local environment with Tomcat

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Documentation related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
[#5674](https://github.com/geosolutions-it/MapStore2/issues/5674)

**What is the new behavior?**
Documentation now has guide for setting up local environment using Tomcat

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
