### PR TITLE
#6180: Save MapSwipe configuration inside the map

### DIFF
--- a/web/client/actions/__tests__/swipe-test.js
+++ b/web/client/actions/__tests__/swipe-test.js
@@ -12,10 +12,12 @@ import {
     setMode,
     setSpyToolRadius,
     setSwipeToolDirection,
+    setSwipeToolConfig,
     SET_ACTIVE,
     SET_MODE,
     SET_SWIPE_TOOL_DIRECTION,
-    SET_SPY_TOOL_RADIUS
+    SET_SPY_TOOL_RADIUS,
+    SET_SWIPE_TOOL_CONFIG
 } from '../swipe';
 
 describe('Test correctness of the swipe actions', () => {
@@ -52,5 +54,12 @@ describe('Test correctness of the swipe actions', () => {
         expect(action).toExist();
         expect(action.type).toBe(SET_SPY_TOOL_RADIUS);
         expect(action.radius).toBe(80);
+    });
+    it('should set tool configuration', () => {
+        const config = { mode: "spy", spy: {radius: 50.00} };
+        const action = setSwipeToolConfig(config);
+        expect(action).toExist();
+        expect(action.type).toBe(SET_SWIPE_TOOL_CONFIG);
+        expect(action.config).toEqual(config);
     });
 });

--- a/web/client/actions/swipe.js
+++ b/web/client/actions/swipe.js
@@ -10,6 +10,20 @@ const SET_ACTIVE = "SWIPE:SET_ACTIVE";
 const SET_MODE = "SWIPE:SET_MODE";
 const SET_SWIPE_TOOL_DIRECTION = "SWIPE:SET_SWIPE_TOOL_DIRECTION";
 const SET_SPY_TOOL_RADIUS = "SWIPE:SET_SPY_TOOL_RADIUS";
+const SET_SWIPE_TOOL_CONFIG = "SWIPE:SET_SWIPE_TOOL_CONFIG";
+
+/**
+ * Sets the configuration for swipe tool, for example from persisted state
+ * @memberof actions.swipe
+ * @param {object} config the tool configuration like { mode: "spy", spy: {radius: 50.00} }
+ * @return {object} of type `SET_SWIPE_TOOL_CONFIG` with config
+ */
+function setSwipeToolConfig(config) {
+    return {
+        type: SET_SWIPE_TOOL_CONFIG,
+        config
+    };
+}
 
 /**
 * Sets the status of boolean values of the swipe redux state
@@ -70,8 +84,10 @@ export {
     setMode,
     setSwipeToolDirection,
     setSpyToolRadius,
+    setSwipeToolConfig,
     SET_ACTIVE,
     SET_MODE,
     SET_SWIPE_TOOL_DIRECTION,
-    SET_SPY_TOOL_RADIUS
+    SET_SPY_TOOL_RADIUS,
+    SET_SWIPE_TOOL_CONFIG
 };

--- a/web/client/epics/__tests__/swipe-test.js
+++ b/web/client/epics/__tests__/swipe-test.js
@@ -7,10 +7,11 @@
  */
 import expect from 'expect';
 
-import { resetLayerSwipeSettingsEpic } from '../swipe';
+import { resetLayerSwipeSettingsEpic, updateSwipeToolConfigMapConfigRawData } from '../swipe';
 import { selectNode } from '../../actions/layers';
 import { testEpic } from './epicTestUtils';
-import { SET_ACTIVE } from '../../actions/swipe';
+import { SET_ACTIVE, SET_SWIPE_TOOL_CONFIG } from '../../actions/swipe';
+import { configureMap } from '../../actions/config';
 
 describe('SWIPE EPICS', () => {
     it('reset activation of layer swipe tool selected nodeType is group', done => {
@@ -27,6 +28,26 @@ describe('SWIPE EPICS', () => {
                 expect(actions.length).toBe(1);
                 expect(actions[0].type).toEqual(SET_ACTIVE);
                 expect(actions[0].active).toEqual(false);
+                done();
+            }, state, done);
+    });
+    it('should update swipe tool state with config from map config raw data', done => {
+        const state = {
+            swipe: {}
+        };
+        const config = {
+            swipe: {
+                mode: "spy",
+                spy: {radius: 50.00} }
+        };
+        testEpic(
+            updateSwipeToolConfigMapConfigRawData,
+            1,
+            configureMap(config, 'map_id', undefined),
+            actions => {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toEqual(SET_SWIPE_TOOL_CONFIG);
+                expect(actions[0].config).toEqual(config.swipe);
                 done();
             }, state, done);
     });

--- a/web/client/epics/swipe.js
+++ b/web/client/epics/swipe.js
@@ -9,8 +9,9 @@
 import Rx from 'rxjs';
 
 import { SELECT_NODE } from '../actions/layers';
-import { setActive } from '../actions/swipe';
+import { setActive, setSwipeToolConfig } from '../actions/swipe';
 import { layerSwipeSettingsSelector } from '../selectors/swipe';
+import { MAP_CONFIG_LOADED } from '../actions/config';
 
 /**
  * Ensures that swipeSettings active is changed back to false when a layer is deselected in TOC or group is selected
@@ -29,6 +30,13 @@ export const resetLayerSwipeSettingsEpic = (action$, store) =>
                 : Rx.Observable.empty();
         });
 
+export const updateSwipeToolConfigMapConfigRawData = action$ =>
+    action$.ofType(MAP_CONFIG_LOADED)
+        .switchMap(({config}) => {
+            return Rx.Observable.of(setSwipeToolConfig(config.swipe || {}));
+        });
+
 export default {
-    resetLayerSwipeSettingsEpic
+    resetLayerSwipeSettingsEpic,
+    updateSwipeToolConfigMapConfigRawData
 };

--- a/web/client/plugins/Swipe.jsx
+++ b/web/client/plugins/Swipe.jsx
@@ -6,12 +6,18 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import { getSelectedLayer } from '../selectors/layers';
-import { layerSwipeSettingsSelector, swipeModeSettingsSelector, spyModeSettingsSelector } from '../selectors/swipe';
+import {
+    layerSwipeSettingsSelector,
+    swipeModeSettingsSelector,
+    spyModeSettingsSelector,
+    swipeToolConfigurationSelector
+} from '../selectors/swipe';
+import { registerCustomSaveHandler } from '../selectors/mapsave';
 import swipe from '../reducers/swipe';
 import epics from '../epics/swipe';
 import {
@@ -28,6 +34,9 @@ import SwipeButton from './swipe/SwipeButton';
 
 
 export const Support = ({ mode, map, layer, active, swipeModeSettings, spyModeSettings }) => {
+    useEffect(() => {
+        registerCustomSaveHandler('swipe', swipeToolConfigurationSelector);
+    }, []);
     if (mode === "spy") {
         return <SpyGlassSupport map={map} layer={layer} active={active} radius={spyModeSettings.radius} />;
     }

--- a/web/client/reducers/__tests__/swipe-test.js
+++ b/web/client/reducers/__tests__/swipe-test.js
@@ -7,7 +7,7 @@
  */
 import expect from 'expect';
 
-import { SET_ACTIVE, SET_SPY_TOOL_RADIUS, SET_MODE, SET_SWIPE_TOOL_DIRECTION  } from '../../actions/swipe';
+import { SET_ACTIVE, SET_SPY_TOOL_RADIUS, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SWIPE_TOOL_CONFIG  } from '../../actions/swipe';
 import swipe from '../swipe';
 
 describe('Swipe tool REDUCERS', () => {
@@ -56,5 +56,14 @@ describe('Swipe tool REDUCERS', () => {
         };
         const state = swipe({}, action);
         expect(state.spy.radius).toBe(80);
+    });
+    it('should update swipe tool state with config', () => {
+        const action = {
+            type: SET_SWIPE_TOOL_CONFIG,
+            config: { mode: "spy", spy: {radius: 50.00} }
+        };
+        const state = swipe({}, action);
+        expect(state.mode).toBe("spy");
+        expect(state.spy.radius).toBe(50.00);
     });
 });

--- a/web/client/reducers/swipe.js
+++ b/web/client/reducers/swipe.js
@@ -7,7 +7,7 @@
  */
 
 import assign from 'object-assign';
-import { SET_ACTIVE, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SPY_TOOL_RADIUS } from '../actions/swipe';
+import { SET_ACTIVE, SET_MODE, SET_SWIPE_TOOL_DIRECTION, SET_SPY_TOOL_RADIUS, SET_SWIPE_TOOL_CONFIG } from '../actions/swipe';
 
 export default (state = {}, action) => {
     switch (action.type) {
@@ -30,6 +30,9 @@ export default (state = {}, action) => {
             radius: action.radius
         };
         return assign({}, state, {spy: newSpySetting});
+    }
+    case SET_SWIPE_TOOL_CONFIG: {
+        return assign({}, state, action.config);
     }
     default:
         return state;

--- a/web/client/selectors/__tests__/swipe-test.js
+++ b/web/client/selectors/__tests__/swipe-test.js
@@ -7,7 +7,7 @@
 */
 import expect from 'expect';
 
-import { layerSwipeSettingsSelector, spyModeSettingsSelector, swipeModeSettingsSelector} from '../swipe';
+import { layerSwipeSettingsSelector, spyModeSettingsSelector, swipeModeSettingsSelector, swipeToolCurrentModeSelector, swipeToolConfigurationSelector} from '../swipe';
 
 describe('SWIPE SELECTORS', () => {
     it('should test layerSwipeSettingsSelector', () => {
@@ -42,5 +42,41 @@ describe('SWIPE SELECTORS', () => {
         };
 
         expect(swipeModeSettingsSelector(state)).toEqual(state.swipe.swipe);
+    });
+    it('should test swipeToolCurrentModeSelector', () => {
+        const state = {
+            swipe: {
+                active: true,
+                mode: "swipe",
+                swipe: {
+                    direction: "cut-vertical"
+                }
+            }
+        };
+
+        expect(swipeToolCurrentModeSelector(state)).toEqual("swipe");
+    });
+    it('should test swipeToolConfigurationSelector', () => {
+        const state = {
+            swipe: {
+                active: true,
+                mode: "swipe",
+                swipe: {
+                    direction: "cut-vertical"
+                }
+            }
+        };
+
+        const expectedConfig = {
+            mode: "swipe",
+            swipe: {
+                direction: "cut-vertical"
+            },
+            spy: {
+                radius: 80
+            }
+        };
+
+        expect(swipeToolConfigurationSelector(state)).toEqual(expectedConfig);
     });
 });

--- a/web/client/selectors/swipe.js
+++ b/web/client/selectors/swipe.js
@@ -9,9 +9,19 @@
 export const layerSwipeSettingsSelector = (state) => state.swipe && state.swipe || { active: false };
 export const spyModeSettingsSelector = state => state?.swipe?.spy || { radius: 80 };
 export const swipeModeSettingsSelector = state => state?.swipe?.swipe || { direction: 'cut-vertical' };
+export const swipeToolCurrentModeSelector = state => state?.swipe?.mode || "swipe";
+
+export const swipeToolConfigurationSelector = (state) => {
+    return {
+        mode: swipeToolCurrentModeSelector(state),
+        spy: spyModeSettingsSelector(state),
+        swipe: swipeModeSettingsSelector(state)
+    };
+};
 
 export default {
     layerSwipeSettingsSelector,
     spyModeSettingsSelector,
-    swipeModeSettingsSelector
+    swipeModeSettingsSelector,
+    swipeToolConfigurationSelector
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Allow adding of MapSwipe configuration inside the map

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6180 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Allow adding of MapSwipe configuration inside the map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
