### PR TITLE
Marker property modal hidden in geostory

### DIFF
--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -12,6 +12,7 @@
     height: 100%;
     top: 0;
     left: 0;
+    z-index: 9999;
 }
 
 .ms-property-picker-cover {


### PR DESCRIPTION
## Description
This PR adds fix to annotation modal hidden behind overlays in Geostory
(Note: Additional unit test not required as the component is present and functionable (for which unit test cases are already in place) but hidden behind the overlays (css issue))

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/issues/6043#issuecomment-712234529

**What is the new behavior?**
The marker property overlay will be visible to perform marker property selection action

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
