### PR TITLE
#6186: Attribute Table - Selection remain active while generating charts

### DIFF
--- a/web/client/epics/__tests__/featuregrid-test.js
+++ b/web/client/epics/__tests__/featuregrid-test.js
@@ -55,7 +55,7 @@ import {
 import { SET_HIGHLIGHT_FEATURES_PATH } from '../../actions/highlight';
 import { CHANGE_DRAWING_STATUS, geometryChanged } from '../../actions/draw';
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
-import { TOGGLE_CONTROL, RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl } from '../../actions/controls';
+import { TOGGLE_CONTROL, RESET_CONTROLS, SET_CONTROL_PROPERTY, toggleControl, setControlProperty } from '../../actions/controls';
 import { ZOOM_TO_EXTENT, clickOnMap } from '../../actions/map';
 import { boxEnd, CHANGE_BOX_SELECTION_STATUS } from '../../actions/box';
 import { CHANGE_LAYER_PROPERTIES, changeLayerParams, browseData } from '../../actions/layers';
@@ -117,7 +117,8 @@ import {
     handleBoxSelectionDrawEnd,
     activateBoxSelectionTool,
     deactivateBoxSelectionTool,
-    deactivateSyncWmsFilterOnFeatureGridClose
+    deactivateSyncWmsFilterOnFeatureGridClose,
+    clearSelectedFeaturesOnOpenWidgetBuilder
 } from '../featuregrid';
 import { onLocationChanged } from 'connected-react-router';
 import { TEST_TIMEOUT, testEpic, addTimeoutEpic } from './epicTestUtils';
@@ -2249,6 +2250,20 @@ describe('featuregrid Epics', () => {
         }, {
             query: {
                 syncWmsFilter: true
+            }
+        }, done);
+    });
+    it('clearSelectedFeaturesOnOpenWidgetBuilder', (done) => {
+        const startActions = [setControlProperty("widgetBuilder", "enabled", false)];
+        testEpic(clearSelectedFeaturesOnOpenWidgetBuilder, 2, startActions, actions => {
+            expect(actions.length).toBe(2);
+            expect(actions[0].type).toBe(SELECT_FEATURES);
+            expect(actions[0].features).toEqual([]);
+            expect(actions[1].type).toBe(CHANGE_BOX_SELECTION_STATUS);
+            expect(actions[1].status).toBe("end");
+        }, {
+            featuregrid: {
+                select: [{id: 'ft-1'}]
             }
         }, done);
     });

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -103,7 +103,7 @@ import {
     setSelectionOptions
 } from '../actions/featuregrid';
 
-import { TOGGLE_CONTROL, resetControls, setControlProperty, toggleControl } from '../actions/controls';
+import { TOGGLE_CONTROL, SET_CONTROL_PROPERTY, resetControls, setControlProperty, toggleControl } from '../actions/controls';
 
 import {
     queryPanelSelector,
@@ -713,6 +713,14 @@ export const resetEditingOnFeatureGridClose = (action$, store) => action$.ofType
                 .switchMap(() => Rx.Observable.of(drawSupportReset())))
 
 );
+export const clearSelectedFeaturesOnOpenWidgetBuilder = (action$, store) =>
+    action$.ofType(SET_CONTROL_PROPERTY)
+        .filter(({control, value}) => (control === "widgetBuilder" && value === false))
+        .switchMap(() => {
+            const selFeatures = selectedFeaturesSelector(store.getState());
+            return selFeatures.length > 0 ? Rx.Observable.of(selectFeatures([]), changeBoxSelectionStatus("end")) : Rx.Observable.empty();
+        });
+
 export const closeRightPanelOnFeatureGridOpen = (action$, store) =>
     action$.ofType(OPEN_FEATURE_GRID)
         .switchMap( () => {


### PR DESCRIPTION
Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Disable select and box selection tool when widgetsBuilder is closed


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6186 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Disable select and box selection tool when widgetsBuilder is closed

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
