### PR TITLE
#5936: MapSearchbar menu visibility fix

### DIFF
--- a/web/client/components/mapcontrols/search/SearchBar.jsx
+++ b/web/client/components/mapcontrols/search/SearchBar.jsx
@@ -213,6 +213,7 @@ export default ({
                             visible: !!error,
                             onClick: clearSearch
                         }, {
+                            visible: showOptions,
                             renderButton: <SearchBarMenu disabled={showOptions} menuItems={searchMenuOptions} />
                         }]}
                 />

--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -315,13 +315,13 @@ describe("test the SearchBar", () => {
     });
 
     it('test showOptions false, only address tool visible', () => {
-        ReactDOM.render(<SearchBar showOptions={false} searchText={""} delay={0} typeAhead={false} />, document.getElementById("container"));
-        let reset = document.getElementsByClassName("glyphicon-search")[0];
-        let cog = document.getElementsByClassName("glyphicon-cog");
-        let zoom = document.getElementsByClassName("glyphicon-zoom-to");
-        expect(reset).toExist();
-        expect(cog.length).toBe(0);
-        expect(zoom.length).toBe(0);
+        ReactDOM.render(<SearchBar splitTools showOptions={false} searchText={""} delay={0} typeAhead={false} />, document.getElementById("container"));
+        let menu = document.getElementsByClassName("glyphicon-menu-hamburger");
+        let search = document.getElementsByClassName("glyphicon-search");
+        let options = document.getElementsByClassName("glyphicon-cog");
+        expect(menu.length).toBe(0);
+        expect(search.length).toBe(1);
+        expect(options.length).toBe(0);
     });
 
     it('test default coordinate format from localConfig', () => {


### PR DESCRIPTION
## Description
This PR adds showOptions visibility validation to search bar menu, which is was missed in recent search bar component refactor

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#5936 

**What is the new behavior?**
Setting configuration option showOptions for Search plugin should influence the visibility of the searchbar burger menu

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
