### PR TITLE
#6207: use ALT for box selection in spatial quick filter

### DIFF
--- a/web/client/components/map/openlayers/BoxSelectionSupport.jsx
+++ b/web/client/components/map/openlayers/BoxSelectionSupport.jsx
@@ -16,7 +16,12 @@ const BoxSelectionSupport = (props) => {
 
     useEffect(() => {
         if (status === "start") {
-            dragBox = new DragBox({});
+            dragBox = new DragBox({
+                condition: function(mapBrowserEvent) {
+                    const originalEvent = (mapBrowserEvent.originalEvent);
+                    return (originalEvent.altKey);
+                }
+            });
             map.addInteraction(dragBox);
         } else if (status === "end") {
             map.removeInteraction(dragBox);

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1578,9 +1578,9 @@
                     "number": "Geben Sie eine Zahl oder einen Ausdruck ein. Examples: 10, > 2, < 10",
                     "date": "Geben Sie ein Datum oder einen Ausdruck ein. Verwenden Sie {format} für das Datum.",
                     "geometry": {
-                        "disabled": "Filterklick auf die Karte / Halten Sie die Strg-Taste gedrückt und klicken Sie, um mehrere zu filtern",
-                        "enabled": "Klicken Sie auf die Karte, um die Ergebnisse zu filtern / Halten Sie die Strg-Taste gedrückt und klicken Sie, um mehrere zu filtern",
-                        "applied": "Entfernen Sie den Filter per Mausklick"
+                        "disabled": "Filter Klicken auf Karte / Alt + Maus ziehen, um einen Box-Filter zu zeichnen. Halten Sie auch die Strg-Taste gedrückt, um dem aktuellen Filter weitere Funktionen hinzuzufügen",
+                        "enabled": "Klicken Sie auf die Karte, um ein Feature auszuwählen / Alt + Maus ziehen, um einen Boxfilter zu zeichnen. Halten Sie die Strg-Taste gedrückt und klicken Sie, um mehrere Features auszuwählen",
+                        "applied": "Auswahl bereinigen"
                     }
                 }
             },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1579,7 +1579,7 @@
                     "number": "Type a number or an expression. Examples: 10, > 2, < 10",
                     "date": "Type a date or an expression. Use {format} for the date.",
                     "geometry": {
-                        "disabled": "Filter clicking on the map / Hold ctrl and click to filter multiple",
+                        "disabled": "Filter on map. Click for point filter / Alt + drag for box filter. Hold (also) CTRL to add the filters to the current ones",
                         "enabled": "Click on the map to filter the results / Hold ctrl and click to filter multiple",
                         "applied": "Remove the filter by mouse click"
                     }

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1579,9 +1579,9 @@
                     "number": "Type a number or an expression. Examples: 10, > 2, < 10",
                     "date": "Type a date or an expression. Use {format} for the date.",
                     "geometry": {
-                        "disabled": "Filter on map. Click for point filter / Alt + drag for box filter. Hold (also) CTRL to add the filters to the current ones",
-                        "enabled": "Click on the map to filter the results / Hold ctrl and click to filter multiple",
-                        "applied": "Remove the filter by mouse click"
+                        "disabled": "Filter clicking on map / Alt + mouse drag to draw a box filter. Hold also ctrl to add more features to the current filter",
+                        "enabled": "Click on map to select a feature / Alt + mouse drag to draw a box filter. Hold ctrl and click to select multiple features",
+                        "applied": "Clean the selection"
                     }
                 }
             },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1579,9 +1579,9 @@
                     "number": "Escriba el número o la expresión. Ejemplos: 10, > 2, < 10",
                     "date": "Escriba una fecha o una expresión. Usa {format} para la fecha.",
                     "geometry": {
-                        "disabled": "Filtrar haciendo clic en el mapa/ Mantenga presionada la tecla Ctrl y haga clic para filtrar múltiples",
-                        "enabled": "Haga clic en el mapa para filtrar los resultados / Mantenga presionada la tecla Ctrl y haga clic para filtrar múltiples",
-                        "applied": "Eliminar el filtro haciendo clic con el mouse"
+                        "disabled": "Hacer clic en el filtro en el mapa / Alt + arrastrar el mouse para dibujar un filtro de cuadro. Mantenga presionada también la tecla Ctrl para agregar más funciones al filtro actual",
+                        "enabled": "Haga clic en el mapa para seleccionar una característica / Alt + arrastre del mouse para dibujar un filtro de cuadro. Mantenga presionada la tecla Ctrl y haga clic para seleccionar varias características",
+                        "applied": "Limpiar la selección"
                     }
                 }
             },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1580,9 +1580,9 @@
                     "number": "Tapez un nombre ou une expression... Exemples : 10, > 2, < 10",
                     "date": "Tapez une date ou une expression. Utilisez {format} pour la date.",
                     "geometry": {
-                        "disabled": "Filtrez en cliquant sur la carte/ Maintenez ctrl et cliquez pour filtrer plusieurs",
-                        "enabled": "Cliquez sur la carte pour filtrer les résultats / Maintenez ctrl et cliquez pour filtrer plusieurs",
-                        "applied": "Supprimez le filtre en cliquant sur la carte"
+                        "disabled": "Filtrer en cliquant sur la carte / Alt + glisser la souris pour dessiner un filtre de boîte. Maintenez également la touche Ctrl pour ajouter plus de fonctionnalités au filtre actuel",
+                        "enabled": "Cliquez sur la carte pour sélectionner une caractéristique / Alt + glissement de la souris pour dessiner un filtre de boîte. Maintenez la touche Ctrl enfoncée et cliquez pour sélectionner plusieurs entités",
+                        "applied": "Nettoyer la sélection"
                     }
                 }
             },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1579,9 +1579,9 @@
                     "number": "Digita un numero o una espressione. Esempi: 10, > 2, < 10",
                     "date":"Digita una data o un'espressione. Utilizza {format} per la data",
                     "geometry": {
-                        "disabled": "Filtra facendo clic sulla mappa / Tieni premuto ctrl e fai clic per filtrare più elementi",
-                        "enabled": "Fai clic sulla mappa per filtrare i risultati / Tieni premuto ctrl e fai clic per filtrare più elementi",
-                        "applied": "Rimuovi il filtro applicato con il click sulla mappa"
+                      "disabled": "Filtra facendo click sulla mappa / Alt + trascinamento per disegnare un filtro rettangolare. Tieni premuto anche ctrl per aggiungere features alla selezione corrente",
+                      "enabled": "Clicca per selezionare le features / Alt + trascinamento per disegnare un filtro rettangolare. Tieni premuto anche ctrl per aggiungere features alla selezione corrente",
+                      "applied": "Pulisci la selezione"
                     }
                 }
             },


### PR DESCRIPTION
## Description
Now the box draw for spatial filter needs alt to be pressed. Need to adjust tooltips.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6207
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
