### PR TITLE
Mobile - Dashboard display problem(#4385)

### DIFF
--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -279,6 +279,7 @@ class QueryPanel extends React.Component {
                 open={this.props.querypanelEnabled}
                 sidebar={this.renderQueryPanel()}
                 sidebarClassName="query-form-panel-container"
+                touch={false}
                 styles={{
                     sidebar: {
                         ...this.props.layout,


### PR DESCRIPTION
## Description
This PR disables touch on react-sidebar component that was causing a blank sidebar on the dashboard when touched and dragged from the left.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4385 

**What is the new behavior?**
Touching on the sidebar is disabled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
