### PR TITLE
Search bar returns always a maximun of 15 results even with custom services #5929

### DIFF
--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -14,6 +14,7 @@ const ConfigUtils = require('../../../../utils/ConfigUtils');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const SearchBar = require('../SearchBar').default;
+import {getTotalMaxResults} from "../../../search/SearchBarUtils";
 
 const TestUtils = require('react-dom/test-utils');
 
@@ -73,8 +74,28 @@ describe("test the SearchBar", () => {
     });
 
     it('test search and reset on enter', () => {
+        let searchOptions = {displaycrs: "EPSG:3857",
+            services: [
+                {type: "wfs",
+                    name: "Meteorites",
+                    displayName: "${properties,name}",
+                    options: {
+                        maxFeatures: 20,
+                        srsName: "EPSG:4326"
+                    },
+                    launchInfoPanel: "single_layer"
+                }]
+        };
         const renderSearchBar = (testHandlers, text) => {
-            return ReactDOM.render(<SearchBar searchText={text} delay={0} typeAhead={false} onSearch={testHandlers.onSearchHandler} onSearchReset={testHandlers.onSearchResetHandler} onSearchTextChange={testHandlers.onSearchTextChangeHandler}/>, document.getElementById("container"));
+            return ReactDOM.render(
+                <SearchBar
+                    searchText={text}
+                    searchOptions={searchOptions}
+                    delay={0} typeAhead={false}
+                    onSearch={testHandlers.onSearchHandler}
+                    onSearchReset={testHandlers.onSearchResetHandler}
+                    onSearchTextChange={testHandlers.onSearchTextChangeHandler}
+                />, document.getElementById("container"));
         };
 
         const testHandlers = {
@@ -100,7 +121,31 @@ describe("test the SearchBar", () => {
     });
 
     it('test that options are passed to search action', () => {
-        let searchOptions = {displaycrs: "EPSG:3857"};
+        let searchOptions = {displaycrs: "EPSG:3857",
+            services: [
+                {
+                    priority: 5,
+                    type: "nomination"
+                },
+                {type: "wfs",
+                    name: "Meteorites",
+                    displayName: "${properties,name}",
+                    options: {
+                        maxFeatures: 20,
+                        srsName: "EPSG:4326"
+                    },
+                    launchInfoPanel: "single_layer"
+                },
+                {type: "wfs",
+                    name: "Meteorites",
+                    displayName: "${properties,name}",
+                    options: {
+                        maxFeatures: undefined,
+                        srsName: "EPSG:4328"
+                    },
+                    launchInfoPanel: "single_layer"
+                }]
+        };
 
         const renderSearchBar = (testHandlers, text) => {
             return ReactDOM.render(
@@ -108,7 +153,7 @@ describe("test the SearchBar", () => {
                     searchOptions={searchOptions}
                     searchText={text}
                     delay={0}
-                    maxResults={23}
+                    maxResults={15}
                     typeAhead={false}
                     onSearch={testHandlers.onSearchHandler}
                     onSearchReset={testHandlers.onSearchResetHandler}
@@ -131,7 +176,7 @@ describe("test the SearchBar", () => {
         TestUtils.Simulate.change(input);
         TestUtils.Simulate.keyDown(input, {key: "Enter", keyCode: 13, which: 13});
         expect(spy.calls.length).toEqual(1);
-        expect(spy).toHaveBeenCalledWith('test', searchOptions, 23);
+        expect(spy).toHaveBeenCalledWith('test', searchOptions, 50);
     });
     it('test error and loading status', () => {
         ReactDOM.render(<SearchBar loading error={{message: "TEST_ERROR"}}/>, document.getElementById("container"));
@@ -487,5 +532,36 @@ describe("test the SearchBar", () => {
         expect(spyOnZoomToExtent).toHaveBeenCalled();
         expect(spyOnZoomToExtent.calls.length).toBe(1);
         expect(spyOnZoomToExtent.calls[0].arguments[0]).toEqual([ 5, 10, 20, 30 ]);
+    });
+
+    it('test the maxFeatures function', ()=> {
+        let services = [
+            {
+                priority: 5,
+                type: "nomination"
+            },
+            {
+                type: "wfs",
+                name: "Meteorites",
+                displayName: "${properties,name}",
+                options: {
+                    maxFeatures: 20,
+                    srsName: "EPSG:4326"
+                },
+                launchInfoPanel: "single_layer"
+            },
+            {
+                type: "wfs",
+                name: "Meteorites",
+                displayName: "${properties,name}",
+                options: {
+                    maxFeatures: undefined,
+                    srsName: "EPSG:4328"
+                },
+                launchInfoPanel: "single_layer"
+            }
+        ];
+
+        expect(getTotalMaxResults(services)).toEqual(50);
     });
 });

--- a/web/client/components/search/SearchBarUtils.js
+++ b/web/client/components/search/SearchBarUtils.js
@@ -6,6 +6,13 @@
  * LICENSE file in the root directory of this source tree.
 */
 
+export const getTotalMaxResults = (services = [], maxResults = 15) => {
+    return services.reduce(function(total, current) {
+        return total + (current?.options?.maxFeatures || maxResults);
+    }, 0) || maxResults;
+};
+
+
 export const defaultSearchWrapper = ({
     searchText,
     selectedItems,
@@ -15,9 +22,10 @@ export const defaultSearchWrapper = ({
     onSearchReset = () => {}
 }) => () => {
     const text = searchText;
+    const totalResults = getTotalMaxResults(searchOptions.services, maxResults);
     if ((text === undefined || text === "") && (!selectedItems || selectedItems.length === 0)) {
         onSearchReset();
     } else if (text !== undefined && text !== "") {
-        onSearch(text, searchOptions, maxResults);
+        onSearch(text, searchOptions, totalResults );
     }
 };


### PR DESCRIPTION


## Description
The search bar returns always a maximum of 15 results even with custom services. This PR makes it so that the maximum results are more dynamic

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#5929

**What is the new behavior?**
The search bar can now be customized to return more than 15 features when the `max feature` field is adjusted

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


## Other useful information
