### PR TITLE
#5607 fix problem when creating a new project

### DIFF
--- a/utility/projects/projectLib.js
+++ b/utility/projects/projectLib.js
@@ -48,7 +48,7 @@ const updateSubmoduleBranch = (outFolder) => {
                 if (err) {
                     reject(err);
                 }
-                process.stdout.write("doing checkout to the branch: ", data.current);
+                process.stdout.write("doing checkout to the branch: " + data.current + "\n");
                 gitProjectMs2.checkout(data.current, null, (error) => {
                     if (error) {
                         reject(error);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

There was a problem with a log message that was causing a the createproject script to be blocked and not catched up by catches statements



**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/MapStore2/issues/5607#issuecomment-709072885

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
