### PR TITLE
#5888 - Annotation marker filter and export current annotation fix

### DIFF
--- a/web/client/actions/__tests__/annotations-test.js
+++ b/web/client/actions/__tests__/annotations-test.js
@@ -79,7 +79,8 @@ const {
     LOAD_DEFAULT_STYLES, loadDefaultStyles,
     LOADING, loading,
     TOGGLE_ANNOTATION_VISIBILITY, toggleVisibilityAnnotation,
-    CHANGE_GEOMETRY_TITLE, changeGeometryTitle
+    CHANGE_GEOMETRY_TITLE, changeGeometryTitle,
+    FILTER_MARKER, filterMarker
 } = require('../annotations');
 
 describe('Test correctness of the annotations actions', () => {
@@ -386,5 +387,10 @@ describe('Test correctness of the annotations actions', () => {
         const result = changeGeometryTitle('New title');
         expect(result.type).toBe(CHANGE_GEOMETRY_TITLE);
         expect(result.title).toBe('New title');
+    });
+    it('filterMarker ', () => {
+        const result = filterMarker('glass');
+        expect(result.type).toBe(FILTER_MARKER);
+        expect(result.filter).toBe('glass');
     });
 });

--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -57,6 +57,7 @@ const SET_DEFAULT_STYLE = 'ANNOTATIONS:SET_DEFAULT_STYLE';
 const LOAD_DEFAULT_STYLES = 'ANNOTATIONS:LOAD_DEFAULT_STYLES';
 const LOADING = 'ANNOTATIONS:LOADING';
 const CHANGE_GEOMETRY_TITLE = 'ANNOTATIONS:CHANGE_GEOMETRY_TITLE';
+const FILTER_MARKER = 'ANNOTATIONS:FILTER_MARKER';
 
 const updateSymbols = (symbols = []) => ({
     type: UPDATE_SYMBOLS,
@@ -382,6 +383,11 @@ const loading = (value, name = "loading") => ({
     value
 });
 
+const filterMarker = (filter) => ({
+    type: FILTER_MARKER,
+    filter
+});
+
 module.exports = {
     SHOW_ANNOTATION,
     EDIT_ANNOTATION,
@@ -455,5 +461,6 @@ module.exports = {
     SET_DEFAULT_STYLE, setDefaultStyle,
     LOAD_DEFAULT_STYLES, loadDefaultStyles,
     LOADING, loading,
-    CHANGE_GEOMETRY_TITLE, changeGeometryTitle
+    CHANGE_GEOMETRY_TITLE, changeGeometryTitle,
+    FILTER_MARKER, filterMarker
 };

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -208,12 +208,13 @@ class Annotations extends React.Component {
 
     renderFieldValue = (field, annotation) => {
         const fieldValue = annotation.properties[field.name] || '';
-        switch (field.type) {
-        case 'html':
-            return <span dangerouslySetInnerHTML={{__html: fieldValue} }/>;
-        default:
-            return fieldValue;
+        if (field.type === 'html') {
+            // Return the text content of the first child of the html string (to prevent collating all texts into a single word)
+            return (new DOMParser).parseFromString(fieldValue, "text/html").documentElement.lastElementChild
+                ?.firstChild
+                ?.textContent || '';
         }
+        return fieldValue;
     };
 
     renderThumbnail = ({featureType, geometry, properties = {}}) => {
@@ -318,7 +319,7 @@ class Annotations extends React.Component {
                                 },
                                 {
                                     glyph: 'download',
-                                    disabled: !(this.props.annotations && this.props.annotations.length > 0),
+                                    disabled: !(annotationsPresent),
                                     tooltip: <Message msgId="annotations.downloadtooltip"/>,
                                     visible: this.props.mode === "list",
                                     onClick: () => { this.props.onDownload(); }
@@ -361,6 +362,7 @@ class Annotations extends React.Component {
             defaultShapeStrokeColor={this.props.defaultShapeStrokeColor}
             defaultStyles={this.props.defaultStyles}
             textRotationStep={this.props.textRotationStep}
+            annotations={this.props.annotations}
         />;
     };
 

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -110,6 +110,8 @@ const {getComponents, coordToArray, validateCoords} = require('../../../utils/An
  * @prop {string} defaultShapeSize default symbol shape size in px
  * @prop {object} defaultStyles object with default symbol styles
  * @prop {number} textRotationStep rotation step of text styler
+ * @prop {function} onFilterMarker triggered when marker/glyph name is specified for filtering
+ * @prop {object[]} annotations list of annotations
  *
  * In addition, as the Identify viewer interface mandates, every feature attribute is mapped as a component property (in addition to the feature object).
  */
@@ -203,7 +205,9 @@ class AnnotationsEditor extends React.Component {
         defaultShapeFillColor: PropTypes.string,
         defaultShapeStrokeColor: PropTypes.string,
         defaultStyles: PropTypes.object,
-        textRotationStep: PropTypes.number
+        textRotationStep: PropTypes.number,
+        onFilterMarker: PropTypes.func,
+        annotations: PropTypes.array
     };
 
     static defaultProps = {
@@ -218,7 +222,8 @@ class AnnotationsEditor extends React.Component {
         maxZoom: 18,
         format: "decimal",
         pointType: "marker",
-        stylerType: "marker"
+        stylerType: "marker",
+        annotations: []
     };
     /**
     @prop {object} removing object to remove, it is also a flag that means we are currently asking for removing an annotation / geometry. Toggles visibility of the confirm dialog
@@ -231,7 +236,7 @@ class AnnotationsEditor extends React.Component {
     };
 
     getConfig = () => {
-        return assign({}, defaultConfig, this.props.config);
+        return {...defaultConfig, ...this.props.config, onFilterMarker: this.props.onFilterMarker};
     };
 
     getBodyItems = (editing) => {
@@ -335,6 +340,7 @@ class AnnotationsEditor extends React.Component {
                             }, {
                                 glyph: 'trash',
                                 tooltipId: "annotations.remove",
+                                disabled: !this.props.annotations.length,
                                 visible: !this.props.selected,
                                 onClick: () => {
                                     this.setState({removing: this.props.id});
@@ -348,8 +354,12 @@ class AnnotationsEditor extends React.Component {
                             {
                                 glyph: 'download',
                                 tooltip: <Message msgId="annotations.downloadcurrenttooltip" />,
+                                disabled: Object.keys(this.validate()).length !== 0,
                                 visible: !this.props.selected,
-                                onClick: () => { this.props.onDownload(this.props.editing); }
+                                onClick: () => {
+                                    const {newFeature, ...features} = this.props.editing;
+                                    this.props.onDownload(features);
+                                }
                             }
                         ]} />
                 </Col>
@@ -446,7 +456,7 @@ class AnnotationsEditor extends React.Component {
             .filter(field => this.getConfig().fields.filter(f => f.name === field).length === 0).map(field => this.renderErrorOn(field))) : null;
     };
 
-    renderModals = (editing) => {
+    renderModals = () => {
         if (this.props.closing) {
             return (<Portal><ConfirmDialog
                 show
@@ -515,7 +525,7 @@ class AnnotationsEditor extends React.Component {
                 <Message msgId="annotations.undoDeleteFeature" />
             </ConfirmDialog></Portal>);
         } else if (this.state.removing || this.props.removing) {
-            return (<ConfirmDialog
+            return (<Portal><ConfirmDialog
                 show
                 modal
                 onClose={()=>{
@@ -535,8 +545,8 @@ class AnnotationsEditor extends React.Component {
                 confirmButtonContent={<Message msgId="annotations.confirm" />}
                 closeText={<Message msgId="annotations.cancel" />}>
                 {this.props.mode === 'editing' ? <Message msgId="annotations.removegeometry"/> :
-                    <Message msgId="annotations.removeannotation" msgParams={{title: editing?.properties?.title}}/>}
-            </ConfirmDialog>);
+                    <Message msgId="annotations.removeannotation" msgParams={{title: this.props?.feature?.properties?.title}}/>}
+            </ConfirmDialog></Portal>);
         }
         return null;
     }
@@ -558,7 +568,7 @@ class AnnotationsEditor extends React.Component {
                 <div style={{flex: 1}}>
                     {this.renderButtons(editing)}
                     {this.renderError(editing)}
-                    {this.renderModals(editing)}
+                    {this.renderModals()}
                     {this.renderBody(editing)}
                 </div>
                 {!isEmpty(this.props.selected) &&

--- a/web/client/components/style/vector/marker/MarkerGlyph.jsx
+++ b/web/client/components/style/vector/marker/MarkerGlyph.jsx
@@ -49,8 +49,8 @@ class MarkerGlyph extends React.Component {
     render() {
         const selectedMarker = this.props.markersOptions.markers.reduce((acc, { markers }) => [...acc, ...markers], []).find((marker) => this.isCurrentStyle(marker)) || {};
         return (
-            <div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', padding: '4px 0' }}>
+            <div className={"marker-container"}>
+                <div className={"marker-icon"}>
                     <div style={{ flex: 1 }}>
                         <Message msgId="draw.marker.icon"/>
                     </div>
@@ -80,7 +80,7 @@ class MarkerGlyph extends React.Component {
                                     backgroundColor: '#ffffff'
                                 }}>
                                 <div style={{ position: 'sticky', top: 0 }}>
-                                    <Filter filterPlaceholder="Filter icons..."/>
+                                    <Filter filterPlaceholder="Filter icons..." filterText={this.props.markersOptions.filter} onFilter={this.props.markersOptions.onFilterMarker}/>
                                 </div>
                                 <div style={{
                                     display: 'flex',
@@ -88,24 +88,27 @@ class MarkerGlyph extends React.Component {
                                     justifyContent: 'center'
                                 }}>
                                     {this.props.markersOptions.glyphs.map(glyph => {
-                                        return (
-                                            <div
-                                                style={{
-                                                    width: 32,
-                                                    height: 32,
-                                                    display: 'flex',
-                                                    alignItems: 'center',
-                                                    justifyContent: 'center',
-                                                    fontSize: 20,
-                                                    cursor: 'pointer',
-                                                    ...(glyph === this.props.style.iconGlyph && {border: '2px solid #1bd2f5'})
-                                                }}
-                                                onClick={() => {
-                                                    this.props.onChange(this.props.style.id, { iconGlyph: glyph });
-                                                }}>
-                                                <i className={`fa fa-${glyph}`}/>
-                                            </div>
-                                        );
+                                        if (this.filterMarkerGlyph(glyph)) {
+                                            return (
+                                                <div
+                                                    style={{
+                                                        width: 32,
+                                                        height: 32,
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        justifyContent: 'center',
+                                                        fontSize: 20,
+                                                        cursor: 'pointer',
+                                                        ...(glyph === this.props.style.iconGlyph && {border: '2px solid #1bd2f5'})
+                                                    }}
+                                                    onClick={() => {
+                                                        this.props.onChange(this.props.style.id, {iconGlyph: glyph});
+                                                    }}>
+                                                    <i className={`fa fa-${glyph}`}/>
+                                                </div>
+                                            );
+                                        }
+                                        return null;
                                     })}
                                 </div>
                             </div>
@@ -113,9 +116,9 @@ class MarkerGlyph extends React.Component {
                     </div>
                 </div>
 
-                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', padding: '4px 0' }}>
+                <div className={"marker-shape"}>
                     <div style={{ flex: 1 }}>
-                            Shape
+                        <Message msgId="draw.marker.shape"/>
                     </div>
                     <div style={{ flex: 1 }}>
                         <MarkerPropertyPicker
@@ -151,6 +154,10 @@ class MarkerGlyph extends React.Component {
 
     selectStyle = (marker) => {
         return this.props.onChange(this.props.style.id, {...this.props.markersOptions.markersConfig.getStyle(marker.style)});
+    };
+
+    filterMarkerGlyph = (marker) =>{
+        return marker && marker.toLowerCase().indexOf(this.props.markersOptions?.filter?.toLowerCase() || '') !== -1;
     };
 }
 

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -24,7 +24,7 @@ const {cancelRemoveAnnotation, confirmRemoveAnnotation, editAnnotation, newAnnot
     changedProperties, setUnsavedStyle, toggleUnsavedStyleModal, addText, download, loadAnnotations,
     changeSelected, resetCoordEditor, changeRadius, changeText, toggleUnsavedGeometryModal, addNewFeature, setInvalidSelected,
     highlightPoint, confirmDeleteFeature, toggleDeleteFtModal, changeFormat, openEditor, updateSymbols, changePointType,
-    setErrorSymbol, toggleVisibilityAnnotation, loadDefaultStyles, changeGeometryTitle
+    setErrorSymbol, toggleVisibilityAnnotation, loadDefaultStyles, changeGeometryTitle, filterMarker
 } = require('../actions/annotations');
 
 const {selectFeatures} = require('../actions/draw');
@@ -75,7 +75,8 @@ const commonEditorActions = {
     onCancelClose: cancelCloseAnnotations,
     onConfirmClose: confirmCloseAnnotations,
     onConfirmRemove: confirmRemoveAnnotation,
-    onDownload: download
+    onDownload: download,
+    onFilterMarker: filterMarker
 };
 const AnnotationsEditor = connect(annotationsInfoSelector,
     {

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -44,7 +44,8 @@ const {
     setEditingFeature,
     setDefaultStyle,
     loading,
-    changeGeometryTitle
+    changeGeometryTitle,
+    filterMarker
 } = require('../../actions/annotations');
 const {PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
 const {drawingFeatures, selectFeatures} = require('../../actions/draw');
@@ -682,11 +683,15 @@ describe('Test the annotations reducer', () => {
         };
         const state = annotations({
             editing: featureColl,
-            selected: feature
+            selected: feature,
+            editedFields: {title: 'Title1'}
         }, addNewFeature(feature));
         expect(state.editing.features[0].properties.isText).toBe(true);
         expect(state.editing.features[0].geometry.coordinates[0]).toBe(1);
         expect(state.editing.features[0].geometry.coordinates[1]).toBe(2);
+        expect(state.editing.properties).toBeTruthy();
+        expect(state.editing.properties.id).toBe('1asdfads');
+        expect(state.editing.properties.title).toBe('Title1');
         expect(state.selected).toBe(null);
     });
 
@@ -1611,5 +1616,12 @@ describe('Test the annotations reducer', () => {
             selected: {properties: {id: '1', geometryTitle: ""}}}, changeGeometryTitle("New title"));
         expect(state.selected).toBeTruthy();
         expect(state.selected.properties.geometryTitle).toBe('New title');
+    });
+    it('Change marker filter option', ()=>{
+        const state = annotations({
+            config: {"config1": 1}
+        }, filterMarker("glass"));
+        expect(state.config).toBeTruthy();
+        expect(state.config.filter).toBe('glass');
     });
 });

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -143,10 +143,12 @@
         border-bottom: none;
         height: auto;
     }
-    .mapstore-annotations-panel-card-description p{
+    .mapstore-annotations-panel-card-description {
         margin: 5px 0 0;
         text-overflow: ellipsis;
-        width: 100px;
+        width: 150px;
+        white-space: nowrap;
+        overflow: hidden;
     }
 }
 
@@ -326,6 +328,7 @@
                     white-space: nowrap;
                     text-overflow: ellipsis;
                     overflow-x: hidden;
+                    width: 150px;
                 }
 
                 > * * {
@@ -719,4 +722,13 @@
     align-items: center;
     font-weight: 600;
     padding: 10px;
+}
+
+.marker-container{
+    .marker-icon, .marker-shape {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 4px 0;
+    }
 }


### PR DESCRIPTION
## Description
Various minor annotation bug fixes (ex. Marker filter, export current annotation fix and some style fixes)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#5888 

**What is the new behavior?**
- Fixed missing properties when exporting current annotation without saving the annotation but geometry
- Geometries card will not expand on lengthier texts instead shows ellipsis
- Marker filter will filter respective glyphs searched

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Before testing: https://github.com/geosolutions-it/MapStore2/issues/5888#issuecomment-696760376