### PR TITLE
#6146 Plugin injection for TOC toolbar

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -15,12 +15,13 @@ const ConfirmModal = require('../maps/modals/ConfirmModal');
 const LayerMetadataModal = require('./fragments/LayerMetadataModal');
 const Proj4js = require('proj4').default;
 const Message = require('../I18N/Message').default;
-const SwipeButton = require('./swipe/SwipeButton');
+
 
 class Toolbar extends React.Component {
 
     static propTypes = {
         groups: PropTypes.array,
+        items: PropTypes.array,
         selectedLayers: PropTypes.array,
         generalInfoFormat: PropTypes.string,
         selectedGroups: PropTypes.array,
@@ -38,6 +39,7 @@ class Toolbar extends React.Component {
 
     static defaultProps = {
         groups: [],
+        items: [],
         selectedLayers: [],
         selectedGroups: [],
         onToolsActions: {
@@ -59,9 +61,7 @@ class Toolbar extends React.Component {
             onGetMetadataRecord: () => {},
             onHideLayerMetadata: () => {},
             onShow: () => {},
-            onLayerInfo: () => {},
-            onSetActive: () => {},
-            onSetSwipeMode: () => {}
+            onLayerInfo: () => {}
         },
         maxDepth: 3,
         text: {
@@ -117,8 +117,7 @@ class Toolbar extends React.Component {
             includeDeleteButtonInSettings: false,
             activateMetedataTool: true,
             activateLayerFilterTool: true,
-            activateLayerInfoTool: true,
-            activateSwipeOnLayer: false
+            activateLayerInfoTool: true
         },
         options: {
             modalOptions: {},
@@ -326,12 +325,9 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                     : null}
-                {this.props.activateTool.activateSwipeOnLayer && (status === 'LAYER') &&
-                    <SwipeButton
-                        status={status}
-                        onToolsActions={this.props.onToolsActions}
-                        swipeSettings={this.props.swipeSettings} />
-                }
+                {this.props.items
+                    .filter(({ selector = () => true }) => selector({ ...this.props, status })) // filter items that should not show
+                    .map(({ Component }) => <Component {...this.props} status={status} />)}
                 <ConfirmModal
                     ref="removelayer"
                     options={{

--- a/web/client/plugins/Swipe.jsx
+++ b/web/client/plugins/Swipe.jsx
@@ -14,12 +14,19 @@ import { getSelectedLayer } from '../selectors/layers';
 import { layerSwipeSettingsSelector, swipeModeSettingsSelector, spyModeSettingsSelector } from '../selectors/swipe';
 import swipe from '../reducers/swipe';
 import * as epics from '../epics/swipe';
+import {
+    setActive,
+    setMode
+} from '../actions/swipe';
+
 
 import { createPlugin } from '../utils/PluginsUtils';
 
 import SwipeSettings from './SwipeSettings';
 import SliderSwipeSupport from '../components/map/openlayers/swipe/SliderSwipeSupport';
 import SpyGlassSupport from '../components/map/openlayers/swipe/SpyGlassSupport';
+import SwipeButton from './swipe/SwipeButton';
+
 
 export const Support = ({ mode, map, layer, active, swipeModeSettings, spyModeSettings }) => {
     if (mode === "spy") {
@@ -58,7 +65,16 @@ export default createPlugin(
         component: SwipeSettings,
         containers: {
             TOC: {
-                name: "Swipe"
+                name: "Swipe",
+                target: "toolbar",
+                selector: ({ status }) => status === 'LAYER',
+                Component: connect(
+                    createSelector(layerSwipeSettingsSelector, (swipeSettings) => ({swipeSettings})),
+                    {
+                        onSetActive: setActive,
+                        onSetSwipeMode: setMode
+                    }
+                )(SwipeButton)
             },
             Map: {
                 name: "Swipe",

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -210,7 +210,6 @@ class LayerTree extends React.Component {
         activateMetedataTool: PropTypes.bool,
         activateWidgetTool: PropTypes.bool,
         activateLayerInfoTool: PropTypes.bool,
-        activateSwipeOnLayer: PropTypes.bool,
         maxDepth: PropTypes.number,
         visibilityCheckType: PropTypes.string,
         settingsOptions: PropTypes.object,
@@ -292,7 +291,6 @@ class LayerTree extends React.Component {
         activateWidgetTool: false,
         activateLayerFilterTool: false,
         activateLayerInfoTool: true,
-        activateSwipeOnLayer: false,
         maxDepth: 3,
         visibilityCheckType: "glyph",
         settingsOptions: {
@@ -403,6 +401,7 @@ class LayerTree extends React.Component {
                     filterText={this.props.filterText}
                     toolbar={
                         <Toolbar
+                            items={this.props.items.filter(({ target }) => target === "toolbar")}
                             groups={this.props.groups}
                             selectedLayers={this.props.selectedLayers}
                             selectedGroups={this.props.selectedGroups}
@@ -427,8 +426,7 @@ class LayerTree extends React.Component {
                                 activateMetedataTool: this.props.activateMetedataTool,
                                 activateWidgetTool: this.props.activateWidgetTool,
                                 activateLayerFilterTool: this.props.activateLayerFilterTool,
-                                activateLayerInfoTool: this.props.updatableLayersCount > 0 && this.props.activateLayerInfoTool,
-                                activateSwipeOnLayer: this.props.activateSwipeOnLayer
+                                activateLayerInfoTool: this.props.updatableLayersCount > 0 && this.props.activateLayerInfoTool
                             }}
                             options={{
                                 modalOptions: {},
@@ -500,8 +498,7 @@ class LayerTree extends React.Component {
                                 onHideLayerMetadata: this.props.hideLayerMetadata,
                                 onShow: this.props.layerPropertiesChangeHandler,
                                 onLayerInfo: this.props.onLayerInfo,
-                                onSetActive: this.props.onSetActive,
-                                onSetSwipeMode: this.props.onSetSwipeMode
+                                onSetActive: this.props.onSetActive
                             }}/>
                     }/>
                 <div className={'mapstore-toc' + bodyClass}>
@@ -591,8 +588,7 @@ const checkPluginsEnhancer = branch(
             "activateLayerFilterTool",
             "activateSettingsTool",
             "FeatureEditor",
-            "activateLayerInfoTool",
-            "activateSwipeOnLayer"
+            "activateLayerInfoTool"
         ],
         ({
             items = [],
@@ -602,8 +598,7 @@ const checkPluginsEnhancer = branch(
             activateSettingsTool = true,
             activateLayerFilterTool = true,
             activateWidgetTool = true,
-            activateLayerInfoTool = true,
-            activateSwipeOnLayer = true
+            activateLayerInfoTool = true
         }) => ({
             activateAddLayerButton: activateAddLayerButton && !!find(items, { name: "MetadataExplorer" }) || false, // requires MetadataExplorer (Catalog)
             activateAddGroupButton: activateAddGroupButton && !!find(items, { name: "AddGroup" }) || false,
@@ -613,15 +608,50 @@ const checkPluginsEnhancer = branch(
             // NOTE: activateWidgetTool is already controlled by a selector. TODO: Simplify investigating on the best approach
             // the button should hide if also widgets plugins is not available. Maybe is a good idea to merge the two plugins
             activateWidgetTool: activateWidgetTool && !!find(items, { name: "WidgetBuilder" }) && !!find(items, { name: "Widgets" }),
-            activateLayerInfoTool: activateLayerInfoTool && !!find(items, { name: "LayerInfo" }) || false,
-            activateSwipeOnLayer: activateSwipeOnLayer && !!find(items, { name: "Swipe" }) || false
+            activateLayerInfoTool: activateLayerInfoTool && !!find(items, { name: "LayerInfo" }) || false
         })
     )
 );
 
 
 /**
- * Provides Table Of Content visualization.
+ * Provides Table Of Content visualization. Lists the layers on the map, organized in groups and provides the possibility to select them.
+ * Based on current layer(s)/group(s) selection, shows a set of tools for the current selection.
+ * This is also a plugin container. Tools injected providing only the name to the container need an internal support (deprecated). Here an example:
+ * ```javascript
+ * export default createPlugin('AddGroup', {
+ *     component: AddGroupPlugin,
+ *     containers: {
+ *         TOC: {
+ *             doNotHide: true,
+ *             name: "AddGroup" // this works only if AddGroup is one of the plugins internally supported by TOC.
+ *         }
+ *     }
+ * });
+ * ```
+ * The new **(recommended)** mode to inject tools in the TOC is by using `target`.
+ * This method allows to insert a component in the defined target. Actually `toolbar` is the only target supported for the `target`, and allows to add a button on the toolbar.
+ * ```javascript
+ * createPlugin(
+ *  'MyPlugin',
+ *  {
+ *      containers: {
+ *         TOC: {
+ *             name: "TOOLNAME", // a name for the current tool.
+ *             target: "toolbar", // the target where to insert the component
+ *             //In case of `target: toolbar`, `selector` determine to show or not show the tool (returning `true` or `false`).
+ *             // As argument of this function you have several information, that will be passed also to the component.
+ *             // - `status`: that can be `LAYER`, `LAYERS`, `GROUP` or `GROUPS`, depending if only one or more than one layer is selected.
+ *             // - `selectedGroups`: current list of selected groups
+ *             // - `selectedLayers`: current list of selected layers
+ *             selector: ({ status }) => status === 'LAYER',
+ *             // The component to render. It receives as props the same object passed to the `selector` function.
+ *             Component: connect(...)(MyButton)
+ *                 createSelector(layerSwipeSettingsSelector, (swipeSettings) => ({swipeSettings})),
+ *             // ...
+ *         },
+ * // ...
+ * ```
  * @memberof plugins
  * @name TOC
  * @class
@@ -854,8 +884,7 @@ const TOCPlugin = connect(tocSelector, {
     onNewWidget: () => createWidget(),
     refreshLayerVersion,
     onLayerInfo: setControlProperty.bind(null, 'layerinfo', 'enabled', true, false),
-    onSetActive: setActive,
-    onSetSwipeMode: setMode
+    onSetActive: setActive
 })(compose(
     securityEnhancer,
     checkPluginsEnhancer

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -17,7 +17,6 @@ const {changeLayerProperties, changeGroupProperties, toggleNode, contextNode,
     moveNode, showSettings, hideSettings, updateSettings, updateNode, removeNode,
     browseData, selectNode, filterLayers, refreshLayerVersion, hideLayerMetadata,
     download} = require('../actions/layers');
-const { setActive, setMode } = require('../actions/swipe');
 const {openQueryBuilder} = require("../actions/layerFilter");
 const {getLayerCapabilities} = require('../actions/layerCapabilities');
 const {zoomToExtent} = require('../actions/map');
@@ -248,7 +247,6 @@ class LayerTree extends React.Component {
         onLayerInfo: PropTypes.func,
         onSetSwipeActive: PropTypes.func,
         updatableLayersCount: PropTypes.number,
-        onSetActive: PropTypes.func,
         onSetSwipeMode: PropTypes.func
     };
 
@@ -332,7 +330,6 @@ class LayerTree extends React.Component {
         refreshLayerVersion: () => {},
         metadataTemplate: null,
         onLayerInfo: () => {},
-        onSetActive: () => {},
         onSetSwipeMode: () => {}
     };
 
@@ -497,8 +494,7 @@ class LayerTree extends React.Component {
                                 onGetMetadataRecord: this.props.onGetMetadataRecord,
                                 onHideLayerMetadata: this.props.hideLayerMetadata,
                                 onShow: this.props.layerPropertiesChangeHandler,
-                                onLayerInfo: this.props.onLayerInfo,
-                                onSetActive: this.props.onSetActive
+                                onLayerInfo: this.props.onLayerInfo
                             }}/>
                     }/>
                 <div className={'mapstore-toc' + bodyClass}>
@@ -883,8 +879,7 @@ const TOCPlugin = connect(tocSelector, {
     hideLayerMetadata,
     onNewWidget: () => createWidget(),
     refreshLayerVersion,
-    onLayerInfo: setControlProperty.bind(null, 'layerinfo', 'enabled', true, false),
-    onSetActive: setActive
+    onLayerInfo: setControlProperty.bind(null, 'layerinfo', 'enabled', true, false)
 })(compose(
     securityEnhancer,
     checkPluginsEnhancer

--- a/web/client/plugins/__tests__/TOC-test.jsx
+++ b/web/client/plugins/__tests__/TOC-test.jsx
@@ -322,6 +322,77 @@ describe('TOCPlugin Plugin', () => {
                 }
             }
         };
+        describe('target: toolbar', () => {
+            it('render custom plugin', () => {
+                const { Plugin } = getPluginForTest(TOCPlugin, {
+                    layers: {
+                        groups: [{ id: 'default', title: 'Default', nodes: [] }],
+                        flat: []
+                    },
+                    maptype: {
+                        mapType: 'openlayers'
+                    }
+                });
+                const WrappedPlugin = dndContext(Plugin);
+                ReactDOM.render(<WrappedPlugin items={[{
+                    name: "Custom",
+                    target: "toolbar",
+                    Component: () => <button id="toolbarCustomButton"></button>
+                }]} />, document.getElementById("container"));
+                expect(document.querySelectorAll(TOOL_BUTTON_SELECTOR).length).toBe(1);
+                expect(document.querySelector(`${TOOL_BUTTON_SELECTOR}#toolbarCustomButton`)).toExist();
+            });
+            it('selector do not show the button when return false', () => {
+                const { Plugin } = getPluginForTest(TOCPlugin, {
+                    layers: {
+                        groups: [{ id: 'default', title: 'Default', nodes: [] }],
+                        flat: []
+                    },
+                    maptype: {
+                        mapType: 'openlayers'
+                    }
+                });
+                const WrappedPlugin = dndContext(Plugin);
+                ReactDOM.render(<WrappedPlugin items={[{
+                    name: "Custom",
+                    target: "toolbar",
+                    selector: () => {
+                        return false;
+                    },
+                    Component: () => <button id="toolbarCustomButton"></button>
+                }]} />, document.getElementById("container"));
+                expect(document.querySelector(`${TOOL_BUTTON_SELECTOR}#toolbarCustomButton`)).toNotExist();
+            });
+            it('selector reads status, selectedGroups, selectedLayers', () => {
+                const { Plugin } = getPluginForTest(TOCPlugin, SELECTED_LAYER_STATE);
+                const WrappedPlugin = dndContext(Plugin);
+                ReactDOM.render(<WrappedPlugin items={[{
+                    name: "Custom",
+                    target: "toolbar",
+                    selector: ({ status, selectedGroups, selectedLayers}) => {
+                        return status === "LAYER" && selectedGroups.length === 0 && selectedLayers[0].id === "topp:states__6";
+                    },
+                    Component: () => <button id="toolbarCustomButton"></button>
+                }]} />, document.getElementById("container"));
+                expect(document.querySelectorAll(TOOL_BUTTON_SELECTOR).length).toBeGreaterThan(0); // other buttons are shown.
+                expect(document.querySelector(`${TOOL_BUTTON_SELECTOR}#toolbarCustomButton`)).toExist();
+            });
+            it('Component receives the property \`status\`', () => {
+                const { Plugin } = getPluginForTest(TOCPlugin, SELECTED_LAYER_STATE);
+                const WrappedPlugin = dndContext(Plugin);
+                ReactDOM.render(<WrappedPlugin items={[{
+                    name: "Custom",
+                    target: "toolbar",
+                    Component: ({ status, selectedGroups, selectedLayers}) => {
+                        expect(status === "LAYER" && selectedGroups.length === 0 && selectedLayers[0].id === "topp:states__6").toBeTruthy();
+                        return <button id={`toolbarCustomButton-${status}`}></button>;
+                    }
+                }]} />, document.getElementById("container"));
+                expect(document.querySelectorAll(TOOL_BUTTON_SELECTOR).length).toBeGreaterThan(0); // other buttons are shown.
+                expect(document.querySelector(`${TOOL_BUTTON_SELECTOR}#toolbarCustomButton-LAYER`)).toExist();
+            });
+        });
+
         it('AddLayer and AddGroup do not show without proper plugins', () => {
             const { Plugin } = getPluginForTest(TOCPlugin, {
                 layers: {

--- a/web/client/plugins/swipe/SwipeButton.jsx
+++ b/web/client/plugins/swipe/SwipeButton.jsx
@@ -11,8 +11,8 @@ const PropTypes = require('prop-types');
 const {Glyphicon, SplitButton, MenuItem} = require('react-bootstrap');
 
 
-const Message = require('../../I18N/Message').default;
-const tooltip = require('../../misc/enhancers/tooltip');
+const Message = require('../../components/I18N/Message').default;
+const tooltip = require('../../components/misc/enhancers/tooltip');
 
 const SplitButtonT = tooltip(SplitButton);
 const splitToolButtonConfig = {
@@ -24,21 +24,21 @@ const splitToolButtonConfig = {
 };
 
 const SwipeButton = (props) => {
-    const {swipeSettings, onToolsActions, status} = props;
+    const { swipeSettings, onSetActive, onSetSwipeMode, status} = props;
 
     const showConfiguration = () => {
         if (!swipeSettings.configuring && (status === 'LAYER')) {
-            onToolsActions.onSetActive(true, "configuring");
+            onSetActive(true, "configuring");
         } else {
-            onToolsActions.onSetActive(false, "configuring");
+            onSetActive(false, "configuring");
         }
     };
 
     const showSwipeTools = () => {
         if (!swipeSettings.active && (status === 'LAYER')) {
-            onToolsActions.onSetActive(true);
+            onSetActive(true);
         } else {
-            onToolsActions.onSetActive(false);
+            onSetActive(false);
         }
     };
 
@@ -50,16 +50,16 @@ const SwipeButton = (props) => {
             <MenuItem
                 active={swipeSettings?.mode === "swipe"}
                 onClick={() => {
-                    onToolsActions.onSetSwipeMode("swipe");
-                    onToolsActions.onSetActive(true);
+                    onSetSwipeMode("swipe");
+                    onSetActive(true);
                 }}>
                 <Glyphicon glyph="vert-dashed"/><Message msgId="toc.swipe" />
             </MenuItem>
             <MenuItem
                 active={swipeSettings?.mode === "spy"}
                 onClick={() => {
-                    onToolsActions.onSetSwipeMode("spy");
-                    onToolsActions.onSetActive(true);
+                    onSetSwipeMode("spy");
+                    onSetActive(true);
                 }}>
                 <Glyphicon glyph="search" /><Message msgId="toc.spyGlass" />
             </MenuItem>
@@ -74,14 +74,14 @@ const SwipeButton = (props) => {
 SwipeButton.propTypes = {
     swipeSettings: PropTypes.object,
     status: PropTypes.string,
-    onToolsActions: PropTypes.object
+    onSetActive: PropTypes.func,
+    onSetSwipeMode: PropTypes.func
 };
 
 SwipeButton.defaultProps = {
     status: "LAYER",
-    onToolsActions: {
-        onToolsActions: () => {}
-    }
+    onSetSwipeMode: () => { },
+    onSetActive: () => { }
 };
 
 module.exports =  SwipeButton;

--- a/web/client/plugins/swipe/__tests__/SwipeButton-test.jsx
+++ b/web/client/plugins/swipe/__tests__/SwipeButton-test.jsx
@@ -13,7 +13,7 @@ const TestUtils = require('react-dom/test-utils');
 
 const SwipeButton = require('../SwipeButton');
 
-const onToolsActions = {
+const actions = {
     onSetActive: () => {},
     onSetSwipeMode: () => {}
 };
@@ -37,7 +37,8 @@ describe('SwipeButton', () => {
         };
 
         ReactDOM.render(<SwipeButton
-            onToolsActions={onToolsActions}
+            onSetActive={actions.onSetActive}
+            onSetSwipeMode={actions.onSetSwipeMode}
             swipeSettings={settings} />, document.getElementById("container"));
 
         const el = document.getElementById('container');
@@ -47,15 +48,16 @@ describe('SwipeButton', () => {
     });
 
     it('should set tool or configuring state active', () => {
-        const spySetActive = expect.spyOn(onToolsActions, 'onSetActive');
-        const spySetSwipeMode = expect.spyOn(onToolsActions, 'onSetSwipeMode');
+        const spySetActive = expect.spyOn(actions, 'onSetActive');
+        const spySetSwipeMode = expect.spyOn(actions, 'onSetSwipeMode');
         const settings = {
             active: true,
             mode: "swipe"
         };
 
         ReactDOM.render(<SwipeButton
-            onToolsActions={onToolsActions}
+            onSetActive={actions.onSetActive}
+            onSetSwipeMode={actions.onSetSwipeMode}
             swipeSettings={settings} />, document.getElementById("container"));
 
         const el = document.getElementById('container');


### PR DESCRIPTION
## Description
This PR allow to inject plugins in TOC Toolbar, as buttons at the end of the list. Swipe plugin has been converted to use it as a first example. 
This is a first step to make the TOC pluggable and remove all wirings between other plugins and TOC.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6146

**What is the new behavior?**
No functional changes. Swipe should work as usual. The changes regards the architecture of connection between TOC and Swipe plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
