### PR TITLE
#6275: Hide layers with no identify content in GFI

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -75,7 +75,7 @@ class DefaultViewer extends React.Component {
     getResponseProperties = () => {
         const validator = this.props.validator(this.props.format);
         const responses = this.props.responses.map(res => res === undefined ? {} : res); // Replace any undefined responses
-        const validResponses = this.props.renderEmpty ? validator.getValidResponses(responses, this.props.renderEmpty) : responses;
+        const validResponses = this.props.renderEmpty ? validator.getValidResponses(responses) : responses;
         const invalidResponses = validator.getNoValidResponses(this.props.responses);
         const emptyResponses = this.props.requests.length === invalidResponses.length;
         const currResponse = this.getCurrentResponse(validResponses[this.props.index]);
@@ -92,7 +92,7 @@ class DefaultViewer extends React.Component {
      */
     getCurrentResponse = (response) => {
         const validator = this.props.validator(this.props.format);
-        return validator.getValidResponses([response], true);
+        return validator.getValidResponses([response]);
     }
 
     renderEmptyLayers = () => {

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -127,7 +127,10 @@ export default props => {
                                 loaded={loaded}
                                 setIndex={setIndex}
                                 missingResponses={missingResponses}
-                                emptyResponses={emptyResponses}/>
+                                emptyResponses={emptyResponses}
+                                validator={validator}
+                                format={format}
+                            />
                             <Toolbar
                                 btnDefaultProps={{ bsStyle: 'primary', className: 'square-button-md' }}
                                 buttons={getFeatureButtons(props)}

--- a/web/client/components/data/identify/LayerSelector.jsx
+++ b/web/client/components/data/identify/LayerSelector.jsx
@@ -13,14 +13,19 @@ import {isEmpty} from 'lodash';
 import localizedProps from '../../misc/enhancers/localizedProps';
 const SelectLocalized = localizedProps(['placeholder', 'clearValueText', 'noResultsText'])(Select);
 
-const LayerSelector = ({ responses = [], index = 0, loaded, setIndex, missingResponses = 0, emptyResponses = false }) => {
+const LayerSelector = ({ responses, index, loaded, setIndex, missingResponses, emptyResponses, validator, format}) => {
     const selectProps = {clearable: false, isSearchable: true};
     const [options, setOptions] = useState([]);
     const [title, setTitle] = useState("");
 
     useEffect(()=>{
         if (!isEmpty(responses)) {
-            setOptions(responses.map(opt=> opt?.layerMetadata?.title));
+            setOptions(responses.map((opt, idx)=> {
+                const value = opt?.layerMetadata?.title;
+                // Display only valid responses in the drop down
+                const valid = !!validator(format)?.getValidResponses([opt]).length;
+                return {label: value, value, idx, style: {display: valid ? 'block' : 'none'}};
+            }));
         }
     }, [responses]);
 
@@ -32,14 +37,13 @@ const LayerSelector = ({ responses = [], index = 0, loaded, setIndex, missingRes
         const idx = event?.idx || 0;
         setIndex(idx);
     };
-
     return (
         <div id="identify-layer-select" style={{flex: "1 1 0%", padding: "0px 4px"}}>
             <SelectLocalized
                 {...selectProps}
                 onChange={onChange}
                 value={title || ""}
-                options={(options).map((name, idx) => ({label: name, value: name, idx }))}
+                options={options}
                 disabled={missingResponses !== 0 || responses.length === 0 || emptyResponses}
                 noResultsText="identifyLayerSelectNoResult"
             />
@@ -47,11 +51,24 @@ const LayerSelector = ({ responses = [], index = 0, loaded, setIndex, missingRes
     );
 };
 
+LayerSelector.defaultProps = {
+    responses: [],
+    index: 0,
+    loaded: false,
+    setIndex: () => {},
+    missingResponses: 0,
+    emptyResponses: false,
+    validator: () => {},
+    format: ""
+};
+
 LayerSelector.propTypes = {
     responses: PropTypes.array,
     setIndex: PropTypes.func,
     index: PropTypes.number,
-    emptyResponses: PropTypes.bool
+    emptyResponses: PropTypes.bool,
+    validator: PropTypes.func,
+    format: PropTypes.string
 };
 
 export default LayerSelector;

--- a/web/client/components/data/identify/__tests__/LayerSelector-test.jsx
+++ b/web/client/components/data/identify/__tests__/LayerSelector-test.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import expect from 'expect';
 import ReactDOM from 'react-dom';
 import LayerSelector from '../LayerSelector';
+import { getValidator } from '../../../../utils/MapInfoUtils';
 import TestUtils from 'react-dom/test-utils';
 
 describe("LayerSelector component", () => {
@@ -34,10 +35,33 @@ describe("LayerSelector component", () => {
         expect(labelValue).toNotExist();
 
     });
+    it('test LayerSelector display only valid responses', () => {
+        const responses = [{layerMetadata: {title: "Test1"}, response: "no features were found"}, {layerMetadata: {title: "Test2"}, response: "GetFeatureInfo results"}];
+        ReactDOM.render(<LayerSelector loaded responses={responses} validator={getValidator} format={"text/plain"}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container).toExist();
+        const select = container.querySelector("#identify-layer-select");
+        expect(select).toExist();
+        const input = container.querySelector('input');
+        expect(input).toBeTruthy();
+
+        TestUtils.act(() => {
+            TestUtils.Simulate.focus(input);
+            TestUtils.Simulate.keyDown(input, { key: 'ArrowDown', keyCode: 40 });
+        });
+        const options = select.querySelectorAll(".Select-option");
+        // Invalid response - first option is hidden
+        expect(options[0].style.display).toBe('none');
+
+        // Valid response - second option is displayed
+        expect(options[1].style.display).toBe('block');
+    });
     it('test LayerSelector with value and setIndex', (done) => {
 
         let config = {
-            responses: [{layerMetadata: {title: "Layer 1"}}, {layerMetadata: {title: "Layer 2"}}],
+            responses: [
+                {layerMetadata: {title: "Layer 1"}, response: "GetFeatureInfo results1"},
+                {layerMetadata: {title: "Layer 2"}, response: "GetFeatureInfo results2"}],
             index: 0
         };
 

--- a/web/client/components/geostory/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/geostory/common/enhancers/withIdentifyPopup.jsx
@@ -98,7 +98,7 @@ export const withIdentifyRequest  = mapPropsStream(props$ => {
                     const {data, queryParams, layerMetadata} = action;
                     const validator = getValidator(mapInfoFormat);
                     const newResponses = responses.concat({response: data, queryParams, layerMetadata});
-                    const newValidResponses = validator.getValidResponses(newResponses, true);
+                    const newValidResponses = validator.getValidResponses(newResponses);
                     return {requests, validResponses: newValidResponses, responses: newResponses};
                 }, {requests: [], responses: [], validResponses: []});
         })

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -47,12 +47,12 @@ import { getValidator } from '../utils/MapInfoUtils';
  * @param {boolean} isVector type of the response received is vector or not
  */
 const isIndexValid = (state, responses, requestIndex, isVector) => {
-    const {configuration, requests, queryableLayers, index} = state;
+    const {configuration, requests, queryableLayers = [], index} = state;
     const {infoFormat} = configuration || {};
 
     // Index when first response received is valid
-    const validResponse = getValidator(infoFormat)?.getValidResponses([responses[requestIndex]], true);
-    const inValidResponse = getValidator(infoFormat)?.getNoValidResponses(responses, true);
+    const validResponse = getValidator(infoFormat)?.getValidResponses([responses[requestIndex]]);
+    const inValidResponse = getValidator(infoFormat)?.getNoValidResponses(responses);
     return ((isUndefined(index) && !!validResponse.length)
         || (!isVector && requests.length === inValidResponse.filter(res=>res).length)
         || (isUndefined(index) && isVector && requests.filter(r=>isEmpty(r)).length === queryableLayers.length) // Check if all requested layers are vector

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -14,7 +14,6 @@ import { isPluginInContext } from './context';
 import { currentLocaleSelector } from './locale';
 import {getValidator} from '../utils/MapInfoUtils';
 import { isCesium } from './maptype';
-import { isMouseMoveIdentifyActiveSelector as identifyFloatingTool } from '../selectors/map';
 import { pluginsSelectorCreator } from './localConfig';
 /**
  * selects mapinfo state
@@ -121,10 +120,9 @@ export const validResponsesSelector = createSelector(
     requestsSelector,
     responsesSelector,
     generalInfoFormatSelector,
-    identifyFloatingTool,
-    (requests, responses, format, renderEmpty) => {
+    (requests, responses, format) => {
         const validatorFormat = getValidator(format);
-        return requests.length === responses.length && validatorFormat.getValidResponses(responses, renderEmpty);
+        return requests.length === responses.length && validatorFormat.getValidResponses(responses);
     });
 
 export const currentResponseSelector = createSelector(

--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -55,9 +55,8 @@ export const Validator = {
         /**
          *Parse the HTML to get only the valid html responses
          */
-        getValidResponses(responses, renderEmpty) {
-            if (renderEmpty) return responses.filter(parseHTMLResponse);
-            return responses;
+        getValidResponses(responses) {
+            return responses.filter(parseHTMLResponse);
         },
         /**
          * Parse the HTML to get only the NOT valid html responses
@@ -70,10 +69,8 @@ export const Validator = {
         /**
          *Parse the TEXT to get only the valid text responses
          */
-        getValidResponses(responses, renderEmpty) {
-            let result = responses.filter(({response}) => response !== "" && (typeof response === "string" && response.indexOf("<?xml") !== 0));
-            if (renderEmpty) result = result.filter(({response}) => (typeof response === "string" && response.indexOf("no features were found") !== 0));
-            return result;
+        getValidResponses(responses) {
+            return responses.filter((res) => res.response !== "" && (typeof res.response === "string" && res.response.indexOf("no features were found") !== 0) && (typeof res.response === "string" && res.response.indexOf("<?xml") !== 0));
         },
         /**
          * Parse the TEXT to get only the NOT valid text responses
@@ -86,10 +83,8 @@ export const Validator = {
         /**
          *Parse the JSON to get only the valid json responses
          */
-        getValidResponses(responses, renderEmpty) {
-            let result = responses.filter(({response}) => response && response.features);
-            if (renderEmpty) result = result.filter(({response}) => renderEmpty && response.features.length);
-            return result;
+        getValidResponses(responses) {
+            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
         },
         /**
          * Parse the JSON to get only the NOT valid json responses
@@ -102,10 +97,8 @@ export const Validator = {
         /**
          *Parse the JSON to get only the valid json responses
          */
-        getValidResponses(responses, renderEmpty) {
-            let result = responses.filter(({response}) => response && response.features);
-            if (renderEmpty) result = result.filter(({response}) => renderEmpty && response.features.length);
-            return result;
+        getValidResponses(responses) {
+            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
         },
         /**
          * Parse the JSON to get only the NOT valid json responses

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -169,7 +169,7 @@ export const getValidator = (format) => {
         getNoValidResponses: () => []
     };
     return {
-        getValidResponses: (responses, renderEmpty = false) => {
+        getValidResponses: (responses) => {
             return responses.reduce((previous, current) => {
                 if (current) {
                     let infoFormat;
@@ -181,7 +181,7 @@ export const getValidator = (format) => {
                     if (current.queryParams && current.queryParams.hasOwnProperty('outputFormat')) {
                         infoFormat = current.queryParams.outputFormat;
                     }
-                    const valid = (Validator[current.format || INFO_FORMATS_BY_MIME_TYPE[infoFormat] || INFO_FORMATS_BY_MIME_TYPE[format]] || defaultValidator).getValidResponses([current], renderEmpty);
+                    const valid = (Validator[current.format || INFO_FORMATS_BY_MIME_TYPE[infoFormat] || INFO_FORMATS_BY_MIME_TYPE[format]] || defaultValidator).getValidResponses([current]);
                     return [...previous, ...valid];
                 }
                 return [...previous];

--- a/web/client/utils/__tests__/FeatureInfoUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoUtils-test.js
@@ -38,12 +38,7 @@ describe('FeatureInfoUtils', () => {
     it('HTML Validator', () => {
         // Default fetch all values
         let results = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML}]);
-        expect(results.length).toBe(2);
-
-        // Identify floating enabled
-        results = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML}], true);
         expect(results.length).toBe(1);
-        expect(results[0].response).toBe(rowHTML);
 
         let notValidResults = Validator.HTML.getNoValidResponses([{response: emptyHTML}, {response: rowHTML}]);
         expect(notValidResults.length).toBe(1);
@@ -53,14 +48,14 @@ describe('FeatureInfoUtils', () => {
         let validRegex = "<div[^>]*>[\\s\\S]*<\\/div>";
         let invalidRegex = "<table[^>]*>[\\s\\S]*<\\/table>";
 
-        let validRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}], true);
+        let validRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}]);
         expect(validRegexResults.length).toBe(1);
         expect(validRegexResults[0].response).toBe(rowHTML);
 
         validRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}]);
-        expect(validRegexResults.length).toBe(2);
+        expect(validRegexResults.length).toBe(1);
 
-        let invalidRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: invalidRegex }}], true);
+        let invalidRegexResults = Validator.HTML.getValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: invalidRegex }}]);
         expect(invalidRegexResults.length).toBe(0);
 
         validRegexResults = Validator.HTML.getNoValidResponses([{response: emptyHTML}, {response: rowHTML, layerMetadata: {regex: validRegex }}]);
@@ -89,10 +84,6 @@ describe('FeatureInfoUtils', () => {
         expect(results[0].response).toBe(validTEXT);
 
         results = Validator.TEXT.getValidResponses([{response: "no features were found"}, {response: validTEXT}]);
-        expect(results.length).toBe(2);
-
-        // Identify floating enabled
-        results = Validator.TEXT.getValidResponses([{response: "no features were found"}, {response: validTEXT}], true);
         expect(results.length).toBe(1);
 
         let notValidResults = Validator.TEXT.getNoValidResponses([{response: notValid}, {response: validTEXT}]);
@@ -107,11 +98,6 @@ describe('FeatureInfoUtils', () => {
     const emptyJSON = {"type": "FeatureCollection", "totalFeatures": "unknown", "features": [], "crs": null};
     it('PROPERTIES Validator', () => {
         let results = Validator.PROPERTIES.getValidResponses([{response: validJSON}, {response: emptyJSON}]);
-        expect(results.length).toBe(2);
-        expect(results[0].response).toBe(validJSON);
-
-        // Identify floating enabled
-        results = Validator.PROPERTIES.getValidResponses([{response: validJSON}, {response: emptyJSON}], true);
         expect(results.length).toBe(1);
         expect(results[0].response).toBe(validJSON);
 

--- a/web/client/utils/__tests__/MapInfoUtils-test.js
+++ b/web/client/utils/__tests__/MapInfoUtils-test.js
@@ -442,27 +442,20 @@ describe('MapInfoUtils', () => {
             },
             undefined
         ];
-        const floatingToolEnabled = true;
 
         let validator = getValidator();
         let validResponses = validator.getValidResponses(response);
-        let validResponsesFloatingTool = validator.getValidResponses(response, floatingToolEnabled);
-        expect(validResponses.length).toBe(2);
-        expect(validResponsesFloatingTool.length).toBe(1);
+        expect(validResponses.length).toBe(1);
 
         // Validate format 'PROPERTIES'
         response.filter(r=> r !== undefined).forEach(res => {res.format = "PROPERTIES"; return res;});
         validResponses = validator.getValidResponses(response);
-        validResponsesFloatingTool = validator.getValidResponses(response, floatingToolEnabled);
-        expect(validResponses.length).toBe(2);
-        expect(validResponsesFloatingTool.length).toBe(1);
+        expect(validResponses.length).toBe(1);
 
         // Validate format 'JSON'
         response.filter(r=> r !== undefined).forEach(res => {res.format = "JSON"; return res;});
         validResponses = validator.getValidResponses(response);
-        validResponsesFloatingTool = validator.getValidResponses(response, floatingToolEnabled);
-        expect(validResponses.length).toBe(2);
-        expect(validResponsesFloatingTool.length).toBe(1);
+        expect(validResponses.length).toBe(1);
     });
 
     it('getNoValidResponses for vector layer', ()=>{


### PR DESCRIPTION
## Description
This PR adds commit to hide the layers with no identify content from the layer selector in GFI

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

##Issue

**What is the current behavior?**
#6275 

**What is the new behavior?**
- Layer with no identify content will be displayed in the layer selector in GFI

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
