### PR TITLE
#6136. WFS Chart - No aggregate

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -295,7 +295,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                     : null}
-                {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && this.props.selectedLayers[0].type !== 'vector' && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
+                {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && this.props.selectedLayers[0].search !== 'vector' && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.wfsdownload.expanded ?
                     <OverlayTrigger
                         key="widgets"
                         placement="top"

--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -72,6 +72,7 @@ function getLayoutOptions({ series = [], cartesian, type, yAxis, xAxisAngle, xAx
                 showgrid: cartesian
             },
             xaxis: {
+                showgrid: cartesian,
                 type: xAxisOpts?.type,
                 showticklabels: !xAxisOpts?.hide,
                 // dtick used to force show all x axis labels.

--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -119,7 +119,7 @@ export const toPlotly = (props) => {
         data: series.map(({ dataKey: yDataKey }) => {
             return {
                 type,
-                name: yAxisLabel ?? yDataKey,
+                name: yAxisLabel || yDataKey,
                 ...getData({ ...props, xDataKey, yDataKey})
             };
         }),

--- a/web/client/components/widgets/builder/wizard/ChartWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/ChartWizard.jsx
@@ -15,7 +15,8 @@ import wfsChartOptions from './common/wfsChartOptions';
 import WPSWidgetOptions from './common/WPSWidgetOptions';
 import WidgetOptions from './common/WidgetOptions';
 import sampleData from '../../enhancers/sampleChartData';
-import wpsChart from '../../enhancers/wpsChart';
+import multiProtocolChart from '../../enhancers/multiProtocolChart';
+
 import dependenciesToWidget from '../../enhancers/dependenciesToWidget';
 import dependenciesToFilter from '../../enhancers/dependenciesToFilter';
 import dependenciesToOptions from '../../enhancers/dependenciesToOptions';
@@ -35,7 +36,7 @@ const enhancePreview = compose(
     dependenciesToWidget,
     dependenciesToFilter,
     dependenciesToOptions,
-    wpsChart,
+    multiProtocolChart,
     loadingState,
     errorChartState,
     emptyChartState

--- a/web/client/components/widgets/builder/wizard/CounterWizard.jsx
+++ b/web/client/components/widgets/builder/wizard/CounterWizard.jsx
@@ -5,31 +5,45 @@
   * This source code is licensed under the BSD-style license found in the
   * LICENSE file in the root directory of this source tree.
   */
-const React = require('react');
-const {isNil} = require('lodash');
-const { compose, lifecycle } = require('recompose');
+import React from 'react';
+import { isNil } from 'lodash';
+import { compose, lifecycle } from 'recompose';
 
-const {wizardHandlers} = require('../../../misc/wizard/enhancers');
-const loadingState = require('../../../misc/enhancers/loadingState')(({loading, data}) => loading || !data, {width: 500, height: 200});
-const wfsChartOptions = require('./common/wfsChartOptions');
-const noAttributes = require('./common/noAttributesEmptyView');
-const WPSChartOptions = require('./common/WPSWidgetOptions').default;
-const CounterOptions = wfsChartOptions(noAttributes(({ options = [] }) => options.length === 0)(WPSChartOptions));
-const WidgetOptions = require('./common/WidgetOptions');
+import { wizardHandlers } from '../../../misc/wizard/enhancers';
+import loadingEnhancer from '../../../misc/enhancers/loadingState';
+import wfsChartOptions from './common/wfsChartOptions';
+import noAttributes from './common/noAttributesEmptyView';
+import WPSChartOptions from './common/WPSWidgetOptions';
 
-const wpsCounter = require('../../enhancers/wpsCounter');
-const dependenciesToFilter = require('../../enhancers/dependenciesToFilter');
-const dependenciesToOptions = require('../../enhancers/dependenciesToOptions');
-const dependenciesToWidget = require('../../enhancers/dependenciesToWidget');
-const emptyChartState = require('../../enhancers/emptyChartState');
-const errorChartState = require('../../enhancers/errorChartState');
+import WidgetOptions from './common/WidgetOptions';
 
-const isCounterOptionsValid = (options = {}) => options.aggregateFunction && options.aggregationAttribute;
+import wpsCounter from '../../enhancers/wpsCounter';
+import dependenciesToFilter from '../../enhancers/dependenciesToFilter';
+import dependenciesToOptions from '../../enhancers/dependenciesToOptions';
+import dependenciesToWidget from '../../enhancers/dependenciesToWidget';
+import emptyChartState from '../../enhancers/emptyChartState';
+import errorChartState from '../../enhancers/errorChartState';
+import WizardContainer from '../../../misc/wizard/WizardContainer';
+import Counter from '../../widget/CounterView';
+
+const CounterOptions = compose(
+    // reset all groupByAttributes (e.g. if change widget type, the value can remain)
+    lifecycle({
+        componentDidMount() {
+            this.props.onChange && this.props.onChange("options.groupByAttributes", undefined);
+        }
+    }),
+    wfsChartOptions,
+    noAttributes(({ options = [] }) => options.length === 0)
+)(WPSChartOptions);
+const loadingState = loadingEnhancer(({ loading, data }) => loading || !data, { width: 500, height: 200 });
+
+export const isCounterOptionsValid = (options = {}, { hasAggregateProcess }) => options.aggregateFunction && options.aggregationAttribute && hasAggregateProcess;
 const triggerSetValid = compose(
     lifecycle({
-        UNSAFE_componentWillReceiveProps: ({ valid, data = [], options = {}, setValid = () => { }, error } = {}) => {
+        UNSAFE_componentWillReceiveProps: ({ valid, data = [], options = {}, setValid = () => { }, error, hasAggregateProcess } = {}) => {
             const isNowValid = !isNil(data[0]) && !error;
-            if (!!valid !== !!isNowValid && isCounterOptionsValid(options)) {
+            if (!!valid !== !!isNowValid && isCounterOptionsValid(options, { hasAggregateProcess })) {
                 setValid(isNowValid);
             }
         }
@@ -53,19 +67,19 @@ const sampleProps = {
     }
 };
 
-const Wizard = wizardHandlers(require('../../../misc/wizard/WizardContainer'));
+const Wizard = wizardHandlers(WizardContainer);
 
 
-const Counter = require('../../widget/CounterView');
 const Preview = enhancePreview(Counter);
-const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid = () => { } }) =>
-    !isCounterOptionsValid(data.options)
+const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid = () => { }, hasAggregateProcess }) =>
+    !isCounterOptionsValid(data.options, { hasAggregateProcess })
         ? <Counter
             {...sampleProps}
-            data={[{data: 42}]}
+            data={[{ data: 42 }]}
             options={data.options}
-            series={[{dataKey: "data"}]} />
+            series={[{ dataKey: "data" }]} />
         : <Preview
+            hasAggregateProcess={hasAggregateProcess}
             {...sampleProps}
             valid={valid}
             dependenciesMap={data.dependenciesMap}
@@ -80,19 +94,21 @@ const CounterPreview = ({ data = {}, layer, dependencies = {}, valid, setValid =
             options={data.options} />;
 
 const enhanceWizard = compose(lifecycle({
-    UNSAFE_componentWillReceiveProps: ({data = {}, valid, setValid = () => {}} = {}) => {
-        if (valid && !isCounterOptionsValid(data.options)) {
+    UNSAFE_componentWillReceiveProps: ({ data = {}, valid, setValid = () => { }, hasAggregateProcess } = {}) => {
+        if (valid && !isCounterOptionsValid(data.options, { hasAggregateProcess })) {
             setValid(false);
         }
-    }})
+    }
+})
 );
-module.exports = enhanceWizard(({ onChange = () => { }, onFinish = () => { }, setPage = () => { }, setValid = () => { }, valid, formOptions, data = {}, layer = {}, step = 0, types, featureTypeProperties, dependencies}) =>
+export default enhanceWizard(({ onChange = () => { }, onFinish = () => { }, setPage = () => { }, setValid = () => { }, valid, formOptions, data = {}, layer = {}, step = 0, types, featureTypeProperties, dependencies, hasAggregateProcess }) =>
     (<Wizard
         step={step}
         setPage={setPage}
         onFinish={onFinish}
-        isStepValid={n => n === 1 ? isCounterOptionsValid(data.options) : true} hideButtons>
+        isStepValid={n => n === 1 ? isCounterOptionsValid(data.options, { hasAggregateProcess }) : true} hideButtons>
         <CounterOptions
+            hasAggregateProcess={hasAggregateProcess}
             dependencies={dependencies}
             key="chart-options"
             formOptions={formOptions}
@@ -102,11 +118,12 @@ module.exports = enhanceWizard(({ onChange = () => { }, onFinish = () => { }, se
             onChange={onChange}
             layer={data.layer || layer}
             sampleChart={<CounterPreview
+                hasAggregateProcess={hasAggregateProcess}
                 data={data}
                 valid={valid}
                 layer={data.layer || layer}
                 dependencies={dependencies}
-                setValid={v => setValid(v && isCounterOptionsValid(data.options))} />}
+                setValid={v => setValid(v && isCounterOptionsValid(data.options, { hasAggregateProcess }))} />}
         />
         <WidgetOptions
             key="widget-options"
@@ -114,10 +131,11 @@ module.exports = enhanceWizard(({ onChange = () => { }, onFinish = () => { }, se
             onChange={onChange}
             layer={data.layer || layer}
             sampleChart={<CounterPreview
+                hasAggregateProcess={hasAggregateProcess}
                 data={data}
                 valid={valid}
                 layer={data.layer || layer}
                 dependencies={dependencies}
-                setValid={v => setValid(v && isCounterOptionsValid(data.options))} />}
+                setValid={v => setValid(v && isCounterOptionsValid(data.options, { hasAggregateProcess }))} />}
         />
     </Wizard>));

--- a/web/client/components/widgets/builder/wizard/__tests__/ChartWizard-test.jsx
+++ b/web/client/components/widgets/builder/wizard/__tests__/ChartWizard-test.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import expect from 'expect';
-import ChartWizard from '../ChartWizard';
+import ChartWizard, { isChartOptionsValid } from '../ChartWizard';
 describe('ChartWizard component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -33,5 +33,24 @@ describe('ChartWizard component', () => {
         const container = document.getElementById('container');
         const el = container.querySelector('.chart-options-form');
         expect(el).toExist();
+    });
+    describe('isChartOptionsValid', () => {
+        it('mandatory operation if process present', () => {
+            expect(isChartOptionsValid({
+                aggregationAttribute: "A",
+                groupByAttributes: "B"
+            }, { hasAggregateProcess: true })).toBeFalsy();
+            expect(isChartOptionsValid({
+                aggregationAttribute: "A",
+                groupByAttributes: "B",
+                aggregateFunction: "SUM"
+            }, { hasAggregateProcess: true })).toBeTruthy();
+        });
+        it('operation not needed if WPS not present', () => {
+            expect(isChartOptionsValid({
+                aggregationAttribute: "A",
+                groupByAttributes: "B"
+            }, { hasAggregateProcess: false })).toBeTruthy();
+        });
     });
 });

--- a/web/client/components/widgets/builder/wizard/__tests__/CounterWizard-test.jsx
+++ b/web/client/components/widgets/builder/wizard/__tests__/CounterWizard-test.jsx
@@ -6,13 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const {get} = require('lodash');
-const expect = require('expect');
-const CounterWizard = require('../CounterWizard');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {get} from 'lodash';
+import expect from 'expect';
+import CounterWizard, { isCounterOptionsValid } from '../CounterWizard';
 
-const describeStates = require('../../../../../test-resources/wfs/describe-states.json');
+import describeStates from '../../../../../test-resources/wfs/describe-states.json';
 describe('CounterWizard component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -44,5 +44,25 @@ describe('CounterWizard component', () => {
         const container = document.getElementById('container');
         const el = container.querySelector('.chart-options-form');
         expect(el).toNotExist();
+    });
+    describe('isChartOptionsValid', () => {
+        it('mandatory operation and attribute if process present', () => {
+            expect(isCounterOptionsValid({
+                aggregationAttribute: "A"
+            }, { hasAggregateProcess: true })).toBeFalsy();
+            expect(isCounterOptionsValid({
+                aggregateFunction: "SUM"
+            }, { hasAggregateProcess: true })).toBeFalsy();
+            expect(isCounterOptionsValid({
+                aggregationAttribute: "A",
+                aggregateFunction: "SUM"
+            }, { hasAggregateProcess: true })).toBeTruthy();
+        });
+        it('invalid if aggregate process missing', () => {
+            expect(isCounterOptionsValid({
+                aggregationAttribute: "A",
+                aggregateFunction: "SUM"
+            }, { hasAggregateProcess: false })).toBeFalsy();
+        });
     });
 });

--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -53,6 +53,7 @@ const getLabelMessageId = (field, data = {}) => `widgets.${field}.${data.type ||
 const placeHolder = <Message msgId={getLabelMessageId("placeHolder")} />;
 
 export default ({
+    hasAggregateProcess,
     data = { options: {} },
     onChange = () => { },
     options = [],
@@ -106,7 +107,7 @@ export default ({
                         />
                     </Col>
                 </FormGroup>
-                <FormGroup controlId="aggregateFunction" className="mapstore-block-width">
+                {hasAggregateProcess ? <FormGroup controlId="aggregateFunction" className="mapstore-block-width">
                     <Col componentClass={ControlLabel} sm={6}>
                         <Message msgId={getLabelMessageId("aggregateFunction", data)} />
                     </Col>
@@ -118,7 +119,7 @@ export default ({
                             onChange={(val) => { onChange("options.aggregateFunction", val && val.value); }}
                         />
                     </Col>
-                </FormGroup>
+                </FormGroup> : null}
                 {formOptions.showUom ?
                     <FormGroup controlId="uom">
                         <Col componentClass={ControlLabel} sm={6}>
@@ -153,7 +154,7 @@ export default ({
                             />
                         </Col>
                     </FormGroup> : null}
-                {formOptions.advancedOptions && data.type === "bar" || data.type === "line"
+                {formOptions.advancedOptions && data.widgetType === "chart" && (data.type === "bar" || data.type === "line")
                     ? <ChartAdvancedOptions data={data} onChange={onChange} />
                     : null}
 

--- a/web/client/components/widgets/builder/wizard/common/__tests__/WPSWidgetOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/WPSWidgetOptions-test.jsx
@@ -31,26 +31,27 @@ describe('WPSWidgetOptions component', () => {
         const el = container.querySelector('.chart-options-form');
         expect(el).toExist();
     });
-    it('Test WPSWidgetOptions onChange for chart context', () => {
+    it('Test WPSWidgetOptions onChange for chart context, WPS gs:Aggregate available', () => {
         const actions = {
-            onChange: () => {}
+            onChange: () => { }
         };
         const spyonChange = expect.spyOn(actions, 'onChange');
-        ReactDOM.render(<WPSWidgetOptions featureTypeProperties={get(describeStates, "featureTypes[0].properties") } data={{type: 'bar'}} onChange={actions.onChange} dependencies={{viewport: {}}}/>, document.getElementById("container"));
+        ReactDOM.render(<WPSWidgetOptions hasAggregateProcess featureTypeProperties={get(describeStates, "featureTypes[0].properties")} data={{ type: 'bar' }} onChange={actions.onChange} dependencies={{ viewport: {} }} />, document.getElementById("container"));
         const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(5); // operation is visible
         // simulate change with tab (for react-select)
         ReactTestUtils.Simulate.change(inputs[0], { target: { value: 'STATE_NAME' } });
-        ReactTestUtils.Simulate.keyDown(inputs[0], {keyCode: 9, key: 'Tab' });
+        ReactTestUtils.Simulate.keyDown(inputs[0], { keyCode: 9, key: 'Tab' });
         expect(spyonChange.calls[0].arguments[0]).toBe("options.groupByAttributes");
         expect(spyonChange.calls[0].arguments[1]).toBe("STATE_NAME");
 
         ReactTestUtils.Simulate.change(inputs[1], { target: { value: 'STATE_NAME' } });
-        ReactTestUtils.Simulate.keyDown(inputs[1], {keyCode: 9, key: 'Tab' });
+        ReactTestUtils.Simulate.keyDown(inputs[1], { keyCode: 9, key: 'Tab' });
         expect(spyonChange.calls[1].arguments[0]).toBe("options.aggregationAttribute");
         expect(spyonChange.calls[1].arguments[1]).toBe("STATE_NAME");
 
         ReactTestUtils.Simulate.change(inputs[2], { target: { value: 'Count' } });
-        ReactTestUtils.Simulate.keyDown(inputs[2], {keyCode: 9, key: 'Tab' });
+        ReactTestUtils.Simulate.keyDown(inputs[2], { keyCode: 9, key: 'Tab' });
         expect(spyonChange.calls[2].arguments[0]).toBe("options.aggregateFunction");
         expect(spyonChange.calls[2].arguments[1]).toBe("Count");
 
@@ -58,12 +59,36 @@ describe('WPSWidgetOptions component', () => {
         expect(spyonChange.calls[3].arguments[0]).toBe("legend");
         expect(spyonChange.calls[3].arguments[1]).toBe(true);
     });
+    it('Test WPSWidgetOptions onChange for chart context, WPS not available', () => {
+        const actions = {
+            onChange: () => { }
+        };
+        const spyonChange = expect.spyOn(actions, 'onChange');
+        ReactDOM.render(<WPSWidgetOptions featureTypeProperties={get(describeStates, "featureTypes[0].properties")} data={{ type: 'bar' }} onChange={actions.onChange} dependencies={{ viewport: {} }} />, document.getElementById("container"));
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(4); // operation is not visible
+        // simulate change with tab (for react-select)
+        ReactTestUtils.Simulate.change(inputs[0], { target: { value: 'STATE_NAME' } });
+        ReactTestUtils.Simulate.keyDown(inputs[0], { keyCode: 9, key: 'Tab' });
+        expect(spyonChange.calls[0].arguments[0]).toBe("options.groupByAttributes");
+        expect(spyonChange.calls[0].arguments[1]).toBe("STATE_NAME");
+
+        ReactTestUtils.Simulate.change(inputs[1], { target: { value: 'STATE_NAME' } });
+        ReactTestUtils.Simulate.keyDown(inputs[1], { keyCode: 9, key: 'Tab' });
+        expect(spyonChange.calls[1].arguments[0]).toBe("options.aggregationAttribute");
+        expect(spyonChange.calls[1].arguments[1]).toBe("STATE_NAME");
+
+
+        ReactTestUtils.Simulate.change(inputs[3]);
+        expect(spyonChange.calls[2].arguments[0]).toBe("legend");
+        expect(spyonChange.calls[2].arguments[1]).toBe(true);
+    });
     it('Test WPSWidgetOptions onChange for counter context', () => {
         const actions = {
             onChange: () => { }
         };
         const spyonChange = expect.spyOn(actions, 'onChange');
-        ReactDOM.render(<WPSWidgetOptions formOptions={{
+        ReactDOM.render(<WPSWidgetOptions hasAggregateProcess formOptions={{
             showColorRamp: false,
             showUom: true,
             showGroupBy: false,
@@ -73,6 +98,7 @@ describe('WPSWidgetOptions component', () => {
         featureTypeProperties={get(describeStates, "featureTypes[0].properties")}
         onChange={actions.onChange} dependencies={{ viewport: {} }} />, document.getElementById("container"));
         const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(3); // groupBy and legend not visible
         // simulate change with tab (for react-select)
         ReactTestUtils.Simulate.change(inputs[0], { target: { value: 'STATE_NAME' } });
         ReactTestUtils.Simulate.keyDown(inputs[0], { keyCode: 9, key: 'Tab' });
@@ -88,28 +114,5 @@ describe('WPSWidgetOptions component', () => {
         ReactTestUtils.Simulate.change(inputs[2], { target: { value: 'test' } });
         expect(spyonChange.calls[2].arguments[0]).toBe("options.seriesOptions.[0].uom");
         expect(spyonChange.calls[2].arguments[1]).toBe("test");
-    });
-
-    it('Test WPSWidgetOptions with rotation slider ', () => {
-        const actions = {
-            onChange: () => { }
-        };
-        ReactDOM.render(<WPSWidgetOptions
-            formOptions={{
-                showColorRamp: false,
-                showUom: true,
-                showGroupBy: false,
-                showLegend: false,
-                advancedOptions: true
-            }}
-            featureTypeProperties={get(describeStates, "featureTypes[0].properties")}
-            onChange={actions.onChange}
-            dependencies={{ viewport: {} }}
-            data={{type: "line", xAxisAngle: 45}}/>, document.getElementById("container"));
-        const slider = document.getElementsByClassName('mapstore-slider');
-        expect(slider).toExist();
-        const tooltip = document.getElementsByClassName('noUi-tooltip')[0];
-        expect(tooltip.innerText).toBe("45°");
-
     });
 });

--- a/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
@@ -115,31 +115,42 @@ describe('wfsChartOptions enhancer', () => {
             }));
             ReactDOM.render(<Sink data={data} featureTypeProperties={featureTypeProperties} />, document.getElementById("container"));
         };
+        const NUM_OPS = [
+            "Count",
+            "Sum",
+            "Average",
+            "StdDev",
+            "Min",
+            "Max",
+            "None"];
+        const NO_NUM_OPS = [
+            "Count", "None"
+        ];
         it('Integer', (done) => {
-            checkOptions({ aggregationAttribute: "Integer" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+            checkOptions({ aggregationAttribute: "Integer" }, props => expect(props.aggregationOptions.every(({ value }) => NUM_OPS.includes(value))).toBeTruthy(), done);
         });
         it('Long', (done) => {
-            checkOptions({ aggregationAttribute: "Long" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+            checkOptions({ aggregationAttribute: "Long" }, props => expect(props.aggregationOptions.every(({ value }) => NUM_OPS.includes(value))).toBeTruthy(), done);
         });
         it('Float', (done) => {
-            checkOptions({ aggregationAttribute: "Float" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+            checkOptions({ aggregationAttribute: "Float" }, props => expect(props.aggregationOptions.every(({ value }) => NUM_OPS.includes(value))).toBeTruthy(), done);
         });
         it('Double Precision', (done) => {
-            checkOptions({ aggregationAttribute: "Double_Precision" }, props => expect(props.aggregationOptions.length).toBeGreaterThan(1), done);
+            checkOptions({ aggregationAttribute: "Double_Precision" }, props => expect(props.aggregationOptions.every(({ value }) => NUM_OPS.includes(value))).toBeTruthy(), done);
         });
         it('String', (done) => {
-            checkOptions({ aggregationAttribute: "String" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+            checkOptions({ aggregationAttribute: "String" }, props => expect(props.aggregationOptions.every(({ value }) => NO_NUM_OPS.includes(value))), done);
         });
         it('Time', (done) => {
-            checkOptions({ aggregationAttribute: "Time" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+            checkOptions({ aggregationAttribute: "Time" }, props => expect(props.aggregationOptions.every(({ value }) => NO_NUM_OPS.includes(value))).toBeTruthy(), done);
         });
 
         it('Date', (done) => {
-            checkOptions({ aggregationAttribute: "Date" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+            checkOptions({ aggregationAttribute: "Date" }, props => expect(props.aggregationOptions.every(({ value }) => NO_NUM_OPS.includes(value))).toBeTruthy(), done);
         });
 
         it('DateTime', (done) => {
-            checkOptions({ aggregationAttribute: "DateTime" }, props => expect(props.aggregationOptions.length).toBe(1), done);
+            checkOptions({ aggregationAttribute: "DateTime" }, props => expect(props.aggregationOptions.every(({ value }) => NO_NUM_OPS.includes(value))).toBeTruthy(), done);
         });
     });
 });

--- a/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/common/__tests__/wfsChartOptions-test.jsx
@@ -5,11 +5,11 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const React = require('react');
-const ReactDOM = require('react-dom');
-const {createSink} = require('recompose');
-const expect = require('expect');
-const wfsChartOptions = require('../wfsChartOptions');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {createSink} from 'recompose';
+import expect from 'expect';
+import wfsChartOptions from '../wfsChartOptions';
 const featureTypeProperties = [
     {
         "name": "Integer",

--- a/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
+++ b/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
@@ -32,6 +32,10 @@ module.exports = compose(
     withProps(({featureTypeProperties = [], data = {}} = {}) => ({
         options: propsToOptions(featureTypeProperties),
         aggregationOptions: getAllowedAggregationOptions(data.options && data.options.aggregationAttribute, featureTypeProperties)
+            // Add None entry if the widget is not a
+            .concat(
+                data?.widgetType !== "counter" ? [{ value: "None", label: "None" }] : []
+            )
     })),
 
 );

--- a/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
+++ b/web/client/components/widgets/builder/wizard/common/wfsChartOptions.js
@@ -6,9 +6,11 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-const {compose, withProps} = require('recompose');
+import {compose, withProps} from 'recompose';
+import localizedProps from '../../../../misc/enhancers/localizedProps';
 
-const {find} = require('lodash');
+
+import {find} from 'lodash';
 
 const propsToOptions = props => props.filter(({type} = {}) => type.indexOf("gml:") !== 0)
     .map( ({name} = {}) => ({label: name, value: name}));
@@ -17,25 +19,24 @@ const getAllowedAggregationOptions = (propertyName, featureTypeProperties = []) 
     const prop = find(featureTypeProperties, {name: propertyName});
     if (prop && (prop.localType === 'number' || prop.localType === 'int')) {
         return [
-            {value: "Count", label: "COUNT"},
-            {value: "Sum", label: "SUM"},
-            {value: "Average", label: "AVG"},
-            {value: "StdDev", label: "STDDEV"},
-            {value: "Min", label: "MIN"},
-            {value: "Max", label: "MAX"}
+            {value: "Count", label: "widgets.operations.COUNT"},
+            { value: "Sum", label: "widgets.operations.SUM"},
+            { value: "Average", label: "widgets.operations.AVG"},
+            { value: "StdDev", label: "widgets.operations.STDDEV"},
+            { value: "Min", label: "widgets.operations.MIN"},
+            { value: "Max", label: "widgets.operations.MAX"}
         ];
     }
-    return [{value: "Count", label: "COUNT"}];
+    return [{ value: "Count", label: "widgets.operations.COUNT"}];
 };
 
-module.exports = compose(
+export default compose(
     withProps(({featureTypeProperties = [], data = {}} = {}) => ({
         options: propsToOptions(featureTypeProperties),
-        aggregationOptions: getAllowedAggregationOptions(data.options && data.options.aggregationAttribute, featureTypeProperties)
-            // Add None entry if the widget is not a
-            .concat(
-                data?.widgetType !== "counter" ? [{ value: "None", label: "None" }] : []
-            )
+        aggregationOptions:
+            (data?.widgetType !== "counter" ? [{ value: "None", label: "widgets.operations.NONE" }] : [])
+                .concat(getAllowedAggregationOptions(data.options && data.options.aggregationAttribute, featureTypeProperties))
     })),
+    localizedProps("aggregationOptions")
 
 );

--- a/web/client/components/widgets/enhancers/__tests__/builderConfiguration-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/builderConfiguration-test.jsx
@@ -11,7 +11,11 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import builderConfiguration from '../builderConfiguration';
 import WB from '../../builder/WidgetBuilder';
-const WidgetBuilder = builderConfiguration(WB);
+import { createSink } from 'recompose';
+
+const WidgetBuilder = builderConfiguration()(WB);
+const WPSWidgetBuilder = builderConfiguration({ needsWPS: true })(WB);
+
 describe('widgets builderConfiguration enhancer', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -32,7 +36,7 @@ describe('widgets builderConfiguration enhancer', () => {
         };
         ReactDOM.render(
             (<WidgetBuilder
-                layer={{url: 'base/web/client/test-resources/widgetbuilder/wms', search: {url: 'base/web/client/test-resources/widgetbuilder/wfs'}}}
+                layer={{ url: 'base/web/client/test-resources/widgetbuilder/wms', search: { url: 'base/web/client/test-resources/widgetbuilder/wfs' } }}
                 onEditorChange={actions.onEditorChange} />),
             document.getElementById("container"));
     });
@@ -48,8 +52,65 @@ describe('widgets builderConfiguration enhancer', () => {
         };
         ReactDOM.render(
             (<WidgetBuilder
-                layer={{url: 'base/web/client/test-resources/widgetbuilder/wms', search: {url: 'base/web/client/test-resources/widgetbuilder/no-data'}}}
+                layer={{ url: 'base/web/client/test-resources/widgetbuilder/wms', search: { url: 'base/web/client/test-resources/widgetbuilder/no-data' } }}
                 onConfigurationError={actions.onConfigurationError} />),
+            document.getElementById("container"));
+    });
+    it('with option needsWPS = true, the missing WPS process causes error', (done) => {
+        const actions = {
+            onConfigurationError: () => {
+                setTimeout(() => {
+                    expect(document.querySelector('.empty-state-container')).toExist();
+                    done();
+                }, 20);
+
+            }
+        };
+        ReactDOM.render(
+            (<WPSWidgetBuilder
+                layer={{ url: 'base/web/client/test-resources/widgetbuilder/no-data', search: { url: 'base/web/client/test-resources/widgetbuilder/wfs' } }}
+                onConfigurationError={actions.onConfigurationError} />),
+            document.getElementById("container"));
+    });
+    it('with option needWPS = false, the contained component receives the hasAggregateProcess = false', (done) => {
+        const Builder = builderConfiguration()(createSink(({hasAggregateProcess}) => {
+            if (hasAggregateProcess === false) {
+                done();
+            }
+        }));
+
+        ReactDOM.render(
+            (<Builder
+                layer={{ url: 'base/web/client/test-resources/widgetbuilder/no-data', search: { url: 'base/web/client/test-resources/widgetbuilder/wfs' } }}
+            />),
+            document.getElementById("container"));
+    });
+    it('the contained component receives the hasAggregateProcess = false if WPS is not available (and needsWPS = false)', (done) => {
+        const Builder = builderConfiguration()(createSink(({ hasAggregateProcess, loading }) => {
+            if (hasAggregateProcess === false) {
+                expect(loading).toBeFalsy();
+                done();
+            }
+        }));
+
+        ReactDOM.render(
+            (<Builder
+                layer={{ url: 'base/web/client/test-resources/widgetbuilder/no-data', search: { url: 'base/web/client/test-resources/widgetbuilder/wfs' } }}
+            />),
+            document.getElementById("container"));
+    });
+    it('the contained component receives the hasAggregateProcess = false if WPS is not available (and needsWPS = false)', (done) => {
+        const Builder = builderConfiguration()(createSink(({ hasAggregateProcess, loading }) => {
+            if (hasAggregateProcess === true) {
+                expect(loading).toBeFalsy();
+                done();
+            }
+        }));
+
+        ReactDOM.render(
+            (<Builder
+                layer={{ url: 'base/web/client/test-resources/widgetbuilder/wms', search: { url: 'base/web/client/test-resources/widgetbuilder/wfs' } }}
+            />),
             document.getElementById("container"));
     });
 });

--- a/web/client/components/widgets/enhancers/__tests__/multiProtocolChart-test.js
+++ b/web/client/components/widgets/enhancers/__tests__/multiProtocolChart-test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {createSink} from 'recompose';
+import expect from 'expect';
+import multiProtocolChart from '../multiProtocolChart';
+
+describe('multiProtocolChart enhancer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('multiProtocolChart WFS data fetch', (done) => {
+        const Sink = multiProtocolChart(createSink( ({data, loading} = {}) => {
+            if (!loading) {
+                expect(data).toExist();
+                expect(data.length).toBe(18);
+                data.map(({ STATE_NAME, LAND_KM}) => {
+                    expect(STATE_NAME).toBeTruthy();
+                    expect(LAND_KM).toBeTruthy();
+                });
+                done();
+            }
+        }));
+        const props = {
+            layer: {
+                name: "test",
+                url: 'base/web/client/test-resources/wfs/Arizona_18_results.json',
+                wpsUrl: 'base/web/client/test-resources/wfs/Arizona_18_results.json',
+                search: { url: 'base/web/client/test-resources/wfs/Arizona_18_results.json'}},
+            options: {
+                aggregationAttribute: "LAND_KM",
+                groupByAttributes: "STATE_NAME"
+            }
+        };
+        ReactDOM.render(<Sink {...props} />, document.getElementById("container"));
+    });
+    it('multiProtocolChart WPS data fetch', (done) => {
+        const Sink = multiProtocolChart(createSink(({ data, loading } = {}) => {
+            if (!loading) {
+                expect(data).toExist();
+                data.map(({ District_N: x, "Sum(Shape_Area)": y }) => {
+                    expect(x).toBeTruthy();
+                    expect(y).toBeTruthy();
+                });
+                done();
+            }
+        }));
+        const props = {
+            layer: {
+                name: "test",
+                url: 'base/web/client/test-resources/widgetbuilder/aggregate',
+                wpsUrl: 'base/web/client/test-resources/widgetbuilder/aggregate',
+                search: { url: 'base/web/client/test-resources/widgetbuilder/aggregate' }
+            },
+            options: {
+                aggregateFunction: "Count",
+                aggregationAttribute: "test",
+                groupByAttributes: "test"
+            }
+        };
+        ReactDOM.render(<Sink {...props} />, document.getElementById("container"));
+    });
+
+});

--- a/web/client/components/widgets/enhancers/__tests__/wfsChart-test.js
+++ b/web/client/components/widgets/enhancers/__tests__/wfsChart-test.js
@@ -10,9 +10,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {createSink} from 'recompose';
 import expect from 'expect';
-import wpsCounter from '../wpsCounter';
+import wfsChart from '../wfsChart';
 
-describe('wpsChart enhancer', () => {
+describe('wfsChart enhancer', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -22,29 +22,33 @@ describe('wpsChart enhancer', () => {
         document.body.innerHTML = '';
         setTimeout(done);
     });
-    it('wpsChart data retrival', (done) => {
-        const Sink = wpsCounter(createSink( ({data, loading} = {}) => {
+    it('wfsChart data retrival', (done) => {
+        const Sink = wfsChart(createSink( ({data, loading} = {}) => {
             if (!loading) {
                 expect(data).toExist();
-                expect(data.length).toBe(6);
+                expect(data.length).toBe(18);
+                data.map(({ STATE_NAME, LAND_KM}) => {
+                    expect(STATE_NAME).toBeTruthy();
+                    expect(LAND_KM).toBeTruthy();
+                });
                 done();
             }
         }));
         const props = {
             layer: {
                 name: "test",
-                url: 'base/web/client/test-resources/widgetbuilder/aggregate',
-                wpsUrl: 'base/web/client/test-resources/widgetbuilder/aggregate',
-                search: {url: 'base/web/client/test-resources/widgetbuilder/aggregate'}},
+                url: 'base/web/client/test-resources/wfs/Arizona_18_results.json',
+                wpsUrl: 'base/web/client/test-resources/wfs/Arizona_18_results.json',
+                search: { url: 'base/web/client/test-resources/wfs/Arizona_18_results.json'}},
             options: {
-                aggregateFunction: "Count",
-                aggregationAttribute: "test"
+                aggregationAttribute: "LAND_KM",
+                groupByAttributes: "STATE_NAME"
             }
         };
         ReactDOM.render(<Sink {...props} />, document.getElementById("container"));
     });
-    it('wpsChart error management', (done) => {
-        const Sink = wpsCounter(createSink( ({error, loading} = {}) => {
+    it('wfsChart error management', (done) => {
+        const Sink = wfsChart(createSink( ({error, loading} = {}) => {
             if (!loading && error) {
                 expect(error).toExist();
                 done();
@@ -58,7 +62,8 @@ describe('wpsChart enhancer', () => {
                 search: {url: 'base/web/client/test-resources/widgetbuilder/aggregate'}},
             options: {
                 aggregateFunction: "Count",
-                aggregationAttribute: "test"
+                aggregationAttribute: "test",
+                groupByAttributes: "test"
             }
         };
         ReactDOM.render(<Sink {...props} />, document.getElementById("container"));

--- a/web/client/components/widgets/enhancers/__tests__/wpsChart-test.js
+++ b/web/client/components/widgets/enhancers/__tests__/wpsChart-test.js
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const {createSink} = require('recompose');
-const expect = require('expect');
-const {isString} = require('lodash');
-const wpsChart = require('../wpsChart');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {createSink} from 'recompose';
+import expect from 'expect';
+import {isString} from 'lodash';
+import wpsChart from '../wpsChart';
 
 describe('wpsChart enhancer', () => {
     beforeEach((done) => {

--- a/web/client/components/widgets/enhancers/builderConfiguration.jsx
+++ b/web/client/components/widgets/enhancers/builderConfiguration.jsx
@@ -1,39 +1,44 @@
-const React = require('react');
-const loadingState = require('../../misc/enhancers/loadingState');
-const emptyState = require('../../misc/enhancers/emptyState');
-const propsStreamFactory = require('../../misc/enhancers/propsStreamFactory');
-const {compose, defaultProps} = require('recompose');
-const {get} = require('lodash');
-const {Observable} = require('rxjs');
-const {describeFeatureType} = require('../../../observables/wfs');
-const {describeProcess} = require('../../../observables/wps/describe');
-const {Message, HTML} = require("../../I18N/I18N");
+import React from 'react';
+import loadingState from '../../misc/enhancers/loadingState';
+import emptyState from '../../misc/enhancers/emptyState';
+import propsStreamFactory from '../../misc/enhancers/propsStreamFactory';
+import {compose, defaultProps} from 'recompose';
+import {get} from 'lodash';
+import {Observable} from 'rxjs';
+import {describeFeatureType} from '../../../observables/wfs';
+import pingAggregateProcess from '../../../observables/widgets/pingAggregateProcess';
+
+import {Message, HTML} from "../../I18N/I18N";
 const TYPES = "ALL";
-const {findGeometryProperty} = require('../../../utils/ogc/WFS/base');
+import {findGeometryProperty} from '../../../utils/ogc/WFS/base';
 
 /**
- * Enhancer that retrieves information about the featuretype attributes and the aggregate process
+ * Enhancer that retrieves information about the featureType attributes and the aggregate process
  * to find out proper information
+ * @param {boolean} options.needsWPS true if the builder needs also WPS
  */
-module.exports = compose(
+export default ({needsWPS} = {}) => compose(
     defaultProps({
         dataStreamFactory: ($props, {onEditorChange = () => {}, onConfigurationError = () => {}} = {}) =>
             $props
                 .distinctUntilChanged( ({layer = {}} = {}, {layer: newLayer} = {})=> layer.name === newLayer.name)
-                .switchMap( ({layer} = {}) => Observable.forkJoin(describeFeatureType({layer}), describeProcess(layer.url, "gs:Aggregate"))
+                .switchMap(({ layer } = {}) => Observable.forkJoin(
+                    describeFeatureType({ layer }),
+                    // if the builder needWPS service, then if missing it emits an exception
+                    // otherwise, it simply sets the flag to false
+                    ...(needsWPS ? [pingAggregateProcess(layer)] : [pingAggregateProcess(layer).catch( () => Observable.of(false))]))
                     .do(([result]) => {
                         const geomProp = get(findGeometryProperty(result.data || {}), "name");
                         if (geomProp) {
                         // set the geometry property (needed for synchronization with a map or any other sort of spatial filter)
                             onEditorChange("geomProp", geomProp);
                         }
-
                     })
-                    .map(([result]) => get(result, "data.featureTypes[0].properties") || [])
-                    .map(featureTypeProperties => ({
+                    .map(([result, hasAggregateProcess]) => ({
+                        hasAggregateProcess: !!hasAggregateProcess,
                         loading: false,
                         types: TYPES,
-                        featureTypeProperties
+                        featureTypeProperties: get(result, "data.featureTypes[0].properties") || []
                     })
                     ))
                 .catch( e => {

--- a/web/client/components/widgets/enhancers/multiProtocolChart.js
+++ b/web/client/components/widgets/enhancers/multiProtocolChart.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import wpsChart from './wpsChart';
+import wfsChart from './wfsChart';
+
+import {branch} from 'recompose';
+
+/**
+ * Wrapper to select the correct enhancer
+ * for the WFS/WPS chart based on the current selection.
+ */
+export default branch(
+    ({ options = {} }) => !options.aggregateFunction || options.aggregateFunction === "None",
+    wfsChart,
+    wpsChart
+);

--- a/web/client/components/widgets/enhancers/wfsChart.js
+++ b/web/client/components/widgets/enhancers/wfsChart.js
@@ -1,0 +1,66 @@
+/**
+  * Copyright 2017, GeoSolutions Sas.
+  * All rights reserved.
+  *
+  * This source code is licensed under the BSD-style license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+const {compose, withProps} = require('recompose');
+const { castArray, sortBy } = require('lodash');
+
+const { getLayerJSONFeature } = require('../../../observables/wfs');
+const propsStreamFactory = require('../../misc/enhancers/propsStreamFactory');
+const Rx = require('rxjs');
+const wfsToChartData = ({ features } = {}, { groupByAttributes}) => {
+
+    return sortBy(features.map(({properties}) => properties), groupByAttributes); // TODO: sort
+};
+const sameFilter = (f1, f2) => f1 === f2;
+const sameOptions = (o1 = {}, o2 = {}) =>
+    o1.aggregateFunction === o2.aggregateFunction
+    && o1.aggregationAttribute === o2.aggregationAttribute
+    && o1.groupByAttributes === o2.groupByAttributes
+    && o1.viewParams === o2.viewParams;
+
+const {getSearchUrl} = require('../../../utils/LayersUtils');
+
+const dataStreamFactory = ($props) =>
+    $props
+        .filter(({layer = {}, options}) => layer.name && getSearchUrl(layer)
+            && options
+            && options.aggregationAttribute // maybe another attribute
+            && options.groupByAttributes // TODO: not needed
+        )
+        .distinctUntilChanged(
+            ({layer = {}, options = {}, filter}, newProps) =>
+                (newProps.layer && layer.name === newProps.layer.name && layer.loadingError === newProps.layer.loadingError)
+                && sameOptions(options, newProps.options)
+                && sameFilter(filter, newProps.filter))
+        .switchMap(
+            ({layer = {}, options, filter, onLoad = () => {}, onLoadError = () => {}}) =>
+                getLayerJSONFeature(
+                    layer,
+                    filter,
+                    { propertyName: [...castArray(options.aggregationAttribute), ...castArray(options.groupByAttributes)] }
+                ).map((response) => ({
+                    loading: false,
+                    isAnimationActive: false,
+                    error: undefined,
+                    data: wfsToChartData(response, options),
+                    series: [{ dataKey: options.aggregationAttribute}],
+                    xAxis: { dataKey: options.groupByAttributes}
+                }))
+                    .do(onLoad)
+                    .catch((e) => Rx.Observable.of({
+                        loading: false,
+                        error: e,
+                        data: []
+                    }).do(onLoadError)
+                    ).startWith({loading: true})
+        );
+module.exports = compose(
+    withProps( () => ({
+        dataStreamFactory
+    })),
+    propsStreamFactory
+);

--- a/web/client/components/widgets/enhancers/wpsChart.js
+++ b/web/client/components/widgets/enhancers/wpsChart.js
@@ -5,11 +5,11 @@
   * This source code is licensed under the BSD-style license found in the
   * LICENSE file in the root directory of this source tree.
   */
-const {compose, withProps} = require('recompose');
-const {isObject, isNil} = require('lodash');
-const wpsAggregate = require('../../../observables/wps/aggregate');
-const propsStreamFactory = require('../../misc/enhancers/propsStreamFactory');
-const Rx = require('rxjs');
+import {compose, withProps} from 'recompose';
+import {isObject, isNil} from 'lodash';
+import wpsAggregate from '../../../observables/wps/aggregate';
+import propsStreamFactory from '../../misc/enhancers/propsStreamFactory';
+import Rx from 'rxjs';
 const wpsAggregateToChartData = ({AggregationResults = [], GroupByAttributes = [], AggregationAttribute, AggregationFunctions} = {}) =>
     AggregationResults.map((res) => ({
         ...GroupByAttributes.reduce((a, p, i) => {
@@ -48,7 +48,7 @@ const sameOptions = (o1 = {}, o2 = {}) =>
     && o1.groupByAttributes === o2.groupByAttributes
     && o1.viewParams === o2.viewParams;
 
-const {getWpsUrl} = require('../../../utils/LayersUtils');
+import {getWpsUrl} from '../../../utils/LayersUtils';
 
 const dataStreamFactory = ($props) =>
     $props
@@ -77,7 +77,7 @@ const dataStreamFactory = ($props) =>
                     }).do(onLoadError)
                     ).startWith({loading: true})
         );
-module.exports = compose(
+export default compose(
     withProps( () => ({
         dataStreamFactory
     })),

--- a/web/client/components/widgets/widget/enhancedWidgets.js
+++ b/web/client/components/widgets/widget/enhancedWidgets.js
@@ -9,7 +9,7 @@ import textWidget from '../enhancers/textWidget';
 import mapWidget from '../enhancers/mapWidget';
 
 // Enhancers for ajax support
-import wpsChart from '../enhancers/wpsChart';
+import multiProtocolChart from '../enhancers/multiProtocolChart';
 import wpsCounter from '../enhancers/wpsCounter';
 import wfsTable from '../enhancers/wfsTable';
 
@@ -47,7 +47,7 @@ export const ChartWidget = compose(
     dependenciesToWidget,
     dependenciesToFilter,
     dependenciesToOptions,
-    wpsChart,
+    multiProtocolChart,
     chartWidget
 )(BaseChartWidget);
 

--- a/web/client/observables/widgets/canGenerateCharts.js
+++ b/web/client/observables/widgets/canGenerateCharts.js
@@ -1,9 +1,15 @@
-const {Observable} = require('rxjs');
-const {describeFeatureType} = require('../wfs');
-const {describeProcess} = require('../wps/describe');
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {Observable} from 'rxjs';
+import {describeFeatureType} from '../wfs';
 /**
- * Tries to retrieve WFS and WPS info to guess if the layer passed can be used as base for a chart
+ * Tries to retrieve WFS info to guess if the layer passed can be used as base for a chart
  * @param  {Object} layer The layer object
  * @return {Observable} a stream that throws an error if the layer can not be used for charts
  */
-module.exports = layer => Observable.forkJoin(describeFeatureType({layer}), describeProcess(layer.url, "gs:Aggregate"));
+export default layer => Observable.forkJoin(describeFeatureType({layer}));

--- a/web/client/observables/widgets/canGenerateCounter.js
+++ b/web/client/observables/widgets/canGenerateCounter.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { Observable } from 'rxjs';
+import { describeFeatureType } from '../wfs';
+import pingAggregateProcess from './pingAggregateProcess';
+
+/**
+ * Tries to retrieve WFS and WPS info to guess if the layer passed can be used as base for a chart
+ * @param  {Object} layer The layer object
+ * @return {Observable} a stream that throws an error if the layer can not be used for counter
+ */
+export default layer => Observable.forkJoin(describeFeatureType({ layer }), pingAggregateProcess(layer));

--- a/web/client/observables/widgets/pingAggregateProcess.js
+++ b/web/client/observables/widgets/pingAggregateProcess.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describeProcess } from '../wps/describe';
+
+/**
+ * Try to get the gs:Aggregate process for the layer passed. Emit an exception if not
+ * found.
+ * @param {object} layer a layer oblect, has a `url` attribute
+ */
+export default function pingAggregateProcess(layer) {
+    return describeProcess(layer.url, "gs:Aggregate");
+}

--- a/web/client/plugins/widgetbuilder/ChartBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/ChartBuilder.jsx
@@ -37,7 +37,7 @@ const Builder = connect(
     },
     wizardStateToProps
 )(compose(
-    builderConfiguration,
+    builderConfiguration({needWPS: false}),
     renameProps({
         editorData: "data",
         onEditorChange: "onChange"

--- a/web/client/plugins/widgetbuilder/CounterBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/CounterBuilder.jsx
@@ -6,27 +6,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
-const { connect } = require('react-redux');
+import React from 'react';
+import { connect } from 'react-redux';
 
-const { compose, renameProps, branch, renderComponent } = require('recompose');
+import { compose, renameProps, branch, renderComponent } from 'recompose';
 
-const BorderLayout = require('../../components/layout/BorderLayout');
+import BorderLayout from '../../components/layout/BorderLayout';
 
-const { insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSetting } = require('../../actions/widgets');
+import { insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSetting } from '../../actions/widgets';
 
-const builderConfiguration = require('../../components/widgets/enhancers/builderConfiguration');
-const chartLayerSelector = require('./enhancers/chartLayerSelector');
-const viewportBuilderConnect = require('./enhancers/connection/viewportBuilderConnect');
-const viewportBuilderConnectMask = require('./enhancers/connection/viewportBuilderConnectMask');
+import builderConfiguration from '../../components/widgets/enhancers/builderConfiguration';
+import counterLayerSelector from './enhancers/counterLayerSelector';
+import viewportBuilderConnect from './enhancers/connection/viewportBuilderConnect';
+import viewportBuilderConnectMask from './enhancers/connection/viewportBuilderConnectMask';
 
-const withExitButton = require('./enhancers/withExitButton');
-const withConnectButton = require('./enhancers/connection/withConnectButton');
+import withExitButton from './enhancers/withExitButton';
+import withConnectButton from './enhancers/connection/withConnectButton';
+import CounterWizard from '../../components/widgets/builder/wizard/CounterWizard';
+import BuilderHeader from './BuilderHeader';
+import BaseToolbar from '../../components/widgets/builder/wizard/counter/Toolbar';
+import LayerSelector from './LayerSelector';
 
-const {
-    wizardStateToProps,
-    wizardSelector
-} = require('./commons');
+import {wizardStateToProps, wizardSelector} from './commons';
 
 const Builder = connect(
     wizardSelector,
@@ -38,14 +39,14 @@ const Builder = connect(
     },
     wizardStateToProps
 )(compose(
-    builderConfiguration,
+    builderConfiguration({ needsWPS: true }),
     renameProps({
         editorData: "data",
         onEditorChange: "onChange"
     })
-)(require('../../components/widgets/builder/wizard/CounterWizard')));
+)(CounterWizard));
 
-const BuilderHeader = require('./BuilderHeader');
+
 const Toolbar = compose(
     connect(
         wizardSelector, {
@@ -59,7 +60,7 @@ const Toolbar = compose(
     viewportBuilderConnect,
     withExitButton(),
     withConnectButton(({ step }) => step === 0)
-)(require('../../components/widgets/builder/wizard/counter/Toolbar'));
+)(BaseToolbar);
 
 /*
  * in case you don't have a layer selected (e.g. dashboard) the chart builder
@@ -70,11 +71,11 @@ const chooseLayerEnhancer = compose(
     viewportBuilderConnectMask,
     branch(
         ({ layer } = {}) => !layer,
-        renderComponent(chartLayerSelector(require('./LayerSelector')))
+        renderComponent(counterLayerSelector(LayerSelector))
     )
 );
 
-module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, editorData, toggleConnection, availableDependencies = [], dependencies, ...props } = {}) =>
+export default chooseLayerEnhancer(({ enabled, onClose = () => { }, exitButton, editorData, toggleConnection, availableDependencies = [], dependencies, ...props } = {}) =>
 
     (<BorderLayout
         header={<BuilderHeader onClose={onClose}><Toolbar

--- a/web/client/plugins/widgetbuilder/TableBuilder.jsx
+++ b/web/client/plugins/widgetbuilder/TableBuilder.jsx
@@ -6,28 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react');
-const { connect } = require('react-redux');
-const {get} = require('lodash');
-const { isGeometryType } = require('../../utils/ogc/WFS/base');
-const { compose, renameProps, branch, renderComponent, mapPropsStream } = require('recompose');
-const InfoPopover = require('../../components/widgets/widget/InfoPopover');
-const Message = require('../../components/I18N/Message').default;
-const BorderLayout = require('../../components/layout/BorderLayout');
+import React from 'react';
+import { connect } from 'react-redux';
+import {get} from 'lodash';
+import { isGeometryType } from '../../utils/ogc/WFS/base';
+import { compose, renameProps, branch, renderComponent, mapPropsStream } from 'recompose';
+import InfoPopover from '../../components/widgets/widget/InfoPopover';
+import Message from '../../components/I18N/Message';
+import BorderLayout from '../../components/layout/BorderLayout';
 
-const { insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSetting } = require('../../actions/widgets');
+import { insertWidget, onEditorChange, setPage, openFilterEditor, changeEditorSetting } from '../../actions/widgets';
 
-const builderConfiguration = require('../../components/widgets/enhancers/builderConfiguration');
-const chartLayerSelector = require('./enhancers/chartLayerSelector');
-const viewportBuilderConnect = require('./enhancers/connection/viewportBuilderConnect');
-const viewportBuilderConnectMask = require('./enhancers/connection/viewportBuilderConnectMask');
-const withExitButton = require('./enhancers/withExitButton');
-const withConnectButton = require('./enhancers/connection/withConnectButton');
-const {
-    wizardStateToProps,
-    wizardSelector
-} = require('./commons');
-
+import builderConfiguration from '../../components/widgets/enhancers/builderConfiguration';
+import chartLayerSelector from './enhancers/chartLayerSelector';
+import viewportBuilderConnect from './enhancers/connection/viewportBuilderConnect';
+import viewportBuilderConnectMask from './enhancers/connection/viewportBuilderConnectMask';
+import withExitButton from './enhancers/withExitButton';
+import withConnectButton from './enhancers/connection/withConnectButton';
+import { wizardStateToProps, wizardSelector} from './commons';
+import TableWizard from '../../components/widgets/builder/wizard/TableWizard';
+import BaseToolbar from '../../components/widgets/builder/wizard/table/Toolbar';
+import LayerSelector from './LayerSelector';
 const Builder = connect(
     wizardSelector,
     {
@@ -38,7 +37,7 @@ const Builder = connect(
     },
     wizardStateToProps
 )(compose(
-    builderConfiguration,
+    builderConfiguration(),
     renameProps({
         editorData: "data",
         onEditorChange: "onChange"
@@ -54,9 +53,9 @@ const Builder = connect(
                 }
             }).ignoreElements()
     ))
-)(require('../../components/widgets/builder/wizard/TableWizard')));
+)(TableWizard));
 
-const BuilderHeader = require('./BuilderHeader');
+import BuilderHeader from './BuilderHeader';
 const Toolbar = compose(
     connect(wizardSelector, {
         openFilterEditor,
@@ -69,7 +68,7 @@ const Toolbar = compose(
     viewportBuilderConnect,
     withExitButton(),
     withConnectButton(({ step }) => step === 0)
-)(require('../../components/widgets/builder/wizard/table/Toolbar'));
+)(BaseToolbar);
 
 /*
  * in case you don't have a layer selected (e.g. dashboard) the table builder
@@ -80,11 +79,11 @@ const chooseLayerEnhancer = compose(
     viewportBuilderConnectMask,
     branch(
         ({ layer } = {}) => !layer,
-        renderComponent(chartLayerSelector(require('./LayerSelector')))
+        renderComponent(chartLayerSelector(LayerSelector))
     )
 );
 
-module.exports = chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData = {}, exitButton, toggleConnection, availableDependencies = [], dependencies, ...props } = {}) =>
+export default chooseLayerEnhancer(({ enabled, onClose = () => { }, editorData = {}, exitButton, toggleConnection, availableDependencies = [], dependencies, ...props } = {}) =>
 
     (<BorderLayout
         header={

--- a/web/client/plugins/widgetbuilder/enhancers/connection/layerSelectorConnect.js
+++ b/web/client/plugins/widgetbuilder/enhancers/connection/layerSelectorConnect.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { connect } from 'react-redux';
+import { onEditorChange } from '../../../../actions/widgets';
+
+export default connect(() => ({}), {
+    onLayerChoice: (l) => onEditorChange("layer", l),
+    onResetChange: onEditorChange
+});

--- a/web/client/plugins/widgetbuilder/enhancers/counterLayerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/counterLayerSelector.js
@@ -7,16 +7,17 @@
  */
 import { compose, defaultProps, setDisplayName } from 'recompose';
 import withBackButton from './withBackButton';
+
 import layerSelector from './layerSelector';
 import layerSelectorConnect from './connection/layerSelectorConnect';
-import canGenerateCharts from '../../../observables/widgets/canGenerateCharts';
-const chartLayerSelector = compose(
-    setDisplayName('ChartLayerSelector'),
+import canGenerateCounter from '../../../observables/widgets/canGenerateCounter';
+const counterLayerSelector = compose(
+    setDisplayName('CounterLayerSelector'),
     layerSelectorConnect,
     defaultProps({
-        layerValidationStream: stream$ => stream$.switchMap(layer => canGenerateCharts(layer))
+        layerValidationStream: stream$ => stream$.switchMap(layer => canGenerateCounter(layer))
     }),
     withBackButton,
     layerSelector
 );
-export default chartLayerSelector;
+export default counterLayerSelector;

--- a/web/client/plugins/widgetbuilder/enhancers/withBackButton.js
+++ b/web/client/plugins/widgetbuilder/enhancers/withBackButton.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// add button to back to widget type selection
+import { withProps } from 'recompose';
+
+const withBackButton = withProps(({ onResetChange = () => { } }) => ({
+    stepButtons: [{
+        glyph: 'arrow-left',
+        tooltipId: "widgets.builder.wizard.backToWidgetTypeSelection",
+        onClick: () => {
+            // options will not be valid anymore in case of layer change
+            onResetChange("options", undefined);
+            onResetChange("widgetType", undefined);
+        }
+    }]
+}));
+export default withBackButton;

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1760,6 +1760,15 @@
             "placeHolder":{
                 "default":"Wählen Sie Attribut"
             },
+            "operations": {
+              "COUNT": "COUNT",
+              "SUM": "SUM",
+              "AVG": "AVG",
+              "STDDEV": "STDDEV",
+              "MIN": "MIN",
+              "MAX": "MAX",
+              "NONE": "No Operation"
+            },
             "groupByAttributes": {
                 "line": "X-Attribut",
                 "pie": "Gruppiere nach",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1761,6 +1761,15 @@
             "placeHolder":{
                 "default":"Select attribute"
             },
+            "operations": {
+              "COUNT": "COUNT",
+              "SUM":"SUM",
+              "AVG":"AVG",
+              "STDDEV":"STDDEV",
+              "MIN":"MIN",
+              "MAX":"MAX",
+              "NONE": "No Operation"
+            },
             "groupByAttributes": {
                 "line": "X Attribute",
                 "pie": "Group By",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1761,6 +1761,15 @@
             "placeHolder":{
                 "default":"Seleccionar atributo"
             },
+            "operations": {
+              "COUNT": "COUNT",
+              "SUM": "SUM",
+              "AVG": "AVG",
+              "STDDEV": "STDDEV",
+              "MIN": "MIN",
+              "MAX": "MAX",
+              "NONE": "Sin operación"
+            },
             "groupByAttributes": {
                 "line": "Atributo X",
                 "pie": "Agrupar por",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1762,6 +1762,15 @@
             "placeHolder": {
                 "default": "Sélectionnez un attribut"
             },
+            "operations": {
+              "COUNT": "COUNT",
+              "SUM": "SUM",
+              "AVG": "AVG",
+              "STDDEV": "STDDEV",
+              "MIN": "MIN",
+              "MAX": "MAX",
+              "NONE": "Aucune opération"
+            },
             "groupByAttributes": {
                 "line": "Attributs X",
                 "pie": "Grouper par",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1761,6 +1761,15 @@
             "placeHolder":{
                 "default":"Seleziona attributo"
             },
+            "operations": {
+              "COUNT": "COUNT",
+              "SUM":"SUM",
+              "AVG":"AVG",
+              "STDDEV":"STDDEV",
+              "MIN":"MIN",
+              "MAX":"MAX",
+              "NONE": "Nessuna Operazione"
+            },
             "groupByAttributes": {
                 "line": "Attributo X",
                 "pie": "Raggruppa per",


### PR DESCRIPTION
## Description
This PR provides functionalities to use WFS only instead of WPS if the user select "Operation": "None" in the chart creation wizard. 
![image](https://user-images.githubusercontent.com/1279510/99086455-db219f00-25c9-11eb-8d15-ae1c688c674a.png)

I preferred to add the None operation to be explicit. to avoid users to have performance problems in case of big datasets they want to aggregate, during the selection. 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
WPS only was supported


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
#6136 and also #6135 (data gaps now may happen, depending on the data behind.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

It's draft because: 
@tdipisa 
- In order to get feedback for the current UI. 
- WPS is not required at all, but only for: 
  - counter widgets (they still require aggregation)
  - do aggregation operation, for charts.
We could change the workflow to allow charts also without WPS, but we need to do some changes on the workflow.
In particular, in dashboard, when you select the layer, if the WPS is not present you could proceed but the counter should not be visible. In the chart options, the operation selector should be visible only if the WPS is available, missing otherwise.

 Please tell me if should I proceed, I can even put this last  improvement in a separate issue.


