### PR TITLE
#5952: set mapstore-backend and print-lib to use a tagged version, added machinery to deploy mapstore-backend to maven with mvn deploy

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-backend</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0-2020.02</version>
   <name>MapStore 2 - Backend</name>
   <url>http://www.geo-solutions.it</url>
 
@@ -97,7 +97,23 @@
                 </configuration>
             </plugin>
     </plugins>
+    <extensions>
+        <!--.............................................-->
+        <!--       GeoSolutions (using wagon ftp)       -->
+        <!--.............................................-->
+      <extension>
+       <groupId>org.apache.maven.wagon</groupId>
+       <artifactId>wagon-ftp</artifactId>
+       <version>1.0-beta-2</version>
+      </extension>
+    </extensions>
   </build>
+  <distributionManagement>
+   <repository>
+    <id>geosolutions</id>
+    <url>ftp://maven.geo-solutions.it/</url>
+   </repository>
+  </distributionManagement>
   <profiles>
   </profiles>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-root</artifactId>
   <packaging>pom</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0-2020.02</version>
   <name>MapStore 2</name>
   <url>http://www.geo-solutions.it</url>
 
@@ -19,6 +19,14 @@
   </dependencies>
 
   <build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/project/custom/templates/backend/pom.xml
+++ b/project/custom/templates/backend/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.__PROJECTNAME__</groupId>
         <artifactId>__PROJECTNAME__-root</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-2020.02</version>
     </parent>
     <artifactId>__PROJECTNAME__-backend</artifactId>
     <packaging>jar</packaging>

--- a/project/custom/templates/pom.xml
+++ b/project/custom/templates/pom.xml
@@ -4,7 +4,7 @@
     <groupId>it.geosolutions.__PROJECTNAME__</groupId>
     <artifactId>__PROJECTNAME__-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-2020.02</version>
     <name>__PROJECTDESCRIPTION__ - Root Project</name>
     <url>http://www.geo-solutions.it</url>
 

--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>it.geosolutions.__PROJECTNAME__</groupId>
     <artifactId>__PROJECTNAME__-root</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-2020.02</version>
   </parent>
   <artifactId>__PROJECTNAME__-web</artifactId>
   <packaging>war</packaging>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>it.geosolutions.mapstore</groupId>
       <artifactId>mapstore-backend</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.0-2020.02</version>
     </dependency>
     <!-- ================================================================ -->
     <!-- GeoStore modules -->

--- a/project/standard/templates/backend/pom.xml
+++ b/project/standard/templates/backend/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.__PROJECTNAME__</groupId>
         <artifactId>__PROJECTNAME__-root</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-2020.02</version>
     </parent>
     <artifactId>__PROJECTNAME__-backend</artifactId>
     <packaging>jar</packaging>

--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -4,7 +4,7 @@
     <groupId>it.geosolutions.__PROJECTNAME__</groupId>
     <artifactId>__PROJECTNAME__-root</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-2020.02</version>
     <name>__PROJECTNAME__ - Root Project</name>
     <url>__REPOURL__</url>
 

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>it.geosolutions.__PROJECTNAME__</groupId>
     <artifactId>__PROJECTNAME__-root</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-2020.02</version>
   </parent>
   <artifactId>__PROJECTNAME__-web</artifactId>
   <packaging>war</packaging>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>it.geosolutions.mapstore</groupId>
       <artifactId>mapstore-backend</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.0-2020.02</version>
     </dependency>
     <!-- ================================================================ -->
     <!-- GeoStore modules -->
@@ -40,7 +40,6 @@
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
-
 
     <dependency>
       <groupId>org.geotools</groupId>
@@ -540,7 +539,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>geosolutions-2.0-SNAPSHOT</version>
+                    <version>geosolutions-2.0-2020.02</version>
                 </dependency>
                 <dependency>
                     <groupId>org.mapfish.geo</groupId>

--- a/release/bin-war/pom.xml
+++ b/release/bin-war/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>it.geosolutions.mapstore</groupId>
             <artifactId>mapstore-web</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-2020.02</version>
             <type>war</type>
             <scope>runtime</scope>
         </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-web</artifactId>
   <packaging>war</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0-2020.02</version>
   <name>MapStore 2 - WAR</name>
   <url>http://www.geo-solutions.it</url>
 
@@ -17,9 +17,9 @@
   <dependencies>
     <!-- MapStore backend -->
     <dependency>
-        <groupId>it.geosolutions.mapstore</groupId>
-        <artifactId>mapstore-backend</artifactId>
-        <version>1.0-SNAPSHOT</version>
+      <groupId>it.geosolutions.mapstore</groupId>
+      <artifactId>mapstore-backend</artifactId>
+      <version>1.0-2020.02</version>
     </dependency>
 
     <!-- ================================================================ -->
@@ -487,6 +487,12 @@
                 </dependency>
             </dependencies>
         </plugin>
+        <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
   <profiles>
@@ -523,7 +529,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>geosolutions-2.0-SNAPSHOT</version>
+            <version>geosolutions-2.0-2020.02</version>
         </dependency>
         <dependency>
             <groupId>org.mapfish.geo</groupId>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
 - [x] Set fixed version for Java packages to 1.0-2020.02
 - [x] Set fixed version for print-lib dependency to 2.0-2020.02
 - [x] Added configuration to deploy java artifacts for mapstore-backend to GeoSolutions maven

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: release versioning

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5952 
