### PR TITLE
Size of bullet points in stories (#5725)

### DIFF
--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -874,6 +874,9 @@
 
                 .ms-text-wrapper {
                     min-height: 40px;
+
+                    /* target bullet points */
+                    ul > li { font-size: @ms-story-font-size-base; }
                 }
 
                 .ms-webpage-wrapper {

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -18,6 +18,7 @@
 @ms-story-font-size-h4: floor((@ms-story-font-size-base * 1.4));
 @ms-story-font-size-h5: @ms-story-font-size-base;
 @ms-story-font-size-h6: floor((@ms-story-font-size-base * 0.85));
+@ms-story-font-size-li: floor((@ms-story-font-size-base * 0.66));
 @ms-story-font-size-caption: 11px;
 @ms-story-size-full: 100%;
 @ms-story-size-large: 85%;
@@ -874,9 +875,6 @@
 
                 .ms-text-wrapper {
                     min-height: 40px;
-
-                    /* target bullet points */
-                    ul > li { font-size: @ms-story-font-size-base; }
                 }
 
                 .ms-webpage-wrapper {
@@ -968,6 +966,9 @@
                     h5 > div,
                     h6 > div,
                     p > div { margin: 0; }
+
+                    /* Bullet point size */
+                    ul > li > div > span { font-size: @ms-story-font-size-li; }
                 }
 
                 /* padding for the first child of content body of text content */


### PR DESCRIPTION
## Description
This PR solves the issue where the size of text in bullets point is different between edit and view mode of rich text editor in stories.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5725 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The bullet point size is the same in edit and view mode
![Screen Recording 2020-08-10 at 17 24 34](https://user-images.githubusercontent.com/28563179/89794352-9bad6780-db2f-11ea-9fca-ac2fb134144b.gif)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
