### PR TITLE
Ables Tabular view to display GeoJSON data from a vector layer

### DIFF
--- a/web/client/observables/wfs.js
+++ b/web/client/observables/wfs.js
@@ -89,7 +89,7 @@ const getPagination = (filterObj = {}, options = {}) =>
  * @param {number} totalFeatures optional number to use in case of a previews request, needed to workaround GEOS-7233.
  * @return {Observable} a stream that emits the GeoJSON or an error.
  */
-const getJSONFeature = (searchUrl, filterObj, options = {}) => {
+const getJSONFeature = (searchUrl, filterObj, options = {}, layer) => {
     const data = FilterUtils.getWFSFilterData(filterObj, options);
 
     const urlParsedObj = Url.parse(searchUrl, true);
@@ -103,6 +103,20 @@ const getJSONFeature = (searchUrl, filterObj, options = {}) => {
         query: params
     });
 
+
+    if (layer.type === 'vector') {
+        return Rx.Observable.defer(() => new Promise((resolve) => {
+            if(!layer.originalFeatures || layer.originalFeatures[0].properties.contextDescriptionName !== layer.features[0].properties.contextDescriptionName){
+                layer.originalFeatures = layer.features;
+            }
+            let features =  createFeatureCollection(layer.originalFeatures);
+            let featuresFiltered = getFeaturesFiltered(features, filterObj);
+            if(featuresFiltered){
+                layer.features = featuresFiltered.features;
+            }
+            resolve(featuresFiltered);
+        }));
+    }
     return Rx.Observable.defer(() =>
         axios.post(queryString, data, {
             timeout: 60000,
@@ -122,8 +136,8 @@ const getJSONFeature = (searchUrl, filterObj, options = {}) => {
  * @param {object} options params that can contain `totalFeatures` and sort options
  * @return {Observable} a stream that emits the GeoJSON or an error.
  */
-const getJSONFeatureWA = (searchUrl, filterObj, { sortOptions = {}, ...options } = {}) =>
-    getJSONFeature(searchUrl, filterObj, options)
+const getJSONFeatureWA = (searchUrl, filterObj, { sortOptions = {}, ...options }, layer = {}) =>
+    getJSONFeature(searchUrl, filterObj, options, layer)
         .catch(error => {
             if (error.name === "OGCError" && error.code === 'NoApplicableCode') {
                 return getJSONFeature(searchUrl, {
@@ -197,3 +211,67 @@ module.exports = {
             }, callback))(response.data)
             )
 };
+
+const createFeatureCollection = (features) => (
+    {
+        crs: {type: "name", properties: {name: "urn:ogc:def:crs:EPSG::4326"}},
+        numberMatched: features.length,
+        numberReturned: features.length,
+        timeStamp: "2020-07-20T11:36:20.118Z",
+        totalFeatures: features.length,
+        type: 'FeatureCollection',
+        features: features
+    }
+)
+
+const getFeaturesFiltered = (features, filterObj) =>{
+    if(filterObj.filterFields && filterObj.filterFields.length !== 0) {
+        const featuresFiltered = features.features.filter(feature => filterFeatures(feature, filterObj.filterFields));
+
+        features.features = featuresFiltered;
+        features.numberMatched = featuresFiltered.length;
+        features.numberReturned = featuresFiltered.length;
+        features.totalFeatures = featuresFiltered.length;
+        return features;
+    }
+    return features;
+
+}
+
+const filterFeatures = (feature, filterFields) =>{
+
+    for(let i = 0; i< filterFields.length; i++){
+        if(feature.properties[filterFields[i].attribute] === undefined ){
+
+            return false;
+
+        }
+        if(filterFields[i].type === "string" &&
+            !feature.properties[filterFields[i].attribute].toLowerCase().includes(filterFields[i].value.toLowerCase())){
+
+            return false;
+
+        }
+
+        if(filterFields[i].type === "number" && !feature.properties[filterFields[i].attribute].includes(filterFields[i].value)){
+
+            return false;
+        }
+
+        if(filterFields[i].type === "date"){
+
+            let dateFeature = new Date(feature.properties[filterFields[i].attribute]);
+            let dateFilter = new Date(filterFields[i].value.startDate);
+
+            if(dateFeature.getFullYear() !== dateFilter.getFullYear() ||
+                dateFeature.getMonth() !== dateFilter.getMonth() ||
+                dateFeature.getDay() !== dateFilter.getDay() ){
+
+                return false;
+            }
+        }
+
+    }
+    return true;
+}
+


### PR DESCRIPTION


## Description
Current MapStore release could display data in tabular view only for a WMS/WFS layer.
The current proposal is designed to display data in tabular view for a vector layer containing GeoJSON data.
The original data are stored in a temporary variable and filtering (from the header of the tabular view) is done locally from original data.
The behaviour is not modified for WMS/WFS layer.

Two files are modified to be able to check the layer type "Vector" and do the same job that the original block does for WMS/WFS.

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

when we add a vector layer (from GeoJSON datas), opening the the tabular view display nothing.

#<issue>
when we add a vector layer, opening the tabular view display the features is the layer. All existing tools in the tabular view still working and filtering from the header too.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
N/A