### PR TITLE
Placeholder for new souce catalog in URL field #5933

### DIFF
--- a/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
 import CatalogServiceEditor from '../CatalogServiceEditor';
+import {defaultPlaceholder} from "../editor/MainFormUtils";
 
 const givenWmsService = {
     url: "url",
@@ -143,5 +144,12 @@ describe('Test CatalogServiceEditor', () => {
 
         const isLocalizedLayerStylesOption = document.querySelector('[data-qa="service-lacalized-layer-styles-option"]');
         expect(isLocalizedLayerStylesOption).toBeNull;
+    });
+    it('test defaultPlaceholder function for the main form placeholder urls', () => {
+        let service = {
+            type: "wms"
+        };
+        let placeholder = defaultPlaceholder(service);
+        expect(placeholder).toBe("example: https://mydomain.com/geoserver/wms");
     });
 });

--- a/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
@@ -150,6 +150,6 @@ describe('Test CatalogServiceEditor', () => {
             type: "wms"
         };
         let placeholder = defaultPlaceholder(service);
-        expect(placeholder).toBe("example: https://mydomain.com/geoserver/wms");
+        expect(placeholder).toBe("e.g. https://mydomain.com/geoserver/wms");
     });
 });

--- a/web/client/components/catalog/editor/MainForm.jsx
+++ b/web/client/components/catalog/editor/MainForm.jsx
@@ -89,7 +89,7 @@ const TmsURLEditor = ({ serviceTypes = [], onChangeServiceProperty, service = {}
                         style={{
                             textOverflow: "ellipsis"
                         }}
-                        placeholder={"example: https://{s}.myUrl.com/{variant}/{z}/{x}/{y}"}
+                        placeholder={"e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}"}
                         value={service && service.url}
                         onChange={(e) => onChangeUrl(e.target.value)} />
                 </React.Fragment>
@@ -101,7 +101,7 @@ const TmsURLEditor = ({ serviceTypes = [], onChangeServiceProperty, service = {}
                             style={{
                                 textOverflow: "ellipsis"
                             }}
-                            placeholder="catalog.urlPlaceholder"
+                            placeholder={defaultPlaceholder(service)}
                             value={service && service.url}
                             onChange={(e) => onChangeUrl(e.target.value)} />
                     </React.Fragment>

--- a/web/client/components/catalog/editor/MainForm.jsx
+++ b/web/client/components/catalog/editor/MainForm.jsx
@@ -16,25 +16,32 @@ import InfoPopover from '../../widgets/widget/InfoPopover';
 import { FormControl as FC, Form, Col, FormGroup, ControlLabel } from "react-bootstrap";
 
 import localizedProps from '../../misc/enhancers/localizedProps';
+import {defaultPlaceholder} from "./MainFormUtils";
 
 const FormControl = localizedProps('placeholder')(FC);
 
 const CUSTOM = "custom";
 const TMS = "tms";
 
-const DefaultURLEditor = ({ service = {}, onChangeUrl = () => { } }) => (<FormGroup controlId="URL">
-    <Col xs={12}>
-        <ControlLabel><Message msgId="catalog.url" /></ControlLabel>
-        <FormControl
-            type="text"
-            style={{
-                textOverflow: "ellipsis"
-            }}
-            placeholder="catalog.urlPlaceholder"
-            value={service && service.url}
-            onChange={(e) => onChangeUrl(e.target.value)} />
-    </Col>
-</FormGroup>);
+const DefaultURLEditor = ({ service = {}, onChangeUrl = () => { } }) => {
+
+    return (
+
+        <FormGroup controlId="URL">
+            <Col xs={12}>
+                <ControlLabel><Message msgId="catalog.url"/></ControlLabel>
+                <FormControl
+                    type="text"
+                    style={{
+                        textOverflow: "ellipsis"
+                    }}
+                    placeholder={defaultPlaceholder(service)}
+                    value={service && service.url}
+                    onChange={(e) => onChangeUrl(e.target.value)}/>
+            </Col>
+        </FormGroup>
+    );
+};
 
 // selector for tile provider
 import CONFIG_PROVIDER from '../../../utils/ConfigProvider';

--- a/web/client/components/catalog/editor/MainFormUtils.js
+++ b/web/client/components/catalog/editor/MainFormUtils.js
@@ -1,9 +1,10 @@
 export const defaultPlaceholder = (service) => {
     let urlPlaceholder = {
-        wfs: "example: https://mydomain.com/geoserver/wfs",
-        wmts: "example: https://mydomain.com/geoserver/gwc/service/wmts",
-        wms: "example: https://mydomain.com/geoserver/wms",
-        csw: "example: https://mydomain.com/geoserver/csw"
+        wfs: "e.g. https://mydomain.com/geoserver/wfs",
+        wmts: "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+        wms: "e.g. https://mydomain.com/geoserver/wms",
+        csw: "e.g. https://mydomain.com/geoserver/csw",
+        tms: "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0"
     };
     for ( const [key, value] of Object.entries(urlPlaceholder)) {
         if ( key === service.type) {

--- a/web/client/components/catalog/editor/MainFormUtils.js
+++ b/web/client/components/catalog/editor/MainFormUtils.js
@@ -1,0 +1,14 @@
+export const defaultPlaceholder = (service) => {
+    let urlPlaceholder = {
+        wfs: "example: https://mydomain.com/geoserver/wfs",
+        wmts: "example: https://mydomain.com/geoserver/gwc/service/wmts",
+        wms: "example: https://mydomain.com/geoserver/wms",
+        csw: "example: https://mydomain.com/geoserver/csw"
+    };
+    for ( const [key, value] of Object.entries(urlPlaceholder)) {
+        if ( key === service.type) {
+            return value;
+        }
+    }
+    return true;
+};


### PR DESCRIPTION
## Description
It would be better to have a placeholder in the empty URL field of a catalog setting panel to inform the user which kind of URL is expected.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: UI enhancement

## Issue

**What is the current behavior?**
#5933

**What is the new behavior?**
All catalog setting panel URLs have placeholders

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
