### PR TITLE
#5832: StyleEditor enableSetDefaultStyle property does not work

### DIFF
--- a/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
+++ b/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
@@ -8,6 +8,8 @@
 import expect from 'expect';
 
 import defaultSettingsTabs, { getStyleTabPlugin } from '../defaultSettingsTabs';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
 const BASE_STYLE_TEST_DATA = {
     settings: {},
@@ -70,5 +72,50 @@ describe('TOCItemsSettings - getStyleTabPlugin', () => {
             const items = defaultSettingsTabs(BASE_STYLE_TEST_DATA);
             expect(items.length).toBe(1);
         }
+    });
+});
+
+describe('TOCItemsSettings - getStyleTabPlugin rendered items', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('getStyleTabPlugin with StyleEditor toolbar and cfg configuration', () => {
+        const DEFAULT_TEST_PARAMS = {
+            ...BASE_STYLE_TEST_DATA,
+            items: [{
+                ToolbarComponent: ({ enableSetDefaultStyle }) => (
+                    <div className="test-toolbar">
+                        {enableSetDefaultStyle ? 'enableSetDefaultStyle' : ''}
+                    </div>
+                ),
+                cfg: {
+                    enableSetDefaultStyle: true
+                },
+                items: [],
+                name: 'StyleEditor',
+                plugin: () => <div></div>,
+                priority: 1,
+                target: 'style'
+            }]
+        };
+
+        const Toolbar = getStyleTabPlugin(DEFAULT_TEST_PARAMS).toolbarComponent;
+        expect(Toolbar).toBeTruthy();
+
+        ReactDOM.render(<Toolbar />, document.getElementById('container'));
+
+        const toolbarNode = document.querySelector('.test-toolbar');
+
+        expect(toolbarNode).toBeTruthy();
+        expect(toolbarNode.innerHTML).toBe('enableSetDefaultStyle');
+
     });
 });

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -184,14 +184,15 @@ export const getStyleTabPlugin = ({ settings, items = [], loadedPlugins, onToggl
     const item = head(candidatePluginItems);
     // StyleEditor case TODO: externalize `onClose` trigger (delegating action dispatch) and components creation to make the two plugins independent
     if (item && item.plugin) {
+        const cfg = item.cfg || item.plugin.cfg;
         return {
             // This is connected on TOCItemsSettings close, not on StyleEditor unmount
             // to prevent re-initialization on each tab switch.
             onClose: () => onToggleStyleEditor(null, false),
-            Component: getConfiguredPlugin({ ...item, cfg: { ...(item.cfg || item.plugin.cfg || {}), active: true } }, loadedPlugins, <LoadingView width={100} height={100} />),
+            Component: getConfiguredPlugin({ ...item, cfg: { ...(cfg || {}), active: true } }, loadedPlugins, <LoadingView width={100} height={100} />),
             toolbarComponent: item.ToolbarComponent
                 && (
-                    item.plugin.cfg && defaultProps(item.plugin.cfg)(item.ToolbarComponent) || item.ToolbarComponent
+                    cfg && defaultProps(cfg)(item.ToolbarComponent) || item.ToolbarComponent
                 )
         };
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds the correct configuration to the StyleEditor toolbar that allow to enable the default style functionality.
Now if the enableSetDefaultStyle is true the button in the toolbar is visible

![image](https://user-images.githubusercontent.com/19175505/92134386-be1e6200-ee09-11ea-94f7-49c0e8a27e5b.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5832

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The default style functionality is visible when the enableSetDefaultStyle is true

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
