### PR TITLE
Error in GFI for (imported) vector layer #5961

### DIFF
--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -258,6 +258,29 @@ describe('MapInfoUtils', () => {
         expect(req1.request.lat).toBe(43);
     });
 
+    it('buildIdentifyRequest works with properties field not defined in the layer object', () => {
+        let props = {
+            map: {
+                zoom: 0,
+                projection: 'EPSG:4326'
+            },
+            point: {
+                latlng: {
+                    lat: 25,
+                    lng: 0
+                }
+            }
+        };
+        let layer = {
+            type: "vector",
+            name: "layer",
+            features: [{}]
+        };
+        let req1 = buildIdentifyRequest(layer, props);
+        expect(req1.request).toExist();
+        expect(req1.request.lat).toBe(25);
+    });
+
     it('getViewer and setViewer test', () => {
         let props = {
             map: {

--- a/web/client/utils/mapinfo/vector.js
+++ b/web/client/utils/mapinfo/vector.js
@@ -16,7 +16,7 @@ module.exports = {
                 lng: props.point.latlng.lng
             },
             metadata: {
-                fields: layer.features && layer.features.length && Object.keys(layer.features[0].properties) || [],
+                fields: layer.features?.[0]?.properties && Object.keys(layer.features[0].properties) || [],
                 title: layer.name,
                 resolution: props.map && props.map && props.map.zoom && MapUtils.getCurrentResolution(props.map.zoom, 0, 21, 96),
                 buffer: props.buffer || 2,


### PR DESCRIPTION
## Description
When getting feature information on a vector layer, when the vector layer has no additional information, there is a perpetual loader in the feature information section. This PR fixes that.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#5961

**What is the new behavior?**
<img width="1353" alt="Screenshot 2020-10-19 at 11 06 21" src="https://user-images.githubusercontent.com/30922279/96418247-2202bb80-11fb-11eb-9304-4c3ca8cea170.png">


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
