### PR TITLE
#5607 Fix checkout to current branch of submodule

### DIFF
--- a/createProject.js
+++ b/createProject.js
@@ -84,6 +84,10 @@ function doWork(params) {
             return project.initGit(params.outFolder);
         })
         .then(() => {
+            process.stdout.write('git init\n');
+            return project.updateSubmoduleBranch(params.outFolder);
+        })
+        .then(() => {
             process.stdout.write('git repo OK!\n');
             process.exit();
         })

--- a/docs/developer-guide/project-creation-script.md
+++ b/docs/developer-guide/project-creation-script.md
@@ -25,7 +25,7 @@ Finally, to create the project, use the following command:
 node ./createProject.js <projectType> <projectName> <projectVersion> <projectDescription> <gitRepositoryUrl> <outputFolder>
 ```
 
-All the arguments except gitRepositoryUrl are mandatory:
+Note that projectName and outputFolder are mandatory:
 
 * **projectName**: short project name that will be used as the repository name on github, webapp path and name in package.json
 * **projectType**: type of project to create, currently two types of projects are supported:

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "redux-immutable-state-invariant": "2.1.0",
     "redux-mock-store": "1.2.2",
     "rimraf": "2.5.2",
-    "simple-git": "1.33.1",
+    "simple-git": "2.20.1",
     "style-loader": "0.12.4",
     "url-loader": "0.5.7",
     "vusion-webfonts-generator": "0.4.1",

--- a/utility/projects/projectLib.js
+++ b/utility/projects/projectLib.js
@@ -33,6 +33,39 @@ const initGit = (outFolder) => {
     });
 };
 
+/**
+ * it does a checkout to a specified folder which in general is rootProject/MapStore2
+ * @param {string} outFolder the folder where to apply the checkout
+ * @return {Promise} the promise to continue the flow of project creation
+ */
+const updateSubmoduleBranch = (outFolder) => {
+    const git = require('simple-git')();
+    const gitProjectMs2 = require('simple-git')(`${outFolder}/MapStore2`);
+
+    return new Promise((resolve, reject) => {
+        try {
+            git.branchLocal( (err, data) => {
+                if (err) {
+                    reject(err);
+                }
+                process.stdout.write("doing checkout to the branch: ", data.current);
+                gitProjectMs2.checkout(data.current, null, (error) => {
+                    if (error) {
+                        reject(error);
+                    }
+                    process.stdout.write("checkout done");
+                    resolve();
+                });
+            });
+        } catch (e) {
+            process.stdout.write("error");
+            process.stdout.write(e);
+            reject(e);
+        }
+    });
+};
+
+
 const copyTemplates = (basePath, outFolder, options, level = 0, path = '') => {
     return readdir(basePath + path)
         .then(files => {
@@ -91,5 +124,6 @@ module.exports = {
     initGit,
     createPackageJSON,
     copyTemplates,
-    copyStaticFiles
+    copyStaticFiles,
+    updateSubmoduleBranch
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

this pr fixes the problem of the checkout to the submodule folder when a project is create from a branch different from master
The npm install point was fixed [here](https://github.com/geosolutions-it/MapStore2/commit/c1894d8ec2d403af9d3d2c8bf90cf7a725bf78d5)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5607 second point

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it does checkout to the submodule after git is initialized and submodule added

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
