### PR TITLE
#6026: Fix map plugin failing test

### DIFF
--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -209,7 +209,8 @@ class MapPlugin extends React.Component {
         isLocalizedLayerStylesEnabled: PropTypes.bool,
         localizedLayerStylesName: PropTypes.string,
         currentLocaleLanguage: PropTypes.string,
-        items: PropTypes.array
+        items: PropTypes.array,
+        onLoadingMapPlugins: PropTypes.array
     };
 
     static defaultProps = {
@@ -247,7 +248,8 @@ class MapPlugin extends React.Component {
         elevationEnabled: false,
         onFontError: () => {},
         onResolutionsChange: () => {},
-        items: []
+        items: [],
+        onLoadingMapPlugins: () => {}
     };
     state = {
         canRender: true
@@ -421,8 +423,10 @@ class MapPlugin extends React.Component {
         return !layer.useForElevation || this.props.mapType === 'cesium' || this.props.elevationEnabled;
     };
     updatePlugins = (props) => {
+        props.onLoadingMapPlugins(true);
         pluginsCreator(props.mapType, props.actions).then((plugins) => {
             this.setState({plugins});
+            props.onLoadingMapPlugins(false, props.mapType);
         });
     };
 }

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -210,7 +210,7 @@ class MapPlugin extends React.Component {
         localizedLayerStylesName: PropTypes.string,
         currentLocaleLanguage: PropTypes.string,
         items: PropTypes.array,
-        onLoadingMapPlugins: PropTypes.array
+        onLoadingMapPlugins: PropTypes.func
     };
 
     static defaultProps = {
@@ -446,4 +446,3 @@ export default createPlugin('Map', {
     },
     epics: mapEpics
 });
-

--- a/web/client/plugins/__tests__/Map-test.jsx
+++ b/web/client/plugins/__tests__/Map-test.jsx
@@ -47,16 +47,25 @@ describe('Map Plugin', () => {
         }, 200);
     });
 
-    it.skip('creates a Map plugin with specified mapType configuration (openlayers)', (done) => {
+    it('creates a Map plugin with specified mapType configuration (openlayers)', (done) => {
         const { Plugin } = getPluginForTest(MapPlugin, { map, maptype: {
             mapType: 'openlayers'
         } });
-        ReactDOM.render(<Plugin pluginCfg={{ shouldLoadFont: false }} />, document.getElementById("container"));
-        setTimeout(() => {
-            expect(document.getElementById('map')).toExist();
-            expect(document.getElementsByClassName('ol-viewport').length).toBe(1);
-            done();
-        }, 200);
+        ReactDOM.render(<Plugin
+            pluginCfg={{ shouldLoadFont: false }}
+            onLoadingMapPlugins={(loading, mapType) => {
+                if (!loading) {
+                    try {
+                        expect(mapType).toBe('openlayers');
+                        expect(document.getElementById('map')).toExist();
+                        expect(document.getElementsByClassName('ol-viewport').length).toBe(1);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                }
+            }}
+        />, document.getElementById("container"));
     });
 
     it('resetOnMapInit epic is activated by INIT_MAP action', () => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Thi PR fixes a test that was failing due to new improvement on asyncronuous request of map type. This commit adds a callback to Map plugin to listen on the loading of map type and ensure the loading phase is ended. (onLoadingMapPlugins)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] CI related changes

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6026

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
