### PR TITLE
Backport 2020.02.xx - #5571 Restore an empty background for Story section (#5729)

### DIFF
--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -958,6 +958,57 @@ describe('Geostory Epics', () => {
             }
         });
     });
+    it('test removes mediaType when resousrce is empty', (done) => {
+        const NUM_ACTIONS = 3;
+        testEpic(addTimeoutEpic(editMediaForBackgroundEpic), NUM_ACTIONS, [
+            editMedia({path: `sections[{"id": "section_id"}].contents[{"id": "content_id"}]`, owner: "geostore"}),
+            chooseMedia(undefined)
+        ],  (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map(a => {
+                switch (a.type) {
+                case SHOW:
+                    expect(a.owner).toEqual("geostore");
+                    break;
+                case SELECT_ITEM:
+                    expect(a.id).toEqual("resource_id");
+                    break;
+                case REMOVE:
+                    expect(a.path).toEqual(`sections[{"id": "section_id"}].contents[{"id": "content_id"}]`);
+                    break;
+                default: expect(true).toBe(false);
+                    break;
+                }
+            });
+            done();
+        }, {
+            geostory: {
+                currentStory: {
+                    resources: [{
+                        id: "resourceId",
+                        type: "image",
+                        data: {
+                            id: "resource_id"
+                        }
+                    }],
+                    sections: [{
+                        id: "section_id",
+                        contents: [{
+                            id: "content_id",
+                            resourceId: "resource_id",
+                            type: "image"
+                        }]
+                    }]
+                }
+            },
+            mediaEditor: {
+                settings: {
+                    mediaType: "image",
+                    sourceId: "geostory"
+                }
+            }
+        });
+    });
     it('test restore background to the empty value when resource is empty', (done) => {
         const NUM_ACTIONS = 3;
         testEpic(addTimeoutEpic(editMediaForBackgroundEpic), NUM_ACTIONS, [
@@ -973,10 +1024,8 @@ describe('Geostory Epics', () => {
                 case SELECT_ITEM:
                     expect(a.id).toEqual("resourceId");
                     break;
-                case UPDATE:
-                    expect(a.mode).toEqual("replace");
+                case REMOVE:
                     expect(a.path).toEqual(`sections[{"id": "section_id"}].contents[{"id": "content_id"}].background`);
-                    expect(a.element).toEqual({resourceId: "", type: null});
                     break;
                 default: expect(true).toBe(false);
                     break;

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -116,10 +116,7 @@ const updateMediaSection = (store, path) => action$ =>
             if (resourceAlreadyPresent) {
                 resourceId = resourceAlreadyPresent.id;
             } else if (isEmpty(resource)) {
-                const emptyMedia = mediaType === MediaTypes.MAP
-                ? {resourceId: '', type: null, map: undefined}
-                : {resourceId: '', type: null};
-                actions = [...actions, update(`${path}`, emptyMedia ), hide()];
+                actions = [...actions, remove(`${path}`), hide()];
             }  else {
             // if the resource is new, add it to the story resources list
                 resourceId = uuid();


### PR DESCRIPTION
Backport 2020.02.xx - #5571 Restore an empty background for Story section (#5729)