### PR TITLE
Fixed bash scripts for bin release

### DIFF
--- a/release/bin/mapstore2-shutdown.sh
+++ b/release/bin/mapstore2-shutdown.sh
@@ -12,6 +12,11 @@ PRGDIR=`pwd`
 EXECUTABLE=shutdown.sh
 CATALINA_HOME="$PRGDIR"
 
+export JAVA_HOME="$PRGDIR/jre/linux"
+export JRE_HOME="$PRGDIR/jre/linux"
+chmod +x jre/linux/bin/*
+
+
 if [ ! -x "$CATALINA_HOME"/bin/"$EXECUTABLE" ]; then
   echo "Cannot find $PRGDIR/$EXECUTABLE"
   echo "The file is absent or does not have execute permission"

--- a/release/bin/mapstore2-startup.sh
+++ b/release/bin/mapstore2-startup.sh
@@ -10,11 +10,10 @@ chmod +x bin/*.sh
 
 # Set local JAVA_HOME
 PRGDIR=`pwd`
-if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME="$PRGDIR/jre/linux"
-    export JRE_HOME="$PRGDIR/jre/linux"
-    chmod +x jre/linux/bin/*
-fi
+
+export JAVA_HOME="$PRGDIR/jre/linux"
+export JRE_HOME="$PRGDIR/jre/linux"
+chmod +x jre/linux/bin/*
 
 echo "Welcome to MapStore2!"
 


### PR DESCRIPTION
## Description
The old script use the local JVM, but is more correct to use the internal JVM, to avoid problems

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**What is the current behavior?**
Depending on the current java version, the binary could not run on linux

**What is the new behavior?**
The binary uses the embedded JRE to start tomcat.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
No need to back-port, if we do not intend to release another binary for 2020.02.xx
The problem of lock file and java ghost process is still present. 