### PR TITLE
Backport 2020.02.xx - #5638 Circle steps now uses the right number of decimals (#5639)

### DIFF
--- a/web/client/components/data/query/GeometryDetails.jsx
+++ b/web/client/components/data/query/GeometryDetails.jsx
@@ -164,11 +164,13 @@ class GeometryDetails extends React.Component {
         );
     };
     renderCircleField = (value, name) => {
+        // radius should have 2 decimals if uom of projections is meter (EPSG:3857)
+        // all other cases it must have at least 6 decimals because coords are converted to EPSG:4326
         return (
             <FormControl
                 type="number"
                 id={"queryform_circle_" + name}
-                defaultValue={this.roundValue(value, !this.isWGS84() || name === 'radius' ? 100 : 1000000)}
+                defaultValue={this.roundValue(value, name === 'radius' && !this.isWGS84() ? 100 : 1000000)}
                 step={this.getStepCircle(this.props.zoom, name)}
                 onChange={(evt) => this.onUpdateCircle(evt.target.value, name)}/>
         );

--- a/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
+++ b/web/client/components/data/query/__tests__/GeometryDetails-test.jsx
@@ -31,8 +31,8 @@ describe('GeometryDetails', () => {
         let geometry = {
             center: {
                 srs: "EPSG:900913",
-                x: -1761074.344349588,
-                y: 5852757.632510748
+                x: -1764074.344349588,
+                y: 5854757.632510748
             },
             projection: "EPSG:900913",
             radius: 836584.05,
@@ -66,6 +66,13 @@ describe('GeometryDetails', () => {
         let panelBodyRows = pb.getElementsByClassName('row');
         expect(panelBodyRows).toExist();
         expect(panelBodyRows.length).toBe(3);
+
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(3);
+        // checking number of decimals
+        expect(inputs[0].value.substring(inputs[0].value.indexOf(".") + 1).length).toBe(6); // "-15.846949"
+        expect(inputs[1].value.substring(inputs[1].value.indexOf(".") + 1).length).toBe(6); // "46.462377"
+        expect(inputs[2].value.substring(inputs[2].value.indexOf(".") + 1).length).toBe(2); // "6114748.17"
 
         expect(pb.childNodes.length).toBe(1);
     });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Backport 2020.02.xx - #5638 Circle steps now uses the right number of decimals (#5639)