### PR TITLE
This modification ables MapStore2 to handle correctly customization o…

### DIFF
--- a/web/client/utils/mapinfo/vector.js
+++ b/web/client/utils/mapinfo/vector.js
@@ -21,7 +21,8 @@ module.exports = {
                 resolution: props.map && props.map && props.map.zoom && MapUtils.getCurrentResolution(props.map.zoom, 0, 21, 96),
                 buffer: props.buffer || 2,
                 units: props.map && props.map.units,
-                rowViewer: layer.rowViewer
+                rowViewer: layer.rowViewer,
+                viewer: layer.viewer
             },
             url: ""
         };


### PR DESCRIPTION
Customization of identity viewer

## Description
This pull request aims to make able  full customization of identity viewer (this viewer is open when a user click on a feature on a layer).
with this PR, developpers have to follow this steps to activate a customized identity viewer : 

1) Create a new component : 
export class XXXViewer extends React.Component {
...
};

2) Connect the component
const XXXConnectedViewer = connect((state) => ({
           ...
        }), {
           ....
        })(XXXViewer);

3) Register the viewer
MapInfoUtils.setViewer("XXXViewer",XXXConnectedViewer  );

4) Add layer the the customized viewer
addLayer({
                        handleClickOnLayer: true,
                        hideLoading: true,
                        id: "xxx",
                        name: "xxx",
                        style: undefined,
                        type: "vector",
                        visibility: true,
                        features: createNewFeatures(action),
                        viewer: {
                            type: 'XXXViewer'
                        }
                    })

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

when a new viewer is registered, is not correctly used whe user selects a feature on a map

#<issue>

when a new viewer is registered, is correctly used whe user selects a feature on a map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
N/A