### PR TITLE
try to fix travis watch count exceed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ script:
 addons:
   firefox: latest
 before_install:
+    # Fixes an issue where the max file watch count is exceeded, triggering ENOSPC
+    - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
     - node -v
     - npm -v
 branches:


### PR DESCRIPTION
## Description
This PR should solve travis errors like [these](https://travis-ci.org/github/geosolutions-it/MapStore2/builds/717309523#L2725)
```
Error from chokidar (/home/travis/build/geosolutions-it/MapStore2/node_modules/lodash-es): Error: ENOSPC: System limit for number of file watchers reached, watch '/home/travis/build/geosolutions-it/MapStore2/node_modules/lodash-es/_Map.js'
Error from chokidar (/home/travis/build/geosolutions-it/MapStore2/node_modules/lodash-es): Error: ENOSPC: System limit for number of file watchers reached, watch '/home/travis/build/geosolutions-it/MapStore2/node_modules/lodash-es/_MapCache.js
```

Note: probably file watching in build test is not necessary.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5806

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
