### PR TITLE
#5388: Fix display of bookmark after logout

### DIFF
--- a/build/docma-config.json
+++ b/build/docma-config.json
@@ -254,6 +254,7 @@
                 "web/client/plugins/ScaleBox.jsx",
                 "web/client/plugins/ScrollTop.jsx",
                 "web/client/plugins/Search.jsx",
+                "web/client/plugins/SearchByBookmark.jsx",
                 "web/client/plugins/SearchServicesConfig.jsx",
                 "web/client/plugins/Share.jsx",
                 "web/client/plugins/StyleEditor.jsx",

--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -171,6 +171,10 @@ export default ({
             searchByBookmarkConfig = item.bookmarkConfig(onToggleControl, enabledSearchBookmarkConfig, activeTool);
         }
     }
+    // Reset activeTool when no bookmark config
+    if (isUndefined(searchByBookmarkConfig) && activeTool === "bookmarkSearch") {
+        onChangeActiveSearchTool("addressSearch");
+    }
 
     const searchConfig = {
         onClick: () => {

--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -7,19 +7,19 @@
 */
 
 import React from 'react';
-import { InputGroup, FormGroup, Glyphicon, Row } from 'react-bootstrap';
-import { isNumber, isEmpty, some, isUndefined } from 'lodash';
+import {FormGroup, Glyphicon, MenuItem} from 'react-bootstrap';
+import {isEmpty, some, isUndefined} from 'lodash';
 
-import CoordinateEntry from '../../misc/coordinateeditors/CoordinateEntry';
 import Message from '../../I18N/Message';
-import DropdownToolbarOptions from '../../misc/toolbar/DropdownToolbarOptions';
+import SearchBarMenu from './SearchBarMenu';
 
 import SearchBarBase from '../../search/SearchBarBase';
 import SearchBarInput from '../../search/SearchBarInput';
 import SearchBarToolbar from '../../search/SearchBarToolbar';
 
 import { defaultSearchWrapper } from '../../search/SearchBarUtils';
-import BookmarkSelect from "../searchbookmarkconfig/BookmarkSelect";
+import BookmarkSelect, {BookmarkOptions} from "../searchbookmarkconfig/BookmarkSelect";
+import CoordinatesSearch, {CoordinateOptions} from "../searchcoordinates/CoordinatesSearch";
 
 export default ({
     activeSearchTool: activeTool = 'addressSearch',
@@ -30,24 +30,6 @@ export default ({
     searchText = '',
     maxResults = 15,
     searchOptions,
-    aeronauticalOptions = {
-        seconds: {
-            decimals: 4,
-            step: 0.0001
-        }
-    },
-    constraintsCoordEditor = {
-        decimal: {
-            lat: {
-                min: -90,
-                max: 90
-            },
-            lon: {
-                min: -180,
-                max: 180
-            }
-        }
-    },
     loading,
     delay,
     blurResetDelay,
@@ -79,50 +61,11 @@ export default ({
     items = [],
     ...props
 }) => {
+
     const search = defaultSearchWrapper({searchText, selectedItems, searchOptions, maxResults, onSearch, onSearchReset});
 
     const clearSearch = () => {
         onSearchReset();
-    };
-
-    const clearCoordinates = () => {
-        onClearCoordinatesSearch({owner: "search"});
-        onChangeCoord("lat", "");
-        onChangeCoord("lon", "");
-    };
-
-    const zoomToPoint = () => {
-        onZoomToPoint({
-            x: parseFloat(coordinate.lon),
-            y: parseFloat(coordinate.lat)
-        }, defaultZoomLevel, "EPSG:4326");
-    };
-
-    const searchByBookmark = (selectedBookmark = {}) => {
-        const {bookmarkConfig, onLayerVisibilityLoad, mapInitial, onZoomToExtent} = props;
-        const {options: bbox = {}, layerVisibilityReload = false} = bookmarkConfig?.selected || selectedBookmark;
-        if (layerVisibilityReload) {
-            onLayerVisibilityLoad({
-                ...mapInitial,
-                map: {
-                    ...mapInitial.map,
-                    bookmark_search_config: bookmarkConfig && bookmarkConfig.bookmarkSearchConfig
-                }
-            }, null, [bbox.west, bbox.south, bbox.east, bbox.north]);
-        } else if (bbox && !isEmpty(bbox)) {
-            onZoomToExtent([bbox.west, bbox.south, bbox.east, bbox.north], "EPSG:4326");
-        }
-    };
-
-    const areValidCoordinates = () => isNumber(coordinate.lon) && isNumber(coordinate.lat);
-
-    const changeCoord = (coord, value) => {
-        let val = isNaN(parseFloat(value)) ? "" : parseFloat(value);
-
-        onChangeCoord(coord, val);
-        if (!areValidCoordinates()) {
-            onClearCoordinatesSearch({owner: "search"});
-        }
     };
 
     const getError = (e) => {
@@ -134,84 +77,68 @@ export default ({
 
     let searchMenuOptions = [];
     if (showAddressSearchOption) {
-        searchMenuOptions.push({
-            active: activeTool === "addressSearch",
-            onClick: () => {
+        searchMenuOptions.push(
+            <MenuItem active={activeTool === "addressSearch"} onClick={()=>{
                 onClearCoordinatesSearch({owner: "search"});
                 onChangeActiveSearchTool("addressSearch");
-            },
-            glyph: searchIcon,
-            text: <Message msgId="search.addressSearch"/>
-        });
+            }}
+            >
+                <Glyphicon glyph={searchIcon}/> <Message msgId="search.addressSearch"/>
+            </MenuItem>);
     }
     if (showCoordinatesSearchOption) {
-        searchMenuOptions.push({
-            active: activeTool === "coordinatesSearch",
-            onClick: () => {
-                if (searchText !== undefined && searchText !== "") {
-                    clearSearch();
-                }
-                onChangeActiveSearchTool("coordinatesSearch");
-            },
-            glyph: "search-coords",
-            text: <Message msgId="search.coordinatesSearch"/>
-        });
+        searchMenuOptions.push(
+            <CoordinateOptions.coordinatesMenuItem
+                activeTool={activeTool}
+                searchText={searchText}
+                clearSearch={clearSearch}
+                onChangeActiveSearchTool={onChangeActiveSearchTool}
+            />);
     }
 
     let searchByBookmarkConfig;
-    // Search by bookmark option
     if (showBookMarkSearchOption && !isEmpty(items)) {
+        const {allowBookmarkEdit, bookmarkConfig} = props;
         const [item] = items;
         if (some(items, "menuItem")) {
-            searchMenuOptions.push(
-                item.menuItem(onChangeActiveSearchTool, activeTool)
-            );
+            const BookmarkMenuItem = item.menuItem;
+            searchMenuOptions.push(<BookmarkMenuItem/>);
         }
-        if (some(items, "bookmarkConfig")) {
-            searchByBookmarkConfig = item.bookmarkConfig(onToggleControl, enabledSearchBookmarkConfig, activeTool);
+        if (some(items, "bookmarkConfig") && bookmarkConfig?.allowUser) {
+            searchByBookmarkConfig = {
+                ...item.bookmarkConfig(onToggleControl, enabledSearchBookmarkConfig, activeTool),
+                ...(!allowBookmarkEdit && {visible: false} )
+            };
+        } else {
+            // Reset activeTool when no bookmark config
+            activeTool === "bookmarkSearch" && onChangeActiveSearchTool("addressSearch");
         }
     }
-    // Reset activeTool when no bookmark config
-    if (isUndefined(searchByBookmarkConfig) && activeTool === "bookmarkSearch") {
-        onChangeActiveSearchTool("addressSearch");
-    }
 
-    const searchConfig = {
-        onClick: () => {
-            if (!enabledSearchServicesConfig) {
-                onToggleControl("searchservicesconfig");
+    const getConfigButtons = () => {
+        if (activeTool === "addressSearch") {
+            return {
+                onClick: () => {
+                    if (!enabledSearchServicesConfig) {
+                        onToggleControl("searchservicesconfig");
+                    }
+                },
+                glyph: "cog",
+                className: "square-button-md no-border ",
+                tooltip: <Message msgId="search.searchservicesbutton"/>,
+                tooltipPosition: "bottom",
+                bsStyle: "default",
+                pullRight: true,
+                visible: showOptions && activeTool === "addressSearch"
+            };
+        } else if (showOptions) {
+            if (activeTool === "coordinatesSearch") {
+                return CoordinateOptions.coordinateFormatChange(format, onChangeFormat, showOptions, activeTool);
+            } else if (activeTool === "bookmarkSearch") {
+                return searchByBookmarkConfig;
             }
-        },
-        glyph: "cog",
-        className: "square-button-md no-border ",
-        tooltip: <Message msgId="search.searchservicesbutton"/>,
-        tooltipPosition: "bottom",
-        bsStyle: "default",
-        pullRight: true,
-        visible: showOptions && activeTool === "addressSearch"
-    };
-
-    const coordinateFormatChange = {
-        buttonConfig: {
-            title: <Glyphicon glyph="cog"/>,
-            tooltipId: "search.changeSearchInputField",
-            tooltipPosition: "bottom",
-            className: "square-button-md no-border",
-            pullRight: true
-        },
-        menuOptions: [
-            {
-                active: format === "decimal",
-                onClick: () => onChangeFormat("decimal"),
-                text: <Message msgId="search.decimal"/>
-            }, {
-                active: format === "aeronautical",
-                onClick: () => onChangeFormat("aeronautical"),
-                text: <Message msgId="search.aeronautical"/>
-            }
-        ],
-        visible: showOptions && activeTool === "coordinatesSearch",
-        Element: DropdownToolbarOptions
+        }
+        return {};
     };
 
     return (<SearchBarBase>
@@ -234,128 +161,56 @@ export default ({
                     onCancelSelectedItem={onCancelSelectedItem}
                     onPurgeResults={onPurgeResults}/>
                 {activeTool === "coordinatesSearch" && showCoordinatesSearchOption &&
-                    <div className="coordinateEditor" style={{flexWrap: format === "decimal" ? "nowrap" : "wrap" }}>
-                        <Row className="entryRow">
-                            <FormGroup>
-                                <InputGroup >
-                                    <InputGroup.Addon style={{minWidth: 45}}><Message msgId="search.latitude"/></InputGroup.Addon>
-                                    <CoordinateEntry
-                                        format={format}
-                                        aeronauticalOptions={aeronauticalOptions}
-                                        coordinate="lat"
-                                        idx={1}
-                                        value={coordinate.lat}
-                                        constraints={constraintsCoordEditor}
-                                        onChange={(dd) => changeCoord("lat", dd)}
-                                        onKeyDown={(e) => {
-                                            if (areValidCoordinates() && e.keyCode === 13) {
-                                                zoomToPoint();
-                                            }
-                                        }}
-                                    />
-                                </InputGroup>
-                            </FormGroup>
-                        </Row>
-                        <Row className="entryRow">
-                            <FormGroup>
-                                <InputGroup>
-                                    <InputGroup.Addon style={{minWidth: 45}}><Message msgId="search.longitude"/></InputGroup.Addon>
-                                    <CoordinateEntry
-                                        format={format}
-                                        aeronauticalOptions={aeronauticalOptions}
-                                        coordinate="lon"
-                                        idx={2}
-                                        value={coordinate.lon}
-                                        constraints={constraintsCoordEditor}
-                                        onChange={(dd) => changeCoord("lon", dd)}
-                                        onKeyDown={(e) => {
-                                            if (areValidCoordinates() && e.keyCode === 13) {
-                                                zoomToPoint();
-                                            }
-                                        }}
-                                    />
-                                </InputGroup>
-                            </FormGroup>
-                        </Row>
-                    </div>
+                    <CoordinatesSearch format={format} defaultZoomLevel={defaultZoomLevel} onClearCoordinatesSearch={onClearCoordinatesSearch} />
                 }
                 {
                     activeTool === "bookmarkSearch" && showBookMarkSearchOption &&
-                        <BookmarkSelect
-                            bookmarkConfig={props.bookmarkConfig}
-                            onPropertyChange={props.onPropertyChange}
-                            searchByBookmark={searchByBookmark}
-                        />
+                        <BookmarkSelect/>
                 }
                 <SearchBarToolbar
                     splitTools={false}
-                    toolbarButtons={[{
-                        ...(activeTool === "addressSearch" ? searchConfig :
-                            showOptions && activeTool === "coordinatesSearch" ? coordinateFormatChange :
-                                showOptions && activeTool === "bookmarkSearch" ? searchByBookmarkConfig : {})
-                    },
-                    {
-                        glyph: removeIcon,
-                        className: "square-button-md no-border",
-                        bsStyle: "default",
-                        pullRight: true,
-                        loading: !isUndefined(loading) && loading,
-                        visible: activeTool === "addressSearch" &&
-                            (searchText !== "" || selectedItems && selectedItems.length > 0) ||
-                            activeTool === "coordinatesSearch" && (isNumber(coordinate.lon) || isNumber(coordinate.lat)),
-                        onClick: () => {
-                            if (activeTool === "addressSearch") {
-                                clearSearch();
-                            } else {
-                                clearCoordinates();
-                            }
-                        }
-                    }, {
-                        glyph: searchIcon,
-                        className: "square-button-md no-border " +
+                    toolbarButtons={[{...getConfigButtons()},
+                        {
+                            glyph: removeIcon,
+                            className: "square-button-md no-border",
+                            bsStyle: "default",
+                            pullRight: true,
+                            loading: !isUndefined(loading) && loading,
+                            visible: activeTool === "addressSearch" &&
+                            (searchText !== "" || selectedItems && selectedItems.length > 0),
+                            onClick: () => {
+                                if (activeTool === "addressSearch") {
+                                    clearSearch();
+                                }
+                            },
+                            ...(activeTool === "coordinatesSearch" &&
+                                CoordinateOptions.removeIcon(activeTool, coordinate, onClearCoordinatesSearch, onChangeCoord))
+                        }, {
+                            glyph: searchIcon,
+                            className: "square-button-md no-border " +
                             (isSearchClickable || activeTool !== "addressSearch" ? "magnifying-glass clickable" : "magnifying-glass"),
-                        bsStyle: "default",
-                        pullRight: true,
-                        tooltipId: activeTool === "bookmarkSearch" ? "search.zoomToBookmark" : "",
-                        tooltipPosition: "bottom",
-                        visible: activeTool === "addressSearch" &&
-                            (!(searchText !== "" || selectedItems && selectedItems.length > 0) || !splitTools) ||
-                            activeTool === "coordinatesSearch" || activeTool === "bookmarkSearch",
-                        disabled: activeTool === "bookmarkSearch" && props.bookmarkConfig && !props.bookmarkConfig.selected,
-                        onClick: () => {
-                            if (activeTool === "coordinatesSearch" && areValidCoordinates()) {
-                                zoomToPoint();
-                            }
-                            if (isSearchClickable) {
-                                search();
-                            }
-                            if (activeTool === "bookmarkSearch") {
-                                searchByBookmark();
-                            }
-                        }
-                    }, {
-                        tooltip: getError(error),
-                        tooltipPosition: "bottom",
-                        className: "square-button-md no-border",
-                        glyph: "warning-sign",
-                        bsStyle: "danger",
-                        glyphClassName: "searcherror",
-                        visible: !!error,
-                        onClick: clearSearch
-                    }, {
-                        buttonConfig: {
-                            title: <Glyphicon glyph="menu-hamburger"/>,
-                            tooltipId: "search.changeSearchInputField",
+                            bsStyle: "default",
+                            pullRight: true,
+                            tooltipPosition: "bottom",
+                            visible: activeTool === "addressSearch" &&
+                            (!(searchText !== "" || selectedItems && selectedItems.length > 0) || !splitTools),
+                            onClick: () => isSearchClickable && search(),
+                            ...(activeTool === "coordinatesSearch" &&
+                                CoordinateOptions.searchIcon(activeTool, coordinate, onZoomToPoint, defaultZoomLevel)),
+                            ...(activeTool === "bookmarkSearch" &&
+                                    BookmarkOptions.searchIcon(activeTool, props))
+                        }, {
+                            tooltip: getError(error),
                             tooltipPosition: "bottom",
                             className: "square-button-md no-border",
-                            pullRight: true
-                        },
-                        menuOptions: [
-                            ...searchMenuOptions
-                        ],
-                        visible: showOptions,
-                        Element: DropdownToolbarOptions
-                    }]}
+                            glyph: "warning-sign",
+                            bsStyle: "danger",
+                            glyphClassName: "searcherror",
+                            visible: !!error,
+                            onClick: clearSearch
+                        }, {
+                            renderButton: <SearchBarMenu disabled={showOptions} menuItems={searchMenuOptions} />
+                        }]}
                 />
             </div>
         </FormGroup>

--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -57,6 +57,7 @@ export default ({
     onChangeFormat = () => {},
     onToggleControl = () => {},
     onZoomToPoint = () => {},
+    onClearBookmarkSearch = () => {},
     onPurgeResults,
     items = [],
     ...props
@@ -80,6 +81,7 @@ export default ({
         searchMenuOptions.push(
             <MenuItem active={activeTool === "addressSearch"} onClick={()=>{
                 onClearCoordinatesSearch({owner: "search"});
+                onClearBookmarkSearch("selected");
                 onChangeActiveSearchTool("addressSearch");
             }}
             >
@@ -93,25 +95,27 @@ export default ({
                 searchText={searchText}
                 clearSearch={clearSearch}
                 onChangeActiveSearchTool={onChangeActiveSearchTool}
+                onClearBookmarkSearch={onClearBookmarkSearch}
             />);
     }
 
     let searchByBookmarkConfig;
     if (showBookMarkSearchOption && !isEmpty(items)) {
-        const {allowBookmarkEdit, bookmarkConfig} = props;
+        const {allowUser, bookmarkSearchConfig: config} = props.bookmarkConfig || {};
         const [item] = items;
         if (some(items, "menuItem")) {
             const BookmarkMenuItem = item.menuItem;
             searchMenuOptions.push(<BookmarkMenuItem/>);
         }
-        if (some(items, "bookmarkConfig") && bookmarkConfig?.allowUser) {
+        if (some(items, "bookmarkConfig")) {
             searchByBookmarkConfig = {
                 ...item.bookmarkConfig(onToggleControl, enabledSearchBookmarkConfig, activeTool),
-                ...(!allowBookmarkEdit && {visible: false} )
+                ...(!allowUser && {visible: false})
             };
-        } else {
-            // Reset activeTool when no bookmark config
-            activeTool === "bookmarkSearch" && onChangeActiveSearchTool("addressSearch");
+        }
+        // Reset activeTool when no valid permission for bookmark
+        if (!allowUser && config?.bookmarks?.length === 0 && activeTool === "bookmarkSearch") {
+            onChangeActiveSearchTool("addressSearch");
         }
     }
 

--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -98,9 +98,9 @@ export default ({
         }, defaultZoomLevel, "EPSG:4326");
     };
 
-    const searchByBookmark = () => {
+    const searchByBookmark = (selectedBookmark = {}) => {
         const {bookmarkConfig, onLayerVisibilityLoad, mapInitial, onZoomToExtent} = props;
-        const {options: bbox = {}, layerVisibilityReload = false} = bookmarkConfig && bookmarkConfig.selected;
+        const {options: bbox = {}, layerVisibilityReload = false} = bookmarkConfig?.selected || selectedBookmark;
         if (layerVisibilityReload) {
             onLayerVisibilityLoad({
                 ...mapInitial,
@@ -281,7 +281,11 @@ export default ({
                 }
                 {
                     activeTool === "bookmarkSearch" && showBookMarkSearchOption &&
-                        <BookmarkSelect bookmarkConfig={props.bookmarkConfig} onPropertyChange={props.onPropertyChange}/>
+                        <BookmarkSelect
+                            bookmarkConfig={props.bookmarkConfig}
+                            onPropertyChange={props.onPropertyChange}
+                            searchByBookmark={searchByBookmark}
+                        />
                 }
                 <SearchBarToolbar
                     splitTools={false}

--- a/web/client/components/mapcontrols/search/SearchBarMenu.jsx
+++ b/web/client/components/mapcontrols/search/SearchBarMenu.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+const {Glyphicon, DropdownButton} = require('react-bootstrap');
+const tooltip = require('../../misc/enhancers/tooltip');
+const React = require('react');
+const uuidv1 = require('uuid/v1');
+
+const DropdownButtonT = tooltip(DropdownButton);
+
+const defaultButtonConfig = {
+    disabled: false,
+    className: "square-button-md",
+    noCaret: true,
+    idDropDown: uuidv1()
+};
+const buttonConfig = {
+    title: <Glyphicon glyph="menu-hamburger"/>,
+    tooltipId: "search.changeSearchInputField",
+    tooltipPosition: "bottom",
+    className: "square-button-md no-border",
+    pullRight: true
+};
+
+/**
+ * SearchBarMenu component to render wrappedComponent menu items
+ * @memberof SearchBar
+ * @param {object} props Component props
+ * @param {array} props.menuItems list of menuItems to display under drop down
+ * @param {bool} props.disabled enable/disable the drop down
+ *
+ */
+const SearchBarMenu = ({
+    menuItems = [],
+    disabled = false
+} = {}) => (
+    <DropdownButtonT disabled={disabled} {...defaultButtonConfig} {...buttonConfig}>
+        {menuItems.length ? menuItems.map(menuItem => menuItem) : null}
+    </DropdownButtonT>
+);
+module.exports = SearchBarMenu;

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -5,7 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import {MenuItem} from "react-bootstrap";
+
 const expect = require('expect');
+const Provider = require("react-redux").Provider;
 
 const ConfigUtils = require('../../../../utils/ConfigUtils');
 const React = require('react');
@@ -15,7 +18,7 @@ const SearchBar = require('../SearchBar').default;
 const TestUtils = require('react-dom/test-utils');
 
 describe("test the SearchBar", () => {
-    const items = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => ({active: true, glyph: "bookmark", text: "Search by bookmark"})}];
+    const items = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => <MenuItem>Search by bookmark</MenuItem>}];
 
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -191,7 +194,8 @@ describe("test the SearchBar", () => {
         expect(search.length).toBe(1);
     });
     it('test zoomToPoint, with search, with decimal, with reset', () => {
-        ReactDOM.render(<SearchBar format="decimal" coordinate={{"lat": 2, "lon": 2}} activeSearchTool="coordinatesSearch" showOptions searchText={"va"} delay={0} typeAhead={false} />, document.getElementById("container"));
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({search: {coordinate: {lat: 2, lon: 2}}})};
+        ReactDOM.render(<Provider store={store}><SearchBar format="decimal" coordinate={{"lat": 2, "lon": 2}} activeSearchTool="coordinatesSearch" showOptions searchText={"va"} delay={0} typeAhead={false} /></Provider>, document.getElementById("container"));
         let reset = document.getElementsByClassName("glyphicon-1-close");
         let search = document.getElementsByClassName("glyphicon-search");
         let cog = document.getElementsByClassName("glyphicon-cog");
@@ -201,7 +205,8 @@ describe("test the SearchBar", () => {
     });
 
     it('test zoomToPoint, with search, with aeronautical, with reset', () => {
-        ReactDOM.render(<SearchBar format="aeronautical" activeSearchTool="coordinatesSearch" showOptions searchText={"va"} delay={0} typeAhead={false} />, document.getElementById("container"));
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({search: {coordinate: {lat: 2, lon: 2}}})};
+        ReactDOM.render(<Provider store={store}><SearchBar format="aeronautical" activeSearchTool="coordinatesSearch" showOptions searchText={"va"} delay={0} typeAhead={false} /></Provider>, document.getElementById("container"));
         let reset = document.getElementsByClassName("glyphicon-1-close");
         let search = document.getElementsByClassName("glyphicon-search");
         let cog = document.getElementsByClassName("glyphicon-cog");
@@ -213,19 +218,27 @@ describe("test the SearchBar", () => {
     });
 
     it('test calling zoomToPoint with onKeyDown event', (done) => {
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({search: {coordinate: {lat: 15, lon: 15}}})
+        };
         ReactDOM.render(
-            <SearchBar
-                format="decimal"
-                activeSearchTool="coordinatesSearch"
-                showOptions
-                onZoomToPoint={(point, zoom, crs) => {
-                    expect(point).toEqual({x: 15, y: 15});
-                    expect(zoom).toEqual(12);
-                    expect(crs).toEqual("EPSG:4326");
-                    done();
-                }}
-                coordinate={{lat: 15, lon: 15}}
-                typeAhead={false} />, document.getElementById("container")
+            <Provider store={store}>
+                <SearchBar
+                    format="decimal"
+                    activeSearchTool="coordinatesSearch"
+                    showOptions
+                    onZoomToPoint={(point, zoom, crs) => {
+                        expect(point).toEqual({x: 15, y: 15});
+                        expect(zoom).toEqual(12);
+                        expect(crs).toEqual("EPSG:4326");
+                        done();
+                    }}
+                    coordinate={{lat: 15, lon: 15}}
+                    typeAhead={false} />
+            </Provider>
+            , document.getElementById("container")
         );
         const container = document.getElementById('container');
         const elements = container.querySelectorAll('input');
@@ -238,16 +251,23 @@ describe("test the SearchBar", () => {
         });
     });
     it('Test SearchBar with not allowed e char for keyDown event', (done) => {
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({search: {coordinate: {lat: 15, lon: 15}}})
+        };
         ReactDOM.render(
-            <SearchBar
-                format="decimal"
-                activeSearchTool="coordinatesSearch"
-                showOptions
-                onZoomToPoint={() => {
-                    expect(true).toBe(false);
-                }}
-                coordinate={{lat: 15, lon: 15}}
-                typeAhead={false} />, document.getElementById("container")
+            <Provider store={store}>
+                <SearchBar
+                    format="decimal"
+                    activeSearchTool="coordinatesSearch"
+                    showOptions
+                    onZoomToPoint={() => {
+                        expect(true).toBe(false);
+                    }}
+                    coordinate={{lat: 15, lon: 15}}
+                    typeAhead={false} />
+            </Provider>, document.getElementById("container")
         );
         const container = document.getElementById('container');
         const elements = container.querySelectorAll('input');
@@ -263,16 +283,23 @@ describe("test the SearchBar", () => {
         });
     });
     it('Test SearchBar with valid onKeyDown event by pressing number 8', () => {
+        const store = {
+            dispatch: () => {},
+            subscribe: () => {},
+            getState: () => ({search: {coordinate: {lat: 1, lon: 1}}})
+        };
         ReactDOM.render(
-            <SearchBar
-                format="decimal"
-                activeSearchTool="coordinatesSearch"
-                showOptions
-                onZoomToPoint={() => {
-                    expect(true).toBe(false);
-                }}
-                coordinate={{lat: 1, lon: 1}}
-                typeAhead={false} />, document.getElementById("container")
+            <Provider store={store}>
+                <SearchBar
+                    format="decimal"
+                    activeSearchTool="coordinatesSearch"
+                    showOptions
+                    onZoomToPoint={() => {
+                        expect(true).toBe(false);
+                    }}
+                    coordinate={{lat: 1, lon: 1}}
+                    typeAhead={false} />
+            </Provider>, document.getElementById("container")
         );
         const container = document.getElementById('container');
         const elements = container.querySelectorAll('input');
@@ -298,17 +325,20 @@ describe("test the SearchBar", () => {
     });
 
     it('test default coordinate format from localConfig', () => {
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({search: {coordinate: {lat: 2, lon: 2}}})};
         ConfigUtils.setConfigProp("defaultCoordinateFormat", "aeronautical");
         const defaultFormat = ConfigUtils.getConfigProp('defaultCoordinateFormat');
         let format;
         ReactDOM.render(
-            <SearchBar
-                format={format || defaultFormat || "decimal"}
-                activeSearchTool="coordinatesSearch"
-                showOptions
-                searchText={"va"}
-                delay={0}
-                typeAhead={false}/>, document.getElementById("container"));
+            <Provider store={store}>
+                <SearchBar
+                    format={format || defaultFormat || "decimal"}
+                    activeSearchTool="coordinatesSearch"
+                    showOptions
+                    searchText={"va"}
+                    delay={0}
+                    typeAhead={false}/>
+            </Provider>, document.getElementById("container"));
         let inputs = document.getElementsByTagName("input");
         expect(inputs.length).toBe(6);
         expect(inputs[0].placeholder).toBe('d');
@@ -320,7 +350,8 @@ describe("test the SearchBar", () => {
     });
 
     it('test searchByBookmark options under menu', () => {
-        ReactDOM.render(<SearchBar showOptions showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items}  />, document.getElementById("container"));
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
+        ReactDOM.render(<Provider store={store}><SearchBar showOptions bookmarkConfig={{selected: {}}} showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items}  /></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         const buttons = container.querySelectorAll('button');
         expect(buttons.length).toBe(3);
@@ -332,7 +363,8 @@ describe("test the SearchBar", () => {
         expect(links[2].innerText).toBe('Search by bookmark');
     });
     it('test searchByBookmark, search button disabled', () => {
-        ReactDOM.render(<SearchBar showOptions showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items} bookmarkConfig={{}}  />, document.getElementById("container"));
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
+        ReactDOM.render(<Provider store={store}><SearchBar showOptions showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items} bookmarkConfig={{}}  /></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         const buttons = container.querySelectorAll('button');
         const cog = document.getElementsByClassName("glyphicon-cog");
@@ -345,17 +377,19 @@ describe("test the SearchBar", () => {
         expect(cog).toExist();
     });
     it('test reset active search tool when no bookmark config', () => {
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
         const actions = {
             onChangeActiveSearchTool: () =>{}
         };
         const spyOnChangeActiveSearchTool = expect.spyOn(actions, 'onChangeActiveSearchTool');
-        ReactDOM.render(<SearchBar showOptions showBookMarkSearchOption onChangeActiveSearchTool={actions.onChangeActiveSearchTool} activeSearchTool="bookmarkSearch" />, document.getElementById("container"));
+        ReactDOM.render(<Provider store={store}><SearchBar bookmarkConfig={{selected: {}}} showOptions showBookMarkSearchOption onChangeActiveSearchTool={actions.onChangeActiveSearchTool} items={items} activeSearchTool="bookmarkSearch" /></Provider>, document.getElementById("container"));
         expect(spyOnChangeActiveSearchTool).toHaveBeenCalled();
         expect(spyOnChangeActiveSearchTool.calls[0].arguments[0]).toBe("addressSearch");
     });
     it('test searchByBookmark, with bookmark selected', () => {
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
         const bookmarkConfig = {selected: {title: "Bookmark1"}, bookmarkSearchConfig: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}};
-        ReactDOM.render(<SearchBar showOptions showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items} bookmarkConfig={bookmarkConfig}  />, document.getElementById("container"));
+        ReactDOM.render(<Provider store={store}><SearchBar showOptions showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items} bookmarkConfig={bookmarkConfig}  /></Provider>, document.getElementById("container"));
         const cmp = document.getElementById('container');
         expect(cmp).toExist();
         const bookmarkSelect = cmp.querySelector('.search-select');
@@ -364,22 +398,24 @@ describe("test the SearchBar", () => {
         expect(buttons[1].disabled).toBeFalsy();
     });
     it('test searchByBookmark, open view bookmarks onToggleControl', () => {
-        const bookmarkConfig = {selected: {title: "Bookmark1"}, bookmarkSearchConfig: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}};
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
+        const bookmarkConfig = {selected: {title: "Bookmark1"}, bookmarkSearchConfig: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}, allowUser: true};
         const actions = {
             onToggleControl: () =>{}
         };
-        const itemsProps = [{bookmarkConfig: (toggleConfig) =>({onClick: () => toggleConfig("searchBookmarkConfig"), glyph: "cog", visible: true}), menuItem: () => ({active: true, glyph: "bookmark", text: "Search by bookmark"})}];
+        const itemsProps = [{bookmarkConfig: (toggleConfig) =>({onClick: () => toggleConfig("searchBookmarkConfig"), glyph: "cog", visible: true}), menuItem: () => <MenuItem>Search by bookmark</MenuItem>}];
         const spyOnToggleControl = expect.spyOn(actions, 'onToggleControl');
         const props = {
             showOptions: true,
             showBookMarkSearchOption: true,
             enabledSearchBookmarkConfig: false,
+            allowBookmarkEdit: true,
             activeSearchTool: "bookmarkSearch",
             onToggleControl: actions.onToggleControl,
             items: itemsProps,
             bookmarkConfig
         };
-        ReactDOM.render(<SearchBar {...props}/>, document.getElementById("container"));
+        ReactDOM.render(<Provider store={store}><SearchBar {...props}/></Provider>, document.getElementById("container"));
         const cmp = document.getElementById('container');
         expect(cmp).toExist();
         const bookmarkSelect = cmp.querySelector('.search-select');
@@ -390,11 +426,12 @@ describe("test the SearchBar", () => {
         expect(spyOnToggleControl.calls[0].arguments[0]).toBe("searchBookmarkConfig");
     });
     it('test searchByBookmark, load a bookmark with onLayerVisibilityLoad', () => {
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
         const bookmarkConfig = {selected: {title: "Bookmark1", layerVisibilityReload: true, options: {west: 5, south: 10, east: 20, north: 30}}, bookmarkSearchConfig: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}};
         const actions = {
             onLayerVisibilityLoad: () =>{}
         };
-        const itemsProps = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => ({active: true, glyph: "bookmark", text: "Search by bookmark"})}];
+        const itemsProps = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => <MenuItem>Search by bookmark</MenuItem>}];
         const spyOnLayerVisibilityLoad = expect.spyOn(actions, 'onLayerVisibilityLoad');
         const props = {
             showOptions: true,
@@ -406,7 +443,7 @@ describe("test the SearchBar", () => {
             bookmarkConfig,
             mapInitial: {map: {layers: "Tests"}}
         };
-        ReactDOM.render(<SearchBar {...props}/>, document.getElementById("container"));
+        ReactDOM.render(<Provider store={store}><SearchBar {...props}/></Provider>, document.getElementById("container"));
         const cmp = document.getElementById('container');
         expect(cmp).toExist();
         const bookmarkSelect = cmp.querySelector('.search-select');
@@ -420,11 +457,12 @@ describe("test the SearchBar", () => {
         expect(spyOnLayerVisibilityLoad.calls[0].arguments[2]).toEqual([5, 10, 20, 30]);
     });
     it('test searchByBookmark, load a bookmark with zoomToExtent', () => {
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};
         const bookmarkConfig = {selected: {title: "Bookmark1", layerVisibilityReload: false, options: {west: 5, south: 10, east: 20, north: 30}}};
         const actions = {
             onZoomToExtent: () => {}
         };
-        const itemsProps = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => ({active: true, glyph: "bookmark", text: "Search by bookmark"})}];
+        const itemsProps = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => <MenuItem>Search by bookmark</MenuItem>}];
         const spyOnZoomToExtent = expect.spyOn(actions, 'onZoomToExtent');
         const props = {
             showOptions: true,
@@ -436,7 +474,7 @@ describe("test the SearchBar", () => {
             bookmarkConfig,
             mapInitial: {map: {layers: "Tests"}}
         };
-        ReactDOM.render(<SearchBar {...props}/>, document.getElementById("container"));
+        ReactDOM.render(<Provider store={store}><SearchBar {...props}/></Provider>, document.getElementById("container"));
         const cmp = document.getElementById('container');
         expect(cmp).toExist();
         const bookmarkSelect = cmp.querySelector('.search-select');

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -354,8 +354,8 @@ describe("test the SearchBar", () => {
         ReactDOM.render(<Provider store={store}><SearchBar showOptions bookmarkConfig={{selected: {}}} showBookMarkSearchOption activeSearchTool="bookmarkSearch" items={items}  /></Provider>, document.getElementById("container"));
         const container = document.getElementById('container');
         const buttons = container.querySelectorAll('button');
-        expect(buttons.length).toBe(3);
-        TestUtils.Simulate.click(buttons[2]);
+        expect(buttons.length).toBe(2);
+        TestUtils.Simulate.click(buttons[1]);
         const links = container.querySelectorAll('a');
         const bookmark = container.getElementsByClassName('glyphicon-bookmark');
         expect(links.length).toBe(3);
@@ -370,8 +370,8 @@ describe("test the SearchBar", () => {
         const cog = document.getElementsByClassName("glyphicon-cog");
         const bookmarkSelect = container.querySelector('.search-select');
         expect(bookmarkSelect).toExist();
-        expect(buttons.length).toBe(3);
-        const searchButton = buttons[1];
+        expect(buttons.length).toBe(2);
+        const searchButton = buttons[0];
         expect(searchButton).toExist();
         expect(searchButton.disabled).toBe(true);
         expect(cog).toExist();
@@ -382,7 +382,7 @@ describe("test the SearchBar", () => {
             onChangeActiveSearchTool: () =>{}
         };
         const spyOnChangeActiveSearchTool = expect.spyOn(actions, 'onChangeActiveSearchTool');
-        ReactDOM.render(<Provider store={store}><SearchBar bookmarkConfig={{selected: {}}} showOptions showBookMarkSearchOption onChangeActiveSearchTool={actions.onChangeActiveSearchTool} items={items} activeSearchTool="bookmarkSearch" /></Provider>, document.getElementById("container"));
+        ReactDOM.render(<Provider store={store}><SearchBar bookmarkConfig={{selected: {}, allowUser: false, bookmarkSearchConfig: {bookmarks: []}}} showOptions showBookMarkSearchOption onChangeActiveSearchTool={actions.onChangeActiveSearchTool} items={items} activeSearchTool="bookmarkSearch" /></Provider>, document.getElementById("container"));
         expect(spyOnChangeActiveSearchTool).toHaveBeenCalled();
         expect(spyOnChangeActiveSearchTool.calls[0].arguments[0]).toBe("addressSearch");
     });
@@ -409,7 +409,6 @@ describe("test the SearchBar", () => {
             showOptions: true,
             showBookMarkSearchOption: true,
             enabledSearchBookmarkConfig: false,
-            allowBookmarkEdit: true,
             activeSearchTool: "bookmarkSearch",
             onToggleControl: actions.onToggleControl,
             items: itemsProps,
@@ -441,6 +440,7 @@ describe("test the SearchBar", () => {
             onLayerVisibilityLoad: actions.onLayerVisibilityLoad,
             items: itemsProps,
             bookmarkConfig,
+            allowUser: true,
             mapInitial: {map: {layers: "Tests"}}
         };
         ReactDOM.render(<Provider store={store}><SearchBar {...props}/></Provider>, document.getElementById("container"));
@@ -449,7 +449,7 @@ describe("test the SearchBar", () => {
         const bookmarkSelect = cmp.querySelector('.search-select');
         expect(bookmarkSelect).toExist();
         const buttons = cmp.querySelectorAll('button');
-        TestUtils.Simulate.click(buttons[1]); // Bookmark config button
+        TestUtils.Simulate.click(buttons[0]); // Search button
         expect(spyOnLayerVisibilityLoad).toHaveBeenCalled();
         expect(spyOnLayerVisibilityLoad.calls.length).toBe(1);
         expect(spyOnLayerVisibilityLoad.calls[0].arguments[0]).toEqual({map: {layers: "Tests", bookmark_search_config: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}}});
@@ -472,6 +472,7 @@ describe("test the SearchBar", () => {
             onZoomToExtent: actions.onZoomToExtent,
             items: itemsProps,
             bookmarkConfig,
+            allowUser: true,
             mapInitial: {map: {layers: "Tests"}}
         };
         ReactDOM.render(<Provider store={store}><SearchBar {...props}/></Provider>, document.getElementById("container"));
@@ -480,7 +481,7 @@ describe("test the SearchBar", () => {
         const bookmarkSelect = cmp.querySelector('.search-select');
         expect(bookmarkSelect).toExist();
         const buttons = cmp.querySelectorAll('button');
-        TestUtils.Simulate.click(buttons[1]); // Bookmark config button
+        TestUtils.Simulate.click(buttons[0]); // Search button
         expect(spyOnZoomToExtent).toHaveBeenCalled();
         expect(spyOnZoomToExtent.calls.length).toBe(1);
         expect(spyOnZoomToExtent.calls[0].arguments[0]).toEqual([ 5, 10, 20, 30 ]);

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -5,12 +5,12 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+const expect = require('expect');
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var SearchBar = require('../SearchBar').default;
 const ConfigUtils = require('../../../../utils/ConfigUtils');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const SearchBar = require('../SearchBar').default;
 
 const TestUtils = require('react-dom/test-utils');
 
@@ -343,6 +343,15 @@ describe("test the SearchBar", () => {
         expect(searchButton).toExist();
         expect(searchButton.disabled).toBe(true);
         expect(cog).toExist();
+    });
+    it('test reset active search tool when no bookmark config', () => {
+        const actions = {
+            onChangeActiveSearchTool: () =>{}
+        };
+        const spyOnChangeActiveSearchTool = expect.spyOn(actions, 'onChangeActiveSearchTool');
+        ReactDOM.render(<SearchBar showOptions showBookMarkSearchOption onChangeActiveSearchTool={actions.onChangeActiveSearchTool} activeSearchTool="bookmarkSearch" />, document.getElementById("container"));
+        expect(spyOnChangeActiveSearchTool).toHaveBeenCalled();
+        expect(spyOnChangeActiveSearchTool.calls[0].arguments[0]).toBe("addressSearch");
     });
     it('test searchByBookmark, with bookmark selected', () => {
         const bookmarkConfig = {selected: {title: "Bookmark1"}, bookmarkSearchConfig: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}};

--- a/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkSelect.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkSelect.jsx
@@ -13,9 +13,9 @@ import {isEmpty} from 'lodash';
 import localizedProps from '../../misc/enhancers/localizedProps';
 const SelectLocalized = localizedProps(['placeholder', 'clearValueText', 'noResultsText'])(Select);
 
-const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange }) => {
+const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange, searchByBookmark }) => {
     const [ options, setOptions ] = useState([]);
-    const { selected = {}, bookmarkSearchConfig = {} } = config || {};
+    const { selected = {}, bookmarkSearchConfig = {}, zoomOnSelect = false } = config || {};
     const { bookmarks = [] } = bookmarkSearchConfig;
     const selectProps = {clearable: true, isSearchable: true, isClearable: true};
 
@@ -29,6 +29,7 @@ const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange }) => {
         const value = event && event.value || "";
         const [selectedBookmark] = bookmarks.filter((b, id)=> (b.title === value &&  id === event.idx));
         onPropertyChange("selected", selectedBookmark);
+        zoomOnSelect && searchByBookmark(selectedBookmark);
     };
 
     return (

--- a/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkSelect.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkSelect.jsx
@@ -7,17 +7,76 @@
 */
 
 import React, {useState, useEffect} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+
 import Select from 'react-select';
 import {isEmpty} from 'lodash';
+
+import {setSearchBookmarkConfig} from '../../../actions/searchbookmarkconfig';
+import {zoomToExtent} from "../../../actions/map";
+import {configureMap} from "../../../actions/config";
 import localizedProps from '../../misc/enhancers/localizedProps';
 const SelectLocalized = localizedProps(['placeholder', 'clearValueText', 'noResultsText'])(Select);
 
-const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange, searchByBookmark }) => {
+/**
+ * BookmarkOptions for Search bar
+ * @memberof BookmarkSelect
+ *
+ */
+export const BookmarkOptions = ({
+    searchByBookmark: (
+        selectedBookmark,
+        onLayerVisibilityLoad,
+        mapInitial,
+        bookmarkSearchConfig,
+        onZoomToExtent) => {
+        const {options: bbox = {}, layerVisibilityReload = false} = selectedBookmark;
+        if (layerVisibilityReload) {
+            onLayerVisibilityLoad({
+                ...mapInitial,
+                map: {
+                    ...mapInitial.map,
+                    bookmark_search_config: bookmarkSearchConfig
+                }
+            }, null, [bbox.west, bbox.south, bbox.east, bbox.north]);
+        } else if (bbox && !isEmpty(bbox)) {
+            onZoomToExtent([bbox.west, bbox.south, bbox.east, bbox.north], "EPSG:4326");
+        }
+    },
+    searchIcon: (activeTool, {onLayerVisibilityLoad, mapInitial, bookmarkConfig, onZoomToExtent})=>({
+        tooltipId: activeTool === "bookmarkSearch" ? "search.zoomToBookmark" : "",
+        tooltipPosition: "bottom",
+        visible: activeTool === "bookmarkSearch" && !bookmarkConfig?.zoomOnSelect,
+        disabled: activeTool === "bookmarkSearch" && !bookmarkConfig.selected,
+        onClick: () => {
+            if (activeTool === "bookmarkSearch") {
+                BookmarkOptions.searchByBookmark(bookmarkConfig.selected,
+                    onLayerVisibilityLoad,
+                    mapInitial,
+                    bookmarkConfig.bookmarkSearchConfig || {},
+                    onZoomToExtent);
+            }
+        }
+    })
+});
+
+/**
+ * BookmarkSelect component
+ * @param {object} props Component props
+ * @param {object} props.bookmarkConfig coordinate position in lat lon
+ * @param {func} props.onPropertyChange triggered on changing the properties of the bookmark
+ * @param {func} props.onLayerVisibilityLoad triggered on select of bookmark when layerVisibility is true on the selected bookmark
+ * @param {object} props.mapInitial initial map properties
+ * @param {func} props.onZoomToExtent triggered on changing coordinate position
+ *
+ */
+const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange, onLayerVisibilityLoad, mapInitial, onZoomToExtent }) => {
     const [ options, setOptions ] = useState([]);
-    const { selected = {}, bookmarkSearchConfig = {}, zoomOnSelect = false } = config || {};
+    const { selected = {}, bookmarkSearchConfig = {}, zoomOnSelect = true } = config || {};
     const { bookmarks = [] } = bookmarkSearchConfig;
     const selectProps = {clearable: true, isSearchable: true, isClearable: true};
+    const {searchByBookmark} = BookmarkOptions;
 
     useEffect(()=>{
         if (!isEmpty(bookmarks)) {
@@ -29,7 +88,11 @@ const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange, searchByBook
         const value = event && event.value || "";
         const [selectedBookmark] = bookmarks.filter((b, id)=> (b.title === value &&  id === event.idx));
         onPropertyChange("selected", selectedBookmark);
-        zoomOnSelect && searchByBookmark(selectedBookmark);
+        zoomOnSelect && searchByBookmark(selectedBookmark,
+            onLayerVisibilityLoad,
+            mapInitial,
+            bookmarkSearchConfig,
+            onZoomToExtent);
     };
 
     return (
@@ -46,12 +109,22 @@ const BookmarkSelect = ({ bookmarkConfig: config, onPropertyChange, searchByBook
                 />
             </div>
         </div>
+
     );
 };
+
 
 BookmarkSelect.propTypes = {
     bookmarkConfig: PropTypes.object.isRequired,
     onPropertyChange: PropTypes.func.isRequired
 };
 
-export default BookmarkSelect;
+export default connect((state)=> {
+    return {
+        bookmarkConfig: state.searchbookmarkconfig || {}
+    };
+}, {
+    onPropertyChange: setSearchBookmarkConfig,
+    onZoomToExtent: zoomToExtent,
+    onLayerVisibilityLoad: configureMap
+})(BookmarkSelect);

--- a/web/client/components/mapcontrols/searchbookmarkconfig/__tests__/BookmarkSelect-test.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/__tests__/BookmarkSelect-test.jsx
@@ -38,13 +38,14 @@ describe("BookmarkList component", () => {
         expect(placeholder.innerText).toBe("search.b_placeholder");
 
     });
-    it('test BookmarkSelect with value and onPropertyChange', (done) => {
+    it('test BookmarkSelect, onPropertyChange and zoomOnSelect', (done) => {
 
         let bookmarkConfig = {
             selected: {title: "Bookmark 1"},
             bookmarkSearchConfig: {
                 bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]
-            }
+            },
+            zoomOnSelect: true
         };
 
         TestUtils.act(() => {
@@ -53,6 +54,15 @@ describe("BookmarkList component", () => {
                     bookmarkConfig={bookmarkConfig}
                     onPropertyChange={
                         (s, value) => {
+                            try {
+                                expect(value.title).toBe('Bookmark 2');
+                            } catch (e) {
+                                done(e);
+                            }
+                            done();
+                        }}
+                    searchByBookmark={
+                        (value) => {
                             try {
                                 expect(value.title).toBe('Bookmark 2');
                             } catch (e) {

--- a/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
@@ -74,11 +74,12 @@ export const CoordinateOptions = ({
             }
         }
     }),
-    coordinatesMenuItem: ({activeTool, searchText, clearSearch, onChangeActiveSearchTool}) =>(
+    coordinatesMenuItem: ({activeTool, searchText, clearSearch, onChangeActiveSearchTool, onClearBookmarkSearch}) =>(
         <MenuItem active={activeTool === "coordinatesSearch"} onClick={() => {
             if (searchText !== undefined && searchText !== "") {
                 clearSearch();
             }
+            onClearBookmarkSearch("selected");
             onChangeActiveSearchTool("coordinatesSearch");
             document.dispatchEvent(new MouseEvent('click'));
         }}>

--- a/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+
+import {isNumber} from "lodash";
+import {FormGroup, Glyphicon, InputGroup, MenuItem, Row} from "react-bootstrap";
+
+import Message from "../../I18N/Message";
+import CoordinateEntry from "../../misc/coordinateeditors/CoordinateEntry";
+import DropdownToolbarOptions from "../../misc/toolbar/DropdownToolbarOptions";
+const { zoomAndAddPoint, changeCoord} = require("../../../actions/search");
+
+/**
+ * CoordinateOptions for Search bar
+ * @memberof CoordinatesSearch
+ *
+ */
+export const CoordinateOptions = ({
+    clearCoordinates: (onClearCoordinatesSearch, onChangeCoord) =>{
+        onClearCoordinatesSearch({owner: "search"});
+        onChangeCoord("lat", "");
+        onChangeCoord("lon", "");
+    },
+    areValidCoordinates: (coordinate) => isNumber(coordinate?.lon) && isNumber(coordinate?.lat),
+    zoomToPoint: (onZoomToPoint, coordinate, defaultZoomLevel = 12) => {
+        onZoomToPoint({
+            x: parseFloat(coordinate.lon),
+            y: parseFloat(coordinate.lat)
+        }, defaultZoomLevel, "EPSG:4326");
+    },
+    coordinateFormatChange: (format, onChangeFormat, showOptions, activeTool) => ({
+        buttonConfig: {
+            title: <Glyphicon glyph="cog"/>,
+            tooltipId: "search.changeSearchInputField",
+            tooltipPosition: "bottom",
+            className: "square-button-md no-border",
+            pullRight: true
+        },
+        menuOptions: [
+            {
+                active: format === "decimal",
+                onClick: () => onChangeFormat("decimal"),
+                text: <Message msgId="search.decimal"/>
+            }, {
+                active: format === "aeronautical",
+                onClick: () => onChangeFormat("aeronautical"),
+                text: <Message msgId="search.aeronautical"/>
+            }
+        ],
+        visible: showOptions && activeTool === "coordinatesSearch",
+        Element: DropdownToolbarOptions
+    }),
+    removeIcon: (
+        activeTool,
+        coordinate,
+        onClearCoordinatesSearch,
+        onChangeCoord) =>({
+        visible: activeTool === "coordinatesSearch" && (isNumber(coordinate.lon) || isNumber(coordinate.lat)),
+        onClick: () => CoordinateOptions.clearCoordinates(onClearCoordinatesSearch, onChangeCoord)
+    }),
+    searchIcon: (activeTool, coordinate, onZoomToPoint, defaultZoomLevel) => ({
+        visible: activeTool === "coordinatesSearch",
+        onClick: () => {
+            if (activeTool === "coordinatesSearch" && CoordinateOptions.areValidCoordinates(coordinate)) {
+                CoordinateOptions.zoomToPoint(onZoomToPoint, coordinate, defaultZoomLevel);
+            }
+        }
+    }),
+    coordinatesMenuItem: ({activeTool, searchText, clearSearch, onChangeActiveSearchTool}) =>(
+        <MenuItem active={activeTool === "coordinatesSearch"} onClick={() => {
+            if (searchText !== undefined && searchText !== "") {
+                clearSearch();
+            }
+            onChangeActiveSearchTool("coordinatesSearch");
+            document.dispatchEvent(new MouseEvent('click'));
+        }}>
+            <Glyphicon glyph={"search-coords"}/> <Message msgId="search.coordinatesSearch"/>
+        </MenuItem>
+    )
+});
+
+
+/**
+ * CoordinatesSearch component
+ * @param {object} props Component props
+ * @param {object} props.coordinate coordinate position in lat lon
+ * @param {string} props.format current format to display the coordinates
+ * @param {func} props.onClearCoordinatesSearch on click clear coordinates
+ * @param {func} props.onZoomToPoint on click zoom to extent
+ * @param {number} props.defaultZoomLevel default zoom level on zoom to extent
+ * @param {func} props.onChangeCoord triggered on changing coordinate position
+ *
+ */
+
+const CoordinatesSearch = ({
+    coordinate = {},
+    format,
+    onClearCoordinatesSearch,
+    onZoomToPoint,
+    onChangeCoord,
+    defaultZoomLevel,
+    aeronauticalOptions = {
+        seconds: {
+            decimals: 4,
+            step: 0.0001
+        }
+    },
+    constraintsCoordEditor = {
+        decimal: {
+            lat: {
+                min: -90,
+                max: 90
+            },
+            lon: {
+                min: -180,
+                max: 180
+            }
+        }
+    }}) => {
+
+    const {zoomToPoint, areValidCoordinates} = CoordinateOptions;
+
+    const changeCoordinates = (coord, value) => {
+        let val = isNaN(parseFloat(value)) ? "" : parseFloat(value);
+
+        onChangeCoord(coord, val);
+        if (!areValidCoordinates()) {
+            onClearCoordinatesSearch({owner: "search"});
+        }
+    };
+
+    const onZoom = () => {
+        zoomToPoint(onZoomToPoint, coordinate, defaultZoomLevel);
+    };
+
+    return (
+        <div className="coordinateEditor" style={{flexWrap: format === "decimal" ? "nowrap" : "wrap" }}>
+            <Row className="entryRow">
+                <FormGroup>
+                    <InputGroup >
+                        <InputGroup.Addon style={{minWidth: 45}}><Message msgId="search.latitude"/></InputGroup.Addon>
+                        <CoordinateEntry
+                            format={format}
+                            aeronauticalOptions={aeronauticalOptions}
+                            coordinate="lat"
+                            idx={1}
+                            value={coordinate.lat}
+                            constraints={constraintsCoordEditor}
+                            onChange={(dd) => changeCoordinates("lat", dd)}
+                            onKeyDown={() => {
+                                if (areValidCoordinates(coordinate)) {
+                                    onZoom();
+                                }
+                            }}
+                        />
+                    </InputGroup>
+                </FormGroup>
+            </Row>
+            <Row className="entryRow">
+                <FormGroup>
+                    <InputGroup>
+                        <InputGroup.Addon style={{minWidth: 45}}><Message msgId="search.longitude"/></InputGroup.Addon>
+                        <CoordinateEntry
+                            format={format}
+                            aeronauticalOptions={aeronauticalOptions}
+                            coordinate="lon"
+                            idx={2}
+                            value={coordinate.lon}
+                            constraints={constraintsCoordEditor}
+                            onChange={(dd) => changeCoordinates("lon", dd)}
+                            onKeyDown={() => {
+                                if (areValidCoordinates(coordinate)) {
+                                    onZoom();
+                                }
+                            }}
+                        />
+                    </InputGroup>
+                </FormGroup>
+            </Row>
+        </div>
+    );
+};
+
+CoordinatesSearch.propTypes = {
+    coordinate: PropTypes.object,
+    format: PropTypes.string,
+    onClearCoordinatesSearch: PropTypes.func,
+    onZoomToPoint: PropTypes.func,
+    onChangeCoord: PropTypes.func,
+    defaultZoomLevel: PropTypes.number
+};
+
+export default connect((state)=>{
+    return {
+        coordinate: state.search.coordinate || {}
+    };
+}, {
+    onZoomToPoint: zoomAndAddPoint,
+    onChangeCoord: changeCoord
+})(CoordinatesSearch);

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -34,6 +34,7 @@ class CoordinatesRow extends React.Component {
         isDraggableEnabled: PropTypes.bool,
         showLabels: PropTypes.bool,
         showDraggable: PropTypes.bool,
+        showToolButtons: PropTypes.bool,
         removeVisible: PropTypes.bool,
         formatVisible: PropTypes.bool,
         removeEnabled: PropTypes.bool
@@ -43,7 +44,8 @@ class CoordinatesRow extends React.Component {
         showLabels: false,
         formatVisible: false,
         onMouseEnter: () => {},
-        onMouseLeave: () => {}
+        onMouseLeave: () => {},
+        showToolButtons: true
     };
 
     constructor(props) {
@@ -189,12 +191,13 @@ class CoordinatesRow extends React.Component {
                         />
                     </InputGroup>
                 </div>
-                <div key="tools">
+                {this.props.showToolButtons && <div key="tools">
                     <Toolbar
-                        btnGroupProps={{ className: 'tools' }}
-                        btnDefaultProps={{ className: 'square-button-md no-border'}}
+                        btnGroupProps={{className: 'tools'}}
+                        btnDefaultProps={{className: 'square-button-md no-border'}}
                         buttons={toolButtons}/>
                 </div>
+                }
             </Row>
         );
     }

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -15,7 +15,7 @@ const {get, isArray} = require('lodash');
 const {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic} = require('../epics/search');
 const {defaultIconStyle} = require('../utils/SearchUtils');
 const {mapSelector} = require('../selectors/map');
-const {setSearchBookmarkConfig} = require('../actions/searchbookmarkconfig');
+const {isAdminUserSelector} = require('../selectors/security');
 const {zoomToExtent} = require( "../actions/map");
 const {configureMap} = require( "../actions/config");
 
@@ -47,7 +47,7 @@ const searchSelector = createSelector([
     state => state.controls && state.controls.searchservicesconfig || null,
     state => state.controls && state.controls.searchBookmarkConfig || null,
     state=> state.mapConfigRawData || {},
-    state => state.searchbookmarkconfig || {}
+    state => state?.searchbookmarkconfig || ''
 ], (searchState, searchservicesconfigControl, searchBookmarkConfigControl, mapInitial, bookmarkConfig) => ({
     enabledSearchServicesConfig: searchservicesconfigControl && searchservicesconfigControl.enabled || false,
     enabledSearchBookmarkConfig: searchBookmarkConfigControl && searchBookmarkConfigControl.enabled || false,
@@ -59,7 +59,8 @@ const searchSelector = createSelector([
     format: get(searchState, "format") || getConfigProp("defaultCoordinateFormat"),
     selectedItems: searchState && searchState.selectedItems,
     mapInitial,
-    bookmarkConfig: bookmarkConfig || {}
+    bookmarkConfig: bookmarkConfig || {},
+    allowBookmarkEdit: (bookmarkConfig?.bookmarkEditing === "ADMIN") && isAdminUserSelector
 }));
 
 const SearchBar = connect(searchSelector, {
@@ -74,7 +75,6 @@ const SearchBar = connect(searchSelector, {
     onSearchReset: resetSearch,
     onSearchTextChange: searchTextChanged,
     onCancelSelectedItem: cancelSelectedItem,
-    onPropertyChange: setSearchBookmarkConfig,
     onZoomToExtent: zoomToExtent,
     onLayerVisibilityLoad: configureMap
 })(require("../components/mapcontrols/search/SearchBar").default);

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -15,9 +15,9 @@ const {get, isArray} = require('lodash');
 const {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic} = require('../epics/search');
 const {defaultIconStyle} = require('../utils/SearchUtils');
 const {mapSelector} = require('../selectors/map');
-const {isAdminUserSelector} = require('../selectors/security');
 const {zoomToExtent} = require( "../actions/map");
 const {configureMap} = require( "../actions/config");
+const {setSearchBookmarkConfig} = require( "../actions/searchbookmarkconfig");
 
 const {
     resultsPurge,
@@ -59,8 +59,7 @@ const searchSelector = createSelector([
     format: get(searchState, "format") || getConfigProp("defaultCoordinateFormat"),
     selectedItems: searchState && searchState.selectedItems,
     mapInitial,
-    bookmarkConfig: bookmarkConfig || {},
-    allowBookmarkEdit: (bookmarkConfig?.bookmarkEditing === "ADMIN") && isAdminUserSelector
+    bookmarkConfig: bookmarkConfig || {}
 }));
 
 const SearchBar = connect(searchSelector, {
@@ -68,6 +67,7 @@ const SearchBar = connect(searchSelector, {
     onChangeCoord: changeCoord,
     onChangeActiveSearchTool: changeActiveSearchTool,
     onClearCoordinatesSearch: removeAdditionalLayer,
+    onClearBookmarkSearch: setSearchBookmarkConfig,
     onChangeFormat: changeFormat,
     onToggleControl: toggleControl,
     onZoomToPoint: zoomAndAddPoint,

--- a/web/client/plugins/SearchByBookmark.jsx
+++ b/web/client/plugins/SearchByBookmark.jsx
@@ -28,26 +28,6 @@ import searchbookmarkconfig from '../reducers/searchbookmarkconfig';
 import {mapInfoSelector, mapSelector} from '../selectors/map';
 import {isLoggedIn, isAdminUserSelector} from '../selectors/security';
 
-/**
- * Bookmark search configuration Plugin. Allow to add and edit additional
- * bookmarks used by search by bookmark plugin. User has to
- * save the map to persist service changes.
- *
- * @function SearchByBookmarkPanel
- * @memberof plugins
- * @param {object} props Component props
- * @param {bool} props.zoomOnSelect cfg.zoomOnSelect zooms to the extent on selecting a value from the bookmark drop down
- * rather than clicking search icon
- * @param {string} props.bookmarkEditing cfg.bookmarkEditing "ADMIN"|"EDIT"|"ALL" sets the user permission restriction
- * for bookmark edit feature
- * @example
- * {
- *     cfg: {
- *         zoomOnSelect: true,
- *         bookmarkEditing: "ADMIN"
- *     }
- * }
- */
 const SearchByBookmarkPanel = (props) => {
     const { enabled, pages, page,
         onPropertyChange,
@@ -163,6 +143,7 @@ const SearchByBookmarkPanel = (props) => {
 
 /**
  * Check whether the user has required permission for bookmark feature
+ * @ignore
  * @param {string} bookmarkEditing user role allowed
  * @param {bool} loggedIn check if the user is logged into mapstore
  * @param {bool} canEdit can user edit the map
@@ -182,6 +163,7 @@ const isAllowedUser = (
 
 /**
  * Search by bookmark menu item for Search bar burgermenu
+ * @ignore
  * @param {object} props Component props
  * @param {bool} props.show enable/disable bookmark menu item
  * @param {func} props.onClick toggle bookmark search
@@ -208,6 +190,7 @@ const BookmarkMenuItem = connect(createSelector([
 
 /**
  * Search by bookmark config for settings(configuration) button in Search bar
+ * @ignore
  * @memberof SearchByBookmark plugin
  * @param {func} toggleConfig enable/disable bookmark config
  * @param {bool} enabled bookmark config toggle status
@@ -255,6 +238,29 @@ const SearchByBookmarkPlugin = connect(selector, {
     updateBookmark,
     onFilter: filterBookmarks})(SearchByBookmarkPanel);
 
+/**
+ * Bookmark search configuration Plugin. Allow to add and edit additional
+ * bookmarks used by search by bookmark plugin. User has to
+ * save the map to persist service changes.
+ *
+ * @name SearchByBookmark
+ * @memberof plugins
+ * @class
+ * @param {bool} cfg.zoomOnSelect cfg.zoomOnSelect zooms to the extent on selecting a value from the bookmark drop down
+ * rather than clicking search icon
+ * @param {string} cfg.bookmarkEditing cfg.bookmarkEditing "ADMIN"|"EDIT"|"ALL" sets the user permission restriction
+ * for bookmark edit feature
+ * - "ADMIN": only admin can edit bookmarks
+ * - "EDIT": only users with edit permission on the current map can edit bookmarks
+ * - "ALL": everyone can edit bookmarks
+ * @example
+ * {
+ *     cfg: {
+ *         zoomOnSelect: true,
+ *         bookmarkEditing: "ADMIN"
+ *     }
+ * }
+ */
 export default createPlugin('SearchByBookmark', {
     component: SearchByBookmarkPlugin,
     containers: {

--- a/web/client/plugins/SearchByBookmark.jsx
+++ b/web/client/plugins/SearchByBookmark.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import { createPlugin } from '../utils/PluginsUtils';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -18,6 +18,7 @@ import Message from './locale/Message';
 import {mapSelector} from '../selectors/map';
 import {toggleControl} from '../actions/controls';
 import {setSearchBookmarkConfig, resetBookmarkConfig, updateBookmark, filterBookmarks} from '../actions/searchbookmarkconfig';
+import {isLoggedIn, isAdminUserSelector} from '../selectors/security';
 import BookmarkList from '../components/mapcontrols/searchbookmarkconfig/BookmarkList';
 import AddNewBookmark from '../components/mapcontrols/searchbookmarkconfig/AddNewBookmark';
 import searchbookmarkconfig from '../reducers/searchbookmarkconfig';
@@ -29,16 +30,21 @@ import searchbookmarkconfig from '../reducers/searchbookmarkconfig';
  *
  * @class SearchByBookmarkPanel
  * @memberof plugins
- * @static
- *
+ * @prop {object} cfg.zoomOnSelect zooms to the extent on selecting a value from the bookmark drop down
+ * rather than clicking search icon
  */
 const SearchByBookmarkPanel = (props) => {
     const { enabled, pages, page,
         onPropertyChange,
         bookmark,
         bookmarkSearchConfig = {},
-        editIdx
+        editIdx,
+        zoomOnSelect = false
     } = props;
+
+    useEffect(()=>{
+        onPropertyChange("zoomOnSelect", zoomOnSelect);
+    }, [onPropertyChange]);
 
     const onClose = () => {
         props.toggleControl("searchBookmarkConfig");
@@ -186,8 +192,11 @@ export default createPlugin('SearchByBookmark', {
     },
     containers: {
         Search: {
-            menuItem: searchMenuItem,
-            bookmarkConfig: searchByBookmarkConfig
+            // Display bookmark setting only when logged in user is an ADMIN
+            ...(isLoggedIn && isAdminUserSelector && {
+                menuItem: searchMenuItem,
+                bookmarkConfig: searchByBookmarkConfig
+            })
         }
     },
     reducers: {

--- a/web/client/reducers/__tests__/searchbookmarkconfig-test.js
+++ b/web/client/reducers/__tests__/searchbookmarkconfig-test.js
@@ -26,7 +26,7 @@ describe('Test the searchbookmarkconfig reducer', () => {
             config: { version: 2, map: {layers: []}}};
 
         const state = searchbookmarkconfig({}, action);
-        expect(state.bookmarkSearchConfig).toBe(undefined);
+        expect(state.bookmarkSearchConfig).toEqual({});
     });
     it('reset searchbookmarkconfig state', () => {
         const state = searchbookmarkconfig(

--- a/web/client/reducers/searchbookmarkconfig.js
+++ b/web/client/reducers/searchbookmarkconfig.js
@@ -19,7 +19,7 @@ export default (state = null, action) => {
     case SET_SEARCH_BOOKMARK_CONFIG:
         return {...state, [action.property]: action.value};
     case MAP_CONFIG_LOADED: {
-        const bookmarkSearchConfig = action.config.map.bookmark_search_config || action.config.map.bookmark_search_config;
+        const bookmarkSearchConfig = action.config.map.bookmark_search_config || {};
         return {...state, bookmarkSearchConfig};
     }
     case RESET_CONTROLS:


### PR DESCRIPTION
## Description
Resets the active search tool when user logouts with search by bookmark selected

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/mapstore2/issues/5388#issuecomment-648836542

**What is the new behavior?**
With search by bookmark selected, when user logouts, the active search tool is reset to default (address search) 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
