### PR TITLE
#5571. fix removing media content on restoration

### DIFF
--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -958,6 +958,57 @@ describe('Geostory Epics', () => {
             }
         });
     });
+    it('test removes mediaType when resousrce is empty', (done) => {
+        const NUM_ACTIONS = 3;
+        testEpic(addTimeoutEpic(editMediaForBackgroundEpic), NUM_ACTIONS, [
+            editMedia({path: `sections[{"id": "section_id"}].contents[{"id": "content_id"}]`, owner: "geostore"}),
+            chooseMedia(undefined)
+        ],  (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map(a => {
+                switch (a.type) {
+                case SHOW:
+                    expect(a.owner).toEqual("geostore");
+                    break;
+                case SELECT_ITEM:
+                    expect(a.id).toEqual("resource_id");
+                    break;
+                case REMOVE:
+                    expect(a.path).toEqual(`sections[{"id": "section_id"}].contents[{"id": "content_id"}]`);
+                    break;
+                default: expect(true).toBe(false);
+                    break;
+                }
+            });
+            done();
+        }, {
+            geostory: {
+                currentStory: {
+                    resources: [{
+                        id: "resourceId",
+                        type: "image",
+                        data: {
+                            id: "resource_id"
+                        }
+                    }],
+                    sections: [{
+                        id: "section_id",
+                        contents: [{
+                            id: "content_id",
+                            resourceId: "resource_id",
+                            type: "image"
+                        }]
+                    }]
+                }
+            },
+            mediaEditor: {
+                settings: {
+                    mediaType: "image",
+                    sourceId: "geostory"
+                }
+            }
+        });
+    });
     it('test restore background to the empty value when resource is empty', (done) => {
         const NUM_ACTIONS = 3;
         testEpic(addTimeoutEpic(editMediaForBackgroundEpic), NUM_ACTIONS, [
@@ -973,10 +1024,8 @@ describe('Geostory Epics', () => {
                 case SELECT_ITEM:
                     expect(a.id).toEqual("resourceId");
                     break;
-                case UPDATE:
-                    expect(a.mode).toEqual("replace");
+                case REMOVE:
                     expect(a.path).toEqual(`sections[{"id": "section_id"}].contents[{"id": "content_id"}].background`);
-                    expect(a.element).toEqual({resourceId: "", type: null});
                     break;
                 default: expect(true).toBe(false);
                     break;

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -116,10 +116,7 @@ const updateMediaSection = (store, path) => action$ =>
             if (resourceAlreadyPresent) {
                 resourceId = resourceAlreadyPresent.id;
             } else if (isEmpty(resource)) {
-                const emptyMedia = mediaType === MediaTypes.MAP
-                ? {resourceId: '', type: null, map: undefined}
-                : {resourceId: '', type: null};
-                actions = [...actions, update(`${path}`, emptyMedia ), hide()];
+                actions = [...actions, remove(`${path}`), hide()];
             }  else {
             // if the resource is new, add it to the story resources list
                 resourceId = uuid();


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5571 [comment(5571)](https://github.com/geosolutions-it/MapStore2/issues/5571#issuecomment-667182652)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
now removes mediacontent on restoration from media editor
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
