### PR TITLE
#5812: GFI swipe fix on mobile view 

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -13,7 +13,7 @@ const HTML = require('../../../components/I18N/HTML');
 const Message = require('../../../components/I18N/Message');
 const {Alert, Panel, Accordion} = require('react-bootstrap');
 const ViewerPage = require('./viewers/ViewerPage');
-const {isEmpty} = require('lodash');
+const {isEmpty, reverse} = require('lodash');
 const {getFormatForResponse} = require('../../../utils/IdentifyUtils');
 
 class DefaultViewer extends React.Component {
@@ -37,7 +37,8 @@ class DefaultViewer extends React.Component {
         setIndex: PropTypes.func,
         showEmptyMessageGFI: PropTypes.bool,
         renderEmpty: PropTypes.bool,
-        loaded: PropTypes.bool
+        loaded: PropTypes.bool,
+        isMobile: PropTypes.bool
     };
 
     static defaultProps = {
@@ -59,7 +60,8 @@ class DefaultViewer extends React.Component {
         renderEmpty: false,
         onNext: () => {},
         onPrevious: () => {},
-        setIndex: () => {}
+        setIndex: () => {},
+        isMobile: false
     };
 
     shouldComponentUpdate(nextProps) {
@@ -171,27 +173,33 @@ class DefaultViewer extends React.Component {
     render() {
         const Container = this.props.container;
         const {currResponse, emptyResponses} = this.getResponseProperties();
+        let componentOrder = [this.renderEmptyLayers(),
+            <Container {...this.props.containerProps}
+                onChangeIndex={(index) => {
+                    this.props.setIndex(index);
+                }}
+                ref="container"
+                index={this.props.index || 0}
+                key={"swiper"}
+                style={this.containerStyle(currResponse)}
+                className="swipeable-view">
+                {this.renderPages()}
+            </Container>
+        ];
+        // Display renderEmptyPages at top in mobile for seamless swipeable view
+        componentOrder = this.props.isMobile ? componentOrder : reverse(componentOrder);
         return (
             <div className="mapstore-identify-viewer">
-                {!emptyResponses ?
-                    <>
-                        <Container {...this.props.containerProps}
-                            onChangeIndex={(index) => {
-                                this.props.setIndex(index);
-                            }}
-                            ref="container"
-                            index={this.props.index || 0}
-                            key={"swiper"}
-                            style={{display: isEmpty(currResponse) ? "none" : "block"}}
-                            className="swipeable-view">
-                            {this.renderPages()}
-                        </Container>
-                        {this.renderEmptyLayers()}
-                    </>
-                    : this.renderEmptyPages()
-                }
+                {!emptyResponses ? componentOrder.map((c)=> c) : this.renderEmptyPages()}
             </div>
         );
+    }
+
+    containerStyle = (currResponse) => {
+        if (isEmpty(currResponse) && this.props.isMobile) {
+            return {height: "100%"};
+        }
+        return {display: isEmpty(currResponse) ? 'none' : 'block'};
     }
 }
 

--- a/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
@@ -128,6 +128,15 @@ describe('DefaultViewer', () => {
         const dom = ReactDOM.findDOMNode(viewer);
         expect(dom.getElementsByClassName("alert").length).toBe(1);
         expect(dom.getElementsByClassName("panel").length).toBe(2);
+
+        // Desktop view
+        const gfiViewer = document.querySelector('.mapstore-identify-viewer');
+        const alertInfo = document.querySelector('.alert-info');
+        const swipeableView = document.querySelector('.swipeable-view');
+        expect(gfiViewer).toBeTruthy();
+        expect(gfiViewer.childNodes.length).toBe(2);
+        expect(gfiViewer.childNodes[0]).toEqual(swipeableView);
+        expect(gfiViewer.childNodes[1]).toEqual(alertInfo);
     });
 
     it('creates the DefaultViewer component with Identify floating', () => {
@@ -229,5 +238,34 @@ describe('DefaultViewer', () => {
         expect(header).toBeTruthy();
         expect(header.innerText).toBe('Layer1');
         expect(panel.length).toBe(1);
+    });
+
+    it('test DefaultViewer component in mobile view', () => {
+        const responses = [{
+            response: "no features were found",
+            layerMetadata: {
+                title: 'a'
+            }
+        }, {
+            response: "B",
+            layerMetadata: {
+                title: 'Layer1'
+            }
+        }];
+        // Mobile view
+        ReactDOM.render(
+            <DefaultViewer isMobile responses={responses} header={SwipeHeader}/>,
+            document.getElementById("container")
+        );
+
+        const mobileContainer = document.getElementById('container');
+        let gfiViewer = mobileContainer.querySelector('.mapstore-identify-viewer');
+        let alertInfo = mobileContainer.querySelector('.alert-info');
+        let swipeableView = mobileContainer.querySelector('.swipeable-view');
+        expect(gfiViewer).toBeTruthy();
+        expect(gfiViewer.childNodes.length).toBe(2);
+        expect(gfiViewer.childNodes[0]).toEqual(alertInfo);
+        expect(gfiViewer.childNodes[1]).toEqual(swipeableView);
+
     });
 });

--- a/web/client/components/data/identify/viewers/HTMLViewer.jsx
+++ b/web/client/components/data/identify/viewers/HTMLViewer.jsx
@@ -23,7 +23,7 @@ class HTMLViewer extends React.Component {
     }
 
     render() {
-        let response = this.props.response;
+        let response = this.props.response || '';
         // gets css rules from the response and removes which are related to body tag.
         let styleMatch = regexpStyle.exec(response);
         let style = styleMatch && styleMatch.length === 2 ? regexpStyle.exec(response)[1] : "";

--- a/web/client/components/data/identify/viewers/ViewerPage.jsx
+++ b/web/client/components/data/identify/viewers/ViewerPage.jsx
@@ -67,7 +67,7 @@ module.exports = class extends React.Component {
 
     render() {
         return (<div
-            style={{width: "100%", height: "100%"}}
+            style={{width: "100%", height: "100%", overflowX: 'auto'}}
             onTouchMove={this.onTouchMove}
             onTouchStart={this.onTouchStart}
             onTouchEnd={this.onTouchEnd}>

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -66,7 +66,7 @@ const selector = createStructuredSelector({
  */
 const identifyIndex = compose(
     connect(
-        createSelector(indexSelector, isLoadedResponseSelector, (index, loaded) => ({ index, loaded })),
+        createSelector(indexSelector, isLoadedResponseSelector, (state) =>state.browser && state.browser.mobile, (index, loaded, isMobile) => ({ index, loaded, isMobile })),
         {
             setIndex: changePage
         }

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -57,6 +57,11 @@
             }
         }
     }
+    .mapstore-identify-viewer {
+        .alert-info{
+            margin-bottom: 10px;
+        }
+    }
 }
 
 #share-container {


### PR DESCRIPTION
## Description
Swipe gesture fix on mobile view for GFI panel viewer

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#5812 

**What is the new behavior?**
The viewer will not be hidden when no feature or empty results in mobile view to enable swipe gesture.
- Desktop view, the renderEmtpyLabels will be displayed at the bottom of the results viewer
- Mobile view the renderEmtpyLabels will be displayed at the top of the results viewer so the user can perform swipe action in the space below seamlessly. This will prevent showing an empty space at top followed by renderEmptyLabels.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
