### PR TITLE
#5994: Missing default center and zoom props in ol maps

### DIFF
--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -88,7 +88,9 @@ class OpenlayersMap extends React.Component {
         registerHooks: true,
         hookRegister: mapUtils,
         interactive: true,
-        onMouseOut: () => {}
+        onMouseOut: () => {},
+        center: { x: 13, y: 45, crs: 'EPSG:4326' },
+        zoom: 5
     };
 
     componentDidMount() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR add default center and zoom props in OpenLayer maps similar to value used for LeafletMap component

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Minor improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5994

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Default props in the OpenLayer map avoid the crash of application if the component is mounted but the map configuration is not loaded yet.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
