### PR TITLE
[Backport for 2020.02.xx]: #6041 Fix problem configuring hyperlinks in story text editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "react-dnd-test-backend": "2.6.0",
     "react-dock": "0.2.4",
     "react-dom": "16.10.1",
-    "react-draft-wysiwyg": "1.13.2",
+    "react-draft-wysiwyg": "npm:@geosolutions/react-draft-wysiwyg@1.14.8",
     "react-draggable": "2.2.6",
     "react-dropzone": "3.13.1",
     "react-error-boundary": "1.2.5",


### PR DESCRIPTION
[Backport for 2020.02.xx]: #6041 Fix problem configuring hyperlinks in story text editor