### PR TITLE
#5976: Add media editor settings configurations to localConfig for GeoStory plugin

### DIFF
--- a/web/client/actions/__tests__/geostory-test.js
+++ b/web/client/actions/__tests__/geostory-test.js
@@ -29,6 +29,7 @@ import {
     UPDATE,
     UPDATE_CURRENT_PAGE,
     UPDATE_SETTING,
+    UPDATE_MEDIA_EDITOR_SETTINGS,
     add,
     clearSaveError,
     editResource,
@@ -49,7 +50,8 @@ import {
     updateCurrentPage,
     updateSetting,
     removeResource, REMOVE_RESOURCE,
-    updateUrlOnScroll, SET_UPDATE_URL_SCROLL
+    updateUrlOnScroll, SET_UPDATE_URL_SCROLL,
+    updateMediaEditorSettings
 } from '../geostory';
 
 describe('test geostory action creators', () => {
@@ -213,5 +215,32 @@ describe('test geostory action creators', () => {
         expect(action.type).toBe(SET_UPDATE_URL_SCROLL);
         expect(action.value).toBe(value);
     });
-
+    it('updateMediaEditorSettings', () => {
+        const mediaEditorSettings = {
+            sourceId: 'geostory',
+            mediaTypes: {
+                image: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                video: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                map: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                }
+            },
+            sources: {
+                geostory: {
+                    name: 'Current story',
+                    type: 'geostory'
+                }
+            }
+        };
+        const action = updateMediaEditorSettings(mediaEditorSettings);
+        expect(action.type).toBe(UPDATE_MEDIA_EDITOR_SETTINGS);
+        expect(action.mediaEditorSettings).toBe(mediaEditorSettings);
+    });
 });

--- a/web/client/actions/geostory.js
+++ b/web/client/actions/geostory.js
@@ -40,6 +40,7 @@ export const UPDATE_CURRENT_PAGE = "GEOSTORY:UPDATE_CURRENT_PAGE";
 export const REMOVE_RESOURCE = "GEOSTORY:REMOVE_RESOURCE";
 export const SET_PENDING_CHANGES = "GEOSTORY:SET_PENDING_CHANGES";
 export const SET_UPDATE_URL_SCROLL = "GEOSTORY:SET_UPDATE_URL_SCROLL";
+export const UPDATE_MEDIA_EDITOR_SETTINGS = "GEOSTORY:UPDATE_MEDIA_EDITOR_SETTINGS";
 /**
  * Adds an entry to current story. The entry can be a section, a content or anything to append in an array (even sub-content)
  *
@@ -238,3 +239,5 @@ export const setPendingChanges = value => ({type: SET_PENDING_CHANGES, value});
  * Sets should url be updated on scroll
  */
 export const updateUrlOnScroll = value => ({type: SET_UPDATE_URL_SCROLL, value});
+
+export const updateMediaEditorSettings = mediaEditorSettings => ({ type: UPDATE_MEDIA_EDITOR_SETTINGS, mediaEditorSettings })

--- a/web/client/actions/geostory.js
+++ b/web/client/actions/geostory.js
@@ -240,4 +240,4 @@ export const setPendingChanges = value => ({type: SET_PENDING_CHANGES, value});
  */
 export const updateUrlOnScroll = value => ({type: SET_UPDATE_URL_SCROLL, value});
 
-export const updateMediaEditorSettings = mediaEditorSettings => ({ type: UPDATE_MEDIA_EDITOR_SETTINGS, mediaEditorSettings })
+export const updateMediaEditorSettings = mediaEditorSettings => ({ type: UPDATE_MEDIA_EDITOR_SETTINGS, mediaEditorSettings });

--- a/web/client/actions/mediaEditor.js
+++ b/web/client/actions/mediaEditor.js
@@ -110,7 +110,7 @@ export const setEditingMedia = (editing) => ({ type: EDITING_MEDIA, editing });
  * show media editor
  * @param {*} owner
  */
-export const show = (owner) => ({type: SHOW, owner});
+export const show = (owner, settings) => ({type: SHOW, owner, settings});
 
 /**
  * edit media reference for resource media

--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -801,6 +801,66 @@ describe('Geostory Epics', () => {
             }
         });
     });
+    it('test openMediaEditorForNewMedia with custom settings for media edtor', (done) => {
+        const NUM_ACTIONS = 2;
+        const mediaEditorSettings = {
+            sourceId: 'geostory',
+            mediaTypes: {
+                image: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                video: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                map: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                }
+            },
+            sources: {
+                geostory: {
+                    name: 'Current story',
+                    type: 'geostory'
+                }
+            }
+        };
+        testEpic(openMediaEditorForNewMedia, NUM_ACTIONS, [
+            add(`sections[{id: "abc"}].contents[{id: "def"}]`, undefined, {type: ContentTypes.MEDIA, id: "102cbcf6-ff39-4b7f-83e4-78841ee13bb9"}),
+            chooseMedia({id: "geostory"})
+        ], (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map(a => {
+                switch (a.type) {
+                case UPDATE:
+                    break;
+                case SHOW:
+                    expect(a.owner).toEqual("geostory");
+                    expect(a.settings).toEqual(mediaEditorSettings);
+                    break;
+                default: expect(true).toBe(false);
+                    break;
+                }
+            });
+            done();
+        }, {
+            geostory: {
+                currentStory: {
+                    resources: [{
+                        id: "geostory",
+                        data: {}
+                    }]
+                },
+                mediaEditorSettings
+            },
+            mediaEditor: {
+                settings: {
+                    mediaType: "image"
+                }
+            }
+        });
+    });
     it('update story with already existing image (geostory)', (done) => {
         const NUM_ACTIONS = 3;
         testEpic(addTimeoutEpic(editMediaForBackgroundEpic), NUM_ACTIONS, [
@@ -1064,6 +1124,79 @@ describe('Geostory Epics', () => {
                         }]
                     }]
                 }
+            },
+            mediaEditor: {
+                settings: {
+                    mediaType: "image",
+                    sourceId: "geostory"
+                }
+            }
+        });
+    });
+    it('should use custom media editor settings if available with editMediaForBackgroundEpic', (done) => {
+        const NUM_ACTIONS = 3;
+        const mediaEditorSettings = {
+            sourceId: 'geostory',
+            mediaTypes: {
+                image: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                video: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                map: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                }
+            },
+            sources: {
+                geostory: {
+                    name: 'Current story',
+                    type: 'geostory'
+                }
+            }
+        };
+        testEpic(addTimeoutEpic(editMediaForBackgroundEpic), NUM_ACTIONS, [
+            editMedia({path: `sections[{"id": "section_id"}].contents[{"id": "content_id"}]`, owner: "geostore"}),
+            chooseMedia({id: "resourceId"})
+        ], (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map(a => {
+                switch (a.type) {
+                case UPDATE:
+                    break;
+                case SHOW:
+                    expect(a.owner).toEqual("geostore");
+                    expect(a.settings).toEqual(mediaEditorSettings);
+                    break;
+                case SELECT_ITEM:
+                    break;
+                default: expect(true).toBe(false);
+                    break;
+                }
+            });
+            done();
+        }, {
+            geostory: {
+                currentStory: {
+                    resources: [{
+                        id: "resourceId",
+                        type: "image",
+                        data: {
+                            id: "resource_id"
+                        }
+                    }],
+                    sections: [{
+                        id: "section_id",
+                        contents: [{
+                            id: "content_id",
+                            resourceId: "resourceId"
+                        }]
+                    }]
+                },
+                mediaEditorSettings
             },
             mediaEditor: {
                 settings: {

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -88,7 +88,8 @@ import {
      isSharedStory,
      resourceByIdSelectorCreator,
      modeSelector,
-     updateUrlOnScrollSelector
+     updateUrlOnScrollSelector,
+     getMediaEditorSettings
 } from '../selectors/geostory';
 import { currentMediaTypeSelector, sourceIdSelector} from '../selectors/mediaEditor';
 
@@ -144,8 +145,9 @@ export const openMediaEditorForNewMedia = (action$, store) =>
                         mediaPath = ".contents[0].contents[0]";
             }
             const path = `${arrayPath}[{"id":"${element.id}"}]${mediaPath}`;
+            const mediaEditorSetting = getMediaEditorSettings(store.getState());
             return Observable.of(
-                showMediaEditor('geostory') // open mediaEditor
+                showMediaEditor('geostory', mediaEditorSetting) // open mediaEditor
             )
                 .merge(
                     action$.let(updateMediaSection(store, path)),
@@ -261,9 +263,10 @@ export const editMediaForBackgroundEpic = (action$, store) =>
             .filter((mediaType) => {
                 return resource && resource.type !== mediaType;
             })
-            .map(() => setMediaType(resource.type)).merge(
+            .map(() => setMediaType(resource.type))
+            .merge(
                 Observable.of(
-                    showMediaEditor(owner),
+                    showMediaEditor(owner, getMediaEditorSettings(store.getState())),
                     selectItem(selectedResource)
                 )
                           .merge(

--- a/web/client/epics/mediaEditor.js
+++ b/web/client/epics/mediaEditor.js
@@ -40,7 +40,8 @@ export const loadMediaEditorDataEpic = (action$, store) =>
     // final version should get mediaType and sourceId from settings, for show (ok for LOAD_MEDIA)
     // now we have only one type/source, so I trigger directly the load of it
     action$.ofType(SHOW, LOAD_MEDIA)
-        .switchMap(() => {
+        .switchMap((action) => {
+            console.log(action);
             return mediaAPI("geostory").load(store) // store is required for local data (e.g. local geostory data)
                 .switchMap(results => {
                     const sId = sourceIdSelector(store.getState());

--- a/web/client/epics/mediaEditor.js
+++ b/web/client/epics/mediaEditor.js
@@ -40,8 +40,7 @@ export const loadMediaEditorDataEpic = (action$, store) =>
     // final version should get mediaType and sourceId from settings, for show (ok for LOAD_MEDIA)
     // now we have only one type/source, so I trigger directly the load of it
     action$.ofType(SHOW, LOAD_MEDIA)
-        .switchMap((action) => {
-            console.log(action);
+        .switchMap(() => {
             return mediaAPI("geostory").load(store) // store is required for local data (e.g. local geostory data)
                 .switchMap(results => {
                     const sId = sourceIdSelector(store.getState());

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -121,6 +121,40 @@ GeoStory.defaultProps = {
  * @memberof plugins
  * @prop {numeric} cfg.interceptionTime default 100, the debounce before calculations of currentPage active section
  * @prop {object[]} cfg.fontFamilies: A list of objects with font family names and sources where to load them from e.g. [{"family": "Comic sans", "src": "link to source"}]
+ * @prop {object} cfg.mediaEditorSettings settings for media editor services divided by media type
+ * @prop {string} cfg.mediaEditorSettings.sourceId selected service identifier used when the modal shows up
+ * @prop {object} cfg.mediaEditorSettings.mediaTypes configuration of source options for each media type: image, video and map
+ * @prop {object} cfg.mediaEditorSettings.sources definition of sources
+ * @example
+ * // example of mediaEditorSettings configuration with only the geostory service
+ * {
+ *   "name": "GeoStory",
+ *   "cfg": {
+ *     "mediaEditorSettings": {
+ *       "sourceId": "geostory",
+ *       "mediaTypes": {
+ *         "image": {
+ *           "defaultSource": "geostory",
+ *           "sources": ["geostory"]
+ *         },
+ *         "video": {
+ *           "defaultSource": "geostory",
+ *           "sources": ["geostory"]
+ *         },
+ *         "map": {
+ *           "defaultSource": "geostory",
+ *           "sources": ["geostory"]
+ *         }
+ *       },
+ *       "sources": {
+ *         "geostory": {
+ *           "name": "Current story",
+ *           "type": "geostory"
+ *         }
+ *       }
+ *     }
+ *   }
+ * }
  */
 export default createPlugin("GeoStory", {
     component: connect(

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -15,7 +15,15 @@ import {createPlugin} from '../utils/PluginsUtils';
 import { Modes, createWebFontLoaderConfig, extractFontNames, scrollToContent } from '../utils/GeoStoryUtils';
 import { getMessageById } from '../utils/LocaleUtils';
 import { basicError } from '../utils/NotificationUtils';
-import { add, update, updateSetting, updateCurrentPage, remove, editWebPage } from '../actions/geostory';
+import {
+    add,
+    update,
+    updateSetting,
+    updateCurrentPage,
+    remove,
+    editWebPage,
+    updateMediaEditorSettings
+} from '../actions/geostory';
 import { editMedia } from '../actions/mediaEditor';
 import * as epics from '../epics/geostory';
 import {
@@ -43,6 +51,8 @@ const GeoStory = ({
     webFont = WebFont,
     onUpdate = () => {},
     onBasicError = () => {},
+    onUpdateMediaEditorSetting,
+    mediaEditorSettings,
     ...props
 }) => {
     const localize = useCallback((id) => getMessageById(messages, id), [messages]);
@@ -58,6 +68,11 @@ const GeoStory = ({
 
     useEffect(() => {
         onUpdate("settings.theme.fontFamilies", fontFamilies, "merge");
+        // we need to store settings for media editor
+        // so we could use them later when we open the media editor plugin
+        if (mediaEditorSettings) {
+            onUpdateMediaEditorSetting(mediaEditorSettings);
+        }
     }, []);
 
     useEffect(() => {
@@ -96,7 +111,8 @@ const storyThemeSelector = (state) => {
 
 GeoStory.defaultProps = {
     storyFonts: [],
-    fontFamilies: []
+    fontFamilies: [],
+    onUpdateMediaEditorSetting: () => {}
 };
 
 /**
@@ -124,7 +140,8 @@ export default createPlugin("GeoStory", {
             remove,
             editMedia,
             editWebPage,
-            onBasicError: basicError
+            onBasicError: basicError,
+            onUpdateMediaEditorSetting: updateMediaEditorSettings
         }
     )(GeoStory),
     reducers: {

--- a/web/client/plugins/__tests__/GeoStory-test.jsx
+++ b/web/client/plugins/__tests__/GeoStory-test.jsx
@@ -41,4 +41,36 @@ describe('GeoStory Plugin', () => {
         expect(actions.length).toEqual(1);
         expect(store.getState().geostory.currentStory.settings.theme.fontFamilies).toEqual(fontFamilies);
     });
+    it('should store the media editor setting with onUpdateMediaEditorSetting', () => {
+        const { Plugin, actions, store } = getPluginForTest(GeoStory, stateMocker({geostory}));
+        const mediaEditorSettings = {
+            sourceId: 'geostory',
+            mediaTypes: {
+                image: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                video: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                map: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                }
+            },
+            sources: {
+                geostory: {
+                    name: 'Current story',
+                    type: 'geostory'
+                }
+            }
+        };
+        ReactDOM.render(<Plugin
+            mediaEditorSettings={mediaEditorSettings}
+        />, document.getElementById('container'));
+
+        expect(actions.length).toBe(2);
+        expect(store.getState().geostory.mediaEditorSettings).toEqual(mediaEditorSettings);
+    });
 });

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -29,7 +29,8 @@ import {
     updateSetting,
     removeResource,
     setPendingChanges,
-    updateUrlOnScroll
+    updateUrlOnScroll,
+    updateMediaEditorSettings
 } from '../../actions/geostory';
 import geostory from '../../reducers/geostory';
 import {
@@ -422,5 +423,32 @@ describe('geostory reducer', () => {
     it('updateUrlOnScroll', () => {
         expect(updateUrlOnScrollSelector( { geostory: geostory(undefined, updateUrlOnScroll(true)) } )).toBeTruthy();
         expect(updateUrlOnScrollSelector( { geostory: geostory(undefined, updateUrlOnScroll(false)) } )).toBeFalsy();
+    });
+    it('should update mediaEditorSettings width updateMediaEditorSettings', () => {
+        const mediaEditorSettings = {
+            sourceId: 'geostory',
+            mediaTypes: {
+                image: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                video: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                map: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                }
+            },
+            sources: {
+                geostory: {
+                    name: 'Current story',
+                    type: 'geostory'
+                }
+            }
+        };
+        const state = geostory(undefined, updateMediaEditorSettings(mediaEditorSettings));
+        expect(state.mediaEditorSettings).toBe(mediaEditorSettings);
     });
 });

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -144,6 +144,45 @@ describe('Test the mediaEditor reducer', () => {
         state = mediaEditor(state, {type: LOCATION_CHANGE});
         expect(state).toEqual(DEFAULT_STATE);
     });
+    it('should keep the current custom settings on LOCATION_CHANGE', () => {
+        const mediaEditorSettings = {
+            sourceId: 'geostory',
+            mediaTypes: {
+                image: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                video: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                },
+                map: {
+                    defaultSource: 'geostory',
+                    sources: ['geostory']
+                }
+            },
+            sources: {
+                geostory: {
+                    name: 'Current story',
+                    type: 'geostory'
+                }
+            }
+        };
+        let state = mediaEditor(undefined, show('owner', mediaEditorSettings));
+        expect(state.settings.mediaTypes).toEqual(mediaEditorSettings.mediaTypes);
+        expect(state.settings.sources).toEqual(mediaEditorSettings.sources);
+        state = mediaEditor(state, {type: LOCATION_CHANGE});
+
+        const { settings: defaultStateSettings, ...defaultState } = DEFAULT_STATE;
+        const { settings: newStateSettings, ...newState } = state;
+
+        expect(newStateSettings.mediaTypes).toEqual(mediaEditorSettings.mediaTypes);
+        expect(newStateSettings.sources).toEqual(mediaEditorSettings.sources);
+
+        expect(defaultState).toEqual(newState);
+        expect(defaultStateSettings.mediaType).toEqual(newStateSettings.mediaType);
+        expect(defaultStateSettings.sourceId).toEqual(newStateSettings.sourceId);
+    });
     it('UPDATE_ITEM with mode replace', () => {
         const map = {
             id: "resId",

--- a/web/client/reducers/geostory.js
+++ b/web/client/reducers/geostory.js
@@ -33,7 +33,8 @@ import {
     UPDATE_SETTING,
     REMOVE_RESOURCE,
     SET_PENDING_CHANGES,
-    SET_UPDATE_URL_SCROLL
+    SET_UPDATE_URL_SCROLL,
+    UPDATE_MEDIA_EDITOR_SETTINGS
 } from '../actions/geostory';
 
 
@@ -252,7 +253,7 @@ export default (state = INITIAL_STATE, action) => {
         return set('currentStory', {...action.story, settings}, state);
     }
     case SELECT_CARD: {
-        return set(`selectedCard`, state.selectedCard === action.card ? "" : action.card, state);
+        return set('selectedCard', state.selectedCard === action.card ? "" : action.card, state);
     }
     case SET_CONTROL: {
         const { control, value } = action;
@@ -266,16 +267,16 @@ export default (state = INITIAL_STATE, action) => {
         const { resource } = action;
         const settings = state.currentStory && state.currentStory.settings || {};
         return compose(
-            set(`resource`, resource),
+            set('resource', resource),
             set('currentStory.settings.storyTitle', settings.storyTitle || resource.name) // TODO check that resource has name prop
 
         )(state);
     }
     case SAVED: case CLEAR_SAVE_ERROR: {
-        return unset(`errors.save`, state);
+        return unset('errors.save', state);
     }
     case SAVE_ERROR: {
-        return set(`errors.save`, castArray(action.error), state);
+        return set('errors.save', castArray(action.error), state);
     }
     case TOGGLE_CARD_PREVIEW: {
         return set('isCollapsed', !state.isCollapsed, state);
@@ -337,13 +338,16 @@ export default (state = INITIAL_STATE, action) => {
     case TOGGLE_CONTENT_FOCUS: {
         const {status, target, selector = "", hideContent = false, path} = action;
         const focusedContent = status ? {target, selector, hideContent, path} : undefined;
-        return set(`focusedContent`, focusedContent, state);
+        return set('focusedContent', focusedContent, state);
     }
     case SET_PENDING_CHANGES: {
-        return set(`pendingChanges`, action.value, state);
+        return set('pendingChanges', action.value, state);
     }
     case SET_UPDATE_URL_SCROLL: {
-        return set(`updateUrlOnScroll`, action.value, state);
+        return set('updateUrlOnScroll', action.value, state);
+    }
+    case UPDATE_MEDIA_EDITOR_SETTINGS: {
+        return set('mediaEditorSettings', action.mediaEditorSettings, state);
     }
     default:
         return state;

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -126,14 +126,27 @@ export default (state = DEFAULT_STATE, action) => {
     }
     case SHOW:
         // setup media editor settings
+        const settings = action.settings && {
+            ...action.settings,
+            // mediaType could be updated during the app lifecycle separately
+            // so we should use the one on the state if available
+            ...(state.settings.mediaType && { mediaType: state.settings.mediaType })
+        };
         return compose(
             set('open', true),
             set('owner', action.owner),
-            // set('settings', action.settings || state.settings), // TODO: allow fine customization
-            // set('stashedSettings', state.settings) // This should allow to use default config or customize for a different usage
+            set('settings', settings || state.settings), // TODO: allow fine customization
+            set('stashedSettings', state.settings) // This should allow to use default config or customize for a different usage
         )(state);
     case LOCATION_CHANGE:
-        return DEFAULT_STATE;
+        return {
+            ...DEFAULT_STATE,
+            settings: {
+                ...state.settings,
+                // restore the default mediaType but keep the current updated settings
+                mediaType: DEFAULT_STATE.settings.mediaType
+            }
+        };
     default:
         return state;
     }

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -293,3 +293,5 @@ export const updateUrlOnScrollSelector = state => get(state, 'geostory.updateUrl
  * @param {object} state application state
  */
 export const currentStoryFonts = state => get(state, "geostory.currentStory.settings.theme.fontFamilies", []);
+
+export const getMediaEditorSettings = state => get(state, 'geostory.mediaEditorSettings');


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces support for custom configuration of media editor settings for GeoStory.
It's possible to change the settings with the property **mediaEditorSettings** in localConfig.json with this cfg:

```js
// example that use only the geostory default service
{
    "name": "GeoStory",
    "cfg": {
        "mediaEditorSettings": {
            "sourceId": "geostory",
            "mediaTypes": {
                "image": {
                    "defaultSource": "geostory",
                    "sources": ["geostory"]
                },
                "video": {
                    "defaultSource": "geostory",
                    "sources": ["geostory"]
                },
                "map": {
                    "defaultSource": "geostory",
                    "sources": ["geostory"]
                }
            },
            "sources": {
                "geostory": {
                    "name": "Current story",
                    "type": "geostory"
                }
            }
        }
    }
}
```

This configuration is useful combined with improvement proposed in the issue _Add the possibility to register a new service to media editor plugin_ (connected to https://github.com/geosolutions-it/MapStore2/issues/5977).

Note: It's only possible to remove geostore configuration with this fix.

It's not possible to test these changes on MapStore but we could test that previous functionalities are not broken (see fixes requested here https://github.com/geosolutions-it/MapStore2/pull/4771)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5976

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
It's possible to override media editor settings of GeoStory in the localConfig.json file

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
