### PR TITLE
Fix initially misaligned About modal(#5749)

### DIFF
--- a/web/client/components/buttons/css/infoButton.css
+++ b/web/client/components/buttons/css/infoButton.css
@@ -1,6 +1,6 @@
 #mapstore-about {
     position: fixed;
-    top: 0;
-    left: calc(50% - 500px);
+    top: -100px;
+    left: calc(50% - 250px);
     width: 500px;
 }


### PR DESCRIPTION
## Description
The "About" modal is draggable, but should initially be properly aligned.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5749 

**What is the new behavior?**
The "About" modal is initially centered and then the user can drag it to new positions

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
