### PR TITLE
Fix Swipe/spyglass tool issue with layer group(#5980)

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/epics', true, /(swipe-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/epics', true, /(swipe-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/epics/__tests__/swipe-test.js
+++ b/web/client/epics/__tests__/swipe-test.js
@@ -31,4 +31,16 @@ describe('SWIPE EPICS', () => {
                 done();
             }, state, done);
     });
+    it('reset activation of layer swipe tool selected nodeType is group', done => {
+        testEpic(
+            resetLayerSwipeSettingsEpic,
+            1,
+            selectNode('groupId', 'group', false),
+            actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toEqual(SET_ACTIVE);
+                expect(actions[0].active).toEqual(false);
+                done();
+            }, {}, done);
+    });
 });

--- a/web/client/epics/__tests__/swipe-test.js
+++ b/web/client/epics/__tests__/swipe-test.js
@@ -32,6 +32,11 @@ describe('SWIPE EPICS', () => {
             }, state, done);
     });
     it('reset activation of layer swipe tool selected nodeType is group', done => {
+        const state = {
+            swipe: {
+                active: true
+            }
+        };
         testEpic(
             resetLayerSwipeSettingsEpic,
             1,
@@ -41,6 +46,6 @@ describe('SWIPE EPICS', () => {
                 expect(actions[0].type).toEqual(SET_ACTIVE);
                 expect(actions[0].active).toEqual(false);
                 done();
-            }, {}, done);
+            }, state, done);
     });
 });

--- a/web/client/epics/swipe.js
+++ b/web/client/epics/swipe.js
@@ -25,7 +25,8 @@ const resetLayerSwipeSettingsEpic = (action$, store) =>
             const state = store.getState();
             const swipeSettings = layerSwipeSettingsSelector(state);
             const selectedLayer = getSelectedLayer(state);
-            return ((swipeSettings.active && selectedLayer === undefined) || nodeType === 'group')
+            return (
+                (swipeSettings.active && selectedLayer === undefined) || (swipeSettings.active && nodeType === 'group'))
                 ? Rx.Observable.of(setActive(false))
                 : Rx.Observable.empty();
         });

--- a/web/client/epics/swipe.js
+++ b/web/client/epics/swipe.js
@@ -14,18 +14,18 @@ import { layerSwipeSettingsSelector } from '../selectors/swipe';
 import { getSelectedLayer } from '../selectors/layers';
 
 /**
- * Ensures that swipeSettings active is changed back to false when a layer is deselected in TOC
+ * Ensures that swipeSettings active is changed back to false when a layer is deselected in TOC or group is selected
  * @memberof epics.swipe
  * @param {external:Observable} action$ manages `SELECT_NODE`
  * @return {external:Observable}
  */
 const resetLayerSwipeSettingsEpic = (action$, store) =>
     action$.ofType(SELECT_NODE)
-        .switchMap(() => {
+        .switchMap(({nodeType}) => {
             const state = store.getState();
             const swipeSettings = layerSwipeSettingsSelector(state);
             const selectedLayer = getSelectedLayer(state);
-            return (swipeSettings.active && selectedLayer === undefined)
+            return ((swipeSettings.active && selectedLayer === undefined) || nodeType === 'group')
                 ? Rx.Observable.of(setActive(false))
                 : Rx.Observable.empty();
         });


### PR DESCRIPTION
## Description
Disable tool when selected nodeType in TOC is group

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5980 
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Disable tool when selected nodeType in TOC is group


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
