### PR TITLE
#5136: Fix issue in TMS printing

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -473,7 +473,7 @@ const PrintUtils = {
         },
         tileprovider: {
             map: (layer) => {
-
+                // details here: http://www.mapfish.org/doc/print/protocol.html#xyz
                 const [providerURL, layerConfig] = getLayerConfig(layer.provider, layer);
                 if (!isEmpty(layerConfig)) {
                     let validURL = extractValidBaseURL({ ...layerConfig, url: layerConfig?.url ?? providerURL });
@@ -488,6 +488,7 @@ const PrintUtils = {
                         .replace("{x}", "${x}")
                         .replace("{y}", "${y}")
                         .replace("{z}", "${z}");
+                    // TODO: support bounds
                     return {
                         baseURL,
                         path_format: pathFormat,
@@ -496,7 +497,33 @@ const PrintUtils = {
                         "opacity": getOpacity(layer),
                         "tileSize": [256, 256],
                         "maxExtent": [-20037508.3392, -20037508.3392, 20037508.3392, 20037508.3392],
-                        "resolutions": MapUtils.getResolutions()
+                        "resolutions": [
+                            156543.03390625,
+                            78271.516953125,
+                            39135.7584765625,
+                            19567.87923828125,
+                            9783.939619140625,
+                            4891.9698095703125,
+                            2445.9849047851562,
+                            1222.9924523925781,
+                            611.4962261962891,
+                            305.74811309814453,
+                            152.87405654907226,
+                            76.43702827453613,
+                            38.218514137268066,
+                            19.109257068634033,
+                            9.554628534317017,
+                            4.777314267158508,
+                            2.388657133579254,
+                            1.194328566789627,
+                            0.5971642833948135
+                        ].filter( (_, i) => {
+                            let isIncluded = true;
+                            if (layerConfig.maxNativeZoom) {
+                                isIncluded = isIncluded && i <= layerConfig.maxNativeZoom;
+                            }
+                            return isIncluded;
+                        })
                     };
                 }
                 return {};

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -534,7 +534,7 @@ describe('PrintUtils', () => {
                 expect(layerSpec.version).toBe("1.0.0");
             });
         });
-        describe.only('tileprovider', () => {
+        describe('tileprovider', () => {
             it('BasemapAT', () => {
                 const testLayer = BasemapAT;
                 const layerSpec = PrintUtils.specCreators.tileprovider.map(testLayer, { projection: "EPSG:900913" });

--- a/web/client/utils/__tests__/PrintUtils-test.js
+++ b/web/client/utils/__tests__/PrintUtils-test.js
@@ -534,7 +534,7 @@ describe('PrintUtils', () => {
                 expect(layerSpec.version).toBe("1.0.0");
             });
         });
-        describe('tileprovider', () => {
+        describe.only('tileprovider', () => {
             it('BasemapAT', () => {
                 const testLayer = BasemapAT;
                 const layerSpec = PrintUtils.specCreators.tileprovider.map(testLayer, { projection: "EPSG:900913" });
@@ -550,9 +550,10 @@ describe('PrintUtils', () => {
                 expect(layerSpec.tileSize).toExist();
                 expect(layerSpec.resolutions).toExist();
                 expect(layerSpec.extension).toBe("png");
+                expect(layerSpec.resolutions.length).toBe(19);
 
             });
-            it('BasemapAT', () => {
+            it('NASAGIBS', () => {
                 const testLayer = NASAGIBS;
                 const layerSpec = PrintUtils.specCreators.tileprovider.map(testLayer, { projection: "EPSG:900913" });
                 expect(layerSpec.type).toEqual("xyz");
@@ -567,6 +568,7 @@ describe('PrintUtils', () => {
                 expect(layerSpec.tileSize).toExist();
                 expect(layerSpec.resolutions).toExist();
                 expect(layerSpec.extension).toBe("jpg");
+                expect(layerSpec.resolutions.length).toBe(9);
 
             });
             it('tileprovider with custom URL', () => {
@@ -584,6 +586,7 @@ describe('PrintUtils', () => {
                 expect(layerSpec.tileSize).toExist();
                 expect(layerSpec.resolutions).toExist();
                 expect(layerSpec.extension).toBe("jpg");
+                expect(layerSpec.resolutions.length).toBe(19);
 
             });
         });


### PR DESCRIPTION
## Description
If the map has custom resolutions the TMS do not print correctly. 
This because the print spec is generated on map resolutions, instead of "x,y,z EPSG:3857 standard resolutions".
Moreover, it adds a filter to exclude resolution higher than the `maxNativeZoom` so the server can get the tiles at the best resolution ( e.g. NASAGIBS for higher level of zoom)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5136

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
