### PR TITLE
Update eslint to babel eslint-parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,12 @@
 {
-  "parser": "babel-eslint",          // https://github.com/babel/babel-eslint
+  "parser": "@babel/eslint-parser",          // https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint#the-present
+  "parserOptions": {
+        "babelOptions": {
+            "configFile": "./build/babel.config.js" // https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint#the-present
+        }
+  },
   "plugins": [
+    "@babel",                        // https: //babeljs.io/blog/2020/07/13/the-state-of-babel-eslint#the-present
     "no-only-tests",                 // https://github.com/levibuzolic/eslint-plugin-no-only-tests
     "react",                         // https://github.com/yannickcr/eslint-plugin-react
     "import"                         // https://github.com/benmosher/eslint-plugin-import

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "index.js",
   "devDependencies": {
     "@babel/core": "7.8.7",
+    "@babel/eslint-parser": "7.11.5",
+    "@babel/eslint-plugin": "7.11.5",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.8.7",
@@ -14,7 +16,6 @@
     "@geosolutions/jsdoc": "3.4.4",
     "@geosolutions/mocha": "6.2.1-3",
     "axios-mock-adapter": "1.16.0",
-    "babel-eslint": "10.0.3",
     "babel-istanbul-loader": "0.1.0",
     "babel-loader": "8.0.5",
     "babel-plugin-add-module-exports": "0.1.4",


### PR DESCRIPTION
## Description

Due to this discussion, in order to avoid build problems we should migrate to @babel/eslint-parser
Hoping this solves the current bugs with the build on jenkins.

https://github.com/eslint/eslint/issues/13566#issuecomment-673978884
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Lib uptdate

<!-- add here the ReadTheDocs link (if needed) -->

#5777


**What is the current behavior?**
Jenkins build frequently fails when use new syntax like 
import React {userEffect, useState} from 'react';
or old issues like

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
