### PR TITLE
#6186. Support for custom spatialFieldOperator in widgetFilter

### DIFF
--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
@@ -15,6 +15,8 @@ import dependenciesToFilter from '../dependenciesToFilter';
 import {
     inputFilterObjSpatial,
     inputQuickFiltersStateAbbr,
+    spatialFilterMultiple,
+    resultSpatialFilterMultiple,
     inputLayerFilterSTATENAME,
     resultFilterOnly,
     resultFilterObjRes1,
@@ -121,6 +123,14 @@ describe('widgets dependenciesToFilter enhancer', () => {
             done();
         }));
         ReactDOM.render(<Sink filter={inputFilterObjSpatial}/>, document.getElementById("container"));
+    });
+    it('dependenciesToFilter with custom spatialFieldOpeartor filter', (done) => {
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(resultSpatialFilterMultiple);
+            done();
+        }));
+        ReactDOM.render(<Sink filter={spatialFilterMultiple} />, document.getElementById("container"));
     });
     it('dependenciesToFilter with mapsync and spatial filter', (done) => {
         const Sink = dependenciesToFilter(createSink( props => {

--- a/web/client/components/widgets/enhancers/utils.js
+++ b/web/client/components/widgets/enhancers/utils.js
@@ -24,7 +24,7 @@ export const getDependencyLayerParams = (layer, dependencies) =>
             "params",
             {}
         );
-export const composeFilterObject = (filterObj, quickFilters, options) => {
+export const composeFilterObject =  (filterObj, quickFilters, options) => {
     const quickFiltersForVisibleProperties = quickFilters && options &&
         Object.keys(quickFilters)
             .filter(qf => find(options.propertyName, f => f === qf))
@@ -37,7 +37,7 @@ export const composeFilterObject = (filterObj, quickFilters, options) => {
         return gridUpdateToQueryUpdate({attribute, ...value}, cFilters);
     }, {});
     if (!isEmpty(filterObj) || !isEmpty(columnsFilters)) {
-        const composedFilterFields = composeAttributeFilters([filterObj, columnsFilters]);
+        const composedFilterFields = composeAttributeFilters([filterObj, columnsFilters], undefined, filterObj?.spatialFieldOperator);
         return {...filterObj, ...composedFilterFields};
     }
     return {};

--- a/web/client/test-resources/widgets/dependenciesToFiltersData.js
+++ b/web/client/test-resources/widgets/dependenciesToFiltersData.js
@@ -21,6 +21,26 @@ export const inputFilterObjSpatial = {
         }
     }
 };
+export const spatialFilterMultiple = {
+    spatialFieldOperator: "OR",
+    spatialField: [{
+        "operation": "INTERSECTS",
+        "attribute": "geometry",
+        "geometry": {
+            "type": "Polygon",
+            "projection": "EPSG:4326",
+            "coordinates": [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
+        }
+    },{
+        "operation": "INTERSECTS",
+        "attribute": "geometry",
+        "geometry": {
+            "type": "Polygon",
+            "projection": "EPSG:4326",
+            "coordinates": [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
+        }
+    }]
+};
 export const inputQuickFiltersStateAbbr = {
     state_abbr: {
         rawValue: "I",
@@ -113,4 +133,15 @@ export const resultQuickFiltersAndDependenciesQF = `<ogc:Filter><ogc:And><ogc:An
 export const resultQuickFiltersAndDependenciesFilter = `<ogc:Filter><ogc:And><ogc:And><ogc:And><ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>state_abbr</ogc:PropertyName><ogc:Literal>*I*</ogc:Literal></ogc:PropertyIsLike></ogc:And></ogc:And></ogc:And></ogc:Filter>`;
 
 export const resultSpatialAndQuickFilters = `<ogc:Filter><ogc:And><ogc:And><ogc:And><ogc:PropertyIsLike matchCase="false" wildCard="*" singleChar="." escapeChar="!"><ogc:PropertyName>state_abbr</ogc:PropertyName><ogc:Literal>*I*</ogc:Literal></ogc:PropertyIsLike></ogc:And></ogc:And><ogc:Intersects><ogc:PropertyName>geometry</ogc:PropertyName><gml:Polygon srsName="EPSG:4326"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:And></ogc:Filter>`;
+export const resultSpatialFilterMultiple =
+    "<ogc:Filter><ogc:And><ogc:Or>"
+    + "<ogc:Intersects>"
+    + "<ogc:PropertyName>geometry</ogc:PropertyName>"
+    + "<gml:Polygon srsName=\"EPSG:4326\"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>"
+    + "</ogc:Intersects>"
+    + "<ogc:Intersects>"
+    + "<ogc:PropertyName>geometry</ogc:PropertyName>"
+    + "<gml:Polygon srsName=\"EPSG:4326\"><gml:exterior><gml:LinearRing><gml:posList>1 1 1 2 2 2 2 1 1 1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>"
+    + "</ogc:Intersects>"
+    + "</ogc:Or></ogc:And></ogc:Filter>";
 


### PR DESCRIPTION
## Description
Supports custom spatialFieldOperator for widgets.
It fixes the issue reported in comment https://github.com/geosolutions-it/MapStore2/issues/6186#issuecomment-732182526

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6186

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
