### PR TITLE
Tooltip settings for groups cannot be stored (#4552)

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -407,7 +407,13 @@ const LayersUtils = {
                 groups = mapState.groups.reduce((g, group) => {
                     let newGroups = g;
                     if (group.title) {
-                        newGroups = LayersUtils.deepChange(newGroups, group.id, 'title', group.title);
+                        const groupMetadata = {
+                            title: group.title,
+                            description: group.description,
+                            tooltipOptions: group.tooltipOptions,
+                            tooltipPlacement: group.tooltipPlacement
+                        };
+                        newGroups = LayersUtils.deepChange(newGroups, group.id, groupMetadata);
                     }
                     newGroups = LayersUtils.deepChange(newGroups, group.id, 'expanded', group.expanded);
                     return newGroups;

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -314,7 +314,14 @@ function transformExtent(projection, center, width, height) {
 }
 
 const groupSaveFormatted = (node) => {
-    return {id: node.id, title: node.title, expanded: node.expanded};
+    return {
+        id: node.id,
+        title: node.title,
+        description: node.description,
+        tooltipOptions: node.tooltipOptions,
+        tooltipPlacement: node.tooltipPlacement,
+        expanded: node.expanded
+    };
 };
 
 

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -71,13 +71,42 @@ describe('LayersUtils', () => {
     });
 
     it('splits layers and groups groups additional data (expanded and title)', () => {
-        const groups = [{id: 'custom.nested001', expanded: true}, {id: 'custom.nested001.nested002', expanded: false}, {id: 'Default', expanded: false}, {id: 'custom', expanded: true, title: {'default': 'Default', 'en-US': 'new'}}];
-        const layers = [{id: 'layer001', group: 'Default'}, {id: 'layer002', group: 'Default'}, {id: 'layer003', group: 'custom.nested001'}, {id: 'layer004', group: 'custom.nested001.nested002'}];
+        const groups = [
+            {id: 'custom.nested001', expanded: true},
+            {id: 'custom.nested001.nested002', expanded: false},
+            {id: 'Default', expanded: false},
+            {id: 'custom', expanded: true, title: {'default': 'Default', 'en-US': 'new'}},
+            {id: 'test', expanded: true, title: "Test-group", description: "description", tooltipOptions: "both", tooltipPlacement: 'right'}
+        ];
+        const layers = [
+            {id: 'layer001', group: 'Default'},
+            {id: 'layer002', group: 'Default'},
+            {id: 'layer003', group: 'custom.nested001'},
+            {id: 'layer004', group: 'custom.nested001.nested002'},
+            {id: 'layer005', group: 'test'}
+        ];
 
         const state = LayersUtils.splitMapAndLayers({groups, layers});
 
         expect(state.layers.groups).toEqual([
-            {expanded: true, id: 'custom', name: 'custom', title: {'default': 'Default', 'en-US': 'new'},
+            {
+                expanded: true,
+                id: 'test',
+                name: 'test',
+                title: 'Test-group',
+                description: 'description',
+                tooltipOptions: 'both',
+                tooltipPlacement: 'right',
+                nodes: ['layer005']
+            },
+            {
+                expanded: true,
+                id: 'custom',
+                name: 'custom',
+                title: {'default': 'Default', 'en-US': 'new'},
+                description: undefined,
+                tooltipOptions: undefined,
+                tooltipPlacement: undefined,
                 nodes: [
                     {expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001',
                         nodes: [

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -233,7 +233,14 @@ describe('Test the MapUtils', () => {
 
             const groups = [
                 {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                {
+                    expanded: false,
+                    id: 'custom',
+                    name: 'custom',
+                    title: 'custom',
+                    description: 'custom-description',
+                    tooltipOptions: 'both',
+                    tooltipPlacement: 'right',
                     nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
                     ]}
             ];
@@ -256,15 +263,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: 'custom-description',
+                        tooltipOptions: 'both',
+                        tooltipPlacement: 'right'
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -600,15 +616,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1013,15 +1038,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1300,15 +1334,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1632,12 +1675,27 @@ describe('Test the MapUtils', () => {
                         tooltipPlacement: undefined, legendOptions: undefined,
                         params: {} } ],
                     groups: [ {
-                        id: 'Default', title: 'Default', expanded: true
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
-                        id: 'custom', title: 'custom', expanded: false
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
-                        id: 'custom.nested001', title: 'nested001', expanded: true
-                    } ],
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
+                    }],
                     text_search_config: '', bookmark_search_config: {} }
             });
         });
@@ -1703,15 +1761,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1850,15 +1917,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -2037,15 +2113,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},


### PR DESCRIPTION
## Description
This PR makes it possible to persist tooltip settings for when a map is exported before saving and when it's saved.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... user feedback

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4552 

**What is the new behavior?**
- When tooltip settings are added to a group and map exported, the exported map will have those settings
- When tooltip settings are added and map saved, the saved map will have those settings even after a refresh

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
