### PR TITLE
fix missing .default for reducers requires

### DIFF
--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -189,6 +189,6 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: {crsselector: require('../reducers/crsselector')},
+    reducers: {crsselector: require('../reducers/crsselector').default},
     epics: {}
 };

--- a/web/client/plugins/ContentTabs.jsx
+++ b/web/client/plugins/ContentTabs.jsx
@@ -115,6 +115,6 @@ module.exports = {
             glyph: 'dashboard'
         }
     }),
-    reducers: {contenttabs: require('../reducers/contenttabs')},
+    reducers: {contenttabs: require('../reducers/contenttabs').default},
     epics: require('../epics/contenttabs')
 };

--- a/web/client/plugins/Cookie.jsx
+++ b/web/client/plugins/Cookie.jsx
@@ -20,6 +20,6 @@ const Cookie = connect((state) => ({
 
 module.exports = {
     CookiePlugin: Cookie,
-    reducers: {cookie: require('../reducers/cookie')},
+    reducers: {cookie: require('../reducers/cookie').default},
     epics: require('../epics/cookies')
 };

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -259,6 +259,6 @@ module.exports = {
             position: 3
         }
     }),
-    reducers: {mapInfo: require('../reducers/mapInfo')},
+    reducers: {mapInfo: require('../reducers/mapInfo').default},
     epics: require('../epics/identify').default
 };

--- a/web/client/plugins/Login.jsx
+++ b/web/client/plugins/Login.jsx
@@ -64,7 +64,7 @@ module.exports = {
             priority: 1
         }
     }),
-    reducers: {security: require('../reducers/security')},
+    reducers: {security: require('../reducers/security').default},
     epics: {
         ...epics,
         comparePendingChanges

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -117,6 +117,6 @@ module.exports = {
             action: () => setControlProperty("measure", "enabled", true)
         }
     }),
-    reducers: {measurement: require('../reducers/measurement')},
+    reducers: {measurement: require('../reducers/measurement').default},
     epics: require('../epics/measurement')
 };

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -271,6 +271,6 @@ module.exports = {
             doNotHide: true
         }
     }),
-    reducers: {catalog: require('../reducers/catalog')},
+    reducers: {catalog: require('../reducers/catalog').default},
     epics: require("../epics/catalog").default(API)
 };

--- a/web/client/stores/StandardStore.js
+++ b/web/client/stores/StandardStore.js
@@ -9,7 +9,7 @@ const assign = require('object-assign');
 
 const {mapConfigHistory, createHistory} = require('../utils/MapHistoryUtils');
 
-const map = mapConfigHistory(require('../reducers/map')).default;
+const map = mapConfigHistory(require('../reducers/map').default);
 
 const layers = require('../reducers/layers').default;
 const mapConfig = require('../reducers/config').default;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
fix missing .default for reducers requires that was not taken into account from the regex replace we used

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Bug introduced with this PR
#6005
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
