### PR TITLE
Fix #5378 MapStore not respecting WMS protocol version!

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -89,6 +89,9 @@ export const searchAndPaginate = (json = {}, startPosition, maxRecords, text) =>
         numberOfRecordsReturned: Math.min(maxRecords, filteredLayers.length),
         nextRecord: startPosition + Math.min(maxRecords, filteredLayers.length) + 1,
         service,
+        layerOptions: {
+            version: (json.WMS_Capabilities || json.WMT_MS_Capabilities)?.$?.version || '1.3.0'
+        },
         records: filteredLayers
             .filter((layer, index) => index >= startPosition - 1 && index < startPosition - 1 + maxRecords)
             .map((layer) => assign({}, layer, { formats: rootFormats, onlineResource, SRS: SRSList, credits: layer.Attribution ? extractCredits(layer.Attribution) : credits}))

--- a/web/client/api/__tests__/WMS-test.js
+++ b/web/client/api/__tests__/WMS-test.js
@@ -136,6 +136,8 @@ describe('Test correctness of the WMS APIs', () => {
                 expect(result.service).toExist();
                 expect(result.records[0].formats.length).toBe(20);
                 expect(result.numberOfRecordsMatched).toBe(5);
+                expect(result.layerOptions).toExist();
+                expect(result.layerOptions.version).toBe('1.3.0');
                 done();
             } catch (ex) {
                 done(ex);
@@ -165,6 +167,8 @@ describe('Test correctness of the WMS APIs', () => {
                 expect(result.service).toExist();
                 expect(result.records[0].formats.length).toBe(42);
                 expect(result.numberOfRecordsMatched).toBe(7);
+                expect(result.layerOptions).toExist();
+                expect(result.layerOptions.version).toBe('1.1.1');
                 done();
             } catch (ex) {
                 done(ex);

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -8,7 +8,6 @@
 const React = require('react');
 const Message = require('../../../../components/I18N/Message');
 const Layers = require('../../../../utils/leaflet/Layers');
-const CoordinatesUtils = require('../../../../utils/CoordinatesUtils');
 const { optionsToVendorParams } = require('../../../../utils/VendorParamsUtils');
 
 const WMSUtils = require('../../../../utils/leaflet/WMSUtils');
@@ -174,8 +173,6 @@ function wmsToLeafletOptions(options) {
         opacity: opacity,
         zIndex: options.zIndex,
         version: options.version || "1.3.0",
-        SRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
-        CRS: CoordinatesUtils.normalizeSRS(options.srs || 'EPSG:3857', options.allowedSRS),
         tileSize: options.tileSize || 256,
         maxZoom: options.maxZoom || 23,
         maxNativeZoom: options.maxNativeZoom || 18

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -223,7 +223,10 @@ const converters = {
                     identifier: record.Name,
                     service: records.service,
                     tags: "",
-                    layerOptions: options && options.layerOptions || {},
+                    layerOptions: {
+                        ...(options?.layerOptions || {}),
+                        ...(records?.layerOptions || {})
+                    },
                     title: LayersUtils.getLayerTitleTranslations(record) || record.Name,
                     formats: castArray(record.formats || []),
                     dimensions: (record.Dimension && castArray(record.Dimension) || []).map((dim) => assign({}, {

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -519,7 +519,8 @@ const LayersUtils = {
             tooltipOptions: layer.tooltipOptions,
             tooltipPlacement: layer.tooltipPlacement,
             legendOptions: layer.legendOptions,
-            tileSize: layer.tileSize
+            tileSize: layer.tileSize,
+            version: layer.version
         },
         layer.params ? { params: layer.params } : {},
         layer.credits ? { credits: layer.credits } : {},

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -194,7 +194,8 @@ describe('Test the MapUtils', () => {
                     type: "wms",
                     url: "",
                     visibility: true,
-                    catalogURL: "url"
+                    catalogURL: "url",
+                    version: '1.3.0'
                 },
                 {
                     allowedSRS: {},
@@ -328,7 +329,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -376,7 +378,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: '1.3.0'
                     },
                     {
                         allowedSRS: {},
@@ -424,7 +427,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -472,7 +476,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -685,7 +690,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -733,7 +739,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -781,7 +788,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -829,7 +837,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -877,7 +886,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -925,7 +935,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -1113,6 +1124,7 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         tileSize: undefined,
+                        version: undefined,
                         legendOptions: { legendWidth: "", legendHeight: 40}
                     },
                     {
@@ -1161,7 +1173,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -1209,6 +1222,7 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: "both",
                         tooltipPlacement: "right",
                         tileSize: undefined,
+                        version: undefined,
                         legendOptions: { legendWidth: 20, legendHeight: 40}
                     }],
                     mapOptions: {
@@ -1411,6 +1425,7 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
+                        version: undefined,
                         tooltipPlacement: undefined, legendOptions: undefined
                     },
                     {
@@ -1458,6 +1473,7 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
+                        version: undefined,
                         tooltipPlacement: undefined, legendOptions: undefined
                     },
                     {
@@ -1505,6 +1521,7 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
+                        version: undefined,
                         tooltipPlacement: undefined, legendOptions: undefined
                     }],
                     mapOptions: {},
@@ -1689,6 +1706,7 @@ describe('Test the MapUtils', () => {
                         thematic: undefined,
                         tooltipOptions: undefined,
                         tileSize: undefined,
+                        version: undefined,
                         tooltipPlacement: undefined, legendOptions: undefined,
                         params: {} } ],
                     groups: [ {
@@ -1843,7 +1861,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -2000,7 +2019,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
@@ -2197,7 +2217,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -2245,7 +2266,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -2293,7 +2315,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     },
                     {
                         allowedSRS: {},
@@ -2341,7 +2364,8 @@ describe('Test the MapUtils', () => {
                         tooltipOptions: undefined,
                         tooltipPlacement: undefined,
                         legendOptions: undefined,
-                        tileSize: undefined
+                        tileSize: undefined,
+                        version: undefined
                     }],
                     mapOptions: {},
                     maxExtent: [-20037508.34, -20037508.34, 20037508.34, 20037508.34],


### PR DESCRIPTION
## Description
Set version prop for WMS layers for future requests. Also I've deleted the CRS and SRS props in leaflet WMSLayer since the only wms option for specifying CRS it has is crs and if it is not set it will override the options set. Leaflet expects crs to be a Leaflet.CRS object, so just passing the string won't work. Since Leaflet viewer seems to support only EPSG:3857 and seeing that the code is wrong anyway I deleted it. It was creating problems for 1.1.1 wms on the test map mentioned in the issue.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5378 

**What is the current behavior?**
#5378 

**What is the new behavior?**
WMS version is preserved.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
