### PR TITLE
#6080: Save (one or multiple) edits in same context

### DIFF
--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -55,7 +55,7 @@ const featuresToGrid = compose(
         newFeatures: [],
         select: [],
         changes: {},
-        focusOnEdit: true,
+        focusOnEdit: false,
         editors,
         dataStreamFactory,
         virtualScroll: true

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -228,7 +228,7 @@ const selector = createSelector(
     changesSelector,
     newFeaturesSelector,
     hasChangesSelector,
-    state => get(state, 'featuregrid.focusOnEdit') || [],
+    state => get(state, 'featuregrid.focusOnEdit', false),
     state => get(state, 'featuregrid.enableColumnFilters'),
     createStructuredSelector(paginationInfo),
     state => get(state, 'featuregrid.pages'),

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -62,7 +62,7 @@ const emptyResultsState = {
     showTimeSync: false,
     open: false,
     canEdit: false,
-    focusOnEdit: true,
+    focusOnEdit: false,
     showAgain: false,
     showPopoverSync: localStorage && localStorage.getItem("showPopoverSync") !== null ? localStorage.getItem("showPopoverSync") === "true" : true,
     mode: MODES.VIEW,
@@ -125,7 +125,7 @@ const applyNewChanges = (features, changedFeatures, updates, updatesGeom) =>
  *     enableColumnFilters: true,
  *     open: false,
  *     canEdit: false,
- *     focusOnEdit: true,
+ *     focusOnEdit: false,
  *     mode: MODES.VIEW,
  *     changes: [],
  *     pagination: {


### PR DESCRIPTION
## Description
Stop toggling off of other rows when data from one row is being edited. This allows for queuing of multiple edits so that they're saved at once.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6080 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Stop toggling off of other rows when data from one row is being edited. This allows for queuing of multiple edits so that they're saved at once.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
