### PR TITLE
Fix #5873 Deactivation of feature filter inside the feature grid doesn't work if the advanced filter panel is opened

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1955,6 +1955,38 @@ describe('featuregrid Epics', () => {
             }]
         }, done);
     });
+    it('featureGridUpdateFilter initiates query when geometry filter is disabled after feature grid opens', done => {
+        const startActions = [openFeatureGrid(), createQuery(), updateFilter({
+            type: 'geometry',
+            enabled: false
+        })];
+
+        testEpic(featureGridUpdateGeometryFilter, 1, startActions, actions => {
+            expect(actions.length).toBe(1);
+            expect(actions[0].type).toBe(UPDATE_QUERY);
+            expect(actions[0].reason).toBe('geometry');
+        }, {
+            featuregrid: {
+                selectedLayer: 'layer',
+                filters: {
+                    geom: {
+                        attribute: 'geom',
+                        enabled: true,
+                        type: 'geometry',
+                        value: {
+                            attribute: 'geom',
+                            method: 'Circle',
+                            operation: 'INTERSECTS'
+                        }
+                    }
+                }
+            },
+            layers: [{
+                id: 'layer',
+                name: 'layer'
+            }]
+        }, done);
+    });
     it('activateTemporaryChangesEpic', (done) => {
         const startActions = [activateTemporaryChanges(true)];
         testEpic(activateTemporaryChangesEpic, 2, startActions, actions => {

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -268,6 +268,11 @@ module.exports = {
                 .map(updateFilterFunc(store)),
             action$.ofType(UPDATE_FILTER)
                 .filter(({update = {}}) => update.type === 'geometry')
+                .take(1)
+                .filter(({update = {}}) => !update.enabled)
+                .map(updateFilterFunc(store)),
+            action$.ofType(UPDATE_FILTER)
+                .filter(({update = {}}) => update.type === 'geometry')
                 .distinctUntilChanged(({update: update1}, {update: update2}) => {
                     return !update1.enabled && update2.enabled && !update1.value && !update2.value ||
                         update1.value === update2.value;


### PR DESCRIPTION
## Description
Trigger the query when feature grid is opened and geometry filter is already applied.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5873 

**What is the current behavior?**
#5873 

**What is the new behavior?**
Description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
