### PR TITLE
#6263: Enhance saving annotation and geometry

### DIFF
--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -335,7 +335,7 @@ class AnnotationsEditor extends React.Component {
                                 onClick: () => {
                                     this.setState({removing: this.props.id});
                                 }
-                            }, {  // TODO should this be included on geometry card
+                            }, {
                                 glyph: 'download',
                                 tooltip: <Message msgId="annotations.downloadcurrenttooltip" />,
                                 visible: true,
@@ -396,7 +396,7 @@ class AnnotationsEditor extends React.Component {
                             {
                                 glyph: 'download',
                                 tooltip: <Message msgId="annotations.downloadcurrenttooltip" />,
-                                disabled: Object.keys(this.validate()).length !== 0,
+                                disabled: Object.keys(this.validate()).length !== 0 || this.props.unsavedChanges,
                                 visible: !this.props.selected,
                                 onClick: () => {
                                     const {newFeature, ...features} = this.props.editing;
@@ -587,6 +587,7 @@ class AnnotationsEditor extends React.Component {
                     this.state.removing && this.setState({removing: null});
                     this.props.onCancelRemove();
                 }}
+                focusConfirm={this.props.removing}
                 onConfirm={() => {
                     if (this.state.removing) {
                         this.setState({removing: null});
@@ -819,14 +820,17 @@ class AnnotationsEditor extends React.Component {
     }
 
     save = () => {
-        const errors = this.validate();
-        if (Object.keys(errors).length === 0) {
-            this.props.onError({});
-            this.props.selected ? this.props.onAddNewFeature() :
+        if (!isEmpty(this.props.selected)) {
+            this.props.onAddNewFeature();
+        } else {
+            const errors = this.validate();
+            if (Object.keys(errors).length === 0) {
+                this.props.onError({});
                 this.props.onSave(this.props.id, assign({}, this.props.editedFields),
                     this.props.editing.features, this.props.editing.style, this.props.editing.newFeature || false, this.props.editing.properties);
-        } else {
-            this.props.onError(errors);
+            } else {
+                this.props.onError(errors);
+            }
         }
     };
 

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -142,7 +142,7 @@ describe("test the AnnotationsEditor Panel", () => {
 
     });
 
-    it('test click save', () => {
+    it('test click save annotation', () => {
         const feature = {
             id: "1",
             title: 'mytitle',
@@ -174,6 +174,40 @@ describe("test the AnnotationsEditor Panel", () => {
         TestUtils.Simulate.click(saveButton);
         expect(spySave.calls.length).toEqual(1);
         expect(spyCancel.calls.length).toEqual(0);
+    });
+
+    it('test click save annotation', () => {
+        const feature = {
+            id: "1",
+            title: 'mytitle',
+            description: '<span><i>desc</i></span>'
+        };
+
+        const testHandlers = {
+            onAddNewFeature: () => {}
+        };
+
+        const spySaveGeometry = expect.spyOn(testHandlers, 'onAddNewFeature');
+        const defaultStyles = {POINT: {
+            marker: ["Test marker"],
+            symbol: ["Test symbol"]
+        }};
+        const viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions}
+            selected={{features: [], properties: {isValidFeature: true}}}
+            editing={{
+                properties: feature,
+                features: [{}]
+            }}
+            defaultStyles={defaultStyles}
+            onAddNewFeature={testHandlers.onAddNewFeature}
+        />, document.getElementById("container"));
+        expect(viewer).toExist();
+
+        let saveButton = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithTag(viewer, "button")[1]);
+
+        expect(saveButton).toExist();
+        TestUtils.Simulate.click(saveButton);
+        expect(spySaveGeometry).toHaveBeenCalled();
     });
 
     it('test click cancel', () => {
@@ -483,7 +517,7 @@ describe("test the AnnotationsEditor Panel", () => {
         };
 
         const spyOnDownload = expect.spyOn(actions, 'onDownload');
-        const viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions}
+        let viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions}
             onDownload={actions.onDownload}
             editing={{
                 features: [{id: "1"}],
@@ -492,20 +526,43 @@ describe("test the AnnotationsEditor Panel", () => {
             }}/>, document.getElementById("container"));
 
         expect(viewer).toExist();
-        const viewerNode = ReactDOM.findDOMNode(viewer);
+        let viewerNode = ReactDOM.findDOMNode(viewer);
         expect(viewerNode.className).toBe('mapstore-annotations-info-viewer');
 
-        const buttonsRow = viewerNode.querySelector('.mapstore-annotations-info-viewer-buttons .noTopMargin');
+        let buttonsRow = viewerNode.querySelector('.mapstore-annotations-info-viewer-buttons .noTopMargin');
         expect(buttonsRow).toBeTruthy();
 
-        const buttons = buttonsRow.querySelectorAll('button');
+        let buttons = buttonsRow.querySelectorAll('button');
         expect(buttons.length).toBe(4);
 
-        const downloadCurrentAnnotation = buttons[3];
-        expect(downloadCurrentAnnotation.disabled).toBe(false);
+        let downloadCurrentAnnotation = buttons[3];
+        expect(downloadCurrentAnnotation.classList.contains('disabled')).toBe(false);
 
         TestUtils.Simulate.click(downloadCurrentAnnotation);
         expect(spyOnDownload).toHaveBeenCalled();
         expect(spyOnDownload.calls[0].arguments[0]).toEqual({features: [{id: "1"}], properties: feature});
+    });
+    it('test onDownload when unsavedChanges', ()=>{
+        const feature = {
+            id: "1",
+            title: 'mytitle',
+            description: '<span><i>desc</i></span>'
+        };
+
+        const viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions}
+            onDownload={actions.onDownload}
+            unsavedChanges
+            editing={{
+                features: [{id: "1"}],
+                properties: feature,
+                newFeature: true
+            }}/>, document.getElementById("container"));
+
+        expect(viewer).toExist();
+        const viewerNode = ReactDOM.findDOMNode(viewer);
+        const buttonsRow = viewerNode.querySelector('.mapstore-annotations-info-viewer-buttons .noTopMargin');
+        const buttons = buttonsRow.querySelectorAll('button');
+        const downloadCurrentAnnotation = buttons[3];
+        expect(downloadCurrentAnnotation.classList.contains('disabled')).toBe(true);
     });
 });

--- a/web/client/components/misc/ConfirmDialog.jsx
+++ b/web/client/components/misc/ConfirmDialog.jsx
@@ -9,6 +9,7 @@
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { ButtonGroup, Glyphicon } from 'react-bootstrap';
 
 import Button from '../misc/Button';
@@ -35,7 +36,8 @@ class ConfirmDialog extends React.Component {
         confirmButtonContent: PropTypes.node,
         confirmButtonDisabled: PropTypes.bool,
         closeText: PropTypes.node,
-        confirmButtonBSStyle: PropTypes.string
+        confirmButtonBSStyle: PropTypes.string,
+        focusConfirm: PropTypes.bool
     };
 
     static defaultProps = {
@@ -48,8 +50,13 @@ class ConfirmDialog extends React.Component {
         confirmButtonDisabled: false,
         confirmButtonContent: <Message msgId="confirm" /> || "Confirm",
         closeText: <Message msgId="close" />,
-        includeCloseButton: true
+        includeCloseButton: true,
+        focusConfirm: false
     };
+
+    componentDidMount() {
+        this.props.focusConfirm && ReactDOM.findDOMNode(this.confirm).focus();
+    }
 
     render() {
         return (<Dialog draggable={this.props.draggable} onClickOut={this.props.onClose} id="confirm-dialog" modal={this.props.modal} style={assign({}, this.props.style, { display: this.props.show ? "block" : "none" })}>
@@ -64,13 +71,15 @@ class ConfirmDialog extends React.Component {
             </div>
             <div role="footer">
                 <ButtonGroup>
-                    <Button onClick={this.props.onConfirm} disabled={this.props.confirmButtonDisabled} bsStyle={this.props.confirmButtonBSStyle}>{this.props.confirmButtonContent}
+                    <Button ref={this.setConfirmRef} onClick={this.props.onConfirm} disabled={this.props.confirmButtonDisabled} bsStyle={this.props.confirmButtonBSStyle}>{this.props.confirmButtonContent}
                     </Button>
                     <Button onClick={this.props.onClose}>{this.props.closeText}</Button>
                 </ButtonGroup>
             </div>
         </Dialog>);
     }
+
+    setConfirmRef = (c) => { this.confirm = c; return this.confirm; };
 }
 
 export default ConfirmDialog;

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -272,6 +272,7 @@
         justify-content: flex-end;
     }
     .coordinates-row-container {
+        font-size: @font-size-small;
         flex: 1 1 auto;
         overflow: hidden auto;
         .glyphicon-menu-hamburger{
@@ -280,6 +281,9 @@
             vertical-align: middle;
         }
         .coordinateRow.aeronautical{
+            span.react-numeric-input{
+                width: 100%
+            }
             .input-group-addon {
                 padding: 4px 6px;
             }
@@ -451,7 +455,7 @@
             }
         }
         .coordinateRow {
-            padding-left: 8px;
+            padding-left: 2px;
             margin: 0;
             .coordinate {
                 display: flex;


### PR DESCRIPTION
## Description
This PR adds some enhancement to saving geometry and annotations

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#6263 

**What is the new behavior?**
- Save geometry doesn't invoke validation on annotation specific fields (Title and description)
- Confirm button on delete geometry will be in focus for easier delete
- Disable the download annotation button when there are unsaved changes

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
