### PR TITLE
#6075: Fix filter on map active by default

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -102,7 +102,8 @@ const {
     hideDrawerOnFeatureGridOpenMobile,
     handleClickOnMap,
     featureGridUpdateGeometryFilter,
-    activateTemporaryChangesEpic
+    activateTemporaryChangesEpic,
+    enableGeometryFilterOnEditMode
 } = require('../featuregrid');
 const { onLocationChanged } = require('connected-react-router');
 
@@ -1931,6 +1932,57 @@ describe('featuregrid Epics', () => {
                 }
             }
         }, done);
+    });
+    it('enableGeometryFilterOnEditMode epic', (done) => {
+        const epicResponse = actions => {
+            expect(actions[0].type).toBe(UPDATE_FILTER);
+            done();
+        };
+
+        const featureGridState1 = {
+            featuregrid: {
+                mode: "EDIT",
+                filters: {}
+            }
+        };
+
+        testEpic(
+            enableGeometryFilterOnEditMode,
+            1,
+            toggleEditMode(),
+            epicResponse,
+            featureGridState1
+        );
+
+        const epicResponse2 = actions => {
+            expect(actions).toBe(undefined);
+            done();
+        };
+
+
+        const featureGridState2 = {
+            featuregrid: {
+                mode: "EDIT",
+                filters: {
+                    ["the_geom"]: {
+                        attribute: "the_geom",
+                        enabled: true,
+                        type: "geometry",
+                        value: {
+                            attribute: "the_geom"
+                        }
+                    }
+                }
+            }
+        };
+
+        testEpic(
+            enableGeometryFilterOnEditMode,
+            1,
+            toggleEditMode(),
+            epicResponse2,
+            featureGridState2
+        );
     });
     it('featureGridUpdateFilter with geometry filter', (done) => {
         const startActions = [openFeatureGrid(), createQuery(), updateFilter({

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -284,6 +284,22 @@ module.exports = {
             .filter(({update = {}}) => update.type !== 'geometry')
             .map(updateFilterFunc(store))
     ),
+    /**
+     * Enables the Geometry filter when entering edit mode in feature grid.
+     * No filter value should have been set otherwise nothing is enabled.
+     * @memberof epics.featuregrid
+     */
+    enableGeometryFilterOnEditMode: (action$, store) =>
+        action$.ofType(TOGGLE_MODE)
+            .filter(() => modeSelector(store.getState()) === MODES.EDIT)
+            .switchMap(() => {
+                const currentFilter = find(getAttributeFilters(store.getState()), f => f.type === 'geometry') || {};
+                return currentFilter.value ? Rx.Observable.empty() : Rx.Observable.of(updateFilter({
+                    attribute: "the_geom",
+                    enabled: true,
+                    type: "geometry"
+                }));
+            }),
     handleClickOnMap: (action$, store) =>
         action$.ofType(UPDATE_FILTER)
             .filter(({update = {}}) => update.type === 'geometry' && update.enabled)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6075 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
GeometryFilter is activated when FeatureGrid is opened

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
