### PR TITLE
Fix #4758 Ability to save resource with thumbnail not allowed

### DIFF
--- a/web/client/components/resources/forms/Thumbnail.jsx
+++ b/web/client/components/resources/forms/Thumbnail.jsx
@@ -100,7 +100,6 @@ class Thumbnail extends React.Component {
                     // with at least one error
                     this.props.onError(errors, this.props.resource.id);
                     this.files  = files;
-                    this.props.onUpdate(null, null);
                 }}
                 onRemove={() => {
                     this.files = null;

--- a/web/client/components/resources/modals/fragments/MainForm.jsx
+++ b/web/client/components/resources/modals/fragments/MainForm.jsx
@@ -55,7 +55,7 @@ module.exports = class MainForm extends React.Component {
                     onRemove={() => onUpdateLinkedResource("thumbnail", "NODATA", "THUMBNAIL", {
                         tail: `/raw?decode=datauri&v=${uuid()}`
                     })}
-                    onUpdate={(data) => onUpdateLinkedResource("thumbnail", data, "THUMBNAIL", {
+                    onUpdate={(data) => onUpdateLinkedResource("thumbnail", data || "NODATA", "THUMBNAIL", {
                         tail: `/raw?decode=datauri&v=${uuid()}`
                     })} />
             </Col>

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -490,8 +490,9 @@ const mapSaveMapResourceEpic = (action$, store) =>
     action$.ofType(SAVE_MAP_RESOURCE)
         .exhaustMap(({resource}) => {
             // filter out invalid attributes
+            // thumbnails are handled separately
             const validAttributesNames = keys(resource.attributes)
-                .filter(attrName => resource.attributes[attrName] !== undefined && resource.attributes[attrName] !== null);
+                .filter(attrName => attrName !== 'thumbnail' && resource.attributes[attrName] !== undefined && resource.attributes[attrName] !== null);
             return Rx.Observable.forkJoin(
                 (() => {
                     // get a context information using the id in the attribute

--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -8,7 +8,7 @@
 const expect = require('expect');
 
 const geoStoreMock = require('./geoStoreMock').default;
-const {createResource, deleteResource, getResourceIdByName} = require('../geostore');
+const {createResource, deleteResource, getResourceIdByName, updateResource} = require('../geostore');
 const testAndResolve = (test = () => {}, value) => (...args) => {
     test(...args);
     return Promise.resolve(value);
@@ -131,6 +131,77 @@ describe('geostore observables for resources management', () => {
                     done(e);
 
                 });
+        });
+
+        it('updateResource linked resource is not created if no thumbnail attribute for resource and data is NODATA', done => {
+            const testResource = {
+                id: 10,
+                data: {},
+                category: "TEST",
+                metadata: {
+                    name: "RES2"
+                },
+                linkedResources: {
+                    thumbnail: {
+                        tail: '/raw?decode=datauri',
+                        data: "NODATA"
+                    }
+                }
+            };
+            const DummyAPI = {
+                getResourceAttribute: () => Promise.reject({status: 404}),
+                putResourceMetadataAndAttributes: () => Promise.resolve(10),
+                putResource: () => Promise.resolve(10),
+                createResource: ({name}) => name.search(/10-thumbnail/) !== -1 ? done(new Error('createResource for thumbnail is called!')) : Promise.resolve(11),
+                updateResourceAttribute: () => Promise.resolve(11)
+            };
+            updateResource(testResource, DummyAPI).subscribe(
+                () => done(),
+                e => done(e)
+            );
+        });
+
+        it('updateResource linked resource is created if data is valid', done => {
+            const testResource = {
+                id: 10,
+                data: {},
+                category: "TEST",
+                metadata: {
+                    name: "RES2"
+                },
+                linkedResources: {
+                    thumbnail: {
+                        tail: '/raw?decode=datauri',
+                        data: "data"
+                    }
+                }
+            };
+
+            let createResourceThumbnail = false;
+
+            const DummyAPI = {
+                getResourceAttribute: () => Promise.reject({status: 404}),
+                putResourceMetadataAndAttributes: () => Promise.resolve(10),
+                putResource: () => Promise.resolve(10),
+                createResource: ({name}) => {
+                    if (name.search(/10-thumbnail/) !== -1) {
+                        createResourceThumbnail = true;
+                    }
+                    return Promise.resolve(11);
+                },
+                updateResourceAttribute: () => Promise.resolve(11)
+            };
+            updateResource(testResource, DummyAPI).subscribe(
+                () => {
+                    try {
+                        expect(createResourceThumbnail).toBe(true);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                },
+                e => done(e)
+            );
         });
     });
 });

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -76,13 +76,14 @@ const updateOrDeleteLinkedResource = (id, attributeName, linkedResource = {}, re
 
 /**
  * Creates a resource on GeoStore and link it to the current resource. Can be used for thumbnails, details and so on
+ * If the data for the resource is "NODATA", it won't be created.
  * @param {number} id the id of the resource
  * @param {string} attributeName the name of the attribute to link
  * @param {object} linkedResource the resource object of the resource to link. This resource have a tail option that can be used to add options URL of the link
  * @param {object} API the API to use (default GeoStoreDAO)
  */
 const createLinkedResource = (id, attributeName, linkedResource, permission, API = GeoStoreDAO) =>
-    Observable.defer(() =>
+    linkedResource.data !== 'NODATA' ? Observable.defer(() =>
         API.createResource({
             name: `${id}-${attributeName}-${uuid()}`
         },
@@ -98,7 +99,7 @@ const createLinkedResource = (id, attributeName, linkedResource, permission, API
                 ...(permission ? [updateResourcePermissions(linkedResourceId, permission, API)] : [])
 
             ]).map(() => linkedResourceId)
-        );
+        ) : Observable.of(-1);
 
 /**
  * Updates a linked resource. Check if the resource already exists as attribute.
@@ -121,7 +122,7 @@ const updateLinkedResource = (id, attributeName, linkedResource, permission, API
                 : createLinkedResource(id, attributeName, linkedResource, permission, API)
         ).catch(
         /* if the attribute doesn't exists or if the linked resource update gave an error
-         * you have to create a new resource for the linked resource.
+         * you have to create a new resource for the linked resource, provided it has valid data.
          * This error can occur if:
          *  - The resource is new
          *  - The resource URL is present as attribute of the main resource but the linked resource doesn't exist anymore.
@@ -129,7 +130,9 @@ const updateLinkedResource = (id, attributeName, linkedResource, permission, API
          *  - The resource is not writable by the user. It happens when a user changes the permission of a resource and doesn't update
          *    the resource permission.
          */
-            (e) => createLinkedResource(id, attributeName, linkedResource, permission, API, e)
+            (e) => linkedResource && linkedResource.data && linkedResource.data !== 'NODATA' ?
+                createLinkedResource(id, attributeName, linkedResource, permission, API, e) :
+                Observable.of(-1)
         );
 /**
  * Updates the permission of the linkedResources that are not modified.
@@ -291,9 +294,11 @@ export const createCategory = (category, API = GeoStoreDAO) =>
  * @return an observable that emits the id of the updated resource
  */
 
-export const updateResource = ({ id, data, permission, metadata, linkedResources = {} } = {}, API = GeoStoreDAO) =>
-// update metadata
-    Observable.forkJoin([
+export const updateResource = ({ id, data, permission, metadata, linkedResources = {} } = {}, API = GeoStoreDAO) => {
+    const linkedResourcesKeys = Object.keys(linkedResources);
+
+    // update metadata
+    return Observable.forkJoin([
         // update data and permissions after data updated
         Observable.defer(
             () => API.putResourceMetadataAndAttributes(id, metadata)
@@ -304,17 +309,18 @@ export const updateResource = ({ id, data, permission, metadata, linkedResources
                     () => API.putResource(id, data)
                 )
                 : Observable.of(res))
-            .switchMap((res)=> permission ? Observable.defer(()=>updateResourcePermissions(id, permission, API)) : Observable.of(res)),
+            .switchMap((res) => permission ? Observable.defer(() => updateResourcePermissions(id, permission, API)) : Observable.of(res)),
         // update linkedResources and permissions after linkedResources updated
-        ...(
-            Object.keys(linkedResources).map(
+        (linkedResourcesKeys.length > 0 ? Observable.forkJoin(
+            ...linkedResourcesKeys.map(
                 attributeName => updateLinkedResource(id, attributeName, linkedResources[attributeName], permission, API)
-                    .switchMap((res)=>permission ?
-                        Observable.defer(()=> updateOtherLinkedResourcesPermissions(id, linkedResources, permission, API))
-                        : Observable.of(res))
             )
-        )
+        ) : Observable.of([]))
+            .switchMap(() => permission ?
+                Observable.defer(() => updateOtherLinkedResourcesPermissions(id, linkedResources, permission, API)) :
+                Observable.of(-1))
     ]).map(() => id);
+};
 
 /**
  * Deletes a resource and Its linked attributes


### PR DESCRIPTION
## Description
Resolves incorrect handling of NODATA is some cases for linked resources.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#4758 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4758 

**What is the new behavior?**
Thumbnail is always in the correct state.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No