### PR TITLE
#5986:Removed owner saving, not needed anymore

### DIFF
--- a/web/client/plugins/maps/MapSave.jsx
+++ b/web/client/plugins/maps/MapSave.jsx
@@ -54,10 +54,9 @@ const SaveBaseDialog = compose(
             onClose();
             onResetMapSaveError(); // reset errors when closing the modal
         },
-        onSave: ({map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, saveMap, isNewResource, user, contextResource}) => resource => {
+        onSave: ({map, layers, groups, backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions, saveMap, isNewResource, contextResource}) => resource => {
             const mapData = MapUtils.saveMapConfiguration(map, layers, groups,
                 backgrounds, textSearchConfig, bookmarkSearchConfig, additionalOptions);
-            const owner = {"owner": user && user.name || null};
             const {metadata, data, attributes, id, ...others} = resource;
             let updates;
             if (!isNewResource) {
@@ -69,7 +68,7 @@ const SaveBaseDialog = compose(
                         ...attributes,
                         context: contextResource?.id || attributes.context
                     },
-                    metadata: {attributes: {...owner}, ...metadata},
+                    metadata: {attributes: null, ...metadata},
                     ...others
                 };
             }


### PR DESCRIPTION
## Description
During the porting of uniforming Save tools, save of "owner" attribute has been ported in the MapSave plugin, but it is not needed anymore.

**NOTE**: owner property is used in a special way by geostore. If owner is present, the map permissions are editable only by owner (and admin). If not present, the permission are straight and logic. For this reason owner has been removed from the rest of the resources. Map was the last with this problem.

**NOTE FOR TESTERS**: maps created before this fix will not have permission editable from people with edit permission on the server side, for this reason, the permission tool is hidden. New maps will not have this limit anymore.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features) <-- test not needed, removed functionality
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5986

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
