### PR TITLE
#5944: Fixed web/pom.xml to include mapstore-backend

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -16,6 +16,11 @@
 
   <dependencies>
     <!-- MapStore backend -->
+    <dependency>
+        <groupId>it.geosolutions.mapstore</groupId>
+        <artifactId>mapstore-backend</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
 
     <!-- ================================================================ -->
     <!-- GeoStore modules -->


### PR DESCRIPTION
## Description
The back-end was removed in error.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5944

**What is the new behavior?**
Now running both tomcat7:run-war and running the built war allow extension installation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
We can mitigate this problem on release by adding the mapstore-backend jar manually to existing installation and release files.
