### PR TITLE
#6089: Template update fix

### DIFF
--- a/web/client/components/data/template/jsx/Template.jsx
+++ b/web/client/components/data/template/jsx/Template.jsx
@@ -30,6 +30,8 @@ class Template extends React.Component {
 
     UNSAFE_componentWillReceiveProps(nextProps) {
         if (nextProps.template !== this.props.template) {
+            // Reset to avoid rendering with old comp value during template update
+            this.comp = null;
             this.parseTemplate(nextProps.template);
         }
     }

--- a/web/client/components/data/template/jsx/__tests__/Template-test.jsx
+++ b/web/client/components/data/template/jsx/__tests__/Template-test.jsx
@@ -128,10 +128,10 @@ describe("Test JSX Template", () => {
                 expect(cmpDom).toExist();
 
                 comp = ReactDOM.render(
-                    <Template template="<div id='template'/>" model={{id: "temp"}} />
+                    <Template template="<div id='template'/>" model={{id: "temp"}} renderContent={(component)=> {
+                        expect(component).toContain('template');
+                    }} />
                     , document.getElementById("container"));
-                const cmpDom1 = document.getElementById("temp");
-                expect(cmpDom1).toExist();
                 done();
             } catch (ex) {
                 done(ex);


### PR DESCRIPTION
## Description
This PR adds a fix to update component data when parsing a new template to serve it via the render content

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6089  (Refer story for more detail and project related to it)

**What is the new behavior?**
When a new template update, the old comp data is cleared to be served with the new parsed template from the callback

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
