### PR TITLE
Remove plugin example link from doc

### DIFF
--- a/docs/developer-guide/plugins-architecture.md
+++ b/docs/developer-guide/plugins-architecture.md
@@ -115,8 +115,3 @@ module.exports = {
    reducers: {myreducer}
 };
 ```
-
-## The Plugins Example Application
-The [example](http://dev.mapstore.geo-solutions.it/mapstore/examples/plugins/) shows the plugins infrastructure power in an interactive way.
-
-The UI allows to add / remove plugins from the base applications, and to configure them using a JSON object with plugins configuration properties.


### PR DESCRIPTION
## Description
The plugin example has been removed, but a link still exists in ducumentation. This removes the link.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

issue https://github.com/geosolutions-it/MapStore2/issues/5894


[//]: # (rtdbot-start)

URL of RTD document: https://mapstore.readthedocs.io/en/remove_plugin_example/ ![Documentation Status](https://readthedocs.org/projects/mapstore/badge/?version=remove_plugin_example)

[//]: # (rtdbot-end)
