### PR TITLE
Migrate reducers selectors to import / export syntax

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,6 @@
+{
+  "upstream": "geosolutions-it/MapStore2",
+  "targetBranchChoices": ["2020.02.xx"],
+  "targetPRLabels": ["backport"],
+  "prTitle": "Backport for {targetBranch} - {commitMessages}"
+}

--- a/build/karma.conf.continuous-test.js
+++ b/build/karma.conf.continuous-test.js
@@ -3,7 +3,7 @@ const path = require("path");
 module.exports = function karmaConfig(config) {
     config.set(require('./testConfig')({
         files: [
-            './web/client/libs/Cesium/Build/Cesium/Cesium.js',
+            './node_modules/cesium/Build/Cesium/Cesium.js',
             'build/tests.webpack.js',
             { pattern: './web/client/test-resources/**/*', included: false },
             { pattern: './web/client/translations/**/*', included: false }

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(MapSearch-test\.jsx?)|(MapSearch-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "webpack-dev-server": "3.7.2"
   },
   "dependencies": {
+    "5to6-codemod": "^1.8.0",
     "@boundlessgeo/jsonix": "2.4.3",
     "@carnesen/redux-add-action-listener-enhancer": "0.0.1",
     "@geosolutions/proj4": "2.4.7",
@@ -139,6 +140,7 @@
     "is-equal": "1.5.5",
     "ismobilejs": "0.5.0",
     "istanbul-instrumenter-loader": "3.0.1",
+    "jscodeshift": "^0.11.0",
     "json-2-csv": "2.1.2",
     "json-loader": "0.5.7",
     "jsonlint-mod": "1.7.5",

--- a/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
@@ -27,7 +27,7 @@ require('../plugins/MarkerLayer');
 const SecurityUtils = require('../../../../utils/SecurityUtils');
 const ConfigUtils = require('../../../../utils/ConfigUtils');
 
-window.CESIUM_BASE_URL = "web/client/libs/Cesium/Build/Cesium";
+window.CESIUM_BASE_URL = "node_modules/cesium/Build/Cesium";
 
 describe('Cesium layer', () => {
     let map;

--- a/web/client/epics/__tests__/widgetsTray-test.js
+++ b/web/client/epics/__tests__/widgetsTray-test.js
@@ -15,9 +15,9 @@ const { SHOW_NOTIFICATION } = require('../../actions/notifications');
 const { rangeDataLoaded, setCollapsed, SET_COLLAPSED } = require('../../actions/timeline');
 const { deleteWidget, insertWidget, toggleCollapseAll, updateWidgetProperty, TOGGLE_COLLAPSE_ALL } = require('../../actions/widgets');
 
-const timeline = require('../../reducers/timeline');
-const dimension = require('../../reducers/dimension');
-const widgets = require('../../reducers/widgets');
+const timeline = require('../../reducers/timeline').default;
+const dimension = require('../../reducers/dimension').default;
+const widgets = require('../../reducers/widgets').default;
 // TEST DATA
 const T1 = '2016-01-01T00:00:00.000Z';
 const T2 = '2016-02-01T00:00:00.000Z';

--- a/web/client/examples/featuregrid/stores/store.js
+++ b/web/client/examples/featuregrid/stores/store.js
@@ -15,12 +15,12 @@ const {clearChanges, setPermission, toggleTool} = require('../../../actions/feat
 const {hasChangesSelector, hasNewFeaturesSelector} = require('../../../selectors/featuregrid');
 module.exports = (plugins) => {
     var reducers = {
-        map: require('../../../reducers/map'),
-        mapConfig: require('../../../reducers/config'),
-        locale: require('../../../reducers/locale'),
-        controls: require('../../../reducers/controls'),
-        layers: require('../../../reducers/controls'),
-        query: require('../../../reducers/query')
+        map: require('../../../reducers/map').default,
+        mapConfig: require('../../../reducers/config').default,
+        locale: require('../../../reducers/locale').default,
+        controls: require('../../../reducers/controls').default,
+        layers: require('../../../reducers/controls').default,
+        query: require('../../../reducers/query').default
     };
     return require('../../../stores/StandardStore')({}, reducers, {
         featureTypeSelectedEpic, wfsQueryEpic, viewportSelectedEpic, redrawSpatialFilterEpic,

--- a/web/client/examples/mouseposition/app.jsx
+++ b/web/client/examples/mouseposition/app.jsx
@@ -12,11 +12,11 @@ var { createStore, combineReducers } = require('redux');
 var { changeBrowserProperties} = require('../../actions/browser');
 var ConfigUtils = require('../../utils/ConfigUtils');
 var Localized = require('../../components/I18N/Localized');
-var browser = require('../../reducers/browser');
+var browser = require('../../reducers/browser').default;
 var {Modal, Grid, Row, Col, Button} = require('react-bootstrap');
 var LMap = require('../../components/map/leaflet/Map');
 var LLayer = require('../../components/map/leaflet/Layer');
-var mouseposition = require('../../reducers/mousePosition');
+var mouseposition = require('../../reducers/mousePosition').default;
 var {changeMousePosition} = require('../../actions/mousePosition');
 var store = createStore(combineReducers({browser, mouseposition}));
 

--- a/web/client/examples/myapp/stores/myappstore.js
+++ b/web/client/examples/myapp/stores/myappstore.js
@@ -1,7 +1,7 @@
 var {createStore, combineReducers, applyMiddleware} = require('redux');
 
 var thunkMiddleware = require('redux-thunk');
-var mapConfig = require('../../../reducers/config');
+var mapConfig = require('../../../reducers/config').default;
 
 // reducers
 const reducers = combineReducers({

--- a/web/client/examples/scalebar/app.jsx
+++ b/web/client/examples/scalebar/app.jsx
@@ -21,8 +21,8 @@ var {changeBrowserProperties} = require('../../actions/browser');
 var ConfigUtils = require('../../utils/ConfigUtils');
 
 var Debug = require('../../components/development/Debug');
-var mapConfig = require('../../reducers/map');
-var browser = require('../../reducers/browser');
+var mapConfig = require('../../reducers/map').default;
+var browser = require('../../reducers/browser').default;
 
 var LMap = require('../../components/map/leaflet/Map');
 var LLayer = require('../../components/map/leaflet/Layer');

--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -186,8 +186,8 @@ const MapStore2 = {
         const actionTrigger = generateActionTrigger(options.startAction || "CHANGE_MAP_VIEW");
         triggerAction = actionTrigger.trigger;
         const appStore = require('../stores/StandardStore').bind(null, initialState || {}, {
-            security: require('../reducers/security'),
-            version: require('../reducers/version')
+            security: require('../reducers/security').default,
+            version: require('../reducers/version').default
         }, {
             jsAPIEpic: actionTrigger.epic,
             ...(options.epics || {})

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -249,7 +249,7 @@ module.exports = {
         }
     }),
     reducers: {
-        annotations: require('../reducers/annotations')
+        annotations: require('../reducers/annotations').default
     },
     epics: require('../epics/annotations')(AnnotationsInfoViewer)
 };

--- a/web/client/plugins/BackgroundSelector.jsx
+++ b/web/client/plugins/BackgroundSelector.jsx
@@ -126,8 +126,8 @@ compose(
 module.exports = {
     BackgroundSelectorPlugin,
     reducers: {
-        controls: require('../reducers/controls'),
-        backgroundSelector: require('../reducers/backgroundselector')
+        controls: require('../reducers/controls').default,
+        backgroundSelector: require('../reducers/backgroundselector').default
     },
     epics: require('../epics/backgroundselector')
 };

--- a/web/client/plugins/Dashboard.jsx
+++ b/web/client/plugins/Dashboard.jsx
@@ -112,6 +112,6 @@ class DashboardPlugin extends React.Component {
 module.exports = {
     DashboardPlugin,
     reducers: {
-        widgets: require('../reducers/widgets')
+        widgets: require('../reducers/widgets').default
     }
 };

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -143,7 +143,7 @@ const Plugin = connect(
 module.exports = {
     DashboardEditorPlugin: Plugin,
     reducers: {
-        dashboard: require('../reducers/dashboard')
+        dashboard: require('../reducers/dashboard').default
     },
     epics: require('../epics/dashboard')
 };

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -133,6 +133,6 @@ module.exports = {
     }),
     epics: require('../epics/dashboards'),
     reducers: {
-        dashboards: require('../reducers/dashboards')
+        dashboards: require('../reducers/dashboards').default
     }
 };

--- a/web/client/plugins/FeatureGrid.jsx
+++ b/web/client/plugins/FeatureGrid.jsx
@@ -49,7 +49,7 @@ module.exports = {
         setDockSize: dockSizeFeatures
     })(require('../components/data/featuregrid_ag/DockedFeatureGrid')),
     reducers: {
-        featuregrid: require('../reducers/featuregrid'),
-        highlight: require('../reducers/highlight')
+        featuregrid: require('../reducers/featuregrid').default,
+        highlight: require('../reducers/highlight').default
     }
 };

--- a/web/client/plugins/FeedbackMask.jsx
+++ b/web/client/plugins/FeedbackMask.jsx
@@ -79,7 +79,7 @@ const FeedbackMaskPlugin = compose(
 module.exports = {
     FeedbackMaskPlugin,
     reducers: {
-        feedbackMask: require('../reducers/feedbackMask')
+        feedbackMask: require('../reducers/feedbackMask').default
     },
     epics: require('../epics/feedbackMask')
 };

--- a/web/client/plugins/FloatingLegend.jsx
+++ b/web/client/plugins/FloatingLegend.jsx
@@ -125,6 +125,6 @@ module.exports = {
         disablePluginIf: "{state('featuregridmode') === 'EDIT'}"
     }),
     reducers: {
-        floatinglegend: require('../reducers/floatinglegend')
+        floatinglegend: require('../reducers/floatinglegend').default
     }
 };

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -133,6 +133,6 @@ module.exports = {
     }),
     epics: require('../epics/geostories'),
     reducers: {
-        geostories: require('../reducers/geostories')
+        geostories: require('../reducers/geostories').default
     }
 };

--- a/web/client/plugins/GlobeViewSwitcher.jsx
+++ b/web/client/plugins/GlobeViewSwitcher.jsx
@@ -9,7 +9,7 @@ const {connect} = require('react-redux');
 
 
 const assign = require('object-assign');
-const globeswitcher = require('../reducers/globeswitcher');
+const globeswitcher = require('../reducers/globeswitcher').default;
 const epics = require('../epics/globeswitcher');
 const {toggle3d} = require('../actions/globeswitcher');
 const {mapTypeSelector, isCesium} = require('../selectors/maptype');

--- a/web/client/plugins/Help.jsx
+++ b/web/client/plugins/Help.jsx
@@ -43,5 +43,5 @@ module.exports = {
             doNotHide: true
         }
     }),
-    reducers: {help: require('../reducers/help')}
+    reducers: {help: require('../reducers/help').default}
 };

--- a/web/client/plugins/Locate.jsx
+++ b/web/client/plugins/Locate.jsx
@@ -52,5 +52,5 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: {locate: require('../reducers/locate')}
+    reducers: {locate: require('../reducers/locate').default}
 };

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -426,12 +426,12 @@ module.exports = {
         onResolutionsChange: setMapResolutions
     })(MapPlugin),
     reducers: {
-        map: require('../reducers/map'),
-        layers: require('../reducers/layers'),
-        draw: require('../reducers/draw'),
-        highlight: require('../reducers/highlight'),
-        maptype: require('../reducers/maptype'),
-        additionallayers: require('../reducers/additionallayers')
+        map: require('../reducers/map').default,
+        layers: require('../reducers/layers').default,
+        draw: require('../reducers/draw').default,
+        highlight: require('../reducers/highlight').default,
+        maptype: require('../reducers/maptype').default,
+        additionallayers: require('../reducers/additionallayers').default
     },
     epics: require('../epics/map')
 };

--- a/web/client/plugins/MapImport.jsx
+++ b/web/client/plugins/MapImport.jsx
@@ -82,7 +82,7 @@ module.exports = {
         }
     }),
     reducers: {
-        mapimport: require('../reducers/mapimport'),
-        style: require('../reducers/style')
+        mapimport: require('../reducers/mapimport').default,
+        style: require('../reducers/style').default
     }
 };

--- a/web/client/plugins/MapSearch.jsx
+++ b/web/client/plugins/MapSearch.jsx
@@ -75,5 +75,5 @@ const SearchBar = connect((state) => ({
 
 module.exports = {
     MapSearchPlugin: SearchBar,
-    reducers: {maps: require('../reducers/maps')}
+    reducers: {maps: require('../reducers/maps').default}
 };

--- a/web/client/plugins/MeasurePanel.jsx
+++ b/web/client/plugins/MeasurePanel.jsx
@@ -62,5 +62,5 @@ module.exports = {
             priority: 2
         }
     }),
-    reducers: {measurement: require('../reducers/measurement')}
+    reducers: {measurement: require('../reducers/measurement').default}
 };

--- a/web/client/plugins/MeasureResults.jsx
+++ b/web/client/plugins/MeasureResults.jsx
@@ -68,5 +68,5 @@ const MeasureResultsPlugin = connect((state) => {
 
 module.exports = {
     MeasureResultsPlugin,
-    reducers: {measurement: require('../reducers/measurement')}
+    reducers: {measurement: require('../reducers/measurement').default}
 };

--- a/web/client/plugins/MousePosition.jsx
+++ b/web/client/plugins/MousePosition.jsx
@@ -152,5 +152,5 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: {mousePosition: require('../reducers/mousePosition')}
+    reducers: {mousePosition: require('../reducers/mousePosition').default}
 };

--- a/web/client/plugins/Notifications.jsx
+++ b/web/client/plugins/Notifications.jsx
@@ -30,7 +30,7 @@ module.exports = {
         }
     )(require('../components/notifications/NotificationContainer')),
     reducers: {
-        notifications: require('../reducers/notifications')
+        notifications: require('../reducers/notifications').default
     },
     epics: {
         clearNotificationOnLocationChange

--- a/web/client/plugins/Playback.jsx
+++ b/web/client/plugins/Playback.jsx
@@ -66,7 +66,7 @@ module.exports = {
     }),
     epics: require('../epics/playback'),
     reducers: {
-        playback: require('../reducers/playback'),
-        dimension: require('../reducers/dimension')
+        playback: require('../reducers/playback').default,
+        dimension: require('../reducers/dimension').default
     }
 };

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -486,5 +486,5 @@ module.exports = {
             doNotHide: true
         }
     }),
-    reducers: {print: require('../reducers/print')}
+    reducers: {print: require('../reducers/print').default}
 };

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -454,9 +454,9 @@ const QueryPanelPlugin = connect(tocSelector, {
 module.exports = {
     QueryPanelPlugin,
     reducers: {
-        queryform: require('../reducers/queryform'),
-        query: require('../reducers/query'),
-        layerFilter: require('../reducers/layerFilter')
+        queryform: require('../reducers/queryform').default,
+        query: require('../reducers/query').default,
+        layerFilter: require('../reducers/layerFilter').default
     },
     epics: {featureTypeSelectedEpic, wfsQueryEpic, viewportSelectedEpic, redrawSpatialFilterEpic, ...autocompleteEpics, ...require('../epics/queryform'), ...layerFilterEpics}
 };

--- a/web/client/plugins/RasterStyler.jsx
+++ b/web/client/plugins/RasterStyler.jsx
@@ -280,5 +280,5 @@ module.exports = {
                 exclusive: true
             }
         }),
-    reducers: {rasterstyler: require('../reducers/rasterstyler')}
+    reducers: {rasterstyler: require('../reducers/rasterstyler').default}
 };

--- a/web/client/plugins/RulesDataGrid.jsx
+++ b/web/client/plugins/RulesDataGrid.jsx
@@ -74,5 +74,5 @@ const RulesDataGridPlugin = connect(
 )(RulesDataGrid);
 module.exports = {
     RulesDataGridPlugin,
-    reducers: {rulesmanager: require('../reducers/rulesmanager')}
+    reducers: {rulesmanager: require('../reducers/rulesmanager').default}
 };

--- a/web/client/plugins/RulesEditor.jsx
+++ b/web/client/plugins/RulesEditor.jsx
@@ -88,7 +88,7 @@ const Plugin = connect(
 module.exports = {
     RulesEditorPlugin: Plugin,
     reducers: {
-        rulesmanager: require('../reducers/rulesmanager')
+        rulesmanager: require('../reducers/rulesmanager').default
     },
     epics: require("../epics/rulesmanager")
 };

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -318,7 +318,7 @@ module.exports = {
     }),
     epics: {searchEpic, searchOnStartEpic, searchItemSelected, zoomAndAddPointEpic, textSearchShowGFIEpic},
     reducers: {
-        search: require('../reducers/search'),
-        mapInfo: require('../reducers/mapInfo')
+        search: require('../reducers/search').default,
+        mapInfo: require('../reducers/mapInfo').default
     }
 };

--- a/web/client/plugins/SearchServicesConfig.jsx
+++ b/web/client/plugins/SearchServicesConfig.jsx
@@ -221,6 +221,6 @@ const SearchServicesPlugin = connect(({controls = {}, searchconfig = {}}) => ({
 module.exports = {
     SearchServicesConfigPlugin: SearchServicesPlugin,
     reducers: {
-        searchconfig: require('../reducers/searchconfig')
+        searchconfig: require('../reducers/searchconfig').default
     }
 };

--- a/web/client/plugins/ShapeFile.jsx
+++ b/web/client/plugins/ShapeFile.jsx
@@ -85,8 +85,8 @@ module.exports = createPlugin(
             }
         },
         reducers: {
-            shapefile: require('../reducers/shapefile'),
-            style: require('../reducers/style')
+            shapefile: require('../reducers/shapefile').default,
+            style: require('../reducers/style').default
         }
     }
 );

--- a/web/client/plugins/Snapshot.jsx
+++ b/web/client/plugins/Snapshot.jsx
@@ -80,6 +80,6 @@ module.exports = {
         }
     }),
     reducers: {
-        snapshot: require('../reducers/snapshot')
+        snapshot: require('../reducers/snapshot').default
     }
 };

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -217,7 +217,7 @@ module.exports = {
         }
     }),
     reducers: {
-        styleeditor: require('../reducers/styleeditor')
+        styleeditor: require('../reducers/styleeditor').default
     },
     epics: require('../epics/styleeditor')
 };

--- a/web/client/plugins/Styler.jsx
+++ b/web/client/plugins/Styler.jsx
@@ -355,8 +355,8 @@ module.exports = {
             }
         }),
     reducers: {
-        styler: require('../reducers/styler'),
-        vectorstyler: require('../reducers/vectorstyler'),
-        rasterstyler: require('../reducers/rasterstyler')
+        styler: require('../reducers/styler').default,
+        vectorstyler: require('../reducers/vectorstyler').default,
+        rasterstyler: require('../reducers/rasterstyler').default
     }
 };

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -890,8 +890,8 @@ module.exports = {
         }
     }),
     reducers: {
-        queryform: require('../reducers/queryform'),
-        query: require('../reducers/query')
+        queryform: require('../reducers/queryform').default,
+        query: require('../reducers/query').default
     },
     // TODO: remove this dependency, it is needed only to use getMetadataRecordById and related actions that can be moved in the TOC
     epics: require("../epics/catalog").default(API)

--- a/web/client/plugins/ThematicLayer.jsx
+++ b/web/client/plugins/ThematicLayer.jsx
@@ -139,7 +139,7 @@ module.exports = {
         }
     }),
     reducers: {
-        thematic: require('../reducers/thematic')
+        thematic: require('../reducers/thematic').default
     },
     epics: require('../epics/thematic')(require('../api/SLDService'))
 };

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -304,7 +304,7 @@ module.exports = {
     }),
     reducers: {
         dimension: require('../reducers/dimension'),
-        timeline: require('../reducers/timeline')
+        timeline: require('../reducers/timeline').default
     },
     epics: require('../epics/timeline')
 };

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -303,7 +303,7 @@ module.exports = {
         }
     }),
     reducers: {
-        dimension: require('../reducers/dimension'),
+        dimension: require('../reducers/dimension').default,
         timeline: require('../reducers/timeline').default
     },
     epics: require('../epics/timeline')

--- a/web/client/plugins/Toolbar.jsx
+++ b/web/client/plugins/Toolbar.jsx
@@ -149,5 +149,5 @@ const toolbarSelector = stateSelector => createSelector([
 
 module.exports = {
     ToolbarPlugin: (stateSelector = 'toolbar') => connect(toolbarSelector(stateSelector))(Toolbar),
-    reducers: {controls: require('../reducers/controls')}
+    reducers: {controls: require('../reducers/controls').default}
 };

--- a/web/client/plugins/Tutorial.jsx
+++ b/web/client/plugins/Tutorial.jsx
@@ -163,7 +163,7 @@ module.exports = {
         }
     }),
     reducers: {
-        tutorial: require('../reducers/tutorial')
+        tutorial: require('../reducers/tutorial').default
     },
     epics
 };

--- a/web/client/plugins/VectorStyler.jsx
+++ b/web/client/plugins/VectorStyler.jsx
@@ -296,6 +296,6 @@ module.exports = {
             }
         }),
     reducers: {
-        vectorstyler: require('../reducers/vectorstyler')
+        vectorstyler: require('../reducers/vectorstyler').default
     }
 };

--- a/web/client/plugins/Version.jsx
+++ b/web/client/plugins/Version.jsx
@@ -52,6 +52,6 @@ module.exports = {
         }
     }),
     reducers: {
-        version: require('../reducers/version')
+        version: require('../reducers/version').default
     }
 };

--- a/web/client/plugins/WFSDownload.jsx
+++ b/web/client/plugins/WFSDownload.jsx
@@ -75,6 +75,6 @@ module.exports = {
     )(DownloadDialog),
     epics: require('../epics/wfsdownload'),
     reducers: {
-        wfsdownload: require('../reducers/wfsdownload')
+        wfsdownload: require('../reducers/wfsdownload').default
     }
 };

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -154,7 +154,7 @@ export default createPlugin("WidgetsPlugin", {
         }
     },
     reducers: {
-        widgets: require('../reducers/widgets')
+        widgets: require('../reducers/widgets').default
     },
     epics: require('../epics/widgets')
 });

--- a/web/client/plugins/manager/GroupManager.jsx
+++ b/web/client/plugins/manager/GroupManager.jsx
@@ -122,6 +122,6 @@ module.exports = {
                 glyph: "1-group-mod"
             }}),
     reducers: {
-        usergroups: require('../../reducers/usergroups')
+        usergroups: require('../../reducers/usergroups').default
     }
 };

--- a/web/client/plugins/manager/Importer.jsx
+++ b/web/client/plugins/manager/Importer.jsx
@@ -190,5 +190,5 @@ module.exports = {
             glyph: "import"
         }
     }),
-    reducers: {importer: require('../../reducers/importer')}
+    reducers: {importer: require('../../reducers/importer').default}
 };

--- a/web/client/plugins/manager/UserManager.jsx
+++ b/web/client/plugins/manager/UserManager.jsx
@@ -121,6 +121,6 @@ module.exports = {
                 glyph: "1-user-mod"
             }}),
     reducers: {
-        users: require('../../reducers/users')
+        users: require('../../reducers/users').default
     }
 };

--- a/web/client/product/__tests__/main-test.jsx
+++ b/web/client/product/__tests__/main-test.jsx
@@ -79,7 +79,7 @@ describe('standard application runner', () => {
     it('testing default appStore plus some extra reducers', () => {
         let defaultConfig = {
             appReducers: {
-                catalog: require("../../reducers/catalog")
+                catalog: require("../../reducers/catalog").default
             }
         };
         mainApp(defaultConfig, {plugins: {}}, (config) => {
@@ -97,7 +97,7 @@ describe('standard application runner', () => {
     it('testing appStore overridng default reducers', () => {
         let defaultConfig = {
             baseReducers: {
-                catalog: require("../../reducers/catalog")
+                catalog: require("../../reducers/catalog").default
             }
         };
         mainApp(defaultConfig, {plugins: {}}, (config) => {

--- a/web/client/product/appConfigEmbedded.js
+++ b/web/client/product/appConfigEmbedded.js
@@ -44,9 +44,9 @@ module.exports = {
     },
     baseReducers: {
         mode: (state = 'embedded') => state,
-        version: require('../reducers/version'),
-        maplayout: require('../reducers/maplayout'),
-        searchconfig: require('../reducers/searchconfig')
+        version: require('../reducers/version').default,
+        maplayout: require('../reducers/maplayout').default,
+        searchconfig: require('../reducers/searchconfig').default
     },
     baseEpics: {
         updateMapLayoutEpic,

--- a/web/client/product/main.jsx
+++ b/web/client/product/main.jsx
@@ -59,10 +59,10 @@ module.exports = (config = {}, pluginsDef, overrideConfig = cfg => cfg) => {
         const appStore = require('../stores/StandardStore').bind(null,
             initialState,
             baseReducers || {
-                maptype: require('../reducers/maptype'),
-                maps: require('../reducers/maps'),
-                maplayout: require('../reducers/maplayout'),
-                version: require('../reducers/version'),
+                maptype: require('../reducers/maptype').default,
+                maps: require('../reducers/maps').default,
+                maplayout: require('../reducers/maplayout').default,
+                version: require('../reducers/version').default,
                 mapPopups: require('../reducers/mapPopups').default,
                 ...appReducers
             },

--- a/web/client/product/plugins/MapType.jsx
+++ b/web/client/product/plugins/MapType.jsx
@@ -63,5 +63,5 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: {maptype: require('../../reducers/maptype')}
+    reducers: {maptype: require('../../reducers/maptype').default}
 };

--- a/web/client/reducers/__tests__/additionallayers-test.js
+++ b/web/client/reducers/__tests__/additionallayers-test.js
@@ -7,16 +7,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {
+import {
     updateAdditionalLayer,
     updateOptionsByOwner,
     removeAdditionalLayer,
     removeAllAdditionalLayers
-} = require('../../actions/additionallayers');
+} from '../../actions/additionallayers';
 
-const additionallayers = require('../additionallayers');
+import additionallayers from '../additionallayers';
 
 describe('Test additional layers reducer', () => {
 

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -6,11 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-const annotations = require('../annotations');
-const {DEFAULT_ANNOTATIONS_STYLES} = require('../../utils/AnnotationsUtils');
-const {isEmpty, round} = require('lodash');
-const {set} = require('../../utils/ImmutableUtils');
+import expect from 'expect';
+
+import annotations from '../annotations';
+import { DEFAULT_ANNOTATIONS_STYLES } from '../../utils/AnnotationsUtils';
+import { isEmpty, round } from 'lodash';
+import { set } from '../../utils/ImmutableUtils';
 
 const testFeatures = {
     point1: {
@@ -27,17 +28,40 @@ const testFeatures = {
     }
 };
 
-const {
-    REMOVE_ANNOTATION, CONFIRM_REMOVE_ANNOTATION, CANCEL_REMOVE_ANNOTATION,
-    EDIT_ANNOTATION, CANCEL_EDIT_ANNOTATION, SAVE_ANNOTATION, TOGGLE_ADD,
-    VALIDATION_ERROR, REMOVE_ANNOTATION_GEOMETRY,
-    NEW_ANNOTATION, SHOW_ANNOTATION, CANCEL_SHOW_ANNOTATION,
-    FILTER_ANNOTATIONS, CLOSE_ANNOTATIONS, CONFIRM_CLOSE_ANNOTATIONS, CANCEL_CLOSE_ANNOTATIONS,
-    toggleDeleteFtModal, confirmDeleteFeature,
-    addText, setUnsavedChanges, setUnsavedStyle,
-    toggleUnsavedChangesModal, toggleUnsavedGeometryModal, toggleUnsavedStyleModal, changedProperties,
-    setInvalidSelected, addNewFeature, resetCoordEditor, changeText, changeRadius, changeSelected,
-    highlightPoint, changeFormat,
+import {
+    REMOVE_ANNOTATION,
+    CONFIRM_REMOVE_ANNOTATION,
+    CANCEL_REMOVE_ANNOTATION,
+    EDIT_ANNOTATION,
+    CANCEL_EDIT_ANNOTATION,
+    SAVE_ANNOTATION,
+    TOGGLE_ADD,
+    VALIDATION_ERROR,
+    REMOVE_ANNOTATION_GEOMETRY,
+    NEW_ANNOTATION,
+    SHOW_ANNOTATION,
+    CANCEL_SHOW_ANNOTATION,
+    FILTER_ANNOTATIONS,
+    CLOSE_ANNOTATIONS,
+    CONFIRM_CLOSE_ANNOTATIONS,
+    CANCEL_CLOSE_ANNOTATIONS,
+    toggleDeleteFtModal,
+    confirmDeleteFeature,
+    addText,
+    setUnsavedChanges,
+    setUnsavedStyle,
+    toggleUnsavedChangesModal,
+    toggleUnsavedGeometryModal,
+    toggleUnsavedStyleModal,
+    changedProperties,
+    setInvalidSelected,
+    addNewFeature,
+    resetCoordEditor,
+    changeText,
+    changeRadius,
+    changeSelected,
+    highlightPoint,
+    changeFormat,
     toggleStyle,
     setStyle,
     updateSymbols,
@@ -45,12 +69,15 @@ const {
     setDefaultStyle,
     loading,
     changeGeometryTitle,
-    filterMarker, initPlugin, hideMeasureWarning, toggleShowAgain
-} = require('../../actions/annotations');
-const {PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
-const {drawingFeatures, selectFeatures} = require('../../actions/draw');
+    filterMarker,
+    initPlugin,
+    hideMeasureWarning,
+    toggleShowAgain
+} from '../../actions/annotations';
 
-const {toggleControl} = require('../../actions/controls');
+import { PURGE_MAPINFO_RESULTS } from '../../actions/mapInfo';
+import { drawingFeatures, selectFeatures } from '../../actions/draw';
+import { toggleControl } from '../../actions/controls';
 
 const testAllProperty = (state, checkState) => {
     Object.keys(state).forEach( s => {

--- a/web/client/reducers/__tests__/backgroundselector-test.js
+++ b/web/client/reducers/__tests__/backgroundselector-test.js
@@ -5,16 +5,18 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const backgroundselector = require('../backgroundselector');
-const {
+import expect from 'expect';
+
+import backgroundselector from '../backgroundselector';
+
+import {
     CREATE_BACKGROUNDS_LIST,
     ADD_BACKGROUND,
     UPDATE_BACKGROUND_THUMBNAIL,
     BACKGROUNDS_CLEAR,
     REMOVE_BACKGROUND,
     CLEAR_MODAL_PARAMETERS
-} = require('../../actions/backgroundselector');
+} from '../../actions/backgroundselector';
 
 describe('Test the backgroundSelector reducer', () => {
     it('trigger add background action ', () => {

--- a/web/client/reducers/__tests__/browser-test.js
+++ b/web/client/reducers/__tests__/browser-test.js
@@ -5,10 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+import expect from 'expect';
 
-var browser = require('../browser');
-var ConfigUtils = require('../../utils/ConfigUtils');
+import browser from '../browser';
+import ConfigUtils from '../../utils/ConfigUtils';
 
 describe('Test the browser reducer', () => {
     it('Get borwser properties', () => {

--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -5,7 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+import expect from 'expect';
+
 const emptyService = {
     title: "",
     type: "wms",
@@ -28,10 +29,34 @@ const serviceNew = {
     type,
     isNew: true
 };
-const catalog = require('../catalog');
-const {RECORD_LIST_LOADED, ADD_LAYER_ERROR, RESET_CATALOG, RECORD_LIST_LOAD_ERROR, CHANGE_CATALOG_FORMAT, CHANGE_CATALOG_MODE,
-    FOCUS_SERVICES_LIST, CHANGE_TITLE, CHANGE_URL, CHANGE_TYPE, CHANGE_SELECTED_SERVICE, CHANGE_SERVICE_PROPERTY, DELETE_CATALOG_SERVICE, SAVING_SERVICE, CHANGE_METADATA_TEMPLATE, TOGGLE_THUMBNAIL, TOGGLE_TEMPLATE, TOGGLE_ADVANCED_SETTINGS, addCatalogService, changeText, changeServiceFormat, setLoading} = require('../../actions/catalog');
-const {MAP_CONFIG_LOADED} = require('../../actions/config');
+import catalog from '../catalog';
+
+import {
+    RECORD_LIST_LOADED,
+    ADD_LAYER_ERROR,
+    RESET_CATALOG,
+    RECORD_LIST_LOAD_ERROR,
+    CHANGE_CATALOG_FORMAT,
+    CHANGE_CATALOG_MODE,
+    FOCUS_SERVICES_LIST,
+    CHANGE_TITLE,
+    CHANGE_URL,
+    CHANGE_TYPE,
+    CHANGE_SELECTED_SERVICE,
+    CHANGE_SERVICE_PROPERTY,
+    DELETE_CATALOG_SERVICE,
+    SAVING_SERVICE,
+    CHANGE_METADATA_TEMPLATE,
+    TOGGLE_THUMBNAIL,
+    TOGGLE_TEMPLATE,
+    TOGGLE_ADVANCED_SETTINGS,
+    addCatalogService,
+    changeText,
+    changeServiceFormat,
+    setLoading
+} from '../../actions/catalog';
+
+import { MAP_CONFIG_LOADED } from '../../actions/config';
 const sampleRecord = {
     boundingBox: {
         extent: [10.686,

--- a/web/client/reducers/__tests__/config-test.js
+++ b/web/client/reducers/__tests__/config-test.js
@@ -5,10 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+import expect from 'expect';
 
-var mapConfig = require('../config');
-const {DETAILS_LOADED, MAP_CREATED} = require('../../actions/maps');
+import mapConfig from '../config';
+import { DETAILS_LOADED, MAP_CREATED } from '../../actions/maps';
 
 
 describe('Test the mapConfig reducer', () => {

--- a/web/client/reducers/__tests__/contenttabs-test.js
+++ b/web/client/reducers/__tests__/contenttabs-test.js
@@ -6,13 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {
-    onTabSelected
-} = require('../../actions/contenttabs');
-
-const contenttabs = require('../contenttabs');
+import { onTabSelected } from '../../actions/contenttabs';
+import contenttabs from '../contenttabs';
 
 describe('Test contenttabs reducer', () => {
 

--- a/web/client/reducers/__tests__/controls-test.js
+++ b/web/client/reducers/__tests__/controls-test.js
@@ -5,10 +5,16 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const controls = require('../controls');
-const {TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SET_CONTROL_PROPERTIES, RESET_CONTROLS} = require('../../actions/controls');
+import controls from '../controls';
+
+import {
+    TOGGLE_CONTROL,
+    SET_CONTROL_PROPERTY,
+    SET_CONTROL_PROPERTIES,
+    RESET_CONTROLS
+} from '../../actions/controls';
 
 describe('Test the controls reducer', () => {
     it('default case', () => {

--- a/web/client/reducers/__tests__/cookie-test.js
+++ b/web/client/reducers/__tests__/cookie-test.js
@@ -5,12 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const cookie = require('../cookie');
-const {
-    SET_COOKIE_VISIBILITY, SET_MORE_DETAILS_VISIBILITY
-} = require('../../actions/cookie');
+import cookie from '../cookie';
+import { SET_COOKIE_VISIBILITY, SET_MORE_DETAILS_VISIBILITY } from '../../actions/cookie';
 
 describe('Test the cookie reducer', () => {
     it('cookie visibility', () => {

--- a/web/client/reducers/__tests__/crsselector-test.js
+++ b/web/client/reducers/__tests__/crsselector-test.js
@@ -5,8 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-var crsSelect = require('../crsselector');
+import expect from 'expect';
+
+import crsSelect from '../crsselector';
 
 describe('Test the mousePosition reducer', () => {
 

--- a/web/client/reducers/__tests__/dashboard-test.js
+++ b/web/client/reducers/__tests__/dashboard-test.js
@@ -5,8 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     setEditorAvailable,
     setEditing,
     triggerShowConnections,
@@ -15,9 +16,11 @@ const {
     dashboardLoaded,
     dashboardSaved,
     dashboardSaveError,
-    dashboardLoading } = require('../../actions/dashboard');
-const { insertWidget, updateWidget, deleteWidget } = require('../../actions/widgets');
-const dashboard = require('../dashboard');
+    dashboardLoading
+} from '../../actions/dashboard';
+
+import { insertWidget, updateWidget, deleteWidget } from '../../actions/widgets';
+import dashboard from '../dashboard';
 describe('Test the dashboard reducer', () => {
     it('setEditorAvailable action', () => {
         const state = dashboard({}, setEditorAvailable( true ));

--- a/web/client/reducers/__tests__/dashboards-test.js
+++ b/web/client/reducers/__tests__/dashboards-test.js
@@ -5,14 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-var dashboards = require('../dashboards');
-const {
-    setDashboardsAvailable,
-    dashboardListLoaded,
-    dashboardsLoading
-} = require('../../actions/dashboards');
+import dashboards from '../dashboards';
+import { setDashboardsAvailable, dashboardListLoaded, dashboardsLoading } from '../../actions/dashboards';
 
 
 describe('Test the dashboards reducer', () => {

--- a/web/client/reducers/__tests__/dimension-test.js
+++ b/web/client/reducers/__tests__/dimension-test.js
@@ -5,11 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-var dimension = require('../dimension');
-const { updateLayerDimensionData, setCurrentTime, setCurrentOffset, moveTime } = require('../../actions/dimension');
-const { layerDimensionDataSelectorCreator } = require('../../selectors/dimension');
+import dimension from '../dimension';
+import { updateLayerDimensionData, setCurrentTime, setCurrentOffset, moveTime } from '../../actions/dimension';
+import { layerDimensionDataSelectorCreator } from '../../selectors/dimension';
 
 describe('Test the dimension reducer', () => {
     it('external action', () => {

--- a/web/client/reducers/__tests__/draw-test.js
+++ b/web/client/reducers/__tests__/draw-test.js
@@ -5,9 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const draw = require('../draw');
-const {GEOMETRY_CHANGED, SET_CURRENT_STYLE} = require('../../actions/draw');
+import expect from 'expect';
+
+import draw from '../draw';
+import { GEOMETRY_CHANGED, SET_CURRENT_STYLE } from '../../actions/draw';
 
 
 describe('Test the draw reducer', () => {

--- a/web/client/reducers/__tests__/featuredmaps-test.js
+++ b/web/client/reducers/__tests__/featuredmaps-test.js
@@ -5,10 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const {setFeaturedMapsEnabled} = require('../../actions/maps');
-const {isFeaturedMapsEnabled} = require('../../selectors/featuredmaps');
-const featuredmaps = require('../featuredmaps');
+import expect from 'expect';
+
+import { setFeaturedMapsEnabled } from '../../actions/maps';
+import { isFeaturedMapsEnabled } from '../../selectors/featuredmaps';
+import featuredmaps from '../featuredmaps';
 
 describe('Test the featuredmaps reducer', () => {
     it('featuredmaps enabled', () => {

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -42,17 +42,50 @@ let newfeature3 = {
         someProp: "someValue"
     }
 };
-const expect = require('expect');
-const featuregrid = require('../featuregrid');
-const {setFeatures, dockSizeFeatures, setLayer, toggleTool, customizeAttribute, selectFeatures, deselectFeatures, createNewFeatures, updateFilter,
-    featureSaving, toggleSelection, clearSelection, MODES, toggleEditMode, toggleViewMode, saveSuccess, clearChanges, saveError, startDrawingFeature,
-    deleteGeometryFeature, geometryChanged, setSelectionOptions, changePage, featureModified, setPermission, disableToolbar, openFeatureGrid, closeFeatureGrid,
-    toggleShowAgain, hideSyncPopover, initPlugin, sizeChange, storeAdvancedSearchFilter, setUp, setTimeSync} = require('../../actions/featuregrid');
-const {featureTypeLoaded, createQuery} = require('../../actions/wfsquery');
+import expect from 'expect';
+import featuregrid from '../featuregrid';
 
-const {changeDrawingStatus} = require('../../actions/draw');
+import {
+    setFeatures,
+    dockSizeFeatures,
+    setLayer,
+    toggleTool,
+    customizeAttribute,
+    selectFeatures,
+    deselectFeatures,
+    createNewFeatures,
+    updateFilter,
+    featureSaving,
+    toggleSelection,
+    clearSelection,
+    MODES,
+    toggleEditMode,
+    toggleViewMode,
+    saveSuccess,
+    clearChanges,
+    saveError,
+    startDrawingFeature,
+    deleteGeometryFeature,
+    geometryChanged,
+    setSelectionOptions,
+    changePage,
+    featureModified,
+    setPermission,
+    disableToolbar,
+    openFeatureGrid,
+    closeFeatureGrid,
+    toggleShowAgain,
+    hideSyncPopover,
+    initPlugin,
+    sizeChange,
+    storeAdvancedSearchFilter,
+    setUp,
+    setTimeSync
+} from '../../actions/featuregrid';
 
-const museam = require('../../test-resources/wfs/museam.json');
+import { featureTypeLoaded, createQuery } from '../../actions/wfsquery';
+import { changeDrawingStatus } from '../../actions/draw';
+import museam from '../../test-resources/wfs/museam.json';
 describe('Test the featuregrid reducer', () => {
 
     it('returns original state on unrecognized action', () => {

--- a/web/client/reducers/__tests__/feedbackMask-test.js
+++ b/web/client/reducers/__tests__/feedbackMask-test.js
@@ -6,10 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {feedbackMaskLoading, feedbackMaskLoaded, feedbackMaskEnabled, detectedNewPage} = require('../../actions/feedbackMask');
-const feedbackMask = require('../feedbackMask');
+import {
+    feedbackMaskLoading,
+    feedbackMaskLoaded,
+    feedbackMaskEnabled,
+    detectedNewPage
+} from '../../actions/feedbackMask';
+
+import feedbackMask from '../feedbackMask';
 
 describe('Test the feedbackMask reducer', () => {
     it('test feedbackMaskLoading', () => {

--- a/web/client/reducers/__tests__/floatinglegend.js
+++ b/web/client/reducers/__tests__/floatinglegend.js
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {RESIZE_LEGEND, EXPAND_LEGEND} = require('../../actions/floatinglegend');
-const floatinglegend = require('../floatinglegend');
+import { RESIZE_LEGEND, EXPAND_LEGEND } from '../../actions/floatinglegend';
+import floatinglegend from '../floatinglegend';
 
 describe('Test the floatinglegend reducer', () => {
     it('change legend size height and/or width', () => {

--- a/web/client/reducers/__tests__/geostories-test.js
+++ b/web/client/reducers/__tests__/geostories-test.js
@@ -5,14 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-var geostories = require('../geostories');
-const {
-    setGeostoriesAvailable,
-    geostoriesListLoaded,
-    geostoriesLoading
-} = require('../../actions/geostories');
+import geostories from '../geostories';
+import { setGeostoriesAvailable, geostoriesListLoaded, geostoriesLoading } from '../../actions/geostories';
 
 
 describe('Test the geostories reducer', () => {

--- a/web/client/reducers/__tests__/geostory-test.js
+++ b/web/client/reducers/__tests__/geostory-test.js
@@ -165,7 +165,7 @@ describe('geostory reducer', () => {
     });
     describe('remove', () => {
         const STATE_STORY = geostory(undefined, setCurrentStory(TEST_STORY));
-        it.skip('as entry', () => {
+        it('as entry', () => {
             const SECTION_ID = TEST_STORY.sections[0].id;
             const CONTENT_ID = TEST_STORY.sections[0].contents[0].id;
             const pathToContentHtml = `sections[{"id":"${SECTION_ID}"}].contents[{"id":"${CONTENT_ID}"}].html`;

--- a/web/client/reducers/__tests__/globeswitcher-test.js
+++ b/web/client/reducers/__tests__/globeswitcher-test.js
@@ -5,10 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const globeswitcher = require('../globeswitcher');
-const {changeMapType} = require('../../actions/maptype');
-const {updateLast2dMapType} = require('../../actions/globeswitcher');
+import expect from 'expect';
+
+import globeswitcher from '../globeswitcher';
+import { changeMapType } from '../../actions/maptype';
+import { updateLast2dMapType } from '../../actions/globeswitcher';
 
 describe('Test the globeswitcher reducer', () => {
     it('check to store last 2d map type', () => {

--- a/web/client/reducers/__tests__/highlight-test.js
+++ b/web/client/reducers/__tests__/highlight-test.js
@@ -5,9 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const highlight = require('../highlight');
-const {SET_HIGHLIGHT_FEATURES_PATH} = require('../../actions/highlight');
+import expect from 'expect';
+
+import highlight from '../highlight';
+import { SET_HIGHLIGHT_FEATURES_PATH } from '../../actions/highlight';
 
 
 describe('Test the highlight reducer', () => {

--- a/web/client/reducers/__tests__/layerFilter-test.js
+++ b/web/client/reducers/__tests__/layerFilter-test.js
@@ -5,11 +5,17 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const { APPLIED_FILTER, STORE_CURRENT_APPLIED_FILTER, INIT_LAYER_FILTER, DISCARD_CURRENT_FILTER} = require("../../actions/layerFilter");
-const { QUERY_FORM_RESET} = require('../../actions/queryform');
-const layerFilter = require('../layerFilter');
+import {
+    APPLIED_FILTER,
+    STORE_CURRENT_APPLIED_FILTER,
+    INIT_LAYER_FILTER,
+    DISCARD_CURRENT_FILTER
+} from '../../actions/layerFilter';
+
+import { QUERY_FORM_RESET } from '../../actions/queryform';
+import layerFilter from '../layerFilter';
 
 describe('Test the layerFilter reducer', () => {
     it('init filter history', () => {

--- a/web/client/reducers/__tests__/layers-test.js
+++ b/web/client/reducers/__tests__/layers-test.js
@@ -5,9 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-var layers = require('../layers');
-const { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP } = require('../../actions/layers');
+import expect from 'expect';
+
+import layers from '../layers';
+import { changeLayerParams, addLayer, addGroup, moveNode, ADD_GROUP } from '../../actions/layers';
 
 
 describe('Test the layers reducer', () => {

--- a/web/client/reducers/__tests__/locale-test.js
+++ b/web/client/reducers/__tests__/locale-test.js
@@ -5,9 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+import expect from 'expect';
 
-var locale = require('../locale');
+import locale from '../locale';
 
 
 describe('Test the locale reducer', () => {

--- a/web/client/reducers/__tests__/locate-test.js
+++ b/web/client/reducers/__tests__/locate-test.js
@@ -5,8 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-var locate = require('../locate');
+import expect from 'expect';
+
+import locate from '../locate';
 
 describe('Test the locate reducer', () => {
 

--- a/web/client/reducers/__tests__/map-test.js
+++ b/web/client/reducers/__tests__/map-test.js
@@ -5,11 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const {round} = require('lodash');
+import expect from 'expect';
 
-var mapConfig = require('../map');
-const { changeMapLimits, PAN_TO, SET_MAP_RESOLUTIONS } = require('../../actions/map');
+import { round } from 'lodash';
+import mapConfig from '../map';
+import { changeMapLimits, PAN_TO, SET_MAP_RESOLUTIONS } from '../../actions/map';
 
 describe('Test the map reducer', () => {
     it('returns original state on unrecognized action', () => {

--- a/web/client/reducers/__tests__/mapEditor-test.js
+++ b/web/client/reducers/__tests__/mapEditor-test.js
@@ -9,10 +9,7 @@ import expect from 'expect';
 
 import mapEditor, {DEFAULT_STATE} from '../mapEditor';
 
-const {
-    hide,
-    show
-} = require('../../actions/mapEditor');
+import { hide, show } from '../../actions/mapEditor';
 
 describe('Test the mapEditor reducer', () => {
     it('HIDE', () => {

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -6,13 +6,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-const mapInfo = require('../mapInfo');
-const { featureInfoClick, toggleEmptyMessageGFI, toggleShowCoordinateEditor, changeFormat, changePage, toggleHighlightFeature, setMapTrigger} = require('../../actions/mapInfo');
-const { MAP_CONFIG_LOADED } = require('../../actions/config');
-const assign = require('object-assign');
+import expect from 'expect';
 
-require('babel-polyfill');
+import mapInfo from '../mapInfo';
+
+import {
+    featureInfoClick,
+    toggleEmptyMessageGFI,
+    toggleShowCoordinateEditor,
+    changeFormat,
+    changePage,
+    toggleHighlightFeature,
+    setMapTrigger
+} from '../../actions/mapInfo';
+
+import { MAP_CONFIG_LOADED } from '../../actions/config';
+import assign from 'object-assign';
+import 'babel-polyfill';
 
 describe('Test the mapInfo reducer', () => {
     let appState = {configuration: {infoFormat: 'text/plain'}, responses: [], requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};

--- a/web/client/reducers/__tests__/mapimport-test.js
+++ b/web/client/reducers/__tests__/mapimport-test.js
@@ -6,10 +6,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const ReactDOM = require('react-dom');
-const expect = require('expect');
-const mapimport = require('../mapimport');
-const { setLayers, onSelectLayer, onError, setLoading, onLayerAdded, updateBBox, onSuccess } = require('../../actions/mapimport');
+import ReactDOM from 'react-dom';
+
+import expect from 'expect';
+import mapimport from '../mapimport';
+
+import {
+    setLayers,
+    onSelectLayer,
+    onError,
+    setLoading,
+    onLayerAdded,
+    updateBBox,
+    onSuccess
+} from '../../actions/mapimport';
+
 const L1 = {name: "L1"};
 const L2 = { name: "L2" };
 const W1 = {name: "TEST", "message": "M1"};

--- a/web/client/reducers/__tests__/maplayout-test.js
+++ b/web/client/reducers/__tests__/maplayout-test.js
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {UPDATE_MAP_LAYOUT} = require('../../actions/maplayout');
-const mapLayout = require('../maplayout');
+import { UPDATE_MAP_LAYOUT } from '../../actions/maplayout';
+import mapLayout from '../maplayout';
 
 describe('Test the map layout reducer', () => {
     it('change layout bounds/style', () => {

--- a/web/client/reducers/__tests__/maps-test.js
+++ b/web/client/reducers/__tests__/maps-test.js
@@ -5,13 +5,19 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const maps = require('../maps');
-const {
-    mapsLoaded, mapsLoading, loadError, mapCreated,
+import maps from '../maps';
+
+import {
+    mapsLoaded,
+    mapsLoading,
+    loadError,
+    mapCreated,
     mapDeleting,
-    mapsSearchTextChanged, setShowMapDetails} = require('../../actions/maps');
+    mapsSearchTextChanged,
+    setShowMapDetails
+} from '../../actions/maps';
 
 const sampleMap = {
     canDelete: false,

--- a/web/client/reducers/__tests__/maptype-test.js
+++ b/web/client/reducers/__tests__/maptype-test.js
@@ -5,9 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const maptype = require('../maptype');
-const {changeMapType} = require('../../actions/maptype');
+import expect from 'expect';
+
+import maptype from '../maptype';
+import { changeMapType } from '../../actions/maptype';
 
 describe('Test the maptype reducer', () => {
     it('set a maptype', () => {

--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -5,9 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-const expect = require('expect');
-const measurement = require('../measurement');
-const {
+import expect from 'expect';
+
+import measurement from '../measurement';
+
+import {
     toggleMeasurement,
     changeUom,
     changeCoordinates,
@@ -18,8 +20,9 @@ const {
     setAnnotationMeasurement,
     setMeasurementConfig,
     setCurrentFeature
-} = require('../../actions/measurement');
-const {RESET_CONTROLS, setControlProperty} = require('../../actions/controls');
+} from '../../actions/measurement';
+
+import { RESET_CONTROLS, setControlProperty } from '../../actions/controls';
 
 describe('Test the measurement reducer', () => {
 

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -10,7 +10,7 @@ import expect from 'expect';
 import mediaEditor, {DEFAULT_STATE} from '../mediaEditor';
 import { LOCATION_CHANGE } from 'connected-react-router';
 
-const {
+import {
     chooseMedia,
     hide,
     loadMediaSuccess,
@@ -21,7 +21,7 @@ const {
     setMediaType,
     show,
     updateItem
-} = require('../../actions/mediaEditor');
+} from '../../actions/mediaEditor';
 
 describe('Test the mediaEditor reducer', () => {
 

--- a/web/client/reducers/__tests__/mousePosition-test.js
+++ b/web/client/reducers/__tests__/mousePosition-test.js
@@ -5,8 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-var mousePosition = require('../mousePosition');
+import expect from 'expect';
+
+import mousePosition from '../mousePosition';
 
 describe('Test the mousePosition reducer', () => {
 

--- a/web/client/reducers/__tests__/notifications-test.js
+++ b/web/client/reducers/__tests__/notifications-test.js
@@ -5,9 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-const {show, hide, clear} = require('../../actions/notifications');
-const notifications = require('../notifications');
+import expect from 'expect';
+
+import { show, hide, clear } from '../../actions/notifications';
+import notifications from '../notifications';
 describe('Test the notifications reducer', () => {
     it('add notification', () => {
         let state = notifications([], show({title: "test", uid: 1}));

--- a/web/client/reducers/__tests__/playback-test.js
+++ b/web/client/reducers/__tests__/playback-test.js
@@ -5,9 +5,23 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-const { updateMetadata, play, pause, stop, setFrames, appendFrames, setCurrentFrame, changeSetting, selectPlaybackRange, framesLoading, STATUS } = require('../../actions/playback');
-const playback = require('../playback');
+import expect from 'expect';
+
+import {
+    updateMetadata,
+    play,
+    pause,
+    stop,
+    setFrames,
+    appendFrames,
+    setCurrentFrame,
+    changeSetting,
+    selectPlaybackRange,
+    framesLoading,
+    STATUS
+} from '../../actions/playback';
+
+import playback from '../playback';
 describe('playback reducer', () => {
     it('default', () => {
         const oldState = {};

--- a/web/client/reducers/__tests__/print-test.js
+++ b/web/client/reducers/__tests__/print-test.js
@@ -5,10 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const print = require('../print');
-const {
+import print from '../print';
+
+import {
     SET_PRINT_PARAMETER,
     PRINT_CAPABILITIES_LOADED,
     PRINT_CAPABILITIES_ERROR,
@@ -19,7 +20,7 @@ const {
     PRINT_CREATED,
     PRINT_ERROR,
     PRINT_CANCEL
-} = require('../../actions/print');
+} from '../../actions/print';
 
 describe('Test the print reducer', () => {
     it('set a printing parameter', () => {

--- a/web/client/reducers/__tests__/query-test.js
+++ b/web/client/reducers/__tests__/query-test.js
@@ -6,11 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-const query = require('../query');
-const {TOGGLE_LAYER_FILTER} = require('../../actions/wfsquery');
-const { reset
-} = require('../../actions/queryform');
+import expect from 'expect';
+
+import query from '../query';
+import { TOGGLE_LAYER_FILTER } from '../../actions/wfsquery';
+import { reset } from '../../actions/queryform';
 
 describe('Test the query reducer', () => {
     it('Test QUERY_FORM_RESET to skip query', () => {

--- a/web/client/reducers/__tests__/queryform-test.js
+++ b/web/client/reducers/__tests__/queryform-test.js
@@ -5,18 +5,26 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const queryform = require('../queryform');
+import expect from 'expect';
 
-const {featureCollection} = require('../../test-resources/featureCollectionZone.js');
-const {
-    UPDATE_FILTER_FIELD_OPTIONS, SET_AUTOCOMPLETE_MODE, TOGGLE_AUTOCOMPLETE_MENU,
+import queryform from '../queryform';
+import { featureCollection } from '../../test-resources/featureCollectionZone.js';
+
+import {
+    UPDATE_FILTER_FIELD_OPTIONS,
+    SET_AUTOCOMPLETE_MODE,
+    TOGGLE_AUTOCOMPLETE_MENU,
     loadFilter,
-    expandCrossLayerFilterPanel, setCrossLayerFilterParameter, resetCrossLayerFilter,
-    addCrossLayerFilterField, updateCrossLayerFilterField, removeCrossLayerFilterField,
+    expandCrossLayerFilterPanel,
+    setCrossLayerFilterParameter,
+    resetCrossLayerFilter,
+    addCrossLayerFilterField,
+    updateCrossLayerFilterField,
+    removeCrossLayerFilterField,
     changeSpatialFilterValue
-} = require('../../actions/queryform');
-const {END_DRAWING, CHANGE_DRAWING_STATUS} = require('../../actions/draw');
+} from '../../actions/queryform';
+
+import { END_DRAWING, CHANGE_DRAWING_STATUS } from '../../actions/draw';
 
 describe('Test the queryform reducer', () => {
 

--- a/web/client/reducers/__tests__/rasterstyler-test.js
+++ b/web/client/reducers/__tests__/rasterstyler-test.js
@@ -5,13 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const rasterstyler = require('../rasterstyler');
-const {
-    SET_RASTERSTYLE_PARAMETER,
-    SET_RASTER_LAYER
-} = require('../../actions/rasterstyler');
+import rasterstyler from '../rasterstyler';
+import { SET_RASTERSTYLE_PARAMETER, SET_RASTER_LAYER } from '../../actions/rasterstyler';
 
 describe('Test the rasterstyler reducer', () => {
     it('set a rasterstyle parameter', () => {

--- a/web/client/reducers/__tests__/rulesmanager-test.js
+++ b/web/client/reducers/__tests__/rulesmanager-test.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var expect = require('expect');
-var rulesmanager = require('../rulesmanager');
+import expect from 'expect';
+
+import rulesmanager from '../rulesmanager';
 
 describe('test rules manager reducer', () => {
 

--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -5,9 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-var search = require('../search');
-const {
+import expect from 'expect';
+
+import search from '../search';
+
+import {
     TEXT_SEARCH_RESULTS_LOADED,
     TEXT_SEARCH_LOADING,
     TEXT_SEARCH_ERROR,
@@ -19,10 +21,9 @@ const {
     changeFormat,
     changeCoord,
     changeActiveSearchTool
-} = require('../../actions/search');
-const {
-    resetControls
-} = require('../../actions/controls');
+} from '../../actions/search';
+
+import { resetControls } from '../../actions/controls';
 
 describe('Test the search reducer', () => {
     it('search results loading', () => {

--- a/web/client/reducers/__tests__/searchconfig-test.js
+++ b/web/client/reducers/__tests__/searchconfig-test.js
@@ -5,10 +5,10 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-const expect = require('expect');
+import expect from 'expect';
 
-const searchconfig = require('../searchconfig');
-const {SET_SEARCH_CONFIG_PROP, RESET_SEARCH_CONFIG, UPDATE_SERVICE} = require('../../actions/searchconfig');
+import searchconfig from '../searchconfig';
+import { SET_SEARCH_CONFIG_PROP, RESET_SEARCH_CONFIG, UPDATE_SERVICE } from '../../actions/searchconfig';
 
 describe('Test the searchconfig reducer', () => {
     it('Map config loaded with textSearchConfig', () => {

--- a/web/client/reducers/__tests__/security-test.js
+++ b/web/client/reducers/__tests__/security-test.js
@@ -5,11 +5,23 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const security = require('../security');
-const {LOGIN_SUCCESS, LOGIN_FAIL, RESET_ERROR, LOGOUT, CHANGE_PASSWORD_SUCCESS, CHANGE_PASSWORD_FAIL, REFRESH_SUCCESS, SESSION_VALID} = require('../../actions/security');
-const { SET_CONTROL_PROPERTY } = require('../../actions/controls');
-const {USERMANAGER_UPDATE_USER} = require('../../actions/users');
+import expect from 'expect';
+
+import security from '../security';
+
+import {
+    LOGIN_SUCCESS,
+    LOGIN_FAIL,
+    RESET_ERROR,
+    LOGOUT,
+    CHANGE_PASSWORD_SUCCESS,
+    CHANGE_PASSWORD_FAIL,
+    REFRESH_SUCCESS,
+    SESSION_VALID
+} from '../../actions/security';
+
+import { SET_CONTROL_PROPERTY } from '../../actions/controls';
+import { USERMANAGER_UPDATE_USER } from '../../actions/users';
 
 describe('Test the security reducer', () => {
     const testToken = "260a670e-4dc0-4719-8bc9-85555d7dcbe1";

--- a/web/client/reducers/__tests__/snapshot-test.js
+++ b/web/client/reducers/__tests__/snapshot-test.js
@@ -5,9 +5,17 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
-var snapshot = require('../snapshot');
-var {CHANGE_SNAPSHOT_STATE, SNAPSHOT_READY, SNAPSHOT_ERROR, SNAPSHOT_ADD_QUEUE, SNAPSHOT_REMOVE_QUEUE} = require('../../actions/snapshot');
+import expect from 'expect';
+
+import snapshot from '../snapshot';
+
+import {
+    CHANGE_SNAPSHOT_STATE,
+    SNAPSHOT_READY,
+    SNAPSHOT_ERROR,
+    SNAPSHOT_ADD_QUEUE,
+    SNAPSHOT_REMOVE_QUEUE
+} from '../../actions/snapshot';
 
 describe('Test the snapshot reducer', () => {
 

--- a/web/client/reducers/__tests__/style-test.js
+++ b/web/client/reducers/__tests__/style-test.js
@@ -5,12 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const style = require('../style');
-const {
-    SET_STYLE_PARAMETER
-} = require('../../actions/style');
+import style from '../style';
+import { SET_STYLE_PARAMETER } from '../../actions/style';
 
 describe('Test the style reducer', () => {
     it('set a style parameter', () => {

--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -6,11 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const styleeditor = require('../styleeditor');
+import styleeditor from '../styleeditor';
 
-const {
+import {
     initStyleService,
     setEditPermissionStyleEditor,
     updateTemporaryStyle,
@@ -21,7 +21,7 @@ const {
     loadedStyle,
     errorStyle,
     updateEditorMetadata
-} = require('../../actions/styleeditor');
+} from '../../actions/styleeditor';
 
 describe('Test styleeditor reducer', () => {
     it('test initStyleService', () => {

--- a/web/client/reducers/__tests__/tasks-test.js
+++ b/web/client/reducers/__tests__/tasks-test.js
@@ -5,10 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+import expect from 'expect';
 
-var {TASK_STARTED, TASK_SUCCESS, TASK_ERROR } = require('../../actions/tasks');
-var tasks = require('../tasks');
+import { TASK_STARTED, TASK_SUCCESS, TASK_ERROR } from '../../actions/tasks';
+import tasks from '../tasks';
 
 describe('Test the tasks reducer', () => {
 

--- a/web/client/reducers/__tests__/thematic-test.js
+++ b/web/client/reducers/__tests__/thematic-test.js
@@ -5,8 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     loadFields,
     fieldsLoaded,
     fieldsError,
@@ -18,8 +19,9 @@ const {
     cancelDirty,
     setInvalidInput,
     resetInvalidInput
-} = require('../../actions/thematic');
-const thematic = require('../thematic');
+} from '../../actions/thematic';
+
+import thematic from '../thematic';
 
 const layer = {
     name: 'mylayer',

--- a/web/client/reducers/__tests__/timeline-test.js
+++ b/web/client/reducers/__tests__/timeline-test.js
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const timeline = require('../timeline');
-const {rangeDataLoaded, selectLayer, timeDataLoading, setCollapsed, setMapSync} = require('../../actions/timeline');
-const { isCollapsed, isMapSync } = require('../../selectors/timeline');
-const expect = require('expect');
+import timeline from '../timeline';
+
+import { rangeDataLoaded, selectLayer, timeDataLoading, setCollapsed, setMapSync } from '../../actions/timeline';
+import { isCollapsed, isMapSync } from '../../selectors/timeline';
+import expect from 'expect';
 
 describe('Test the timeline reducer', () => {
     it('change the layer histogram and rangedata', () => {

--- a/web/client/reducers/__tests__/tutorial-test.js
+++ b/web/client/reducers/__tests__/tutorial-test.js
@@ -7,10 +7,11 @@
  */
 
 
-const expect = require('expect');
-const tutorial = require('../tutorial');
+import expect from 'expect';
 
-const {
+import tutorial from '../tutorial';
+
+import {
     START_TUTORIAL,
     INIT_TUTORIAL,
     SETUP_TUTORIAL,
@@ -19,7 +20,7 @@ const {
     RESET_TUTORIAL,
     CLOSE_TUTORIAL,
     TOGGLE_TUTORIAL
-} = require('../../actions/tutorial');
+} from '../../actions/tutorial';
 
 describe('Test the tutorial reducer', () => {
 

--- a/web/client/reducers/__tests__/usergroups-test.js
+++ b/web/client/reducers/__tests__/usergroups-test.js
@@ -5,13 +5,23 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const usergroups = require('../usergroups');
-const {
-    GETGROUPS, EDITGROUP, EDITGROUPDATA,
-    SEARCHTEXTCHANGED, SEARCHUSERS, UPDATEGROUP, DELETEGROUP, STATUS_SUCCESS, STATUS_LOADING, STATUS_SAVED, STATUS_ERROR
-} = require('../../actions/usergroups');
+import usergroups from '../usergroups';
+
+import {
+    GETGROUPS,
+    EDITGROUP,
+    EDITGROUPDATA,
+    SEARCHTEXTCHANGED,
+    SEARCHUSERS,
+    UPDATEGROUP,
+    DELETEGROUP,
+    STATUS_SUCCESS,
+    STATUS_LOADING,
+    STATUS_SAVED,
+    STATUS_ERROR
+} from '../../actions/usergroups';
 
 describe('Test the usergroups reducer', () => {
     it('default loading', () => {

--- a/web/client/reducers/__tests__/users-test.js
+++ b/web/client/reducers/__tests__/users-test.js
@@ -5,15 +5,20 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const users = require('../users');
-const {
-    USERMANAGER_GETUSERS, USERMANAGER_EDIT_USER, USERMANAGER_EDIT_USER_DATA,
-    USERMANAGER_UPDATE_USER, USERMANAGER_DELETE_USER, USERMANAGER_GETGROUPS
-} = require('../../actions/users');
+import users from '../users';
 
-const {UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED} = require('../../actions/usergroups');
+import {
+    USERMANAGER_GETUSERS,
+    USERMANAGER_EDIT_USER,
+    USERMANAGER_EDIT_USER_DATA,
+    USERMANAGER_UPDATE_USER,
+    USERMANAGER_DELETE_USER,
+    USERMANAGER_GETGROUPS
+} from '../../actions/users';
+
+import { UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED } from '../../actions/usergroups';
 
 describe('Test the users reducer', () => {
     it('default loading', () => {

--- a/web/client/reducers/__tests__/version-test.js
+++ b/web/client/reducers/__tests__/version-test.js
@@ -5,9 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var expect = require('expect');
+import expect from 'expect';
 
-var version = require('../version');
+import version from '../version';
 
 
 describe('Test the version reducer', () => {

--- a/web/client/reducers/__tests__/wfsdownload-test.js
+++ b/web/client/reducers/__tests__/wfsdownload-test.js
@@ -5,11 +5,16 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {
-    onDownloadOptionChange, downloadFeatures, onDownloadFinished, onFormatOptionsFetch, updateFormats} = require('../../actions/wfsdownload');
-const wfsdownload = require('../wfsdownload');
+import {
+    onDownloadOptionChange,
+    downloadFeatures,
+    onDownloadFinished,
+    onFormatOptionsFetch,
+    updateFormats
+} from '../../actions/wfsdownload';
 
-const expect = require('expect');
+import wfsdownload from '../wfsdownload';
+import expect from 'expect';
 
 describe('Test the wfsdownload reducer', () => {
     it('downloadFeatures', () => {

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {
+import {
     editWidget,
     editNewWidget,
     changeEditorSetting,
@@ -24,15 +24,14 @@ const {
     toggleCollapseAll,
     toggleTray,
     DEFAULT_TARGET
-} = require('../../actions/widgets');
-const {configureMap} = require('../../actions/config');
-const {dashboardLoaded} = require('../../actions/dashboard');
-const widgets = require('../widgets');
-const {getFloatingWidgets, getVisibleFloatingWidgets, getCollapsedIds} = require('../../selectors/widgets');
+} from '../../actions/widgets';
 
-
-const expect = require('expect');
-const {find, get} = require('lodash');
+import { configureMap } from '../../actions/config';
+import { dashboardLoaded } from '../../actions/dashboard';
+import widgets from '../widgets';
+import { getFloatingWidgets, getVisibleFloatingWidgets, getCollapsedIds } from '../../selectors/widgets';
+import expect from 'expect';
+import { find, get } from 'lodash';
 
 describe('Test the widgets reducer', () => {
     it('initial state', () => {

--- a/web/client/reducers/additionallayers.js
+++ b/web/client/reducers/additionallayers.js
@@ -7,13 +7,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     UPDATE_ADDITIONAL_LAYER,
     REMOVE_ADDITIONAL_LAYER,
     UPDATE_OPTIONS_BY_OWNER,
     REMOVE_ALL_ADDITIONAL_LAYERS
-} = require('../actions/additionallayers');
-const { head, pickBy, identity, isObject, isArray } = require('lodash');
+} from '../actions/additionallayers';
+
+import { head, pickBy, identity, isObject, isArray } from 'lodash';
 
 function additionallayers(state = [], action) {
     switch (action.type) {
@@ -56,4 +57,4 @@ function additionallayers(state = [], action) {
     }
 }
 
-module.exports = additionallayers;
+export default additionallayers;

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -6,31 +6,76 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const assign = require('object-assign');
-const {transformLineToArcs} = require('../utils/CoordinatesUtils');
+import assign from 'object-assign';
 
-const circle = require('@turf/circle').default;
+import { transformLineToArcs } from '../utils/CoordinatesUtils';
+import circle from '@turf/circle';
+import { PURGE_MAPINFO_RESULTS } from '../actions/mapInfo';
+import { TOGGLE_CONTROL } from '../actions/controls';
+import { FEATURES_SELECTED, DRAWING_FEATURE } from '../actions/draw';
 
-const {PURGE_MAPINFO_RESULTS} = require('../actions/mapInfo');
-const {TOGGLE_CONTROL} = require('../actions/controls');
-const {FEATURES_SELECTED, DRAWING_FEATURE} = require('../actions/draw');
-const {REMOVE_ANNOTATION, CONFIRM_REMOVE_ANNOTATION, CANCEL_REMOVE_ANNOTATION, CLOSE_ANNOTATIONS,
-    CONFIRM_CLOSE_ANNOTATIONS, CANCEL_CLOSE_ANNOTATIONS,
-    EDIT_ANNOTATION, CANCEL_EDIT_ANNOTATION, SAVE_ANNOTATION, TOGGLE_ADD, VALIDATION_ERROR, REMOVE_ANNOTATION_GEOMETRY,
-    TOGGLE_STYLE, SET_STYLE, NEW_ANNOTATION, SHOW_ANNOTATION, CANCEL_SHOW_ANNOTATION, FILTER_ANNOTATIONS,
-    UNSAVED_CHANGES, TOGGLE_GEOMETRY_MODAL, TOGGLE_CHANGES_MODAL, CHANGED_PROPERTIES, TOGGLE_STYLE_MODAL, UNSAVED_STYLE,
-    ADD_TEXT, CHANGED_SELECTED, RESET_COORD_EDITOR, CHANGE_RADIUS, CHANGE_TEXT,
-    ADD_NEW_FEATURE, SET_EDITING_FEATURE, SET_INVALID_SELECTED, TOGGLE_DELETE_FT_MODAL, CONFIRM_DELETE_FEATURE, HIGHLIGHT_POINT,
-    CHANGE_FORMAT, UPDATE_SYMBOLS, ERROR_SYMBOLS, SET_DEFAULT_STYLE, LOADING, CHANGE_GEOMETRY_TITLE, FILTER_MARKER,
-    HIDE_MEASURE_WARNING, TOGGLE_SHOW_AGAIN, INIT_PLUGIN
-} = require('../actions/annotations');
+import {
+    REMOVE_ANNOTATION,
+    CONFIRM_REMOVE_ANNOTATION,
+    CANCEL_REMOVE_ANNOTATION,
+    CLOSE_ANNOTATIONS,
+    CONFIRM_CLOSE_ANNOTATIONS,
+    CANCEL_CLOSE_ANNOTATIONS,
+    EDIT_ANNOTATION,
+    CANCEL_EDIT_ANNOTATION,
+    SAVE_ANNOTATION,
+    TOGGLE_ADD,
+    VALIDATION_ERROR,
+    REMOVE_ANNOTATION_GEOMETRY,
+    TOGGLE_STYLE,
+    SET_STYLE,
+    NEW_ANNOTATION,
+    SHOW_ANNOTATION,
+    CANCEL_SHOW_ANNOTATION,
+    FILTER_ANNOTATIONS,
+    UNSAVED_CHANGES,
+    TOGGLE_GEOMETRY_MODAL,
+    TOGGLE_CHANGES_MODAL,
+    CHANGED_PROPERTIES,
+    TOGGLE_STYLE_MODAL,
+    UNSAVED_STYLE,
+    ADD_TEXT,
+    CHANGED_SELECTED,
+    RESET_COORD_EDITOR,
+    CHANGE_RADIUS,
+    CHANGE_TEXT,
+    ADD_NEW_FEATURE,
+    SET_EDITING_FEATURE,
+    SET_INVALID_SELECTED,
+    TOGGLE_DELETE_FT_MODAL,
+    CONFIRM_DELETE_FEATURE,
+    HIGHLIGHT_POINT,
+    CHANGE_FORMAT,
+    UPDATE_SYMBOLS,
+    ERROR_SYMBOLS,
+    SET_DEFAULT_STYLE,
+    LOADING,
+    CHANGE_GEOMETRY_TITLE,
+    FILTER_MARKER,
+    HIDE_MEASURE_WARNING,
+    TOGGLE_SHOW_AGAIN,
+    INIT_PLUGIN
+} from '../actions/annotations';
 
-const {validateCoordsArray, getAvailableStyler, convertGeoJSONToInternalModel, addIds, validateFeature,
-    getComponents, updateAllStyles, getBaseCoord} = require('../utils/AnnotationsUtils');
-const {set} = require('../utils/ImmutableUtils');
-const {head, findIndex, isNil, slice, castArray, get} = require('lodash');
+import {
+    validateCoordsArray,
+    getAvailableStyler,
+    convertGeoJSONToInternalModel,
+    addIds,
+    validateFeature,
+    getComponents,
+    updateAllStyles,
+    getBaseCoord
+} from '../utils/AnnotationsUtils';
 
-const uuid = require('uuid');
+import { set } from '../utils/ImmutableUtils';
+import { head, findIndex, isNil, slice, castArray, get } from 'lodash';
+import uuid from 'uuid';
 
 const fixCoordinates = (coords, type) => {
     switch (type) {
@@ -671,4 +716,4 @@ function annotations(state = {validationErrors: {}}, action) {
     }
 }
 
-module.exports = annotations;
+export default annotations;

--- a/web/client/reducers/backgroundselector.js
+++ b/web/client/reducers/backgroundselector.js
@@ -6,10 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { ADD_BACKGROUND, SET_BACKGROUND_MODAL_PARAMS, UPDATE_BACKGROUND_THUMBNAIL, BACKGROUNDS_CLEAR, ALLOW_BACKGROUNDS_DELETION,
-    REMOVE_BACKGROUND, CREATE_BACKGROUNDS_LIST, CLEAR_MODAL_PARAMETERS, CONFIRM_DELETE_BACKGROUND_MODAL} = require('../actions/backgroundselector');
-const {RESET_CATALOG} = require('../actions/catalog');
-const assign = require('object-assign');
+import {
+    ADD_BACKGROUND,
+    SET_BACKGROUND_MODAL_PARAMS,
+    UPDATE_BACKGROUND_THUMBNAIL,
+    BACKGROUNDS_CLEAR,
+    ALLOW_BACKGROUNDS_DELETION,
+    REMOVE_BACKGROUND,
+    CREATE_BACKGROUNDS_LIST,
+    CLEAR_MODAL_PARAMETERS,
+    CONFIRM_DELETE_BACKGROUND_MODAL
+} from '../actions/backgroundselector';
+
+import { RESET_CATALOG } from '../actions/catalog';
+import assign from 'object-assign';
 
 function backgroundselector(state = null, action) {
     switch (action.type) {
@@ -97,4 +107,4 @@ function backgroundselector(state = null, action) {
     }
 }
 
-module.exports = backgroundselector;
+export default backgroundselector;

--- a/web/client/reducers/browser.js
+++ b/web/client/reducers/browser.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var { CHANGE_BROWSER_PROPERTIES} = require('../actions/browser');
-var assign = require('object-assign');
+import { CHANGE_BROWSER_PROPERTIES } from '../actions/browser';
+
+import assign from 'object-assign';
 
 function browser(state = null, action) {
     switch (action.type) {
@@ -21,4 +22,4 @@ function browser(state = null, action) {
     }
 }
 
-module.exports = browser;
+export default browser;

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     RECORD_LIST_LOADED,
     RECORD_LIST_LOAD_ERROR,
     CHANGE_CATALOG_FORMAT,
@@ -29,15 +29,13 @@ const {
     TOGGLE_THUMBNAIL,
     TOGGLE_TEMPLATE,
     TOGGLE_ADVANCED_SETTINGS
-} = require('../actions/catalog');
-const {
-    MAP_CONFIG_LOADED
-} = require('../actions/config');
-const { set } = require('../utils/ImmutableUtils');
+} from '../actions/catalog';
 
-const {isNil} = require('lodash');
-const assign = require('object-assign');
-const uuid = require('uuid');
+import { MAP_CONFIG_LOADED } from '../actions/config';
+import { set } from '../utils/ImmutableUtils';
+import { isNil } from 'lodash';
+import assign from 'object-assign';
+import uuid from 'uuid';
 
 const emptyService = {
     url: "",
@@ -212,4 +210,4 @@ function catalog(state = {
     }
 }
 
-module.exports = catalog;
+export default catalog;

--- a/web/client/reducers/config.js
+++ b/web/client/reducers/config.js
@@ -6,14 +6,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {MAP_CONFIG_LOADED, MAP_INFO_LOAD_START, MAP_INFO_LOADED, MAP_INFO_LOAD_ERROR, MAP_CONFIG_LOAD_ERROR, MAP_SAVE_ERROR, MAP_SAVED, RESET_MAP_SAVE_ERROR} = require('../actions/config');
-const {MAP_CREATED, DETAILS_LOADED} = require('../actions/maps');
+import {
+    MAP_CONFIG_LOADED,
+    MAP_INFO_LOAD_START,
+    MAP_INFO_LOADED,
+    MAP_INFO_LOAD_ERROR,
+    MAP_CONFIG_LOAD_ERROR,
+    MAP_SAVE_ERROR,
+    MAP_SAVED,
+    RESET_MAP_SAVE_ERROR
+} from '../actions/config';
 
-const assign = require('object-assign');
-const ConfigUtils = require('../utils/ConfigUtils');
-const {set, unset} = require('../utils/ImmutableUtils');
-const {transformLineToArcs} = require('../utils/CoordinatesUtils');
-const {findIndex, castArray} = require('lodash');
+import { MAP_CREATED, DETAILS_LOADED } from '../actions/maps';
+import assign from 'object-assign';
+import ConfigUtils from '../utils/ConfigUtils';
+import { set, unset } from '../utils/ImmutableUtils';
+import { transformLineToArcs } from '../utils/CoordinatesUtils';
+import { findIndex, castArray } from 'lodash';
 
 function mapConfig(state = null, action) {
     let map;
@@ -128,4 +137,4 @@ function mapConfig(state = null, action) {
     }
 }
 
-module.exports = mapConfig;
+export default mapConfig;

--- a/web/client/reducers/contenttabs.js
+++ b/web/client/reducers/contenttabs.js
@@ -6,10 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-    ON_TAB_SELECTED,
-    SET_TABS_HIDDEN
-} = require('../actions/contenttabs');
+import { ON_TAB_SELECTED, SET_TABS_HIDDEN } from '../actions/contenttabs';
 
 function contenttabs(state = {selected: "maps"}, action) {
     switch (action.type) {
@@ -33,4 +30,4 @@ function contenttabs(state = {selected: "maps"}, action) {
     }
 }
 
-module.exports = contenttabs;
+export default contenttabs;

--- a/web/client/reducers/controls.js
+++ b/web/client/reducers/controls.js
@@ -6,8 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SET_CONTROL_PROPERTIES, RESET_CONTROLS} = require('../actions/controls');
-const assign = require('object-assign');
+import {
+    TOGGLE_CONTROL,
+    SET_CONTROL_PROPERTY,
+    SET_CONTROL_PROPERTIES,
+    RESET_CONTROLS
+} from '../actions/controls';
+
+import assign from 'object-assign';
 /**
  * Manages the state of the controls in MapStore2
  * The root elements of the state returned by this reducers ar variable, but they have
@@ -87,4 +93,4 @@ function controls(state = {}, action) {
     }
 }
 
-module.exports = controls;
+export default controls;

--- a/web/client/reducers/cookie.js
+++ b/web/client/reducers/cookie.js
@@ -6,8 +6,13 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const {SET_COOKIE_VISIBILITY, SET_MORE_DETAILS_VISIBILITY, SET_DETAILS_COOKIE_HTML} = require('../actions/cookie');
-const assign = require('object-assign');
+import {
+    SET_COOKIE_VISIBILITY,
+    SET_MORE_DETAILS_VISIBILITY,
+    SET_DETAILS_COOKIE_HTML
+} from '../actions/cookie';
+
+import assign from 'object-assign';
 
 function cookie(state = {
     html: {}
@@ -27,4 +32,4 @@ function cookie(state = {
     }
 }
 
-module.exports = cookie;
+export default cookie;

--- a/web/client/reducers/crsselector.js
+++ b/web/client/reducers/crsselector.js
@@ -1,6 +1,5 @@
-const {CHANGE_CRS_INPUT_VALUE} = require('../actions/crsselector');
-
-const assign = require('object-assign');
+import { CHANGE_CRS_INPUT_VALUE } from '../actions/crsselector';
+import assign from 'object-assign';
 function crsselector(state = {projections: []}, action) {
     switch (action.type) {
     case CHANGE_CRS_INPUT_VALUE:
@@ -12,4 +11,4 @@ function crsselector(state = {projections: []}, action) {
     }
 }
 
-module.exports = crsselector;
+export default crsselector;

--- a/web/client/reducers/dashboard.js
+++ b/web/client/reducers/dashboard.js
@@ -6,10 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { SET_EDITING, SET_EDITOR_AVAILABLE, SHOW_CONNECTIONS, TRIGGER_SAVE_MODAL, TRIGGER_SAVE_AS_MODAL, DASHBOARD_LOADING, DASHBOARD_LOADED, DASHBOARD_SAVED, DASHBOARD_RESET, SAVE_ERROR} = require('../actions/dashboard');
-const {INSERT, UPDATE, DELETE} = require('../actions/widgets');
-const {set} = require('../utils/ImmutableUtils');
-const {castArray} = require('lodash');
+import {
+    SET_EDITING,
+    SET_EDITOR_AVAILABLE,
+    SHOW_CONNECTIONS,
+    TRIGGER_SAVE_MODAL,
+    TRIGGER_SAVE_AS_MODAL,
+    DASHBOARD_LOADING,
+    DASHBOARD_LOADED,
+    DASHBOARD_SAVED,
+    DASHBOARD_RESET,
+    SAVE_ERROR
+} from '../actions/dashboard';
+
+import { INSERT, UPDATE, DELETE } from '../actions/widgets';
+import { set } from '../utils/ImmutableUtils';
+import { castArray } from 'lodash';
 function dashboard(state = {
     showConnections: true
 }, action) {
@@ -52,4 +64,4 @@ function dashboard(state = {
         return state;
     }
 }
-module.exports = dashboard;
+export default dashboard;

--- a/web/client/reducers/dashboards.js
+++ b/web/client/reducers/dashboards.js
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { MAPS_LIST_LOADING } = require('../actions/maps');
-const { LOCATION_CHANGE } = require('connected-react-router');
+import { MAPS_LIST_LOADING } from '../actions/maps';
 
-const { DASHBOARDS_LIST_LOADED, SET_DASHBOARDS_AVAILABLE, LOADING } = require('../actions/dashboards');
-const {set} = require('../utils/ImmutableUtils');
-const { castArray } = require('lodash');
+import { LOCATION_CHANGE } from 'connected-react-router';
+import { DASHBOARDS_LIST_LOADED, SET_DASHBOARDS_AVAILABLE, LOADING } from '../actions/dashboards';
+import { set } from '../utils/ImmutableUtils';
+import { castArray } from 'lodash';
 
 function dashboards(state = {
     enabled: false,
@@ -56,4 +56,4 @@ function dashboards(state = {
     }
 }
 
-module.exports = dashboards;
+export default dashboards;

--- a/web/client/reducers/dimension.js
+++ b/web/client/reducers/dimension.js
@@ -1,9 +1,9 @@
-const { UPDATE_LAYER_DIMENSION_DATA, SET_CURRENT_TIME, SET_OFFSET_TIME, MOVE_TIME } = require('../actions/dimension');
-const { REMOVE_NODE } = require('../actions/layers');
-const { RESET_CONTROLS } = require('../actions/controls');
-const { set } = require('../utils/ImmutableUtils');
-const moment = require('moment');
-const {mapValues, pickBy } = require('lodash');
+import { UPDATE_LAYER_DIMENSION_DATA, SET_CURRENT_TIME, SET_OFFSET_TIME, MOVE_TIME } from '../actions/dimension';
+import { REMOVE_NODE } from '../actions/layers';
+import { RESET_CONTROLS } from '../actions/controls';
+import { set } from '../utils/ImmutableUtils';
+import moment from 'moment';
+import { mapValues, pickBy } from 'lodash';
 
 /**
  * Provide state for current time and dimension info.
@@ -32,7 +32,7 @@ const {mapValues, pickBy } = require('lodash');
  * @param {action} action
  * @example
  */
-module.exports = (state = {}, action) => {
+export default (state = {}, action) => {
     switch (action.type) {
     case UPDATE_LAYER_DIMENSION_DATA: {
         return set(`data[${action.dimension}][${action.layerId}]`, action.data, state);

--- a/web/client/reducers/draw.js
+++ b/web/client/reducers/draw.js
@@ -6,9 +6,14 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const {CHANGE_DRAWING_STATUS, SET_CURRENT_STYLE, GEOMETRY_CHANGED, DRAW_SUPPORT_STOPPED} = require('../actions/draw');
+import {
+    CHANGE_DRAWING_STATUS,
+    SET_CURRENT_STYLE,
+    GEOMETRY_CHANGED,
+    DRAW_SUPPORT_STOPPED
+} from '../actions/draw';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 const initialState = {
     drawStatus: null,
@@ -43,4 +48,4 @@ function draw(state = initialState, action) {
     }
 }
 
-module.exports = draw;
+export default draw;

--- a/web/client/reducers/featuredmaps.js
+++ b/web/client/reducers/featuredmaps.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { MAPS_LIST_LOADING, FEATURED_MAPS_SET_ENABLED, INVALIDATE_FEATURED_MAPS } = require('../actions/maps');
+import { MAPS_LIST_LOADING, FEATURED_MAPS_SET_ENABLED, INVALIDATE_FEATURED_MAPS } from '../actions/maps';
 
-const {set} = require('../utils/ImmutableUtils');
+import { set } from '../utils/ImmutableUtils';
 
 function featuredmaps(state = {}, action) {
     switch (action.type) {
@@ -27,4 +27,4 @@ function featuredmaps(state = {}, action) {
         return state;
     }
 }
-module.exports = featuredmaps;
+export default featuredmaps;

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -5,9 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-const assign = require("object-assign");
-const {head, get} = require("lodash");
-const {
+import assign from 'object-assign';
+
+import { head, get } from 'lodash';
+
+import {
     SELECT_FEATURES,
     DESELECT_FEATURES,
     TOGGLE_FEATURES_SELECTION,
@@ -21,7 +23,8 @@ const {
     CLEAR_CHANGES,
     CHANGE_PAGE,
     DOCK_SIZE_FEATURES,
-    SET_LAYER, TOGGLE_TOOL,
+    SET_LAYER,
+    TOGGLE_TOOL,
     CUSTOMIZE_ATTRIBUTE,
     SET_SELECTION_OPTIONS,
     TOGGLE_MODE,
@@ -42,18 +45,12 @@ const {
     GRID_QUERY_RESULT,
     LOAD_MORE_FEATURES,
     SET_UP,
-    SET_TIME_SYNC,
-    ENABLE_GEOMETRY_FILTER
-} = require('../actions/featuregrid');
-const {
-    FEATURE_TYPE_LOADED,
-    QUERY_CREATE
-} = require('../actions/wfsquery');
-const {
-    CHANGE_DRAWING_STATUS
-} = require('../actions/draw');
+    SET_TIME_SYNC
+} from '../actions/featuregrid';
 
-const uuid = require('uuid');
+import { FEATURE_TYPE_LOADED, QUERY_CREATE } from '../actions/wfsquery';
+import { CHANGE_DRAWING_STATUS } from '../actions/draw';
+import uuid from 'uuid';
 
 const emptyResultsState = {
     advancedFilters: {},
@@ -394,12 +391,9 @@ function featuregrid(state = emptyResultsState, action) {
     case SET_TIME_SYNC: {
         return assign({}, state, {timeSync: action.value});
     }
-    case ENABLE_GEOMETRY_FILTER: {
-        return assign({}, state, {geometryFilterEnabled: action.enable});
-    }
     default:
         return state;
     }
 }
 
-module.exports = featuregrid;
+export default featuregrid;

--- a/web/client/reducers/feedbackMask.js
+++ b/web/client/reducers/feedbackMask.js
@@ -6,7 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {FEEDBACK_MASK_LOADING, FEEDBACK_MASK_LOADED, FEEDBACK_MASK_ENABLED, DETECTED_NEW_PAGE} = require('../actions/feedbackMask');
+import {
+    FEEDBACK_MASK_LOADING,
+    FEEDBACK_MASK_LOADED,
+    FEEDBACK_MASK_ENABLED,
+    DETECTED_NEW_PAGE
+} from '../actions/feedbackMask';
 
 function feedbackMask(state = {}, action) {
     switch (action.type) {
@@ -32,4 +37,4 @@ function feedbackMask(state = {}, action) {
     }
 }
 
-module.exports = feedbackMask;
+export default feedbackMask;

--- a/web/client/reducers/floatinglegend.js
+++ b/web/client/reducers/floatinglegend.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { RESIZE_LEGEND, EXPAND_LEGEND } = require('../actions/floatinglegend');
+import { RESIZE_LEGEND, EXPAND_LEGEND } from '../actions/floatinglegend';
 
-const {set} = require('../utils/ImmutableUtils');
+import { set } from '../utils/ImmutableUtils';
 /**
  * Manages the state of the floatinglegend
  * The properties represent the shape of the state
@@ -31,4 +31,4 @@ function floatinglegend(state = {}, action) {
         return state;
     }
 }
-module.exports = floatinglegend;
+export default floatinglegend;

--- a/web/client/reducers/geostories.js
+++ b/web/client/reducers/geostories.js
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { MAPS_LIST_LOADING } = require('../actions/maps');
-const { LOCATION_CHANGE } = require('connected-react-router');
+import { MAPS_LIST_LOADING } from '../actions/maps';
 
-const { GEOSTORIES_LIST_LOADED, SET_GEOSTORIES_AVAILABLE, LOADING } = require('../actions/geostories');
-const {set} = require('../utils/ImmutableUtils');
-const { castArray } = require('lodash');
+import { LOCATION_CHANGE } from 'connected-react-router';
+import { GEOSTORIES_LIST_LOADED, SET_GEOSTORIES_AVAILABLE, LOADING } from '../actions/geostories';
+import { set } from '../utils/ImmutableUtils';
+import { castArray } from 'lodash';
 
 function geostories(state = {
     enabled: false,
@@ -56,4 +56,4 @@ function geostories(state = {
     }
 }
 
-module.exports = geostories;
+export default geostories;

--- a/web/client/reducers/globeswitcher.js
+++ b/web/client/reducers/globeswitcher.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {MAP_TYPE_CHANGED} = require('../actions/maptype');
-const {UPDATE_LAST_2D_MAPTYPE} = require('../actions/globeswitcher');
+import { MAP_TYPE_CHANGED } from '../actions/maptype';
+
+import { UPDATE_LAST_2D_MAPTYPE } from '../actions/globeswitcher';
 /**
  * state for globeswitcher tooltip. holds the last 2d mapType.
  * @memberof reducers
@@ -32,4 +33,4 @@ function globeswitcher(state = {last2dMapType: "leaflet"}, action) {
     }
 }
 
-module.exports = globeswitcher;
+export default globeswitcher;

--- a/web/client/reducers/help.js
+++ b/web/client/reducers/help.js
@@ -6,13 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {
-    CHANGE_HELP_STATE,
-    CHANGE_HELP_TEXT,
-    CHANGE_HELPWIN_VIZ
-} = require('../actions/help');
+import { CHANGE_HELP_STATE, CHANGE_HELP_TEXT, CHANGE_HELPWIN_VIZ } from '../actions/help';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 function help(state = null, action) {
     switch (action.type) {
@@ -35,4 +31,4 @@ function help(state = null, action) {
     }
 }
 
-module.exports = help;
+export default help;

--- a/web/client/reducers/highlight.js
+++ b/web/client/reducers/highlight.js
@@ -6,13 +6,9 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const {
-    HIGHLIGHT_STATUS,
-    UPDATE_HIGHLIGHTED,
-    SET_HIGHLIGHT_FEATURES_PATH
-} = require('../actions/highlight');
+import { HIGHLIGHT_STATUS, UPDATE_HIGHLIGHTED, SET_HIGHLIGHT_FEATURES_PATH } from '../actions/highlight';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 const initialState = {
     status: 'disabled',
@@ -41,4 +37,4 @@ function highlight(state = initialState, action) {
     }
 }
 
-module.exports = highlight;
+export default highlight;

--- a/web/client/reducers/importer.js
+++ b/web/client/reducers/importer.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     IMPORTS_LOADING,
     IMPORTS_LIST_LOADED,
     IMPORTS_LIST_LOAD_ERROR,
@@ -34,14 +34,11 @@ const {
     IMPORTER_WORKSPACE_CREATED,
     IMPORTER_WORKSPACE_CREATION_ERROR,
     IMPORTER_WORKSPACE_STATUS_CHANGE
-} = require('../actions/importer');
+} from '../actions/importer';
 
-const {
-    MANAGER_ITEM_SELECTED
-} = require('../actions/manager');
-
-const assign = require('object-assign');
-const {head, findIndex} = require('lodash');
+import { MANAGER_ITEM_SELECTED } from '../actions/manager';
+import assign from 'object-assign';
+import { head, findIndex } from 'lodash';
 
 // constant used to reset the state only if the importer tool is passed to the reducer
 // see case: MANAGER_ITEM_SELECTED
@@ -408,4 +405,4 @@ function importer(state = {}, action) {
     }
 }
 
-module.exports = importer;
+export default importer;

--- a/web/client/reducers/layerFilter.js
+++ b/web/client/reducers/layerFilter.js
@@ -7,8 +7,14 @@
 */
 
 
-const { APPLIED_FILTER, STORE_CURRENT_APPLIED_FILTER, INIT_LAYER_FILTER, DISCARD_CURRENT_FILTER} = require("../actions/layerFilter");
-const { QUERY_FORM_RESET} = require('../actions/queryform');
+import {
+    APPLIED_FILTER,
+    STORE_CURRENT_APPLIED_FILTER,
+    INIT_LAYER_FILTER,
+    DISCARD_CURRENT_FILTER
+} from '../actions/layerFilter';
+
+import { QUERY_FORM_RESET } from '../actions/queryform';
 const initialState = {};
 
 function layerFilter(state = initialState, action) {
@@ -33,4 +39,4 @@ function layerFilter(state = initialState, action) {
     }
 }
 
-module.exports = layerFilter;
+export default layerFilter;

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -6,18 +6,39 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var { LAYER_LOADING, LAYER_LOAD, LAYER_ERROR, CHANGE_LAYER_PARAMS, CHANGE_LAYER_PROPERTIES, CHANGE_GROUP_PROPERTIES,
-    TOGGLE_NODE, SORT_NODE, REMOVE_NODE, UPDATE_NODE, MOVE_NODE, ADD_LAYER, REMOVE_LAYER, ADD_GROUP,
-    SHOW_SETTINGS, HIDE_SETTINGS, UPDATE_SETTINGS, REFRESH_LAYERS, LAYERS_REFRESH_ERROR, LAYERS_REFRESHED, CLEAR_LAYERS, SELECT_NODE, FILTER_LAYERS, SHOW_LAYER_METADATA, HIDE_LAYER_METADATA
-} = require('../actions/layers');
+import {
+    LAYER_LOADING,
+    LAYER_LOAD,
+    LAYER_ERROR,
+    CHANGE_LAYER_PARAMS,
+    CHANGE_LAYER_PROPERTIES,
+    CHANGE_GROUP_PROPERTIES,
+    TOGGLE_NODE,
+    SORT_NODE,
+    REMOVE_NODE,
+    UPDATE_NODE,
+    MOVE_NODE,
+    ADD_LAYER,
+    REMOVE_LAYER,
+    ADD_GROUP,
+    SHOW_SETTINGS,
+    HIDE_SETTINGS,
+    UPDATE_SETTINGS,
+    REFRESH_LAYERS,
+    LAYERS_REFRESH_ERROR,
+    LAYERS_REFRESHED,
+    CLEAR_LAYERS,
+    SELECT_NODE,
+    FILTER_LAYERS,
+    SHOW_LAYER_METADATA,
+    HIDE_LAYER_METADATA
+} from '../actions/layers';
 
-const {TOGGLE_CONTROL} = require('../actions/controls');
-
-var assign = require('object-assign');
-const uuidv1 = require('uuid/v1');
-var {isObject, isArray, head, isString, includes, castArray} = require('lodash');
-
-const LayersUtils = require('../utils/LayersUtils');
+import { TOGGLE_CONTROL } from '../actions/controls';
+import assign from 'object-assign';
+import uuidv1 from 'uuid/v1';
+import { isObject, isArray, head, isString, includes, castArray } from 'lodash';
+import LayersUtils from '../utils/LayersUtils';
 
 /**
 Removes a group even if it is nested
@@ -482,4 +503,4 @@ function layers(state = { flat: [] }, action) {
     }
 }
 
-module.exports = layers;
+export default layers;

--- a/web/client/reducers/localConfig.js
+++ b/web/client/reducers/localConfig.js
@@ -6,10 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {LOCAL_CONFIG_LOADED} = require('../actions/localConfig');
+import { LOCAL_CONFIG_LOADED } from '../actions/localConfig';
 
-const assign = require('object-assign');
-const ConfigUtils = require('../utils/ConfigUtils');
+import assign from 'object-assign';
+import ConfigUtils from '../utils/ConfigUtils';
 const initialState = ConfigUtils.getDefaults();
 function controls(state = initialState, action) {
     switch (action.type) {
@@ -20,4 +20,4 @@ function controls(state = initialState, action) {
     }
 }
 
-module.exports = controls;
+export default controls;

--- a/web/client/reducers/locale.js
+++ b/web/client/reducers/locale.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {CHANGE_LOCALE, LOCALE_LOAD_ERROR} = require('../actions/locale');
+import { CHANGE_LOCALE, LOCALE_LOAD_ERROR } from '../actions/locale';
 
 function locale(state = null, action) {
     switch (action.type) {
@@ -25,4 +25,4 @@ function locale(state = null, action) {
     }
 }
 
-module.exports = locale;
+export default locale;

--- a/web/client/reducers/locate.js
+++ b/web/client/reducers/locate.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {CHANGE_LOCATE_STATE, LOCATE_ERROR} = require('../actions/locate');
+import { CHANGE_LOCATE_STATE, LOCATE_ERROR } from '../actions/locate';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 function locate(state = {state: "DISABLED"}, action) {
     switch (action.type) {
@@ -26,4 +26,4 @@ function locate(state = {state: "DISABLED"}, action) {
 
 }
 
-module.exports = locate;
+export default locate;

--- a/web/client/reducers/map.js
+++ b/web/client/reducers/map.js
@@ -6,15 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {CHANGE_MAP_VIEW, CHANGE_MOUSE_POINTER,
-    CHANGE_ZOOM_LVL, CHANGE_MAP_CRS, CHANGE_MAP_SCALES, PAN_TO,
-    CHANGE_MAP_STYLE, CHANGE_ROTATION, UPDATE_VERSION, ZOOM_TO_POINT,
-    RESIZE_MAP, CHANGE_MAP_LIMITS, SET_MAP_RESOLUTIONS,
-    TOGGLE_UNSAVED_MAP_CHANGES_DIALOG, REGISTER_EVENT_LISTENER, UNREGISTER_EVENT_LISTENER} = require('../actions/map');
+import {
+    CHANGE_MAP_VIEW,
+    CHANGE_MOUSE_POINTER,
+    CHANGE_ZOOM_LVL,
+    CHANGE_MAP_CRS,
+    CHANGE_MAP_SCALES,
+    PAN_TO,
+    CHANGE_MAP_STYLE,
+    CHANGE_ROTATION,
+    UPDATE_VERSION,
+    ZOOM_TO_POINT,
+    RESIZE_MAP,
+    CHANGE_MAP_LIMITS,
+    SET_MAP_RESOLUTIONS,
+    REGISTER_EVENT_LISTENER,
+    UNREGISTER_EVENT_LISTENER
+} from '../actions/map';
 
-var assign = require('object-assign');
-var MapUtils = require('../utils/MapUtils');
-var CoordinatesUtils = require('../utils/CoordinatesUtils');
+import assign from 'object-assign';
+import MapUtils from '../utils/MapUtils';
+import CoordinatesUtils from '../utils/CoordinatesUtils';
 
 function mapConfig(state = {eventListeners: {}}, action) {
     switch (action.type) {
@@ -110,9 +122,6 @@ function mapConfig(state = {eventListeners: {}}, action) {
     case UPDATE_VERSION: {
         return assign({}, state, {version: action.version});
     }
-    case TOGGLE_UNSAVED_MAP_CHANGES_DIALOG: {
-        return assign({}, state, { showUnsavedMapChangesDialog: !(state && state.showUnsavedMapChangesDialog) });
-    }
     case REGISTER_EVENT_LISTENER: {
         return assign({}, state,
             {eventListeners: assign({}, state.eventListeners || {},
@@ -133,4 +142,4 @@ function mapConfig(state = {eventListeners: {}}, action) {
     }
 }
 
-module.exports = mapConfig;
+export default mapConfig;

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     ERROR_FEATURE_INFO,
     EXCEPTIONS_FEATURE_INFO,
     LOAD_FEATURE_INFO,
@@ -31,15 +31,13 @@ const {
     TOGGLE_SHOW_COORD_EDITOR,
     SET_CURRENT_EDIT_FEATURE_QUERY,
     SET_MAP_TRIGGER
-} = require('../actions/mapInfo');
-const {
-    MAP_CONFIG_LOADED
-} = require('../actions/config');
-const {RESET_CONTROLS} = require('../actions/controls');
+} from '../actions/mapInfo';
 
-const assign = require('object-assign');
-const {findIndex, isUndefined, isEmpty} = require('lodash');
-const {getValidator} = require('../utils/MapInfoUtils');
+import { MAP_CONFIG_LOADED } from '../actions/config';
+import { RESET_CONTROLS } from '../actions/controls';
+import assign from 'object-assign';
+import { findIndex, isUndefined, isEmpty } from 'lodash';
+import { getValidator } from '../utils/MapInfoUtils';
 
 /**
  * Identifies when to update a index when the display information trigger is click (GFI panel)
@@ -455,4 +453,4 @@ function mapInfo(state = initState, action) {
     }
 }
 
-module.exports = mapInfo;
+export default mapInfo;

--- a/web/client/reducers/mapimport.js
+++ b/web/client/reducers/mapimport.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     SET_LAYERS,
     ON_ERROR,
     ON_SELECT_LAYER,
@@ -16,11 +16,11 @@ const {
     ON_SUCCESS,
     ON_SHAPE_ERROR,
     ON_LAYER_SKIPPED
-} = require('../actions/mapimport');
-const {uniqWith} = require('lodash');
-const {TOGGLE_CONTROL} = require('../actions/controls');
+} from '../actions/mapimport';
 
-const assign = require('object-assign');
+import { uniqWith } from 'lodash';
+import { TOGGLE_CONTROL } from '../actions/controls';
+import assign from 'object-assign';
 
 const initialState = {
     layers: null,
@@ -87,4 +87,4 @@ function mapimport(state = initialState, action) {
     }
 }
 
-module.exports = mapimport;
+export default mapimport;

--- a/web/client/reducers/maplayout.js
+++ b/web/client/reducers/maplayout.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {UPDATE_MAP_LAYOUT} = require('../actions/maplayout');
-const assign = require('object-assign');
+import { UPDATE_MAP_LAYOUT } from '../actions/maplayout';
+
+import assign from 'object-assign';
 
 function mapLayout(state = { layout: {}, boundingMapRect: {} }, action) {
     switch (action.type) {
@@ -20,4 +21,4 @@ function mapLayout(state = { layout: {}, boundingMapRect: {} }, action) {
     }
 }
 
-module.exports = mapLayout;
+export default mapLayout;

--- a/web/client/reducers/maps.js
+++ b/web/client/reducers/maps.js
@@ -6,14 +6,29 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-    MAPS_LIST_LOADED, MAPS_LIST_LOADING, MAPS_LIST_LOAD_ERROR, MAP_CREATED, MAP_ERROR, MAP_UPDATING,
-    MAP_DELETING, ATTRIBUTE_UPDATED, PERMISSIONS_LIST_LOADING,
-    THUMBNAIL_ERROR, UPDATE_DETAILS,
-    MAPS_SEARCH_TEXT_CHANGED, SEARCH_FILTER_CHANGED, SET_SEARCH_FILTER, SET_CONTEXTS, LOADING, METADATA_CHANGED,
-    SHOW_DETAILS} = require('../actions/maps');
-const assign = require('object-assign');
-const {isNil} = require('lodash');
+import {
+    MAPS_LIST_LOADED,
+    MAPS_LIST_LOADING,
+    MAPS_LIST_LOAD_ERROR,
+    MAP_CREATED,
+    MAP_ERROR,
+    MAP_UPDATING,
+    MAP_DELETING,
+    ATTRIBUTE_UPDATED,
+    PERMISSIONS_LIST_LOADING,
+    THUMBNAIL_ERROR,
+    UPDATE_DETAILS,
+    MAPS_SEARCH_TEXT_CHANGED,
+    SEARCH_FILTER_CHANGED,
+    SET_SEARCH_FILTER,
+    SET_CONTEXTS,
+    LOADING,
+    METADATA_CHANGED,
+    SHOW_DETAILS
+} from '../actions/maps';
+
+import assign from 'object-assign';
+import { isNil } from 'lodash';
 /**
  * Manages the state of the maps list search with it's results
  * The properties represent the shape of the state
@@ -196,4 +211,4 @@ function maps(state = {
     }
 }
 
-module.exports = maps;
+export default maps;

--- a/web/client/reducers/maptype.js
+++ b/web/client/reducers/maptype.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {MAP_TYPE_CHANGED} = require('../actions/maptype');
+import { MAP_TYPE_CHANGED } from '../actions/maptype';
+
 /**
  * stores state for the mapType to use (typically one of leaflet, openlayers, cesium... )
  * @memberof reducers
@@ -27,4 +28,4 @@ function maptype(state = {mapType: "leaflet"}, action) {
     }
 }
 
-module.exports = maptype;
+export default maptype;

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const {
+import {
     CHANGE_MEASUREMENT_TOOL,
     CHANGE_MEASUREMENT_STATE,
     CHANGE_UOM,
@@ -20,14 +20,14 @@ const {
     INIT,
     SET_MEASUREMENT_CONFIG,
     SET_ANNOTATION_MEASUREMENT
-} = require('../actions/measurement');
-const {TOGGLE_CONTROL, RESET_CONTROLS, SET_CONTROL_PROPERTY} = require('../actions/controls');
-const {set} = require('../utils/ImmutableUtils');
-const {getGeomTypeSelected} = require('../utils/MeasurementUtils');
-const {isPolygon} = require('../utils/openlayers/DrawUtils');
-const {dropRight, isEmpty, findIndex, isNumber} = require('lodash');
+} from '../actions/measurement';
 
-const assign = require('object-assign');
+import { TOGGLE_CONTROL, RESET_CONTROLS, SET_CONTROL_PROPERTY } from '../actions/controls';
+import { set } from '../utils/ImmutableUtils';
+import { getGeomTypeSelected } from '../utils/MeasurementUtils';
+import { isPolygon } from '../utils/openlayers/DrawUtils';
+import { dropRight, isEmpty, findIndex, isNumber } from 'lodash';
+import assign from 'object-assign';
 const defaultState = {
     lineMeasureEnabled: true,
     geomType: "LineString",
@@ -284,4 +284,4 @@ function measurement(state = defaultState, action) {
     }
 }
 
-module.exports = measurement;
+export default measurement;

--- a/web/client/reducers/mousePosition.js
+++ b/web/client/reducers/mousePosition.js
@@ -6,18 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {
+import {
     CHANGE_MOUSE_POSITION,
     CHANGE_MOUSE_POSITION_CRS,
     CHANGE_MOUSE_POSITION_STATE
-} = require('../actions/mousePosition');
+} from '../actions/mousePosition';
 
-const {
-    MOUSE_MOVE,
-    MOUSE_OUT
-} = require('../actions/map');
-
-const assign = require('object-assign');
+import { MOUSE_MOVE, MOUSE_OUT } from '../actions/map';
+import assign from 'object-assign';
 
 function mousePosition(state = {enabled: true, position: null, crs: null}, action) {
     switch (action.type) {
@@ -44,4 +40,4 @@ function mousePosition(state = {enabled: true, position: null, crs: null}, actio
     }
 }
 
-module.exports = mousePosition;
+export default mousePosition;

--- a/web/client/reducers/notifications.js
+++ b/web/client/reducers/notifications.js
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {SHOW_NOTIFICATION, HIDE_NOTIFICATION, CLEAR_NOTIFICATIONS} = require('../actions/notifications');
+import { SHOW_NOTIFICATION, HIDE_NOTIFICATION, CLEAR_NOTIFICATIONS } from '../actions/notifications';
+
 /**
  * Manages the notifications.
  * @memberof reducers
@@ -41,4 +42,4 @@ function notifications(state = [], action = {}) {
         return state;
     }
 }
-module.exports = notifications;
+export default notifications;

--- a/web/client/reducers/playback.js
+++ b/web/client/reducers/playback.js
@@ -1,6 +1,19 @@
-const { PLAY, PAUSE, STOP, STATUS, SET_FRAMES, APPEND_FRAMES, FRAMES_LOADING, SET_CURRENT_FRAME, SELECT_PLAYBACK_RANGE, CHANGE_SETTING, UPDATE_METADATA } = require('../actions/playback');
-const { RESET_CONTROLS } = require('../actions/controls');
-const { set } = require('../utils/ImmutableUtils');
+import {
+    PLAY,
+    PAUSE,
+    STOP,
+    STATUS,
+    SET_FRAMES,
+    APPEND_FRAMES,
+    FRAMES_LOADING,
+    SET_CURRENT_FRAME,
+    SELECT_PLAYBACK_RANGE,
+    CHANGE_SETTING,
+    UPDATE_METADATA
+} from '../actions/playback';
+
+import { RESET_CONTROLS } from '../actions/controls';
+import { set } from '../utils/ImmutableUtils';
 
 const DEFAULT_SETTINGS = {
     timeStep: 1,
@@ -9,7 +22,7 @@ const DEFAULT_SETTINGS = {
     following: true
 };
 
-module.exports = (state = { status: STATUS.STOP, currentFrame: -1, settings: DEFAULT_SETTINGS}, action) => {
+export default (state = { status: STATUS.STOP, currentFrame: -1, settings: DEFAULT_SETTINGS}, action) => {
     switch (action.type) {
     case PLAY: {
         return set(`status`, STATUS.PLAY, state);

--- a/web/client/reducers/print.js
+++ b/web/client/reducers/print.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     SET_PRINT_PARAMETER,
     PRINT_CAPABILITIES_LOADED,
     PRINT_CAPABILITIES_ERROR,
@@ -17,12 +17,11 @@ const {
     PRINT_CREATED,
     PRINT_ERROR,
     PRINT_CANCEL
-} = require('../actions/print');
+} from '../actions/print';
 
-const {TOGGLE_CONTROL} = require('../actions/controls');
-const {isObject, get} = require('lodash');
-
-const assign = require('object-assign');
+import { TOGGLE_CONTROL } from '../actions/controls';
+import { isObject, get } from 'lodash';
+import assign from 'object-assign';
 
 const initialSpec = {
     antiAliasing: true,
@@ -132,4 +131,4 @@ function print(state = {spec: initialSpec, capabilities: null, map: null, isLoad
     }
 }
 
-module.exports = print;
+export default print;

--- a/web/client/reducers/query.js
+++ b/web/client/reducers/query.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     FEATURE_TYPE_SELECTED,
     FEATURE_TYPE_LOADED,
     FEATURE_TYPE_ERROR,
@@ -20,12 +20,11 @@ const {
     UPDATE_QUERY,
     TOGGLE_SYNC_WMS,
     TOGGLE_LAYER_FILTER
-} = require('../actions/wfsquery');
+} from '../actions/wfsquery';
 
-const {QUERY_FORM_RESET} = require('../actions/queryform');
-const {RESET_CONTROLS} = require('../actions/controls');
-
-const assign = require('object-assign');
+import { QUERY_FORM_RESET } from '../actions/queryform';
+import { RESET_CONTROLS } from '../actions/controls';
+import assign from 'object-assign';
 
 const extractData = (feature) => {
     return ['STATE_NAME', 'STATE_ABBR', 'SUB_REGION', 'STATE_FIPS' ].map((attribute) => ({
@@ -144,4 +143,4 @@ function query(state = initialState, action) {
     }
 }
 
-module.exports = query;
+export default query;

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     ADD_FILTER_FIELD,
     REMOVE_FILTER_FIELD,
     UPDATE_FILTER_FIELD,
@@ -31,7 +31,6 @@ const {
     ZONE_FILTER,
     ZONE_SEARCH,
     UPDATE_GEOMETRY,
-    // OPEN_MENU,
     ZONE_CHANGE,
     ZONES_RESET,
     ZONE_SEARCH_ERROR,
@@ -48,19 +47,14 @@ const {
     SET_AUTOCOMPLETE_MODE,
     TOGGLE_AUTOCOMPLETE_MENU,
     LOAD_FILTER
-} = require('../actions/queryform');
+} from '../actions/queryform';
 
-const {
-    END_DRAWING,
-    CHANGE_DRAWING_STATUS
-} = require('../actions/draw');
-
-const assign = require('object-assign');
-
-const union = require('turf-union');
-const bbox = require('turf-bbox');
-const {get} = require('lodash');
-const {set, arrayUpsert, arrayDelete} = require('../utils/ImmutableUtils');
+import { END_DRAWING, CHANGE_DRAWING_STATUS } from '../actions/draw';
+import assign from 'object-assign';
+import union from 'turf-union';
+import bbox from 'turf-bbox';
+import { get } from 'lodash';
+import { set, arrayUpsert, arrayDelete } from '../utils/ImmutableUtils';
 
 const initialState = {
     searchUrl: null,
@@ -510,4 +504,4 @@ function queryform(state = initialState, action) {
     }
 }
 
-module.exports = queryform;
+export default queryform;

--- a/web/client/reducers/rasterstyler.js
+++ b/web/client/reducers/rasterstyler.js
@@ -6,14 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-    SET_RASTERSTYLE_PARAMETER,
-    SET_RASTER_LAYER
-} = require('../actions/rasterstyler');
+import { SET_RASTERSTYLE_PARAMETER, SET_RASTER_LAYER } from '../actions/rasterstyler';
 
-
-const assign = require('object-assign');
-const { STYLER_RESET } = require('../actions/styler');
+import assign from 'object-assign';
+import { STYLER_RESET } from '../actions/styler';
 
 const initialSpec = {
     pseudoband: {band: '1', contrast: 'none', algorithm: "none", gammaValue: 1, min: 1, max: 255},
@@ -66,4 +62,4 @@ function rasterstyler(state = initialSpec, action) {
     }
 }
 
-module.exports = rasterstyler;
+export default rasterstyler;

--- a/web/client/reducers/rulesmanager.js
+++ b/web/client/reducers/rulesmanager.js
@@ -6,17 +6,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const assign = require('object-assign');
-const wk = require('wellknown');
-const {isEmpty} = require("lodash");
+import assign from 'object-assign';
 
-const { RULES_SELECTED, OPTIONS_LOADED, UPDATE_FILTERS_VALUES,
-    LOADING, EDIT_RULE, SET_FILTER, CLEAN_EDITING, RULE_SAVED} = require('../actions/rulesmanager');
-const {
-    CHANGE_DRAWING_STATUS
-} = require('../actions/draw');
+import wk from 'wellknown';
+import { isEmpty, head, value, uniq, concat } from 'lodash';
 
-const _ = require('lodash');
+import {
+    RULES_SELECTED,
+    OPTIONS_LOADED,
+    UPDATE_FILTERS_VALUES,
+    LOADING,
+    EDIT_RULE,
+    SET_FILTER,
+    CLEAN_EDITING,
+    RULE_SAVED
+} from '../actions/rulesmanager';
+
+import { CHANGE_DRAWING_STATUS } from '../actions/draw';
 const defaultState = {
     services: {
         WFS: [
@@ -75,12 +81,12 @@ function rulesmanager(state = defaultState, action) {
         const existingRules = state.selectedRules || [];
         if (action.unselect) {
             return assign({}, state, {
-                selectedRules: _(existingRules).filter(
-                    rule => !_.head(newRules.filter(unselected => unselected.id === rule.id))).value()
+                selectedRules: value(existingRules.filter(
+                    rule => !head(newRules.filter(unselected => unselected.id === rule.id))))
             });
         }
         return assign({}, state, {
-            selectedRules: _(existingRules).concat(newRules).uniq(rule => rule.id).value()});
+            selectedRules: value(uniq(concat(existingRules, newRules), rule => rule.id))});
     }
     case UPDATE_FILTERS_VALUES: {
         const filtersValues = state.filtersValues || {};
@@ -100,9 +106,9 @@ function rulesmanager(state = defaultState, action) {
     case LOADING:
         return assign({}, state, {loading: action.loading});
     case SET_FILTER: {
-        const {key, value} = action;
-        if (value) {
-            return assign({}, state, {filters: {...state.filters, [key]: value}});
+        const {key, val} = action;
+        if (val) {
+            return assign({}, state, {filters: {...state.filters, [key]: val}});
         }
         const {[key]: omit, ...newFilters} = state.filters;
         return assign({}, state, {filters: newFilters});
@@ -146,4 +152,4 @@ function rulesmanager(state = defaultState, action) {
     }
 }
 
-module.exports = rulesmanager;
+export default rulesmanager;

--- a/web/client/reducers/rulesmanager.js
+++ b/web/client/reducers/rulesmanager.js
@@ -9,7 +9,7 @@
 import assign from 'object-assign';
 
 import wk from 'wellknown';
-import { isEmpty, head, value, uniq, concat } from 'lodash';
+import { isEmpty, head, uniq, concat } from 'lodash';
 
 import {
     RULES_SELECTED,
@@ -81,12 +81,11 @@ function rulesmanager(state = defaultState, action) {
         const existingRules = state.selectedRules || [];
         if (action.unselect) {
             return assign({}, state, {
-                selectedRules: value(existingRules.filter(
-                    rule => !head(newRules.filter(unselected => unselected.id === rule.id))))
+                selectedRules: existingRules.filter(
+                    rule => !head(newRules.filter(unselected => unselected.id === rule.id)))
             });
         }
-        return assign({}, state, {
-            selectedRules: value(uniq(concat(existingRules, newRules), rule => rule.id))});
+        return assign({}, state, { selectedRules: uniq(concat(existingRules, newRules), rule => rule.id)});
     }
     case UPDATE_FILTERS_VALUES: {
         const filtersValues = state.filtersValues || {};
@@ -106,9 +105,9 @@ function rulesmanager(state = defaultState, action) {
     case LOADING:
         return assign({}, state, {loading: action.loading});
     case SET_FILTER: {
-        const {key, val} = action;
-        if (val) {
-            return assign({}, state, {filters: {...state.filters, [key]: val}});
+        const {key, value} = action;
+        if (value) {
+            return assign({}, state, {filters: {...state.filters, [key]: value}});
         }
         const {[key]: omit, ...newFilters} = state.filters;
         return assign({}, state, {filters: newFilters});

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     TEXT_SEARCH_RESULTS_LOADED,
     TEXT_SEARCH_RESULTS_PURGE,
     TEXT_SEARCH_RESET,
@@ -21,10 +21,10 @@ const {
     CHANGE_SEARCH_TOOL,
     CHANGE_FORMAT,
     CHANGE_COORD
-} = require('../actions/search');
-const {RESET_CONTROLS} = require('../actions/controls');
+} from '../actions/search';
 
-const assign = require('object-assign');
+import { RESET_CONTROLS } from '../actions/controls';
+import assign from 'object-assign';
 /**
  * Manages the state of the map search with it's results
  * The properties represent the shape of the state
@@ -135,4 +135,4 @@ function search(state = null, action) {
     }
 }
 
-module.exports = search;
+export default search;

--- a/web/client/reducers/searchconfig.js
+++ b/web/client/reducers/searchconfig.js
@@ -5,12 +5,11 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-var {
-    SET_SEARCH_CONFIG_PROP, RESET_SEARCH_CONFIG,
-    UPDATE_SERVICE} = require('../actions/searchconfig');
-var {RESET_CONTROLS} = require('../actions/controls');
-var {MAP_CONFIG_LOADED} = require('../actions/config');
-const assign = require('object-assign');
+import { SET_SEARCH_CONFIG_PROP, RESET_SEARCH_CONFIG, UPDATE_SERVICE } from '../actions/searchconfig';
+
+import { RESET_CONTROLS } from '../actions/controls';
+import { MAP_CONFIG_LOADED } from '../actions/config';
+import assign from 'object-assign';
 
 function searchconfig(state = null, action) {
     switch (action.type) {
@@ -42,4 +41,4 @@ function searchconfig(state = null, action) {
     }
 }
 
-module.exports = searchconfig;
+export default searchconfig;

--- a/web/client/reducers/security.js
+++ b/web/client/reducers/security.js
@@ -6,14 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { LOGIN_SUCCESS, LOGIN_FAIL, LOGOUT, CHANGE_PASSWORD_SUCCESS, CHANGE_PASSWORD_FAIL, RESET_ERROR, REFRESH_SUCCESS, SESSION_VALID } = require('../actions/security');
-const { SET_CONTROL_PROPERTY } = require('../actions/controls');
-const { USERMANAGER_UPDATE_USER } = require('../actions/users');
+import {
+    LOGIN_SUCCESS,
+    LOGIN_FAIL,
+    LOGOUT,
+    CHANGE_PASSWORD_SUCCESS,
+    CHANGE_PASSWORD_FAIL,
+    RESET_ERROR,
+    REFRESH_SUCCESS,
+    SESSION_VALID
+} from '../actions/security';
 
-const SecurityUtils = require('../utils/SecurityUtils');
-
-const assign = require('object-assign');
-const {cloneDeep, head} = require('lodash');
+import { SET_CONTROL_PROPERTY } from '../actions/controls';
+import { USERMANAGER_UPDATE_USER } from '../actions/users';
+import SecurityUtils from '../utils/SecurityUtils';
+import assign from 'object-assign';
+import { cloneDeep, head } from 'lodash';
 
 function security(state = {user: null, errorCause: null}, action) {
     switch (action.type) {
@@ -96,4 +104,4 @@ function security(state = {user: null, errorCause: null}, action) {
     }
 }
 
-module.exports = security;
+export default security;

--- a/web/client/reducers/selection.js
+++ b/web/client/reducers/selection.js
@@ -6,11 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {
-    CHANGE_SELECTION_STATE
-} = require('../actions/selection');
+import { CHANGE_SELECTION_STATE } from '../actions/selection';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 function selection(state = {
     geomType: null
@@ -28,4 +26,4 @@ function selection(state = {
     }
 }
 
-module.exports = selection;
+export default selection;

--- a/web/client/reducers/snapshot.js
+++ b/web/client/reducers/snapshot.js
@@ -6,9 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var {CHANGE_SNAPSHOT_STATE, SNAPSHOT_ERROR, SNAPSHOT_READY, SNAPSHOT_ADD_QUEUE, SNAPSHOT_REMOVE_QUEUE} = require('../actions/snapshot');
+import {
+    CHANGE_SNAPSHOT_STATE,
+    SNAPSHOT_ERROR,
+    SNAPSHOT_READY,
+    SNAPSHOT_ADD_QUEUE,
+    SNAPSHOT_REMOVE_QUEUE
+} from '../actions/snapshot';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 function snapshot(state = null, action) {
     switch (action.type) {
@@ -59,4 +65,4 @@ function snapshot(state = null, action) {
 
 }
 
-module.exports = snapshot;
+export default snapshot;

--- a/web/client/reducers/style.js
+++ b/web/client/reducers/style.js
@@ -6,11 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-    SET_STYLE_PARAMETER
-} = require('../actions/style');
+import { SET_STYLE_PARAMETER } from '../actions/style';
 
-const assign = require('object-assign');
+import assign from 'object-assign';
 
 const initialSpec = {
     color: { r: 0, g: 0, b: 255, a: 1 },
@@ -30,4 +28,4 @@ function style(state = initialSpec, action) {
     }
 }
 
-module.exports = style;
+export default style;

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     UPDATE_TEMPORARY_STYLE,
     UPDATE_STATUS,
     ERROR_STYLE,
@@ -17,9 +17,9 @@ const {
     INIT_STYLE_SERVICE,
     SET_EDIT_PERMISSION,
     UPDATE_EDITOR_METADATA
-} = require('../actions/styleeditor');
+} from '../actions/styleeditor';
 
-const isString = require('lodash/isString');
+import isString from 'lodash/isString';
 
 function styleeditor(state = {}, action) {
     switch (action.type) {
@@ -129,4 +129,4 @@ function styleeditor(state = {}, action) {
     }
 }
 
-module.exports = styleeditor;
+export default styleeditor;

--- a/web/client/reducers/styler.js
+++ b/web/client/reducers/styler.js
@@ -6,14 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-    SET_VECTOR_LAYER
-} = require('../actions/vectorstyler');
-const {
-    SET_RASTER_LAYER
-} = require('../actions/rasterstyler');
+import { SET_VECTOR_LAYER } from '../actions/vectorstyler';
 
-const { SET_STYLER_LAYER, STYLER_RESET } = require('../actions/styler');
+import { SET_RASTER_LAYER } from '../actions/rasterstyler';
+import { SET_STYLER_LAYER, STYLER_RESET } from '../actions/styler';
 function styler(state = {}, action) {
     switch (action.type) {
     case SET_VECTOR_LAYER: {
@@ -33,4 +29,4 @@ function styler(state = {}, action) {
     }
 }
 
-module.exports = styler;
+export default styler;

--- a/web/client/reducers/tasks.js
+++ b/web/client/reducers/tasks.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-var { TASK_STARTED, TASK_SUCCESS, TASK_ERROR } = require('../actions/tasks');
-var assign = require('object-assign');
+import { TASK_STARTED, TASK_SUCCESS, TASK_ERROR } from '../actions/tasks';
+
+import assign from 'object-assign';
 
 function tasks(state = {}, action) {
     switch (action.type) {
@@ -45,4 +46,4 @@ function tasks(state = {}, action) {
     }
 }
 
-module.exports = tasks;
+export default tasks;

--- a/web/client/reducers/thematic.js
+++ b/web/client/reducers/thematic.js
@@ -6,12 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { LOAD_FIELDS, FIELDS_LOADED, FIELDS_ERROR, LOAD_CLASSIFICATION,
-    CLASSIFICATION_LOADED, CLASSIFICATION_ERROR,
-    CHANGE_CONFIGURATION, CHANGE_DIRTY,
-    CHANGE_INPUT_VALIDITY} = require('../actions/thematic');
-const { HIDE_SETTINGS } = require('../actions/layers');
-const assign = require('object-assign');
+import {
+    LOAD_FIELDS,
+    FIELDS_LOADED,
+    FIELDS_ERROR,
+    LOAD_CLASSIFICATION,
+    CLASSIFICATION_LOADED,
+    CLASSIFICATION_ERROR,
+    CHANGE_CONFIGURATION,
+    CHANGE_DIRTY,
+    CHANGE_INPUT_VALIDITY
+} from '../actions/thematic';
+
+import { HIDE_SETTINGS } from '../actions/layers';
+import assign from 'object-assign';
 
 const initialState = {
     loadingFields: false,
@@ -102,4 +110,4 @@ function thematic(state = initialState, action) {
     }
 }
 
-module.exports = thematic;
+export default thematic;

--- a/web/client/reducers/timeline.js
+++ b/web/client/reducers/timeline.js
@@ -1,9 +1,8 @@
-const { RANGE_CHANGED } = require('../actions/timeline');
-const { REMOVE_NODE } = require('../actions/layers');
-const { RESET_CONTROLS } = require('../actions/controls');
-const { RANGE_DATA_LOADED, LOADING, SELECT_LAYER, SET_COLLAPSED, SET_MAP_SYNC } = require('../actions/timeline');
-const { set } = require('../utils/ImmutableUtils');
-const { assign, pickBy, has } = require('lodash');
+import { REMOVE_NODE } from '../actions/layers';
+import { RESET_CONTROLS } from '../actions/controls';
+import { RANGE_CHANGED, RANGE_DATA_LOADED, LOADING, SELECT_LAYER, SET_COLLAPSED, SET_MAP_SYNC } from '../actions/timeline';
+import { set } from '../utils/ImmutableUtils';
+import { assign, pickBy, has } from 'lodash';
 
 /**
  * Provides state for the timeline. Example:
@@ -47,7 +46,7 @@ const { assign, pickBy, has } = require('lodash');
  * @param {action} action
 
  */
-module.exports = (state = {
+export default (state = {
     settings: {
         autoSelect: true, // selects the first layer available as guide layer. This is a configuration only setting for now
         collapsed: false

--- a/web/client/reducers/tutorial.js
+++ b/web/client/reducers/tutorial.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     START_TUTORIAL,
     INIT_TUTORIAL,
     SETUP_TUTORIAL,
@@ -15,11 +15,11 @@ const {
     RESET_TUTORIAL,
     CLOSE_TUTORIAL,
     TOGGLE_TUTORIAL
-} = require('../actions/tutorial');
+} from '../actions/tutorial';
 
-const assign = require('object-assign');
-const React = require('react');
-const I18N = require('../components/I18N/I18N');
+import assign from 'object-assign';
+import React from 'react';
+import I18N from '../components/I18N/I18N';
 
 const initialState = {
     run: false,
@@ -167,4 +167,4 @@ function tutorial(state = initialState, action) {
     }
 }
 
-module.exports = tutorial;
+export default tutorial;

--- a/web/client/reducers/usergroups.js
+++ b/web/client/reducers/usergroups.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     GETGROUPS,
     SEARCHUSERS,
     EDITGROUP,
@@ -14,8 +14,9 @@ const {
     DELETEGROUP,
     UPDATEGROUP,
     SEARCHTEXTCHANGED
-} = require('../actions/usergroups');
-const assign = require('object-assign');
+} from '../actions/usergroups';
+
+import assign from 'object-assign';
 function usergroups(state = {
     start: 0,
     limit: 12
@@ -122,4 +123,4 @@ function usergroups(state = {
         return state;
     }
 }
-module.exports = usergroups;
+export default usergroups;

--- a/web/client/reducers/users.js
+++ b/web/client/reducers/users.js
@@ -6,15 +6,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-    USERMANAGER_GETUSERS, USERMANAGER_EDIT_USER, USERMANAGER_EDIT_USER_DATA, USERMANAGER_UPDATE_USER, USERMANAGER_DELETE_USER,
-    USERMANAGER_GETGROUPS, USERS_SEARCH_TEXT_CHANGED
-} = require('../actions/users');
+import {
+    USERMANAGER_GETUSERS,
+    USERMANAGER_EDIT_USER,
+    USERMANAGER_EDIT_USER_DATA,
+    USERMANAGER_UPDATE_USER,
+    USERMANAGER_DELETE_USER,
+    USERMANAGER_GETGROUPS,
+    USERS_SEARCH_TEXT_CHANGED
+} from '../actions/users';
 
-const {UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED} = require('../actions/usergroups');
-const assign = require('object-assign');
-
-const {findIndex} = require('lodash');
+import { UPDATEGROUP, STATUS_CREATED, DELETEGROUP, STATUS_DELETED } from '../actions/usergroups';
+import assign from 'object-assign';
+import { findIndex } from 'lodash';
 /**
  * Reducer for a user
  * * It contains the following parts:
@@ -150,4 +154,4 @@ function users(state = {
         return state;
     }
 }
-module.exports = users;
+export default users;

--- a/web/client/reducers/vectorstyler.js
+++ b/web/client/reducers/vectorstyler.js
@@ -6,17 +6,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
+import {
     NEW_VECTOR_RULE,
     SELECT_VECTOR_RULE,
     REMOVE_VECTOR_RULE,
     SET_VECTORSTYLE_PARAMETER,
     SET_VECTOR_LAYER,
     SET_VECTOR_RULE_PARAMETER
-} = require('../actions/vectorstyler');
-const { STYLER_RESET } = require('../actions/styler');
-const assign = require('object-assign');
-const {isObject, findIndex} = require('lodash');
+} from '../actions/vectorstyler';
+
+import { STYLER_RESET } from '../actions/styler';
+import assign from 'object-assign';
+import { isObject, findIndex } from 'lodash';
 const baseStyle = {
     Point: {
         type: "Point",
@@ -132,4 +133,4 @@ function vectorstyler(state = initialSpec, action) {
     }
 }
 
-module.exports = vectorstyler;
+export default vectorstyler;

--- a/web/client/reducers/version.js
+++ b/web/client/reducers/version.js
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { CHANGE_VERSION, LOAD_VERSION_ERROR } = require('../actions/version');
-const assign = require('object-assign');
+import { CHANGE_VERSION, LOAD_VERSION_ERROR } from '../actions/version';
+
+import assign from 'object-assign';
 
 /**
  * Manages the state of the version identifier
@@ -40,4 +41,4 @@ function version(state = null, action) {
     }
 }
 
-module.exports = version;
+export default version;

--- a/web/client/reducers/wfsdownload.js
+++ b/web/client/reducers/wfsdownload.js
@@ -5,7 +5,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {DOWNLOAD_OPTIONS_CHANGE, DOWNLOAD_FEATURES, DOWNLOAD_FINISHED, FORMAT_OPTIONS_FETCH, FORMAT_OPTIONS_UPDATE} = require('../actions/wfsdownload');
+import {
+    DOWNLOAD_OPTIONS_CHANGE,
+    DOWNLOAD_FEATURES,
+    DOWNLOAD_FINISHED,
+    FORMAT_OPTIONS_FETCH,
+    FORMAT_OPTIONS_UPDATE
+} from '../actions/wfsdownload';
 
 /**
  * reducer for wfsdownload
@@ -58,4 +64,4 @@ function wfsdownload( state = {downloadOptions: {singlePage: true}}, action) {
     }
 }
 
-module.exports = wfsdownload;
+export default wfsdownload;

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -6,20 +6,34 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { EDIT_NEW, INSERT, EDIT, UPDATE_PROPERTY, UPDATE_LAYER, DELETE, EDITOR_CHANGE, EDITOR_SETTING_CHANGE, CHANGE_LAYOUT, CLEAR_WIDGETS, DEFAULT_TARGET,
-    ADD_DEPENDENCY, REMOVE_DEPENDENCY, LOAD_DEPENDENCIES, RESET_DEPENDENCIES, TOGGLE_COLLAPSE, TOGGLE_COLLAPSE_ALL, TOGGLE_TRAY, toggleCollapse} = require('../actions/widgets');
-const {
-    MAP_CONFIG_LOADED
-} = require('../actions/config');
-const {
-    DASHBOARD_LOADED,
-    DASHBOARD_RESET
-} = require('../actions/dashboard');
+import {
+    EDIT_NEW,
+    INSERT,
+    EDIT,
+    UPDATE_PROPERTY,
+    UPDATE_LAYER,
+    DELETE,
+    EDITOR_CHANGE,
+    EDITOR_SETTING_CHANGE,
+    CHANGE_LAYOUT,
+    CLEAR_WIDGETS,
+    DEFAULT_TARGET,
+    ADD_DEPENDENCY,
+    REMOVE_DEPENDENCY,
+    LOAD_DEPENDENCIES,
+    RESET_DEPENDENCIES,
+    TOGGLE_COLLAPSE,
+    TOGGLE_COLLAPSE_ALL,
+    TOGGLE_TRAY,
+    toggleCollapse
+} from '../actions/widgets';
 
-const assign = require('object-assign');
-const set = require('lodash/fp/set');
-const { get, find, omit, mapValues, castArray} = require('lodash');
-const {arrayUpsert, compose, arrayDelete} = require('../utils/ImmutableUtils');
+import { MAP_CONFIG_LOADED } from '../actions/config';
+import { DASHBOARD_LOADED, DASHBOARD_RESET } from '../actions/dashboard';
+import assign from 'object-assign';
+import set from 'lodash/fp/set';
+import { get, find, omit, mapValues, castArray } from 'lodash';
+import { arrayUpsert, compose, arrayDelete } from '../utils/ImmutableUtils';
 
 const emptyState = {
     dependencies: {
@@ -248,4 +262,4 @@ function widgetsReducer(state = emptyState, action) {
     }
 }
 
-module.exports = widgetsReducer;
+export default widgetsReducer;

--- a/web/client/selectors/__tests__/additionallayers-test.js
+++ b/web/client/selectors/__tests__/additionallayers-test.js
@@ -7,10 +7,9 @@
 */
 
 
-const expect = require('expect');
-const {
-    additionalLayersSelector
-} = require('../additionallayers');
+import expect from 'expect';
+
+import { additionalLayersSelector } from '../additionallayers';
 
 const state = {
     additionallayers: [

--- a/web/client/selectors/__tests__/annotations-test.js
+++ b/web/client/selectors/__tests__/annotations-test.js
@@ -6,9 +6,11 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {isEmpty, isArray} = require('lodash');
-const {
+import expect from 'expect';
+
+import { isEmpty, isArray } from 'lodash';
+
+import {
     annotationsLayerSelector,
     multiGeometrySelector,
     removingSelector,
@@ -35,7 +37,7 @@ const {
     annotationsListSelector,
     symbolListSelector,
     editGeometrySelector
-} = require("../annotations");
+} from '../annotations';
 
 const state = {
     controls: {

--- a/web/client/selectors/__tests__/automapupdate-test.js
+++ b/web/client/selectors/__tests__/automapupdate-test.js
@@ -6,9 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {getWMSLayers, refreshingLayers} = require('../automapupdate');
-const reducer = require('../../reducers/layers');
+import expect from 'expect';
+
+import { getWMSLayers, refreshingLayers } from '../automapupdate';
+import reducer from '../../reducers/layers';
 
 const state = {
     layers: {

--- a/web/client/selectors/__tests__/backgroundselector-test.js
+++ b/web/client/selectors/__tests__/backgroundselector-test.js
@@ -6,12 +6,14 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {metadataSourceSelector,
+import {
+    metadataSourceSelector,
     modalParamsSelector,
     backgroundListSelector,
-    isDeletedIdSelector} = require('../backgroundselector');
+    isDeletedIdSelector
+} from '../backgroundselector';
 
 const backgrounds = [{id: '1', thumbId: 10}, {id: '2', thumbnail: {url: 'url', data: 'binary'}}];
 const modalParams = {editing: true, loading: true};

--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     activeSelector,
     authkeyParamNameSelector,
     delayAutoSearchSelector,
@@ -28,9 +29,9 @@ const {
     servicesSelector,
     serviceListOpenSelector,
     tileSizeOptionsSelector
-} = require("../catalog");
+} from '../catalog';
 
-const {set} = require('../../utils/ImmutableUtils');
+import { set } from '../../utils/ImmutableUtils';
 const url = "https://demo.geo-solutions.it/geoserver/wms";
 const state = {
     controls: {

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     queryPanelSelector,
     wfsDownloadAvailable,
     wfsDownloadSelector,
@@ -18,7 +19,7 @@ const {
     activeTabSettingsSelector,
     drawerEnabledControlSelector,
     showCoordinateEditorSelector
-} = require("../controls");
+} from '../controls';
 
 const state = {
     controls: {

--- a/web/client/selectors/__tests__/crsselector-test.js
+++ b/web/client/selectors/__tests__/crsselector-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {crsInputValueSelector} = require('../crsselector');
+import expect from 'expect';
+
+import { crsInputValueSelector } from '../crsselector';
 describe('Test layers selectors', () => {
     it('test crsInputValueSelector', () => {
         const props = crsInputValueSelector({crsselector: {value: 'EPSG:4326'}});

--- a/web/client/selectors/__tests__/cswtocatalog-test.js
+++ b/web/client/selectors/__tests__/cswtocatalog-test.js
@@ -5,9 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
-const {cswToCatalogSelector} = require('../cswtocatalog');
-const _ = require('lodash');
+import expect from 'expect';
+
+import { cswToCatalogSelector } from '../cswtocatalog';
+import _ from 'lodash';
 /** Geonetwork Style **/
 const sampleCSWRecord = {
     boundingBox: {

--- a/web/client/selectors/__tests__/dashboard-test.js
+++ b/web/client/selectors/__tests__/dashboard-test.js
@@ -5,9 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const {
+import {
     isDashboardAvailable,
     isDashboardEditing,
     showConnectionsSelector,
@@ -17,7 +17,8 @@ const {
     isDashboardLoading,
     getDashboardSaveErrors,
     buttonCanEdit
-} = require('../dashboard');
+} from '../dashboard';
+
 describe('dashboard selectors', () => {
     it('test isDashboardAvailable selector', () => {
         const state = {dashboard: {editor: {available: true}}};

--- a/web/client/selectors/__tests__/dimension-test.js
+++ b/web/client/selectors/__tests__/dimension-test.js
@@ -6,11 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const expect = require('expect');
-const dimension = require('../../reducers/dimension');
-const { updateLayerDimensionData } = require('../../actions/dimension');
+import expect from 'expect';
 
-const { layerDimensionRangeSelector, layerDimensionSelectorCreator, layerTimeSequenceSelectorCreator } = require('../dimension');
+import dimension from '../../reducers/dimension';
+import { updateLayerDimensionData } from '../../actions/dimension';
+
+import {
+    layerDimensionRangeSelector,
+    layerDimensionSelectorCreator,
+    layerTimeSequenceSelectorCreator
+} from '../dimension';
 
 describe('Test dimension selectors', () => {
     it('currentTimeRangeSelector', () => {

--- a/web/client/selectors/__tests__/featuredmaps-test.js
+++ b/web/client/selectors/__tests__/featuredmaps-test.js
@@ -5,12 +5,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const expect = require('expect');
+import expect from 'expect';
 
-const {
-    searchTextSelector,
-    isFeaturedMapsEnabled
-} = require('../featuredmaps');
+import { searchTextSelector, isFeaturedMapsEnabled } from '../featuredmaps';
 
 describe('featuredMaps selectors', () => {
     it('test searchTextSelector', () => {

--- a/web/client/selectors/__tests__/featuregrid-test.js
+++ b/web/client/selectors/__tests__/featuregrid-test.js
@@ -6,9 +6,11 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const assign = require('object-assign');
-const {
+import expect from 'expect';
+
+import assign from 'object-assign';
+
+import {
     isFeatureGridOpen,
     hasChangesSelector,
     getTitleSelector,
@@ -35,7 +37,7 @@ const {
     queryOptionsSelector,
     showTimeSync,
     timeSyncActive
-} = require('../featuregrid');
+} from '../featuregrid';
 
 const idFt1 = "idFt1";
 const idFt2 = "idFt2";
@@ -62,11 +64,10 @@ let feature2 = {
         someProp: "someValue"
     }
 };
-const featuregrid = require('../../reducers/featuregrid');
-const { setUp, setTimeSync } = require('../../actions/featuregrid');
-
-const dimension = require('../../reducers/dimension');
-const { updateLayerDimensionData } = require('../../actions/dimension');
+import featuregrid from '../../reducers/featuregrid';
+import { setUp, setTimeSync } from '../../actions/featuregrid';
+import dimension from '../../reducers/dimension';
+import { updateLayerDimensionData } from '../../actions/dimension';
 
 let initialState = {
     query: {

--- a/web/client/selectors/__tests__/feedbackmask-test.js
+++ b/web/client/selectors/__tests__/feedbackmask-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {feedbackMaskSelector} = require('../feedbackmask');
+import expect from 'expect';
+
+import { feedbackMaskSelector } from '../feedbackmask';
 
 const state = {
     feedbackMask: {

--- a/web/client/selectors/__tests__/floatinglegend-test.js
+++ b/web/client/selectors/__tests__/floatinglegend-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {legendSizeSelector, legendExpandedSelector} = require('../floatinglegend');
+import expect from 'expect';
+
+import { legendSizeSelector, legendExpandedSelector } from '../floatinglegend';
 
 describe('Test floatinglegend selectors', () => {
     it('test legendSizeSelector', () => {

--- a/web/client/selectors/__tests__/highlight-test.js
+++ b/web/client/selectors/__tests__/highlight-test.js
@@ -6,11 +6,19 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
-    selectedFeatures, filteredspatialObject, filteredspatialObjectCoord,
-    filteredGeometry, filteredSpatialObjectId, filteredSpatialObjectCrs,
-    filteredspatialObjectType, filteredFeatures, highlighedFeatures} = require('../highlight');
+import expect from 'expect';
+
+import {
+    selectedFeatures,
+    filteredspatialObject,
+    filteredspatialObjectCoord,
+    filteredGeometry,
+    filteredSpatialObjectId,
+    filteredSpatialObjectCrs,
+    filteredspatialObjectType,
+    filteredFeatures,
+    highlighedFeatures
+} from '../highlight';
 
 const idFt1 = "idFt1";
 const idFt2 = "idFt2";

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -6,13 +6,27 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
-    getLayerFromName, getLayerFromId, layersSelector, layerSelectorWithMarkers, groupsSelector, selectedNodesSelector, layerFilterSelector, layerSettingSelector,
-    layerMetadataSelector, wfsDownloadSelector, backgroundControlsSelector,
-    currentBackgroundSelector, tempBackgroundSelector, centerToMarkerSelector,
-    getLayersWithDimension, elementSelector, queryableSelectedLayersSelector
-} = require('../layers');
+import expect from 'expect';
+
+import {
+    getLayerFromName,
+    getLayerFromId,
+    layersSelector,
+    layerSelectorWithMarkers,
+    groupsSelector,
+    selectedNodesSelector,
+    layerFilterSelector,
+    layerSettingSelector,
+    layerMetadataSelector,
+    wfsDownloadSelector,
+    backgroundControlsSelector,
+    currentBackgroundSelector,
+    tempBackgroundSelector,
+    centerToMarkerSelector,
+    getLayersWithDimension,
+    elementSelector,
+    queryableSelectedLayersSelector
+} from '../layers';
 
 describe('Test layers selectors', () => {
     it('test getLayerFromName', () => {

--- a/web/client/selectors/__tests__/locale-test.js
+++ b/web/client/selectors/__tests__/locale-test.js
@@ -6,8 +6,13 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {currentLocaleSelector, currentMessagesSelector, currentLocaleLanguageSelector} = require('../locale');
+import expect from 'expect';
+
+import {
+    currentLocaleSelector,
+    currentMessagesSelector,
+    currentLocaleLanguageSelector
+} from '../locale';
 
 const state = {
     locale: {

--- a/web/client/selectors/__tests__/localizedLayerStyles-test.js
+++ b/web/client/selectors/__tests__/localizedLayerStyles-test.js
@@ -6,15 +6,16 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
+import expect from 'expect';
 
-const {
+import {
     isLocalizedLayerStylesEnabledSelector,
     isLocalizedLayerStylesEnabledDashboardsSelector,
     localizedLayerStylesNameSelector,
     localizedLayerStylesEnvSelector
-} = require('../localizedLayerStyles');
-const {currentLocaleLanguageSelector} = require('../locale');
+} from '../localizedLayerStyles';
+
+import { currentLocaleLanguageSelector } from '../locale';
 
 const givenName = 'example';
 const givenState = {

--- a/web/client/selectors/__tests__/map-test.js
+++ b/web/client/selectors/__tests__/map-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     mapSelector,
     projectionSelector,
     mapVersionSelector,
@@ -23,7 +24,8 @@ const {
     isMouseMoveActiveSelector,
     isMouseMoveCoordinatesActiveSelector,
     isMouseMoveIdentifyActiveSelector
-} = require('../map');
+} from '../map';
+
 const center = {x: 1, y: 1};
 let state = {
     map: {center: center},

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -7,9 +7,11 @@
 */
 
 
-const expect = require('expect');
-const { set } = require('../../utils/ImmutableUtils');
-const {
+import expect from 'expect';
+
+import { set } from '../../utils/ImmutableUtils';
+
+import {
     mapInfoRequestsSelector,
     generalInfoFormatSelector,
     stopGetFeatureInfoSelector,
@@ -23,7 +25,7 @@ const {
     filterNameListSelector,
     overrideParamsSelector,
     mapTriggerSelector
-} = require('../mapInfo');
+} from '../mapInfo';
 
 const QUERY_PARAMS = {
     service: 'WMS',

--- a/web/client/selectors/__tests__/mapInitialConfig-test.js
+++ b/web/client/selectors/__tests__/mapInitialConfig-test.js
@@ -5,8 +5,9 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-const expect = require('expect');
-const {hasMapAccessLoadingError} = require('../mapInitialConfig');
+import expect from 'expect';
+
+import { hasMapAccessLoadingError } from '../mapInitialConfig';
 
 let state = {
     mapInitialConfig: {

--- a/web/client/selectors/__tests__/maplayout-test.js
+++ b/web/client/selectors/__tests__/maplayout-test.js
@@ -6,8 +6,17 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const { mapLayoutSelector, mapLayoutValuesSelector, checkConditionsSelector, rightPanelOpenSelector, bottomPanelOpenSelector, boundingMapRectSelector, mapPaddingSelector} = require('../maplayout');
+import expect from 'expect';
+
+import {
+    mapLayoutSelector,
+    mapLayoutValuesSelector,
+    checkConditionsSelector,
+    rightPanelOpenSelector,
+    bottomPanelOpenSelector,
+    boundingMapRectSelector,
+    mapPaddingSelector
+} from '../maplayout';
 
 describe('Test map layout selectors', () => {
     it('test mapLayoutSelector no state', () => {

--- a/web/client/selectors/__tests__/maps-test.js
+++ b/web/client/selectors/__tests__/maps-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     mapNameSelector,
     mapFromIdSelector,
     mapsResultsSelector,
@@ -20,7 +21,7 @@ const {
     mapThumbnailsUriFromIdSelector,
     searchTextSelector,
     searchParamsSelector
-} = require('../maps');
+} from '../maps';
 
 const name = "name";
 const description = "description";

--- a/web/client/selectors/__tests__/mapsave-test.js
+++ b/web/client/selectors/__tests__/mapsave-test.js
@@ -6,11 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
-    mapOptionsToSaveSelector,
-    registerCustomSaveHandler
-} = require("../mapsave");
+import expect from 'expect';
+
+import { mapOptionsToSaveSelector, registerCustomSaveHandler } from '../mapsave';
 
 const state = {
     custom: {

--- a/web/client/selectors/__tests__/maptype-test.js
+++ b/web/client/selectors/__tests__/maptype-test.js
@@ -7,13 +7,9 @@
 */
 
 
-const expect = require('expect');
-const {
-    mapTypeSelector,
-    isCesium,
-    isOpenlayers,
-    isLeaflet
-} = require('../maptype');
+import expect from 'expect';
+
+import { mapTypeSelector, isCesium, isOpenlayers, isLeaflet } from '../maptype';
 
 describe('Test maptype', () => {
     it('test mapTypeSelector default', () => {

--- a/web/client/selectors/__tests__/measurement-test.js
+++ b/web/client/selectors/__tests__/measurement-test.js
@@ -7,19 +7,21 @@
 */
 
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     isCoordinateEditorEnabledSelector,
     showAddAsAnnotationSelector,
     measurementSelector,
     getValidFeatureSelector
-} = require('../measurement');
-const {
+} from '../measurement';
+
+import {
     polyFeatureNotClosedInvalid,
     polyFeatureNotClosed,
     lineFeature3,
     lineFeatureWithoutGeom
-} = require('../../test-resources/drawsupport/features');
+} from '../../test-resources/drawsupport/features';
 
 describe('Test maptype', () => {
     it('test isCoordinateEditorEnabledSelector', () => {

--- a/web/client/selectors/__tests__/plugins-test.js
+++ b/web/client/selectors/__tests__/plugins-test.js
@@ -6,9 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const { isPageConfigured } = require('../plugins');
-const {set} = require('lodash');
+import expect from 'expect';
+
+import { isPageConfigured } from '../plugins';
+import { set } from 'lodash';
 
 describe('Test page selector', () => {
     it('test isImporterConfigured default', () => {

--- a/web/client/selectors/__tests__/query-test.js
+++ b/web/client/selectors/__tests__/query-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     wfsURL,
     wfsURLSelector,
     wfsFilter,
@@ -23,7 +24,8 @@ const {
     attributesSelector,
     isSyncWmsActive,
     isFilterActive
-} = require('../query');
+} from '../query';
+
 const STRANGE_LAYER_NAME = "test.workspace:test.layer";
 const idFt1 = "idFt1";
 const idFt2 = "idFt2";

--- a/web/client/selectors/__tests__/queryform-test.js
+++ b/web/client/selectors/__tests__/queryform-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     availableCrossLayerFilterLayersSelector,
     spatialFieldSelector,
     spatialFieldGeomSelector,
@@ -18,7 +19,7 @@ const {
     queryFormUiStateSelector,
     storedFilterSelector,
     appliedFilterSelector
-} = require('../queryform');
+} from '../queryform';
 
 const circle = "Circle";
 const attribute = "the_geom";

--- a/web/client/selectors/__tests__/router-test.js
+++ b/web/client/selectors/__tests__/router-test.js
@@ -6,11 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
-    pathnameSelector,
-    searchSelector
-} = require("../router");
+import expect from 'expect';
+
+import { pathnameSelector, searchSelector } from '../router';
 const pathname = "/viewer/openlayers/123";
 const search = "?showHome=true";
 const state = {

--- a/web/client/selectors/__tests__/rulesmanager-test.js
+++ b/web/client/selectors/__tests__/rulesmanager-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {rulesSelector, optionsSelector} = require('../rulesmanager');
+import expect from 'expect';
+
+import { rulesSelector, optionsSelector } from '../rulesmanager';
 
 describe('test rules manager selectors', () => {
 

--- a/web/client/selectors/__tests__/security-test.js
+++ b/web/client/selectors/__tests__/security-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     userSelector,
     userRoleSelector,
     isAdminUserSelector,
@@ -15,7 +16,8 @@ const {
     securityTokenSelector,
     userGroupSecuritySelector,
     userParamsSelector
-} = require('../security');
+} from '../security';
+
 const id = 1833;
 const name = 'teo';
 const role = 'ADMIN';

--- a/web/client/selectors/__tests__/styleeditor-test.js
+++ b/web/client/selectors/__tests__/styleeditor-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     temporaryIdSelector,
     templateIdSelector,
     statusStyleSelector,
@@ -29,7 +30,7 @@ const {
     selectedStyleFormatSelector,
     editorMetadataSelector,
     selectedStyleMetadataSelector
-} = require('../styleeditor');
+} from '../styleeditor';
 
 describe('Test styleeditor selector', () => {
     it('test temporaryIdSelector', () => {

--- a/web/client/selectors/__tests__/timeline-test.js
+++ b/web/client/selectors/__tests__/timeline-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {
+import expect from 'expect';
+
+import {
     isCollapsed,
     hasLayers,
     isVisible,
@@ -16,13 +17,13 @@ const {
     itemsSelector,
     rangeDataSelector,
     multidimOptionsSelectorCreator
-} = require('../timeline');
-const { set, compose } = require('../../utils/ImmutableUtils');
+} from '../timeline';
 
-const timeline = require('../../reducers/timeline');
-const { rangeDataLoaded } = require('../../actions/timeline');
-const dimension = require('../../reducers/dimension');
-const { updateLayerDimensionData } = require('../../actions/dimension');
+import { set, compose } from '../../utils/ImmutableUtils';
+import timeline from '../../reducers/timeline';
+import { rangeDataLoaded } from '../../actions/timeline';
+import dimension from '../../reducers/dimension';
+import { updateLayerDimensionData } from '../../actions/dimension';
 
 const T1 = '2016-01-01T00:00:00.000Z';
 const T2 = '2016-02-01T00:00:00.000Z';

--- a/web/client/selectors/__tests__/tutorial-test.js
+++ b/web/client/selectors/__tests__/tutorial-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {tutorialSelector} = require('../tutorial');
+import expect from 'expect';
+
+import { tutorialSelector } from '../tutorial';
 
 describe('Test tutorial selector', () => {
     it('test tutorialSelector', () => {

--- a/web/client/selectors/__tests__/version-test.js
+++ b/web/client/selectors/__tests__/version-test.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const expect = require('expect');
-const {versionSelector, validateVersion} = require('../version');
+import expect from 'expect';
+
+import { versionSelector, validateVersion } from '../version';
 
 describe('Test version selector', () => {
     it('test versionSelector default', () => {

--- a/web/client/selectors/__tests__/widgets-test.js
+++ b/web/client/selectors/__tests__/widgets-test.js
@@ -5,9 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { DEFAULT_TARGET } = require('../../actions/widgets');
-const expect = require('expect');
-const {
+import { DEFAULT_TARGET } from '../../actions/widgets';
+
+import expect from 'expect';
+
+import {
     getFloatingWidgets,
     getFloatingWidgetsLayout,
     getDashboardWidgets,
@@ -23,8 +25,9 @@ const {
     availableDependenciesForEditingWidgetSelector,
     returnToFeatureGridSelector,
     isTrayEnabled
-} = require('../widgets');
-const {set} = require('../../utils/ImmutableUtils');
+} from '../widgets';
+
+import { set } from '../../utils/ImmutableUtils';
 describe('widgets selectors', () => {
     it('getFloatingWidgets', () => {
         const state = set(`widgets.containers[${DEFAULT_TARGET}].widgets`, [{title: "TEST"}], {});

--- a/web/client/selectors/additionallayers.js
+++ b/web/client/selectors/additionallayers.js
@@ -6,7 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {get} = require('lodash');
+import { get } from 'lodash';
 
 /**
  * selects additionallayers state
@@ -21,8 +21,4 @@ const {get} = require('lodash');
  * @param  {object} state the state
  * @return {array} array of layers items eg: [{ id: 'layerId', actionType: 'override', options: {}, owner: 'myplugin' }]
  */
-const additionalLayersSelector = state => get(state, 'additionallayers') || [];
-
-module.exports = {
-    additionalLayersSelector
-};
+export const additionalLayersSelector = state => get(state, 'additionallayers') || [];

--- a/web/client/selectors/annotations.js
+++ b/web/client/selectors/annotations.js
@@ -6,54 +6,55 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {createSelector} = require('reselect');
-const {layersSelector} = require('./layers');
-const {projectionSelector} = require('./map');
-const {isOpenlayers} = require('./maptype');
-const {isMapInfoOpen} = require('./mapInfo');
-const {head, get} = require('lodash');
-const assign = require('object-assign');
-const { getConfigProp } = require('../utils/ConfigUtils');
+import { createSelector } from 'reselect';
 
-const annotationsLayerSelector = createSelector([
+import { layersSelector } from './layers';
+import { projectionSelector } from './map';
+import { isOpenlayers } from './maptype';
+import { isMapInfoOpen } from './mapInfo';
+import { head, get } from 'lodash';
+import assign from 'object-assign';
+import { getConfigProp } from '../utils/ConfigUtils';
+
+export const annotationsLayerSelector = createSelector([
     layersSelector
 ], (layers) => head(layers.filter(l => l.id === 'annotations'))
 );
 
-const multiGeometrySelector = (state) => get(state, 'annotations.config.multiGeometry', false);
-const removingSelector = (state) => get(state, "annotations.removing");
-const formatSelector = (state) => get(state, "annotations.format");
-const aeronauticalOptionsSelector = (state) => get(state, "annotations.aeronauticalOptions");
-const showUnsavedChangesModalSelector = (state) => get(state, "annotations.showUnsavedChangesModal", false);
-const showUnsavedStyleModalSelector = (state) => get(state, "annotations.showUnsavedStyleModal", false);
-const showUnsavedGeometryModalSelector = (state) => get(state, "annotations.showUnsavedGeometryModal", false);
-const showDeleteFeatureModalSelector = (state) => get(state, "annotations.showDeleteFeatureModal", false);
-const closingSelector = (state) => !!get(state, "annotations.closing");
-const editingSelector = (state) => get(state, "annotations.editing");
-const editGeometrySelector = (state) => get(state, "annotations.editGeometry", true);
-const featureTypeSelector = (state) => get(state, "annotations.featureType");
-const coordinateEditorEnabledSelector = (state) => get(state, "annotations.coordinateEditorEnabled");
-const drawingSelector = (state) => !!get(state, "annotations.drawing");
-const stylerTypeSelector = (state) => get(state, "annotations.stylerType");
-const drawingTextSelector = (state) => get(state, "annotations.drawingText");
-const currentSelector = (state) => get(state, "annotations.current");
-const editedFieldsSelector = (state) => get(state, "annotations.editedFields", {});
-const stylingSelector = (state) => !!get(state, "annotations.styling");
-const selectedSelector = (state) => get(state, "annotations.selected", null);
-const unsavedChangesSelector = (state) => get(state, "annotations.unsavedChanges", false);
-const unsavedGeometrySelector = (state) => get(state, "annotations.unsavedGeometry", false);
-const unsavedStyleSelector = (state) => get(state, "annotations.unsavedStyle", false);
-const errorsSelector = (state) => get(state, "annotations.validationErrors", {});
-const configSelector = (state) => get(state, "annotations.config", {});
-const symbolListSelector = (state) => get(state, "annotations.symbolList", []);
-const symbolErrorsSelector = (state) => get(state, "annotations.symbolErrors", []);
-const modeSelector = (state) => editingSelector(state) && 'editing' || annotationsLayerSelector(state) && currentSelector(state) && 'detail' || 'list';
-const defaultStylesSelector = state => state.annotations.defaultStyles;
-const loadingSelector = state => state.annotations.loading;
-const showAgainSelector = (state) => get(state, "annotations.showAgain", false);
-const showPopupWarningSelector = (state) => get(state, "annotations.showPopupWarning", true);
+export const multiGeometrySelector = (state) => get(state, 'annotations.config.multiGeometry', false);
+export const removingSelector = (state) => get(state, "annotations.removing");
+export const formatSelector = (state) => get(state, "annotations.format");
+export const aeronauticalOptionsSelector = (state) => get(state, "annotations.aeronauticalOptions");
+export const showUnsavedChangesModalSelector = (state) => get(state, "annotations.showUnsavedChangesModal", false);
+export const showUnsavedStyleModalSelector = (state) => get(state, "annotations.showUnsavedStyleModal", false);
+export const showUnsavedGeometryModalSelector = (state) => get(state, "annotations.showUnsavedGeometryModal", false);
+export const showDeleteFeatureModalSelector = (state) => get(state, "annotations.showDeleteFeatureModal", false);
+export const closingSelector = (state) => !!get(state, "annotations.closing");
+export const editingSelector = (state) => get(state, "annotations.editing");
+export const editGeometrySelector = (state) => get(state, "annotations.editGeometry", true);
+export const featureTypeSelector = (state) => get(state, "annotations.featureType");
+export const coordinateEditorEnabledSelector = (state) => get(state, "annotations.coordinateEditorEnabled");
+export const drawingSelector = (state) => !!get(state, "annotations.drawing");
+export const stylerTypeSelector = (state) => get(state, "annotations.stylerType");
+export const drawingTextSelector = (state) => get(state, "annotations.drawingText");
+export const currentSelector = (state) => get(state, "annotations.current");
+export const editedFieldsSelector = (state) => get(state, "annotations.editedFields", {});
+export const stylingSelector = (state) => !!get(state, "annotations.styling");
+export const selectedSelector = (state) => get(state, "annotations.selected", null);
+export const unsavedChangesSelector = (state) => get(state, "annotations.unsavedChanges", false);
+export const unsavedGeometrySelector = (state) => get(state, "annotations.unsavedGeometry", false);
+export const unsavedStyleSelector = (state) => get(state, "annotations.unsavedStyle", false);
+export const errorsSelector = (state) => get(state, "annotations.validationErrors", {});
+export const configSelector = (state) => get(state, "annotations.config", {});
+export const symbolListSelector = (state) => get(state, "annotations.symbolList", []);
+export const symbolErrorsSelector = (state) => get(state, "annotations.symbolErrors", []);
+export const modeSelector = (state) => editingSelector(state) && 'editing' || annotationsLayerSelector(state) && currentSelector(state) && 'detail' || 'list';
+export const defaultStylesSelector = state => state.annotations.defaultStyles;
+export const loadingSelector = state => state.annotations.loading;
+export const showAgainSelector = (state) => get(state, "annotations.showAgain", false);
+export const showPopupWarningSelector = (state) => get(state, "annotations.showPopupWarning", true);
 
-const annotationsInfoSelector = (state) => (assign({}, {
+export const annotationsInfoSelector = (state) => (assign({}, {
     symbolErrors: symbolErrorsSelector(state),
     showEdit: isOpenlayers(state),
     canEdit: editGeometrySelector(state),
@@ -87,11 +88,11 @@ const annotationsInfoSelector = (state) => (assign({}, {
     showPopupWarning: showPopupWarningSelector(state)
 }) );
 
-const annotationsSelector = (state) => ({
+export const annotationsSelector = (state) => ({
     ...(state.annotations || {})
 });
 
-const annotationsListSelector = createSelector([
+export const annotationsListSelector = createSelector([
     annotationsInfoSelector,
     annotationsSelector,
     annotationsLayerSelector,
@@ -117,43 +118,9 @@ const annotationsListSelector = createSelector([
     config: info.config
 } : { })));
 
-const annotationSelector = createSelector([annotationsListSelector], (annotations) => {
+export const annotationSelector = createSelector([annotationsListSelector], (annotations) => {
     const id = annotations.current;
     return {
         annotation: head(annotations.annotations.filter(a => a.properties.id === id))
     };
 });
-
-module.exports = {
-    multiGeometrySelector,
-    symbolErrorsSelector,
-    modeSelector,
-    annotationsLayerSelector,
-    annotationsInfoSelector,
-    aeronauticalOptionsSelector,
-    annotationsSelector,
-    annotationsListSelector,
-    annotationSelector,
-    removingSelector,
-    showUnsavedChangesModalSelector,
-    showUnsavedStyleModalSelector,
-    closingSelector,
-    editingSelector,
-    drawingSelector,
-    stylerTypeSelector,
-    drawingTextSelector,
-    currentSelector,
-    editedFieldsSelector,
-    stylingSelector,
-    unsavedChangesSelector,
-    showUnsavedGeometryModalSelector,
-    unsavedGeometrySelector,
-    unsavedStyleSelector,
-    formatSelector,
-    errorsSelector,
-    configSelector,
-    symbolListSelector,
-    defaultStylesSelector,
-    loadingSelector,
-    editGeometrySelector
-};

--- a/web/client/selectors/automapupdate.js
+++ b/web/client/selectors/automapupdate.js
@@ -6,15 +6,15 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {createSelector} = require('reselect');
+import { createSelector } from 'reselect';
 
-const getWMSLayers = (state) => state.layers && state.layers.flat && state.layers.flat.filter((l) => l.type === 'wms' && l.group !== 'background') || [];
+export const getWMSLayers = (state) => state.layers && state.layers.flat && state.layers.flat.filter((l) => l.type === 'wms' && l.group !== 'background') || [];
 
-const refreshingLayers = (state) => state.layers && state.layers.refreshing || [];
+export const refreshingLayers = (state) => state.layers && state.layers.refreshing || [];
 
-const mapUpdateOptions = (state) => state.controls && state.controls.mapUpdate && state.controls.mapUpdate.options || {bbox: true, search: true, dimensions: true, title: false};
+export const mapUpdateOptions = (state) => state.controls && state.controls.mapUpdate && state.controls.mapUpdate.options || {bbox: true, search: true, dimensions: true, title: false};
 
-const autoMapUpdateSelector = createSelector([
+export const autoMapUpdateSelector = createSelector([
     getWMSLayers,
     refreshingLayers
 ], (layers, refreshing) => ({
@@ -22,10 +22,3 @@ const autoMapUpdateSelector = createSelector([
     length: layers.length || 0,
     count: (layers.length - refreshing.length) + 1 || 0
 }));
-
-module.exports = {
-    getWMSLayers,
-    refreshingLayers,
-    autoMapUpdateSelector,
-    mapUpdateOptions
-};

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -6,52 +6,46 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {createSelector, createStructuredSelector} = require('reselect');
-const {get, pick} = require('lodash');
+import { createSelector, createStructuredSelector } from 'reselect';
+import { get, pick } from 'lodash';
 
-const staticServicesSelector = (state) => get(state, "catalog.default.staticServices");
-const servicesSelector = (state) => get(state, "catalog.services");
-const servicesSelectorWithBackgrounds = createSelector(staticServicesSelector, servicesSelector, (staticServices, services) => ({
+import { projectionSelector } from './map';
+
+export const staticServicesSelector = (state) => get(state, "catalog.default.staticServices");
+export const servicesSelector = (state) => get(state, "catalog.services");
+export const servicesSelectorWithBackgrounds = createSelector(staticServicesSelector, servicesSelector, (staticServices, services) => ({
     ...services,
     ...(pick(staticServices, "default_map_backgrounds"))
 }));
-const selectedStaticServiceTypeSelector =
+export const selectedStaticServiceTypeSelector =
     (state) => get(state, `catalog.default.staticServices["${get(state, 'catalog.selectedService')}"].type`, "csw");
-const {projectionSelector} = require('./map');
 
 // Picks configured tile sizes from state, otherwise default is [256, 512]
-const tileSizeOptionsSelector = state => get(state, 'catalog.default.tileSizes', [256, 512]);
+export const tileSizeOptionsSelector = state => get(state, 'catalog.default.tileSizes', [256, 512]);
 
-module.exports = {
-    groupSelector: (state) => get(state, "controls.metadataexplorer.group"),
-    savingSelector: (state) => get(state, "catalog.saving"),
-    resultSelector: (state) => get(state, "catalog.result"),
-    serviceListOpenSelector: (state) => get(state, "catalog.openCatalogServiceList"),
-    newServiceSelector: (state) => get(state, "catalog.newService"),
-    staticServicesSelector,
-    servicesSelector,
-    servicesSelectorWithBackgrounds,
-    newServiceTypeSelector: (state) => get(state, "catalog.newService.type", "csw"),
-    selectedCatalogSelector: (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"]`),
-    selectedStaticServiceTypeSelector,
-    selectedServiceTypeSelector: (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"].type`, selectedStaticServiceTypeSelector(state)),
-    selectedServiceLayerOptionsSelector: (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"].layerOptions`, {}),
-    searchOptionsSelector: (state) => get(state, "catalog.searchOptions"),
-    loadingErrorSelector: (state) => get(state, "catalog.loadingError"),
-    loadingSelector: (state) => get(state, "catalog.loading", false),
-    selectedServiceSelector: (state) => get(state, "catalog.selectedService"),
-    modeSelector: (state) => get(state, "catalog.mode", "view"),
-    layerErrorSelector: (state) => get(state, "catalog.layerError"),
-    searchTextSelector: (state) => get(state, "catalog.searchOptions.text", ""),
-    activeSelector: (state) => get(state, "controls.toolbar.active") === "metadataexplorer" || get(state, "controls.metadataexplorer.enabled"),
-    authkeyParamNameSelector: (state) => {
-        return (get(state, "localConfig.authenticationRules") || []).filter(a => a.method === "authkey").map(r => r.authkeyParamName) || [];
-    },
-    pageSizeSelector: (state) => get(state, "catalog.pageSize", 4),
-    delayAutoSearchSelector: (state) => get(state, "catalog.delayAutoSearch", 1000),
-    // information from the state needed to perform searches on catalog
-    catalogSearchInfoSelector: createStructuredSelector({
-        projection: projectionSelector
-    }),
-    tileSizeOptionsSelector
+export const groupSelector = (state) => get(state, "controls.metadataexplorer.group");
+export const savingSelector = (state) => get(state, "catalog.saving");
+export const resultSelector = (state) => get(state, "catalog.result");
+export const serviceListOpenSelector = (state) => get(state, "catalog.openCatalogServiceList");
+export const newServiceSelector = (state) => get(state, "catalog.newService");
+export const newServiceTypeSelector = (state) => get(state, "catalog.newService.type", "csw");
+export const selectedCatalogSelector = (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"]`);
+export const selectedServiceTypeSelector = (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"].type`, selectedStaticServiceTypeSelector(state));
+export const selectedServiceLayerOptionsSelector = (state) => get(state, `catalog.services["${get(state, 'catalog.selectedService')}"].layerOptions`, {});
+export const searchOptionsSelector = (state) => get(state, "catalog.searchOptions");
+export const loadingErrorSelector = (state) => get(state, "catalog.loadingError");
+export const loadingSelector = (state) => get(state, "catalog.loading", false);
+export const selectedServiceSelector = (state) => get(state, "catalog.selectedService");
+export const modeSelector = (state) => get(state, "catalog.mode", "view");
+export const layerErrorSelector = (state) => get(state, "catalog.layerError");
+export const searchTextSelector = (state) => get(state, "catalog.searchOptions.text", "");
+export const activeSelector = (state) => get(state, "controls.toolbar.active") === "metadataexplorer" || get(state, "controls.metadataexplorer.enabled");
+export const authkeyParamNameSelector = (state) => {
+    return (get(state, "localConfig.authenticationRules") || []).filter(a => a.method === "authkey").map(r => r.authkeyParamName) || [];
 };
+export const pageSizeSelector = (state) => get(state, "catalog.pageSize", 4);
+export const delayAutoSearchSelector = (state) => get(state, "catalog.delayAutoSearch", 1000);
+// information from the state needed to perform searches on catalog
+export const catalogSearchInfoSelector = createStructuredSelector({
+    projection: projectionSelector
+});

--- a/web/client/selectors/config.js
+++ b/web/client/selectors/config.js
@@ -6,8 +6,4 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const loadAfterThemeSelector = (state) => state.localConfig && state.localConfig.loadAfterTheme;
-
-module.exports = {
-    loadAfterThemeSelector
-};
+export const loadAfterThemeSelector = (state) => state.localConfig && state.localConfig.loadAfterTheme;

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -1,6 +1,14 @@
-const {get} = require('lodash');
-const createControlVariableSelector = (name, attribute) => state => get(state, `controls[${name}][${attribute}]`);
-const createControlEnabledSelector = name => createControlVariableSelector(name, 'enabled');
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { get } from 'lodash';
+export const createControlVariableSelector = (name, attribute) => state => get(state, `controls[${name}][${attribute}]`);
+export const createControlEnabledSelector = name => createControlVariableSelector(name, 'enabled');
 
 
 /**
@@ -9,23 +17,18 @@ const createControlEnabledSelector = name => createControlVariableSelector(name,
  * @param  {object} state the state
  * @return {boolean} the showCoordinateEditor in the state
  */
-const showCoordinateEditorSelector = (state) => get(state, "controls.measure.showCoordinateEditor");
+export const showCoordinateEditorSelector = (state) => get(state, "controls.measure.showCoordinateEditor");
 
-module.exports = {
-    createControlEnabledSelector,
-    createControlVariableSelector,
-    showCoordinateEditorSelector,
-    measureSelector: (state) => get(state, "controls.measure.enabled"),
-    queryPanelSelector: (state) => get(state, "controls.queryPanel.enabled"),
-    printSelector: (state) => get(state, "controls.print.enabled"),
-    wfsDownloadAvailable: state => !!get(state, "controls.wfsdownload.available"),
-    wfsDownloadSelector: state => !!get(state, "controls.wfsdownload.enabled"),
-    widgetBuilderAvailable: state => get(state, "controls.widgetBuilder.available", false),
-    widgetBuilderSelector: (state) => get(state, "controls.widgetBuilder.enabled"),
-    initialSettingsSelector: state => get(state, "controls.layersettings.initialSettings") || {},
-    originalSettingsSelector: state => get(state, "controls.layersettings.originalSettings") || {},
-    activeTabSettingsSelector: state => get(state, "controls.layersettings.activeTab") || 'general',
-    drawerEnabledControlSelector: (state) => get(state, "controls.drawer.enabled", false),
-    unsavedMapSelector: (state) => get(state, "controls.unsavedMap.enabled", false),
-    unsavedMapSourceSelector: (state) => get(state, "controls.unsavedMap.source", "")
-};
+export const measureSelector = (state) => get(state, "controls.measure.enabled");
+export const queryPanelSelector = (state) => get(state, "controls.queryPanel.enabled");
+export const printSelector = (state) => get(state, "controls.print.enabled");
+export const wfsDownloadAvailable = state => !!get(state, "controls.wfsdownload.available");
+export const wfsDownloadSelector = state => !!get(state, "controls.wfsdownload.enabled");
+export const widgetBuilderAvailable = state => get(state, "controls.widgetBuilder.available", false);
+export const widgetBuilderSelector = (state) => get(state, "controls.widgetBuilder.enabled");
+export const initialSettingsSelector = state => get(state, "controls.layersettings.initialSettings") || {};
+export const originalSettingsSelector = state => get(state, "controls.layersettings.originalSettings") || {};
+export const activeTabSettingsSelector = state => get(state, "controls.layersettings.activeTab") || 'general';
+export const drawerEnabledControlSelector = (state) => get(state, "controls.drawer.enabled", false);
+export const unsavedMapSelector = (state) => get(state, "controls.unsavedMap.enabled", false);
+export const unsavedMapSourceSelector = (state) => get(state, "controls.unsavedMap.source", "");

--- a/web/client/selectors/crsselector.js
+++ b/web/client/selectors/crsselector.js
@@ -6,9 +6,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const crsInputValueSelector = state => state && state.crsselector && state.crsselector.value;
-
-
-module.exports = {
-    crsInputValueSelector
-};
+export const crsInputValueSelector = state => state && state.crsselector && state.crsselector.value;

--- a/web/client/selectors/cswtocatalog.js
+++ b/web/client/selectors/cswtocatalog.js
@@ -6,12 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const assign = require('object-assign');
-const {head} = require('lodash');
-const urlUtil = require('url');
+import assign from 'object-assign';
+
+import { head } from 'lodash';
+import urlUtil from 'url';
 
 
-const getBaseCatalogUrl = (url) => {
+export const getBaseCatalogUrl = (url) => {
     return url && url.substring(0, url.lastIndexOf("/"));
 };
 /**
@@ -19,7 +20,7 @@ const getBaseCatalogUrl = (url) => {
  * records:
  *
  */
-const cswToCatalogSelector = (catalog) => {
+export const cswToCatalogSelector = (catalog) => {
     let result = catalog.result;
     let searchOptions = catalog.searchOptions;
     if (result && result.records) {
@@ -116,4 +117,3 @@ const cswToCatalogSelector = (catalog) => {
     }
     return null;
 };
-module.exports = {cswToCatalogSelector};

--- a/web/client/selectors/dashboard.js
+++ b/web/client/selectors/dashboard.js
@@ -1,27 +1,24 @@
-const {createSelector} = require('reselect');
-const {pathnameSelector} = require('../selectors/router');
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-const isDashboardAvailable = state => state && state.dashboard && state.dashboard.editor && state.dashboard.editor.available;
-const isShowSaveOpen = state => state && state.dashboard && state.dashboard.showSaveModal;
-const isShowSaveAsOpen = state => state && state.dashboard && state.dashboard.showSaveAsModal;
-const isDashboardEditing = state => state && state.dashboard && state.dashboard.editing;
-const showConnectionsSelector = state => state && state.dashboard && state.dashboard.showConnections;
-const dashboardResource = state => state && state.dashboard && state.dashboard.resource;
-const isDashboardLoading = state => state && state.dashboard && state.dashboard.loading;
-const getDashboardSaveErrors = state => state && state.dashboard && state.dashboard.saveErrors;
-const isBrowserMobile = state => state && state.browser && state.browser.mobile;
-const buttonCanEdit = createSelector(pathnameSelector, dashboardResource, isBrowserMobile,
+
+import { createSelector } from 'reselect';
+import { pathnameSelector } from './router';
+
+export const isDashboardAvailable = state => state && state.dashboard && state.dashboard.editor && state.dashboard.editor.available;
+export const isShowSaveOpen = state => state && state.dashboard && state.dashboard.showSaveModal;
+export const isShowSaveAsOpen = state => state && state.dashboard && state.dashboard.showSaveAsModal;
+export const isDashboardEditing = state => state && state.dashboard && state.dashboard.editing;
+export const showConnectionsSelector = state => state && state.dashboard && state.dashboard.showConnections;
+export const dashboardResource = state => state && state.dashboard && state.dashboard.resource;
+export const isDashboardLoading = state => state && state.dashboard && state.dashboard.loading;
+export const getDashboardSaveErrors = state => state && state.dashboard && state.dashboard.saveErrors;
+export const isBrowserMobile = state => state && state.browser && state.browser.mobile;
+export const buttonCanEdit = createSelector(pathnameSelector, dashboardResource, isBrowserMobile,
     (path, resource, isMobile) => isMobile ? !isMobile : (resource && resource.canEdit || isNaN(path.substr(-4))));
 
-module.exports = {
-    isDashboardAvailable,
-    isShowSaveOpen,
-    isShowSaveAsOpen,
-    isDashboardEditing,
-    showConnectionsSelector,
-    dashboardResource,
-    isDashboardLoading,
-    getDashboardSaveErrors,
-    isBrowserMobile,
-    buttonCanEdit
-};

--- a/web/client/selectors/dashboards.js
+++ b/web/client/selectors/dashboards.js
@@ -6,12 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = {
-    searchTextSelector: state => state && state.dashboards && state.dashboards.searchText,
-    searchParamsSelector: state => state && state.dashboards && state.dashboards.options && state.dashboards.options.params,
-    resultsSelector: state => state && state.dashboards && state.dashboards.results,
-    totalCountSelector: state => state && state.dashboards && state.dashboards.totalCount,
-    isLoadingSelector: state => state && state.dashboards && state.dashboards.loading,
-    areDashboardsAvailable: state => state && state.dashboards && state.dashboards.available,
-    isEditDialogOpen: state => state && state.dashboards && state.dashboards.showModal && state.dashboards.showModal.edit
-};
+
+export const searchTextSelector = state => state && state.dashboards && state.dashboards.searchText;
+export const searchParamsSelector = state => state && state.dashboards && state.dashboards.options && state.dashboards.options.params;
+export const resultsSelector = state => state && state.dashboards && state.dashboards.results;
+export const totalCountSelector = state => state && state.dashboards && state.dashboards.totalCount;
+export const isLoadingSelector = state => state && state.dashboards && state.dashboards.loading;
+export const areDashboardsAvailable = state => state && state.dashboards && state.dashboards.available;
+export const isEditDialogOpen = state => state && state.dashboards && state.dashboards.showModal && state.dashboards.showModal.edit;

--- a/web/client/selectors/dimension.js
+++ b/web/client/selectors/dimension.js
@@ -5,16 +5,17 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { layersSelector } = require('./layers');
-const { createSelector } = require('reselect');
-const {get, find} = require('lodash');
+import { layersSelector } from './layers';
 
-const layerDimensionDataSelectorCreator = (layerId, dimension) => (state) => get(state, `dimension.data[${dimension}][${layerId}]`);
+import { createSelector } from 'reselect';
+import { get, find } from 'lodash';
 
-const getLayerStaticDimension = (layer = {}, dimension) => {
+export const layerDimensionDataSelectorCreator = (layerId, dimension) => (state) => get(state, `dimension.data[${dimension}][${layerId}]`);
+
+export const getLayerStaticDimension = (layer = {}, dimension) => {
     return find(layer.dimensions || [], { name: dimension });
 };
-const layerDimensionSelectorCreator = (layer, dimension) => (state) => {
+export const layerDimensionSelectorCreator = (layer, dimension) => (state) => {
     return layerDimensionDataSelectorCreator(layer.id, dimension)(state) || getLayerStaticDimension(layer, dimension);
 
 };
@@ -25,7 +26,7 @@ const layerDimensionSelectorCreator = (layer, dimension) => (state) => {
  * @param {object} state the current state
  * @return {object} a map of id -> time dimension configuration for layers that have one dimension named "time".
  */
-const timeDataSelector = state => layersSelector(state).reduce((timeDataMap, layer) => {
+export const timeDataSelector = state => layersSelector(state).reduce((timeDataMap, layer) => {
     const timeData = layerDimensionSelectorCreator(layer, "time")(state);
     if (timeData) {
         return {
@@ -40,24 +41,24 @@ const timeDataSelector = state => layersSelector(state).reduce((timeDataMap, lay
  * Returns a list of layers with time data
  * @param {object} state application state
  */
-const layersWithTimeDataSelector = state => layersSelector(state).filter(l => getLayerStaticDimension(l, "time"));
+export const layersWithTimeDataSelector = state => layersSelector(state).filter(l => getLayerStaticDimension(l, "time"));
 
-const currentTimeSelector = state => {
+export const currentTimeSelector = state => {
     const currentTime = get(state, 'dimension.currentTime');
     return currentTime && currentTime.split('/')[0];
 };
 
-const offsetTimeSelector = state => get(state, 'dimension.offsetTime');
+export const offsetTimeSelector = state => get(state, 'dimension.offsetTime');
 
-const offsetEnabledSelector = state => !!offsetTimeSelector(state);
+export const offsetEnabledSelector = state => !!offsetTimeSelector(state);
 // get times sorted by date
-const timeSequenceSelector = createSelector(
+export const timeSequenceSelector = createSelector(
     timeDataSelector,
     data => Object.keys(data)
         .reduce((acc, cur) =>
             [
                 ...acc,
-                ...data[cur] && data[cur].values || []
+                ...(data[cur] && data[cur].values || [])
             ],
         [])
         .sort() || []);
@@ -67,12 +68,12 @@ const timeSequenceSelector = createSelector(
  * Returns the time dimension values for the selected layer, sorted
  * @param {object} layer layer object (only id is required)
  */
-const layerTimeSequenceSelectorCreator =
+export const layerTimeSequenceSelectorCreator =
     layer =>
         state =>
             [...get(layerDimensionSelectorCreator(layer, "time")(state), "values", [])].sort();
 
-const layerDimensionRangeSelector = (state, layerId) => {
+export const layerDimensionRangeSelector = (state, layerId) => {
     const timeRange = layerDimensionDataSelectorCreator(layerId, "time")(state);
     const dataRange = timeRange && timeRange.domain && timeRange.domain.split('--');
     if (dataRange && dataRange.length === 2) {
@@ -89,17 +90,4 @@ const layerDimensionRangeSelector = (state, layerId) => {
         };
     }
     return null;
-};
-
-module.exports = {
-    layerDimensionRangeSelector,
-    layerDimensionSelectorCreator,
-    layerDimensionDataSelectorCreator,
-    layerTimeSequenceSelectorCreator,
-    timeSequenceSelector,
-    currentTimeSelector,
-    layersWithTimeDataSelector,
-    timeDataSelector,
-    offsetTimeSelector,
-    offsetEnabledSelector
 };

--- a/web/client/selectors/draw.js
+++ b/web/client/selectors/draw.js
@@ -5,13 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const {get} = require('lodash');
-const changedGeometriesSelector = state => state && state.draw && state.draw.tempFeatures;
-const drawSupportActiveSelector = (state) => {
+import { get } from 'lodash';
+
+export const changedGeometriesSelector = state => state && state.draw && state.draw.tempFeatures;
+export const drawSupportActiveSelector = (state) => {
     const drawStatus = get(state, "draw.drawStatus", false);
     return drawStatus && drawStatus !== 'clean' && drawStatus !== 'stop';
-};
-module.exports = {
-    drawSupportActiveSelector,
-    changedGeometriesSelector
 };

--- a/web/client/selectors/featuredmaps.js
+++ b/web/client/selectors/featuredmaps.js
@@ -12,29 +12,28 @@
  * @memberof selectors
  * @static
  */
-const { get } = require('lodash');
-module.exports = {
-    /**
-     * invalidation flag, triggers featuredmaps reload when changed
-     * @memberof selectors.featuredmaps
-     * @param {object} state applications state
-     * @return {boolean} invalidation flag value
-     */
-    invalidationSelector: state => state && state.featuredmaps && state.featuredmaps.invalidate || false,
-    /**
-     * selects searchText from featuredmaps, it's updated only on map list loading (press enter on search map)
-     * @memberof selectors.featuredmaps
-     * @param  {object}  state applications state
-     * @return {string}  current searched text
-     */
-    searchTextSelector: state => state && state.featuredmaps && state.featuredmaps.searchText || '',
-    /**
-     * selects flag for featuredmaps enabled
-     * @memberof selectors.featuredmaps
-     * @param  {object}  state applications state
-     * @return {boolean}  current searched text
-     */
-    isFeaturedMapsEnabled: state => get(state, "featuredmaps.enabled")
+import { get } from 'lodash';
 
-};
+
+/**
+ * invalidation flag, triggers featuredmaps reload when changed
+ * @memberof selectors.featuredmaps
+ * @param {object} state applications state
+ * @return {boolean} invalidation flag value
+ */
+export const invalidationSelector = state => state && state.featuredmaps && state.featuredmaps.invalidate || false;
+/**
+ * selects searchText from featuredmaps, it's updated only on map list loading (press enter on search map)
+ * @memberof selectors.featuredmaps
+ * @param  {object}  state applications state
+ * @return {string}  current searched text
+ */
+export const searchTextSelector = state => state && state.featuredmaps && state.featuredmaps.searchText || '';
+/**
+ * selects flag for featuredmaps enabled
+ * @memberof selectors.featuredmaps
+ * @param  {object}  state applications state
+ * @return {boolean}  current searched text
+ */
+export const isFeaturedMapsEnabled = state => get(state, "featuredmaps.enabled");
 

--- a/web/client/selectors/feedbackmask.js
+++ b/web/client/selectors/feedbackmask.js
@@ -6,8 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {get} = require('lodash');
+import { get } from 'lodash';
 
-module.exports = {
-    feedbackMaskSelector: state => get(state, 'feedbackMask', {})
-};
+
+export const feedbackMaskSelector = state => get(state, 'feedbackMask', {});

--- a/web/client/selectors/floatinglegend.js
+++ b/web/client/selectors/floatinglegend.js
@@ -13,21 +13,20 @@
  * @static
  */
 
-module.exports = {
-    /**
-     * Get size of floatinglegend
-     * @function
-     * @memberof selectors.floatinglegend
-     * @param  {object} state the state
-     * @return {object} size {width: 0, height: 0}
-     */
-    legendSizeSelector: state => state.floatinglegend && state.floatinglegend.size || {width: 0, height: 0},
-    /**
-     * Get expanded state of floatinglegend
-     * @function
-     * @memberof selectors.floatinglegend
-     * @param  {object} state the state
-     * @return {boolean}
-     */
-    legendExpandedSelector: state => state.floatinglegend && state.floatinglegend.expanded ? true : false
-};
+
+/**
+ * Get size of floatinglegend
+ * @function
+ * @memberof selectors.floatinglegend
+ * @param  {object} state the state
+ * @return {object} size {width: 0, height: 0}
+ */
+export const legendSizeSelector = state => state.floatinglegend && state.floatinglegend.size || {width: 0, height: 0};
+/**
+ * Get expanded state of floatinglegend
+ * @function
+ * @memberof selectors.floatinglegend
+ * @param  {object} state the state
+ * @return {boolean}
+ */
+export const legendExpandedSelector = state => state.floatinglegend && state.floatinglegend.expanded ? true : false;

--- a/web/client/selectors/geostories.js
+++ b/web/client/selectors/geostories.js
@@ -6,12 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = {
-    searchTextSelector: state => state && state.geostories && state.geostories.searchText,
-    searchParamsSelector: state => state && state.geostories && state.geostories.options && state.geostories.options.params,
-    resultsSelector: state => state && state.geostories && state.geostories.results,
-    totalCountSelector: state => state && state.geostories && state.geostories.totalCount,
-    isLoadingSelector: state => state && state.geostories && state.geostories.loading,
-    areGeostoriesAvailable: state => state && state.geostories && state.geostories.available,
-    isEditDialogOpen: state => state && state.geostories && state.geostories.showModal && state.geostories.showModal.edit
-};
+
+export const searchTextSelector = state => state && state.geostories && state.geostories.searchText;
+export const searchParamsSelector = state => state && state.geostories && state.geostories.options && state.geostories.options.params;
+export const resultsSelector = state => state && state.geostories && state.geostories.results;
+export const totalCountSelector = state => state && state.geostories && state.geostories.totalCount;
+export const isLoadingSelector = state => state && state.geostories && state.geostories.loading;
+export const areGeostoriesAvailable = state => state && state.geostories && state.geostories.available;
+export const isEditDialogOpen = state => state && state.geostories && state.geostories.showModal && state.geostories.showModal.edit;

--- a/web/client/selectors/highlight.js
+++ b/web/client/selectors/highlight.js
@@ -1,15 +1,23 @@
-const {get} = require('lodash');
-const {createSelector} = require('reselect');
-const {reprojectGeoJson} = require('../utils/CoordinatesUtils');
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-const selectedFeatures = (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures") || [];
-const filteredspatialObject = (state) => get(state, state && state.featuregrid && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
-const filteredGeometry = (state) => filteredspatialObject(state) && filteredspatialObject(state).geometry;
-const filteredspatialObjectType = (state) => filteredGeometry(state) && filteredGeometry(state).type || "Polygon";
-const filteredspatialObjectCoord = (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [];
-const filteredSpatialObjectCrs = (state) => filteredGeometry(state) && filteredGeometry(state).projection || "EPSG:3857";
-const filteredSpatialObjectId = (state) => filteredGeometry(state) && filteredGeometry(state).id || "spatial_object";
-const filteredFeatures = createSelector(
+import { get } from 'lodash';
+import { createSelector } from 'reselect';
+import { reprojectGeoJson } from '../utils/CoordinatesUtils';
+
+export const selectedFeatures = (state) => get(state, state && state.highlight && state.highlight.featuresPath || "highlight.emptyFeatures") || [];
+export const filteredspatialObject = (state) => get(state, state && state.featuregrid && state.featuregrid.open && state.featuregrid.showFilteredObject && "query.filterObj.spatialField" || "emptyObject");
+export const filteredGeometry = (state) => filteredspatialObject(state) && filteredspatialObject(state).geometry;
+export const filteredspatialObjectType = (state) => filteredGeometry(state) && filteredGeometry(state).type || "Polygon";
+export const filteredspatialObjectCoord = (state) => filteredGeometry(state) && filteredGeometry(state).coordinates || [];
+export const filteredSpatialObjectCrs = (state) => filteredGeometry(state) && filteredGeometry(state).projection || "EPSG:3857";
+export const filteredSpatialObjectId = (state) => filteredGeometry(state) && filteredGeometry(state).id || "spatial_object";
+export const filteredFeatures = createSelector(
     [
         filteredspatialObjectCoord,
         filteredspatialObjectType,
@@ -40,15 +48,10 @@ const filteredFeatures = createSelector(
 
 );
 
-const highlighedFeatures = createSelector(
+export const highlighedFeatures = createSelector(
     [
         filteredFeatures,
         selectedFeatures
     ],
     (featuresFiltered, featuresSelected) => [ ...featuresSelected, ...featuresFiltered]
 );
-
-module.exports = {
-    selectedFeatures, filteredFeatures, filteredSpatialObjectId, filteredSpatialObjectCrs, filteredspatialObjectCoord,
-    filteredspatialObjectType, filteredGeometry, filteredspatialObject, highlighedFeatures
-};

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -13,7 +13,6 @@ import LayersUtils from '../utils/LayersUtils';
 import { defaultIconStyle } from '../utils/SearchUtils';
 import { getNormalizedLatLon } from '../utils/CoordinatesUtils';
 import { clickedPointWithFeaturesSelector } from './mapInfo';
-import { defaultQueryableFilter } from '../utils/MapInfoUtils';
 import { get, head, isEmpty, find, isObject, isArray, castArray } from 'lodash';
 import { flattenGroups } from '../utils/TOCUtils';
 
@@ -133,7 +132,7 @@ export const elementSelector = (state) => {
 * @param {object} state the state
 * @return {array} the queriable layers
 */
-export const queryableLayersSelector = state => layersSelector(state).filter(defaultQueryableFilter);
+export const queryableLayersSelector = state => layersSelector(state).filter(MapInfoUtils.defaultQueryableFilter);
 /**
  * Return loading error state for selected layer
  * @param {object} state the state
@@ -145,4 +144,4 @@ export const selectedLayerLoadingErrorSelector = state => (getSelectedLayer(stat
  * @param {object} state the state
  * @return {array} the queriable selected layers
  */
-export const queryableSelectedLayersSelector = state => getSelectedLayers(state).filter(defaultQueryableFilter);
+export const queryableSelectedLayersSelector = state => getSelectedLayers(state).filter(MapInfoUtils.defaultQueryableFilter);

--- a/web/client/selectors/layers.js
+++ b/web/client/selectors/layers.js
@@ -6,33 +6,32 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {createSelector} = require('reselect');
+import { createSelector } from 'reselect';
 
-const MapInfoUtils = require('../utils/MapInfoUtils');
-const LayersUtils = require('../utils/LayersUtils');
-const {defaultIconStyle} = require('../utils/SearchUtils');
-const {getNormalizedLatLon} = require('../utils/CoordinatesUtils');
-const {clickedPointWithFeaturesSelector} = require('./mapInfo');
-const {defaultQueryableFilter} = require('../utils/MapInfoUtils');
+import MapInfoUtils from '../utils/MapInfoUtils';
+import LayersUtils from '../utils/LayersUtils';
+import { defaultIconStyle } from '../utils/SearchUtils';
+import { getNormalizedLatLon } from '../utils/CoordinatesUtils';
+import { clickedPointWithFeaturesSelector } from './mapInfo';
+import { defaultQueryableFilter } from '../utils/MapInfoUtils';
+import { get, head, isEmpty, find, isObject, isArray, castArray } from 'lodash';
+import { flattenGroups } from '../utils/TOCUtils';
 
-const {get, head, isEmpty, find, isObject, isArray, castArray} = require('lodash');
-const {flattenGroups} = require('../utils/TOCUtils');
-
-const layersSelector = ({layers, config} = {}) => layers && isArray(layers) ? layers : layers && layers.flat || config && config.layers || [];
-const currentBackgroundLayerSelector = state => head(layersSelector(state).filter(l => l && l.visibility && l.group === "background"));
-const getLayerFromId = (state, id) => head(layersSelector(state).filter(l => l.id === id));
-const getLayerFromName = (state, name) => head(layersSelector(state).filter(l => l.name === name));
-const allBackgroundLayerSelector = state => layersSelector(state).filter(l => l.group === "background");
-const highlightPointSelector = state => state.annotations && state.annotations.showMarker && state.annotations.clickPoint;
-const geoColderSelector = state => state.search && state.search;
+export const layersSelector = ({layers, config} = {}) => layers && isArray(layers) ? layers : layers && layers.flat || config && config.layers || [];
+export const currentBackgroundLayerSelector = state => head(layersSelector(state).filter(l => l && l.visibility && l.group === "background"));
+export const getLayerFromId = (state, id) => head(layersSelector(state).filter(l => l.id === id));
+export const getLayerFromName = (state, name) => head(layersSelector(state).filter(l => l.name === name));
+export const allBackgroundLayerSelector = state => layersSelector(state).filter(l => l.group === "background");
+export const highlightPointSelector = state => state.annotations && state.annotations.showMarker && state.annotations.clickPoint;
+export const geoColderSelector = state => state.search && state.search;
 
 // TODO currently loading flag causes a re-creation of the selector on any pan
 // to avoid this separate loading from the layer object
 
-const centerToMarkerSelector = (state) => get(state, "mapInfo.centerToMarker", '');
-const additionalLayersSelector = state => get(state, "additionallayers", []);
+export const centerToMarkerSelector = (state) => get(state, "mapInfo.centerToMarker", '');
+export const additionalLayersSelector = state => get(state, "additionallayers", []);
 
-const layerSelectorWithMarkers = createSelector(
+export const layerSelectorWithMarkers = createSelector(
     [layersSelector, clickedPointWithFeaturesSelector, geoColderSelector, centerToMarkerSelector, additionalLayersSelector,
         highlightPointSelector],
     (layers = [], markerPosition, geocoder, centerToMarker, additionalLayers, highlightPoint) => {
@@ -84,35 +83,35 @@ const layerSelectorWithMarkers = createSelector(
     }
 );
 
-const rawGroupsSelector = (state) => state.layers && state.layers.flat && state.layers.groups || [];
-const groupsSelector = (state) => state.layers && state.layers.flat && state.layers.groups && LayersUtils.denormalizeGroups(state.layers.flat, state.layers.groups).groups || [];
+export const rawGroupsSelector = (state) => state.layers && state.layers.flat && state.layers.groups || [];
+export const groupsSelector = (state) => state.layers && state.layers.flat && state.layers.groups && LayersUtils.denormalizeGroups(state.layers.flat, state.layers.groups).groups || [];
 
-const selectedNodesSelector = (state) => state.layers && state.layers.selected || [];
-const getSelectedLayers = state => {
+export const selectedNodesSelector = (state) => state.layers && state.layers.selected || [];
+export const getSelectedLayers = state => {
     const selectedIds = selectedNodesSelector(state);
     return selectedIds.map((id) => find(layersSelector(state), {id}));
 };
-const getSelectedLayer = state => {
+export const getSelectedLayer = state => {
     const selected = getSelectedLayers(state) || [];
     return selected && selected[0];
 };
-const layerFilterSelector = (state) => state.layers && state.layers.filter || '';
-const layerSettingSelector = (state) => state.layers && state.layers.settings || {expanded: false, options: {opacity: 1}};
-const layerMetadataSelector = (state) => state.layers && state.layers.layerMetadata || {expanded: false, metadataRecord: {}, maskLoading: false};
-const wfsDownloadSelector = (state) => state.controls && state.controls.wfsdownload ? { expanded: state.controls.wfsdownload.enabled } : {expanded: false};
+export const layerFilterSelector = (state) => state.layers && state.layers.filter || '';
+export const layerSettingSelector = (state) => state.layers && state.layers.settings || {expanded: false, options: {opacity: 1}};
+export const layerMetadataSelector = (state) => state.layers && state.layers.layerMetadata || {expanded: false, metadataRecord: {}, maskLoading: false};
+export const wfsDownloadSelector = (state) => state.controls && state.controls.wfsdownload ? { expanded: state.controls.wfsdownload.enabled } : {expanded: false};
 
-const backgroundControlsSelector = (state) => (state.controls && state.controls.backgroundSelector) || {};
-const currentBackgroundSelector = (state) => {
+export const backgroundControlsSelector = (state) => (state.controls && state.controls.backgroundSelector) || {};
+export const currentBackgroundSelector = (state) => {
     const controls = backgroundControlsSelector(state);
     const layers = allBackgroundLayerSelector(state) || [];
     return controls.currentLayer && !isEmpty(controls.currentLayer) ? controls.currentLayer : head(layers.filter((l) => l.visibility)) || {};
 };
-const tempBackgroundSelector = (state) => {
+export const tempBackgroundSelector = (state) => {
     const controls = backgroundControlsSelector(state);
     const layers = allBackgroundLayerSelector(state) || [];
     return controls.tempLayer && !isEmpty(controls.tempLayer) ? controls.tempLayer : head(layers.filter((l) => l.visibility)) || {};
 };
-const getLayersWithDimension = (state, dimension) =>
+export const getLayersWithDimension = (state, dimension) =>
     (layersSelector(state) || [])
         .filter(l =>
             l
@@ -122,7 +121,7 @@ const getLayersWithDimension = (state, dimension) =>
 /**
  * gets the actual node opened in settings modal
 */
-const elementSelector = (state) => {
+export const elementSelector = (state) => {
     const settings = layerSettingSelector(state);
     const layers = layersSelector(state);
     const groups = groupsSelector(state);
@@ -134,43 +133,16 @@ const elementSelector = (state) => {
 * @param {object} state the state
 * @return {array} the queriable layers
 */
-const queryableLayersSelector = state => layersSelector(state).filter(defaultQueryableFilter);
+export const queryableLayersSelector = state => layersSelector(state).filter(defaultQueryableFilter);
 /**
  * Return loading error state for selected layer
  * @param {object} state the state
  * @return {boolean} true if selected layer has error
  */
-const selectedLayerLoadingErrorSelector = state => (getSelectedLayer(state) || {}).loadingError === 'Error';
+export const selectedLayerLoadingErrorSelector = state => (getSelectedLayer(state) || {}).loadingError === 'Error';
 /**
  * Return queriable selected layers
  * @param {object} state the state
  * @return {array} the queriable selected layers
  */
-const queryableSelectedLayersSelector = state => getSelectedLayers(state).filter(defaultQueryableFilter);
-
-module.exports = {
-    getLayerFromName,
-    layersSelector,
-    rawGroupsSelector,
-    layerSelectorWithMarkers,
-    queryableLayersSelector,
-    groupsSelector,
-    currentBackgroundLayerSelector,
-    allBackgroundLayerSelector,
-    getLayerFromId,
-    getLayersWithDimension,
-    selectedNodesSelector,
-    getSelectedLayer,
-    getSelectedLayers,
-    layerFilterSelector,
-    layerSettingSelector,
-    layerMetadataSelector,
-    wfsDownloadSelector,
-    backgroundControlsSelector,
-    currentBackgroundSelector,
-    tempBackgroundSelector,
-    centerToMarkerSelector,
-    elementSelector,
-    selectedLayerLoadingErrorSelector,
-    queryableSelectedLayersSelector
-};
+export const queryableSelectedLayersSelector = state => getSelectedLayers(state).filter(defaultQueryableFilter);

--- a/web/client/selectors/locale.js
+++ b/web/client/selectors/locale.js
@@ -6,18 +6,15 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {createSelector} = require('reselect');
-const {head} = require('lodash');
+import { createSelector } from 'reselect';
 
-const currentLocaleSelector = (state) => state.locale && state.locale.current || 'en-US';
-const currentMessagesSelector = (state) => state.locale && state.locale.messages || {};
+import { head } from 'lodash';
 
-const currentLocaleLanguageSelector = createSelector([
+export const currentLocaleSelector = (state) => state.locale && state.locale.current || 'en-US';
+export const currentMessagesSelector = (state) => state.locale && state.locale.messages || {};
+
+export const currentLocaleLanguageSelector = createSelector([
     currentLocaleSelector
 ], (currentLocale) => head(currentLocale.split('-')));
 
-module.exports = {
-    currentLocaleSelector,
-    currentLocaleLanguageSelector,
-    currentMessagesSelector
-};
+

--- a/web/client/selectors/localizedLayerStyles.js
+++ b/web/client/selectors/localizedLayerStyles.js
@@ -6,10 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const {has, get, find} = require('lodash');
-const {createSelector} = require('reselect');
+import { has, get, find } from 'lodash';
 
-const {currentLocaleLanguageSelector} = require('./locale');
+import { createSelector } from 'reselect';
+import { currentLocaleLanguageSelector } from './locale';
 
 /**
  * selects localizedLayerStyles state
@@ -24,7 +24,7 @@ const {currentLocaleLanguageSelector} = require('./locale');
  * @param  {object} state the state
  * @return {boolean} true if the localizedLayerStyles property is defined
  */
-const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig.localizedLayerStyles');
+export const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig.localizedLayerStyles');
 
 /**
  * selects localizedLayerStyles value from state
@@ -32,7 +32,7 @@ const isLocalizedLayerStylesEnabledSelector = (state) => has(state, 'localConfig
  * @param  {object} state the state
  * @return {boolean} boolean if the localizedLayerStyles property is defined
  */
-const isLocalizedLayerStylesEnabledDashboardsSelector = (state) => {
+export const isLocalizedLayerStylesEnabledDashboardsSelector = (state) => {
     const dashboardPlugins = get(state, "localConfig.plugins.dashboard", []);
     const dashboardEditorPlugin = find(dashboardPlugins, item => item.name === 'DashboardEditor') || {};
     return get(dashboardEditorPlugin, "cfg.catalog.localizedLayerStyles", false);
@@ -44,7 +44,7 @@ const isLocalizedLayerStylesEnabledDashboardsSelector = (state) => {
  * @param  {object} state the state
  * @return {string} the localizedLayerStyles param name
  */
-const localizedLayerStylesNameSelector = (state) => get(state, 'localConfig.localizedLayerStyles.name', 'mapstore_language');
+export const localizedLayerStylesNameSelector = (state) => get(state, 'localConfig.localizedLayerStyles.name', 'mapstore_language');
 
 /**
  * generates localizedLayerStyles env object
@@ -52,7 +52,7 @@ const localizedLayerStylesNameSelector = (state) => get(state, 'localConfig.loca
  * @param  {object} state the state
  * @return {object} object that represents ENV param
  */
-const localizedLayerStylesEnvSelector = createSelector(
+export const localizedLayerStylesEnvSelector = createSelector(
     isLocalizedLayerStylesEnabledSelector,
     localizedLayerStylesNameSelector,
     currentLocaleLanguageSelector,
@@ -67,10 +67,3 @@ const localizedLayerStylesEnvSelector = createSelector(
         return env;
     }
 );
-
-module.exports = {
-    isLocalizedLayerStylesEnabledSelector,
-    localizedLayerStylesNameSelector,
-    localizedLayerStylesEnvSelector,
-    isLocalizedLayerStylesEnabledDashboardsSelector
-};

--- a/web/client/selectors/map.js
+++ b/web/client/selectors/map.js
@@ -6,9 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const CoordinatesUtils = require('../utils/CoordinatesUtils');
-const {createSelector} = require('reselect');
-const {get} = require('lodash');
+import CoordinatesUtils from '../utils/CoordinatesUtils';
+
+import { createSelector } from 'reselect';
+import { get } from 'lodash';
 
 /**
  * selects map state
@@ -24,17 +25,17 @@ const {get} = require('lodash');
  * @param  {object} state the state
  * @return {object} the map configuration
  */
-const mapSelector = (state) => state.map && state.map.present || state.map || state.config && state.config.map || null;
+export const mapSelector = (state) => state.map && state.map.present || state.map || state.config && state.config.map || null;
 
-const projectionSelector = createSelector([mapSelector], (map) => map && map.projection);
-const stateMapIdSelector = (state) => get(mapSelector(state), "mapId") && parseInt(get(mapSelector(state), "mapId"), 10) || null;
-const mapIdSelector = (state) => get(state, "mapInitialConfig.mapId") && parseInt(get(state, "mapInitialConfig.mapId"), 10) || stateMapIdSelector(state);
-const mapInfoSelector = state => get(mapSelector(state), "info");
-const mapInfoLoadingSelector = state => get(mapSelector(state), "loadingInfo", false);
-const mapSaveErrorsSelector = state => get(mapSelector(state), "mapSaveErrors");
-const mapInfoDetailsUriFromIdSelector = state => get(mapInfoSelector(state), "details");
-const mapInfoDetailsSettingsFromIdSelector = state => get(mapInfoSelector(state), "detailsSettings");
-const mapIsEditableSelector = state => {
+export const projectionSelector = createSelector([mapSelector], (map) => map && map.projection);
+export const stateMapIdSelector = (state) => get(mapSelector(state), "mapId") && parseInt(get(mapSelector(state), "mapId"), 10) || null;
+export const mapIdSelector = (state) => get(state, "mapInitialConfig.mapId") && parseInt(get(state, "mapInitialConfig.mapId"), 10) || stateMapIdSelector(state);
+export const mapInfoSelector = state => get(mapSelector(state), "info");
+export const mapInfoLoadingSelector = state => get(mapSelector(state), "loadingInfo", false);
+export const mapSaveErrorsSelector = state => get(mapSelector(state), "mapSaveErrors");
+export const mapInfoDetailsUriFromIdSelector = state => get(mapInfoSelector(state), "details");
+export const mapInfoDetailsSettingsFromIdSelector = state => get(mapInfoSelector(state), "detailsSettings");
+export const mapIsEditableSelector = state => {
     const mapInfoCanEdit = get(mapInfoSelector(state), 'canEdit');
     if (mapInfoCanEdit === undefined) {
         return get(state, 'context.resource.canEdit');
@@ -43,20 +44,20 @@ const mapIsEditableSelector = state => {
 };
 
 // TODO: move these in selectors/localConfig.js or selectors/config.js
-const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
-const mapConstraintsSelector = state => state.localConfig && state.localConfig.mapConstraints || {};
-const configuredRestrictedExtentSelector = (state) => mapConstraintsSelector(state).restrictedExtent;
-const configuredExtentCrsSelector = (state) => mapConstraintsSelector(state).crs;
-const configuredMinZoomSelector = state => {
+export const projectionDefsSelector = (state) => state.localConfig && state.localConfig.projectionDefs || [];
+export const mapConstraintsSelector = state => state.localConfig && state.localConfig.mapConstraints || {};
+export const configuredRestrictedExtentSelector = (state) => mapConstraintsSelector(state).restrictedExtent;
+export const configuredExtentCrsSelector = (state) => mapConstraintsSelector(state).crs;
+export const configuredMinZoomSelector = state => {
     const constraints = mapConstraintsSelector(state);
     const projection = projectionSelector(state);
     return projection && get(constraints, `projectionsConstraints["${projection}"].minZoom`) || get(constraints, 'minZoom');
 };
 // END localConfig selectors
 
-const mapLimitsSelector = state => get(mapSelector(state), "limits");
-const minZoomSelector = state => get(mapLimitsSelector(state), "minZoom" );
-const resolutionsSelector = state => get(mapSelector(state), "resolutions");
+export const mapLimitsSelector = state => get(mapSelector(state), "limits");
+export const minZoomSelector = state => get(mapLimitsSelector(state), "minZoom" );
+export const resolutionsSelector = state => get(mapSelector(state), "resolutions");
 
 /**
  * Get the scales of the current map
@@ -65,7 +66,7 @@ const resolutionsSelector = state => get(mapSelector(state), "resolutions");
  * @param  {object} state the state
  * @return {number[]} the scales of the map
  */
-const scalesSelector = createSelector(
+export const scalesSelector = createSelector(
     [resolutionsSelector, projectionSelector],
     (resolutions, projection) => {
         if (resolutions && projection) {
@@ -83,7 +84,7 @@ const scalesSelector = createSelector(
  * @param  {object} state the state
  * @return {number} version of the map
  */
-const mapVersionSelector = (state) => state.map && state.map.present && state.map.present.version || 1;
+export const mapVersionSelector = (state) => state.map && state.map.present && state.map.present.version || 1;
 /**
  * Get name/title of the map
  * @function
@@ -91,36 +92,12 @@ const mapVersionSelector = (state) => state.map && state.map.present && state.ma
  * @param  {object} state the state
  * @return {string} name/title of the map
  */
-const mapNameSelector = (state) => state.map && state.map.present && state.map.present.info && state.map.present.info.name || '';
+export const mapNameSelector = (state) => state.map && state.map.present && state.map.present.info && state.map.present.info.name || '';
 
-const mouseMoveListenerSelector = (state) => get(mapSelector(state), 'eventListeners.mousemove', []);
+export const mouseMoveListenerSelector = (state) => get(mapSelector(state), 'eventListeners.mousemove', []);
 
-const isMouseMoveActiveSelector = (state) => !!mouseMoveListenerSelector(state).length;
+export const isMouseMoveActiveSelector = (state) => !!mouseMoveListenerSelector(state).length;
 
-const isMouseMoveCoordinatesActiveSelector = (state) => mouseMoveListenerSelector(state).includes('mouseposition');
+export const isMouseMoveCoordinatesActiveSelector = (state) => mouseMoveListenerSelector(state).includes('mouseposition');
 
-const isMouseMoveIdentifyActiveSelector = (state) =>  mouseMoveListenerSelector(state).includes('identifyFloatingTool');
-
-module.exports = {
-    mapInfoDetailsUriFromIdSelector,
-    mapInfoDetailsSettingsFromIdSelector,
-    mapSelector,
-    scalesSelector,
-    projectionSelector,
-    minZoomSelector,
-    mapIdSelector,
-    projectionDefsSelector,
-    mapVersionSelector,
-    mapNameSelector,
-    configuredMinZoomSelector,
-    configuredExtentCrsSelector,
-    configuredRestrictedExtentSelector,
-    mapInfoSelector,
-    mapInfoLoadingSelector,
-    mapSaveErrorsSelector,
-    mapIsEditableSelector,
-    mouseMoveListenerSelector,
-    isMouseMoveActiveSelector,
-    isMouseMoveCoordinatesActiveSelector,
-    isMouseMoveIdentifyActiveSelector
-};
+export const isMouseMoveIdentifyActiveSelector = (state) =>  mouseMoveListenerSelector(state).includes('identifyFloatingTool');

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -6,18 +6,16 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const { get, omit, isArray } = require('lodash');
+import { get, omit, isArray } from 'lodash';
 
-const { createSelector, createStructuredSelector } = require('reselect');
-
-const { mapSelector } = require('./map');
-const { isPluginInContext } = require('./context');
-const { currentLocaleSelector } = require('./locale');
-const MapInfoUtils = require('../utils/MapInfoUtils');
-const {isCesium} = require('./maptype');
-const {isMouseMoveIdentifyActiveSelector: identifyFloatingTool } = require('../selectors/map');
-
-const {pluginsSelectorCreator} = require('./localConfig');
+import { createSelector, createStructuredSelector } from 'reselect';
+import { mapSelector } from './map';
+import { isPluginInContext } from './context';
+import { currentLocaleSelector } from './locale';
+import MapInfoUtils from '../utils/MapInfoUtils';
+import { isCesium } from './maptype';
+import { isMouseMoveIdentifyActiveSelector as identifyFloatingTool } from '../selectors/map';
+import { pluginsSelectorCreator } from './localConfig';
 /**
  * selects mapinfo state
  * @name mapinfo
@@ -25,7 +23,7 @@ const {pluginsSelectorCreator} = require('./localConfig');
  * @static
  */
 
-const isMapPopup =  createSelector(
+export const isMapPopup =  createSelector(
     (state) => pluginsSelectorCreator("desktop")(state) || {},
     isCesium,
     (plugins, cesium) => {
@@ -39,8 +37,8 @@ const isMapPopup =  createSelector(
   * @param  {object} state the state
   * @return {object} the mapinfo requests
   */
-const mapInfoRequestsSelector = state => get(state, "mapInfo.requests") || [];
-const isMapInfoOpen = createSelector(
+export const mapInfoRequestsSelector = state => get(state, "mapInfo.requests") || [];
+export const isMapInfoOpen = createSelector(
     mapInfoRequestsSelector,
     isPluginInContext('Identify'),
     isMapPopup,
@@ -53,27 +51,27 @@ const isMapInfoOpen = createSelector(
  * @param  {object} state the state
  * @return {string}       the maptype in the state
  */
-const generalInfoFormatSelector = (state) => get(state, "mapInfo.configuration.infoFormat", "text/plain");
-const showEmptyMessageGFISelector = (state) => get(state, "mapInfo.configuration.showEmptyMessageGFI", true);
-const mapInfoConfigurationSelector = (state) => get(state, "mapInfo.configuration", {});
+export const generalInfoFormatSelector = (state) => get(state, "mapInfo.configuration.infoFormat", "text/plain");
+export const showEmptyMessageGFISelector = (state) => get(state, "mapInfo.configuration.showEmptyMessageGFI", true);
+export const mapInfoConfigurationSelector = (state) => get(state, "mapInfo.configuration", {});
 
-const measureActiveSelector = (state) => get(state, "controls.measure.enabled") && (get(state, "measurement.lineMeasureEnabled") || get(state, "measurement.areaMeasureEnabled") || get(state, "measurement.bearingMeasureEnabled"));
+export const measureActiveSelector = (state) => get(state, "controls.measure.enabled") && (get(state, "measurement.lineMeasureEnabled") || get(state, "measurement.areaMeasureEnabled") || get(state, "measurement.bearingMeasureEnabled"));
 /**
  * Clicked point of mapInfo
  * @param {object} state the state
  */
-const clickPointSelector = state => state && state.mapInfo && state.mapInfo.clickPoint;
-const clickLayerSelector = state => state && state.mapInfo && state.mapInfo.clickLayer;
-const showMarkerSelector = state => state && state.mapInfo && state.mapInfo.showMarker;
-const itemIdSelector = state => get(state, "mapInfo.itemId", null);
-const overrideParamsSelector = state => get(state, "mapInfo.overrideParams", {});
-const filterNameListSelector = state => get(state, "mapInfo.filterNameList", []);
-const drawSupportActiveSelector = (state) => {
+export const clickPointSelector = state => state && state.mapInfo && state.mapInfo.clickPoint;
+export const clickLayerSelector = state => state && state.mapInfo && state.mapInfo.clickLayer;
+export const showMarkerSelector = state => state && state.mapInfo && state.mapInfo.showMarker;
+export const itemIdSelector = state => get(state, "mapInfo.itemId", null);
+export const overrideParamsSelector = state => get(state, "mapInfo.overrideParams", {});
+export const filterNameListSelector = state => get(state, "mapInfo.filterNameList", []);
+export const drawSupportActiveSelector = (state) => {
     const drawStatus = get(state, "draw.drawStatus", false);
     return drawStatus && drawStatus !== 'clean' && drawStatus !== 'stop';
 };
-const annotationsEditingSelector = (state) => get(state, "annotations.editing");
-const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false);
+export const annotationsEditingSelector = (state) => get(state, "annotations.editing");
+export const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false);
 
 /**
  * selects stopGetFeatureInfo from state
@@ -81,7 +79,7 @@ const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false)
  * @param  {object} state the state
  * @return {boolean} true if the get feature info has to stop the request
  */
-const stopGetFeatureInfoSelector = createSelector(
+export const stopGetFeatureInfoSelector = createSelector(
     mapInfoDisabledSelector,
     measureActiveSelector,
     drawSupportActiveSelector,
@@ -98,27 +96,27 @@ const stopGetFeatureInfoSelector = createSelector(
 /**
  * Defines the general options of the identifyTool to build the request
  */
-const identifyOptionsSelector = createStructuredSelector({
+export const identifyOptionsSelector = createStructuredSelector({
     format: generalInfoFormatSelector,
     map: mapSelector,
     point: clickPointSelector,
     currentLocale: currentLocaleSelector
 });
 
-const isHighlightEnabledSelector = (state = {}) => state.mapInfo && state.mapInfo.highlight;
+export const isHighlightEnabledSelector = (state = {}) => state.mapInfo && state.mapInfo.highlight;
 
-const indexSelector = (state = {}) => state && state.mapInfo && state.mapInfo.index;
+export const indexSelector = (state = {}) => state && state.mapInfo && state.mapInfo.index;
 
-const responsesSelector = state => state.mapInfo && state.mapInfo.responses || [];
+export const responsesSelector = state => state.mapInfo && state.mapInfo.responses || [];
 
-const requestsSelector = state => state?.mapInfo?.requests || [];
+export const requestsSelector = state => state?.mapInfo?.requests || [];
 
-const isLoadedResponseSelector = state => state?.mapInfo?.loaded;
+export const isLoadedResponseSelector = state => state?.mapInfo?.loaded;
 
 /**
  * Gets only the valid responses
  */
-const validResponsesSelector = createSelector(
+export const validResponsesSelector = createSelector(
     requestsSelector,
     responsesSelector,
     generalInfoFormatSelector,
@@ -128,15 +126,15 @@ const validResponsesSelector = createSelector(
         return requests.length === responses.length && validatorFormat.getValidResponses(responses, renderEmpty);
     });
 
-const currentResponseSelector = createSelector(
+export const currentResponseSelector = createSelector(
     validResponsesSelector, indexSelector,
     (responses = [], index = 0) => responses[index]
 );
-const currentFeatureSelector = state => {
+export const currentFeatureSelector = state => {
     const currentResponse = currentResponseSelector(state) || {};
     return get(currentResponse, 'layerMetadata.features');
 };
-const currentFeatureCrsSelector = state => {
+export const currentFeatureCrsSelector = state => {
     const currentResponse = currentResponseSelector(state) || {};
     return get(currentResponse, 'layerMetadata.featuresCrs');
 };
@@ -145,7 +143,7 @@ const currentFeatureCrsSelector = state => {
  * Returns the a function that returns the correct style based on the geometry type, to use in the highlight
  * @param {feature} f the feature in json format
  */
-const getStyleForFeature = (style) => (f = {}) =>
+export const getStyleForFeature = (style) => (f = {}) =>
     f.style
         || (f.geometry && (f.geometry.type === "Point" || f.geometry.type === "MultiPoint"))
     // point style circle requires radius (it's strange circle should be a default)
@@ -155,7 +153,7 @@ const getStyleForFeature = (style) => (f = {}) =>
 /**
  * Create a function that add the style property to the feature.
  */
-const applyMapInfoStyle = style => f => ({
+export const applyMapInfoStyle = style => f => ({
     ...f,
     style: getStyleForFeature(style)(f)
 });
@@ -164,7 +162,7 @@ const applyMapInfoStyle = style => f => ({
  * @param {object} state the application state
  * @returns {object} style object
  */
-const highlightStyleSelector = state => get(state, 'mapInfo.highlightStyle', {
+export const highlightStyleSelector = state => get(state, 'mapInfo.highlightStyle', {
     color: '#3388ff',
     weight: 4,
     radius: 4,
@@ -173,7 +171,7 @@ const highlightStyleSelector = state => get(state, 'mapInfo.highlightStyle', {
     fillOpacity: 0.2
 });
 
-const clickedPointWithFeaturesSelector = createSelector(
+export const clickedPointWithFeaturesSelector = createSelector(
     clickPointSelector,
     isHighlightEnabledSelector,
     currentFeatureSelector,
@@ -194,40 +192,12 @@ const clickedPointWithFeaturesSelector = createSelector(
 
 );
 
-const currentEditFeatureQuerySelector = state => state.mapInfo?.currentEditFeatureQuery;
+export const currentEditFeatureQuerySelector = state => state.mapInfo?.currentEditFeatureQuery;
 
-const mapTriggerSelector = state => {
+export const mapTriggerSelector = state => {
     if (state.mapInfo?.configuration?.trigger === undefined) {
         return 'click';
     }
     return state.mapInfo.configuration.trigger;
 };
 
-
-module.exports = {
-    isMapInfoOpen,
-    indexSelector,
-    responsesSelector,
-    requestsSelector,
-    validResponsesSelector,
-    currentFeatureSelector,
-    currentFeatureCrsSelector,
-    clickedPointWithFeaturesSelector,
-    highlightStyleSelector,
-    identifyOptionsSelector,
-    clickPointSelector,
-    clickLayerSelector,
-    generalInfoFormatSelector,
-    mapInfoRequestsSelector,
-    stopGetFeatureInfoSelector,
-    showEmptyMessageGFISelector,
-    mapInfoConfigurationSelector,
-    isHighlightEnabledSelector,
-    itemIdSelector,
-    overrideParamsSelector,
-    filterNameListSelector,
-    isMapPopup,
-    currentEditFeatureQuerySelector,
-    mapTriggerSelector,
-    isLoadedResponseSelector
-};

--- a/web/client/selectors/mapInitialConfig.js
+++ b/web/client/selectors/mapInitialConfig.js
@@ -5,7 +5,8 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-const {get} = require('lodash');
+import { get } from 'lodash';
+
 /**
  * Checks for an error when a map is accessed
  * @function
@@ -13,9 +14,5 @@ const {get} = require('lodash');
  * @param  {object} state the state
  * @return {object} error object
  */
-const hasMapAccessLoadingError = (state) => get(state, "mapInitialConfig.loadingError");
-const mapIdSelector = (state) => state.mapInitialConfig?.mapId;
-module.exports = {
-    hasMapAccessLoadingError,
-    mapIdSelector
-};
+export const hasMapAccessLoadingError = (state) => get(state, "mapInitialConfig.loadingError");
+export const mapIdSelector = (state) => state.mapInitialConfig?.mapId;

--- a/web/client/selectors/maplayout.js
+++ b/web/client/selectors/maplayout.js
@@ -5,9 +5,10 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-const {head} = require('lodash');
-const {mapSelector} = require('./map');
-const {parseLayoutValue} = require('../utils/MapUtils');
+import { head } from 'lodash';
+
+import { mapSelector } from './map';
+import { parseLayoutValue } from '../utils/MapUtils';
 
 /**
  * selects map layout state
@@ -24,7 +25,7 @@ const {parseLayoutValue} = require('../utils/MapUtils');
  * @return {object} the layout of the map
  */
 
-const mapLayoutSelector = (state) => state.maplayout && state.maplayout.layout || {};
+export const mapLayoutSelector = (state) => state.maplayout && state.maplayout.layout || {};
 
 /**
  * Get map layout bounds left, top, bottom and right
@@ -33,7 +34,7 @@ const mapLayoutSelector = (state) => state.maplayout && state.maplayout.layout |
  * @param  {object} state the state
  * @return {object} boundingMapRect {left, top, bottom, right}
  */
-const boundingMapRectSelector = (state) => state.maplayout && state.maplayout.boundingMapRect || {};
+export const boundingMapRectSelector = (state) => state.maplayout && state.maplayout.boundingMapRect || {};
 
 /**
  * Retrieve only specific attribute from map layout
@@ -43,7 +44,7 @@ const boundingMapRectSelector = (state) => state.maplayout && state.maplayout.bo
  * @param  {object} attributes attributes to retrieve, bool {left: true}
  * @return {object} selected attributes of layout of the map
  */
-const mapLayoutValuesSelector = (state, attributes = {}) => {
+export const mapLayoutValuesSelector = (state, attributes = {}) => {
     const layout = mapLayoutSelector(state);
     return layout && Object.keys(layout).filter(key =>
         attributes[key]).reduce((a, key) => ({...a, [key]: layout[key]}),
@@ -58,7 +59,7 @@ const mapLayoutValuesSelector = (state, attributes = {}) => {
  * @param  {array} conditions array of object, [{ key: 'left', value: 300 }, { key: 'right', value: 0, type: 'not' }]
  * @return {boolean} returns true if the layout attributes match with the provided conditions
  */
-const checkConditionsSelector = (state, conditions = []) => {
+export const checkConditionsSelector = (state, conditions = []) => {
     const layout = mapLayoutSelector(state);
     const check = !!head(conditions.filter(c => layout[c.key]).map(c => {
         if (c.type === 'not') {
@@ -76,7 +77,7 @@ const checkConditionsSelector = (state, conditions = []) => {
  * @param  {object} state the state
  * @return {boolean} returns true if right panels are open
  */
-const rightPanelOpenSelector = state => {
+export const rightPanelOpenSelector = state => {
     // need to remove 658 and manage it from the state with all dafault layout variables
     return checkConditionsSelector(state, [{ key: 'right', value: 658 }]);
 };
@@ -87,7 +88,7 @@ const rightPanelOpenSelector = state => {
  * @param  {object} state the state
  * @return {boolean} returns true if bottom panel is open
  */
-const bottomPanelOpenSelector = state => {
+export const bottomPanelOpenSelector = state => {
     // need to remove 30 and manage it from the state with all dafault layout variables
     return checkConditionsSelector(state, [{ key: 'bottom', value: 30, type: 'not' }]);
 };
@@ -98,7 +99,7 @@ const bottomPanelOpenSelector = state => {
  * @returns {object} object with `left,bottom,right,top` properties, in pixels, containing the map layout
  */
 
-const mapPaddingSelector = state => {
+export const mapPaddingSelector = state => {
     const map = mapSelector(state);
     const boundingMapRect = boundingMapRectSelector(state);
     return boundingMapRect && map && map.size && {
@@ -107,14 +108,4 @@ const mapPaddingSelector = state => {
         right: parseLayoutValue(boundingMapRect.right, map.size.width),
         top: parseLayoutValue(boundingMapRect.top, map.size.height)
     };
-};
-
-module.exports = {
-    mapLayoutSelector,
-    mapLayoutValuesSelector,
-    checkConditionsSelector,
-    rightPanelOpenSelector,
-    bottomPanelOpenSelector,
-    boundingMapRectSelector,
-    mapPaddingSelector
 };

--- a/web/client/selectors/maps.js
+++ b/web/client/selectors/maps.js
@@ -5,7 +5,7 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree.
 */
-const {find, get} = require('lodash');
+import { find, get } from 'lodash';
 
 /**
  * selects maps state
@@ -14,22 +14,22 @@ const {find, get} = require('lodash');
  * @static
 */
 
-const mapsResultsSelector = (state) => get(state, "maps.results", []);
-const totalCountSelector = state => get(state, "maps.totalCount");
-const mapFromIdSelector = (state, id) => find(mapsResultsSelector(state), m => m.id === id);
-const mapNameSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).name || "";
-const mapMetadataSelector = (state) => get(state, "maps.metadata", {});
-const isMapsLastPageSelector = (state) => state && state.maps && state.maps.totalCount === state.maps.start;
-const mapDescriptionSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).description || "";
-const mapDetailsUriFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).details || "";
-const mapPermissionsFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).permissions || "";
-const mapThumbnailsUriFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).thumbnail || "";
-const searchTextSelector = state => state && state.maps && state.maps.searchText;
-const searchParamsSelector = state => ({start: get(state, 'maps.start'), limit: get(state, 'maps.limit')});
-const searchFilterSelector = state => state && state.maps && state.maps.searchFilter;
-const contextsSelector = state => state && state.maps && state.maps.contexts;
-const loadingSelector = state => state && state.maps && state.maps.loading;
-const loadFlagsSelector = state => state && state.maps && state.maps.loadFlags;
+export const mapsResultsSelector = (state) => get(state, "maps.results", []);
+export const totalCountSelector = state => get(state, "maps.totalCount");
+export const mapFromIdSelector = (state, id) => find(mapsResultsSelector(state), m => m.id === id);
+export const mapNameSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).name || "";
+export const mapMetadataSelector = (state) => get(state, "maps.metadata", {});
+export const isMapsLastPageSelector = (state) => state && state.maps && state.maps.totalCount === state.maps.start;
+export const mapDescriptionSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).description || "";
+export const mapDetailsUriFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).details || "";
+export const mapPermissionsFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).permissions || "";
+export const mapThumbnailsUriFromIdSelector = (state, id) => mapFromIdSelector(state, id) && mapFromIdSelector(state, id).thumbnail || "";
+export const searchTextSelector = state => state && state.maps && state.maps.searchText;
+export const searchParamsSelector = state => ({start: get(state, 'maps.start'), limit: get(state, 'maps.limit')});
+export const searchFilterSelector = state => state && state.maps && state.maps.searchFilter;
+export const contextsSelector = state => state && state.maps && state.maps.contexts;
+export const loadingSelector = state => state && state.maps && state.maps.loading;
+export const loadFlagsSelector = state => state && state.maps && state.maps.loadFlags;
 /**
  * Get flag for enable/disable of the map card details
  * @function
@@ -37,24 +37,4 @@ const loadFlagsSelector = state => state && state.maps && state.maps.loadFlags;
  * @param  {object} state the state
  * @return {boolean} showMapDetails flag for the map card details
  */
-const showMapDetailsSelector = (state) => get(state, "maps.showMapDetails");
-
-module.exports = {
-    mapNameSelector,
-    mapFromIdSelector,
-    showMapDetailsSelector,
-    mapsResultsSelector,
-    totalCountSelector,
-    mapMetadataSelector,
-    isMapsLastPageSelector,
-    mapDescriptionSelector,
-    mapDetailsUriFromIdSelector,
-    mapPermissionsFromIdSelector,
-    mapThumbnailsUriFromIdSelector,
-    searchTextSelector,
-    searchParamsSelector,
-    searchFilterSelector,
-    contextsSelector,
-    loadingSelector,
-    loadFlagsSelector
-};
+export const showMapDetailsSelector = (state) => get(state, "maps.showMapDetails");

--- a/web/client/selectors/mapsave.js
+++ b/web/client/selectors/mapsave.js
@@ -6,21 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const MapUtils = require('../utils/MapUtils');
-const {mapSelector} = require('./map');
-const {createStructuredSelector} = require('reselect');
-const {servicesSelector, selectedServiceSelector} = require('./catalog');
-const {getFloatingWidgets, getCollapsedState, getFloatingWidgetsLayout} = require('./widgets');
-const { mapInfoConfigurationSelector } = require('./mapInfo');
-const { currentTimeSelector, offsetTimeSelector } = require('./dimension');
-const { selectedLayerSelector } = require('./timeline');
-const { layersSelector, groupsSelector } = require('../selectors/layers');
-const { backgroundListSelector } = require('../selectors/backgroundselector');
-const { textSearchConfigSelector, bookmarkSearchConfigSelector } = require('./searchconfig');
+import MapUtils from '../utils/MapUtils';
+
+import { mapSelector } from './map';
+import { createStructuredSelector } from 'reselect';
+import { servicesSelector, selectedServiceSelector } from './catalog';
+import { getFloatingWidgets, getCollapsedState, getFloatingWidgetsLayout } from './widgets';
+import { mapInfoConfigurationSelector } from './mapInfo';
+import { currentTimeSelector, offsetTimeSelector } from './dimension';
+import { selectedLayerSelector } from './timeline';
+import { layersSelector, groupsSelector } from '../selectors/layers';
+import { backgroundListSelector } from '../selectors/backgroundselector';
+import { textSearchConfigSelector, bookmarkSearchConfigSelector } from './searchconfig';
 
 const customSaveHandlers = {};
 
-const registerCustomSaveHandler = (section, handler) => {
+export const registerCustomSaveHandler = (section, handler) => {
     if (handler) {
         customSaveHandlers[section] = handler;
     } else {
@@ -28,7 +29,7 @@ const registerCustomSaveHandler = (section, handler) => {
     }
 };
 
-const basicMapOptionsToSaveSelector = createStructuredSelector({
+export const basicMapOptionsToSaveSelector = createStructuredSelector({
     catalogServices: createStructuredSelector({
         services: servicesSelector,
         selectedService: selectedServiceSelector
@@ -48,7 +49,7 @@ const basicMapOptionsToSaveSelector = createStructuredSelector({
     })
 });
 
-const mapOptionsToSaveSelector = (state) => {
+export const mapOptionsToSaveSelector = (state) => {
     const customState = Object.keys(customSaveHandlers).reduce((acc, fragment) => {
         return {
             ...acc,
@@ -63,7 +64,7 @@ const mapOptionsToSaveSelector = (state) => {
  * @param {object} state the application state
  * @return the map to save
  */
-const mapSaveSelector = state => {
+export const mapSaveSelector = state => {
     const map = mapSelector(state);
     const layers = layersSelector(state);
     const groups = groupsSelector(state);
@@ -79,7 +80,7 @@ const mapSaveSelector = state => {
  * @param {object} state
  * @returns {boolean} true if there are pending changes to save.
  */
-const mapHasPendingChangesSelector = state => {
+export const mapHasPendingChangesSelector = state => {
     const updatedMap = mapSaveSelector(state);
     const currentMap = mapSelector(state) || {};
     const { canEdit } = currentMap.info || {};
@@ -87,4 +88,3 @@ const mapHasPendingChangesSelector = state => {
     return (canEdit || !currentMap.mapId) && !MapUtils.compareMapChanges(mapConfigRawData, updatedMap);
 };
 
-module.exports = { mapSaveSelector, mapOptionsToSaveSelector, mapHasPendingChangesSelector, registerCustomSaveHandler};

--- a/web/client/selectors/maptype.js
+++ b/web/client/selectors/maptype.js
@@ -19,7 +19,7 @@
  * @param  {object} state the state
  * @return {string}       the maptype in the state
  */
-const mapTypeSelector = (state) => state && state.maptype && state.maptype.mapType || 'leaflet';
+export const mapTypeSelector = (state) => state && state.maptype && state.maptype.mapType || 'leaflet';
 
 /**
  * Check if the mapType is cesium
@@ -28,13 +28,6 @@ const mapTypeSelector = (state) => state && state.maptype && state.maptype.mapTy
  * @param  {object} state the state
  * @return {boolean}
  */
-const isCesium = state => mapTypeSelector(state) === "cesium";
-const isLeaflet = state => mapTypeSelector(state) === "leaflet";
-const isOpenlayers = state => mapTypeSelector(state) === "openlayers";
-
-module.exports = {
-    mapTypeSelector,
-    isCesium,
-    isLeaflet,
-    isOpenlayers
-};
+export const isCesium = state => mapTypeSelector(state) === "cesium";
+export const isLeaflet = state => mapTypeSelector(state) === "leaflet";
+export const isOpenlayers = state => mapTypeSelector(state) === "openlayers";

--- a/web/client/selectors/measurement.js
+++ b/web/client/selectors/measurement.js
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const { isOpenlayers } = require('../selectors/maptype');
-const { showCoordinateEditorSelector } = require('../selectors/controls');
-const { set } = require('../utils/ImmutableUtils');
-const { validateFeatureCoordinates } = require('../utils/MeasureUtils');
+import { isOpenlayers } from '../selectors/maptype';
+
+import { showCoordinateEditorSelector } from '../selectors/controls';
+import { set } from '../utils/ImmutableUtils';
+import { validateFeatureCoordinates } from '../utils/MeasureUtils';
 
 /**
  * selects measurement state
@@ -24,8 +25,8 @@ const { validateFeatureCoordinates } = require('../utils/MeasureUtils');
  * @param  {object} state the state
  * @return {boolean} the showCoordinateEditor in the state
  */
-const isCoordinateEditorEnabledSelector = (state) => showCoordinateEditorSelector(state) && !state.measurement.isDrawing && isOpenlayers(state);
-const showAddAsAnnotationSelector = (state) => state && state.measurement && state.measurement.showAddAsAnnotation;
+export const isCoordinateEditorEnabledSelector = (state) => showCoordinateEditorSelector(state) && !state.measurement.isDrawing && isOpenlayers(state);
+export const showAddAsAnnotationSelector = (state) => state && state.measurement && state.measurement.showAddAsAnnotation;
 
 /**
  * selects the trueBearing object from state
@@ -33,7 +34,7 @@ const showAddAsAnnotationSelector = (state) => state && state.measurement && sta
  * @param  {object} state the state
  * @return {object} the trueBearing in the state
  */
-const isTrueBearingEnabledSelector = (state) => state && state.measurement && state.measurement.trueBearing && state.measurement.trueBearing.measureTrueBearing;
+export const isTrueBearingEnabledSelector = (state) => state && state.measurement && state.measurement.trueBearing && state.measurement.trueBearing.measureTrueBearing;
 
 /**
  * validating feature that can contain invalid coordinates
@@ -41,7 +42,7 @@ const isTrueBearingEnabledSelector = (state) => state && state.measurement && st
  * if the number of valid coords is < min for that geomType then
  * return empty coordinates
 */
-const getValidFeatureSelector = (state) => {
+export const getValidFeatureSelector = (state) => {
     let feature = state.measurement.feature || {};
     if (feature.geometry) {
         feature = set("geometry.coordinates", validateFeatureCoordinates(feature.geometry || {}), feature);
@@ -49,7 +50,7 @@ const getValidFeatureSelector = (state) => {
     return feature;
 };
 
-const measurementSelector = (state) => {
+export const measurementSelector = (state) => {
     return state.measurement && {
         ...state.measurement,
         feature: getValidFeatureSelector(state)
@@ -62,13 +63,4 @@ const measurementSelector = (state) => {
  * @param  {object} state the state
  * @return {boolean} geomType of the measurement
  */
-const geomTypeSelector = (state) => state?.measurement?.geomType;
-
-module.exports = {
-    measurementSelector,
-    getValidFeatureSelector,
-    isCoordinateEditorEnabledSelector,
-    showAddAsAnnotationSelector,
-    isTrueBearingEnabledSelector,
-    geomTypeSelector
-};
+export const geomTypeSelector = (state) => state?.measurement?.geomType;

--- a/web/client/selectors/playback.js
+++ b/web/client/selectors/playback.js
@@ -5,29 +5,29 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-const { createSelector} = require('reselect');
+import { createSelector } from 'reselect';
 
-const playbackSettingsSelector = state => state && state.playback && state.playback.settings;
-const frameDurationSelector = state => ((playbackSettingsSelector(state) || {}).frameDuration || 5); // seconds
-const statusSelector = state => state && state.playback && state.playback.status;
-const framesSelector = state => state && state.playback && state.playback.frames;
-const lastFrameSelector = state => {
+export const playbackSettingsSelector = state => state && state.playback && state.playback.settings;
+export const frameDurationSelector = state => ((playbackSettingsSelector(state) || {}).frameDuration || 5); // seconds
+export const statusSelector = state => state && state.playback && state.playback.status;
+export const framesSelector = state => state && state.playback && state.playback.frames;
+export const lastFrameSelector = state => {
     const frames = framesSelector(state) || [];
     return frames[frames.length - 1];
 };
-const loadingSelector = state => state && state.playback && state.playback.framesLoading;
+export const loadingSelector = state => state && state.playback && state.playback.framesLoading;
 
-const currentFrameSelector = state => state && state.playback && state.playback.currentFrame;
-const range = state => state && state.playback && state.playback.playbackRange;
-const playbackRangeSelector = state => {
+export const currentFrameSelector = state => state && state.playback && state.playback.currentFrame;
+export const range = state => state && state.playback && state.playback.playbackRange;
+export const playbackRangeSelector = state => {
     return range(state);
 };
 
-const currentFrameValueSelector = state => (framesSelector(state) || [])[currentFrameSelector(state)];
+export const currentFrameValueSelector = state => (framesSelector(state) || [])[currentFrameSelector(state)];
 
-const playbackMetadataSelector = state => state && state.playback && state.playback.metadata;
+export const playbackMetadataSelector = state => state && state.playback && state.playback.metadata;
 
-const hasPrevNextAnimationSteps = createSelector(
+export const hasPrevNextAnimationSteps = createSelector(
     framesSelector,
     currentFrameSelector,
     (frames = [], index) => ({
@@ -35,17 +35,3 @@ const hasPrevNextAnimationSteps = createSelector(
         hasPrevious: frames[index - 1]
     })
 );
-
-module.exports = {
-    playbackSettingsSelector,
-    frameDurationSelector,
-    statusSelector,
-    loadingSelector,
-    lastFrameSelector,
-    framesSelector,
-    currentFrameSelector,
-    currentFrameValueSelector,
-    playbackRangeSelector,
-    playbackMetadataSelector,
-    hasPrevNextAnimationSteps
-};

--- a/web/client/selectors/print.js
+++ b/web/client/selectors/print.js
@@ -6,8 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-module.exports = {
-    currentLayouts: (state) => state.print && state.print.capabilities &&
-        state.print.capabilities.layouts.filter((layout) => layout.name.indexOf(state.print.spec.sheet) === 0) || [],
-    twoPageEnabled: (state) => state.print && state.print.spec && state.print.spec.includeLegend
-};
+
+export const currentLayouts = (state) => state.print && state.print.capabilities &&
+    state.print.capabilities.layouts.filter((layout) => layout.name.indexOf(state.print.spec.sheet) === 0) || [];
+export const twoPageEnabled = (state) => state.print && state.print.spec && state.print.spec.includeLegend;

--- a/web/client/selectors/query.js
+++ b/web/client/selectors/query.js
@@ -1,23 +1,31 @@
-const {isNil, get, head, isArray, findIndex} = require('lodash');
+/**
+* Copyright 2016, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import { isNil, get, head, isArray, findIndex } from 'lodash';
 
 /**
  * Selects the featureType name of the query filterObject
  * @param {object} state
  */
-const queryFeatureTypeName = state => get(state, "query.filterObj.featureTypeName");
+export const queryFeatureTypeName = state => get(state, "query.filterObj.featureTypeName");
 /**
  * Create a selector for the featureType data (attributes and so on) for the featureType provided as parameter
  * @param {string} featureTypeName
  * @return {function} a selector to get the featureType data
  */
-const featureTypeSelectorCreator = (featureTypeName) => state => get(state, `query.featureTypes["${featureTypeName}"]`);
+export const featureTypeSelectorCreator = (featureTypeName) => state => get(state, `query.featureTypes["${featureTypeName}"]`);
 
 /**
  * Returns the original DescribeFeature JSON object of the passed featureType from the state
  * @param {object} state the application state
  * @param {string} featureTypeName the featureType name
  */
-const layerDescribeSelector = (state, featureTypeName) => get(featureTypeSelectorCreator(featureTypeName)(state), 'original');
+export const layerDescribeSelector = (state, featureTypeName) => get(featureTypeSelectorCreator(featureTypeName)(state), 'original');
 
 /**
  * selects query state
@@ -26,55 +34,52 @@ const layerDescribeSelector = (state, featureTypeName) => get(featureTypeSelecto
  * @static
  */
 
-module.exports = {
-    wfsURL: state => state && state.query && state.query.searchUrl,
-    wfsURLSelector: state => state && state.query && state.query.url,
-    wfsFilter: state => state && state.query && state.query.filterObj,
-    attributesSelector: state => get(featureTypeSelectorCreator(queryFeatureTypeName(state))(state), `attributes`),
-    typeNameSelector: state => get(state, "query.typeName"),
-    resultsSelector: (state) => get(state, "query.result.features"),
-    featureCollectionResultSelector: state => {
-        const results = get(state, "query.result");
-        return {
-            ...results,
-            features: (results && results.features || []).filter(f => !isNil(f.geometry))
-        };
-    },
-    getFeatureById: (state, id) => {
-        let features = state && state.query && state.query.result && state.query.result.features;
-        return head(features.filter(f => f.id === id));
-    },
-    paginationInfo: {
-        startIndex: (state) => get(state, "query.filterObj.pagination.startIndex"),
-        maxFeatures: (state) => get(state, "query.filterObj.pagination.maxFeatures"),
-        resultSize: (state) =>get(state, "query.result.features.length"),
-        totalFeatures: (state) => get(state, "query.result.totalFeatures")
-    },
-    isDescribeLoaded: (state, name) => {
-        const ft = featureTypeSelectorCreator(name)(state);
-        if (ft && ft.attributes && ft.geometry && ft.original) {
-            return true;
-        }
-        return false;
-    },
-    describeSelector: (state) => layerDescribeSelector(state, queryFeatureTypeName(state)),
-    featureTypeSelectorCreator,
-    layerDescribeSelector,
-    featureLoadingSelector: (state) => get(state, "query.featureLoading"),
-    isSyncWmsActive: (state) => get(state, "query.syncWmsFilter", false),
-    /**
-     * return true if a filter is applied to query
-     * @memberof selectors.query
-     * @param  {object} state the state
-     * @return {boolean}
-     */
-    isFilterActive: state => {
-        const crossLayerFilter = get(state, 'query.filterObj.crossLayerFilter');
-        const spatialField = get(state, 'query.filterObj.spatialField');
-        const filterFields = get(state, 'query.filterObj.filterFields');
-        return !!(filterFields && head(filterFields)
-        || spatialField && (spatialField.method && spatialField.operation && spatialField.geometry ||
-            isArray(spatialField) && findIndex(spatialField, field => field.method && field.operation && field.geometry) > -1)
-        || crossLayerFilter && crossLayerFilter.collectGeometries && crossLayerFilter.operation);
+
+export const wfsURL = state => state && state.query && state.query.searchUrl;
+export const wfsURLSelector = state => state && state.query && state.query.url;
+export const wfsFilter = state => state && state.query && state.query.filterObj;
+export const attributesSelector = state => get(featureTypeSelectorCreator(queryFeatureTypeName(state))(state), `attributes`);
+export const typeNameSelector = state => get(state, "query.typeName");
+export const resultsSelector = (state) => get(state, "query.result.features");
+export const featureCollectionResultSelector = state => {
+    const results = get(state, "query.result");
+    return {
+        ...results,
+        features: (results && results.features || []).filter(f => !isNil(f.geometry))
+    };
+};
+export const getFeatureById = (state, id) => {
+    let features = state && state.query && state.query.result && state.query.result.features;
+    return head(features.filter(f => f.id === id));
+};
+export const paginationInfo = {
+    startIndex: (state) => get(state, "query.filterObj.pagination.startIndex"),
+    maxFeatures: (state) => get(state, "query.filterObj.pagination.maxFeatures"),
+    resultSize: (state) =>get(state, "query.result.features.length"),
+    totalFeatures: (state) => get(state, "query.result.totalFeatures")
+};
+export const isDescribeLoaded = (state, name) => {
+    const ft = featureTypeSelectorCreator(name)(state);
+    if (ft && ft.attributes && ft.geometry && ft.original) {
+        return true;
     }
+    return false;
+};
+export const describeSelector = (state) => layerDescribeSelector(state, queryFeatureTypeName(state));
+export const featureLoadingSelector = (state) => get(state, "query.featureLoading");
+export const isSyncWmsActive = (state) => get(state, "query.syncWmsFilter", false);
+/**
+ * return true if a filter is applied to query
+ * @memberof selectors.query
+ * @param  {object} state the state
+ * @return {boolean}
+ */
+export const isFilterActive = state => {
+    const crossLayerFilter = get(state, 'query.filterObj.crossLayerFilter');
+    const spatialField = get(state, 'query.filterObj.spatialField');
+    const filterFields = get(state, 'query.filterObj.filterFields');
+    return !!(filterFields && head(filterFields)
+    || spatialField && (spatialField.method && spatialField.operation && spatialField.geometry ||
+        isArray(spatialField) && findIndex(spatialField, field => field.method && field.operation && field.geometry) > -1)
+    || crossLayerFilter && crossLayerFilter.collectGeometries && crossLayerFilter.operation);
 };

--- a/web/client/selectors/queryform.js
+++ b/web/client/selectors/queryform.js
@@ -1,39 +1,35 @@
-const {get} = require('lodash');
-const {createSelector} = require('reselect');
+/**
+* Copyright 2016, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
 
-const {layersSelector} = require('./layers');
+import { get } from 'lodash';
+import { createSelector } from 'reselect';
+import { layersSelector } from './layers';
+import { currentLocaleSelector } from './locale';
+import { getLocalizedProp } from '../utils/LocaleUtils';
 
-const {currentLocaleSelector} = require('./locale');
-
-const {getLocalizedProp} = require('../utils/LocaleUtils');
-
-const crossLayerFilterSelector = state => get(state, "queryform.crossLayerFilter");
+export const crossLayerFilterSelector = state => get(state, "queryform.crossLayerFilter");
 // TODO we should also check if the layer are from the same source to allow cross layer filtering
-const availableCrossLayerFilterLayersSelector = state =>(layersSelector(state) || []).filter(({type, group} = {}) => type === "wms" && group !== "background").map(({title, ...layer}) => ({...layer, title: getLocalizedProp(currentLocaleSelector(state), title)}));
-const spatialFieldGeomSelector = state => get(state, "queryform.spatialField.geometry");
-const spatialFieldSelector = state => get(state, "queryform.spatialField");
-const attributePanelExpandedSelector = state => get(state, "queryform.attributePanelExpanded");
-const spatialPanelExpandedSelector = state => get(state, "queryform.spatialPanelExpanded");
-const crossLayerExpandedSelector = state => get(state, "queryform.crossLayerExpanded");
-const queryFormUiStateSelector = createSelector(attributePanelExpandedSelector, spatialPanelExpandedSelector, crossLayerExpandedSelector, (attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded) => ({
+export const availableCrossLayerFilterLayersSelector = state =>(layersSelector(state) || []).filter(({type, group} = {}) => type === "wms" && group !== "background").map(({title, ...layer}) => ({...layer, title: getLocalizedProp(currentLocaleSelector(state), title)}));
+export const spatialFieldGeomSelector = state => get(state, "queryform.spatialField.geometry");
+export const spatialFieldSelector = state => get(state, "queryform.spatialField");
+export const attributePanelExpandedSelector = state => get(state, "queryform.attributePanelExpanded");
+export const spatialPanelExpandedSelector = state => get(state, "queryform.spatialPanelExpanded");
+export const crossLayerExpandedSelector = state => get(state, "queryform.crossLayerExpanded");
+export const queryFormUiStateSelector = createSelector(attributePanelExpandedSelector, spatialPanelExpandedSelector, crossLayerExpandedSelector, (attributePanelExpanded, spatialPanelExpanded, crossLayerExpanded) => ({
     attributePanelExpanded,
     spatialPanelExpanded,
     crossLayerExpanded
 }));
-const storedFilterSelector = state => get(state, "layerFilter.persisted");
-const appliedFilterSelector = state => get(state, "layerFilter.applied");
+export const storedFilterSelector = state => get(state, "layerFilter.persisted");
+export const appliedFilterSelector = state => get(state, "layerFilter.applied");
 
-module.exports = {
-    spatialFieldSelector,
-    spatialFieldMethodSelector: state => get(state, "queryform.spatialField.method"),
-    spatialFieldGeomSelector,
-    maxFeaturesWPSSelector: state => get(state, "queryform.maxFeaturesWPS"),
-    spatialFieldGeomTypeSelector: state => spatialFieldGeomSelector(state) && spatialFieldGeomSelector(state).type || "Polygon",
-    spatialFieldGeomProjSelector: state => spatialFieldGeomSelector(state) && spatialFieldGeomSelector(state).projection || "EPSG:4326",
-    spatialFieldGeomCoordSelector: state => spatialFieldGeomSelector(state) && spatialFieldGeomSelector(state).coordinates || [],
-    crossLayerFilterSelector,
-    availableCrossLayerFilterLayersSelector,
-    queryFormUiStateSelector,
-    storedFilterSelector,
-    appliedFilterSelector
-};
+export const spatialFieldMethodSelector = state => get(state, "queryform.spatialField.method");
+export const maxFeaturesWPSSelector = state => get(state, "queryform.maxFeaturesWPS");
+export const spatialFieldGeomTypeSelector = state => spatialFieldGeomSelector(state) && spatialFieldGeomSelector(state).type || "Polygon";
+export const spatialFieldGeomProjSelector = state => spatialFieldGeomSelector(state) && spatialFieldGeomSelector(state).projection || "EPSG =4326";
+export const spatialFieldGeomCoordSelector = state => spatialFieldGeomSelector(state) && spatialFieldGeomSelector(state).coordinates || [];

--- a/web/client/selectors/router.js
+++ b/web/client/selectors/router.js
@@ -1,7 +1,6 @@
 
-const {get} = require('lodash');
+import { get } from 'lodash';
 
-module.exports = {
-    pathnameSelector: (state) => get(state, "router.location.pathname") || "/",
-    searchSelector: (state) => get(state, "router.location.search") || ""
-};
+
+export const pathnameSelector = (state) => get(state, "router.location.pathname") || "/";
+export const searchSelector = (state) => get(state, "router.location.search") || "";

--- a/web/client/selectors/rulesmanager.js
+++ b/web/client/selectors/rulesmanager.js
@@ -6,11 +6,12 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const assign = require('object-assign');
-const _ = require('lodash');
-const {createSelector} = require('reselect');
+import assign from 'object-assign';
 
-const rulesSelector = (state) => {
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+
+export const rulesSelector = (state) => {
     if (!state.rulesmanager || !state.rulesmanager.rules) {
         return [];
     }
@@ -30,7 +31,7 @@ const rulesSelector = (state) => {
     });
 };
 
-const optionsSelector = (state) => {
+export const optionsSelector = (state) => {
     const stateOptions = state.rulesmanager && state.rulesmanager.options || {};
     const options = {};
     options.roles = stateOptions.roles;
@@ -43,15 +44,15 @@ const optionsSelector = (state) => {
     options.layersCount = stateOptions.layersCount || 0;
     return options;
 };
-const EMPTY_FILTERS = {};
-const filterSelector = (state) => state.rulesmanager && state.rulesmanager.filters || EMPTY_FILTERS;
-const selectedRules = (state) => state.rulesmanager && state.rulesmanager.selectedRules || [];
-const activeRuleSelector = (state) => state.rulesmanager && state.rulesmanager.activeRule;
-const servicesConfigSel = (state) => state.rulesmanager && state.rulesmanager.services;
-const servicesSelector = createSelector(servicesConfigSel, (services) => ( services && Object.keys(services).map(service => ({value: service, label: service}))
+export const EMPTY_FILTERS = {};
+export const filterSelector = (state) => state.rulesmanager && state.rulesmanager.filters || EMPTY_FILTERS;
+export const selectedRules = (state) => state.rulesmanager && state.rulesmanager.selectedRules || [];
+export const activeRuleSelector = (state) => state.rulesmanager && state.rulesmanager.activeRule;
+export const servicesConfigSel = (state) => state.rulesmanager && state.rulesmanager.services;
+export const servicesSelector = createSelector(servicesConfigSel, (services) => ( services && Object.keys(services).map(service => ({value: service, label: service}))
 ));
-const targetPositionSelector = (state) => state.rulesmanager && state.rulesmanager.targetPosition || EMPTY_FILTERS;
-const rulesEditorToolbarSelector = createSelector(selectedRules, targetPositionSelector, (sel, {offsetFromTop}) => {
+export const targetPositionSelector = (state) => state.rulesmanager && state.rulesmanager.targetPosition || EMPTY_FILTERS;
+export const rulesEditorToolbarSelector = createSelector(selectedRules, targetPositionSelector, (sel, {offsetFromTop}) => {
     return {
         showAdd: sel.length === 0,
         showEdit: sel.length === 1,
@@ -61,23 +62,8 @@ const rulesEditorToolbarSelector = createSelector(selectedRules, targetPositionS
         showCache: sel.length === 0
     };
 });
-const isRulesManagerConfigured = state => state.localConfig && state.localConfig.plugins && !!state.localConfig.plugins.rulesmanager;
-const isEditorActive = state => state.rulesmanager && !!state.rulesmanager.activeRule;
-const triggerLoadSel = state => state.rulesmanager && state.rulesmanager.triggerLoad;
-const isLoading = state => state.rulesmanager && state.rulesmanager.loading;
-const geometryStateSel = state => state.rulesmanager && state.rulesmanager.geometryState;
-module.exports = {
-    rulesSelector,
-    optionsSelector,
-    selectedRules,
-    filterSelector,
-    servicesSelector,
-    rulesEditorToolbarSelector,
-    isEditorActive,
-    activeRuleSelector,
-    servicesConfigSel,
-    triggerLoadSel,
-    isLoading,
-    isRulesManagerConfigured,
-    geometryStateSel
-};
+export const isRulesManagerConfigured = state => state.localConfig && state.localConfig.plugins && !!state.localConfig.plugins.rulesmanager;
+export const isEditorActive = state => state.rulesmanager && !!state.rulesmanager.activeRule;
+export const triggerLoadSel = state => state.rulesmanager && state.rulesmanager.triggerLoad;
+export const isLoading = state => state.rulesmanager && state.rulesmanager.loading;
+export const geometryStateSel = state => state.rulesmanager && state.rulesmanager.geometryState;

--- a/web/client/selectors/security.js
+++ b/web/client/selectors/security.js
@@ -6,10 +6,11 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const assign = require('object-assign');
-const {get} = require('lodash');
+import assign from 'object-assign';
 
-const rulesSelector = (state) => {
+import { get } from 'lodash';
+
+export const rulesSelector = (state) => {
     if (!state.security || !state.security.rules) {
         return [];
     }
@@ -29,10 +30,10 @@ const rulesSelector = (state) => {
     });
 };
 
-const userSelector = (state) => state && state.security && state.security.user;
-const userGroupSecuritySelector = (state) => get(state, "security.user.groups.group");
-const userRoleSelector = (state) => userSelector(state) && userSelector(state).role;
-const userParamsSelector = (state) => {
+export const userSelector = (state) => state && state.security && state.security.user;
+export const userGroupSecuritySelector = (state) => get(state, "security.user.groups.group");
+export const userRoleSelector = (state) => userSelector(state) && userSelector(state).role;
+export const userParamsSelector = (state) => {
     const user = userSelector(state);
     return {
         id: user.id,
@@ -40,14 +41,7 @@ const userParamsSelector = (state) => {
     };
 };
 
-module.exports = {
-    rulesSelector,
-    userSelector,
-    userParamsSelector,
-    isLoggedIn: state => state && state.security && state.security.user,
-    userRoleSelector,
-    securityTokenSelector: state => state.security && state.security.token,
-    userGroupSecuritySelector,
-    isAdminUserSelector: (state) => userRoleSelector(state) === "ADMIN",
-    isUserSelector: (state) => userRoleSelector(state) === "USER"
-};
+export const isLoggedIn = state => state && state.security && state.security.user;
+export const securityTokenSelector = state => state.security && state.security.token;
+export const isAdminUserSelector = (state) => userRoleSelector(state) === "ADMIN";
+export const isUserSelector = (state) => userRoleSelector(state) === "USER";

--- a/web/client/selectors/styleeditor.js
+++ b/web/client/selectors/styleeditor.js
@@ -6,9 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const { get, head, uniqBy, find, isString } = require('lodash');
-const { layerSettingSelector, getSelectedLayer } = require('./layers');
-const { STYLE_ID_SEPARATOR, extractFeatureProperties } = require('../utils/StyleEditorUtils');
+import { get, head, uniqBy, find, isString } from 'lodash';
+
+import { layerSettingSelector, getSelectedLayer } from './layers';
+import { STYLE_ID_SEPARATOR, extractFeatureProperties } from '../utils/StyleEditorUtils';
 
 /**
  * selects styleeditor state
@@ -23,98 +24,98 @@ const { STYLE_ID_SEPARATOR, extractFeatureProperties } = require('../utils/Style
  * @param  {object} state the state
  * @return {string} id/name of temporary style
  */
-const temporaryIdSelector = state => get(state, 'styleeditor.temporaryId');
+export const temporaryIdSelector = state => get(state, 'styleeditor.temporaryId');
 /**
  * selects templateId from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string} id/name of template style
  */
-const templateIdSelector = state => get(state, 'styleeditor.templateId');
+export const templateIdSelector = state => get(state, 'styleeditor.templateId');
 /**
  * selects status of style editor from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string} '', 'edit' or 'template'
  */
-const statusStyleSelector = state => get(state, 'styleeditor.status');
+export const statusStyleSelector = state => get(state, 'styleeditor.status');
 /**
  * selects error of style editor from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {object} error object eg: { global: { status: 404, message: 'Error' } }
  */
-const errorStyleSelector = state => get(state, 'styleeditor.error') || {};
+export const errorStyleSelector = state => get(state, 'styleeditor.error') || {};
 /**
  * selects loading state of style editor from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {bool}
  */
-const loadingStyleSelector = state => get(state, 'styleeditor.loading');
+export const loadingStyleSelector = state => get(state, 'styleeditor.loading');
 /**
  * selects current format of temporary style from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string}
  */
-const formatStyleSelector = state => get(state, 'styleeditor.format') || 'css';
+export const formatStyleSelector = state => get(state, 'styleeditor.format') || 'css';
 /**
  * selects current langage version of temporary style from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {object}
  */
-const languageVersionStyleSelector = state => get(state, 'styleeditor.languageVersion') || {};
+export const languageVersionStyleSelector = state => get(state, 'styleeditor.languageVersion') || {};
 /**
  * selects code of style in editing from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string}
  */
-const codeStyleSelector = state => get(state, 'styleeditor.code');
+export const codeStyleSelector = state => get(state, 'styleeditor.code');
 /**
  * selects initial code of style in editing from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {string}
  */
-const initialCodeStyleSelector = state => get(state, 'styleeditor.initialCode') || '';
+export const initialCodeStyleSelector = state => get(state, 'styleeditor.initialCode') || '';
 /**
  * selects add boolean from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {bool}
  */
-const addStyleSelector = state => get(state, 'styleeditor.addStyle') || '';
+export const addStyleSelector = state => get(state, 'styleeditor.addStyle') || '';
 /**
  * selects enabled state of style editor from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {bool}
  */
-const enabledStyleEditorSelector = state => get(state, 'styleeditor.enabled');
+export const enabledStyleEditorSelector = state => get(state, 'styleeditor.enabled');
 /**
  * selects style editor service from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {object} eg: styleService: {baseUrl: '/geoserver/', formats: ['css', 'sld'], availableUrls: ['http://localhost:8081/geoserver/']}
  */
-const styleServiceSelector = state => get(state, 'styleeditor.service') || {};
+export const styleServiceSelector = state => get(state, 'styleeditor.service') || {};
 /**
  * selects canEdit status of styleeditor service from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {bool}
  */
-const canEditStyleSelector = state => get(state, 'styleeditor.canEdit');
+export const canEditStyleSelector = state => get(state, 'styleeditor.canEdit');
 /**
  * selects layer with current changes applied in settings session from state
  * @memberof selectors.styleeditor
  * @param  {object} state the state
  * @return {object} layer object
  */
-const getUpdatedLayer = state => {
+export const getUpdatedLayer = state => {
     const settings = layerSettingSelector(state);
     const selectedLayer = getSelectedLayer(state) || {};
     return {...selectedLayer, ...(settings && settings.options || {})};
@@ -125,7 +126,7 @@ const getUpdatedLayer = state => {
  * @param  {object} state the state
  * @return {string} layer object
  */
-const geometryTypeSelector = state => {
+export const geometryTypeSelector = state => {
     const updatedLayer = getUpdatedLayer(state);
     const { geometryType = 'vector' } = extractFeatureProperties(updatedLayer);
     return geometryType;
@@ -136,7 +137,7 @@ const geometryTypeSelector = state => {
  * @param  {object} state the state
  * @return {object}
  */
-const layerPropertiesSelector = state => {
+export const layerPropertiesSelector = state => {
     const updatedLayer = getUpdatedLayer(state);
     const { properties = {} } = extractFeatureProperties(updatedLayer);
     return properties;
@@ -147,7 +148,7 @@ const layerPropertiesSelector = state => {
  * @param  {object} state the state
  * @return {string}
  */
-const selectedStyleSelector = state => {
+export const selectedStyleSelector = state => {
     const updatedLayer = getUpdatedLayer(state);
     return updatedLayer.style
     || updatedLayer.availableStyles && updatedLayer.availableStyles[0] && updatedLayer.availableStyles[0].name;
@@ -158,7 +159,7 @@ const selectedStyleSelector = state => {
  * @param  {object} state the state
  * @return {string}
  */
-const selectedStyleFormatSelector = state => {
+export const selectedStyleFormatSelector = state => {
     const { availableStyles = []} = getUpdatedLayer(state) || {};
     const styleName = selectedStyleSelector(state);
     return head(availableStyles.filter(({ name }) => name === styleName).map(({ format }) => format));
@@ -169,7 +170,7 @@ const selectedStyleFormatSelector = state => {
  * @param  {object} state the state
  * @return {object}
  */
-const getAllStyles = (state) => {
+export const getAllStyles = (state) => {
     const updatedLayer = getUpdatedLayer(state);
     const availableStyles = updatedLayer.availableStyles || [];
     const { name: defaultStyle } = head(availableStyles) || {};
@@ -188,16 +189,16 @@ const getAllStyles = (state) => {
     };
 };
 
-const editorMetadataSelector = (state) => state?.styleeditor?.metadata;
+export const editorMetadataSelector = (state) => state?.styleeditor?.metadata;
 
-const selectedStyleMetadataSelector = (state) => {
+export const selectedStyleMetadataSelector = (state) => {
     const { availableStyles = []} = getUpdatedLayer(state) || {};
     const styleName = selectedStyleSelector(state);
     const style = find(availableStyles, ({ name }) => styleName === name) || {};
     return style.metadata || {};
 };
 
-module.exports = {
+export default {
     temporaryIdSelector,
     templateIdSelector,
     statusStyleSelector,

--- a/web/client/selectors/swipe.js
+++ b/web/client/selectors/swipe.js
@@ -6,11 +6,11 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-const layerSwipeSettingsSelector = (state) => state.swipe && state.swipe || { active: false };
-const spyModeSettingsSelector = state => state?.swipe?.spy || { radius: 80 };
-const swipeModeSettingsSelector = state => state?.swipe?.swipe || { direction: 'cut-vertical' };
+export const layerSwipeSettingsSelector = (state) => state.swipe && state.swipe || { active: false };
+export const spyModeSettingsSelector = state => state?.swipe?.spy || { radius: 80 };
+export const swipeModeSettingsSelector = state => state?.swipe?.swipe || { direction: 'cut-vertical' };
 
-export {
+export default {
     layerSwipeSettingsSelector,
     spyModeSettingsSelector,
     swipeModeSettingsSelector

--- a/web/client/selectors/timeline.js
+++ b/web/client/selectors/timeline.js
@@ -1,26 +1,42 @@
-const { get, head } = require('lodash');
-const {createSelector} = require('reselect');
-const { createShallowSelector } = require('../utils/ReselectUtils');
-const { reprojectBbox } = require('../utils/CoordinatesUtils');
-const { timeIntervalToSequence, timeIntervalToIntervalSequence, analyzeIntervalInRange, isTimeDomainInterval } = require('../utils/TimeUtils');
-const { timeDataSelector, currentTimeSelector, offsetTimeSelector, layerDimensionRangeSelector, layersWithTimeDataSelector, layerDimensionDataSelectorCreator } = require('../selectors/dimension');
-const { mapSelector, projectionSelector } = require('../selectors/map');
-const {getLayerFromId} = require('../selectors/layers');
-const rangeSelector = state => get(state, 'timeline.range');
-const rangeDataSelector = state => get(state, 'timeline.rangeData');
+import { get, head } from 'lodash';
+import { createSelector } from 'reselect';
+import { createShallowSelector } from '../utils/ReselectUtils';
+import { reprojectBbox } from '../utils/CoordinatesUtils';
+
+import {
+    timeIntervalToSequence,
+    timeIntervalToIntervalSequence,
+    analyzeIntervalInRange,
+    isTimeDomainInterval
+} from '../utils/TimeUtils';
+
+import {
+    timeDataSelector,
+    currentTimeSelector,
+    offsetTimeSelector,
+    layerDimensionRangeSelector,
+    layersWithTimeDataSelector,
+    layerDimensionDataSelectorCreator
+} from '../selectors/dimension';
+
+import { mapSelector, projectionSelector } from '../selectors/map';
+import { getLayerFromId } from '../selectors/layers';
+
+export const rangeSelector = state => get(state, 'timeline.range');
+export const rangeDataSelector = state => get(state, 'timeline.rangeData');
 
 // items
 const MAX_ITEMS = 50;
 
-const isCollapsed = state => get(state, 'timeline.settings.collapsed');
+export const isCollapsed = state => get(state, 'timeline.settings.collapsed');
 
-const isAutoSelectEnabled = state => get(state, 'timeline.settings.autoSelect');
+export const isAutoSelectEnabled = state => get(state, 'timeline.settings.autoSelect');
 
 /**
  * Selector of mapSync. If mapSync is true, the timeline shows only data in the current viewport.
  * @return the flag of sync of the timeline with the map viewport
  */
-const isMapSync = state => get(state, 'timeline.settings.mapSync'); // TODO: get live filter enabled flag
+export const isMapSync = state => get(state, 'timeline.settings.mapSync'); // TODO: get live filter enabled flag
 /**
  * Converts the list of timestamps into timeline items.
  * If a timestamp is a start/end/resolution, and items in viewRange are less than MAX_ITEMS, returns tha array of items,
@@ -30,7 +46,7 @@ const isMapSync = state => get(state, 'timeline.settings.mapSync'); // TODO: get
  * @param {object} viewRange start/end object representing the date range of the view
  * @returns {array[object]} items to pass to timeline.
  */
-const timeStampToItems = (ISOString, viewRange) => {
+export const timeStampToItems = (ISOString, viewRange) => {
     const [start, end, duration] = ISOString.split("/");
     if (duration && duration !== "0") {
         // prevent overflows, indicating only the count of items in the interval
@@ -66,7 +82,7 @@ const timeStampToItems = (ISOString, viewRange) => {
  * @param {object} range start/end object representing the range of the view
  * @returns {array[object]} items to pass to timeline.
  */
-const valuesToItems = (values, range) => (values || []).reduce((acc, ISOString) => [...acc, ...timeStampToItems(ISOString, range)], []).filter(v => v && v.start);
+export const valuesToItems = (values, range) => (values || []).reduce((acc, ISOString) => [...acc, ...timeStampToItems(ISOString, range)], []).filter(v => v && v.start);
 
 /**
  * Converts range data into items.If values are present, it returns values' items, otherwise it will return histogram items.
@@ -74,7 +90,7 @@ const valuesToItems = (values, range) => (values || []).reduce((acc, ISOString) 
  * @param {object} range start/stop object representing the range of the view
  * @returns {array[object]} items to pass to timeline.
  */
-const rangeDataToItems = (rangeData = {}, range) => {
+export const rangeDataToItems = (rangeData = {}, range) => {
     if (rangeData.domain && rangeData.domain.values) {
         return valuesToItems(rangeData.domain.values, range);
     }
@@ -101,7 +117,7 @@ const rangeDataToItems = (rangeData = {}, range) => {
  * @param {object} range start/end object that represent the view range
  * @param {object} rangeData object that contains domain or histogram
  */
-const getTimeItems = (data = {}, range, rangeData) => {
+export const getTimeItems = (data = {}, range, rangeData) => {
     if (data && data.values || data && data.domain && !isTimeDomainInterval(data.domain)) {
         return valuesToItems(data.values || data.domain.split(','), range);
     } else if (rangeData && rangeData.histogram) {
@@ -116,7 +132,7 @@ const getTimeItems = (data = {}, range, rangeData) => {
  * @param {object} state the state
  * @return {object[]} items to show in the timeline in the [visjs timeline data object format](http://visjs.org/docs/timeline/#Data_Format)
  */
-const itemsSelector = createShallowSelector(
+export const itemsSelector = createShallowSelector(
     timeDataSelector,
     rangeSelector,
     rangeDataSelector,
@@ -132,28 +148,28 @@ const itemsSelector = createShallowSelector(
             .reduce((acc, layerItems) => [...acc, ...layerItems], [])]
     )
 );
-const loadingSelector = state => get(state, "timeline.loading");
-const selectedLayerSelector = state => get(state, "timeline.selectedLayer");
+export const loadingSelector = state => get(state, "timeline.loading");
+export const selectedLayerSelector = state => get(state, "timeline.selectedLayer");
 
-const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(state));
-const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
-const selectedLayerTimeDimensionConfiguration = state => selectedLayerData(state) && selectedLayerData(state).dimensions && head(selectedLayerData(state).dimensions.filter((x) => x.name === "time"));
-const selectedLayerUrl = state => get(selectedLayerTimeDimensionConfiguration(state), "source.url");
+export const selectedLayerData = state => getLayerFromId(state, selectedLayerSelector(state));
+export const selectedLayerName = state => selectedLayerData(state) && selectedLayerData(state).name;
+export const selectedLayerTimeDimensionConfiguration = state => selectedLayerData(state) && selectedLayerData(state).dimensions && head(selectedLayerData(state).dimensions.filter((x) => x.name === "time"));
+export const selectedLayerUrl = state => get(selectedLayerTimeDimensionConfiguration(state), "source.url");
 
-const currentTimeRangeSelector = createSelector(
+export const currentTimeRangeSelector = createSelector(
     currentTimeSelector,
     offsetTimeSelector,
     (start, end) => ({ start, end })
 );
-const selectedLayerDataRangeSelector = state => layerDimensionRangeSelector(state, selectedLayerSelector(state));
+export const selectedLayerDataRangeSelector = state => layerDimensionRangeSelector(state, selectedLayerSelector(state));
 
 /**
  * Select layers visible in the timeline
  */
-const timelineLayersSelector = layersWithTimeDataSelector; // TODO: allow exclusion.
+export const timelineLayersSelector = layersWithTimeDataSelector; // TODO: allow exclusion.
 
-const hasLayers = createSelector(timelineLayersSelector, (layers = []) => layers.length > 0);
-const isVisible = state => !isCollapsed(state) && hasLayers(state);
+export const hasLayers = createSelector(timelineLayersSelector, (layers = []) => layers.length > 0);
+export const isVisible = state => !isCollapsed(state) && hasLayers(state);
 
 
 /**
@@ -163,7 +179,7 @@ const isVisible = state => !isCollapsed(state) && hasLayers(state);
  * @param {string} layerId The layer ID
  * @returns a selector for multidimensional requests options (`bbox`)
  */
-const multidimOptionsSelectorCreator = layerId => state => {
+export const multidimOptionsSelectorCreator = layerId => state => {
     const { bbox: viewport } = mapSelector(state) || {};
     if (!viewport ) {
         return {};
@@ -204,25 +220,4 @@ const multidimOptionsSelectorCreator = layerId => state => {
         bbox: `${minx},${miny},${maxx},${maxy},${crs}`
     };
 
-};
-
-module.exports = {
-    isVisible,
-    isCollapsed,
-    currentTimeRangeSelector,
-    timelineLayersSelector,
-    hasLayers,
-    itemsSelector,
-    rangeSelector,
-    isAutoSelectEnabled,
-    loadingSelector,
-    selectedLayerSelector,
-    selectedLayerData,
-    selectedLayerTimeDimensionConfiguration,
-    selectedLayerDataRangeSelector,
-    selectedLayerName,
-    selectedLayerUrl,
-    rangeDataSelector,
-    isMapSync,
-    multidimOptionsSelectorCreator
 };

--- a/web/client/selectors/tutorial.js
+++ b/web/client/selectors/tutorial.js
@@ -19,8 +19,8 @@
  * @param  {object} state the state
  * @return {object}       the tutorial in the state
  */
-const tutorialSelector = (state) => state && state.tutorial;
+export const tutorialSelector = (state) => state && state.tutorial;
 
-module.exports = {
+export default {
     tutorialSelector
 };

--- a/web/client/selectors/vectorstyler.js
+++ b/web/client/selectors/vectorstyler.js
@@ -6,17 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {createSelector} = require('reselect');
-const {head} = require('lodash');
+import { createSelector } from 'reselect';
 
-const ruleselctor = (state) => state.vectorstyler && state.vectorstyler.rule && head(state.vectorstyler.rules.filter((r) => {return r.id === state.vectorstyler.rule; }));
+import { head } from 'lodash';
 
-const symbolselector = createSelector([ruleselctor],
+export const ruleselctor = (state) => state.vectorstyler && state.vectorstyler.rule && head(state.vectorstyler.rules.filter((r) => {return r.id === state.vectorstyler.rule; }));
+
+export const symbolselector = createSelector([ruleselctor],
     (rule) => ({
         shapeStyle: rule && rule.symbol || {}
     }));
-
-module.exports = {
-    ruleselctor,
-    symbolselector
-};

--- a/web/client/selectors/version.js
+++ b/web/client/selectors/version.js
@@ -6,10 +6,5 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const versionSelector = (state) => state.version && state.version.current || '';
-const validateVersion = version => version && version.indexOf('${mapstore2.version}') === -1 && version.indexOf('no-version') === -1 ? true : false;
-
-module.exports = {
-    versionSelector,
-    validateVersion
-};
+export const versionSelector = (state) => state.version && state.version.current || '';
+export const validateVersion = version => version && version.indexOf('${mapstore2.version}') === -1 && version.indexOf('no-version') === -1 ? true : false;

--- a/web/client/selectors/widgets.js
+++ b/web/client/selectors/widgets.js
@@ -6,31 +6,31 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const { find, get, castArray, isArray } = require('lodash');
-const {mapSelector} = require('./map');
-const {getSelectedLayer} = require('./layers');
-const {pathnameSelector} = require('./router');
-const {DEFAULT_TARGET, DEPENDENCY_SELECTOR_KEY, WIDGETS_REGEX} = require('../actions/widgets');
-const { getWidgetsGroups, getWidgetDependency} = require('../utils/WidgetsUtils');
+import { find, get, castArray, isArray } from 'lodash';
 
-const {isDashboardAvailable, isDashboardEditing} = require('./dashboard');
-const { createSelector, createStructuredSelector} = require('reselect');
-const { createShallowSelector } = require('../utils/ReselectUtils');
+import { mapSelector } from './map';
+import { getSelectedLayer } from './layers';
+import { pathnameSelector } from './router';
+import { DEFAULT_TARGET, DEPENDENCY_SELECTOR_KEY, WIDGETS_REGEX } from '../actions/widgets';
+import { getWidgetsGroups, getWidgetDependency } from '../utils/WidgetsUtils';
+import { isDashboardAvailable, isDashboardEditing } from './dashboard';
+import { createSelector, createStructuredSelector } from 'reselect';
+import { createShallowSelector } from '../utils/ReselectUtils';
 
-const getEditorSettings = state => get(state, "widgets.builder.settings");
-const getDependenciesMap = s => get(s, "widgets.dependencies") || {};
-const getDependenciesKeys = s => Object.keys(getDependenciesMap(s)).map(k => getDependenciesMap(s)[k]);
-const getEditingWidget = state => get(state, "widgets.builder.editor");
-const getWidgetLayer = createSelector(
+export const getEditorSettings = state => get(state, "widgets.builder.settings");
+export const getDependenciesMap = s => get(s, "widgets.dependencies") || {};
+export const getDependenciesKeys = s => Object.keys(getDependenciesMap(s)).map(k => getDependenciesMap(s)[k]);
+export const getEditingWidget = state => get(state, "widgets.builder.editor");
+export const getWidgetLayer = createSelector(
     getEditingWidget,
     getSelectedLayer,
     state => isDashboardAvailable(state) && isDashboardEditing(state),
     ({layer} = {}, selectedLayer, dashboardEditing) => layer || !dashboardEditing && selectedLayer
 );
 
-const getFloatingWidgets = state => get(state, `widgets.containers[${DEFAULT_TARGET}].widgets`);
-const getCollapsedState = state => get(state, `widgets.containers[${DEFAULT_TARGET}].collapsed`);
-const getVisibleFloatingWidgets = createSelector(
+export const getFloatingWidgets = state => get(state, `widgets.containers[${DEFAULT_TARGET}].widgets`);
+export const getCollapsedState = state => get(state, `widgets.containers[${DEFAULT_TARGET}].collapsed`);
+export const getVisibleFloatingWidgets = createSelector(
     getFloatingWidgets,
     getCollapsedState,
     (widgets, collapsed) => {
@@ -40,19 +40,19 @@ const getVisibleFloatingWidgets = createSelector(
         return widgets;
     }
 );
-const getWidgetAttributeFilter = (id, attributeName) => createSelector(
+export const getWidgetAttributeFilter = (id, attributeName) => createSelector(
     getVisibleFloatingWidgets,
     (widgets) => {
         const widget = find(widgets, {id});
         return widget && widget.quickFilters && widget.options && find(widget.options.propertyName, f => f === attributeName) && widget.quickFilters[attributeName] || {};
     });
 
-const getCollapsedIds = createSelector(
+export const getCollapsedIds = createSelector(
     getCollapsedState,
     (collapsed = {}) => Object.keys(collapsed)
 );
-const getMapWidgets = state => (getFloatingWidgets(state) || []).filter(({ widgetType } = {}) => widgetType === "map");
-const getTableWidgets = state => (getFloatingWidgets(state) || []).filter(({ widgetType } = {}) => widgetType === "table");
+export const getMapWidgets = state => (getFloatingWidgets(state) || []).filter(({ widgetType } = {}) => widgetType === "map");
+export const getTableWidgets = state => (getFloatingWidgets(state) || []).filter(({ widgetType } = {}) => widgetType === "table");
 
 /**
  * Find in the state the available dependencies to connect
@@ -61,7 +61,7 @@ const getTableWidgets = state => (getFloatingWidgets(state) || []).filter(({ wid
  * because there were conflict between map and other widgets
  * (the map were containing other widgets) .
  */
-const availableDependenciesSelector = createSelector(
+export const availableDependenciesSelector = createSelector(
     getMapWidgets,
     getTableWidgets,
     mapSelector,
@@ -78,7 +78,7 @@ const availableDependenciesSelector = createSelector(
  * this selector adds some more filtering on tables when a widget is in edit mode
  * and the table widgets does not share the same dataset (layername)
  */
-const availableDependenciesForEditingWidgetSelector = createSelector(
+export const availableDependenciesForEditingWidgetSelector = createSelector(
     getMapWidgets,
     getTableWidgets,
     mapSelector,
@@ -106,74 +106,54 @@ const availableDependenciesForEditingWidgetSelector = createSelector(
  * returns if the dependency selector state
  * @param {object} state the state
  */
-const getDependencySelectorConfig = state => get(getEditorSettings(state), `${DEPENDENCY_SELECTOR_KEY}`);
+export const getDependencySelectorConfig = state => get(getEditorSettings(state), `${DEPENDENCY_SELECTOR_KEY}`);
 /**
  * Determines if the dependencySelector is active
  * @param {object} state the state
  */
-const isWidgetSelectionActive = state => get(getDependencySelectorConfig(state), 'active');
+export const isWidgetSelectionActive = state => get(getDependencySelectorConfig(state), 'active');
 
-const getWidgetsDependenciesGroups = createSelector(
+export const getWidgetsDependenciesGroups = createSelector(
     getFloatingWidgets,
     widgets => getWidgetsGroups(widgets)
 );
-const getFloatingWidgetsLayout = state => get(state, `widgets.containers[${DEFAULT_TARGET}].layouts`);
-const getFloatingWidgetsCurrentLayout = state => get(state, `widgets.containers[${DEFAULT_TARGET}].layout`);
+export const getFloatingWidgetsLayout = state => get(state, `widgets.containers[${DEFAULT_TARGET}].layouts`);
+export const getFloatingWidgetsCurrentLayout = state => get(state, `widgets.containers[${DEFAULT_TARGET}].layout`);
 
-const getDashboardWidgets = state => get(state, `widgets.containers[${DEFAULT_TARGET}].widgets`);
+export const getDashboardWidgets = state => get(state, `widgets.containers[${DEFAULT_TARGET}].widgets`);
 
-const isTrayEnabled = state => get(state, "widgets.tray");
+export const isTrayEnabled = state => get(state, "widgets.tray");
 
-module.exports = {
-    getFloatingWidgets,
-    getVisibleFloatingWidgets,
-    getCollapsedState,
-    getCollapsedIds,
-    getFloatingWidgetsLayout,
-    getFloatingWidgetsCurrentLayout,
-    // let's use the same container for the moment
-    getDashboardWidgets,
-    dashboardHasWidgets: state => (getDashboardWidgets(state) || []).length > 0,
-    getDashboardWidgetsLayout: state => get(state, `widgets.containers[${DEFAULT_TARGET}].layouts`),
-    getEditingWidget,
-    getEditingWidgetLayer: state => get(getEditingWidget(state), "layer"),
-    returnToFeatureGridSelector: (state) => get(state, "widgets.builder.editor.returnToFeatureGrid", false),
-    getEditingWidgetFilter: state => get(getEditingWidget(state), "filter"),
-    getEditorSettings,
-    getWidgetLayer,
-    getMapWidgets,
-    getWidgetAttributeFilter,
-    availableDependenciesSelector,
-    availableDependenciesForEditingWidgetSelector,
-    dashBoardDependenciesSelector: () => ({}), // TODO dashboard dependencies
-    /**
-     * transforms dependencies in the form `{ k1: "path1", k1, "path2" }` into
-     * a map like `{k1: v1, k2: v2}` where `v1 = get("path1", state)`.
-     * Dependencies paths map comes from getDependenciesMap.
-     * map.... is a special path that brings to the map of mapstore.
-     */
-    dependenciesSelector: createShallowSelector(
-        getDependenciesMap,
-        getDependenciesKeys,
-        // produces the array of values of the keys in getDependenciesKeys
-        state => getDependenciesKeys(state).map(k =>
-            k.indexOf("map.") === 0
-                ? get(mapSelector(state), k.slice(4))
-                : k.match(WIDGETS_REGEX)
-                    ? getWidgetDependency(k, getFloatingWidgets(state))
-                    : get(state, k) ),
-        // iterate the dependencies keys to set the dependencies values in a map
-        (map, keys, values) => keys.reduce((acc, k, i) => ({
-            ...acc,
-            [Object.keys(map)[i]]: values[i]
-        }), {})
-    ),
-    isWidgetSelectionActive,
-    getDependencySelectorConfig,
-    getWidgetsDependenciesGroups,
-    widgetsConfig: createStructuredSelector({
-        widgets: getFloatingWidgets,
-        layouts: getFloatingWidgetsLayout
-    }),
-    isTrayEnabled
-};
+// let's use the same container for the moment
+export const dashboardHasWidgets = state => (getDashboardWidgets(state) || []).length > 0;
+export const getDashboardWidgetsLayout = state => get(state, `widgets.containers[${DEFAULT_TARGET}].layouts`);
+export const getEditingWidgetLayer = state => get(getEditingWidget(state), "layer");
+export const returnToFeatureGridSelector = (state) => get(state, "widgets.builder.editor.returnToFeatureGrid", false);
+export const getEditingWidgetFilter = state => get(getEditingWidget(state), "filter");
+export const dashBoardDependenciesSelector = () => ({}); // TODO dashboard dependencies
+/**
+ * transforms dependencies in the form `{ k1: "path1", k1, "path2" }` into
+ * a map like `{k1: v1, k2: v2}` where `v1 = get("path1", state)`.
+ * Dependencies paths map comes from getDependenciesMap.
+ * map.... is a special path that brings to the map of mapstore.
+ */
+export const dependenciesSelector = createShallowSelector(
+    getDependenciesMap,
+    getDependenciesKeys,
+    // produces the array of values of the keys in getDependenciesKeys
+    state => getDependenciesKeys(state).map(k =>
+        k.indexOf("map.") === 0
+            ? get(mapSelector(state), k.slice(4))
+            : k.match(WIDGETS_REGEX)
+                ? getWidgetDependency(k, getFloatingWidgets(state))
+                : get(state, k) ),
+    // iterate the dependencies keys to set the dependencies values in a map
+    (map, keys, values) => keys.reduce((acc, k, i) => ({
+        ...acc,
+        [Object.keys(map)[i]]: values[i]
+    }), {})
+);
+export const widgetsConfig = createStructuredSelector({
+    widgets: getFloatingWidgets,
+    layouts: getFloatingWidgetsLayout
+});

--- a/web/client/selectors/widgetsTray.js
+++ b/web/client/selectors/widgetsTray.js
@@ -5,9 +5,16 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const { createSelector } = require('reselect');
-const { getFloatingWidgets, getFloatingWidgetsCurrentLayout, getCollapsedIds, getCollapsedState } = require('./widgets');
-const { find, findIndex, sortBy } = require('lodash');
+import { createSelector } from 'reselect';
+
+import {
+    getFloatingWidgets,
+    getFloatingWidgetsCurrentLayout,
+    getCollapsedIds,
+    getCollapsedState
+} from './widgets';
+
+import { find, findIndex, sortBy } from 'lodash';
 
 /**
  * Only widgets that are not pinned (static) can be in tray
@@ -18,7 +25,7 @@ const noStaticWidgets = w => !w.dataGrid || !w.dataGrid.static;
  * A selector that retrieves widgets to display in the tray area
  * @return the widgets to display in the tray area
  */
-const trayWidgets = createSelector(
+export const trayWidgets = createSelector(
     getFloatingWidgets,
     getCollapsedIds,
     getFloatingWidgetsCurrentLayout,
@@ -45,6 +52,4 @@ const trayWidgets = createSelector(
             })
 );
 
-module.exports = {
-    trayWidgets
-};
+export default trayWidgets;

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -9,10 +9,10 @@ const assign = require('object-assign');
 
 const {mapConfigHistory, createHistory} = require('../utils/MapHistoryUtils');
 
-const map = mapConfigHistory(require('../reducers/map'));
+const map = mapConfigHistory(require('../reducers/map')).default;
 
-const layers = require('../reducers/layers');
-const mapConfig = require('../reducers/config');
+const layers = require('../reducers/layers').default;
+const mapConfig = require('../reducers/config').default;
 
 const DebugUtils = require('../utils/DebugUtils').default;
 const {combineEpics, combineReducers} = require('../utils/PluginsUtils');
@@ -42,13 +42,13 @@ module.exports = (initialState = {defaultState: {}, mobile: {}}, appReducers = {
     const history = storeOpts.noRouter ? null : require('./History').default;
     const allReducers = combineReducers(plugins, {
         ...appReducers,
-        localConfig: require('../reducers/localConfig'),
-        locale: require('../reducers/locale'),
+        localConfig: require('../reducers/localConfig').default,
+        locale: require('../reducers/locale').default,
         locales: () => {return null; },
-        browser: require('../reducers/browser'),
-        controls: require('../reducers/controls'),
+        browser: require('../reducers/browser').default,
+        controls: require('../reducers/controls').default,
         theme: require('../reducers/theme').default,
-        help: require('../reducers/help'),
+        help: require('../reducers/help').default,
         map: () => {return null; },
         mapInitialConfig: () => {return null; },
         mapConfigRawData: () => null,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Migrate reducers and selectors to es6 syntax 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>
old 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
