### PR TITLE
#5960: Localized form control for bookmark config

### DIFF
--- a/web/client/components/mapcontrols/searchbookmarkconfig/AddNewBookmark.jsx
+++ b/web/client/components/mapcontrols/searchbookmarkconfig/AddNewBookmark.jsx
@@ -11,8 +11,12 @@ import PropTypes from 'prop-types';
 import {Button, Col, ControlLabel, FormControl as FC, FormGroup, Glyphicon, OverlayTrigger, Tooltip} from "react-bootstrap";
 import Message from "../../I18N/Message";
 import {inRange} from 'lodash';
+import * as NumberFormControl from '../../I18N/IntlNumberFormControl';
+
 import localizedProps from '../../misc/enhancers/localizedProps';
 const FormControl = localizedProps('placeholder')(FC);
+const IntlNumberFormControl = localizedProps('placeholder')(NumberFormControl);
+
 
 const validate = (bookmark = {}) =>{
     const {options = {}, title = ''} = bookmark;
@@ -27,8 +31,7 @@ const AddNewBookmark = (props) => {
     const {onPropertyChange, bookmark = {}, bbox: currentBBox} = props;
     const {options: bboxAttributes = {}, title, layerVisibilityReload = false} = bookmark;
 
-    const onChange = (event) => {
-        const {value, name} = event.target;
+    const onChange = (value, name) => {
         const options = {...bookmark.options,  [name]: parseFloat(value)};
         onPropertyChange("bookmark", {...bookmark, options});
     };
@@ -112,13 +115,13 @@ const AddNewBookmark = (props) => {
                 <div className={"field-top-bottom"}>
                     <FormGroup validationState={validateFunc("north")}>
                         <ControlLabel><Message msgId={"search.b_bbox_north"}/></ControlLabel>
-                        <FormControl
+                        <IntlNumberFormControl
                             placeholder="search.b_bbox_north_placeholder"
                             min={-90} max={90}
                             name={"north"}
                             type="number"
-                            onChange={onChange}
-                            value={bboxAttributes.north || ""}
+                            onChange={(v)=>onChange(v, 'north')}
+                            value={bboxAttributes.north}
                         />
                     </FormGroup>
                 </div>
@@ -126,26 +129,26 @@ const AddNewBookmark = (props) => {
                     <div className={"field-left-right"}>
                         <FormGroup validationState={validateFunc("west")}>
                             <ControlLabel><Message msgId={"search.b_bbox_west"}/></ControlLabel>
-                            <FormControl
+                            <IntlNumberFormControl
                                 placeholder="search.b_bbox_west_placeholder"
                                 min={-180} max={180}
                                 name={"west"}
                                 type="number"
-                                onChange={onChange}
-                                value={bboxAttributes.west || ""}
+                                onChange={(v)=>onChange(v, 'west')}
+                                value={bboxAttributes.west}
                             />
                         </FormGroup>
                     </div>
                     <div className={"field-left-right"}>
                         <FormGroup validationState={validateFunc("east")}>
                             <ControlLabel><Message msgId={"search.b_bbox_east"}/></ControlLabel>
-                            <FormControl
+                            <IntlNumberFormControl
                                 placeholder="search.b_bbox_east_placeholder"
                                 min={-180} max={180}
                                 name={"east"}
                                 type="number"
-                                onChange={onChange}
-                                value={bboxAttributes.east || ""}
+                                onChange={(v)=>onChange(v, 'east')}
+                                value={bboxAttributes.east}
                             />
                         </FormGroup>
                     </div>
@@ -153,13 +156,13 @@ const AddNewBookmark = (props) => {
                 <div className={"field-top-bottom"}>
                     <FormGroup validationState={validateFunc("south")}>
                         <ControlLabel><Message msgId={"search.b_bbox_south"}/></ControlLabel>
-                        <FormControl
+                        <IntlNumberFormControl
                             placeholder="search.b_bbox_south_placeholder"
                             min={-90} max={90}
                             name={"south"}
                             type="number"
-                            onChange={onChange}
-                            value={bboxAttributes.south || ""}
+                            onChange={(v)=>onChange(v, 'south')}
+                            value={bboxAttributes.south}
                         />
                     </FormGroup>
                 </div>


### PR DESCRIPTION
## Description
This PR replaces the bootstrap formcontrol with custom formcontrol with localization feature to bookmark config.
Note: No additional test cases added to cover this scenario as they are already covered as part of the field validation in AddNewBookmark-test and IntlFormcontrol specific test cases are already in place.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#5960 

**What is the new behavior?**
Changing language will have effect on the delimiter and separator of the bounding box fields in bookmark

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
