### PR TITLE
#5623 Improved icon image input

### DIFF
--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -155,9 +155,7 @@ export const fields = {
     image: ({
         label,
         value,
-        config: {
-            isValid
-        },
+        config: {},
         onChange
     }) => {
 
@@ -167,25 +165,25 @@ export const fields = {
         let [url, setUrl] = useState("");
 
         const onImgSourceChange = (event)=> {
-            const url = event.target.value;
-            setUrl(url);
+            const imageUrl = event.target.value;
+            setUrl(imageUrl);
             setLoadingShown(true);
             setIconShown(false);
             setImageShown(false);
-            onChange(url);
-        }
+            onChange(imageUrl);
+        };
 
         const onImgLoad = ()=> {
             setImageShown(true);
             setLoadingShown(false);
             setIconShown(false);
-        }
+        };
 
         const onImgError = ()=> {
             setImageShown(false);
             setLoadingShown(false);
             setIconShown(true);
-        }
+        };
 
         return (
             <PropertyField
@@ -207,10 +205,10 @@ export const fields = {
                         style={{ position: 'absolute', right: 4, top: 4, width: 22, height: 22, objectFit: 'contain' }}/>
                     <div
                         style={{ position: 'absolute', right: 8, top: 6}}
-                        className={iconShown ? "": "collapse"}>
+                        className={iconShown ? "" : "collapse"}>
                         <OverlayTrigger placement="top"
-                            overlay={<Tooltip><Message msgId={url.length == 0 ? "styleeditor.missingImageUrl" : "styleeditor.invalidImageUrl"} /></Tooltip>}>
-                            <Glyphicon glyph="exclamation-sign"></Glyphicon>
+                            overlay={<Tooltip><Message msgId={url.length === 0 ? "styleeditor.missingImageUrl" : "styleeditor.invalidImageUrl"} /></Tooltip>}>
+                            <Glyphicon glyph="exclamation-sign"/>
                         </OverlayTrigger>
                     </div>
                     <div

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useRef, useState, useEffect } from 'react';
-import { FormGroup, FormControl as FormControlRB  } from 'react-bootstrap';
+import { OverlayTrigger, Glyphicon, Tooltip, FormGroup, FormControl as FormControlRB  } from 'react-bootstrap';
 import isObject from 'lodash/isObject';
 import omit from 'lodash/omit';
 import isNil from 'lodash/isNil';
@@ -161,19 +161,62 @@ export const fields = {
         onChange
     }) => {
 
-        const valid = !isValid || isValid({ value });
+        let [imageShown, setImageShown] = useState(false);
+        let [loadingShown, setLoadingShown] = useState(false);
+        let [iconShown, setIconShown] = useState(true);
+        let [url, setUrl] = useState("");
+
+        const onImgSourceChange = (event)=> {
+            const url = event.target.value;
+            setUrl(url);
+            setLoadingShown(true);
+            setIconShown(false);
+            setImageShown(false);
+            onChange(url);
+        }
+
+        const onImgLoad = ()=> {
+            setImageShown(true);
+            setLoadingShown(false);
+            setIconShown(false);
+        }
+
+        const onImgError = ()=> {
+            setImageShown(false);
+            setLoadingShown(false);
+            setIconShown(true);
+        }
+
         return (
             <PropertyField
                 label={label}
-                invalid={!valid}>
-                <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                    <FormGroup style={{ flex: 1 }}>
+                invalid={iconShown}>
+                <div style={{ position: 'relative' }}>
+                    <FormGroup>
                         <FormControl
+                            style={{paddingRight: 26}}
                             placeholder="styleeditor.placeholderEnterImageUrl"
                             value={value}
-                            onChange={event => onChange(event.target.value)}/>
+                            onChange={onImgSourceChange}/>
                     </FormGroup>
-                    <img src={value} style={{ width: 28, height: 28, objectFit: 'contain' }}/>
+                    <img
+                        className={imageShown ? "" : "collapse"}
+                        onLoad={onImgLoad}
+                        onError={onImgError}
+                        src={value}
+                        style={{ position: 'absolute', right: 4, top: 4, width: 22, height: 22, objectFit: 'contain' }}/>
+                    <div
+                        style={{ position: 'absolute', right: 8, top: 6}}
+                        className={iconShown ? "": "collapse"}>
+                        <OverlayTrigger placement="top"
+                            overlay={<Tooltip><Message msgId={url.length == 0 ? "styleeditor.missingImageUrl" : "styleeditor.invalidImageUrl"} /></Tooltip>}>
+                            <Glyphicon glyph="exclamation-sign"></Glyphicon>
+                        </OverlayTrigger>
+                    </div>
+                    <div
+                        style={{ position: 'absolute', right: 4, top: 4, width: 20, height: 20}}
+                        className={loadingShown ? "mapstore-small-size-loader" : "collapse"}>
+                    </div>
                 </div>
             </PropertyField>
         );

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2033,6 +2033,8 @@
             "contrastEnhancement": "Kontrastverbesserung",
             "placeholderInput": "Wert eingeben",
             "placeholderEnterImageUrl": "Bild-URL eingeben",
+            "missingImageUrl": "Fehlende Bild-URL",
+            "invalidImageUrl": "Ungültige Bild-URL",
             "selectPlaceholder": "Wert auswählen",
             "noResultsSelectInput": "Keine Ergebnisse",
             "channelAuto": "Auto",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2040,6 +2040,8 @@
             "contrastEnhancement": "Contrast enhancement",
             "placeholderInput": "Enter value",
             "placeholderEnterImageUrl": "Enter image url",
+            "missingImageUrl": "Missing image url",
+            "invalidImageUrl": "Invalid image url",
             "selectPlaceholder": "Select value",
             "noResultsSelectInput": "No results",
             "channelAuto": "Auto",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2034,6 +2034,8 @@
             "contrastEnhancement": "Mejora de contraste",
             "placeholderInput": "Introducir valor",
             "placeholderEnterImageUrl": "Ingresar url de imagen",
+            "missingImageUrl": "Falta la URL de la imagen",
+            "invalidImageUrl": "URL de imagen no válida",
             "selectPlaceholder": "Seleccionar valor",
             "noResultsSelectInput": "Sin resultados",
             "channelAuto": "Auto",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2035,6 +2035,8 @@
             "contrastEnhancement": "Contrast enhancement",
             "placeholderInput": "Entrez une valeur",
             "placeholderEnterImageUrl": "Entrez l'URL de l'image",
+            "missingImageUrl": "URL d'image manquante",
+            "invalidImageUrl": "URL d'image incorrecte",
             "selectPlaceholder": "Sélectionnez la valeur",
             "noResultsSelectInput": "Aucun résultat",
             "channelAuto": "Auto",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2034,6 +2034,8 @@
             "contrastEnhancement": "Miglioramento del contrasto",
             "placeholderInput": "Inserisci valore",
             "placeholderEnterImageUrl": "Inserisci l'URL dell'immagine",
+            "missingImageUrl": "URL immagine mancante",
+            "invalidImageUrl": "URL immagine non valido",
             "selectPlaceholder": "Seleziona valore",
             "noResultsSelectInput": "Nessun risultato",
             "channelAuto": "Auto",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/issues/5623
The current icon image input does not show an indication of image validity. 
It shows a broken image visual for invalid image URLs and does not display any warning text

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
![5623](https://user-images.githubusercontent.com/4329962/92693365-375c0e80-f34e-11ea-9c4e-6bbc78e1896b.gif)

1. without text, a warning icon is displayed
2. on icon mouse hover, a tooltip shows a "Missing URL" message
3. when the provided text is not a valid image URL, icon is shown and the tooltip message "Invalid URL" is displayed
4. if the provided text is a valid image URL, the image is displayed inline
5. when the text inside the input changes, a loading icon is displayed


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Image source validity is captured by the native image [onerror](https://www.w3schools.com/jsref/event_onerror.asp) event

