### PR TITLE
#6026: Ensure layer registration is imported before map loading

### DIFF
--- a/web/client/plugins/map/index.js
+++ b/web/client/plugins/map/index.js
@@ -46,8 +46,12 @@ const Empty = () => { return <span/>; };
 
 const pluginsCreator = (mapType, actions) => {
 
-    return import('./' + mapType + '/index').then((module) => {
-        import('../../components/map/' + mapType + '/plugins/index');
+    return Promise.all([
+        import('./' + mapType + '/index'),
+        // wait until the layer registration is complete
+        // to ensure the layer can create the layer based on type
+        import('../../components/map/' + mapType + '/plugins/index')
+    ]).then(([ module ]) => {
         const components = module.default;
         const LMap = connect((state) => ({
             projectionDefs: projectionDefsSelector(state),


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This fix ensures that the layer registration is imported before map loading. In some context such as mapstore api the layers were not visible anymore. This happens also sometime in mapstore but it's not consistent probably due to asynch loading

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6026

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

This fix is part of the miigration of the codebase syntax from es5 to es6 for plugins

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
