### PR TITLE
#6179: MapSwipe shouldn't be deactivated when the layer is deactivated

### DIFF
--- a/web/client/epics/__tests__/swipe-test.js
+++ b/web/client/epics/__tests__/swipe-test.js
@@ -13,24 +13,6 @@ import { testEpic } from './epicTestUtils';
 import { SET_ACTIVE } from '../../actions/swipe';
 
 describe('SWIPE EPICS', () => {
-    it('reset activation of layer swipe tool if it was active', done => {
-        const state = {
-            swipe: {
-                active: true
-            }
-        };
-
-        testEpic(
-            resetLayerSwipeSettingsEpic,
-            1,
-            selectNode('layerId', 'layer', false),
-            actions => {
-                expect(actions.length).toBe(1);
-                expect(actions[0].type).toEqual(SET_ACTIVE);
-                expect(actions[0].active).toEqual(false);
-                done();
-            }, state, done);
-    });
     it('reset activation of layer swipe tool selected nodeType is group', done => {
         const state = {
             swipe: {

--- a/web/client/epics/swipe.js
+++ b/web/client/epics/swipe.js
@@ -11,7 +11,6 @@ import Rx from 'rxjs';
 import { SELECT_NODE } from '../actions/layers';
 import { setActive } from '../actions/swipe';
 import { layerSwipeSettingsSelector } from '../selectors/swipe';
-import { getSelectedLayer } from '../selectors/layers';
 
 /**
  * Ensures that swipeSettings active is changed back to false when a layer is deselected in TOC or group is selected
@@ -24,9 +23,8 @@ export const resetLayerSwipeSettingsEpic = (action$, store) =>
         .switchMap(({nodeType}) => {
             const state = store.getState();
             const swipeSettings = layerSwipeSettingsSelector(state);
-            const selectedLayer = getSelectedLayer(state);
             return (
-                (swipeSettings.active && selectedLayer === undefined) || (swipeSettings.active && nodeType === 'group'))
+                swipeSettings.active && nodeType === 'group')
                 ? Rx.Observable.of(setActive(false))
                 : Rx.Observable.empty();
         });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
MapSwipe is not deactivated when layer is toggled from the TOC

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6179 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
MapSwipe is not deactivated when layer is toggled from the TOC

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
