### PR TITLE
#6168: Filter feature selection in feature grid is disabled when advanced search is closed

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -1048,12 +1048,17 @@ describe('featuregrid Epics', () => {
     });
 
     it('test askChangesConfirmOnFeatureGridClose', (done) => {
-        testEpic(askChangesConfirmOnFeatureGridClose, 2, closeFeatureGridConfirm(), actions => {
-            expect(actions.length).toBe(2);
+        testEpic(askChangesConfirmOnFeatureGridClose, 3, closeFeatureGridConfirm(), actions => {
+            expect(actions.length).toBe(3);
             actions.map((action) => {
                 switch (action.type) {
                 case CLOSE_FEATURE_GRID:
                     expect(action.type).toBe(CLOSE_FEATURE_GRID);
+                    break;
+                case UPDATE_FILTER:
+                    expect(action.type).toBe(UPDATE_FILTER);
+                    expect(action.update).toExist();
+                    expect(action.update.enabled).toBe(false);
                     break;
                 case SELECT_FEATURES:
                     expect(action.type).toBe(SELECT_FEATURES);

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -445,7 +445,8 @@ export const handleClickOnMap = (action$, store) =>
             })
                 .takeUntil(Rx.Observable.merge(
                     action$.ofType(UPDATE_FILTER).filter(({update = {}}) => update.type === 'geometry' && !update.enabled),
-                    action$.ofType(CLOSE_FEATURE_GRID, LOCATION_CHANGE)
+                    // action$.switchMap(() => Rx.Observable.zip([action$.ofType(CLOSE_FEATURE_GRID_CONFIRM), action$.ofType(CLOSE_FEATURE_GRID)])),
+                    action$.ofType(LOCATION_CHANGE)
                 )));
 export const handleBoxSelectionDrawEnd =  (action$, store) =>
     action$.ofType(UPDATE_FILTER)
@@ -844,7 +845,11 @@ export const askChangesConfirmOnFeatureGridClose = (action$, store) => action$.o
     if (hasChangesSelector(state) || hasNewFeaturesSelector(state)) {
         return Rx.Observable.of(toggleTool("featureCloseConfirm", true));
     }
-    return Rx.Observable.of(closeFeatureGrid(), selectFeatures([]));
+    return Rx.Observable.of(closeFeatureGrid(), updateFilter({
+        attribute: "the_geom",
+        enabled: false,
+        type: "geometry"
+    }), selectFeatures([]));
 });
 export const onClearChangeConfirmedFeatureGrid = (action$) => action$.ofType(CLEAR_CHANGES_CONFIRMED)
     .switchMap( () => Rx.Observable.of(clearChanges(), toggleTool("clearConfirm", false)));

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -445,7 +445,6 @@ export const handleClickOnMap = (action$, store) =>
             })
                 .takeUntil(Rx.Observable.merge(
                     action$.ofType(UPDATE_FILTER).filter(({update = {}}) => update.type === 'geometry' && !update.enabled),
-                    // action$.switchMap(() => Rx.Observable.zip([action$.ofType(CLOSE_FEATURE_GRID_CONFIRM), action$.ofType(CLOSE_FEATURE_GRID)])),
                     action$.ofType(LOCATION_CHANGE)
                 )));
 export const handleBoxSelectionDrawEnd =  (action$, store) =>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the issue where when the Advanced Search is opened > then feature editor gets automatically closed > then Advanced Search closed, the map can nolonger handle clicks that were added by the `handleClickOnMap` epic

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6168 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The map still handles clicks that update filter even when Advanced Search is opened and closed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
