### PR TITLE
#6208 Problem creating Map Templates in application contexts

### DIFF
--- a/web/client/components/contextcreator/ConfigureMapTemplates.jsx
+++ b/web/client/components/contextcreator/ConfigureMapTemplates.jsx
@@ -177,6 +177,7 @@ export default ({
             user={user}
             loading={loading && (loadFlags.templateSaving || loadFlags.templateLoading)}
             resource={editedTemplate}
+            isNewResource={!editedTemplate}
             clickOutEnabled={false}
             category="TEMPLATE"
             show={showUploadDialog}

--- a/web/client/components/contextcreator/__tests__/ConfigureMapTemplates-test.jsx
+++ b/web/client/components/contextcreator/__tests__/ConfigureMapTemplates-test.jsx
@@ -11,7 +11,10 @@ import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
 import expect from 'expect';
 import { find, get } from 'lodash';
+import { setObservableConfig } from 'recompose';
+import rxjsConfig from 'recompose/rxjsObservableConfig';
 import ConfigureMapTemplate from '../ConfigureMapTemplates';
+setObservableConfig(rxjsConfig);
 
 describe('ConfigureMapTemplate component', () => {
     beforeEach((done) => {
@@ -65,5 +68,24 @@ describe('ConfigureMapTemplate component', () => {
         TestUtils.Simulate.click(confirmButton);
 
         expect(onDeleteSpy).toHaveBeenCalled();
+    });
+    it('ConfigureMapTemplate name is editable in SaveDialog when editedTemplate is not provided', () => {
+        const template = {
+            id: 1,
+            name: 'template',
+            description: 'desc'
+        };
+
+        ReactDOM.render(<ConfigureMapTemplate showUploadDialog mapTemplates={[template]}/>, document.getElementById("container"));
+
+        const dialog = document.getElementsByClassName('ms-map-properties')[0];
+        expect(dialog).toExist();
+        const input = Array.prototype.filter.call(dialog.getElementsByTagName('input'), inputEl => inputEl.getAttribute('placeholder') === 'saveDialog.namePlaceholder')[0];
+        expect(input).toExist();
+
+        input.value = 'x';
+        TestUtils.Simulate.change(input);
+
+        expect(input.value).toBe('x');
     });
 });

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -916,12 +916,10 @@ describe('contextcreator epics', () => {
             expect(actions[5].type).toBe(LOADING);
         }, {
             contextcreator: {
-                newContext: {
-                    templates: [{
-                        id: 1,
-                        format: 'json'
-                    }]
-                }
+                templates: [{
+                    id: 1,
+                    format: 'json'
+                }]
             }
         }, done);
     });

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -225,9 +225,9 @@ export const deleteTemplateEpic = (action$, store) => action$
     .ofType(DELETE_TEMPLATE)
     .switchMap(({resource}) => deleteResource(resource).map(() => {
         const state = store.getState();
-        const newContext = newContextSelector(state);
+        const templates = templatesSelector(state) || [];
 
-        return setTemplates(get(newContext, 'templates', []).filter(template => template.id !== resource.id));
+        return setTemplates(templates.filter(template => template.id !== resource.id));
     }).let(wrapStartStop(
         loading(true, "loading"),
         loading(false, "loading"),
@@ -247,7 +247,7 @@ export const editTemplateEpic = (action$, store) => action$
     .ofType(EDIT_TEMPLATE)
     .switchMap(({id}) => {
         const state = store.getState();
-        const template = find(get(newContextSelector(state), 'templates', []), t => t.id === id) || {};
+        const template = find(templatesSelector(state), t => t.id === id) || {};
 
         return (id ? Rx.Observable.defer(() => Api.getData(id)) : Rx.Observable.of(null))
             .switchMap(data => Rx.Observable.of(
@@ -275,9 +275,8 @@ export const resetOnShowDialog = (action$, store) => action$
     .ofType(SHOW_DIALOG)
     .flatMap(({dialogName, show: showDialogBool}) => {
         const state = store.getState();
-        const context = newContextSelector(state) || {};
         const editedTemplateId = editedTemplateSelector(state);
-        const templates = context.templates || [];
+        const templates = templatesSelector(state);
 
         return showDialogBool ?
             Rx.Observable.of(...(dialogName === 'uploadTemplate' && !editedTemplateId ? [setFileDropStatus(), setParsedTemplate()] : []),

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -276,7 +276,7 @@ export const resetOnShowDialog = (action$, store) => action$
     .flatMap(({dialogName, show: showDialogBool}) => {
         const state = store.getState();
         const editedTemplateId = editedTemplateSelector(state);
-        const templates = templatesSelector(state);
+        const templates = templatesSelector(state) || [];
 
         return showDialogBool ?
             Rx.Observable.of(...(dialogName === 'uploadTemplate' && !editedTemplateId ? [setFileDropStatus(), setParsedTemplate()] : []),


### PR DESCRIPTION
## Description
Added isNewResource prop to SaveDialog in ConfigureMapTemplates for proper hanleSaveModal behaviour. Also changed old newContextSelector to templatesSelector in template epics, since this is the correct one to use at the moment. It fixed some incorrect behaviours in editing and deleting templates.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6208 
[mapstore2-georchestra/#293](https://github.com/georchestra/mapstore2-georchestra/issues/293)


**What is the current behavior?**
#6208 

**What is the new behavior?**
The dialog for creating new templates is completely functional.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No