### PR TITLE
Fix #5750 Map Catalog remains empty

### DIFF
--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -668,7 +668,7 @@ describe('Get Map Resource By Category Epic', () => {
             expect(actions[0].value).toBe(true);
             expect(actions[0].name).toBe('loadingMaps');
             expect(actions[1].type).toBe(MAPS_LIST_LOADED);
-            expect(actions[1].maps).toEqual({success: true, totalCount: 0, results: ""});
+            expect(actions[1].maps).toEqual({success: true, totalCount: 0, results: []});
             expect(actions[1].params).toEqual(params);
             expect(actions[1].searchText).toBe('test');
             expect(actions[2].type).toBe(LOADING);

--- a/web/client/epics/__tests__/maps-test.js
+++ b/web/client/epics/__tests__/maps-test.js
@@ -656,6 +656,28 @@ describe('Get Map Resource By Category Epic', () => {
             });
         }))
     );
+    it('test getMapsResourcesByCategoryEpic with empty results string', (done) => {
+        const mock = new MockAdapter(axios);
+        mock.onGet().reply(200, {success: true, totalCount: 0, results: ""});
+        testEpic(addTimeoutEpic(getMapsResourcesByCategoryEpic), 3, getMapResourcesByCategory('MAP', 'test', {
+            baseUrl,
+            params: { start: 0, limit: 12 }
+        }), actions => {
+            expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[0].value).toBe(true);
+            expect(actions[0].name).toBe('loadingMaps');
+            expect(actions[1].type).toBe(MAPS_LIST_LOADED);
+            expect(actions[1].maps).toEqual({success: true, totalCount: 0, results: ""});
+            expect(actions[1].params).toEqual(params);
+            expect(actions[1].searchText).toBe('test');
+            expect(actions[2].type).toBe(LOADING);
+            expect(actions[2].value).toBe(false);
+            expect(actions[2].name).toBe('loadingMaps');
+            mock.restore();
+            done();
+        });
+    });
     it('test getMapsResourcesByCategoryEpic with an error', (done) => {
         const mock = new MockAdapter(axios);
         mock.onPost().reply(404);

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -295,7 +295,12 @@ const getMapsResourcesByCategoryEpic = (action$, store) =>
                     .switchMap((response) => getContextNames(response).switchMap(responseWithContext => {
                         // category is required to identify maps for detail card. It's missing from this entry point
                         return Rx.Observable.of(
-                            mapsLoaded({...responseWithContext, results: responseWithContext?.results?.map(res => ({...res, category: {name: "MAP"}}))}, opts.params, searchText)
+                            mapsLoaded({
+                                ...responseWithContext,
+                                results: isArray(responseWithContext.results) ?
+                                    responseWithContext.results?.map(res => ({...res, category: {name: "MAP"}})) :
+                                    responseWithContext.results
+                            }, opts.params, searchText)
                         );
                     }
                     ))

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -248,7 +248,7 @@ const getMapsResourcesByCategoryEpic = (action$, store) =>
             const getContextNames = ({results, ...other}) => {
                 const maps = isArray(results) ? results : (results === "" ? [] : [results]);
                 return maps.length === 0 ?
-                    Rx.Observable.of({results, ...other}) :
+                    Rx.Observable.of({results: [], ...other}) :
                     Rx.Observable.forkJoin(
                         maps.map(({context}) => context ?
                             getResource(context, {includeAttributes: false, withData: false, withPermissions: false})
@@ -297,9 +297,7 @@ const getMapsResourcesByCategoryEpic = (action$, store) =>
                         return Rx.Observable.of(
                             mapsLoaded({
                                 ...responseWithContext,
-                                results: isArray(responseWithContext.results) ?
-                                    responseWithContext.results?.map(res => ({...res, category: {name: "MAP"}})) :
-                                    responseWithContext.results
+                                results: responseWithContext.results?.map(res => ({...res, category: {name: "MAP"}}))
                             }, opts.params, searchText)
                         );
                     }


### PR DESCRIPTION
## Description
Properly account for empty results in getMapsResourcesByCategoryEpic.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#5750 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5750 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The search text is maintained.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No