### PR TITLE
Improve augment store to avoid to update the state twice

### DIFF
--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -197,13 +197,18 @@ export const updateStore = ({ rootReducer, rootEpic, reducers = {}, epics = {} }
 export const augmentStore = ({ reducers = {}, epics = {} } = {}, store) => {
     const rootReducer = fetchReducer();
     const reducer = (state, action) => {
+        const initialStoreKeys = Object.keys(rootReducer({}, {}));
         const newState = {...state, ...rootReducer(state, action)};
-        return Object.keys(reducers).reduce((previous, current) => {
-            return {
-                ...previous,
-                [current]: reducers[current](previous[current], action)
-            };
-        }, newState);
+        return Object.keys(reducers)
+            // avoid to update the state twice
+            // if the original store contains the same reducers
+            .filter((key) => initialStoreKeys.indexOf(key) === -1)
+            .reduce((previous, current) => {
+                return {
+                    ...previous,
+                    [current]: reducers[current](previous[current], action)
+                };
+            }, newState);
     };
     (store || getStore()).replaceReducer(reducer);
     const rootEpic = fetchEpic();

--- a/web/client/utils/__tests__/StateUtils-test.js
+++ b/web/client/utils/__tests__/StateUtils-test.js
@@ -7,8 +7,16 @@
  */
 import ReactDOM from 'react-dom';
 import expect from 'expect';
-import {setStore, getStore, createStore, updateStore} from '../StateUtils';
+import {
+    PERSISTED_STORE_NAME,
+    setStore,
+    getStore,
+    createStore,
+    updateStore,
+    augmentStore
+} from '../StateUtils';
 import Rx from 'rxjs';
+import { setConfigProp } from '../ConfigUtils';
 
 describe('StateUtils', () => {
     beforeEach((done) => {
@@ -148,5 +156,51 @@ describe('StateUtils', () => {
         store.dispatch({ type: "fake" });
         expect(spy2.calls.length > 0).toBe(true);
         expect(spy1.calls.length).toBe(beforeUpdateCalls);
+    });
+    it('should use the new added reducers (augmentStore)', () => {
+        const rootReducer = () => ({});
+        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);
+        const store = {
+            replaceReducer: (reducer) => {
+                reducer();
+            }
+        };
+        let reducersKeys = [];
+        augmentStore({ reducers: {
+            map: () => {
+                reducersKeys.push('map');
+                return {};
+            },
+            controls: () => {
+                reducersKeys.push('controls');
+                return {};
+            }
+        } }, store);
+        expect(reducersKeys).toEqual([ 'map', 'controls' ]);
+        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', undefined);
+    });
+    it('should not use the new added reducers if they are available in the root reducer (augmentStore)', () => {
+        const rootReducer = () => ({
+            map: () => ({})
+        });
+        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);
+        const store = {
+            replaceReducer: (reducer) => {
+                reducer();
+            }
+        };
+        let reducersKeys = [];
+        augmentStore({ reducers: {
+            map: () => {
+                reducersKeys.push('map');
+                return {};
+            },
+            controls: () => {
+                reducersKeys.push('controls');
+                return {};
+            }
+        } }, store);
+        expect(reducersKeys).toEqual([ 'controls' ]);
+        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', undefined);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The function augmentStore in StateUtils allow to add new reducers to the store at runtime. This PR should fix the case in which a reducers has been initialiazed in the appReducers and then added twice with the reducers argument of augmentStore. This PR introduces a control in the augmentStore function that stop the update of new reducers if they were available in the initial store.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No difference in the MapStore application, this enhancement fix helps the use of plugins imported dynamically.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
