### PR TITLE
#6238: Review parsing of properties with 0 values in the Visual Style Editor

### DIFF
--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -171,7 +171,7 @@ const property = {
         type: 'slider',
         label,
         config: {
-            range: { min: 0, max: 100 },
+            range: { min: 1, max: 100 },
             format: {
                 from: value => Math.round(value),
                 to: value => Math.round(value) + ' px'

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -263,6 +263,42 @@ export const filterArrayToFilterObject = (filterArr) => {
     };
 };
 
+/**
+ * Remove all invalid properties from a json symbolizer used by style editor
+ * @param  {object} symbolizer symbolizer object
+ * @return  {object} symbolizer without unused properties
+ */
+function cleanJSONSymbolizer(symbolizer) {
+    const symbolizerWithoutUndefined = omitBy(symbolizer, isUndefined);
+    const newSymbolizer = Object.keys(symbolizerWithoutUndefined).reduce((acc, key) => {
+        switch(key) {
+            case 'haloColor':
+            case 'haloWidth':
+                return symbolizerWithoutUndefined.kind === 'Text' && symbolizerWithoutUndefined.haloWidth === 0
+                    ? acc
+                    : { ...acc, [key]: symbolizerWithoutUndefined[key] };
+            case 'outlineWidth':
+            case 'outlineColor':
+            case 'outlineOpacity':
+                return symbolizerWithoutUndefined.kind === 'Fill' && symbolizerWithoutUndefined.outlineWidth === 0
+                    ? acc
+                    : { ...acc, [key]: symbolizerWithoutUndefined[key] };
+            case 'strokeWidth':
+            case 'strokeColor':
+            case 'strokeOpacity':
+                return symbolizerWithoutUndefined.kind === 'Mark' && symbolizerWithoutUndefined.strokeWidth === 0
+                    ? acc
+                    : { ...acc, [key]: symbolizerWithoutUndefined[key] };
+            case 'graphicFill':
+            case 'graphicStroke':
+                return { ...acc, [key]: cleanJSONSymbolizer(symbolizerWithoutUndefined[key]) };
+            default:
+                return { ...acc, [key]: symbolizerWithoutUndefined[key] };
+        } 
+    }, {});
+    return newSymbolizer;
+}
+
 export function parseJSONStyle(style) {
 
     if (!(style && style.rules)) {
@@ -293,7 +329,7 @@ export function parseJSONStyle(style) {
                             : undefined,
                         ...(rule.scaleDenominator && { scaleDenominator: rule.scaleDenominator }),
                         symbolizers: [
-                            omitBy({
+                            cleanJSONSymbolizer({
                                 ...omit(rule, [
                                     'ruleId',
                                     'classification',
@@ -306,7 +342,7 @@ export function parseJSONStyle(style) {
                                 ]),
                                 kind: rule.symbolizerKind || 'Fill',
                                 color: entry.color
-                            }, isUndefined)
+                            })
                         ]
                     };
                 });
@@ -325,7 +361,7 @@ export function parseJSONStyle(style) {
                     name: rule.name || '',
                     ...(rule.scaleDenominator && { scaleDenominator: rule.scaleDenominator }),
                     symbolizers: [
-                        omitBy({
+                        cleanJSONSymbolizer({
                             ...omit(rule, [
                                 'ruleId',
                                 'classification',
@@ -339,7 +375,7 @@ export function parseJSONStyle(style) {
                             ]),
                             kind: 'Raster',
                             ...(colorMap && { colorMap })
-                        }, isUndefined)
+                        })
                     ]
                 };
             }
@@ -350,7 +386,7 @@ export function parseJSONStyle(style) {
                 ...rule,
                 filter,
                 symbolizers: (rule?.symbolizers || [])
-                    .map((symbolizer) => omitBy(symbolizer, isUndefined))
+                    .map((symbolizer) => cleanJSONSymbolizer(symbolizer))
             };
         }))
     };

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -271,30 +271,30 @@ export const filterArrayToFilterObject = (filterArr) => {
 function cleanJSONSymbolizer(symbolizer) {
     const symbolizerWithoutUndefined = omitBy(symbolizer, isUndefined);
     const newSymbolizer = Object.keys(symbolizerWithoutUndefined).reduce((acc, key) => {
-        switch(key) {
-            case 'haloColor':
-            case 'haloWidth':
-                return symbolizerWithoutUndefined.kind === 'Text' && symbolizerWithoutUndefined.haloWidth === 0
-                    ? acc
-                    : { ...acc, [key]: symbolizerWithoutUndefined[key] };
-            case 'outlineWidth':
-            case 'outlineColor':
-            case 'outlineOpacity':
-                return symbolizerWithoutUndefined.kind === 'Fill' && symbolizerWithoutUndefined.outlineWidth === 0
-                    ? acc
-                    : { ...acc, [key]: symbolizerWithoutUndefined[key] };
-            case 'strokeWidth':
-            case 'strokeColor':
-            case 'strokeOpacity':
-                return symbolizerWithoutUndefined.kind === 'Mark' && symbolizerWithoutUndefined.strokeWidth === 0
-                    ? acc
-                    : { ...acc, [key]: symbolizerWithoutUndefined[key] };
-            case 'graphicFill':
-            case 'graphicStroke':
-                return { ...acc, [key]: cleanJSONSymbolizer(symbolizerWithoutUndefined[key]) };
-            default:
-                return { ...acc, [key]: symbolizerWithoutUndefined[key] };
-        } 
+        switch (key) {
+        case 'haloColor':
+        case 'haloWidth':
+            return symbolizerWithoutUndefined.kind === 'Text' && symbolizerWithoutUndefined.haloWidth === 0
+                ? acc
+                : { ...acc, [key]: symbolizerWithoutUndefined[key] };
+        case 'outlineWidth':
+        case 'outlineColor':
+        case 'outlineOpacity':
+            return symbolizerWithoutUndefined.kind === 'Fill' && symbolizerWithoutUndefined.outlineWidth === 0
+                ? acc
+                : { ...acc, [key]: symbolizerWithoutUndefined[key] };
+        case 'strokeWidth':
+        case 'strokeColor':
+        case 'strokeOpacity':
+            return symbolizerWithoutUndefined.kind === 'Mark' && symbolizerWithoutUndefined.strokeWidth === 0
+                ? acc
+                : { ...acc, [key]: symbolizerWithoutUndefined[key] };
+        case 'graphicFill':
+        case 'graphicStroke':
+            return { ...acc, [key]: cleanJSONSymbolizer(symbolizerWithoutUndefined[key]) };
+        default:
+            return { ...acc, [key]: symbolizerWithoutUndefined[key] };
+        }
     }, {});
     return newSymbolizer;
 }

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -546,4 +546,199 @@ describe('StyleEditorUtils test', () => {
             color: '#333333'
         });
     });
+    it('should remove halo if haloWidth is equal to 0', () => {
+        const style = {
+            name: 'Style',
+            rules: [ {
+                name: 'Rule',
+                symbolizers: [
+                    {
+                        allowOverlap: true,
+                        color: '#333333',
+                        fontStyle: 'normal',
+                        fontWeight: 'normal',
+                        haloColor: '#ffffff',
+                        haloWidth: 0,
+                        kind: 'Text',
+                        label: 'Label',
+                        offset: [0, 0],
+                        size: 14,
+                        symbolizerId: 'id'
+                    }
+                ]
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(1);
+        expect(formattedJSONStyle.rules[0].symbolizers[0]).toEqual({
+            allowOverlap: true,
+            color: '#333333',
+            fontStyle: 'normal',
+            fontWeight: 'normal',
+            kind: 'Text',
+            label: 'Label',
+            offset: [0, 0],
+            size: 14,
+            symbolizerId: 'id'
+        });
+    });
+    it('should remove outline if outlineWidth is equal to 0', () => {
+        const style = {
+            name: 'Style',
+            rules: [ {
+                name: 'Rule',
+                symbolizers: [
+                    {
+                        color: '#dddddd',
+                        fillOpacity: 1,
+                        kind: 'Fill',
+                        outlineColor: '#777777',
+                        outlineWidth: 0,
+                        symbolizerId: 'id'
+                    }
+                ]
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(1);
+        expect(formattedJSONStyle.rules[0].symbolizers[0]).toEqual({
+            color: '#dddddd',
+            fillOpacity: 1,
+            kind: 'Fill',
+            symbolizerId: 'id'
+        });
+    });
+    it('should remove stroke if strokeWidth is equal to 0', () => {
+        const style = {
+            name: 'Style',
+            rules: [ {
+                name: 'Rule',
+                symbolizers: [
+                    {
+                        color: '#dddddd',
+                        fillOpacity: 1,
+                        kind: 'Mark',
+                        radius: 16,
+                        rotate: 0,
+                        strokeColor: '#777777',
+                        strokeOpacity: 1,
+                        strokeWidth: 0,
+                        symbolizerId: 'id',
+                        wellKnownName: 'Circle'
+                    }
+                ]
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(1);
+        expect(formattedJSONStyle.rules[0].symbolizers[0]).toEqual({
+            color: '#dddddd',
+            fillOpacity: 1,
+            kind: 'Mark',
+            radius: 16,
+            rotate: 0,
+            symbolizerId: 'id',
+            wellKnownName: 'Circle'
+        });
+    });
+    it('should remove stroke in graphicStroke if strokeWidth is equal to 0', () => {
+        const style = {
+            name: 'Style',
+            rules: [ {
+                name: 'Rule',
+                symbolizers: [
+                    {
+                        cap: "round",
+                        color: "#777777",
+                        graphicStroke: {
+                            color: '#dddddd',
+                            fillOpacity: 1,
+                            kind: 'Mark',
+                            radius: 16,
+                            rotate: 0,
+                            strokeColor: '#777777',
+                            strokeOpacity: 1,
+                            strokeWidth: 0,
+                            wellKnownName: 'Circle'
+                        },
+                        join: 'round',
+                        kind: 'Line',
+                        opacity: 1,
+                        symbolizerId: 'id',
+                        width: 1
+                    }
+                ]
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(1);
+        expect(formattedJSONStyle.rules[0].symbolizers[0]).toEqual({
+            cap: "round",
+            color: "#777777",
+            graphicStroke: {
+                color: '#dddddd',
+                fillOpacity: 1,
+                kind: 'Mark',
+                radius: 16,
+                rotate: 0,
+                wellKnownName: 'Circle'
+            },
+            join: 'round',
+            kind: 'Line',
+            opacity: 1,
+            symbolizerId: 'id',
+            width: 1
+        });
+    });
+
+    it('should remove stroke in graphicFill if strokeWidth is equal to 0', () => {
+        const style = {
+            name: 'Style',
+            rules: [ {
+                name: 'Rule',
+                symbolizers: [
+                    {
+                        color: '#dddddd',
+                        fillOpacity: 1,
+                        graphicFill: {
+                            color: '#dddddd',
+                            fillOpacity: 1,
+                            kind: 'Mark',
+                            radius: 16,
+                            rotate: 0,
+                            strokeColor: '#777777',
+                            strokeOpacity: 1,
+                            strokeWidth: 0,
+                            wellKnownName: 'Circle'
+                        },
+                        kind: 'Fill',
+                        outlineColor: '#777777',
+                        outlineWidth: 0,
+                        symbolizerId: 'id'
+                    }
+                ]
+            }]
+        };
+
+        const formattedJSONStyle = parseJSONStyle(style);
+        expect(formattedJSONStyle.rules.length).toBe(1);
+        expect(formattedJSONStyle.rules[0].symbolizers[0]).toEqual({
+            color: '#dddddd',
+            fillOpacity: 1,
+            graphicFill: {
+                color: '#dddddd',
+                fillOpacity: 1,
+                kind: 'Mark',
+                radius: 16,
+                rotate: 0,
+                wellKnownName: 'Circle'
+            },
+            kind: 'Fill',
+            symbolizerId: 'id'
+        });
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds a function that clean symboizer object before they are used by style parser, with this improvement we could remove all unused properties and keep consistency in the rendering with different style encoding

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6238

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Added minimum size of 1px for properties listed in the issue and updated symbolizers to get the correct rendering of styles

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
