### PR TITLE
ContextCreator save fix

### DIFF
--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -879,6 +879,24 @@ describe('contextcreator epics', () => {
             map: {}
         }, done);
     });
+    it('saveContextResource with an error', (done) => {
+        mockAxios.onPost().reply(404);
+        const startActions = [saveNewContext("/")];
+        testEpic(saveContextResource, 3, startActions, actions => {
+            expect(actions.length).toBe(3);
+            expect(actions[0].type).toBe(LOADING);
+            expect(actions[1].type).toBe(SHOW_NOTIFICATION);
+            expect(actions[1].level).toBe('error');
+            expect(actions[2].type).toBe(LOADING);
+        }, {
+            contextcreator: {
+                resource: {
+                    name: 'context'
+                }
+            },
+            map: {}
+        }, done);
+    });
     it('editTemplateEpic with id', (done) => {
         mockAxios.onGet().reply(200, 'data');
         const startActions = [editTemplate(1)];

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -118,15 +118,6 @@ export const saveContextResource = (action$, store) => action$
         };
 
         return (resource && resource.id ? updateResource : createResource)(newResource)
-            .catch(({status, data}) => Rx.Observable.of(error({
-                title: 'contextCreator.saveErrorNotification.titleContext',
-                message: saveContextErrorStatusToMessage(status),
-                position: "tc",
-                autoDismiss: 5,
-                values: {
-                    data
-                }
-            }), loading(false, 'contextSaving')))
             .switchMap(rid => Rx.Observable.merge(
                 // LOCATION_CHANGE triggers notifications clear, need to work around that
                 // can't wait for CLEAR_NOTIFICATIONS, because either in firefox notification action doesn't trigger
@@ -144,6 +135,15 @@ export const saveContextResource = (action$, store) => action$
                     loading(false, 'contextSaving')
                 ),
             ))
+            .catch(({status, data}) => Rx.Observable.of(error({
+                title: 'contextCreator.saveErrorNotification.titleContext',
+                message: saveContextErrorStatusToMessage(status),
+                position: "tc",
+                autoDismiss: 5,
+                values: {
+                    data
+                }
+            }), loading(false, 'contextSaving')))
             .startWith(loading(true, 'contextSaving'));
     });
 


### PR DESCRIPTION
## Description
While [enabling](https://github.com/geosolutions-it/austrocontrol-C125/pull/213) Contexts on austrocontrol noticed that when context is saved with an error, it is still reported as a success. This fixes that behaviour.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#5965 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
