### PR TITLE
Timeline showing but WMTS layer with time dimension are not supported #5786

### DIFF
--- a/web/client/epics/dimension.js
+++ b/web/client/epics/dimension.js
@@ -48,7 +48,7 @@ module.exports = {
         action$
             .ofType(ADD_LAYER)
             .filter(
-                ({ layer = {} } = {}) => layer.id && layer.url && layer.name && (layer.type === "wms" || layer.type === "wmts")
+                ({ layer = {} } = {}) => layer.id && layer.url && layer.name && (layer.type === "wms")
             )
             // find out possible multidim URL
             // TODO: find out a better way to extract or discover multidim URL


### PR DESCRIPTION
## Description
Ensure that when adding a new layer, if it is a WMTS layer, the timeline should not render

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5786

**What is the new behavior?**
When adding a new layer, if it is a WMTS layer, the timeline will not show

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
