### PR TITLE
#6166: Display on load error for failed WFS requests

### DIFF
--- a/web/client/components/map/openlayers/Layer.jsx
+++ b/web/client/components/map/openlayers/Layer.jsx
@@ -294,6 +294,10 @@ export default class OpenlayersLayer extends React.Component {
             this.imageLoadEndStream$ = imageLoadEndStream$;
             this.imageStopStream$ = imageStopStream$;
 
+            this.layer.getSource().on('vectorerror', () => {
+                this.props.onLayerLoad(options.id, {error: true});
+            });
+
             if (options.refresh) {
                 let counter = 0;
                 this.refreshTimer = setInterval(() => {

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -2576,6 +2576,33 @@ describe('Openlayers layer', () => {
             map={map} />, document.getElementById("container"));
         expect(layer.layer.getSource()).toExist();
     });
+    it('render wfs layer with error', () => {
+        mockAxios.onGet().reply(r => {
+            expect(r.url.indexOf('SAMPLE_URL') >= 0 ).toBeTruthy();
+            return [200, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<ows:ExceptionReport xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+            "  <ows:Exception exceptionCode=\"InvalidParameterValue\" locator=\"srsname\">\n" +
+            "    <ows:ExceptionText>msWFSGetFeature(): WFS server error. Invalid GetFeature Request</ows:ExceptionText>\n" +
+            "  </ows:Exception>\n" +
+            "</ows:ExceptionReport>"];
+        });
+        const options = {
+            type: 'wfs',
+            visibility: true,
+            url: 'SAMPLE_URL',
+            name: 'osm:vector_tile'
+        };
+        const layer = ReactDOM.render(<OpenlayersLayer
+            type="wfs"
+            options={{
+                ...options
+            }}
+            map={map} />, document.getElementById("container"));
+        expect(layer.layer.getSource()).toExist();
+        layer.layer.getSource().on('vectorerror', (e)=>{
+            expect(e).toBeTruthy();
+        });
+    });
     it('test second render wfs layer', (done) => {
         let clearCalled = false;
         mockAxios.onGet().reply(r => {

--- a/web/client/components/map/openlayers/plugins/WFSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WFSLayer.js
@@ -22,6 +22,7 @@ const createLoader = (source, options) => (extent, resolution, projection) => {
     var proj = projection.getCode();
     const onError = () => {
         source.removeLoadedExtent(extent);
+        source.dispatchEvent('vectorerror');
     };
     getFeature(options.url, options.name, {
         // bbox: extent.join(',') + ',' + proj,


### PR DESCRIPTION
## Description
This PR adds on load error to layer when WFS requests fails

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6166 When a WFS fails, no error or exception shown anywhere in the application

**What is the new behavior?**
When a WFS request fails, the error prop is added to layer and the same is indicated in TOC eventually

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Sample WFS request: http://ogc4u.geosrbija.rs/test/rpj/wfs