### PR TITLE
#5857: Measure geometry export and annotation style fix

### DIFF
--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -208,12 +208,13 @@ class Annotations extends React.Component {
 
     renderFieldValue = (field, annotation) => {
         const fieldValue = annotation.properties[field.name] || '';
-        switch (field.type) {
-        case 'html':
-            return <span dangerouslySetInnerHTML={{__html: fieldValue} }/>;
-        default:
-            return fieldValue;
+        if (field.type === 'html') {
+            // Return the text content of the first child of the html string (to prevent collating all texts into a single word)
+            return (new DOMParser).parseFromString(fieldValue, "text/html").documentElement.lastElementChild
+                ?.firstChild
+                ?.textContent || '';
         }
+        return fieldValue;
     };
 
     renderThumbnail = ({featureType, geometry, properties = {}}) => {

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -622,7 +622,7 @@ class AnnotationsEditor extends React.Component {
                                 <Message msgId={"annotations.tabStyle"}/>
                             </NavItem>
                         </Nav>
-                        <div style={{flex: 1, overflow: 'auto', paddingTop: 8}}>
+                        <div className={'tab-container'}>
                             {this.state.tabValue === 'coordinates' &&
                             <GeometryEditor
                                 options={this.props.config && this.props.config.geometryEditorOptions}

--- a/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/Annotations-test.js
@@ -190,7 +190,7 @@ describe("test the Annotations Panel", () => {
             "properties": {
                 "id": "819b4120-aa2c-11ea-95b6-c74060290256",
                 "title": "Poly",
-                "description": "<p>Description</p>",
+                "description": "<p>Description</p><p>Next Line</p>",
                 "visibility": true
             },
             "features": [
@@ -222,6 +222,8 @@ describe("test the Annotations Panel", () => {
         expect(sideCard.length).toBe(1);
         const sideCardTitle = TestUtils.scryRenderedDOMComponentsWithClass(container, "mapstore-annotations-panel-card-title");
         expect(sideCardTitle[0].innerText).toBe('Poly');
+        const sideCardDescription = TestUtils.scryRenderedDOMComponentsWithClass(container, "mapstore-annotations-panel-card-description");
+        expect(sideCardDescription[0].innerText).toBe('Description');
         const sideCardTools = document.querySelectorAll('.mapstore-side-card-tool .btn-group');
         expect(sideCardTools).toBeTruthy();
         const cardButtons = sideCardTools[0].querySelectorAll('button');

--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -106,6 +106,12 @@ describe('measurement epics', () => {
                 expect(actions[0].type).toBe("TOGGLE_CONTROL");
                 expect(actions[1].type).toBe("ANNOTATIONS:NEW");
                 expect(actions[2].type).toBe("ANNOTATIONS:SET_EDITING_FEATURE");
+                expect(actions[2].feature.features).toBeTruthy();
+                expect(actions[2].feature.features.length).toBe(4);
+                expect(actions[2].feature.features[0].geometry.type).toBe("LineString");
+                expect(actions[2].feature.features[1].geometry.type).toBe("Point");
+                expect(actions[2].feature.features[2].geometry.type).toBe("Point");
+                expect(actions[2].feature.features[3].geometry.type).toBe("Point");
                 done();
             }, null);
     });
@@ -152,6 +158,7 @@ describe('measurement epics', () => {
                 const innerFeatures = resultFeatures[0].features;
                 expect(innerFeatures.length).toBe(4);
                 expect(innerFeatures[0].geometry).toExist();
+                expect(innerFeatures[0].geometry.type).toBe('LineString');
                 expect(innerFeatures[0].geometry.textLabels).toExist();
                 expect(innerFeatures[0].geometry.textLabels[0].text).toBe("2,937,911.16 m | 061.17° T");
                 expect(innerFeatures[0].geometry.textLabels[1].text).toBe("1,837,281.12 m | 140.72° T");

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -143,10 +143,12 @@
         border-bottom: none;
         height: auto;
     }
-    .mapstore-annotations-panel-card-description p{
+    .mapstore-annotations-panel-card-description {
         margin: 5px 0 0;
         text-overflow: ellipsis;
-        width: 100px;
+        width: 150px;
+        white-space: nowrap;
+        overflow: hidden;
     }
 }
 
@@ -382,10 +384,14 @@
         width: 100%;
         height: 100%;
         flex-direction: column;
-        .ms-style-manager {
+        .tab-container{
+            flex: 1;
+            padding-top: 8px;
             position: relative;
             overflow-y: auto;
             overflow-x: hidden;
+        }
+        .ms-style-manager {
             .Select *{
                 font-size: inherit !important;
             }
@@ -706,11 +712,6 @@
 
 .modal-dialog-container{
     border: none;
-}
-
-.ms-style-manager {
-    position: absolute;
-    width: 100%;
 }
 
 .label-texts {

--- a/web/client/utils/MeasurementUtils.js
+++ b/web/client/utils/MeasurementUtils.js
@@ -50,7 +50,7 @@ const convertGeometryToGeoJSON = (feature, uom, measureValueStyle) => {
     return [{
         type: 'Feature',
         geometry: {
-            type: feature.geometry.type === 'LineString' ? 'MultiPoint' : feature.geometry.type,
+            type: feature.geometry.type,
             coordinates: validateFeatureCoordinates(feature.geometry),
             textLabels: feature.geometry.textLabels
         },

--- a/web/client/utils/__tests__/MeasurementUtils-test.js
+++ b/web/client/utils/__tests__/MeasurementUtils-test.js
@@ -62,7 +62,7 @@ describe('MeasurementUtils', () => {
         expect(geoJson.features.length).toBe(2);
         expect(geoJson.features[0].type).toBe('Feature');
         expect(geoJson.features[0].geometry).toExist();
-        expect(geoJson.features[0].geometry.type).toBe('MultiPoint');
+        expect(geoJson.features[0].geometry.type).toBe('LineString');
         expect(geoJson.features[0].geometry.coordinates).toEqual(features[0].geometry.coordinates);
         expect(geoJson.features[0].properties).toExist();
         expect(geoJson.features[0].properties.geometryGeodesic).toExist();


### PR DESCRIPTION
## Description
Fix for measure geometry of type LineString exported as Point and some styling issue in Annotations panel.
(_PR contains both fixes as they are related to Annotations_)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#5857  & https://github.com/geosolutions-it/MapStore2/issues/5775#issuecomment-690435228

**What is the new behavior?**
- Exported geometry from Measure is imported as expected ('LineString' as 'LineString' instead of 'MultiPoint')
- Annotation description is contained within the card and displays ellipsis when content is lengthier
- Style panel will not display additional scrollbar 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
