### PR TITLE
Search Service - show GFI

### DIFF
--- a/web/client/components/mapcontrols/search/SearchResultList.jsx
+++ b/web/client/components/mapcontrols/search/SearchResultList.jsx
@@ -14,7 +14,7 @@ import assign from 'object-assign';
 import SearchResult from './SearchResult';
 import I18N from '../../I18N/I18N';
 
-import { showGFIForService } from '../../../utils/SearchUtils';
+import { showGFIForService, layerIsVisibleForGFI } from '../../../utils/SearchUtils';
 
 export default class SearchResultList extends React.Component {
     static propTypes = {
@@ -54,6 +54,9 @@ export default class SearchResultList extends React.Component {
     renderResults = () => {
         return this.props.results.map((item, idx)=> {
             const service = this.findService(item) || {};
+            const searchLayerObj = find(this.props.layers, {name: service.options?.typeName});
+            const visible = showGFIForService(service);
+            const disabled = !layerIsVisibleForGFI(searchLayerObj, service);
             return (<SearchResult
                 subTitle={service.subTitle}
                 idField={service.idField}
@@ -63,9 +66,10 @@ export default class SearchResultList extends React.Component {
                 onItemClick={this.onItemClick}
                 tools={[{
                     id: 'open-gfi',
-                    visible: showGFIForService(find(this.props.layers, {name: service.options?.typeName}), service),
+                    visible,
+                    disabled,
                     glyph: 'info-sign',
-                    tooltipId: 'search.showGFI',
+                    tooltipId: visible && disabled ? 'search.layerMustBeVisible' : 'search.showGFI',
                     onClick: e => {
                         e.stopPropagation();
                         this.props.showGFI(item);

--- a/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
@@ -148,44 +148,71 @@ describe("test the SearchResultList", () => {
         expect(spy).toHaveBeenCalledWith(items[0], mapConfig);
     });
 
-    it('test showGFI button when it is enabled', () => {
-        const tb = ReactDOM.render(<SearchResultList searchOptions={{
-            services: [{
+    it('test showGFI button is enabled when openFeatureInfoButton=true', () => {
+        const tb = ReactDOM.render(<SearchResultList results={[{
+            id: "ID",
+            properties: {
+                prop1: 1
+            },
+            __SERVICE__: {
                 id: "S1",
                 displayName: "S1",
                 subTitle: "S1",
+                options: {
+                    typeName: 'layerName'
+                },
                 launchInfoPanel: 'single_layer',
-                openFeatureInfoButtonEnabled: true,
-                forceSearchLayerVisibility: true
-            }]
-        }} results={[{
-            id: "ID",
-            properties: {
-                prop1: 1
-            },
-            __SERVICE__: "S1"
-        }]} notFoundMessage="not found"/>, document.getElementById("container"));
+                openFeatureInfoButtonEnabled: true
+            }
+        }]} layers={[{id: 'layerId', name: 'layerName', visibility: true}]} notFoundMessage="not found"/>, document.getElementById("container"));
         expect(tb).toExist();
-        const button = document.querySelector('.search-result button');
+        const button = document.getElementById('open-gfi');
         expect(button).toExist();
+        expect(button.getAttribute('disabled')).toBe(null);
     });
 
-    it('test showGFI button when it is disabled', () => {
-        const tb = ReactDOM.render(<SearchResultList searchOptions={{
-            services: [{
-                id: "S1",
-                displayName: "S1",
-                subTitle: "S1"
-            }]
-        }} results={[{
+    it('test showGFI button is not present when openFeatureButtonEnabled=false', () => {
+        const tb = ReactDOM.render(<SearchResultList results={[{
             id: "ID",
             properties: {
                 prop1: 1
             },
-            __SERVICE__: "S1"
-        }]} notFoundMessage="not found"/>, document.getElementById("container"));
+            __SERVICE__: {
+                id: "S1",
+                displayName: "S1",
+                subTitle: "S1",
+                options: {
+                    typeName: 'layerName'
+                },
+                launchInfoPanel: 'single_layer',
+                openFeatureInfoButtonEnabled: false
+            }
+        }]} layers={[{id: 'layerId', name: 'layerName', visibility: true}]} notFoundMessage="not found"/>, document.getElementById("container"));
         expect(tb).toExist();
-        const button = document.querySelector('.search-result button');
+        const button = document.getElementById('open-gfi');
         expect(button).toNotExist();
+    });
+
+    it('test showGFI button is disabled when openFeatureButtonEnabled=true and the target layer is not visible', () => {
+        const tb = ReactDOM.render(<SearchResultList results={[{
+            id: "ID",
+            properties: {
+                prop1: 1
+            },
+            __SERVICE__: {
+                id: "S1",
+                displayName: "S1",
+                subTitle: "S1",
+                options: {
+                    typeName: 'layerName'
+                },
+                launchInfoPanel: 'single_layer',
+                openFeatureInfoButtonEnabled: true
+            }
+        }]} layers={[{id: 'layerId', name: 'layerName', visibility: false}]} notFoundMessage="not found"/>, document.getElementById("container"));
+        expect(tb).toExist();
+        const button = document.getElementById('open-gfi');
+        expect(button).toExist();
+        expect(button.getAttribute('disabled')).toBe('');
     });
 });

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -308,6 +308,84 @@ describe('search Epics', () => {
         expect(zoomToExtentAction.extent.length).toEqual(4);
     });
 
+    it('searchItemSelected epic with a service with openFeatureInfoButtonEnabled=false', () => {
+        let action = selectSearchItem({
+            "id": "Feature_1",
+            "type": "Feature",
+            "bbox": [125, 10, 126, 11],
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[100, 10], [100, 20]]
+            },
+            "properties": {
+                "name": "Dinagat Islands"
+            },
+            "__SERVICE__": {
+                launchInfoPanel: "single_layer",
+                openFeatureInfoButtonEnabled: false,
+                options: {
+                    typeName: "gs:layername"
+                }
+            }
+        }, {
+            size: {
+                width: 200,
+                height: 200
+            },
+            projection: "EPSG:4326"
+        });
+        store.dispatch( action );
+
+        let actions = store.getActions();
+        let expectedActions = [ZOOM_TO_EXTENT, TEXT_SEARCH_ADD_MARKER, SHOW_MAPINFO_MARKER, FEATURE_INFO_CLICK];
+        let actionsType = actions.map(a => a.type);
+
+        expectedActions.forEach((a) => {
+            expect(actionsType.indexOf(a)).toNotBe(-1);
+        });
+    });
+
+    it('searchItemSelected epic with a service with openFeatureInfoButtonEnabled=true', () => {
+        let action = selectSearchItem({
+            "id": "Feature_1",
+            "type": "Feature",
+            "bbox": [125, 10, 126, 11],
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[100, 10], [100, 20]]
+            },
+            "properties": {
+                "name": "Dinagat Islands"
+            },
+            "__SERVICE__": {
+                launchInfoPanel: "single_layer",
+                openFeatureInfoButtonEnabled: true,
+                options: {
+                    typeName: "gs:layername"
+                }
+            }
+        }, {
+            size: {
+                width: 200,
+                height: 200
+            },
+            projection: "EPSG:4326"
+        });
+        store.dispatch( action );
+
+        let actions = store.getActions();
+        let expectedActions = [ZOOM_TO_EXTENT, TEXT_SEARCH_ADD_MARKER, SHOW_MAPINFO_MARKER];
+        let actionsType = actions.map(a => a.type);
+
+        expectedActions.forEach((a) => {
+            expect(actionsType.indexOf(a)).toNotBe(-1);
+        });
+
+        let featureInfoClickAction = actions.filter(m => m.type === FEATURE_INFO_CLICK);
+        expect(featureInfoClickAction).toExist();
+        expect(featureInfoClickAction.length).toBe(0);
+    });
+
     it('zoomAndAddPointEpic ADD addiditonalLayer and zoom to point', () => {
         let action = zoomAndAddPoint({x: 1, y: 0}, 10, "EPSG:4326");
         store.dispatch( action );

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -38,7 +38,7 @@ import {
 } from '../actions/search';
 
 import CoordinatesUtils from '../utils/CoordinatesUtils';
-import {defaultIconStyle, showGFIForService} from '../utils/SearchUtils';
+import {defaultIconStyle, showGFIForService, layerIsVisibleForGFI} from '../utils/SearchUtils';
 import {generateTemplateString} from '../utils/TemplateUtils';
 
 import {API} from '../api/searchText';
@@ -152,7 +152,7 @@ export const searchItemSelected = (action$, store) =>
                             }
                             return [
                                 ...(forceVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
-                                featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId),
+                                ...(!item.__SERVICE__.openFeatureInfoButtonEnabled ? [featureInfoClick({ latlng }, typeName, filterNameList, overrideParams, itemId)] : []),
                                 showMapinfoMarker(),
                                 ...actions
                             ];
@@ -200,7 +200,7 @@ export const textSearchShowGFIEpic = (action$, store) =>
             const latlng = { lng: coord[0], lat: coord[1] };
 
             return !!coord &&
-                showGFIForService(layerObj, item?.__SERVICE__) ?
+                showGFIForService(item?.__SERVICE__) && layerIsVisibleForGFI(layerObj, item?.__SERVICE__) ?
                 Rx.Observable.of(
                     ...(item?.__SERVICE__?.forceSearchLayerVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
                     featureInfoClick({ latlng }, typeName, [typeName], { [typeName]: { info_format: "application/json" } }, item.id),

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -697,6 +697,7 @@
             "addAsLayer": "Als Ebene hinzufügen"
         },
         "search":{
+            "layerMustBeVisible": "Die Zielschicht ist inaktiv",
             "decimal": "Dezimal",
             "aeronautical": "Luftfahrt",
             "changeSearchInputField": "Ändern Sie das Suchwerkzeug",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -697,6 +697,7 @@
             "addAsLayer": "Add as layer"
         },
         "search":{
+            "layerMustBeVisible": "The target layer is inactive",
             "decimal": "Decimal",
             "aeronautical": "Aeronautical",
             "changeSearchInputField": "Change the search tool",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -697,6 +697,7 @@
             "addAsLayer": "Agregar como capa"
         },
         "search":{
+            "layerMustBeVisible": "La capa de destino está inactiva",
             "decimal": "Decimal",
             "aeronautical": "Aeronáutica",
             "changeSearchInputField": "Cambiar la herramienta de búsqueda",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -697,6 +697,7 @@
             "addAsLayer": "Ajouter comme couche"
         },
         "search": {
+            "layerMustBeVisible": "Le calque cible est inactif",
             "decimal": "Décimal",
             "aeronautical": "Aéronautique",
             "changeSearchInputField": "Changer l'outil de recherche",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -697,6 +697,7 @@
             "addAsLayer": "Aggiungi come livello"
         },
         "search":{
+            "layerMustBeVisible": "Il livello di destinazione è inattivo",
             "decimal": "Decimali",
             "aeronautical": "Aeronautiche",
             "changeSearchInputField": "Cambia lo strumento di ricerca",

--- a/web/client/utils/SearchUtils.js
+++ b/web/client/utils/SearchUtils.js
@@ -14,11 +14,12 @@ const defaultIconStyle = {
     shadowSize: [41, 41]
 };
 
-const showGFIForService = (searchLayerObj, service) => service?.launchInfoPanel === 'single_layer' &&
-    !!service?.openFeatureInfoButtonEnabled &&
-    (service?.forceSearchLayerVisibility || !!searchLayerObj?.visibility);
+const showGFIForService = (service) => service?.launchInfoPanel === 'single_layer' && !!service?.openFeatureInfoButtonEnabled;
+
+const layerIsVisibleForGFI = (searchLayerObj, service) => service?.forceSearchLayerVisibility || !!searchLayerObj?.visibility;
 
 module.exports = {
     defaultIconStyle,
-    showGFIForService
+    showGFIForService,
+    layerIsVisibleForGFI
 };

--- a/web/client/utils/__tests__/SearchUtils-test.js
+++ b/web/client/utils/__tests__/SearchUtils-test.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 const expect = require('expect');
-const {defaultIconStyle, showGFIForService} = require('../SearchUtils');
+const {defaultIconStyle, showGFIForService, layerIsVisibleForGFI} = require('../SearchUtils');
 
 
 describe('SearchUtils test', () => {
@@ -21,18 +21,18 @@ describe('SearchUtils test', () => {
         });
     });
     it('showGFIForService with feature info button enabled', () => {
-        expect(showGFIForService({visibility: true}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true})).toBe(true);
+        expect(showGFIForService({launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true})).toBe(true);
     });
     it('showGFIForService with feature info button disabled', () => {
-        expect(showGFIForService({visibility: true}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: false})).toBe(false);
+        expect(showGFIForService({launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: false})).toBe(false);
     });
     it('showGFIForService wrong launch info panel', () => {
-        expect(showGFIForService({visibility: true}, {launchInfoPanel: 'all_layers', openFeatureInfoButtonEnabled: true})).toBe(false);
+        expect(showGFIForService({launchInfoPanel: 'all_layers', openFeatureInfoButtonEnabled: true})).toBe(false);
     });
-    it('showGFIForService layer hidden no force visibility', () => {
-        expect(showGFIForService({visibility: false}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true})).toBe(false);
+    it('layerIsVisibleForGFI layer hidden no force visibility', () => {
+        expect(layerIsVisibleForGFI({visibility: false}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true})).toBe(false);
     });
-    it('showGFIForService layer hidden with force visibility', () => {
-        expect(showGFIForService({visibility: false}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true, forceSearchLayerVisibility: true})).toBe(true);
+    it('layerIsVisibleForGFI layer hidden with force visibility', () => {
+        expect(layerIsVisibleForGFI({visibility: false}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true, forceSearchLayerVisibility: true})).toBe(true);
     });
 });


### PR DESCRIPTION
## Description
Changes to GFI button.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: enhancement

## Issue
#5386 

**What is the current behavior?**
In search bar if the service has "Use button to open feature info" enabled then a button to zoom in and perform GFI request will be present in search results. Clicking on the whole bar will do the same thing. If the source layer is not active the button is not present, unless "Force search layer visibility" options is also set.

**What is the new behavior?**
The button is greyed out if the source layer is inactive, instead of being not present at all. Clicking on GFI button performs GFI, zooms in to and highlights the feature. Clicking on the bar does the zoom in and highlight without the GFI request. If "Use button to open feature info" option is disabled then clicking on the bar will do the GFI request.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No