### PR TITLE
#6196: Cesium map on click error fix

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -13,7 +13,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ConfigUtils from '../../../utils/ConfigUtils';
 import ClickUtils from '../../../utils/cesium/ClickUtils';
-import { ZOOM_TO_EXTENT_HOOK, registerHook } from '../../../utils/MapUtils';
+import {
+    ZOOM_TO_EXTENT_HOOK,
+    registerHook,
+    GET_PIXEL_FROM_COORDINATES_HOOK,
+    GET_COORDINATES_FROM_PIXEL_HOOK
+} from '../../../utils/MapUtils';
 import { reprojectBbox } from '../../../utils/CoordinatesUtils';
 import assign from 'object-assign';
 import { throttle } from 'lodash';
@@ -335,6 +340,12 @@ class CesiumMap extends React.Component {
         this.pauserStream$ = pauserStream$;
     };
     registerHooks = () => {
+        // Unregister hooks as coming from a leaflet or openlayer map retains hooks
+        // causing issue in feature info click
+        this.props.hookRegister.registerHook(GET_PIXEL_FROM_COORDINATES_HOOK);
+        this.props.hookRegister.registerHook(GET_COORDINATES_FROM_PIXEL_HOOK);
+
+        // Register hook
         this.props.hookRegister.registerHook(ZOOM_TO_EXTENT_HOOK, (extent, { crs, duration } = {}) => {
             // TODO: manage padding and maxZoom
             const bounds = reprojectBbox(extent, crs, 'EPSG:4326');

--- a/web/client/components/map/cesium/__tests__/Map-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Map-test-chrome.jsx
@@ -15,7 +15,7 @@ import {
     getHook,
     ZOOM_TO_EXTENT_HOOK,
     registerHook,
-    createRegisterHooks
+    createRegisterHooks, GET_PIXEL_FROM_COORDINATES_HOOK, GET_COORDINATES_FROM_PIXEL_HOOK
 } from '../../../../utils/MapUtils';
 
 
@@ -247,7 +247,9 @@ describe('CesiumMap', () => {
             const map = ReactDOM.render(<CesiumMap id="mymap" center={{y: 43.9, x: 10.3}} zoom={11}/>, document.getElementById("container"));
             expect(map).toExist();
             expect(ReactDOM.findDOMNode(map).id).toBe('mymap');
-            expect(getHook(ZOOM_TO_EXTENT_HOOK)).toExist();
+            expect(getHook(ZOOM_TO_EXTENT_HOOK)).toBeTruthy();
+            expect(getHook(GET_PIXEL_FROM_COORDINATES_HOOK)).toBeFalsy();
+            expect(getHook(GET_COORDINATES_FROM_PIXEL_HOOK)).toBeFalsy();
         });
         it("with custom hookRegister", () => {
             const customHooRegister = createRegisterHooks();


### PR DESCRIPTION
## Description
This PR adds a fix for error when on click cesium map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6196 

**What is the new behavior?**
- Unregister the hooks causing issue when in cesium map
- GFI panel open with data of the clicked point on map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
