### PR TITLE
#6262: Modify true bearing label

### DIFF
--- a/web/client/components/map/leaflet/__tests__/MeasurementSupport-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/MeasurementSupport-test.jsx
@@ -341,7 +341,7 @@ describe('Leaflet MeasurementSupport', () => {
             }
         };
         let distanceStr = L.GeometryUtil.readableDistance(distance, isMetric, isFeet, isNauticalMile, precision, options);
-        expect(distanceStr).toBe("080° T");
+        expect(distanceStr).toBe("080°");
     });
     it('test L.GeometryUtil.readableDistance length with trehsold', () => {
         const distance = 1;
@@ -558,7 +558,7 @@ describe('Leaflet MeasurementSupport', () => {
         L.Draw.Polyline.prototype._markers = [L.marker([50.5, 30.5]), L.marker([52.5, 30.5])];
 
         let distanceStr = L.Draw.Polyline.prototype._getMeasurementString();
-        expect(distanceStr).toBe("084.8239° T");
+        expect(distanceStr).toBe("084.8239°");
 
     });
 

--- a/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
@@ -477,8 +477,8 @@ describe('Openlayers MeasurementSupport', () => {
         changedFeatures = spyOnChangeGeometry.calls[1].arguments[0];
         expect(spyOnChangeGeometry).toHaveBeenCalled();
         expect(changedFeatures[1].geometry.textLabels).toExist();
-        expect(changedFeatures[1].geometry.textLabels[0].text).toBe("4.99 m | 180° T");
-        expect(changedFeatures[1].geometry.textLabels[1].text).toBe("5.09 m | 168° T");
+        expect(changedFeatures[1].geometry.textLabels[0].text).toBe("4.99 m | 180°");
+        expect(changedFeatures[1].geometry.textLabels[1].text).toBe("5.09 m | 168°");
         expect(cmp.textLabels.length).toBe(4);
         expect(cmp.textLabels[2].type).toBe("LineString");
         expect(cmp.textLabels[2].textId).toBe(1);
@@ -522,8 +522,8 @@ describe('Openlayers MeasurementSupport', () => {
         expect(spyOnChangeGeometry).toHaveBeenCalled();
         let changedFeatures = spyOnChangeGeometry.calls[0].arguments[0];
         expect(changedFeatures[0].geometry.textLabels).toExist();
-        expect(changedFeatures[0].geometry.textLabels[0].text).toBe("4.99 m | 180° T");
-        expect(changedFeatures[0].geometry.textLabels[1].text).toBe("5.09 m | 168° T");
+        expect(changedFeatures[0].geometry.textLabels[0].text).toBe("4.99 m | 180°");
+        expect(changedFeatures[0].geometry.textLabels[1].text).toBe("5.09 m | 168°");
 
         // Hide show length and bearing combination label
         cmp = renderMeasurement({
@@ -602,7 +602,7 @@ describe('Openlayers MeasurementSupport', () => {
         expect(changedFeatures.length).toBe(1);
         expect(changedFeatures[0].type).toBe("Feature");
         expect(changedFeatures[0].geometry.coordinates.length).toBe(2);
-        expect(changedFeatures[0].properties.values[0].formattedValue).toContain("T");
+        expect(changedFeatures[0].properties.values[0].formattedValue).toNotContain("T");
         expect(changedFeatures[0].properties.values[0].type).toContain("bearing");
     });
     it('test drawState restore on geomType change', () => {

--- a/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
@@ -161,13 +161,13 @@ describe("test the CoordinatesEditor Panel", () => {
                     type: 'Polygon',
                     coordinates: [[10, 10], [6, 6], [6, 6]],
                     textLabels: [
-                        {text: '2 m | 060° T', position: [10, 10]},
-                        {text: '3 m | 078° T', position: [6, 6]},
-                        {text: '3 m | 090° T', position: [6, 6]}]},
+                        {text: '2 m | 060°', position: [10, 10]},
+                        {text: '3 m | 078°', position: [6, 6]},
+                        {text: '3 m | 090°', position: [6, 6]}]},
                 properties: {
                     values: [{
                         value: 100,
-                        formattedValue: '10 m | 070° T',
+                        formattedValue: '10 m | 070°',
                         position: [10, 10],
                         type: 'length'
                     }]}
@@ -195,9 +195,9 @@ describe("test the CoordinatesEditor Panel", () => {
         const inputs = TestUtils.scryRenderedDOMComponentsWithTag(editor, "input");
         const labelTexts = TestUtils.scryRenderedDOMComponentsWithClass(editor, "label-texts");
         expect(labelTexts).toExist();
-        expect(labelTexts[0].innerText).toBe("2 m | 060° T");
-        expect(labelTexts[1].innerText).toBe("3 m | 078° T");
-        expect(labelTexts[2].innerText).toBe("3 m | 090° T");
+        expect(labelTexts[0].innerText).toBe("2 m | 060°");
+        expect(labelTexts[1].innerText).toBe("3 m | 078°");
+        expect(labelTexts[2].innerText).toBe("3 m | 090°");
         const submits = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-ok");
         expect(submits).toExist();
         const submit = submits[0];
@@ -271,7 +271,7 @@ describe("test the CoordinatesEditor Panel", () => {
                 properties: {
                     values: [{
                         value: 100,
-                        formattedValue: '10 m | 070° T',
+                        formattedValue: '10 m | 070°',
                         position: [10, 10],
                         type: 'length'
                     }]}
@@ -298,7 +298,7 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(inputs).toExist();
         let labelTexts = TestUtils.scryRenderedDOMComponentsWithClass(editor, "label-texts");
         expect(labelTexts).toExist();
-        expect(labelTexts[1].innerText).toBe("10 m | 070° T");
+        expect(labelTexts[1].innerText).toBe("10 m | 070°");
         const submits = TestUtils.scryRenderedDOMComponentsWithClass(editor, "glyphicon-ok");
         expect(submits).toExist();
         const submit = submits[0];

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -238,7 +238,7 @@ describe("test the MeasureComponent", () => {
         cmp = ReactDOM.render(
             <MeasureComponent measurement={{...measurement, bearing: 45}} bearingMeasureEnabled bearingMeasureValueEnabled trueBearingLabel = {<Message msgId="True Bearing"/>}/>, document.getElementById("container")
         );
-        expect(bearingSpan.innerHTML).toBe("<h3><strong>045° T</strong></h3>");
+        expect(bearingSpan.innerHTML).toBe("<h3><strong>045°</strong></h3>");
 
         const bearingTitleText = TestUtils.findRenderedDOMComponentWithClass(cmp, 'form-group');
         expect(bearingTitleText.textContent).toContain('True Bearing');
@@ -246,17 +246,17 @@ describe("test the MeasureComponent", () => {
         cmp = ReactDOM.render(
             <MeasureComponent measurement={{...measurement, bearing: 135.235648, trueBearing: {...measurement.trueBearing, fractionDigits: 4}}} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
-        expect(bearingSpan.innerHTML).toBe("<h3><strong>135.2356° T</strong></h3>");
+        expect(bearingSpan.innerHTML).toBe("<h3><strong>135.2356°</strong></h3>");
 
         cmp = ReactDOM.render(
             <MeasureComponent measurement={{...measurement, bearing: 225.83202, trueBearing: {...measurement.trueBearing, fractionDigits: 2}}} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
-        expect(bearingSpan.innerHTML).toBe("<h3><strong>225.83° T</strong></h3>");
+        expect(bearingSpan.innerHTML).toBe("<h3><strong>225.83°</strong></h3>");
 
         cmp = ReactDOM.render(
             <MeasureComponent measurement={assign({}, measurement, {bearing: 315})} bearingMeasureEnabled bearingMeasureValueEnabled/>, document.getElementById("container")
         );
-        expect(bearingSpan.innerHTML).toBe("<h3><strong>315° T</strong></h3>");
+        expect(bearingSpan.innerHTML).toBe("<h3><strong>315°</strong></h3>");
     });
 
     it('test uom format area and lenght', () => {

--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -35,14 +35,14 @@ describe('measurement epics', () => {
                     ],
                     "textLabels": [
                         {
-                            "text": "2,937,911.16 m | 061.17° T",
+                            "text": "2,937,911.16 m | 061.17°",
                             "position": [
                                 -127.53661546263791,
                                 46.54526898530547
                             ]
                         },
                         {
-                            "text": "1,837,281.12 m | 140.72° T",
+                            "text": "1,837,281.12 m | 140.72°",
                             "position": [
                                 -101.23884662739748,
                                 42.09680198161091
@@ -67,14 +67,14 @@ describe('measurement epics', () => {
         ],
         "textLabels": [
             {
-                "text": "2,937,911.16 m | 061.17° T",
+                "text": "2,937,911.16 m | 061.17°",
                 "position": [
                     -127.53661546263791,
                     46.54526898530547
                 ]
             },
             {
-                "text": "1,837,281.12 m | 140.72° T",
+                "text": "1,837,281.12 m | 140.72°",
                 "position": [
                     -101.23884662739748,
                     42.09680198161091
@@ -137,8 +137,8 @@ describe('measurement epics', () => {
                 expect(resultFeatures.length).toBe(4);
                 expect(resultFeatures[0].geometry).toExist();
                 expect(resultFeatures[0].geometry.textLabels).toExist();
-                expect(resultFeatures[0].geometry.textLabels[0].text).toBe("2,937,911.16 m | 061.17° T");
-                expect(resultFeatures[0].geometry.textLabels[1].text).toBe("1,837,281.12 m | 140.72° T");
+                expect(resultFeatures[0].geometry.textLabels[0].text).toBe("2,937,911.16 m | 061.17°");
+                expect(resultFeatures[0].geometry.textLabels[1].text).toBe("1,837,281.12 m | 140.72°");
                 expect(resultFeatures[0].properties).toExist();
                 expect(resultFeatures[0].properties.geometryGeodesic).toExist();
                 done();
@@ -163,8 +163,8 @@ describe('measurement epics', () => {
                 expect(innerFeatures[0].geometry).toExist();
                 expect(innerFeatures[0].geometry.type).toBe('LineString');
                 expect(innerFeatures[0].geometry.textLabels).toExist();
-                expect(innerFeatures[0].geometry.textLabels[0].text).toBe("2,937,911.16 m | 061.17° T");
-                expect(innerFeatures[0].geometry.textLabels[1].text).toBe("1,837,281.12 m | 140.72° T");
+                expect(innerFeatures[0].geometry.textLabels[0].text).toBe("2,937,911.16 m | 061.17°");
+                expect(innerFeatures[0].geometry.textLabels[1].text).toBe("1,837,281.12 m | 140.72°");
                 done();
             }, null);
     });

--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -76,9 +76,9 @@ const toggleMeasureTool = toggleControl.bind(null, 'measure', null);
  * @prop {boolean} defaultOptions.showAddAsAnnotation: if true, shows the button addAsAnnotation in the toolbar
  * @prop {boolean} defaultOptions.showLengthAndBearingLabel: if true, shows the length and bearing data in the map as segment label and also in measurement panel
  * @prop {object} defaultOptions.trueBearing: allows measurement configuration of angular distance from true north to the object. ISO Spec (https://www.sis.se/api/document/preview/905247/)
- * @prop {boolean} defaultOptions.trueBearing.measureTrueBearing: if true, displays the measurement in true bearing (000° T).
+ * @prop {boolean} defaultOptions.trueBearing.measureTrueBearing: if true, displays the measurement in true bearing (000°).
  * @prop {integer} defaultOptions.trueBearing.fractionDigits: Value denotes the fractional digit to used for the representation of true bearing.
- * For example this enables measurement in true bearing with fractional digits of 2 (000.00° - 359.99° T)
+ * For example this enables measurement in true bearing with fractional digits of 2 (000.00° - 359.99°)
  * ```
  * "trueBearing": {
  *  "measureTrueBearing": true,

--- a/web/client/utils/MeasureUtils.js
+++ b/web/client/utils/MeasureUtils.js
@@ -39,7 +39,7 @@ export function getFormattedBearingValue(azimuth = 0, {measureTrueBearing = fals
             prefix = "0";
         }
         const adjValue = fractionDigits > 0  ? azimuth.toFixed(fractionDigits) : Math.floor(azimuth);
-        bearing =  prefix + adjValue + "° " + "T";
+        bearing =  prefix + adjValue + "°";
     }
 
     return bearing;

--- a/web/client/utils/__tests__/MeasureUtils-test.js
+++ b/web/client/utils/__tests__/MeasureUtils-test.js
@@ -96,13 +96,13 @@ describe('MeasureUtils', () => {
     it('test true bearing getFormattedBearingValue', () => {
         const trueBearing = {measureTrueBearing: true, fractionDigits: 0};
         let val = getFormattedBearingValue(1.111, trueBearing);
-        expect(val).toBe("001° T");
+        expect(val).toBe("001°");
         val = getFormattedBearingValue(91.111, trueBearing);
-        expect(val).toBe("091° T");
+        expect(val).toBe("091°");
         val = getFormattedBearingValue(181.111, {...trueBearing, fractionDigits: 2});
-        expect(val).toBe("181.11° T");
+        expect(val).toBe("181.11°");
         val = getFormattedBearingValue(320.58921, {...trueBearing, fractionDigits: 4});
-        expect(val).toBe("320.5892° T");
+        expect(val).toBe("320.5892°");
     });
     it('testing isValidGeometry() with all valid coords (line geom)', () => {
         const isValid = isValidGeometry(lineFeature.geometry);


### PR DESCRIPTION
## Description
This PR modifies the true bearing label by removing the notation ""T""

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#6262 

**What is the new behavior?**
The true bearing label will be displayed as Ex: 050° and not as 050° T

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
