### PR TITLE
Availability to define a filter for a layer

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -202,7 +202,8 @@ export default class ContextCreator extends React.Component {
             "MapExport",
             "Undo",
             "Redo",
-            "Expander"
+            "Expander",
+            "FilterLayer"
         ],
         ignoreViewerPlugins: false,
         allAvailablePlugins: [],


### PR DESCRIPTION
## Description
Adds FilterLayer plugin to default viewerPlugins in ContextCreator.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

## Issue
#5721 
[mapstore2-georchestra/#249](https://github.com/georchestra/mapstore2-georchestra/issues/249)

**What is the current behavior?**
You cannot add filters to layers in context.

**What is the new behavior?**
You can add filters to layers in context.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No