### PR TITLE
#5843 - Bookmark visibility layer reload fix

### DIFF
--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -169,7 +169,7 @@ export default ({
                 }
                 {
                     activeTool === "bookmarkSearch" && showBookMarkSearchOption &&
-                        <BookmarkSelect/>
+                        <BookmarkSelect mapInitial={props.mapInitial}/>
                 }
                 <SearchBarToolbar
                     splitTools={false}

--- a/web/client/components/mapcontrols/searchbookmarkconfig/__tests__/BookmarkSelect-test.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/__tests__/BookmarkSelect-test.jsx
@@ -91,4 +91,43 @@ describe("BookmarkList component", () => {
         expect(spyOnchange.calls[2].arguments[0].value.title).toBe("Bookmark 2");
 
     });
+
+    it('test BookmarkSelect, onLayerVisibilityLoad', () => {
+        const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {
+            selected: {title: "Bookmark 1"},
+            zoomOnSelect: true,
+            bookmarkSearchConfig: {
+                bookmarks: [{title: "Bookmark 1", layerVisibilityReload: true, options: {west: 1, east: 1, north: 1, south: 1}}, {title: "Bookmark 2"}]
+            }}})};
+
+        const spyOnchange = expect.spyOn(store, "dispatch");
+
+        ReactDOM.render(
+            <Provider store={store}>
+                <BookmarkSelect mapInitial={{map: {layer: "Test"}}}/>,
+            </Provider>,
+            document.getElementById("container"));
+
+        const cmp = document.getElementById('container');
+        expect(cmp).toBeTruthy();
+
+        const input = cmp.querySelector('input');
+        expect(input).toBeTruthy();
+
+        TestUtils.Simulate.change(input, { target: { value: 'Bookmark 1' } });
+        TestUtils.Simulate.keyDown(input, {keyCode: 9, key: 'Tab' });
+
+        let selectValue = cmp.querySelector('.Select-value-label');
+        expect(selectValue.innerText).toBe("Bookmark 1");
+        expect(spyOnchange).toHaveBeenCalled();
+        expect(spyOnchange.calls[0].arguments[0].type).toBe("SET_SEARCH_BOOKMARK_CONFIG");
+        expect(spyOnchange.calls[0].arguments[0].value).toBeTruthy();
+        expect(spyOnchange.calls[0].arguments[0].value.title).toBe("Bookmark 1");
+
+        expect(spyOnchange.calls[1].arguments[0].type).toBe("MAP_CONFIG_LOADED");
+        expect(spyOnchange.calls[1].arguments[0].config).toBeTruthy();
+        expect(spyOnchange.calls[1].arguments[0].config.map).toBeTruthy();
+        expect(spyOnchange.calls[1].arguments[0].config.map.layer).toEqual("Test");
+        expect(spyOnchange.calls[1].arguments[0].config.map.bookmark_search_config).toBeTruthy();
+    });
 });


### PR DESCRIPTION
## Description
Fix for the the bookmark layer visibility reload on select 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#5843 

**What is the new behavior?**
When bookmark with layer visibility toggle is set to true, is selected, the map should load with initial map config.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
