### PR TITLE
#5987: Fix swipe bar misalignment when resizing browser window

### DIFF
--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -5,29 +5,18 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-import React, {useEffect, useRef } from 'react';
+import React, {useEffect, useRef, useState } from 'react';
 import Draggable from 'react-draggable';
 
 import EffectSupport from './EffectSupport';
 
 const VSlider = ({ type, map, widthRef }) => {
 
-    const childRef = useRef(null);
-
-    const fakeDrag = () => {
-        const clickEvent = new MouseEvent("mousedown", {
-            bubbles: true,
-            cancelable: true,
-            x: 0,
-            y: 0
-          });
-        // const clickEvent = document.createEvent('MouseEvents');
-        // clickEvent.initEvent("mousedown", true, true);
-        childRef.current.dispatchEvent(clickEvent);
-    };
+    const [pos, setPos] = useState();
 
     const onWindowResize = () => {
-        fakeDrag();
+        setPos({x: 0, y: 0});
+        widthRef.current = map.getProperties().size[0] / 2;
     };
 
     useEffect(() => {
@@ -39,15 +28,16 @@ const VSlider = ({ type, map, widthRef }) => {
     }, [ type ]);
 
     const onDragVerticalHandler = (e, ui) => {
-        console.log("UI", ui);
-        console.log("EVENT", e);
         widthRef.current += ui.deltaX;
+        setPos({x: ui.x, y: ui.y});
         map.render();
     };
 
     return (
-        <Draggable axis="x" bounds="parent" onDrag={(e, ui) => onDragVerticalHandler(e, ui)}>
-            <div ref={childRef} className="mapstore-swipe-slider" style={{
+        <Draggable
+            position={pos}
+            bounds="parent" onDrag={(e, ui) => onDragVerticalHandler(e, ui)}>
+            <div className="mapstore-swipe-slider" style={{
                 height: "100%",
                 top: '0px',
                 left: `${map.getProperties().size[0] / 2}px`,
@@ -60,15 +50,29 @@ const VSlider = ({ type, map, widthRef }) => {
 
 const HSlider = ({ type, map, heightRef }) => {
 
+    const [pos, setPos] = useState();
+
+    const onWindowResize = () => {
+        setPos({x: 0, y: 0});
+        heightRef.current = map.getProperties().size[1] / 2;
+    };
+
+    useEffect(() => {
+        window.addEventListener('resize', onWindowResize);
+    }, [ type ]);
+
     useEffect(() => {
         heightRef.current = map.getProperties().size[1] / 2;
     }, [ type ]);
 
     const onDragHorizontalHandler = (e, ui) => {
         heightRef.current += ui.deltaY;
+        setPos({x: ui.x, y: ui.y});
         map.render();
     };
-    return (<Draggable axis="y" bounds="parent" onDrag={(e, ui) => onDragHorizontalHandler(e, ui)}>
+    return (<Draggable
+        position={pos}
+        bounds="parent" onDrag={(e, ui) => onDragHorizontalHandler(e, ui)}>
         <div className="mapstore-swipe-slider" style={{
             height: "12px",
             top: `${map.getProperties().size[1] / 2}px`,

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -21,6 +21,9 @@ const VSlider = ({ type, map, widthRef }) => {
 
     useEffect(() => {
         window.addEventListener('resize', onWindowResize);
+        return () => {
+            window.removeEventListener('resize', onWindowResize);
+        };
     }, [ type ]);
 
     useEffect(() => {
@@ -36,7 +39,8 @@ const VSlider = ({ type, map, widthRef }) => {
     return (
         <Draggable
             position={pos}
-            bounds="parent" onDrag={(e, ui) => onDragVerticalHandler(e, ui)}>
+            bounds="parent"
+            onDrag={(e, ui) => onDragVerticalHandler(e, ui)}>
             <div className="mapstore-swipe-slider" style={{
                 height: "100%",
                 top: '0px',
@@ -59,6 +63,9 @@ const HSlider = ({ type, map, heightRef }) => {
 
     useEffect(() => {
         window.addEventListener('resize', onWindowResize);
+        return () => {
+            window.removeEventListener('resize', onWindowResize);
+        };
     }, [ type ]);
 
     useEffect(() => {
@@ -72,7 +79,8 @@ const HSlider = ({ type, map, heightRef }) => {
     };
     return (<Draggable
         position={pos}
-        bounds="parent" onDrag={(e, ui) => onDragHorizontalHandler(e, ui)}>
+        bounds="parent"
+        onDrag={(e, ui) => onDragHorizontalHandler(e, ui)}>
         <div className="mapstore-swipe-slider" style={{
             height: "12px",
             top: `${map.getProperties().size[1] / 2}px`,

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -12,18 +12,42 @@ import EffectSupport from './EffectSupport';
 
 const VSlider = ({ type, map, widthRef }) => {
 
+    const childRef = useRef(null);
+
+    const fakeDrag = () => {
+        const clickEvent = new MouseEvent("mousedown", {
+            bubbles: true,
+            cancelable: true,
+            x: 0,
+            y: 0
+          });
+        // const clickEvent = document.createEvent('MouseEvents');
+        // clickEvent.initEvent("mousedown", true, true);
+        childRef.current.dispatchEvent(clickEvent);
+    };
+
+    const onWindowResize = () => {
+        fakeDrag();
+    };
+
+    useEffect(() => {
+        window.addEventListener('resize', onWindowResize);
+    }, [ type ]);
+
     useEffect(() => {
         widthRef.current = map.getProperties().size[0] / 2;
     }, [ type ]);
 
     const onDragVerticalHandler = (e, ui) => {
+        console.log("UI", ui);
+        console.log("EVENT", e);
         widthRef.current += ui.deltaX;
         map.render();
     };
 
     return (
         <Draggable axis="x" bounds="parent" onDrag={(e, ui) => onDragVerticalHandler(e, ui)}>
-            <div className="mapstore-swipe-slider" style={{
+            <div ref={childRef} className="mapstore-swipe-slider" style={{
                 height: "100%",
                 top: '0px',
                 left: `${map.getProperties().size[0] / 2}px`,

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -14,10 +14,17 @@ import EffectSupport from './EffectSupport';
 const VSlider = ({ type, map, widthRef }) => {
 
     const [pos, setPos] = useState();
+    const [showArrows, setShowArrows] = useState(true);
 
     const onWindowResize = () => {
         setPos({x: 0, y: 0});
         widthRef.current = map.getProperties().size[0] / 2;
+    };
+
+    const onDragVerticalHandler = (e, ui) => {
+        widthRef.current += ui.deltaX;
+        setPos({x: ui.x, y: ui.y});
+        map.render();
     };
 
     useEffect(() => {
@@ -26,17 +33,10 @@ const VSlider = ({ type, map, widthRef }) => {
             window.removeEventListener('resize', onWindowResize);
         };
     }, [ type ]);
-    const [showArrows, setShowArrows] = useState(true);
 
     useEffect(() => {
         widthRef.current = map.getProperties().size[0] / 2;
     }, [ type ]);
-
-    const onDragVerticalHandler = (e, ui) => {
-        widthRef.current += ui.deltaX;
-        setPos({x: ui.x, y: ui.y});
-        map.render();
-    };
 
     return (
         <Draggable
@@ -73,10 +73,17 @@ const VSlider = ({ type, map, widthRef }) => {
 const HSlider = ({ type, map, heightRef }) => {
 
     const [pos, setPos] = useState();
+    const [showArrows, setShowArrows] = useState(true);
 
     const onWindowResize = () => {
         setPos({x: 0, y: 0});
         heightRef.current = map.getProperties().size[1] / 2;
+    };
+
+    const onDragHorizontalHandler = (e, ui) => {
+        heightRef.current += ui.deltaY;
+        setPos({x: ui.x, y: ui.y});
+        map.render();
     };
 
     useEffect(() => {
@@ -85,17 +92,11 @@ const HSlider = ({ type, map, heightRef }) => {
             window.removeEventListener('resize', onWindowResize);
         };
     }, [ type ]);
-    const [showArrows, setShowArrows] = useState(true);
 
     useEffect(() => {
         heightRef.current = map.getProperties().size[1] / 2;
     }, [ type ]);
 
-    const onDragHorizontalHandler = (e, ui) => {
-        heightRef.current += ui.deltaY;
-        setPos({x: ui.x, y: ui.y});
-        map.render();
-    };
     return (<Draggable
         position={pos}
         bounds="parent"

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -16,6 +16,7 @@ const VSlider = ({ type, map, widthRef }) => {
     const [pos, setPos] = useState();
     const [showArrows, setShowArrows] = useState(true);
 
+    // reset the slider positon to prevent misalignment between handler and cut positions
     const onWindowResize = () => {
         setPos({x: 0, y: 0});
         widthRef.current = map.getProperties().size[0] / 2;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixes issue where swipe bar and layer cut are misaligned when browser is resized.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5987 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The layer cut and swipe bar remained aligned by snaping back to initial positions, similar to how ESRI solves the problem

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
