### PR TITLE
Uniformation of Edit Properties and detail card

### DIFF
--- a/web/client/components/resources/ResourceGrid.jsx
+++ b/web/client/components/resources/ResourceGrid.jsx
@@ -46,7 +46,7 @@ module.exports = ({
     category = 'MAP',
     resources = [],
     resource,
-    loadedResource,
+    detailsText,
     id,
     style,
     bottom,
@@ -121,7 +121,7 @@ module.exports = ({
                 show={showDetailsSheet}
                 readOnly
                 title={resource?.name || resource?.metadata?.name}
-                detailsText={loadedResource?.linkedResources?.details?.data}
+                detailsText={detailsText}
                 onClose={onHideDetailsSheet}/>
         </Grid>
     );

--- a/web/client/components/resources/enhancers/resourceGrid.js
+++ b/web/client/components/resources/enhancers/resourceGrid.js
@@ -85,7 +85,12 @@ const resourceGrid = compose(
             setLoadingResource(false);
         }
     }),
-    mapProps(({loading, loadingResource, ...other}) => ({...other, loading: loading || loadingResource || false }))
+    mapProps(({loading, loadingResource, loadedResource, ...other}) => ({
+        ...other,
+        loadedResource,
+        loading: loading || loadingResource || false,
+        detailsText: loadedResource?.linkedResources?.details?.data === 'NODATA' ? undefined : loadedResource?.linkedResources?.details?.data
+    }))
 );
 
 module.exports = resourceGrid;

--- a/web/client/components/resources/modals/enhancers/__tests__/handleDetailsDownload-test.jsx
+++ b/web/client/components/resources/modals/enhancers/__tests__/handleDetailsDownload-test.jsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import expect from 'expect';
+import ReactDOM from 'react-dom';
+import axios from 'axios';
+import MockAdapter from "axios-mock-adapter";
+import { createSink, setObservableConfig } from 'recompose';
+import rxjsConfig from 'recompose/rxjsObservableConfig';
+
+import handleDetailsDownload from '../handleDetailsDownload';
+
+setObservableConfig(rxjsConfig);
+
+describe('handleDetailsDownload enhancer', () => {
+    let mockAxios;
+
+    beforeEach((done) => {
+        mockAxios = new MockAdapter(axios);
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        mockAxios.restore();
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('details are loaded', done => {
+        const res = {
+            id: 10,
+            name: 'test resource',
+            attributes: {
+                details: 'rest/geostore/data/1000'
+            }
+        };
+        const Sink = handleDetailsDownload(createSink(props => {
+            if (!props.loading) {
+                try {
+                    expect(props.linkedResources).toExist();
+                    expect(props.linkedResources.details).toExist();
+                    expect(props.linkedResources.details.category).toBe('DETAILS');
+                    expect(props.linkedResources.details.data).toBe('details data');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }
+        }));
+
+        mockAxios.onGet('/rest/geostore/data/1000').reply(200, 'details data');
+
+        ReactDOM.render(<Sink loading resource={res}/>, document.getElementById('container'));
+    });
+
+    it('details attribute doesnt exist', done => {
+        const res = {
+            id: 10,
+            name: 'test resource'
+        };
+        const Sink = handleDetailsDownload(createSink(props => {
+            if (!props.loading) {
+                try {
+                    expect(props.linkedResources).toExist();
+                    expect(props.linkedResources.details).toExist();
+                    expect(props.linkedResources.details.category).toBe('DETAILS');
+                    expect(props.linkedResources.details.data).toBe('NODATA');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }
+        }));
+
+        ReactDOM.render(<Sink loading resource={res}/>, document.getElementById('container'));
+    });
+});

--- a/web/client/components/resources/modals/enhancers/handleDetailsDownload.js
+++ b/web/client/components/resources/modals/enhancers/handleDetailsDownload.js
@@ -30,7 +30,7 @@ export default mapPropsStream(props$ => {
                         ...(props.linkedResources || {}),
                         details: {
                             category: 'DETAILS',
-                            data: detailsText
+                            data: detailsText || 'NODATA'
                         }
                     };
 

--- a/web/client/components/resources/modals/fragments/Details.jsx
+++ b/web/client/components/resources/modals/fragments/Details.jsx
@@ -65,9 +65,16 @@ export default ({
                     onHideDetailsSheet();
                 }}
                 onSave={editorText => {
+                    let newDetailsText = editorStateToDetailsText(editorText);
+
                     onHideDetailsSheet();
                     setDetailsBackup();
-                    onUpdateLinkedResource('details', editorStateToDetailsText(editorText), 'DETAILS');
+
+                    if (!newDetailsText || newDetailsText === '<p><br></p>') {
+                        newDetailsText = savedDetailsText;
+                    }
+
+                    onUpdateLinkedResource('details', newDetailsText, 'DETAILS');
                 }}>
                 <Editor {...editorProps} editorState={editorState} onUpdateEditorState={setEditorState}/>
             </DetailsSheet>

--- a/web/client/components/resources/modals/fragments/Details.jsx
+++ b/web/client/components/resources/modals/fragments/Details.jsx
@@ -74,7 +74,7 @@ export default ({
                         newDetailsText = savedDetailsText;
                     }
 
-                    onUpdateLinkedResource('details', newDetailsText, 'DETAILS');
+                    onUpdateLinkedResource('details', newDetailsText || 'NODATA', 'DETAILS');
                 }}>
                 <Editor {...editorProps} editorState={editorState} onUpdateEditorState={setEditorState}/>
             </DetailsSheet>

--- a/web/client/components/resources/modals/fragments/__tests__/Details-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/Details-test.jsx
@@ -90,4 +90,48 @@ describe('Details component', () => {
 
         expect(onHideDetailsSheetSpy.calls.length).toBe(2);
     });
+    it('saved text changes on save', () => {
+        const handlers = {
+            onUpdateLinkedResource: () => {}
+        };
+        const onUpdateLinkedResourceSpy = expect.spyOn(handlers, 'onUpdateLinkedResource');
+
+        ReactDOM.render(<Details showDetailsSheet savedDetailsText="text" editorState={htmlToDraftJSEditorState('<p>newtext</p>')} onUpdateLinkedResource={handlers.onUpdateLinkedResource}/>, document.getElementById('container'));
+        const detailsSheet = document.getElementsByClassName('ms-details-sheet')[0];
+        expect(detailsSheet).toExist();
+        const sheetModal = document.getElementsByClassName('modal-fixed')[0];
+        expect(sheetModal).toExist();
+        const sheetModalFooter = sheetModal.getElementsByClassName('modal-footer')[0];
+        expect(sheetModalFooter).toExist();
+        const buttons = sheetModalFooter.getElementsByTagName('button');
+        expect(buttons).toExist();
+        expect(buttons.length).toBe(2);
+
+        TestUtils.Simulate.click(buttons[1]);
+
+        expect(onUpdateLinkedResourceSpy).toHaveBeenCalled();
+        expect(onUpdateLinkedResourceSpy.calls[0].arguments).toEqual(['details', '<p>newtext</p>\n', 'DETAILS']);
+    });
+    it('saved text does not change if onSave saves with empty string', () => {
+        const handlers = {
+            onUpdateLinkedResource: () => {}
+        };
+        const onUpdateLinkedResourceSpy = expect.spyOn(handlers, 'onUpdateLinkedResource');
+
+        ReactDOM.render(<Details showDetailsSheet savedDetailsText="text" editorState={htmlToDraftJSEditorState('')} onUpdateLinkedResource={handlers.onUpdateLinkedResource}/>, document.getElementById('container'));
+        const detailsSheet = document.getElementsByClassName('ms-details-sheet')[0];
+        expect(detailsSheet).toExist();
+        const sheetModal = document.getElementsByClassName('modal-fixed')[0];
+        expect(sheetModal).toExist();
+        const sheetModalFooter = sheetModal.getElementsByClassName('modal-footer')[0];
+        expect(sheetModalFooter).toExist();
+        const buttons = sheetModalFooter.getElementsByTagName('button');
+        expect(buttons).toExist();
+        expect(buttons.length).toBe(2);
+
+        TestUtils.Simulate.click(buttons[1]);
+
+        expect(onUpdateLinkedResourceSpy).toHaveBeenCalled();
+        expect(onUpdateLinkedResourceSpy.calls[0].arguments).toEqual(['details', 'text', 'DETAILS']);
+    });
 });

--- a/web/client/components/resources/modals/fragments/__tests__/Details-test.jsx
+++ b/web/client/components/resources/modals/fragments/__tests__/Details-test.jsx
@@ -134,4 +134,26 @@ describe('Details component', () => {
         expect(onUpdateLinkedResourceSpy).toHaveBeenCalled();
         expect(onUpdateLinkedResourceSpy.calls[0].arguments).toEqual(['details', 'text', 'DETAILS']);
     });
+    it('saved text is NODATA if onSave saves with empty string and there is no savedDetailsText', () => {
+        const handlers = {
+            onUpdateLinkedResource: () => {}
+        };
+        const onUpdateLinkedResourceSpy = expect.spyOn(handlers, 'onUpdateLinkedResource');
+
+        ReactDOM.render(<Details showDetailsSheet editorState={htmlToDraftJSEditorState('')} onUpdateLinkedResource={handlers.onUpdateLinkedResource}/>, document.getElementById('container'));
+        const detailsSheet = document.getElementsByClassName('ms-details-sheet')[0];
+        expect(detailsSheet).toExist();
+        const sheetModal = document.getElementsByClassName('modal-fixed')[0];
+        expect(sheetModal).toExist();
+        const sheetModalFooter = sheetModal.getElementsByClassName('modal-footer')[0];
+        expect(sheetModalFooter).toExist();
+        const buttons = sheetModalFooter.getElementsByTagName('button');
+        expect(buttons).toExist();
+        expect(buttons.length).toBe(2);
+
+        TestUtils.Simulate.click(buttons[1]);
+
+        expect(onUpdateLinkedResourceSpy).toHaveBeenCalled();
+        expect(onUpdateLinkedResourceSpy.calls[0].arguments).toEqual(['details', 'NODATA', 'DETAILS']);
+    });
 });

--- a/web/client/components/resources/modals/fragments/editors/QuillEditor.jsx
+++ b/web/client/components/resources/modals/fragments/editors/QuillEditor.jsx
@@ -28,9 +28,7 @@ const Editor = ({
             bounds={"#ms-details-editor"}
             value={editorState || '<p><br></p>'}
             onChange={(details) => {
-                if (details && details !== '<p><br></p>') {
-                    onUpdateEditorState(details);
-                }
+                onUpdateEditorState(details);
             }}
             modules={modules} />
     </div>

--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -149,7 +149,11 @@ describe('geostore observables for resources management', () => {
                 }
             };
             const DummyAPI = {
-                getResourceAttribute: () => Promise.reject({status: 404}),
+                getResourceAttributes: () => Promise.resolve([{
+                    name: 'details',
+                    type: 'STRING',
+                    value: 'rest/geostore/data/134'
+                }]),
                 putResourceMetadataAndAttributes: () => Promise.resolve(10),
                 putResource: () => Promise.resolve(10),
                 createResource: ({name}) => name.search(/10-thumbnail/) !== -1 ? done(new Error('createResource for thumbnail is called!')) : Promise.resolve(11),
@@ -180,7 +184,11 @@ describe('geostore observables for resources management', () => {
             let createResourceThumbnail = false;
 
             const DummyAPI = {
-                getResourceAttribute: () => Promise.reject({status: 404}),
+                getResourceAttributes: () => Promise.resolve([{
+                    name: 'details',
+                    type: 'STRING',
+                    value: 'rest/geostore/data/134'
+                }]),
                 putResourceMetadataAndAttributes: () => Promise.resolve(10),
                 putResource: () => Promise.resolve(10),
                 createResource: ({name}) => {


### PR DESCRIPTION
## Description
Did what was asked [here](https://github.com/geosolutions-it/MapStore2/issues/5772#issuecomment-703566201). Also currently when details are edited and are saved with an empty string is deletes old details without a possibility to undo the delete, so instead it doesn't change the details text now if user saves an empty string. The only way to delete is through the delete button with proper behavior.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5772 

**What is the current behavior?**
#5772 

**What is the new behavior?**
Description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
