### PR TITLE
Wrong command to include printing plugin in DEV guide

### DIFF
--- a/docs/developer-guide/building-and-deploying.md
+++ b/docs/developer-guide/building-and-deploying.md
@@ -118,7 +118,7 @@ The [MapStore printing engine](https://github.com/geosolutions-it/mapfish-print/
 To build your own version of MapStore with the printing module included, you can enable the
 **printing** profile:
 
-`./build.sh [version_identifier] -Pprinting`
+`./build.sh [version_identifier] printing`
 
 It is also possible to build only the printing extension as a zip (to be unzipped on your deployed MapStore). To do that:
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixed wrong command in documentation for the inclusion of the printing module.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [X] Other... Please describe: small doc update, see description

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5824

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5824

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information


[//]: # (rtdbot-start)

URL of RTD document: https://mapstore.readthedocs.io/en/tdipisa-patch-6/ ![Documentation Status](https://readthedocs.org/projects/mapstore/badge/?version=tdipisa-patch-6)

[//]: # (rtdbot-end)
