### PR TITLE
Restore initial position after feature info close

### DIFF
--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -279,7 +279,7 @@ export const zoomToVisibleAreaEpic = (action$, store) =>
         .filter(() => centerToMarkerSelector(store.getState()))
         .switchMap((action) =>
             action$.ofType(LOAD_FEATURE_INFO, ERROR_FEATURE_INFO)
-                .switchMap(() => {
+                .mergeMap(() => {
                     const state = store.getState();
                     const map = mapSelector(state);
                     const mapProjection = projectionSelector(state);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes a regression that occured, where when the feature info is closed, the map is not restored to initial position

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
[#241](https://github.com/geosolutions-it/austrocontrol-C125/issues/241)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
This PR fixes a regression that occured, where when the feature info is closed, the map is not restored to initial position

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
