### PR TITLE
Backport 2020 02 xx - #4552: Persist tooltip settings for groups in TOC

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -407,7 +407,13 @@ const LayersUtils = {
                 groups = mapState.groups.reduce((g, group) => {
                     let newGroups = g;
                     if (group.title) {
-                        newGroups = LayersUtils.deepChange(newGroups, group.id, 'title', group.title);
+                        const groupMetadata = {
+                            title: group.title,
+                            description: group.description,
+                            tooltipOptions: group.tooltipOptions,
+                            tooltipPlacement: group.tooltipPlacement
+                        };
+                        newGroups = LayersUtils.deepChange(newGroups, group.id, groupMetadata);
                     }
                     newGroups = LayersUtils.deepChange(newGroups, group.id, 'expanded', group.expanded);
                     return newGroups;

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -314,7 +314,14 @@ function transformExtent(projection, center, width, height) {
 }
 
 const groupSaveFormatted = (node) => {
-    return {id: node.id, title: node.title, expanded: node.expanded};
+    return {
+        id: node.id,
+        title: node.title,
+        description: node.description,
+        tooltipOptions: node.tooltipOptions,
+        tooltipPlacement: node.tooltipPlacement,
+        expanded: node.expanded
+    };
 };
 
 

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -71,13 +71,42 @@ describe('LayersUtils', () => {
     });
 
     it('splits layers and groups groups additional data (expanded and title)', () => {
-        const groups = [{id: 'custom.nested001', expanded: true}, {id: 'custom.nested001.nested002', expanded: false}, {id: 'Default', expanded: false}, {id: 'custom', expanded: true, title: {'default': 'Default', 'en-US': 'new'}}];
-        const layers = [{id: 'layer001', group: 'Default'}, {id: 'layer002', group: 'Default'}, {id: 'layer003', group: 'custom.nested001'}, {id: 'layer004', group: 'custom.nested001.nested002'}];
+        const groups = [
+            {id: 'custom.nested001', expanded: true},
+            {id: 'custom.nested001.nested002', expanded: false},
+            {id: 'Default', expanded: false},
+            {id: 'custom', expanded: true, title: {'default': 'Default', 'en-US': 'new'}},
+            {id: 'test', expanded: true, title: "Test-group", description: "description", tooltipOptions: "both", tooltipPlacement: 'right'}
+        ];
+        const layers = [
+            {id: 'layer001', group: 'Default'},
+            {id: 'layer002', group: 'Default'},
+            {id: 'layer003', group: 'custom.nested001'},
+            {id: 'layer004', group: 'custom.nested001.nested002'},
+            {id: 'layer005', group: 'test'}
+        ];
 
         const state = LayersUtils.splitMapAndLayers({groups, layers});
 
         expect(state.layers.groups).toEqual([
-            {expanded: true, id: 'custom', name: 'custom', title: {'default': 'Default', 'en-US': 'new'},
+            {
+                expanded: true,
+                id: 'test',
+                name: 'test',
+                title: 'Test-group',
+                description: 'description',
+                tooltipOptions: 'both',
+                tooltipPlacement: 'right',
+                nodes: ['layer005']
+            },
+            {
+                expanded: true,
+                id: 'custom',
+                name: 'custom',
+                title: {'default': 'Default', 'en-US': 'new'},
+                description: undefined,
+                tooltipOptions: undefined,
+                tooltipPlacement: undefined,
                 nodes: [
                     {expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001',
                         nodes: [

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -232,7 +232,14 @@ describe('Test the MapUtils', () => {
 
             const groups = [
                 {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
-                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                {
+                    expanded: false,
+                    id: 'custom',
+                    name: 'custom',
+                    title: 'custom',
+                    description: 'custom-description',
+                    tooltipOptions: 'both',
+                    tooltipPlacement: 'right',
                     nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
                     ]}
             ];
@@ -255,15 +262,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: 'custom-description',
+                        tooltipOptions: 'both',
+                        tooltipPlacement: 'right'
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -598,15 +614,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1011,15 +1036,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1297,15 +1331,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1628,12 +1671,27 @@ describe('Test the MapUtils', () => {
                         tooltipPlacement: undefined, legendOptions: undefined,
                         params: {} } ],
                     groups: [ {
-                        id: 'Default', title: 'Default', expanded: true
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
-                        id: 'custom', title: 'custom', expanded: false
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
-                        id: 'custom.nested001', title: 'nested001', expanded: true
-                    } ],
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
+                    }],
                     text_search_config: '' }
             });
         });
@@ -1698,15 +1756,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1843,15 +1910,24 @@ describe('Test the MapUtils', () => {
                     groups: [{
                         id: 'Default',
                         title: 'Default',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom',
                         title: 'custom',
-                        expanded: false
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }, {
                         id: 'custom.nested001',
                         title: 'nested001',
-                        expanded: true
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
                     }],
                     layers: [{
                         allowedSRS: {},
@@ -1924,6 +2000,329 @@ describe('Test the MapUtils', () => {
                     infoFormat: "text/html",
                     showEmptyMessageGFI: false
                 },
+                version: 2
+            });
+        });
+
+        it('save map configuration with bookmark config', () => {
+
+            const flat = [
+                {
+                    allowedSRS: {},
+                    bbox: {},
+                    dimensions: [],
+                    id: "layer001",
+                    loading: true,
+                    name: "layer001",
+                    params: {},
+                    search: {},
+                    singleTile: false,
+                    thumbURL: "THUMB_URL",
+                    title: "layer001",
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url"
+                },
+                {
+                    allowedSRS: {},
+                    bbox: {},
+                    dimensions: [],
+                    id: "layer002",
+                    loading: true,
+                    name: "layer002",
+                    params: {},
+                    search: {},
+                    singleTile: false,
+                    title: "layer002",
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url"
+                },
+                {
+                    allowedSRS: {},
+                    bbox: {},
+                    dimensions: [],
+                    id: "layer003",
+                    loading: true,
+                    name: "layer003",
+                    params: {},
+                    search: {},
+                    singleTile: false,
+                    title: "layer003",
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url"
+                },
+                {
+                    allowedSRS: {},
+                    bbox: {},
+                    dimensions: [],
+                    id: "layer004",
+                    loading: true,
+                    name: "layer004",
+                    params: {},
+                    search: {},
+                    singleTile: false,
+                    title: "layer004",
+                    type: "wms",
+                    url: "",
+                    visibility: true,
+                    catalogURL: "url",
+                    origin: [100000, 100000]
+                }
+            ];
+
+            const groups = [
+                {expanded: true, id: 'Default', name: 'Default', title: 'Default', nodes: ['layer001', 'layer002']},
+                {expanded: false, id: 'custom', name: 'custom', title: 'custom',
+                    nodes: [{expanded: true, id: 'custom.nested001', name: 'nested001', title: 'nested001', nodes: ['layer003']}
+                    ]}
+            ];
+
+            const mapConfig = {
+                center: {x: 0, y: 0, crs: 'EPSG:4326'},
+                maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                projection: 'EPSG:900913',
+                text_search_config: '',
+                units: 'm',
+                mapInfoControl: true,
+                zoom: 10
+            };
+
+            const saved = saveMapConfiguration(mapConfig, flat, groups, [], '', {
+                bookmarks: [{
+                    options: {west: -123, south: 42, east: -60, north: 53},
+                    title: 'Vancover', layerVisibilityReload: true
+                }]});
+            expect(saved).toEqual({
+                map: {
+                    center: {crs: 'EPSG:4326', x: 0, y: 0},
+                    backgrounds: [],
+                    mapInfoControl: true,
+                    groups: [{
+                        id: 'Default',
+                        title: 'Default',
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
+                    }, {
+                        id: 'custom',
+                        title: 'custom',
+                        expanded: false,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
+                    }, {
+                        id: 'custom.nested001',
+                        title: 'nested001',
+                        expanded: true,
+                        description: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined
+                    }],
+                    layers: [{
+                        allowedSRS: {},
+                        thumbURL: "THUMB_URL",
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer001",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer001",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer001",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer002",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer002",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer002",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer003",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer003",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer003",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: undefined,
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    },
+                    {
+                        allowedSRS: {},
+                        thumbURL: undefined,
+                        availableStyles: undefined,
+                        layerFilter: undefined,
+                        bbox: {},
+                        requestEncoding: undefined,
+                        capabilitiesURL: undefined,
+                        description: undefined,
+                        dimensions: [],
+                        features: undefined,
+                        queryable: undefined,
+                        featureInfo: undefined,
+                        format: undefined,
+                        group: undefined,
+                        hideLoading: false,
+                        handleClickOnLayer: false,
+                        id: "layer004",
+                        matrixIds: undefined,
+                        maxZoom: undefined,
+                        maxNativeZoom: undefined,
+                        name: "layer004",
+                        opacity: undefined,
+                        params: {},
+                        provider: undefined,
+                        search: {},
+                        singleTile: false,
+                        source: undefined,
+                        style: undefined,
+                        styleName: undefined,
+                        styles: undefined,
+                        tileMatrixSet: undefined,
+                        tiled: undefined,
+                        title: "layer004",
+                        transparent: undefined,
+                        type: "wms",
+                        url: "",
+                        visibility: true,
+                        catalogURL: "url",
+                        hidden: false,
+                        useForElevation: false,
+                        origin: [100000, 100000],
+                        thematic: undefined,
+                        tooltipOptions: undefined,
+                        tooltipPlacement: undefined,
+                        legendOptions: undefined
+                    }],
+                    mapOptions: {},
+                    maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
+                    projection: 'EPSG:900913',
+                    text_search_config: '',
+                    units: 'm',
+                    zoom: 10
+                },
+                bookmarks: [{
+                    options: {west: -123, south: 42, east: -60, north: 53},
+                    title: 'Vancover', layerVisibilityReload: true
+                }],
                 version: 2
             });
         });


### PR DESCRIPTION
Backport 2020 02 xx - #4552: Persist tooltip settings for groups in TOC