### PR TITLE
backport-2020.02.xx - #5795: Show format setting for only WMS and CSW catalog services

### DIFF
--- a/web/client/components/catalog/editor/AdvancedSettings/index.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/index.js
@@ -20,10 +20,10 @@ const getPanel = (type) => {
     switch (type) {
     case "tms":
         return TMSAdvancedEditor;
+    case "wmts":
     case "wfs":
         return CommonAdvancedSettings;
     case "wms":
-    case "wmts":
     case "csw":
         return RasterAdvancedSettings;
     default:


### PR DESCRIPTION
Backport 5795-backport-2020.02.xx - #5795: Show format setting for only WMS and CSW catalog services