### PR TITLE
use minimal bundle for the required functionalities

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "ogc-schemas": "2.6.1",
     "ol": "5.3.0",
     "pdfviewer": "0.3.2",
-    "plotly.js": "1.57.1",
+    "plotly.js-cartesian-dist": "1.57.1",
     "prop-types": "15.7.2",
     "qrcode.react": "0.9.3",
     "query-string": "6.9.0",

--- a/web/client/components/charts/PlotlyChart.jsx
+++ b/web/client/components/charts/PlotlyChart.jsx
@@ -1,0 +1,4 @@
+// customizable method: use your own `Plotly` object
+import createPlotlyComponent from 'react-plotly.js/factory';
+import Plotly from 'plotly.js-cartesian-dist';
+export const Plot = createPlotlyComponent(Plotly);

--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Plot from 'react-plotly.js';
+import { Plot } from './PlotlyChart';
 import { sameToneRangeColors } from '../../utils/ColorUtils';
+
 export const COLOR_DEFAULTS = {
     base: 190,
     range: 0,


### PR DESCRIPTION
## Description
This PR should fix issue of out of memory for JS compression, using a smaller bundle for PlotlyJS

future improvement can load it dynamically (it is still 1MB not Gzipped)