### PR TITLE
improve {de,}activatePlugin fr-FR translations

### DIFF
--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2775,8 +2775,8 @@
                 "tooltips": {
                     "enableUserPlugin": "Activer la sélection du plugin actuel pour l'utilisateur",
                     "disableUserPlugin": "Désactiver la sélection du plugin actuel pour l'utilisateur",
-                    "activatePlugin": "Désactiver la sélection du plugin actuel pour l'utilisateur",
-                    "deactivatePlugin": "Désactiver le chargement de ce plugin au démarrage",
+                    "activatePlugin": "Activer ce plugin au chargement du contexte",
+                    "deactivatePlugin": "Désactiver ce plugin au chargement du contexte",
                     "editConfiguration": "Modifier la configuration du plugin",
                     "pluginDocumentation": "Ouvrir la documentation de configuration du plugin",
                     "uploadPlugin": "Ajouter une extension à MapStore",


### PR DESCRIPTION
noticed that `activatePlugin` had the same translation as `disableUserPlugin` which was highly confusing. Tried improving both while here..  and i have to admit im still confused by the disable/enable userplugin notions - their fr translation isnt clear to me, is it 'Allow user to disable the plugin' and 'Dont allow user to disable the plugin' ? or 'remove' instead of 'disable' ? in that case the fr translation could really be improved. I havent found yet a mapstore2 documentation about context creation... but there are many docs :D

@catmorales @MaelREBOUX looking at the labels used in the burger menu i find '_Catalogue_' above '_Catalogue de cartes_' confusing. _Catalogue_ doesnt convey the meaning '_catalogue de couches à ajouter / de services_', so maybe we should use _Ajouter une couche_ instead ? and maybe _Catalogue de cartes_ should be _Bibliotheque de cartes_ ? Are there only the maps created by the user there, or also the maps created by other users and shared to the current user ?

@tdipisa i looked at the **en** and **it** translations, and the same wording is used. You never had feedback from confused users, everyone directly understood _catalog_ as _a way to add layers to the current map_ ?