### PR TITLE
Sync to map button state not retained when toggling editing on / off inside the featuregrid (#5657)

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -172,7 +172,7 @@ module.exports = ({
             tooltipId="featuregrid.toolbar.syncOnMap"
             disabled={disableToolbar}
             active={isSyncActive}
-            visible={mode === "VIEW" && showSyncOnMapButton}
+            visible={showSyncOnMapButton}
             onClick={events.sync}
             glyph="map-filter"
             renderPopover={syncPopover.showPopoverSync}

--- a/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
+++ b/web/client/components/data/featuregrid/toolbars/__tests__/Toolbar-test.jsx
@@ -308,25 +308,28 @@ describe('Featuregrid toolbar component', () => {
         ReactDOM.render(<Toolbar mode="EDIT" selectedCount={0} hasSupportedGeometry={false} />, document.getElementById("container"));
         const el = document.getElementsByClassName("featuregrid-toolbar")[0];
         expect(el).toExist();
-        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(1);
+        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(2);
         expect(isVisibleButton(document.getElementById("fg-add-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-back-view"))).toBe(true);
+        expect(isVisibleButton(document.getElementById("fg-grid-map-filter"))).toBe(true);
 
         ReactDOM.render(<Toolbar mode="EDIT" selectedCount={1} hasSupportedGeometry={false} />, document.getElementById("container"));
-        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(2);
+        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(3);
         expect(isVisibleButton(document.getElementById("fg-add-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-draw-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-delete-geometry"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-remove-features"))).toBe(true);
         expect(isVisibleButton(document.getElementById("fg-back-view"))).toBe(true);
+        expect(isVisibleButton(document.getElementById("fg-grid-map-filter"))).toBe(true);
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
 
         ReactDOM.render(<Toolbar mode="EDIT" selectedCount={1} hasSupportedGeometry={false} hasChanges/>, document.getElementById("container"));
-        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(2);
+        expect(filter(document.getElementsByClassName("square-button"), function(b) { return isVisibleButton(b); }).length).toBe(3);
         expect(isVisibleButton(document.getElementById("fg-draw-feature"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-delete-geometry"))).toBe(false);
         expect(isVisibleButton(document.getElementById("fg-save-feature"))).toBe(true);
         expect(isVisibleButton(document.getElementById("fg-cancel-editing"))).toBe(true);
+        expect(isVisibleButton(document.getElementById("fg-grid-map-filter"))).toBe(true);
     });
 
     it('check zoom-all button if all features has no geom', () => {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -20,7 +20,7 @@ const {changeDrawingStatus, GEOMETRY_CHANGED, drawSupportReset} = require('../ac
 const requestBuilder = require('../utils/ogc/WFST/RequestBuilder');
 const {findGeometryProperty} = require('../utils/ogc/WFS/base');
 const { FEATURE_INFO_CLICK, HIDE_MAPINFO_MARKER} = require('../actions/mapInfo');
-const {query, QUERY, QUERY_CREATE, QUERY_RESULT, LAYER_SELECTED_FOR_SEARCH, FEATURE_TYPE_LOADED, UPDATE_QUERY, featureTypeSelected, createQuery, updateQuery, TOGGLE_SYNC_WMS, QUERY_ERROR, FEATURE_LOADING, toggleSyncWms} = require('../actions/wfsquery');
+const {query, QUERY, QUERY_CREATE, QUERY_RESULT, LAYER_SELECTED_FOR_SEARCH, FEATURE_TYPE_LOADED, UPDATE_QUERY, featureTypeSelected, createQuery, updateQuery, TOGGLE_SYNC_WMS, QUERY_ERROR, FEATURE_LOADING} = require('../actions/wfsquery');
 const {reset, QUERY_FORM_SEARCH, loadFilter} = require('../actions/queryform');
 const {zoomToExtent, CLICK_ON_MAP} = require('../actions/map');
 const {projectionSelector} = require('../selectors/map');
@@ -326,13 +326,6 @@ module.exports = {
 
                 return selectFeatures(feature && geometryFilter && geometryFilter.value ? [feature] : []);
             }),
-    toggleSyncOnEdit: (action$, store) =>
-        action$.ofType(TOGGLE_MODE)
-            .filter(() => modeSelector(store.getState()) === MODES.EDIT)
-            .flatMap(() => Rx.Observable.merge(
-                Rx.Observable.of(...(isSyncWmsActive(store.getState()) ? [toggleSyncWms()] : [])),
-                action$.ofType(TOGGLE_MODE, CLOSE_FEATURE_GRID, LOCATION_CHANGE).take(1).flatMap(() => Rx.Observable.of(toggleSyncWms()))
-            )),
     activateTemporaryChangesEpic: (action$) =>
         action$.ofType(ACTIVATE_TEMPORARY_CHANGES)
             .flatMap(({activated}) => Rx.Observable.of(


### PR DESCRIPTION
## Description
This PR ensures that the sync to map button state in featuregrid is retained when toggling editing on / off

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5657 

**What is the new behavior?**
Retain sync to map button state in featuregrid after edit toggle

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
