### PR TITLE
Save the templates list of map-templates plugin inside map-templates configuration

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -94,6 +94,7 @@ export default class ContextCreator extends React.Component {
         editedCfg: PropTypes.string,
         isCfgValidated: PropTypes.bool,
         cfgError: PropTypes.object,
+        mapTemplates: PropTypes.array,
         parsedTemplate: PropTypes.object,
         editedTemplate: PropTypes.object,
         fileDropStatus: PropTypes.string,
@@ -308,7 +309,7 @@ export default class ContextCreator extends React.Component {
                             showDescriptionTooltip={this.props.showPluginDescriptionTooltip}
                             descriptionTooltipDelay={this.props.pluginDescriptionTooltipDelay}
                             showDialog={this.props.showDialog}
-                            mapTemplates={this.props.newContext.templates}
+                            mapTemplates={this.props.mapTemplates}
                             parsedTemplate={this.props.parsedTemplate}
                             editedTemplate={this.props.editedTemplate}
                             fileDropStatus={this.props.fileDropStatus}

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -26,7 +26,7 @@ import {SAVE_CONTEXT, SAVE_TEMPLATE, LOAD_CONTEXT, LOAD_TEMPLATE, DELETE_TEMPLAT
     setWasTutorialShown, setTutorialStep} from '../actions/contextcreator';
 import {newContextSelector, resourceSelector, creationStepSelector, mapConfigSelector, mapViewerLoadedSelector, contextNameCheckedSelector,
     editedPluginSelector, editedCfgSelector, validationStatusSelector, parsedCfgSelector, cfgErrorSelector,
-    pluginsSelector, initialEnabledPluginsSelector, editedTemplateSelector, tutorialsSelector,
+    pluginsSelector, initialEnabledPluginsSelector, templatesSelector, editedTemplateSelector, tutorialsSelector,
     wasTutorialShownSelector} from '../selectors/contextcreator';
 import {CONTEXTS_LIST_LOADED} from '../actions/contextmanager';
 import {wrapStartStop} from '../observables/epics';
@@ -82,7 +82,17 @@ export const saveContextResource = (action$, store) => action$
         const plugins = pluginsSelector(state);
         const context = newContextSelector(state);
         const resource = resourceSelector(state);
-        const pluginsArray = flattenPluginTree(plugins).filter(plugin => plugin.enabled);
+        const templates = templatesSelector(state);
+        const pluginsArray = flattenPluginTree(plugins).filter(plugin => plugin.enabled).map(plugin => plugin.name === 'MapTemplates' ? ({
+            ...plugin,
+            pluginConfig: {
+                ...plugin.pluginConfig,
+                cfg: {
+                    ...(plugin.pluginConfig.cfg || {}),
+                    allowedTemplates: templates.filter(template => template.enabled).map(template => pick(template, 'id'))
+                }
+            }
+        }) : plugin);
         const unselectablePlugins = makePlugins(pluginsArray.filter(plugin => !plugin.isUserPlugin));
         const userPlugins = makePlugins(pluginsArray.filter(plugin => plugin.isUserPlugin));
 
@@ -90,8 +100,7 @@ export const saveContextResource = (action$, store) => action$
             ...context,
             mapConfig,
             plugins: {desktop: unselectablePlugins},
-            userPlugins,
-            templates: get(context, 'templates', []).filter(template => template.enabled).map(template => pick(template, 'id'))
+            userPlugins
         };
         const newResource = resource && resource.id ? {
             ...omit(resource, 'name', 'description'),

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -13,7 +13,7 @@ import ConfigUtils from '../utils/ConfigUtils';
 import {createPlugin} from '../utils/PluginsUtils';
 import {newContextSelector, resourceSelector, creationStepSelector, reloadConfirmSelector, showDialogSelector, isLoadingSelector,
     loadFlagsSelector, isValidContextNameSelector, contextNameCheckedSelector, pluginsSelector, editedPluginSelector, editedCfgSelector,
-    validationStatusSelector, cfgErrorSelector, parsedTemplateSelector, fileDropStatusSelector, editedTemplateSelector,
+    validationStatusSelector, cfgErrorSelector, templatesSelector, parsedTemplateSelector, fileDropStatusSelector, editedTemplateSelector,
     availablePluginsFilterTextSelector, availableTemplatesFilterTextSelector, enabledPluginsFilterTextSelector,
     enabledTemplatesFilterTextSelector, showBackToPageConfirmationSelector, tutorialStepSelector} from '../selectors/contextcreator';
 import {mapTypeSelector} from '../selectors/maptype';
@@ -40,6 +40,7 @@ export const contextCreatorSelector = createStructuredSelector({
     editedCfg: editedCfgSelector,
     isCfgValidated: validationStatusSelector,
     cfgError: cfgErrorSelector,
+    mapTemplates: templatesSelector,
     parsedTemplate: parsedTemplateSelector,
     editedTemplate: editedTemplateSelector,
     fileDropStatus: fileDropStatusSelector,

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -29,6 +29,7 @@ export const cfgErrorSelector = state => state.contextcreator && state.contextcr
 export const validationStatusSelector = state => get(state, 'contextcreator.validationStatus', true);
 export const parsedTemplateSelector = state => state.contextcreator && state.contextcreator.parsedTemplate;
 export const fileDropStatusSelector = state => state.contextcreator && state.contextcreator.fileDropStatus;
+export const templatesSelector = state => state.contextcreator?.templates;
 export const editedTemplateSelector = state => state.contextcreator && state.contextcreator.editedTemplate;
 export const filterTextSelector = state => state.contextcreator && state.contextcreator.filterText;
 export const availablePluginsFilterTextSelector = createSelector(filterTextSelector, filterText => get(filterText, 'availablePlugins'));

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -128,7 +128,7 @@
         }
 
         & > .modal-body {
-            flex: 1;
+            flex: 1 1 auto;
             padding: 0;
             display: flex;
             height: inherit;


### PR DESCRIPTION
## Description
Templates are saved inside MapTemplates plugin configuration.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5709 

**What is the current behavior?**
Templates are saved in the context root.

**What is the new behavior?**
Description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No