### PR TITLE
#5843 - zoomToExtent fix on bookmark select when map load

### DIFF
--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -454,7 +454,9 @@ describe("test the SearchBar", () => {
         expect(spyOnLayerVisibilityLoad.calls.length).toBe(1);
         expect(spyOnLayerVisibilityLoad.calls[0].arguments[0]).toEqual({map: {layers: "Tests", bookmark_search_config: {bookmarks: [{title: "Bookmark 1"}, {title: "Bookmark 2"}]}}});
         expect(spyOnLayerVisibilityLoad.calls[0].arguments[1]).toEqual(null);
-        expect(spyOnLayerVisibilityLoad.calls[0].arguments[2]).toEqual([5, 10, 20, 30]);
+        expect(spyOnLayerVisibilityLoad.calls[0].arguments[2]).toBeTruthy();
+        expect(spyOnLayerVisibilityLoad.calls[0].arguments[2].bounds).toEqual([ 5, 10, 20, 30 ]);
+        expect(spyOnLayerVisibilityLoad.calls[0].arguments[2].crs).toBe('EPSG:4326');
     });
     it('test searchByBookmark, load a bookmark with zoomToExtent', () => {
         const store = {dispatch: () => {}, subscribe: () => {}, getState: () => ({searchbookmarkconfig: {selected: {}}})};

--- a/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkSelect.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/BookmarkSelect.jsx
@@ -39,7 +39,7 @@ export const BookmarkOptions = ({
                     ...mapInitial.map,
                     bookmark_search_config: bookmarkSearchConfig
                 }
-            }, null, [bbox.west, bbox.south, bbox.east, bbox.north]);
+            }, null, {bounds: [bbox.west, bbox.south, bbox.east, bbox.north], crs: mapInitial?.map?.center?.crs || "EPSG:4326"});
         } else if (bbox && !isEmpty(bbox)) {
             onZoomToExtent([bbox.west, bbox.south, bbox.east, bbox.north], "EPSG:4326");
         }

--- a/web/client/components/mapcontrols/searchbookmarkconfig/__tests__/BookmarkSelect-test.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/__tests__/BookmarkSelect-test.jsx
@@ -129,5 +129,8 @@ describe("BookmarkList component", () => {
         expect(spyOnchange.calls[1].arguments[0].config.map).toBeTruthy();
         expect(spyOnchange.calls[1].arguments[0].config.map.layer).toEqual("Test");
         expect(spyOnchange.calls[1].arguments[0].config.map.bookmark_search_config).toBeTruthy();
+        expect(spyOnchange.calls[1].arguments[0].zoomToExtent).toBeTruthy();
+        expect(spyOnchange.calls[1].arguments[0].zoomToExtent.bounds).toEqual([1, 1, 1, 1]);
+        expect(spyOnchange.calls[1].arguments[0].zoomToExtent.crs).toBe("EPSG:4326");
     });
 });


### PR DESCRIPTION
## Description
When map loaded with initial config on bookmark select the map zooms to extent

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/issues/5843#issuecomment-690148312

**What is the new behavior?**
When bookmark is selected with visibility reload, the map is loaded with initial config and it zooms to extent set on the bookmark

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
