### PR TITLE
#6053: Improved error handling for extensions

### DIFF
--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -145,11 +145,21 @@ function withExtensions(AppComponent) {
                                 };
                                 return { plugin: pluginDef, translations: plugins[pluginName].translations || "" };
                             });
+                        }).catch(e => {
+                            // log the errors before re-throwing
+                            console.error(`Error loading MapStore extension "${pluginName}":`, e); // eslint-disable-line
+                            return null;
                         });
                     })).then((loaded) => {
-                        callback(loaded.reduce((previous, current) => {
-                            return { ...previous, ...current.plugin };
-                        }, {}), loaded.map(p => p.translations).filter(p => p !== ""));
+                        callback(
+                            loaded
+                                .filter(l => l !== null) // exclude extensions that triggered errors
+                                .reduce((previous, current) => {
+                                    return { ...previous, ...current.plugin };
+                                }, {}),
+                            loaded
+                                .filter(l => l !== null) // exclude extensions that triggered errors
+                                .map(p => p.translations).filter(p => p !== ""));
                     }).catch(() => {
                         callback({}, []);
                     });


### PR DESCRIPTION
- If one extension loading caused problems, the others are anyway are loaded. 
- If one extension loading / eval causes an error, the error is logged error is logged reporting the exception and the plugin name that caused it. 

## Description

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6053
**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
