### PR TITLE
Fix #6092 Configure search services with a Single layer problems

### DIFF
--- a/web/client/components/search/SearchBarInput.jsx
+++ b/web/client/components/search/SearchBarInput.jsx
@@ -34,12 +34,9 @@ const SearchBarInput = ({
 }, context) => {
     const inputRef = React.useRef();
     const prevSelectedItemsLengthRef = React.useRef();
-    const onBlurTimeout = React.useRef();
-    const onChangeTimeout = React.useRef();
-    const [startOnBlurTimeout, setStartOnBlurTimeout] = React.useState();
-    const [executeOnBlurTimeout, setExecuteOnBlurTimeout] = React.useState();
-    const [startOnChangeTimeout, setStartOnChangeTimeout] = React.useState();
-    const [executeOnChangeTimeout, setExecuteOnChangeTimeout] = React.useState();
+    const [onBlurTimeout, setOnBlurTimeout] = React.useState();
+    const [onChangeTimeout, setOnChangeTimeout] = React.useState();
+    const [executeOnChange, setExecuteOnChange] = React.useState(false);
 
     React.useEffect(() => {
         const prevSelectedItemsLength = prevSelectedItemsLengthRef.current;
@@ -58,45 +55,13 @@ const SearchBarInput = ({
         prevSelectedItemsLengthRef.current = selectedItems && selectedItems.length;
     });
 
-    // onBlur delay
-    React.useEffect(() => {
-        if (onBlurTimeout) {
-            if (executeOnBlurTimeout) {
-                onPurgeResults();
-                onBlurTimeout.current = 0;
-                setExecuteOnBlurTimeout(false);
-            }
-            if (startOnBlurTimeout) {
-                if (onBlurTimeout.current) {
-                    clearTimeout(onBlurTimeout.current);
-                }
-                onBlurTimeout.current = setTimeout(() => {
-                    setExecuteOnBlurTimeout(true);
-                }, blurResetDelay);
-                setStartOnBlurTimeout(false);
-            }
-        }
-    });
-
     // onChange delay
     React.useEffect(() => {
-        if (onChangeTimeout) {
-            if (executeOnChangeTimeout) {
-                onSearch();
-                onChangeTimeout.current = 0;
-                setExecuteOnChangeTimeout(false);
-            }
-            if (startOnChangeTimeout) {
-                if (onChangeTimeout.current) {
-                    clearTimeout(onChangeTimeout.current);
-                }
-                onChangeTimeout.current = setTimeout(() => {
-                    setExecuteOnChangeTimeout(true);
-                }, delay);
-                setStartOnChangeTimeout(false);
-            }
+        if (executeOnChange) {
+            onSearch();
+            setExecuteOnChange(false);
         }
-    });
+    }, [executeOnChange, onSearch]);
 
     let actualPlaceholder = "search.addressSearch";
     if (!placeholder && context.messages) {
@@ -132,7 +97,12 @@ const SearchBarInput = ({
         onBlur={() => {
             // delay this to make the click on result run anyway
             if (hideOnBlur) {
-                setStartOnBlurTimeout(true);
+                if (onBlurTimeout) {
+                    clearTimeout(onBlurTimeout);
+                }
+                setOnBlurTimeout(setTimeout(() => {
+                    onPurgeResults();
+                }, blurResetDelay));
             }
         }}
         onFocus={() => {
@@ -144,7 +114,12 @@ const SearchBarInput = ({
             let text = e.target.value;
             onSearchTextChange(text);
             if (typeAhead) {
-                setStartOnChangeTimeout(true);
+                if (onChangeTimeout) {
+                    clearTimeout(onChangeTimeout);
+                }
+                setOnChangeTimeout(setTimeout(() => {
+                    setExecuteOnChange(true);
+                }, delay));
             }
         }}
     />;

--- a/web/client/plugins/map/index.js
+++ b/web/client/plugins/map/index.js
@@ -53,7 +53,6 @@ const pluginsCreator = (mapType, actions) => {
             projectionDefs: projectionDefsSelector(state),
             mousePosition: isMouseMoveActiveSelector(state)
         }), assign({}, {
-            onCreationError: () => {},
             onMapViewChanges: changeMapView,
             onClick: clickOnMap,
             onMouseMove: mouseMove,

--- a/web/client/utils/SearchUtils.js
+++ b/web/client/utils/SearchUtils.js
@@ -16,7 +16,7 @@ const defaultIconStyle = {
 
 const showGFIForService = (service) => service?.launchInfoPanel === 'single_layer' && !!service?.openFeatureInfoButtonEnabled;
 
-const layerIsVisibleForGFI = (searchLayerObj, service) => service?.forceSearchLayerVisibility || !!searchLayerObj?.visibility;
+const layerIsVisibleForGFI = (searchLayerObj, service) => !!searchLayerObj && (service?.forceSearchLayerVisibility || !!searchLayerObj.visibility);
 
 module.exports = {
     defaultIconStyle,

--- a/web/client/utils/__tests__/SearchUtils-test.js
+++ b/web/client/utils/__tests__/SearchUtils-test.js
@@ -35,4 +35,7 @@ describe('SearchUtils test', () => {
     it('layerIsVisibleForGFI layer hidden with force visibility', () => {
         expect(layerIsVisibleForGFI({visibility: false}, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true, forceSearchLayerVisibility: true})).toBe(true);
     });
+    it('layerIsVisibleForGFI layer doesn\'t exist', () => {
+        expect(layerIsVisibleForGFI(undefined, {launchInfoPanel: 'single_layer', openFeatureInfoButtonEnabled: true, forceSearchLayerVisibility: true})).toBe(false);
+    });
 });


### PR DESCRIPTION
## Description
Disable GFI button if the layer doesn't exist. This should prevent the second point from happening(once again in the map linked in the issue the search service is for the layer that is not present on the map, the one on the map is gs:us_states). The first point is invalid since the search service is for the non existant layer, although I couldn't reproduce the exact behaviour demonstrated in the gif. For me the show gfi button was always enabled. On the gif it is disabled so by clicking there the whole bar click is triggered, so just zooming on the feature is the expected behaviour I believe. I've also noticed issues with onBlur behaviour of SearchBar which I addressed. Also after recent PR of es5 to es6 migration the maps were not opening for me, that was fixed as well.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#6092 

**What is the current behavior?**
#6092 

**What is the new behavior?**
Description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
