### PR TITLE
#5804: use custom resolutions from options in ol WMS layer implementa…

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -622,6 +622,28 @@ describe('Openlayers layer', () => {
         map.getLayers().item(0).getSource().refresh();
     });
 
+    it('test wms custom resolutions', () => {
+        var options = {
+            "type": "wms",
+            "visibility": true,
+            "name": "nurc:Arc_Sample",
+            "group": "Meteo",
+            "format": "image/png",
+            "singleTile": false,
+            "resolutions": [100, 10, 3, 2, 1],
+            "url": "http://sample.server/geoserver/wms"
+        };
+        // create layers
+        var layer = ReactDOM.render(
+            <OpenlayersLayer type="wms"
+                options={options} map={map} />, document.getElementById("container"));
+
+        expect(layer).toExist();
+        // count layers
+        expect(map.getLayers().getLength()).toBe(1);
+        expect(map.getLayers().item(0).getSource().tileGrid.getResolutions().length).toBe(5);
+    });
+
     it('creates a wmts layer for openlayers map', () => {
         var options = {
             "type": "wmts",

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -166,7 +166,7 @@ const createLayer = (options, map) => {
         params: queryParameters,
         tileGrid: new TileGrid({
             extent: extent,
-            resolutions: MapUtils.getResolutions(),
+            resolutions: options.resolutions || MapUtils.getResolutions(),
             tileSize: options.tileSize ? options.tileSize : 256,
             origin: options.origin ? options.origin : [extent[0], extent[1]]
         })
@@ -246,7 +246,7 @@ Layers.registerType('wms', {
             } else {
                 const tileGrid = new TileGrid({
                     extent: extent,
-                    resolutions: MapUtils.getResolutions(),
+                    resolutions: newOptions.resolutions || MapUtils.getResolutions(),
                     tileSize: newOptions.tileSize ? newOptions.tileSize : 256,
                     origin: newOptions.origin ? newOptions.origin : [extent[0], extent[1]]
                 });


### PR DESCRIPTION
…tion, if available

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5804 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5804 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Custom tile grid resolutions can be passed in WMS layer options, and they will be used instead of the default

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
