### PR TITLE
Search Service - show GFI

### DIFF
--- a/web/client/components/mapcontrols/search/SearchResultList.jsx
+++ b/web/client/components/mapcontrols/search/SearchResultList.jsx
@@ -14,6 +14,8 @@ import assign from 'object-assign';
 import SearchResult from './SearchResult';
 import I18N from '../../I18N/I18N';
 
+import OverlayTriggerCustom from '../../misc/OverlayTriggerCustom';
+
 import { showGFIForService, layerIsVisibleForGFI } from '../../../utils/SearchUtils';
 
 export default class SearchResultList extends React.Component {
@@ -66,10 +68,12 @@ export default class SearchResultList extends React.Component {
                 onItemClick={this.onItemClick}
                 tools={[{
                     id: 'open-gfi',
+                    keyProp: 'open-gfi',
                     visible,
                     disabled,
                     glyph: 'info-sign',
                     tooltipId: visible && disabled ? 'search.layerMustBeVisible' : 'search.showGFI',
+                    customOverlayTrigger: OverlayTriggerCustom, // to make sure that a tooltip is triggered in chrome when the button is disabled
                     onClick: e => {
                         e.stopPropagation();
                         this.props.showGFI(item);

--- a/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchResultList-test.jsx
@@ -214,5 +214,10 @@ describe("test the SearchResultList", () => {
         const button = document.getElementById('open-gfi');
         expect(button).toExist();
         expect(button.getAttribute('disabled')).toBe('');
+
+        TestUtils.Simulate.mouseOver(button);
+
+        const tooltip = document.getElementById('tooltip-open-gfi');
+        expect(tooltip).toExist();
     });
 });

--- a/web/client/components/misc/OverlayTriggerCustom.jsx
+++ b/web/client/components/misc/OverlayTriggerCustom.jsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root dir
+ ectory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import { Overlay } from 'react-bootstrap';
+
+import withContainer from './WithContainer';
+
+/**
+ * OverlayTrigger custom implementation to work around a tooltip not being triggered
+ * on mouse hover if the button being overlayed is disabled in Chrome. The workaround is to wrap
+ * the child component with a span. Potentially can be expanded to support the features of OverlayTrigger
+ * and replace it completely.
+ */
+class OverlayTriggerCustom extends React.Component {
+    static propTypes = {
+        overlay: PropTypes.element,
+        placement: PropTypes.string,
+        container: PropTypes.element
+    };
+
+    static defaultProps = {
+        placement: 'right'
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            show: false
+        };
+        this.target = React.createRef();
+    }
+
+    render() {
+        return (
+            <>
+                <span ref={this.target} onMouseOver={() => this.setState({show: true})} onMouseOut={() => this.setState({show: false})}>
+                    {React.Children.only(this.props.children)}
+                </span>
+                <Overlay
+                    show={this.state.show}
+                    onHide={() => this.setState({ show: false })}
+                    placement={this.props.placement}
+                    container={this.props.container}
+                    target={() => this.target && this.target.current && ReactDOM.findDOMNode(this.target.current)}
+                >
+                    {this.props.overlay}
+                </Overlay>
+            </>
+        );
+    }
+}
+
+export default withContainer(OverlayTriggerCustom);

--- a/web/client/components/misc/__tests__/OverlayTriggerCustom-test.jsx
+++ b/web/client/components/misc/__tests__/OverlayTriggerCustom-test.jsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root dir
+ ectory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+import expect from 'expect';
+import { Tooltip, Button } from 'react-bootstrap';
+
+import OverlayTriggerCustom from '../OverlayTriggerCustom';
+
+const overlay = <Tooltip id="tooltip-test"><span>Message</span></Tooltip>;
+
+describe('OverlayTriggerCustom component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('tooltip on button hover', () => {
+        const testComponent = (
+            <OverlayTriggerCustom overlay={overlay}>
+                <Button id="test-button">
+                    Button
+                </Button>
+            </OverlayTriggerCustom>
+        );
+
+        ReactDOM.render(testComponent, document.getElementById('container'));
+        const button = document.getElementById('test-button');
+        expect(button).toExist();
+
+        TestUtils.Simulate.mouseOver(button);
+
+        const overlayElement = document.getElementById('tooltip-test');
+        expect(overlayElement).toExist();
+    });
+    it('tooltip on disabled button hover', () => {
+        const testComponent = (
+            <OverlayTriggerCustom overlay={overlay}>
+                <Button id="test-button" disabled>
+                    Button
+                </Button>
+            </OverlayTriggerCustom>
+        );
+
+        ReactDOM.render(testComponent, document.getElementById('container'));
+        const button = document.getElementById('test-button');
+        expect(button).toExist();
+
+        TestUtils.Simulate.mouseOver(button);
+
+        const overlayElement = document.getElementById('tooltip-test');
+        expect(overlayElement).toExist();
+    });
+});

--- a/web/client/components/misc/enhancers/tooltip.jsx
+++ b/web/client/components/misc/enhancers/tooltip.jsx
@@ -30,12 +30,12 @@ const {omit} = require('lodash');
  */
 module.exports = branch(
     ({tooltip, tooltipId} = {}) => tooltip || tooltipId,
-    (Wrapped) => ({tooltip, tooltipId, tooltipPosition = "top", tooltipTrigger, keyProp, idDropDown, args, ...props} = {}) => (<OverlayTrigger
+    (Wrapped) => ({tooltip, tooltipId, tooltipPosition = "top", tooltipTrigger, keyProp, idDropDown, args, customOverlayTrigger: CustomOverlayTrigger = OverlayTrigger, ...props} = {}) => (<CustomOverlayTrigger
         trigger={tooltipTrigger}
         id={idDropDown}
         key={keyProp}
         placement={tooltipPosition}
-        overlay={<Tooltip id={"tooltip-" + {keyProp}}>{tooltipId ? <Message msgId={tooltipId} msgParams={{data: args}} /> : tooltip}</Tooltip>}><Wrapped {...props}/></OverlayTrigger>),
+        overlay={<Tooltip id={"tooltip-" + keyProp}>{tooltipId ? <Message msgId={tooltipId} msgParams={{data: args}} /> : tooltip}</Tooltip>}><Wrapped {...props}/></CustomOverlayTrigger>),
     // avoid to pass non needed props
     (Wrapped) => (props) => <Wrapped {...(omit(props, ["tooltipId", "tooltip"]))}>{props.children}</Wrapped>
 );


### PR DESCRIPTION
## Description
Addressing [this](https://github.com/geosolutions-it/MapStore2/issues/5386#issuecomment-691067643). On my machine firefox works fine, but on Chromium if button is disabled the tooltips were not shown at all. This concerns any such button(for example location button in NavBar). The issue seems to be that if the button is disabled mouseover event handlers are not triggered for some reason. To resolve this I've found a solution in writing custom OverlayTrigger that will wrap the button in span that will handle showing the tooltip.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5386 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No