### PR TITLE
#6043: Fix annotation modal overlap in Geostory

### DIFF
--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -417,3 +417,7 @@
 .modal.fade.in .modal-dialog.modal-dialog-draggable{
     .transition(none);
 }
+
+.fade.in.modal{
+    z-index: 9999;
+}

--- a/web/client/themes/default/less/style-editor.less
+++ b/web/client/themes/default/less/style-editor.less
@@ -267,7 +267,7 @@ Ported to CodeMirror by Peter Kroon
 }
 
 .ms-color-picker-overlay {
-    z-index: 1000;
+    z-index: 9999;
     .ms-sketch-picker {
         background: @ms2-color-background;
         .shadow-far();


### PR DESCRIPTION
## Description
This PR adds fix to annotation modal hidden behind overlays in Geostory
(Note: Additional unit test not required as the component is present and functionable (for which unit test cases are already in place) but hidden behind the overlays (css issue))

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6043 

**What is the new behavior?**
The modals of annotation and style overlays is displayed while editing a map in geostory and not hidden behind the overlays of  geostory

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
