### PR TITLE
#5882: Highlight icon anchor position fix for symbol

### DIFF
--- a/web/client/utils/openlayers/Icons.js
+++ b/web/client/utils/openlayers/Icons.js
@@ -18,13 +18,14 @@ import highlightIcon from './highlight.png';
 const markers = MarkerUtils.markers.extra;
 const extraMarker = markers.icons[0];
 const extraMarkerShadow = markers.icons[1];
+const anchorYSize = markers.size[1];
 
 const glyphs = MarkerUtils.getGlyphs('fontawesome');
 
 
-const getHighlightStyle = ({highlight, rotation = 0}) => (highlight ? [new Style({
+const getHighlightStyle = ({highlight, rotation = 0}, size) => (highlight ? [new Style({
     image: new Icon({
-        anchor: [ 0.5, (markers.size[1] + 18) * 2 ],
+        anchor: [ 0.5, size ],
         rotation,
         anchorXUnits: 'fraction',
         anchorYUnits: 'pixels',
@@ -62,8 +63,7 @@ export default {
                     offsetY: -markers.size[1] * 2 / 3,
                     fill: new Fill({color: '#FFFFFF'})
                 })
-
-            })].concat(getHighlightStyle(options.style));
+            })].concat(getHighlightStyle(options.style, (anchorYSize + 15) * 2));
         }
     },
     standard: {
@@ -91,7 +91,9 @@ export default {
                     })
                 }), markerStyle[0]];
             }
-            return markerStyle.concat(getHighlightStyle(style));
+            let size = isArray(style.size) ? style.size[1] : isNumber(style.size) ? style.size : 0;
+            size = size > 32 ? size + (size * 0.75) : (anchorYSize + 10);
+            return markerStyle.concat(getHighlightStyle(style, size));
         }
     },
     html: {

--- a/web/client/utils/openlayers/__tests__/Icons-test.js
+++ b/web/client/utils/openlayers/__tests__/Icons-test.js
@@ -63,6 +63,7 @@ describe('Icons openlayers styles', () => {
         expect(highlightStyle).toExist();
         const highlightStyleIcon = highlightStyle.getImage();
         expect(highlightStyleIcon).toExist();
+        expect(highlightStyleIcon.anchor_).toEqual([0.5, 122]);
     });
     it('test standard getIcon iconUrl, no shadow, no highlight', () => {
         const getIcon = Icons.standard.getIcon;
@@ -91,7 +92,7 @@ describe('Icons openlayers styles', () => {
     });
     it('test standard getIcon iconUrl, yes shadow, yes highlight', () => {
         const getIcon = Icons.standard.getIcon;
-        const options = {
+        let options = {
             style: {
                 iconAnchor: [0.5, 0.5],
                 anchorXUnits: "fraction",
@@ -104,7 +105,7 @@ describe('Icons openlayers styles', () => {
                 highlight: true
             }
         };
-        const styles = getIcon(options);
+        let styles = getIcon(options);
         expect(styles).toExist();
         expect(styles.length).toBe(3);
         const icon = styles[1];
@@ -115,16 +116,39 @@ describe('Icons openlayers styles', () => {
         expect(iconImage.getOrigin()).toEqual([0, 0]);
         expect(iconImage.getRotation()).toEqual(1);
         expect(iconImage.getSize()).toEqual([14, 14]);
-        const highlightStyle = styles[2];
+        let highlightStyle = styles[2];
         expect(highlightStyle).toExist();
-        const highlightStyleIcon = highlightStyle.getImage();
+        let highlightStyleIcon = highlightStyle.getImage();
         expect(highlightStyleIcon).toExist();
+        expect(highlightStyleIcon.anchor_).toEqual([0.5, 56]);
         const shadowStyle = styles[0];
         expect(shadowStyle).toExist();
         const shadowStyleImage = shadowStyle.getImage();
         expect(shadowStyleImage).toExist();
         expect(shadowStyleImage.getAnchor()).toEqual([12, 41]);
         expect(new RegExp("/assets/img.png").test(shadowStyleImage.getSrc())).toEqual(true);
+
+        // Icon style size as integer
+        options = {
+            style: {
+                iconAnchor: [0.5, 0.5],
+                anchorXUnits: "fraction",
+                anchorYUnits: "fraction",
+                rotation: 1,
+                size: 36,
+                anchorOrigin: "top-left",
+                iconUrl: "/assets/img.png",
+                shadowUrl: "/assets/img.png",
+                highlight: true
+            }
+        };
+        styles = getIcon(options);
+        expect(styles).toExist();
+        highlightStyle = styles[2];
+        expect(highlightStyle).toExist();
+        highlightStyleIcon = highlightStyle.getImage();
+        expect(highlightStyleIcon).toExist();
+        expect(highlightStyleIcon.anchor_).toEqual([0.5, 63]);
     });
     it('test standard getIcon iconUrl, anchor pixel', () => {
         const getIcon = Icons.standard.getIcon;


### PR DESCRIPTION
## Description
Anchor position of the highlight icon on 'symbol' has been corrected such that the icon displays just above the symbol and not far from it

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#5882 

**What is the new behavior?**
- The anchor position has been adjusted such that the highlight icon will not display far from the symbol 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
