### PR TITLE
#5292: Fixed opacity issues in printing

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -243,7 +243,7 @@ const PrintUtils = {
         wms: {
             map: (layer, spec) => ({
                 "baseURL": PrintUtils.normalizeUrl(layer.url) + '?',
-                "opacity": layer.opacity || 1.0,
+                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                 "singleTile": false,
                 "type": "WMS",
                 "layers": [
@@ -300,7 +300,7 @@ const PrintUtils = {
             map: (layer, spec) => ({
                 type: 'Vector',
                 name: layer.name,
-                "opacity": layer.opacity || 1.0,
+                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                 styleProperty: "ms_style",
                 styles: {
                     1: PrintUtils.toOpenLayers2Style(layer, layer.style),
@@ -323,7 +323,7 @@ const PrintUtils = {
             map: (layer) => ({
                 type: 'Vector',
                 name: layer.name,
-                "opacity": layer.opacity || 1.0,
+                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                 styleProperty: "ms_style",
                 styles: {
                     1: PrintUtils.toOpenLayers2Style(layer, layer.style),
@@ -341,9 +341,9 @@ const PrintUtils = {
             )
         },
         osm: {
-            map: () => ({
+            map: (layer = {}) => ({
                 "baseURL": "http://a.tile.openstreetmap.org/",
-                "opacity": 1,
+                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                 "singleTile": false,
                 "type": "OSM",
                 "maxExtent": [
@@ -381,9 +381,9 @@ const PrintUtils = {
             })
         },
         mapquest: {
-            map: () => ({
+            map: (layer = {}) => ({
                 "baseURL": "http://otile1.mqcdn.com/tiles/1.0.0/map/",
-                "opacity": 1,
+                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                 "singleTile": false,
                 "type": "OSM",
                 "maxExtent": [
@@ -458,7 +458,7 @@ const PrintUtils = {
                     "style": layer.style,
                     "name": layer.name,
                     "requestEncoding": layer.requestEncoding === "RESTful" ? "REST" : layer.requestEncoding,
-                    "opacity": layer.opacity || layer.opacity === 0 ? 0 : 1.0,
+                    "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                     "version": layer.version || "1.0.0"
                 };
             }
@@ -485,7 +485,7 @@ const PrintUtils = {
                         path_format: pathFormat,
                         "type": 'xyz',
                         "extension": validURL.split('.').pop() || "png",
-                        "opacity": layer.opacity || layer.opacity === 0 ? 0 : 1.0,
+                        "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                         "tileSize": [256, 256],
                         "maxExtent": [-20037508.3392, -20037508.3392, 20037508.3392, 20037508.3392],
                         "resolutions": MapUtils.getResolutions()
@@ -501,7 +501,7 @@ const PrintUtils = {
                 const layerName = layer.tileMapUrl.split(layer.tileMapService + "/")[1];
                 return {
                     type: 'tms',
-                    opacity: layer.opacity || layer.opacity === 0 ? 0 : 1.0,
+                    opacity: layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
                     layer: layerName,
                     // baseURL for mapfish print required to remove the version
                     baseURL: layer.tileMapService.substring(0, layer.tileMapService.lastIndexOf("/1.0.0")),

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -37,6 +37,14 @@ const getGeomType = function(layer) {
 const isAnnotationLayer = (layer) => {
     return layer.id === "annotations" || layer.name === "Measurements";
 };
+
+/**
+ * Extracts the correct opacity from layer. if Undefined, the opacity is `1`.
+ * @ignore
+ * @param {object} layer the MapStore layer
+ */
+const getOpacity = layer => layer.opacity || (layer.opacity === 0 ? 0 : 1.0);
+
 /**
  * Utilities for Print
  * @memberof utils
@@ -243,7 +251,7 @@ const PrintUtils = {
         wms: {
             map: (layer, spec) => ({
                 "baseURL": PrintUtils.normalizeUrl(layer.url) + '?',
-                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                "opacity": getOpacity(layer),
                 "singleTile": false,
                 "type": "WMS",
                 "layers": [
@@ -300,7 +308,7 @@ const PrintUtils = {
             map: (layer, spec) => ({
                 type: 'Vector',
                 name: layer.name,
-                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                "opacity": getOpacity(layer),
                 styleProperty: "ms_style",
                 styles: {
                     1: PrintUtils.toOpenLayers2Style(layer, layer.style),
@@ -323,7 +331,7 @@ const PrintUtils = {
             map: (layer) => ({
                 type: 'Vector',
                 name: layer.name,
-                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                "opacity": getOpacity(layer),
                 styleProperty: "ms_style",
                 styles: {
                     1: PrintUtils.toOpenLayers2Style(layer, layer.style),
@@ -343,7 +351,7 @@ const PrintUtils = {
         osm: {
             map: (layer = {}) => ({
                 "baseURL": "http://a.tile.openstreetmap.org/",
-                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                "opacity": getOpacity(layer),
                 "singleTile": false,
                 "type": "OSM",
                 "maxExtent": [
@@ -383,7 +391,7 @@ const PrintUtils = {
         mapquest: {
             map: (layer = {}) => ({
                 "baseURL": "http://otile1.mqcdn.com/tiles/1.0.0/map/",
-                "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                "opacity": getOpacity(layer),
                 "singleTile": false,
                 "type": "OSM",
                 "maxExtent": [
@@ -458,7 +466,7 @@ const PrintUtils = {
                     "style": layer.style,
                     "name": layer.name,
                     "requestEncoding": layer.requestEncoding === "RESTful" ? "REST" : layer.requestEncoding,
-                    "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                    "opacity": getOpacity(layer),
                     "version": layer.version || "1.0.0"
                 };
             }
@@ -485,7 +493,7 @@ const PrintUtils = {
                         path_format: pathFormat,
                         "type": 'xyz',
                         "extension": validURL.split('.').pop() || "png",
-                        "opacity": layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                        "opacity": getOpacity(layer),
                         "tileSize": [256, 256],
                         "maxExtent": [-20037508.3392, -20037508.3392, 20037508.3392, 20037508.3392],
                         "resolutions": MapUtils.getResolutions()
@@ -501,7 +509,7 @@ const PrintUtils = {
                 const layerName = layer.tileMapUrl.split(layer.tileMapService + "/")[1];
                 return {
                     type: 'tms',
-                    opacity: layer.opacity || (layer.opacity === 0 ? 0 : 1.0),
+                    opacity: getOpacity(layer),
                     layer: layerName,
                     // baseURL for mapfish print required to remove the version
                     baseURL: layer.tileMapService.substring(0, layer.tileMapService.lastIndexOf("/1.0.0")),

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -457,6 +457,38 @@ describe('PrintUtils', () => {
         expect(rgb).toBe("rgb(255, 255, 255)");
     });
     describe('specCreators', () => {
+        describe('opacity', () => {
+            const testBase = {
+                wms: layer,
+                wmts: KVP1,
+                vector: vectorLayer,
+                tms: TMS110_1,
+                tileprovider: BasemapAT,
+                osm: {
+                    "group": "background",
+                    "source": "osm",
+                    "name": "mapnik",
+                    "title": "Open Street Map",
+                    "type": "osm",
+                    "visibility": true,
+                    "singleTile": false,
+                    "dimensions": [],
+                    "id": "mapnik__0",
+                    "loading": false,
+                    "loadingError": false
+                }
+            };
+            it('check opacity for all layers to be 1 for undefined, therwise its value', () => {
+                Object.keys(PrintUtils.specCreators).map( k => {
+                    const fun = PrintUtils.specCreators[k].map;
+                    // 0 must remain
+                    expect(fun({ ...(testBase[k] || {}), opacity: 0 }, { projection: "EPSG:900913" }).opacity).toEqual(0);
+                    expect(fun({ ...(testBase[k] || {}), opacity: 0.5 }, { projection: "EPSG:900913" }).opacity).toEqual(0.5);
+                    expect(fun({ ...(testBase[k] || {}), opacity: undefined }, { projection: "EPSG:900913" }).opacity).toEqual(1);
+
+                } );
+            });
+        });
         describe('WMTS', () => {
             const checkMatrixIds = (layerSpec, tileMatrixSet) => layerSpec.matrixIds.map((mid, index) => {
                 const tileMatrixEntry = tileMatrixSet.TileMatrix[index];


### PR DESCRIPTION
## Description
This PR fixes this issue: https://github.com/geosolutions-it/MapStore2/issues/5292#issuecomment-702773635
Moreover fixes other minor issues found in WMS/OSM/Vector layers and printing (opacity = 0 becomes 1).
Added unit tests for all the use cases about opacity

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5292

**What is the new behavior?**
Now the opacity is correct for every layer
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
