### PR TITLE
#5944: fixed issue on upload backend

### DIFF
--- a/backend/src/main/java/it/geosolutions/mapstore/UploadPluginController.java
+++ b/backend/src/main/java/it/geosolutions/mapstore/UploadPluginController.java
@@ -267,7 +267,7 @@ public class UploadPluginController {
             int remove = -1;
             for (int count = 0; count < plugins.size(); count++) {
                 JsonNode node = plugins.get(count);
-                if (json.get("name").asText().equals(node.get("value").get("name").asText())) {
+                if (json.get("name").asText().equals(node.get("name").asText())) {
                     remove = count;
                 }
             }


### PR DESCRIPTION
## Description
This problem is probably due to a wrong back-port of a wrong PR merge, so a fix applied to releases 2020.02.00, is not present anymore on 2020.02.xx.
Everything is ok on master, this issue affects only 2020.02.xx
and also latest release binary and war uploaded on github release should be already fixed during update (it was not working so I used the latest jar for mapstore back-end).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5944
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
