### PR TITLE
Show format setting for only WMS and CSW catalog services(#5795)

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/index.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/index.js
@@ -20,10 +20,10 @@ const getPanel = (type) => {
     switch (type) {
     case "tms":
         return TMSAdvancedEditor;
+    case "wmts":
     case "wfs":
         return CommonAdvancedSettings;
     case "wms":
-    case "wmts":
     case "csw":
         return RasterAdvancedSettings;
     default:


### PR DESCRIPTION
## Description
This PR makes a change to use CommonAdvancedSettings for WMTS service

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5795 

**What is the new behavior?**
Format setting is not shown for WMTS service in Catalog settings

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
