### PR TITLE
Cosmetic documentation fix: Newline required for list

### DIFF
--- a/docs/developer-guide/application-tutorial.md
+++ b/docs/developer-guide/application-tutorial.md
@@ -1,4 +1,5 @@
 Writing a new MapStore based application can be done following these steps:
+
  * create a new folder for the application, inside the MapStore directory tree (e.g. web/client/examples/myapp), and the following folder structure:
 
 ```


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other: Documentation

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Bullet list in app tutorial is broken.

**What is the new behavior?**
Bullet list in app tutorial is fixed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
