### PR TITLE
#6251: Fix default marker style

### DIFF
--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -493,6 +493,8 @@ class AnnotationsEditor extends React.Component {
                     onSetAnnotationMeasurement={this.setAnnotationMeasurement}
                     setPopupWarning={this.setPopupWarning}
                     showPopupWarning={this.props.showPopupWarning}
+                    defaultPointType={this.getConfig().defaultPointType}
+                    defaultStyles={this.props.defaultStyles}
                 />
                 }
             </div>
@@ -745,7 +747,6 @@ class AnnotationsEditor extends React.Component {
                                 defaultShapeSize={this.props.defaultShapeSize}
                                 defaultShapeFillColor={this.props.defaultShapeFillColor}
                                 defaultShapeStrokeColor={this.props.defaultShapeStrokeColor}
-                                defaultPointType={this.getConfig().defaultPointType}
                                 defaultStyles={this.props.defaultStyles}
                                 lineDashOptions={this.props.lineDashOptions}
                                 markersOptions={this.getConfig()}

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -34,7 +34,9 @@ const FeaturesList = (props) => {
         isMeasureEditDisabled,
         onSetAnnotationMeasurement,
         showPopupWarning,
-        setPopupWarning
+        setPopupWarning,
+        defaultStyles,
+        defaultPointType
     } = props;
     const {features = []} = editing || {};
     const isValidFeature = get(props, "selected.properties.isValidFeature", true);
@@ -71,7 +73,7 @@ const FeaturesList = (props) => {
                             visible: isMeasureEditDisabled,
                             disabled: !isValidFeature,
                             onClick: () => {
-                                const style = [{ ...DEFAULT_ANNOTATIONS_STYLES.Point, highlight: true, id: uuidv1()}];
+                                const style = [{ ...defaultStyles.POINT?.[defaultPointType], highlight: true, id: uuidv1()}];
                                 onClickGeometry("Point", style);
                             },
                             tooltip: <Message msgId="annotations.titles.marker" />,

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -219,7 +219,9 @@ FeaturesList.defaultProps = {
     onStyleGeometry: () => {},
     onSetAnnotationMeasurement: () => {},
     onSelectFeature: () => {},
-    isMeasureEditDisabled: true
+    setTabValue: () => {},
+    isMeasureEditDisabled: true,
+    defaultPointType: 'marker'
 };
 
 export default FeaturesList;

--- a/web/client/components/mapcontrols/annotations/__tests__/FeatureList-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/FeatureList-test.js
@@ -49,7 +49,56 @@ describe("test FeatureList component", () => {
         const buttons = container.querySelectorAll("button");
         expect(buttons.length).toBe(1);
     });
+    it('test geometries toolbar', () => {
+        const editing = {
+            features: [{
+                properties: {id: '1', isValidFeature: true, geometryTitle: 'Polygon'},
+                geometry: {type: "Polygon"}
+            }]
+        };
+        const actions = {
+            onAddGeometry: () => {},
+            onSetStyle: () => {},
+            onStyleGeometry: () => {},
+            onStartDrawing: () => {},
+            onAddText: () => {}
+        };
+        const defaultStyle = {POINT: {
+            marker: ["Test marker"],
+            symbol: ["Test symbol"]
+        }};
+        const spyOnAddGeometry = expect.spyOn(actions, "onAddGeometry");
+        const spyOnSetStyle = expect.spyOn(actions, "onSetStyle");
+        const spyOnStyleGeometry = expect.spyOn(actions, "onStyleGeometry");
+        const spyOnStartDrawing = expect.spyOn(actions, "onStartDrawing");
+        const spyOnAddText = expect.spyOn(actions, "onAddText");
+        ReactDOM.render(<FeaturesList editing={editing}
+            defaultStyles={defaultStyle}
+            defaultPointType={'symbol'}
+            onAddGeometry={actions.onAddGeometry}
+            onSetStyle={actions.onSetStyle}
+            onStyleGeometry={actions.onStyleGeometry}
+            onStartDrawing={actions.onStartDrawing}
+            onAddText={actions.onAddText}
+        />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container).toBeTruthy();
 
+        const geometriesToolbar = document.querySelector('.geometries-toolbar');
+        const buttons = geometriesToolbar.children[1].getElementsByTagName('button');
+        [...buttons].forEach((btn, index)=>{
+            TestUtils.Simulate.click(btn);
+            expect(spyOnSetStyle).toHaveBeenCalled();
+            if (index === 0) {
+                const [style] = spyOnSetStyle.calls[0].arguments[0];
+                expect(style["0"]).toEqual('Test symbol');
+            }
+            index === 3 && expect(spyOnAddText).toHaveBeenCalled();
+            expect(spyOnAddGeometry).toHaveBeenCalled();
+            expect(spyOnStartDrawing).toHaveBeenCalled();
+            expect(spyOnStyleGeometry).toHaveBeenCalled();
+        });
+    });
     it('test render with feature card', () => {
         const editing = {
             features: [{


### PR DESCRIPTION
## Description
This PR adds a fix to set default marker style from localConfig

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6251 

**What is the new behavior?**
Setting the defaultPointType parameter from localConfig will set the marker style accordingly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
