### PR TITLE
Fix issue where setting hyperlinks introduces a space (#5726)

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "react-dnd-test-backend": "2.6.0",
     "react-dock": "0.2.4",
     "react-dom": "16.10.1",
-    "react-draft-wysiwyg": "1.13.2",
+    "react-draft-wysiwyg": "github:geosolutions-it/react-draft-wysiwyg#master",
     "react-draggable": "2.2.6",
     "react-dropzone": "3.13.1",
     "react-error-boundary": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "react-dnd-test-backend": "2.6.0",
     "react-dock": "0.2.4",
     "react-dom": "16.10.1",
-    "react-draft-wysiwyg": "github:geosolutions-it/react-draft-wysiwyg#master",
+    "react-draft-wysiwyg": "npm:@geosolutions/react-draft-wysiwyg@1.14.6",
     "react-draggable": "2.2.6",
     "react-dropzone": "3.13.1",
     "react-error-boundary": "1.2.5",


### PR DESCRIPTION
## Description
This PR fixes the issue where react-draft-wysiwyg introduces a space after hyperlinks are added. To solve, the library was forked in [geosolutions-it org](https://github.com/geosolutions-it/react-draft-wysiwyg) and patch applied. The reference to the library in the package.json file is changed to point to geosolutions npm.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5726 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No space after adding a hyperlink

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
