### PR TITLE
#6095 Enabled extensions by default

### DIFF
--- a/web/client/components/app/main.jsx
+++ b/web/client/components/app/main.jsx
@@ -12,7 +12,6 @@ import ReactDOM from 'react-dom';
 import LocaleUtils from '../../utils/LocaleUtils';
 import StandardStore from '../../stores/StandardStore';
 import StandardApp from './StandardApp';
-
 /**
  * main entry point of application.
  * This function provide basic functionality to initialize an application in the MapStore framework.

--- a/web/client/components/app/main.jsx
+++ b/web/client/components/app/main.jsx
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 import LocaleUtils from '../../utils/LocaleUtils';
 import StandardStore from '../../stores/StandardStore';
 import StandardApp from './StandardApp';
+
 /**
  * main entry point of application.
  * This function provide basic functionality to initialize an application in the MapStore framework.

--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -17,6 +17,13 @@ import PluginsUtils from '../../utils/PluginsUtils';
 import { augmentStore } from '../../utils/StateUtils';
 import { LOAD_EXTENSIONS, PLUGIN_UNINSTALLED } from '../../actions/contextcreator';
 
+/**
+ * This HOC adds to StandardApp (or whatever customization) the
+ * possibility to dynamically load extensions. For more info see
+ * MapStore developer documentation about extensions.
+ * @param {Component} AppComponent the App component
+ * @returns the App component that loads the extensions. The new component accepts the additional prop `enableExtensions` that can be set to `false` if need to disable this loading.
+ */
 function withExtensions(AppComponent) {
 
     class WithExtensions extends Component {
@@ -29,7 +36,7 @@ function withExtensions(AppComponent) {
 
         static defaultProps = {
             pluginsDef: { plugins: {}, requires: {} },
-            enableExtensions: false
+            enableExtensions: true
         };
 
         state = {


### PR DESCRIPTION
## Description
Originally the extension enable was explitly enabled by this flag, by default false. 
https://github.com/geosolutions-it/MapStore2/blob/4d46bd687fa6323898211fac924e8b0f79c59480/web/client/product/main.jsx#L94

During a refactor this behavior has been externalized in a separated HOC that wraps the app to add extensions loading. The flag has been moved inside the enhancer. so it should be set to true.
Now we have a standard main and a product main, and the possibility to add or remove this HOC by code, so to have a good standard, if we add he HOC we man we want the feature, and it can be disabled under certain conditions from the flag.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6095

**What is the new behavior?**
Extensions will work on standard product

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
