### PR TITLE
#6235 fix map sync button popup position

### DIFF
--- a/web/client/components/data/featuregrid/toolbars/TButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TButton.jsx
@@ -15,15 +15,14 @@ const hideStyle = {
 };
 const normalStyle = {};
 const getStyle = (visible) => visible ? normalStyle : hideStyle;
-
-export const SimpleTButton = ({disabled, id, visible, onClick, glyph, active, className = "square-button", ...props}) => {
-    return (<Button {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
-        style={getStyle(visible)}
-        className={className}
-        onClick={() => !disabled && onClick()}>
-        <Glyphicon glyph={glyph}/>
-    </Button>);
-};
-
-
-export default SimpleTButton;
+export default class SimpleTButton extends React.Component {
+    render() {
+        const { disabled, id, visible, onClick, glyph, active, className = "square-button", ...props } = this.props;
+        return (<Button {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
+            style={getStyle(visible)}
+            className={className}
+            onClick={() => !disabled && onClick()}>
+            <Glyphicon glyph={glyph} />
+        </Button>);
+    }
+}

--- a/web/client/components/data/featuregrid/toolbars/TButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TButton.jsx
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import { Button, Glyphicon } from 'react-bootstrap';
 
 const hideStyle = {
@@ -16,6 +18,18 @@ const hideStyle = {
 const normalStyle = {};
 const getStyle = (visible) => visible ? normalStyle : hideStyle;
 export default class SimpleTButton extends React.Component {
+    propTypes = {
+        disabled: PropTypes.bool,
+        id: PropTypes.string,
+        visible: PropTypes.bool,
+        onClick: PropTypes.func,
+        glyph: PropTypes.string,
+        active: PropTypes.bool,
+        className: PropTypes.string
+    }
+    defaultProps = {
+        className: "square-button"
+    }
     render() {
         const { disabled, id, visible, onClick, glyph, active, className = "square-button", ...props } = this.props;
         return (<Button {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}

--- a/web/client/components/data/featuregrid/toolbars/TButton.jsx
+++ b/web/client/components/data/featuregrid/toolbars/TButton.jsx
@@ -5,8 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { forwardRef } from 'react';
 
 import { Button, Glyphicon } from 'react-bootstrap';
 
@@ -17,26 +16,14 @@ const hideStyle = {
 };
 const normalStyle = {};
 const getStyle = (visible) => visible ? normalStyle : hideStyle;
-export default class SimpleTButton extends React.Component {
-    propTypes = {
-        disabled: PropTypes.bool,
-        id: PropTypes.string,
-        visible: PropTypes.bool,
-        onClick: PropTypes.func,
-        glyph: PropTypes.string,
-        active: PropTypes.bool,
-        className: PropTypes.string
-    }
-    defaultProps = {
-        className: "square-button"
-    }
-    render() {
-        const { disabled, id, visible, onClick, glyph, active, className = "square-button", ...props } = this.props;
-        return (<Button {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
-            style={getStyle(visible)}
-            className={className}
-            onClick={() => !disabled && onClick()}>
-            <Glyphicon glyph={glyph} />
-        </Button>);
-    }
-}
+export const SimpleTButton = forwardRef(({ disabled, id, visible, onClick, glyph, active, className = "square-button", ...props }, ref) => {
+    return (<Button ref={ref} {...props} bsStyle={active ? "success" : "primary"} disabled={disabled} id={`fg-${id}`}
+        style={getStyle(visible)}
+        className={className}
+        onClick={() => !disabled && onClick()}>
+        <Glyphicon glyph={glyph} />
+    </Button>);
+});
+
+
+export default SimpleTButton;


### PR DESCRIPTION
## Description
The problem is that SimpleTButton needed to be a class component. Going to convert from draft as well as added properties names.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6235
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
