### PR TITLE
#6266: Allow override of default user locale via localConfig.json 

### DIFF
--- a/docs/developer-guide/internationalization.md
+++ b/docs/developer-guide/internationalization.md
@@ -48,6 +48,43 @@ Setting locales in localConfig.json file is doable only for supported locales pr
 The default behavior is to use those already configured in "supportedLocales" object.
 You can customize the messages by editing the data.code-CODE.json files.
 
+You can also add the `defaultUserLocale` property to localConfig.json to override the initial user locale:
+```javascript
+{
+    "defaultUserLocale": "it",
+
+    "defaultState": {
+        "locales": {
+            "supportedLocales": {
+                "en": {
+                    "code": "en-EN",
+                    "description": "English"
+                },
+                "it": {
+                    "code": "it-IT",
+                    "description": "Italiano"
+                }
+            }
+        }
+    }
+}
+```
+MapStore will select the initial user locale based on the browser language and the supported locales if the `defaultUserLocale` is not defined.
+The property `defaultUserLocale` could be useful inside custom application where the locale is stored in other sources rather than using the browser language:
+
+```javascript
+// example
+import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
+import cookies from 'js-cookie';
+
+// ...
+const defaultUserLocale = cookies.get('default_app_locale');
+if (defaultUserLocale) {
+  setConfigProp('defaultUserLocale', defaultUserLocale);
+}
+// ...
+```
+
 # How to add a new language
 
 Let's say we want to add the russian language.

--- a/docs/developer-guide/internationalization.md
+++ b/docs/developer-guide/internationalization.md
@@ -51,7 +51,7 @@ You can customize the messages by editing the data.code-CODE.json files.
 You can also add the `defaultUserLocale` property to localConfig.json to override the initial user locale:
 ```javascript
 {
-    "defaultUserLocale": "it",
+    "defaultUserLocale": "it-IT",
 
     "defaultState": {
         "locales": {

--- a/docs/developer-guide/internationalization.md
+++ b/docs/developer-guide/internationalization.md
@@ -32,7 +32,7 @@ You can configure MapStore to provide to the user only a restricted list of sele
     "locales": {
         "supportedLocales": {
             "en": {
-                "code": "en-EN",
+                "code": "en-US",
                 "description": "English"
             },
             "it": {
@@ -48,16 +48,18 @@ Setting locales in localConfig.json file is doable only for supported locales pr
 The default behavior is to use those already configured in "supportedLocales" object.
 You can customize the messages by editing the data.code-CODE.json files.
 
-You can also add the `defaultUserLocale` property to localConfig.json to override the initial user locale:
+The `locale` property determines the language to use for the application. If not specified, the language will be selected checking the browser's locale first. If the browser locale is not supported, MapStore will select the first language available in `supportedLocales`.
+
+Example of localConfig.json with the optional locale property.
 ```javascript
 {
-    "defaultUserLocale": "it-IT",
+    "locale": "it-IT", // locale code
 
     "defaultState": {
         "locales": {
             "supportedLocales": {
                 "en": {
-                    "code": "en-EN",
+                    "code": "en-US",
                     "description": "English"
                 },
                 "it": {
@@ -69,8 +71,7 @@ You can also add the `defaultUserLocale` property to localConfig.json to overrid
     }
 }
 ```
-MapStore will select the initial user locale based on the browser language and the supported locales if the `defaultUserLocale` is not defined.
-The property `defaultUserLocale` could be useful inside custom application where the locale is stored in other sources rather than using the browser language:
+The property `locale` could be useful inside custom application where the locale is stored in other sources rather than using the browser language:
 
 ```javascript
 // example
@@ -78,9 +79,9 @@ import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import cookies from 'js-cookie';
 
 // ...
-const defaultUserLocale = cookies.get('default_app_locale');
-if (defaultUserLocale) {
-  setConfigProp('defaultUserLocale', defaultUserLocale);
+const locale = cookies.get('app_locale'); // locale code it-IT for example
+if (locale) {
+  setConfigProp('locale', locale);
 }
 // ...
 ```

--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -18,7 +18,6 @@ import { localConfigLoaded } from '../../actions/localConfig';
 import { loadPrintCapabilities } from '../../actions/print';
 
 import ConfigUtils from '../../utils/ConfigUtils';
-import {getUserLocale} from '../../utils/LocaleUtils';
 import PluginsUtils from '../../utils/PluginsUtils';
 
 import url from 'url';
@@ -172,7 +171,7 @@ class StandardApp extends React.Component {
         if (this.props.onInit) {
             this.props.onInit(this.store, this.afterInit.bind(this, [config]), config);
         } else {
-            const locale = getUserLocale();
+            const locale = ConfigUtils.getConfigProp('defaultUserLocale');
             this.store.dispatch(loadLocale(null, locale));
             this.afterInit(config);
         }

--- a/web/client/components/app/StandardApp.jsx
+++ b/web/client/components/app/StandardApp.jsx
@@ -171,7 +171,7 @@ class StandardApp extends React.Component {
         if (this.props.onInit) {
             this.props.onInit(this.store, this.afterInit.bind(this, [config]), config);
         } else {
-            const locale = ConfigUtils.getConfigProp('defaultUserLocale');
+            const locale = ConfigUtils.getConfigProp('locale');
             this.store.dispatch(loadLocale(null, locale));
             this.afterInit(config);
         }

--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -60,7 +60,7 @@ function withExtensions(AppComponent) {
             if (translations.length > 0) {
                 ConfigUtils.setConfigProp("translationsPath", [...castArray(ConfigUtils.getConfigProp("translationsPath")), ...translations.map(this.getAssetPath)]);
             }
-            const locale =  ConfigUtils.getConfigProp('defaultUserLocale');
+            const locale =  ConfigUtils.getConfigProp('locale');
             store.dispatch(loadLocale(null, locale));
         };
 

--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -9,7 +9,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { loadLocale } from '../../actions/locale';
-import {getUserLocale} from '../../utils/LocaleUtils';
 import castArray from 'lodash/castArray';
 import axios from '../../libs/ajax';
 import ConfigUtils from '../../utils/ConfigUtils';
@@ -61,7 +60,7 @@ function withExtensions(AppComponent) {
             if (translations.length > 0) {
                 ConfigUtils.setConfigProp("translationsPath", [...castArray(ConfigUtils.getConfigProp("translationsPath")), ...translations.map(this.getAssetPath)]);
             }
-            const locale = getUserLocale();
+            const locale =  ConfigUtils.getConfigProp('defaultUserLocale');
             store.dispatch(loadLocale(null, locale));
         };
 

--- a/web/client/examples/featuregrid/app.jsx
+++ b/web/client/examples/featuregrid/app.jsx
@@ -14,7 +14,6 @@ const {changeBrowserProperties} = require('../../actions/browser');
 const {loadLocale} = require('../../actions/locale');
 
 const ConfigUtils = require('../../utils/ConfigUtils').default;
-const {getUserLocale} = require('../../utils/LocaleUtils');
 const {getPlugins} = require('../../utils/PluginsUtils');
 
 
@@ -27,7 +26,7 @@ function startApp() {
 
     store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
     ConfigUtils.loadConfiguration().then(() => {
-        let locale = getUserLocale();
+        let locale = ConfigUtils.getConfigProp('defaultUserLocale');
         store.dispatch(loadLocale('../../translations', locale));
     });
 

--- a/web/client/examples/featuregrid/app.jsx
+++ b/web/client/examples/featuregrid/app.jsx
@@ -14,6 +14,7 @@ const {changeBrowserProperties} = require('../../actions/browser');
 const {loadLocale} = require('../../actions/locale');
 
 const ConfigUtils = require('../../utils/ConfigUtils').default;
+const {getUserLocale} = require('../../utils/LocaleUtils');
 const {getPlugins} = require('../../utils/PluginsUtils');
 
 
@@ -26,7 +27,7 @@ function startApp() {
 
     store.dispatch(changeBrowserProperties(ConfigUtils.getBrowserProperties()));
     ConfigUtils.loadConfiguration().then(() => {
-        let locale = ConfigUtils.getConfigProp('defaultUserLocale');
+        let locale = getUserLocale();
         store.dispatch(loadLocale('../../translations', locale));
     });
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces the `locale` property inside of localConfig to allow override of the initial user locale.
Some examples:

- force default initial language
```
{
    "locale": "it-IT",

    "defaultState": {
        "locales": {
            "supportedLocales": {
                "en": {
                    "code": "en-EN",
                    "description": "English"
                },
                "it": {
                    "code": "it-IT",
                    "description": "Italiano"
                }
            }
        }
    }
}
```
- custom app
```js
import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
import cookies from 'js-cookie';
const locale = cookies.get('locale');
if (locale) {
  setConfigProp('locale', locale);
}
```

This PR removes also `getUserLocale()` inside StandardApp because it's a duplication. See [loadLocale](https://github.com/geosolutions-it/MapStore2/blob/v2020.02.02/web/client/actions/locale.js#L68) thunk where the fallback locale is `getUserLocale()` if the language is undefined.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6266

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
It's possible to set `locale` property in localConfig.json to override the initial user locale of StandardApp. This enhancement should not change current behaviour of MapStore product so it should display the language of the browser as before.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information


