### PR TITLE
#6057: Allow OSM background selection for custom CRS

### DIFF
--- a/web/client/components/background/PreviewIcon.jsx
+++ b/web/client/components/background/PreviewIcon.jsx
@@ -46,7 +46,7 @@ class PreviewIcon extends React.Component {
         const compatibleWmts = this.props.layer.type === "wmts" && has(this.props.layer.allowedSRS, this.props.projection);
         const containerClass = this.props.vertical ? 'background-preview-icon-container-vertical' : 'background-preview-icon-container-horizontal';
         const type = this.props.layer.visibility ? ' bg-primary' : ' bg-body';
-        const valid = ((validCrs || compatibleWmts || this.props.layer.type === "wms" || this.props.layer.type === "empty") && !this.props.layer.invalid );
+        const valid = ((validCrs || compatibleWmts || ["wms", "empty", "osm"].includes(this.props.layer.type)) && !this.props.layer.invalid );
 
         const click = !valid ? () => {} : () => {
             this.props.onToggle();

--- a/web/client/components/background/PreviewIcon.jsx
+++ b/web/client/components/background/PreviewIcon.jsx
@@ -8,7 +8,7 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const {indexOf, has} = require('lodash');
+const {indexOf, has, includes} = require('lodash');
 require('./css/previewicon.css');
 
 class PreviewIcon extends React.Component {
@@ -46,7 +46,7 @@ class PreviewIcon extends React.Component {
         const compatibleWmts = this.props.layer.type === "wmts" && has(this.props.layer.allowedSRS, this.props.projection);
         const containerClass = this.props.vertical ? 'background-preview-icon-container-vertical' : 'background-preview-icon-container-horizontal';
         const type = this.props.layer.visibility ? ' bg-primary' : ' bg-body';
-        const valid = ((validCrs || compatibleWmts || ["wms", "empty", "osm"].includes(this.props.layer.type)) && !this.props.layer.invalid );
+        const valid = ((validCrs || compatibleWmts || includes(["wms", "empty", "osm"], this.props.layer.type)) && !this.props.layer.invalid );
 
         const click = !valid ? () => {} : () => {
             this.props.onToggle();

--- a/web/client/components/background/__tests__/PreviewIcon-test.jsx
+++ b/web/client/components/background/__tests__/PreviewIcon-test.jsx
@@ -36,29 +36,43 @@ describe("test the PreviewIcon", () => {
             setCurrentBackgroundLayer: () => {}
         };
 
-        const layer = {
+        const layers = [{
             type: "empty",
             visibility: true,
             id: 'layer'
-        };
+        },
+        {
+            type: "wms",
+            visibility: true,
+            id: 'layer'
+        },
+        {
+            type: "osm",
+            visibility: true,
+            id: 'layer'
+        }];
 
         const spyPropertiesChange = expect.spyOn(actions, 'onPropertiesChange');
         const spyToggle = expect.spyOn(actions, 'onToggle');
         const spyLayerChange = expect.spyOn(actions, 'onLayerChange');
         const spySetCurrentBackgroundLayer = expect.spyOn(actions, 'setCurrentBackgroundLayer');
 
-        const previewIcon = ReactDOM.render(<PreviewIcon onPropertiesChange={actions.onPropertiesChange} onToggle={actions.onToggle} onLayerChange={actions.onLayerChange} setCurrentBackgroundLayer={actions.setCurrentBackgroundLayer} vertical layer={layer}/>, document.getElementById("container"));
-        expect(previewIcon).toExist();
-        const node = ReactDOM.findDOMNode(previewIcon);
-        expect(node).toExist();
-        const image = node.querySelector('.background-preview-icon-frame').children[0];
-        ReactTestUtils.Simulate.mouseOver(image);
-        expect(spyLayerChange).toHaveBeenCalled();
-        ReactTestUtils.Simulate.click(image);
-        expect(spyPropertiesChange).toHaveBeenCalled();
-        expect(spyToggle).toHaveBeenCalled();
-        expect(spyPropertiesChange).toHaveBeenCalledWith("layer", {visibility: true});
-        expect(spySetCurrentBackgroundLayer).toHaveBeenCalledWith("layer");
+        layers.map((layer, i)=>{
+            const previewIcon = ReactDOM.render(<PreviewIcon onPropertiesChange={actions.onPropertiesChange} onToggle={actions.onToggle} onLayerChange={actions.onLayerChange} setCurrentBackgroundLayer={actions.setCurrentBackgroundLayer} vertical layer={layer}/>, document.getElementById("container"));
+            expect(previewIcon).toExist();
+            const node = ReactDOM.findDOMNode(previewIcon);
+            expect(node).toExist();
+            const image = node.querySelector('.background-preview-icon-frame').children[0];
+            ReactTestUtils.Simulate.mouseOver(image);
+            expect(spyLayerChange).toHaveBeenCalled();
+            expect(spyLayerChange.calls[i].arguments[1].type).toBe(layer.type);
+            ReactTestUtils.Simulate.click(image);
+            expect(spyPropertiesChange).toHaveBeenCalled();
+            expect(spyToggle).toHaveBeenCalled();
+            expect(spyPropertiesChange).toHaveBeenCalledWith("layer", {visibility: true});
+            expect(spySetCurrentBackgroundLayer).toHaveBeenCalledWith("layer");
+        });
+
 
     });
 

--- a/web/client/components/background/__tests__/PreviewIcon-test.jsx
+++ b/web/client/components/background/__tests__/PreviewIcon-test.jsx
@@ -57,7 +57,7 @@ describe("test the PreviewIcon", () => {
         const spyLayerChange = expect.spyOn(actions, 'onLayerChange');
         const spySetCurrentBackgroundLayer = expect.spyOn(actions, 'setCurrentBackgroundLayer');
 
-        layers.map((layer, i)=>{
+        layers.forEach((layer, i)=>{
             const previewIcon = ReactDOM.render(<PreviewIcon onPropertiesChange={actions.onPropertiesChange} onToggle={actions.onToggle} onLayerChange={actions.onLayerChange} setCurrentBackgroundLayer={actions.setCurrentBackgroundLayer} vertical layer={layer}/>, document.getElementById("container"));
             expect(previewIcon).toExist();
             const node = ReactDOM.findDOMNode(previewIcon);


### PR DESCRIPTION
## Description
This PR adds a feature to allow the selection of OSM background layer from the background selector regardless of the CRS. As the Openlayer will be able to project based on the projection defs given in the local config for the custom CRS used.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6057 

**What is the new behavior?**
User can select the background layer of type OSM for the custom CRS

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
