### PR TITLE
MapTip functionality

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -35,7 +35,7 @@ var {
     SET_MAP_TRIGGER, setMapTrigger
 } = require('../mapInfo');
 
-describe('Test correctness of the map actions', () => {
+describe('Test correctness of the mapInfo actions', () => {
 
     it('gets vector info', () => {
         const retval = getVectorInfo('layer', 'request', 'metadata');
@@ -75,9 +75,10 @@ describe('Test correctness of the map actions', () => {
     });
 
     it('change mapInfo format', () => {
-        const retval = changeMapInfoFormat('testFormat');
+        const retval = changeMapInfoFormat('featureInfo', 'testFormat');
 
         expect(retval.type).toBe(CHANGE_MAPINFO_FORMAT);
+        expect(retval.gfiType).toBe('featureInfo');
         expect(retval.infoFormat).toBe('testFormat');
     });
 

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -33,6 +33,8 @@ const TOGGLE_SHOW_COORD_EDITOR = 'IDENTIFY:TOGGLE_SHOW_COORD_EDITOR';
 const EDIT_LAYER_FEATURES = 'IDENTIFY:EDIT_LAYER_FEATURES';
 const SET_CURRENT_EDIT_FEATURE_QUERY = 'IDENTIFY:CURRENT_EDIT_FEATURE_QUERY';
 const SET_MAP_TRIGGER = 'IDENTIFY:SET_MAP_TRIGGER';
+const SET_ENABLE_MAP_TIP_FORMAT = 'IDENTIFY:SET_ENABLE_MAP_TIP_FORMAT';
+const SET_MAP_TIP_ACTIVE_LAYER_ID = 'IDENTIFY:SET_MAP_TIP_ACTIVE_LAYER_ID';
 
 const TOGGLE_EMPTY_MESSAGE_GFI = "IDENTIFY:TOGGLE_EMPTY_MESSAGE_GFI";
 const toggleEmptyMessageGFI = () => ({type: TOGGLE_EMPTY_MESSAGE_GFI});
@@ -126,6 +128,7 @@ function purgeMapInfoResults() {
 
 /**
  * Set a new format for GetFeatureInfo request.
+ * @param gfiType {string} 'featureInfo' or 'mapTip'
  * @param mimeType {string} correct value are:
  *   - "text/plain"
  *   - "text/html"
@@ -134,9 +137,10 @@ function purgeMapInfoResults() {
  *   - "application/vnd.ogc.gml"
  *   - "application/vnd.ogc.gml/3.1.1"
  */
-function changeMapInfoFormat(mimeType) {
+function changeMapInfoFormat(gfiType, mimeType) {
     return {
         type: CHANGE_MAPINFO_FORMAT,
+        gfiType,
         infoFormat: mimeType
     };
 }
@@ -274,6 +278,16 @@ const setMapTrigger = (trigger) => ({
     trigger
 });
 
+const setEnableMapTipFormat = (enable) => ({
+    type: SET_ENABLE_MAP_TIP_FORMAT,
+    enable
+});
+
+const setMapTipActiveLayerId = (layerId) => ({
+    type: SET_MAP_TIP_ACTIVE_LAYER_ID,
+    layerId
+});
+
 module.exports = {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
@@ -320,5 +334,7 @@ module.exports = {
     UPDATE_FEATURE_INFO_CLICK_POINT, updateFeatureInfoClickPoint,
     EDIT_LAYER_FEATURES, editLayerFeatures,
     SET_CURRENT_EDIT_FEATURE_QUERY, setCurrentEditFeatureQuery,
-    SET_MAP_TRIGGER, setMapTrigger
+    SET_MAP_TRIGGER, setMapTrigger,
+    SET_ENABLE_MAP_TIP_FORMAT, setEnableMapTipFormat,
+    SET_MAP_TIP_ACTIVE_LAYER_ID, setMapTipActiveLayerId
 };

--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -59,7 +59,10 @@ class DefaultLayer extends React.Component {
         isDraggable: PropTypes.bool,
         isDragging: PropTypes.bool,
         isOver: PropTypes.bool,
-        language: PropTypes.string
+        language: PropTypes.string,
+        showMapTipActiveButton: PropTypes.bool,
+        mapTipActiveLayerId: PropTypes.string,
+        changeMapTipActiveLayer: PropTypes.func
     };
 
     static defaultProps = {
@@ -85,7 +88,9 @@ class DefaultLayer extends React.Component {
         hideOpacityTooltip: false,
         connectDragPreview: (x) => x,
         connectDragSource: (x) => x,
-        connectDropTarget: (x) => x
+        connectDropTarget: (x) => x,
+        showMapTipActiveButton: false,
+        changeMapTipActiveLayer: () => {}
     };
 
     getTitle = (layer) => {
@@ -133,6 +138,17 @@ class DefaultLayer extends React.Component {
                 propertiesChangeHandler={this.props.propertiesChangeHandler} />);
     }
 
+    renderMapTipActive = () => {
+        const active = this.props.node.id === this.props.mapTipActiveLayerId;
+
+        return this.props.showMapTipActiveButton && this.props.node.loadingError !== 'Error' ?
+            (<LayersTool key="maptipactivecheck"
+                tooltip={active ? "toc.mapTipDeactivate" : "toc.mapTipActivate"}
+                node={this.props.node}
+                glyph={active ? 'star' : 'star-empty'}
+                onClick={node => this.props.changeMapTipActiveLayer(active ? undefined : node.id)}/>) : null;
+    }
+
     renderToolsLegend = (isEmpty) => {
         return this.props.node.loadingError === 'Error' || isEmpty ?
             null
@@ -161,6 +177,7 @@ class DefaultLayer extends React.Component {
             <div className="toc-default-layer-head">
                 {grab}
                 {this.renderVisibility()}
+                {this.renderMapTipActive()}
                 <ToggleFilter node={this.props.node} propertiesChangeHandler={this.props.propertiesChangeHandler}/>
                 <Title
                     tooltipOptions={this.props.tooltipOptions}

--- a/web/client/components/TOC/fragments/settings/FeatureInfoEditor.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfoEditor.jsx
@@ -39,13 +39,15 @@ class FeatureInfoEditor extends React.Component {
         element: PropTypes.object,
         onChange: PropTypes.func,
         onShowEditor: PropTypes.func,
-        enableIFrameModule: PropTypes.bool
+        enableIFrameModule: PropTypes.bool,
+        settingName: PropTypes.string
     };
 
     static defaultProps = {
         showEditor: false,
         element: {},
         enableIFrameModule: false,
+        settingName: 'featureInfo',
         onChange: () => {},
         onShowEditor: () => {}
     };
@@ -56,7 +58,7 @@ class FeatureInfoEditor extends React.Component {
 
     UNSAFE_componentWillMount() {
         this.setState({
-            template: this.props.element && this.props.element.featureInfo && this.props.element.featureInfo.template || ' '
+            template: this.props.element?.[this.props.settingName]?.template || ' '
         });
     }
 
@@ -97,8 +99,8 @@ class FeatureInfoEditor extends React.Component {
 
     close = () => {
         this.props.onShowEditor(!this.props.showEditor);
-        this.props.onChange('featureInfo', {
-            ...(this.props.element && this.props.element.featureInfo || {}),
+        this.props.onChange(this.props.settingName, {
+            ...(this.props.element?.[this.props.settingName] || {}),
             template: this.state.template
         });
     };

--- a/web/client/components/TOC/fragments/settings/GFI.jsx
+++ b/web/client/components/TOC/fragments/settings/GFI.jsx
@@ -28,14 +28,16 @@ module.exports = class extends React.Component {
         element: PropTypes.object,
         defaultInfoFormat: PropTypes.object,
         onChange: PropTypes.func,
-        formatCards: PropTypes.object
+        formatCards: PropTypes.object,
+        settingName: PropTypes.string
     };
 
     static defaultProps = {
         element: {},
         defaultInfoFormat: [],
         onChange: () => {},
-        formatCards: {}
+        formatCards: {},
+        settingName: 'featureInfo'
     };
 
     getInfoFormat = (infoFormats) => {
@@ -49,7 +51,7 @@ module.exports = class extends React.Component {
                     description: this.props.formatCards[infoFormat] && this.props.formatCards[infoFormat].descId && <Message msgId={this.props.formatCards[infoFormat].descId}/> || '',
                     size: 'sm'
                 },
-                body: Body && <Body template={this.props.element.featureInfo && this.props.element.featureInfo.template || ''} {...this.props}/> || null
+                body: Body && <Body settingName={this.props.settingName} template={this.props.element[this.props.settingName]?.template || ''} {...this.props}/> || null
             };
         });
     }
@@ -61,14 +63,14 @@ module.exports = class extends React.Component {
             <span>
                 <Accordion
                     fillContainer
-                    activePanel={this.props.element.featureInfo && this.props.element.featureInfo.format}
+                    activePanel={this.props.element[this.props.settingName]?.format}
                     panels={data}
                     onSelect={value => {
-                        const isEqualFormat = this.props.element.featureInfo && this.props.element.featureInfo.format && value === this.props.element.featureInfo.format;
-                        this.props.onChange("featureInfo", {
-                            ...(this.props.element && this.props.element.featureInfo || {}),
+                        const isEqualFormat = this.props.element[this.props.settingName]?.format && value === this.props.element[this.props.settingName].format;
+                        this.props.onChange(this.props.settingName, {
+                            ...(this.props.element?.[this.props.settingName] || {}),
                             format: !isEqualFormat ? value : '',
-                            viewer: this.props.element.featureInfo ? this.props.element.featureInfo.viewer : undefined
+                            viewer: this.props.element[this.props.settingName] ? this.props.element[this.props.settingName].viewer : undefined
                         });
                     }}/>
             </span>

--- a/web/client/components/TOC/fragments/settings/__tests__/GFI-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/GFI-test.jsx
@@ -8,7 +8,7 @@
 const React = require('react');
 const expect = require('expect');
 const ReactDOM = require('react-dom');
-const FeatureInfo = require('../FeatureInfo');
+const GFI = require('../GFI');
 const MapInfoUtils = require('../../../../../utils/MapInfoUtils');
 const defaultInfoFormat = MapInfoUtils.getAvailableInfoFormat();
 const TestUtils = require('react-dom/test-utils');
@@ -53,7 +53,7 @@ describe("test FeatureInfo", () => {
     });
 
     it('test rendering', () => {
-        ReactDOM.render(<FeatureInfo formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
+        ReactDOM.render(<GFI formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
         const testComponent = document.getElementsByClassName('test-preview');
         expect(testComponent.length).toBe(4);
         const modalEditor = document.getElementsByClassName('ms-resizable-modal');
@@ -62,7 +62,7 @@ describe("test FeatureInfo", () => {
     });
 
     it('test changes on click', done => {
-        ReactDOM.render(<FeatureInfo onChange={(key, value) => {
+        ReactDOM.render(<GFI onChange={(key, value) => {
             expect(key).toBe('featureInfo');
             expect(value.format).toBe('TEXT');
             done();

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -38,6 +38,7 @@ module.exports = props => {
         index,
         viewerOptions = {},
         format,
+        gfiType,
         dock = true,
         position,
         size,
@@ -163,6 +164,7 @@ module.exports = props => {
                 <Viewer
                     index={index}
                     setIndex={setIndex}
+                    gfiType={gfiType}
                     format={format}
                     missingResponses={missingResponses}
                     responses={responses}

--- a/web/client/components/data/identify/PopupViewer.jsx
+++ b/web/client/components/data/identify/PopupViewer.jsx
@@ -11,7 +11,7 @@ import {defaultViewerHandlers, defaultViewerDefaultProps} from './enhancers/defa
 import { compose, defaultProps} from 'recompose';
 import {connect} from 'react-redux';
 import { createSelector} from 'reselect';
-import {indexSelector, responsesSelector, requestsSelector, showEmptyMessageGFISelector, generalInfoFormatSelector, validResponsesSelector, isLoadedResponseSelector} from '../../../selectors/mapInfo';
+import {indexSelector, responsesSelector, requestsSelector, showEmptyMessageGFISelector, featureInfoClickFormatSelector, identifyGfiTypeSelector, validResponsesSelector, isLoadedResponseSelector} from '../../../selectors/mapInfo';
 import {changePage} from '../../../actions/mapInfo';
 import Viewer from './DefaultViewer';
 import {isArray, isUndefined} from 'lodash';
@@ -43,23 +43,27 @@ const selector = createSelector([
     responsesSelector,
     validResponsesSelector,
     requestsSelector,
-    generalInfoFormatSelector,
+    featureInfoClickFormatSelector,
+    identifyGfiTypeSelector,
     showEmptyMessageGFISelector,
     identifyFloatingTool,
-    isLoadedResponseSelector],
-(responses, validResponses, requests, format, showEmptyMessageGFI, renderEmpty, loaded) => ({
+    isLoadedResponseSelector,
+    state => state?.mapInfo?.warning],
+(responses, validResponses, requests, format, gfiType, showEmptyMessageGFI, renderEmpty, loaded, warning) => ({
     responses,
     validResponses,
     requests,
     format,
+    gfiType,
     showEmptyMessageGFI,
     missingResponses: (requests || []).length - (responses || []).length,
     renderEmpty,
-    loaded
+    loaded: warning === 'NO_QUERYABLE_LAYERS' || loaded,
+    noQueryableLayers: warning === 'NO_QUERYABLE_LAYERS'
 }));
 
 
-export  default compose(
+export default compose(
     connect(selector),
     defaultProps({
         responses: [],

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {lifecycle, withHandlers, compose} = require('recompose');
+const {lifecycle, withHandlers, mapProps, compose} = require('recompose');
 const {set} = require('../../../../utils/ImmutableUtils');
 const {isNil, isNaN} = require('lodash');
 
@@ -64,13 +64,19 @@ const identifyHandlers = withHandlers({
  */
 const identifyLifecycle = compose(
     identifyHandlers,
+    mapProps(({enableMapTipFormat, enableMapTipFormatState, mouseMoveIdentifyActive, ...props}) => ({
+        ...props,
+        enableMapTipFormat: enableMapTipFormatState ?? enableMapTipFormat
+    })),
     lifecycle({
-        componentDidMount() {
+        componentDidMount(prevProps) {
             const {
                 enabled,
                 changeMousePointer = () => {},
                 disableCenterToMarker,
-                onEnableCenterToMarker = () => {}
+                onEnableCenterToMarker = () => {},
+                enableMapTipFormat = false,
+                setEnableMapTipFormat = () => {}
             } = this.props;
 
             if (enabled) {
@@ -79,6 +85,10 @@ const identifyLifecycle = compose(
 
             if (!disableCenterToMarker) {
                 onEnableCenterToMarker();
+            }
+
+            if (prevProps?.enableMapTipFormat !== enableMapTipFormat) {
+                setEnableMapTipFormat(enableMapTipFormat);
             }
         },
         componentWillUnmount() {

--- a/web/client/components/data/identify/viewers/JSONViewer.jsx
+++ b/web/client/components/data/identify/viewers/JSONViewer.jsx
@@ -14,9 +14,9 @@ const Viewers = {
     PROPERTIES: require('./PropertiesViewer')
 };
 
-module.exports = shouldUpdate((props, nextProps) => nextProps.response !== props.response)(
+module.exports = shouldUpdate((props, nextProps) => nextProps.response !== props.response || nextProps.gfiType !== props.gfiType)(
     props => {
-        const type = props.layer && props.layer.featureInfo && props.layer.featureInfo.format && (props.layer.featureInfo.template && props.layer.featureInfo.template !== '<p><br></p>') && props.layer.featureInfo.format || 'PROPERTIES';
+        const type = props.layer?.[props.gfiType]?.format && (props.layer[props.gfiType].template && props.layer[props.gfiType].template !== '<p><br></p>') && props.layer[props.gfiType].format || 'PROPERTIES';
         const Viewer = Viewers[type] || Viewers.PROPERTIES;
         return <Viewer {...props}/>;
     }

--- a/web/client/components/data/identify/viewers/TemplateViewer.jsx
+++ b/web/client/components/data/identify/viewers/TemplateViewer.jsx
@@ -11,11 +11,11 @@ const {template} = require('lodash');
 const TemplateUtils = require('../../../../utils/TemplateUtils');
 const HtmlRenderer = require('../../../misc/HtmlRenderer');
 
-module.exports = ({layer = {}, response}) => (
+module.exports = ({layer = {}, gfiType, response}) => (
     <div className="ms-template-viewer">
         {response.features.map((feature, i) =>
             <div key={i}>
-                <HtmlRenderer html={template(TemplateUtils.getCleanTemplate(layer.featureInfo && layer.featureInfo.template || '', feature, /\$\{.*?\}/g, 2, 1))(feature)}/>
+                <HtmlRenderer html={template(TemplateUtils.getCleanTemplate(layer[gfiType]?.template || '', feature, /\$\{.*?\}/g, 2, 1))(feature)}/>
             </div>
         )}
     </div>

--- a/web/client/components/data/identify/viewers/ViewerPage.jsx
+++ b/web/client/components/data/identify/viewers/ViewerPage.jsx
@@ -14,7 +14,8 @@ module.exports = class extends React.Component {
         format: PropTypes.string,
         viewers: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
         response: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.node]),
-        layer: PropTypes.object
+        layer: PropTypes.object,
+        gfiType: PropTypes.string
     };
 
     onTouchStart = (event) => {
@@ -60,7 +61,7 @@ module.exports = class extends React.Component {
     renderPage = () => {
         const Viewer = typeof this.props.viewers === 'function' ? this.props.viewers : this.props.viewers[this.props.format];
         if (Viewer) {
-            return <Viewer response={this.props.response} layer={this.props.layer}/>;
+            return <Viewer response={this.props.response} layer={this.props.layer} gfiType={this.props.gfiType}/>;
         }
         return null;
     };

--- a/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
+++ b/web/client/components/data/identify/viewers/__tests__/viewers-test.jsx
@@ -17,7 +17,7 @@ const SimpleRowViewer = (props) => {
     return <div>{['name', 'description'].map((key) => <span key={key}>{key}:{props[key]}</span>)}</div>;
 };
 
-describe('Identity Viewers', () => {
+describe('Identify viewers', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -88,11 +88,41 @@ describe('Identity Viewers', () => {
         expect(cmpDom.innerText.indexOf('This is my viewer: 1') !== -1).toBe(true);
     });
 
-    it('test JSONViewer with TEMPLATE', () => {
+    it('test JSONViewer with TEMPLATE and gfiType=featureInfo', () => {
         const cmp = ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
+                        format: 'TEMPLATE',
+                        template: '<p id="my-template">the property name is ${ properties.name }</p>'
+                    }
+                }}
+                response={{
+                    features: [{
+                        id: 1,
+                        properties: {
+                            name: 'myname',
+                            description: 'mydescription'
+                        }
+                    }]
+                }} />, document.getElementById("container"));
+        expect(cmp).toExist();
+
+        const cmpDom = ReactDOM.findDOMNode(cmp);
+        expect(cmpDom).toExist();
+
+        const templateDOM = document.getElementById('my-template');
+        expect(templateDOM.innerHTML).toBe('the property name is myname');
+
+    });
+
+    it('test JSONViewer with TEMPLATE and gfiType=mapTip', () => {
+        const cmp = ReactDOM.render(
+            <JSONViewer
+                gfiType="mapTip"
+                layer={{
+                    mapTip: {
                         format: 'TEMPLATE',
                         template: '<p id="my-template">the property name is ${ properties.name }</p>'
                     }
@@ -119,6 +149,7 @@ describe('Identity Viewers', () => {
     it('test JSONViewer with TEMPLATE and missing properties', () => {
         const cmp = ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE',
@@ -147,6 +178,7 @@ describe('Identity Viewers', () => {
     it('test JSONViewer with TEMPLATE with tag inside variable', () => {
         ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE',
@@ -168,6 +200,7 @@ describe('Identity Viewers', () => {
 
         ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE',
@@ -191,6 +224,7 @@ describe('Identity Viewers', () => {
     it('test JSONViewer with TEMPLATE multiple features', () => {
         const cmp = ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE',
@@ -226,6 +260,7 @@ describe('Identity Viewers', () => {
         // when template is missing, undefined or equal to <p><br></p> response is displayed in PROPERTIES format
         ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE'
@@ -246,6 +281,7 @@ describe('Identity Viewers', () => {
 
         ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE',
@@ -268,6 +304,7 @@ describe('Identity Viewers', () => {
         // <p><br></p> is the value of react-quill when empty
         ReactDOM.render(
             <JSONViewer
+                gfiType="featureInfo"
                 layer={{
                     featureInfo: {
                         format: 'TEMPLATE',

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -9,7 +9,7 @@
 const expect = require('expect');
 const { LOCATION_CHANGE } = require('connected-react-router');
 const { ZOOM_TO_POINT, clickOnMap, CHANGE_MAP_VIEW, UNREGISTER_EVENT_LISTENER, REGISTER_EVENT_LISTENER} = require('../../actions/map');
-const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, SET_CURRENT_EDIT_FEATURE_QUERY, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature, editLayerFeatures, updateFeatureInfoClickPoint, purgeMapInfoResults } = require('../../actions/mapInfo');
+const { FEATURE_INFO_CLICK, UPDATE_CENTER_TO_MARKER, PURGE_MAPINFO_RESULTS, NEW_MAPINFO_REQUEST, LOAD_FEATURE_INFO, NO_QUERYABLE_LAYERS, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, SHOW_MAPINFO_MARKER, HIDE_MAPINFO_MARKER, GET_VECTOR_INFO, SET_CURRENT_EDIT_FEATURE_QUERY, CLEAR_WARNING, loadFeatureInfo, featureInfoClick, closeIdentify, toggleHighlightFeature, editLayerFeatures, updateFeatureInfoClickPoint, purgeMapInfoResults } = require('../../actions/mapInfo');
 const { REMOVE_MAP_POPUP } = require('../../actions/mapPopups');
 const { TEXT_SEARCH_CANCEL_ITEM } = require('../../actions/search');
 const {
@@ -102,29 +102,31 @@ describe('identify Epics', () => {
             }
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        const NUM_ACTIONS = 5;
+        const NUM_ACTIONS = 6;
         testEpic(getFeatureInfoOnFeatureInfoClick, NUM_ACTIONS, sentActions, (actions) => {
             try {
-                expect(actions.length).toBe(5);
-                const [a0, a1, a2, a3, a4] = actions;
+                expect(actions.length).toBe(6);
+                const [a0, a1, a2, a3, a4, a5] = actions;
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
-                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a1.reqId).toExist();
-                expect(a1.request).toExist();
-                expect(a2).toExist();
+                expect(a1.type).toBe(CLEAR_WARNING);
+                expect(a1).toExist();
                 expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a2.reqId).toExist();
                 expect(a2.request).toExist();
                 expect(a3).toExist();
-                expect(a3.type).toBe(LOAD_FEATURE_INFO);
-                expect(a3.data).toExist();
-                expect(a3.requestParams).toExist();
+                expect(a3.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a3.reqId).toExist();
-                expect(a3.layerMetadata.title).toBe(state.layers.flat[a3.requestParams.id === "TEST" ? 0 : 1].title);
+                expect(a3.request).toExist();
                 expect(a4).toExist();
+                expect(a4.type).toBe(LOAD_FEATURE_INFO);
+                expect(a4.data).toExist();
+                expect(a4.requestParams).toExist();
+                expect(a4.reqId).toExist();
                 expect(a4.layerMetadata.title).toBe(state.layers.flat[a4.requestParams.id === "TEST" ? 0 : 1].title);
+                expect(a5).toExist();
+                expect(a5.layerMetadata.title).toBe(state.layers.flat[a5.requestParams.id === "TEST" ? 0 : 1].title);
                 done();
             } catch (ex) {
                 done(ex);
@@ -159,24 +161,26 @@ describe('identify Epics', () => {
             }
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } }, "TEST", ["TEST"], {"TEST": {cql_filter: "id>1"}}, "province_view.5")];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
+        testEpic(getFeatureInfoOnFeatureInfoClick, 4, sentActions, ([a0, a1, a2, a3]) => {
             try {
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
-                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a1.reqId).toExist();
-                expect(a1.request).toExist();
-                expect(a1.request.cql_filter).toExist();
-                expect(a1.request.cql_filter).toBe("id>1");
+                expect(a1.type).toBe(CLEAR_WARNING);
                 expect(a2).toExist();
-                expect(a2.type).toBe(LOAD_FEATURE_INFO);
-                expect(a2.data).toExist();
-                expect(a2.data.features).toExist();
-                expect(a2.data.features.length).toBe(1);
-                expect(a2.requestParams).toExist();
+                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a2.reqId).toExist();
-                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
+                expect(a2.request).toExist();
+                expect(a2.request.cql_filter).toExist();
+                expect(a2.request.cql_filter).toBe("id>1");
+                expect(a3).toExist();
+                expect(a3.type).toBe(LOAD_FEATURE_INFO);
+                expect(a3.data).toExist();
+                expect(a3.data.features).toExist();
+                expect(a3.data.features.length).toBe(1);
+                expect(a3.requestParams).toExist();
+                expect(a3.reqId).toExist();
+                expect(a3.layerMetadata.title).toBe(state.layers.flat[0].title);
                 done();
             } catch (ex) {
                 done(ex);
@@ -255,22 +259,24 @@ describe('identify Epics', () => {
             }
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
+        testEpic(getFeatureInfoOnFeatureInfoClick, 4, sentActions, ([a0, a1, a2, a3]) => {
             try {
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
-                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a1.reqId).toExist();
-                expect(a1.request).toExist();
+                expect(a1.type).toBe(CLEAR_WARNING);
                 expect(a2).toExist();
-                expect(a2.type).toBe(ERROR_FEATURE_INFO);
-                expect(a2).toExist();
-                expect(a2.type).toBe(ERROR_FEATURE_INFO);
-                expect(a2.error).toExist();
+                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a2.reqId).toExist();
-                expect(a2.requestParams).toExist();
-                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
+                expect(a2.request).toExist();
+                expect(a3).toExist();
+                expect(a3.type).toBe(ERROR_FEATURE_INFO);
+                expect(a3).toExist();
+                expect(a3.type).toBe(ERROR_FEATURE_INFO);
+                expect(a3.error).toExist();
+                expect(a3.reqId).toExist();
+                expect(a3.requestParams).toExist();
+                expect(a3.layerMetadata.title).toBe(state.layers.flat[0].title);
                 done();
             } catch (ex) {
                 done(ex);
@@ -296,20 +302,22 @@ describe('identify Epics', () => {
             }
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
+        testEpic(getFeatureInfoOnFeatureInfoClick, 4, sentActions, ([a0, a1, a2, a3]) => {
             try {
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
-                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a1.reqId).toExist();
-                expect(a1.request).toExist();
+                expect(a1.type).toBe(CLEAR_WARNING);
                 expect(a2).toExist();
-                expect(a2.type).toBe(EXCEPTIONS_FEATURE_INFO);
-                expect(a2.exceptions).toExist();
+                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a2.reqId).toExist();
-                expect(a2.requestParams).toExist();
-                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
+                expect(a2.request).toExist();
+                expect(a3).toExist();
+                expect(a3.type).toBe(EXCEPTIONS_FEATURE_INFO);
+                expect(a3.exceptions).toExist();
+                expect(a3.reqId).toExist();
+                expect(a3.requestParams).toExist();
+                expect(a3.layerMetadata.title).toBe(state.layers.flat[0].title);
                 done();
             } catch (ex) {
                 done(ex);
@@ -355,17 +363,19 @@ describe('identify Epics', () => {
             layers: LAYERS
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 4, sentActions, ([a0, a1, a2, a3]) => {
+        testEpic(getFeatureInfoOnFeatureInfoClick, 5, sentActions, ([a0, a1, a2, a3, a4]) => {
             try {
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
-                expect(a1.type).toBe(GET_VECTOR_INFO);
-                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a2.reqId).toExist();
-                expect(a2.request).toExist();
-                expect(a3).toExist();
-                expect(a3.type).toBe(LOAD_FEATURE_INFO);
+                expect(a1.type).toBe(CLEAR_WARNING);
+                expect(a2).toExist();
+                expect(a2.type).toBe(GET_VECTOR_INFO);
+                expect(a3.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a3.reqId).toExist();
+                expect(a3.request).toExist();
+                expect(a4).toExist();
+                expect(a4.type).toBe(LOAD_FEATURE_INFO);
                 done();
             } catch (ex) {
                 done(ex);
@@ -392,20 +402,22 @@ describe('identify Epics', () => {
             }
         };
         const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
-        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, ([a0, a1, a2]) => {
+        testEpic(getFeatureInfoOnFeatureInfoClick, 4, sentActions, ([a0, a1, a2, a3]) => {
             try {
                 expect(a0).toExist();
                 expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
                 expect(a1).toExist();
-                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
-                expect(a1.reqId).toExist();
-                expect(a1.request).toExist();
+                expect(a1.type).toBe(CLEAR_WARNING);
                 expect(a2).toExist();
-                expect(a2.type).toBe(LOAD_FEATURE_INFO);
-                expect(a2.data).toExist();
-                expect(a2.requestParams).toExist();
+                expect(a2.type).toBe(NEW_MAPINFO_REQUEST);
                 expect(a2.reqId).toExist();
-                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
+                expect(a2.request).toExist();
+                expect(a3).toExist();
+                expect(a3.type).toBe(LOAD_FEATURE_INFO);
+                expect(a3.data).toExist();
+                expect(a3.requestParams).toExist();
+                expect(a3.reqId).toExist();
+                expect(a3.layerMetadata.title).toBe(state.layers.flat[0].title);
                 done();
             } catch (ex) {
                 done(ex);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -18,7 +18,8 @@ import {
     featureInfoClick, updateCenterToMarker, purgeMapInfoResults,
     exceptionsFeatureInfo, loadFeatureInfo, errorFeatureInfo,
     noQueryableLayers, newMapInfoRequest, getVectorInfo,
-    showMapinfoMarker, hideMapinfoMarker, setCurrentEditFeatureQuery
+    showMapinfoMarker, hideMapinfoMarker, setCurrentEditFeatureQuery,
+    clearWarning
 } from '../actions/mapInfo';
 
 import { SET_CONTROL_PROPERTIES, SET_CONTROL_PROPERTY, TOGGLE_CONTROL } from '../actions/controls';
@@ -37,7 +38,8 @@ import { stopGetFeatureInfoSelector, identifyOptionsSelector,
     clickPointSelector, clickLayerSelector,
     isMapPopup, isHighlightEnabledSelector,
     itemIdSelector, overrideParamsSelector, filterNameListSelector,
-    currentEditFeatureQuerySelector, mapTriggerSelector } from '../selectors/mapInfo';
+    currentEditFeatureQuerySelector, mapTriggerSelector,
+    identifyGfiTypeSelector, mapTipActiveLayerIdSelector} from '../selectors/mapInfo';
 import { centerToMarkerSelector, queryableLayersSelector, queryableSelectedLayersSelector } from '../selectors/layers';
 import { modeSelector, getAttributeFilters, isFeatureGridOpen } from '../selectors/featuregrid';
 import { spatialFieldSelector } from '../selectors/queryform';
@@ -123,12 +125,20 @@ export default {
     getFeatureInfoOnFeatureInfoClick: (action$, { getState = () => { } }) =>
         action$.ofType(FEATURE_INFO_CLICK)
             .switchMap(({ point, filterNameList = [], overrideParams = {} }) => {
+                const gfiType = identifyGfiTypeSelector(getState());
+                const mapTipActiveLayerId = mapTipActiveLayerIdSelector(getState());
+
                 // Reverse - To query layer in same order as in TOC
                 let queryableLayers = reverse(queryableLayersSelector(getState()));
                 const queryableSelectedLayers = queryableSelectedLayersSelector(getState());
                 if (queryableSelectedLayers.length) {
                     queryableLayers = queryableSelectedLayers;
                 }
+
+                if (gfiType === 'mapTip') {
+                    queryableLayers = queryableLayers.filter(l => l.id === mapTipActiveLayerId);
+                }
+
                 if (queryableLayers.length === 0) {
                     return Rx.Observable.of(purgeMapInfoResults(), noQueryableLayers());
                 }
@@ -146,7 +156,7 @@ export default {
                 })))
                     .mergeMap(layer => {
                         let env = localizedLayerStylesEnvSelector(getState());
-                        let { url, request, metadata } = MapInfoUtils.buildIdentifyRequest(layer, {...identifyOptionsSelector(getState()), env});
+                        let { url, request, metadata } = MapInfoUtils.buildIdentifyRequest(layer, {...identifyOptionsSelector(getState()), env, gfiType });
                         // request override
                         if (itemIdSelector(getState()) && overrideParamsSelector(getState())) {
                             request = {...request, ...overrideParamsSelector(getState())[layer.name]};
@@ -179,7 +189,7 @@ export default {
                 if (point && point.modifiers && point.modifiers.ctrl === true && point.multiSelection) {
                     return out$;
                 }
-                return out$.startWith(purgeMapInfoResults());
+                return out$.startWith(purgeMapInfoResults(), clearWarning());
             }),
     /**
      * if `clickLayer` is present, this means that `handleClickOnLayer` is true for the clicked layer, so the marker have to be hidden, because

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -327,7 +327,8 @@
                     "viewerOptions": {
                         "container": "{context.ReactSwipe}"
                     },
-                    "showEdit": true
+                    "showEdit": true,
+                    "enableMapTipFormat": true
                 },
                 "override": {
                   "Toolbar": {
@@ -376,7 +377,12 @@
             },
             "FilterLayer",
             "AddGroup",
-            "TOCItemsSettings",
+            {
+              "name": "TOCItemsSettings",
+              "cfg": {
+                "showMapTipTab": true
+              }
+            },
             "Tutorial", "MapFooter", {
                 "name": "Measure",
                 "cfg": {

--- a/web/client/plugins/TOCItemsSettings.jsx
+++ b/web/client/plugins/TOCItemsSettings.jsx
@@ -19,7 +19,7 @@ import {updateSettingsLifecycle} from "../components/TOC/enhancers/tocItemsSetti
 import TOCItemsSettings from '../components/TOC/TOCItemsSettings';
 import defaultSettingsTabs from './tocitemssettings/defaultSettingsTabs';
 import { initialSettingsSelector, originalSettingsSelector, activeTabSettingsSelector } from '../selectors/controls';
-import {layerSettingSelector, layersSelector, groupsSelector, elementSelector} from '../selectors/layers';
+import {layerSettingSelector, groupsSelector, elementSelector} from '../selectors/layers';
 import {mapLayoutValuesSelector} from '../selectors/maplayout';
 import {currentLocaleSelector, currentLocaleLanguageSelector} from '../selectors/locale';
 import {isAdminUserSelector} from '../selectors/security';
@@ -29,7 +29,6 @@ import {toggleStyleEditor} from '../actions/styleeditor';
 
 const tocItemsSettingsSelector = createSelector([
     layerSettingSelector,
-    layersSelector,
     groupsSelector,
     currentLocaleSelector,
     currentLocaleLanguageSelector,
@@ -40,7 +39,7 @@ const tocItemsSettingsSelector = createSelector([
     activeTabSettingsSelector,
     elementSelector,
     isLocalizedLayerStylesEnabledSelector
-], (settings, layers, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, initialSettings, originalSettings, activeTab, element, isLocalizedLayerStylesEnabled) => ({
+], (settings, groups, currentLocale, currentLocaleLanguage, dockStyle, isAdmin, initialSettings, originalSettings, activeTab, element, isLocalizedLayerStylesEnabled) => ({
     settings,
     element,
     groups,

--- a/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
+++ b/web/client/plugins/tocitemssettings/defaultSettingsTabs.js
@@ -113,11 +113,14 @@ const formatCards = {
         )
     }
 };
-import FeatureInfoCmp from '../../components/TOC/fragments/settings/FeatureInfo';
+import GFICmp from '../../components/TOC/fragments/settings/GFI';
 const FeatureInfo = defaultProps({
     formatCards,
     defaultInfoFormat: MapInfoUtils.getAvailableInfoFormat()
-})(FeatureInfoCmp);
+})(GFICmp);
+const MapTip = defaultProps({
+    settingName: 'mapTip'
+})(FeatureInfo);
 
 const configuredPlugins = {};
 
@@ -200,7 +203,7 @@ export const getStyleTabPlugin = ({ settings, items = [], loadedPlugins, onToggl
     return {};
 };
 
-export default ({ showFeatureInfoTab = true, loadedPlugins, items, onToggleStyleEditor, ...props }) => {
+export default ({ showFeatureInfoTab = true, showMapTipTab = false, loadedPlugins, items, onToggleStyleEditor, ...props }) => {
 
     return [
         {
@@ -241,6 +244,22 @@ export default ({ showFeatureInfoTab = true, loadedPlugins, items, onToggleStyle
                     tooltipId: 'layerProperties.editCustomFormat',
                     visible: !props.showEditor && props.element && props.element.featureInfo && props.element.featureInfo.format === 'TEMPLATE' || false,
                     onClick: () => props.onShowEditor && props.onShowEditor(!props.showEditor)
+                }
+            ]
+        },
+        {
+            id: 'maptip',
+            titleId: 'layerProperties.mapTip',
+            tooltipId: 'layerProperties.mapTip',
+            glyph: '1-map',
+            visible: showMapTipTab && isLayerNode(props) && isWMS(props) && !props.element?.mapTip?.viewer,
+            Component: MapTip,
+            toolbar: [
+                {
+                    glyph: 'pencil',
+                    tooltipId: 'layerProperties.editCustomFormat',
+                    visible: !props.showEditor && props.element?.mapTip?.format === 'TEMPLATE' || false,
+                    onClick: () => props.onShowEditor?.(!props.showEditor)
                 }
             ]
         },

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -220,14 +220,32 @@ describe('Test the mapInfo reducer', () => {
         expect(state.enabled).toBe(false);
     });
 
-    it('change mapinfo format', () => {
-        let state = mapInfo({}, {type: 'CHANGE_MAPINFO_FORMAT', infoFormat: "testFormat"});
+    it('change mapinfo format with featureInfo', () => {
+        let state = mapInfo({}, {type: 'CHANGE_MAPINFO_FORMAT', gfiType: 'featureInfo', infoFormat: "testFormat"});
         expect(state).toExist();
-        expect(state.configuration.infoFormat).toBe("testFormat");
+        expect(state.configuration.infoFormat).toEqual({featureInfo: 'testFormat'});
 
-        state = mapInfo({configuration: {infoFormat: 'oldFormat'}}, {type: 'CHANGE_MAPINFO_FORMAT', infoFormat: "newFormat"});
+        state = mapInfo({configuration: {infoFormat: {featureInfo: 'oldFormat'}}}, {type: 'CHANGE_MAPINFO_FORMAT', gfiType: 'featureInfo', infoFormat: "newFormat"});
         expect(state).toExist();
-        expect(state.configuration.infoFormat).toBe('newFormat');
+        expect(state.configuration.infoFormat).toEqual({featureInfo: 'newFormat'});
+
+        state = mapInfo({configuration: {infoFormat: 'oldFormat'}}, {type: 'CHANGE_MAPINFO_FORMAT', gfiType: 'featureInfo', infoFormat: "newFormat"});
+        expect(state).toExist();
+        expect(state.configuration.infoFormat).toEqual({featureInfo: 'newFormat'});
+    });
+
+    it('change mapinfo format with mapTip', () => {
+        let state = mapInfo({}, {type: 'CHANGE_MAPINFO_FORMAT', gfiType: 'mapTip', infoFormat: "testFormat"});
+        expect(state).toExist();
+        expect(state.configuration.infoFormat).toEqual({mapTip: 'testFormat'});
+
+        state = mapInfo({configuration: {infoFormat: {mapTip: 'oldFormat'}}}, {type: 'CHANGE_MAPINFO_FORMAT', gfiType: 'mapTip', infoFormat: "newFormat"});
+        expect(state).toExist();
+        expect(state.configuration.infoFormat).toEqual({mapTip: 'newFormat'});
+
+        state = mapInfo({configuration: {infoFormat: 'oldFormat'}}, {type: 'CHANGE_MAPINFO_FORMAT', gfiType: 'mapTip', infoFormat: "newFormat"});
+        expect(state).toExist();
+        expect(state.configuration.infoFormat).toEqual({featureInfo: 'oldFormat', mapTip: 'newFormat'});
     });
 
     it('show reverese geocode', () => {

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -30,7 +30,9 @@ const {
     CHANGE_FORMAT,
     TOGGLE_SHOW_COORD_EDITOR,
     SET_CURRENT_EDIT_FEATURE_QUERY,
-    SET_MAP_TRIGGER
+    SET_MAP_TRIGGER,
+    SET_ENABLE_MAP_TIP_FORMAT,
+    SET_MAP_TIP_ACTIVE_LAYER_ID
 } = require('../actions/mapInfo');
 const {
     MAP_CONFIG_LOADED
@@ -38,7 +40,7 @@ const {
 const {RESET_CONTROLS} = require('../actions/controls');
 
 const assign = require('object-assign');
-const {findIndex, isUndefined} = require('lodash');
+const {findIndex, isUndefined, isString} = require('lodash');
 const {getValidator} = require('../utils/MapInfoUtils');
 
 /**
@@ -291,10 +293,16 @@ function mapInfo(state = initState, action) {
         });
     }
     case CHANGE_MAPINFO_FORMAT: {
+        const stateInfoFormat = state.configuration?.infoFormat;
+        const infoFormat = isString(stateInfoFormat) ? {featureInfo: stateInfoFormat} : stateInfoFormat;
+
         return {...state,
             configuration: {
                 ...state.configuration,
-                infoFormat: action.infoFormat
+                infoFormat: {
+                    ...(infoFormat || {}),
+                    [action.gfiType]: action.infoFormat
+                }
             }
         };
     }
@@ -444,6 +452,21 @@ function mapInfo(state = initState, action) {
             configuration: {
                 ...state.configuration,
                 trigger: action.trigger
+            }
+        };
+    }
+    case SET_ENABLE_MAP_TIP_FORMAT: {
+        return {
+            ...state,
+            enableMapTipFormat: action.enable
+        };
+    }
+    case SET_MAP_TIP_ACTIVE_LAYER_ID: {
+        return {
+            ...state,
+            configuration: {
+                ...state.configuration,
+                mapTipActiveLayerId: action.layerId
             }
         };
     }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -80,6 +80,7 @@
             "groupProperties": "Gruppeneigenschaften",
             "featureInfo": "Feature Info",
             "featureInfoFormatLbl": "Identifiziere das Antwortformat",
+            "mapTip": "GFI Tooltip",
             "legenderror": "Legende ist nicht verfügbar",
             "editCustomFormat": "Bearbeiten Sie das benutzerdefinierte Format",
             "exampleOfResponse": "Beispiel",
@@ -516,6 +517,8 @@
             "epsgNotSupported": "KBS {epsg} wird für das Zoomen auf den Layer nicht unterstützt",
             "filterIconEnabled": "Ebenenfilter deaktivieren",
             "filterIconDisabled": "Ebenenfilter aktivieren",
+            "mapTipActivate": "Aktivieren Sie die Ebene für MapTip",
+            "mapTipDeactivate": "Deaktivieren Sie die Ebene für MapTip",
             "refreshOptions": {
                 "bbox": "BBOX aktualisieren",
                 "search": "Suchoptionen aktualisieren",
@@ -665,6 +668,7 @@
             "redoBtnTooltip": "Gehe vorwärts"
         },
         "infoFormatLbl": "Identifiziere das Antwortformat",
+        "mapTipFormatLbl": "Format des GFI-Tooltips",
         "infoTriggerLabel": "Auslöseereignis für Identifizieren",
         "click": "Click",
         "hover": "Hover",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -80,6 +80,7 @@
             "groupProperties": "Group properties",
             "featureInfo": "Feature Info",
             "featureInfoFormatLbl": "Identify response format",
+            "mapTip": "GFI Tooltip",
             "legenderror": "Legend is not available",
             "editCustomFormat": "Edit custom format",
             "exampleOfResponse": "Example",
@@ -516,6 +517,8 @@
             "epsgNotSupported": "CRS {epsg} not supported for zoom to layer",
             "filterIconEnabled": "Disable layer filter",
             "filterIconDisabled": "Enable layer filter",
+            "mapTipActivate": "Activate layer for MapTip",
+            "mapTipDeactivate": "Deactivate layer for MapTip",
             "refreshOptions": {
                 "bbox": "Update BBOX",
                 "search": "Update search options",
@@ -665,6 +668,7 @@
             "redoBtnTooltip": "Go forward"
         },
         "infoFormatLbl": "Information sheet format",
+        "mapTipFormatLbl": "GFI Tooltip format",
         "infoTriggerLabel": "Trigger event for the display of the information sheet",
         "click": "On click on the feature",
         "hover": "Hover the feature",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -80,6 +80,7 @@
             "groupProperties": "Propiedades del grupo",
             "featureInfo": "Información de la capa",
             "featureInfoFormatLbl": "Identificar el formato de respuesta",
+            "mapTip": "Descripción emergente de GFI",
             "legenderror": "La leyenda no está disponible",
             "editCustomFormat": "Editar formato personalizado",
             "exampleOfResponse": "Ejemplo",
@@ -516,6 +517,8 @@
             "epsgNotSupported": "CRS {epsg} no es compatible con el zoom a la capa",
             "filterIconEnabled": "Deshabilitar filtro de capa",
             "filterIconDisabled": "Habilitar filtro de capa",
+            "mapTipActivate": "Activar capa para MapTip",
+            "mapTipDeactivate": "Desactivar capa para MapTip",
             "refreshOptions": {
                 "bbox": "Refrescar BBOX",
                 "search": "Refrescar las opciones de búsqueda",
@@ -665,6 +668,7 @@
             "redoBtnTooltip": "Ir hacia adelante"
         },
         "infoFormatLbl": "Identificar el formato de respuesta",
+        "mapTipFormatLbl": "Formato de la descripción emergente de GFI",
         "infoTriggerLabel": "Evento desencadenante para identificar",
         "click": "Click",
         "hover": "Hover",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -80,6 +80,7 @@
             "groupProperties": "Propriétés du groupe",
             "featureInfo": "Informations attributaires de l'objet",
             "featureInfoFormatLbl": "Information, format de la réponse",
+            "mapTip": "Info-bulle GFI",
             "legenderror": "La légende n'est pas disponible",
             "editCustomFormat": "Modifier le format personnalisé",
             "exampleOfResponse": "Exemple",
@@ -516,6 +517,8 @@
             "epsgNotSupported": "CRS {epsg} non pris en charge pour le zoom sur la couche",
             "filterIconEnabled": "Désactiver le filtre de couche",
             "filterIconDisabled": "Activer le filtre de couche",
+            "mapTipActivate": "Activer la couche pour MapTip",
+            "mapTipDeactivate": "Désactiver le calque pour MapTip",
             "refreshOptions": {
                 "bbox": "Mettre à jour la BBOX",
                 "search": "Mettre à jour les options de recherche",
@@ -665,6 +668,7 @@
             "redoBtnTooltip": "Aller en avant"
         },
         "infoFormatLbl": "Format de la fiche d'information",
+        "mapTipFormatLbl": "Format de l'info-bulle GFI",
         "infoTriggerLabel": "Événement déclencheur de l'affichage de la fiche d'information",
         "click": "au clic sur l'objet",
         "hover": "au survol de l'objet",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -80,6 +80,7 @@
             "groupProperties": "Proprietà del gruppo",
             "featureInfo": "Feature Info",
             "featureInfoFormatLbl": "Formato risposta interrogazioni su mappa",
+            "mapTip": "Descrizione comando GFI",
             "legenderror": "Legenda non disponibile",
             "editCustomFormat": "Edita formato",
             "exampleOfResponse": "Esempio",
@@ -516,6 +517,8 @@
             "epsgNotSupported": "CRS {epsg} non supportato per zoom al layer",
             "filterIconEnabled": "Disattiva il filtro",
             "filterIconDisabled": "Attiva il filtro",
+            "mapTipActivate": "Attiva il livello per MapTip",
+            "mapTipDeactivate": "Disattiva il layer per MapTip",
             "refreshOptions": {
                 "bbox": "Aggiorna area di zoom",
                 "search": "Aggiorna opzioni di ricerca",
@@ -665,6 +668,7 @@
             "redoBtnTooltip": "Vai avanti"
         },
         "infoFormatLbl": "Formato risposte interrogazioni su mappa",
+        "mapTipFormatLbl": "Formato della descrizione comando di GFI",
         "infoTriggerLabel": "Evento trigger interrogazioni su mappa",
         "click": "Click",
         "hover": "Hover",

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -510,6 +510,7 @@ const LayersUtils = {
             handleClickOnLayer: layer.handleClickOnLayer || false,
             queryable: layer.queryable,
             featureInfo: layer.featureInfo,
+            mapTip: layer.mapTip,
             catalogURL: layer.catalogURL,
             capabilitiesURL: layer.capabilitiesURL,
             useForElevation: layer.useForElevation || false,

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -63,26 +63,34 @@ const MapInfoUtils = {
     /**
      * @return {string} the info format value from layer, otherwise the info format in settings
      */
-    getDefaultInfoFormatValueFromLayer: (layer, props) =>
-        layer.featureInfo
-            && layer.featureInfo.format
-            && INFO_FORMATS[layer.featureInfo.format]
+    getDefaultInfoFormatValueFromLayer: (layer, props) => {
+        const gfiType = props.gfiType || 'featureInfo';
+        const layerFormat = layer[gfiType]?.format;
+
+        return layerFormat
+            && INFO_FORMATS[layerFormat]
             || props.format
-            || MapInfoUtils.getDefaultInfoFormatValue(),
-    getLayerFeatureInfoViewer(layer) {
-        if (layer.featureInfo
-            && layer.featureInfo.viewer) {
-            return layer.featureInfo.viewer;
+            || MapInfoUtils.getDefaultInfoFormatValue();
+    },
+    getLayerGfiViewer(layer, options) {
+        const gfiType = options.gfiType || 'featureInfo';
+
+        if (layer[gfiType]
+            && layer[gfiType].viewer) {
+            return layer[gfiType].viewer;
         }
         return {};
     },
     /**
-     * returns feature info options of layer
+     * returns gfi options of layer
      * @param layer {object} layer object
      * @return {object} feature info options
      */
-    getLayerFeatureInfo(layer) {
-        return layer && layer.featureInfo && {...layer.featureInfo} || {};
+    getLayerGfiOptions(layer) {
+        return {
+            featureInfo: layer?.featureInfo,
+            mapTip: layer?.mapTip
+        };
     },
     clickedPointToGeoJson(clickedPoint) {
         if (!clickedPoint) {
@@ -139,9 +147,9 @@ const MapInfoUtils = {
     buildIdentifyRequest(layer, options) {
         if (MapInfoUtils.services[layer.type]) {
             let infoFormat = MapInfoUtils.getDefaultInfoFormatValueFromLayer(layer, options);
-            let viewer = MapInfoUtils.getLayerFeatureInfoViewer(layer);
-            const featureInfo = MapInfoUtils.getLayerFeatureInfo(layer);
-            return MapInfoUtils.services[layer.type].buildRequest(layer, options, infoFormat, viewer, featureInfo);
+            let viewer = MapInfoUtils.getLayerGfiViewer(layer, options);
+            const gfiOptions = MapInfoUtils.getLayerGfiOptions(layer);
+            return MapInfoUtils.services[layer.type].buildRequest(layer, options, infoFormat, viewer, gfiOptions);
         }
         return {};
     },

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -19,7 +19,7 @@ var {
     setViewer,
     getLabelFromValue,
     getDefaultInfoFormatValueFromLayer,
-    getLayerFeatureInfo,
+    getLayerGfiOptions,
     filterRequestParams
 } = require('../MapInfoUtils');
 
@@ -540,10 +540,11 @@ describe('MapInfoUtils', () => {
         expect(htmlFormat).toBe('text/html');
     });
 
-    it('getLayerFeatureInfo', () => {
-        expect(getLayerFeatureInfo()).toEqual({});
-        expect(getLayerFeatureInfo({})).toEqual({});
-        expect(getLayerFeatureInfo({featureInfo: {format: 'TEXT'}})).toEqual({format: 'TEXT'});
+    it('getLayerGfiOption', () => {
+        expect(getLayerGfiOptions()).toEqual({featureInfo: undefined, mapTip: undefined});
+        expect(getLayerGfiOptions({})).toEqual({featureInfo: undefined, mapTip: undefined});
+        expect(getLayerGfiOptions({id: 'layerId', name: 'layerName', featureInfo: {format: 'TEXT'}})).toEqual({featureInfo: {format: 'TEXT'}, mapTip: undefined});
+        expect(getLayerGfiOptions({id: 'layerId', name: 'layerName', featureInfo: {format: 'TEXT'}, mapTip: {format: 'HTML'}})).toEqual({featureInfo: {format: 'TEXT'}, mapTip: {format: 'HTML'}});
     });
 
     it('filterRequestParams', () => {

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -328,7 +328,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -376,7 +377,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -424,7 +426,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -472,7 +475,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -685,7 +689,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -733,7 +738,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -781,7 +787,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -829,7 +836,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -877,7 +885,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -925,7 +934,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -1113,7 +1123,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         tileSize: undefined,
-                        legendOptions: { legendWidth: "", legendHeight: 40}
+                        legendOptions: { legendWidth: "", legendHeight: 40},
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -1161,7 +1172,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -1209,7 +1221,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: "both",
                         tooltipPlacement: "right",
                         tileSize: undefined,
-                        legendOptions: { legendWidth: 20, legendHeight: 40}
+                        legendOptions: { legendWidth: 20, legendHeight: 40},
+                        mapTip: undefined
                     }],
                     mapOptions: {
                         view: {
@@ -1411,7 +1424,8 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
-                        tooltipPlacement: undefined, legendOptions: undefined
+                        tooltipPlacement: undefined, legendOptions: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -1458,7 +1472,8 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
-                        tooltipPlacement: undefined, legendOptions: undefined
+                        tooltipPlacement: undefined, legendOptions: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -1505,7 +1520,8 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
-                        tooltipPlacement: undefined, legendOptions: undefined
+                        tooltipPlacement: undefined, legendOptions: undefined,
+                        mapTip: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -1689,7 +1705,7 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
-                        tooltipPlacement: undefined, legendOptions: undefined,
+                        tooltipPlacement: undefined, legendOptions: undefined, mapTip: undefined,
                         params: {} } ],
                     groups: [ {
                         id: 'Default',
@@ -1843,7 +1859,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -2000,7 +2017,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -2197,7 +2215,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -2245,7 +2264,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -2293,7 +2313,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     },
                     {
                         allowedSRS: {},
@@ -2341,7 +2362,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        mapTip: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],

--- a/web/client/utils/mapinfo/wfs.js
+++ b/web/client/utils/mapinfo/wfs.js
@@ -26,7 +26,7 @@ const assign = require('object-assign');
  * @param {string} viewer
  * @return {object} an object with `request`, containing request params, `metadata` with some info about the layer and the request, and `url` to send the request to.
  */
-const buildRequest = (layer, { map = {}, point, currentLocale, params, maxItems = 10 } = {}, infoFormat, viewer, featureInfo) => {
+const buildRequest = (layer, { map = {}, point, currentLocale, params, maxItems = 10 } = {}, infoFormat, viewer, gfiOptions = {}) => {
     /* In order to create a valid feature info request
      * we create a bbox of 101x101 pixel that wrap the point.
      * center point is re-projected then is built a box of 101x101pixel around it
@@ -49,7 +49,8 @@ const buildRequest = (layer, { map = {}, point, currentLocale, params, maxItems 
             title: isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title,
             regex: layer.featureInfoRegex,
             viewer,
-            featureInfo
+            featureInfo: gfiOptions.featureInfo,
+            mapTip: gfiOptions.mapTip
         },
         url: getLayerUrl(layer).replace(/[?].*$/g, '')
     };

--- a/web/client/utils/mapinfo/wms.js
+++ b/web/client/utils/mapinfo/wms.js
@@ -25,7 +25,7 @@ module.exports = {
      * @param {string} viewer
      * @return {object} an object with `request`, containing request paarams, `metadata` with some info about the layer and the request, and `url` to send the request to.
      */
-    buildRequest: (layer, { sizeBBox, map = {}, point, currentLocale, params: defaultParams, maxItems = 10, env } = {}, infoFormat, viewer, featureInfo) => {
+    buildRequest: (layer, { sizeBBox, map = {}, point, currentLocale, params: defaultParams, maxItems = 10, env } = {}, infoFormat, viewer, gfiOptions = {}) => {
         /* In order to create a valid feature info request
          * we create a bbox of 101x101 pixel that wrap the point.
          * center point is re-projected then is built a box of 101x101pixel around it
@@ -80,7 +80,8 @@ module.exports = {
                 title: isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title,
                 regex: layer.featureInfoRegex,
                 viewer,
-                featureInfo
+                featureInfo: gfiOptions.featureInfo,
+                mapTip: gfiOptions.mapTip
             },
             url: getLayerUrl(layer).replace(/[?].*$/g, '')
         };


### PR DESCRIPTION
## Description
Adds an ability to configure format separately for GFI tooltip, set active layer to get feature info for the tooltip.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
[MapStore2-C098/#83](https://github.com/geosolutions-it/MapStore2-C098/issues/83)
#5897 

**What is the current behavior?**
[MapStore2-C098/#83](https://github.com/geosolutions-it/MapStore2-C098/issues/83)

**What is the new behavior?**
New tab in settiings to configure format for GFI tooltip per layer, combobox in settings for default format for GFI tooltip, a new button alongside visibility in TOC to set a layer as active for GFI tooltip to restrict the GFI request only to that layer.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No