### PR TITLE
#6254: The Embed mode is no longer present for the map in the Contents section

### DIFF
--- a/web/client/plugins/maps/MapsGrid.jsx
+++ b/web/client/plugins/maps/MapsGrid.jsx
@@ -40,7 +40,7 @@ export default compose(
     resourceGrid,
     // add and configure share tool panel
     compose(
-        defaultProps({ shareOptions: { embedPanel: false } }),
+        defaultProps({ shareOptions: { embedPanel: true } }),
         withShareTool
     )
 )(ResourceGrid);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Show embed panel on Contents section

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6254 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Show embed panel on Contents section

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
