### PR TITLE
#5575 removed GeometryCollection creation for MultiPoint features

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -480,14 +480,15 @@ export default class DrawSupport extends React.Component {
                     let newMultiGeom = this.toMulti(this.createOLGeometry({type: newDrawMethod, coordinates: [coordinates]}));
                     if (features.length === 1 && !features[0].geometry) {
                         previousGeometries = [];
-                        geomCollection = new GeometryCollection([newMultiGeom]);
+                        geomCollection = newMultiGeom.clone();
                     } else {
                         previousGeometries = this.toMulti(head(drawnFeatures).getGeometry());
                         if (previousGeometries.getGeometries) {
                             let geoms = this.replaceCirclesWithPolygons(head(drawnFeatures));
                             geomCollection = new GeometryCollection([...geoms, newMultiGeom]);
                         } else {
-                            geomCollection = new GeometryCollection([previousGeometries, newMultiGeom]);
+                            geomCollection = previousGeometries.clone();
+                            geomCollection.appendPoint(newMultiGeom.getPoint(0));
                         }
                     }
                     sketchFeature.setGeometry(geomCollection);


### PR DESCRIPTION
## Description

After trying a couple of different layers to reproduce this bug, I find that,
the issue is only present with data sets that have **MultiPoint** geometry type
which is the **tasmania_cities** layer.

Data is stored & retrieved as a MultiPoint feature, but editing that feature via OpenLayers
converts geometry to a **GeometryCollection** which is the actual problem here.

With this pull request, instead of creating a GeometryCollection for MultiPoint features,
I have kept the feature geometry type as MultiPoint and all newly added/edited 
Point features are appended to that MultiPoint feature instead of a GeometryCollection

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Users are unable to persist a feature's geometry.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
A feature's geometry can be edited & saved successfully,


**Editing a geometry**
![5575-edit](https://user-images.githubusercontent.com/4329962/88309776-7808b580-cd17-11ea-831c-2bcf61e0eb4a.gif)
 
**Creating a new geometry**
![5575-create](https://user-images.githubusercontent.com/4329962/88309848-98387480-cd17-11ea-8cd3-99810a5ed5a6.gif)



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
