### PR TITLE
#6063: use the new geostore parameter to limit the result of "all use…

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -327,7 +327,7 @@ const Api = {
     getAvailableGroups: function(user) {
         if (user && user.role === "ADMIN") {
             return axios.get(
-                "usergroups/?all=true",
+                "usergroups/?all=true&users=false",
                 this.addBaseUrl({
                     headers: {
                         'Accept': "application/json"

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -197,28 +197,7 @@ describe('Test correctness of the GeoStore APIs', () => {
                     {
                         "groupName": "everyone",
                         "id": 1,
-                        "restUsers": {
-                            "User": [
-                                {
-                                    "groupsNames": "everyone",
-                                    "id": 3,
-                                    "name": "user",
-                                    "role": "USER"
-                                },
-                                {
-                                    "groupsNames": "everyone",
-                                    "id": 2,
-                                    "name": "admin",
-                                    "role": "ADMIN"
-                                },
-                                {
-                                    "groupsNames": "everyone",
-                                    "id": 1,
-                                    "name": "guest",
-                                    "role": "GUEST"
-                                }
-                            ]
-                        }
+                        "restUsers": {}
                     },
                     {
                         "description": "test",
@@ -246,28 +225,7 @@ describe('Test correctness of the GeoStore APIs', () => {
                 "UserGroup": {
                     "groupName": "everyone",
                     "id": 1,
-                    "restUsers": {
-                        "User": [
-                            {
-                                "groupsNames": "everyone",
-                                "id": 3,
-                                "name": "user",
-                                "role": "USER"
-                            },
-                            {
-                                "groupsNames": "everyone",
-                                "id": 2,
-                                "name": "admin",
-                                "role": "ADMIN"
-                            },
-                            {
-                                "groupsNames": "everyone",
-                                "id": 1,
-                                "name": "guest",
-                                "role": "GUEST"
-                            }
-                        ]
-                    }
+                    "restUsers": {}
                 }
             }
         };


### PR DESCRIPTION
…rgroups" rest API, so that it does not include nested users

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Uses a new parameter in geostore to NOT download all nested users when getting the "all groups" list. This is needed to avoid downloading a big payload when a lot of users and groups are stored in the database.

This PR needs to be merged on geostore for this flag to work: https://github.com/geosolutions-it/geostore/pull/217

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
