### PR TITLE
feat: add helper to create polygon from radius and center

### DIFF
--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -25,7 +25,7 @@ import {
     head,
     last
 } from 'lodash';
-
+import turfCircle from '@turf/circle';
 import lineIntersect from '@turf/line-intersect';
 import polygonToLinestring from '@turf/polygon-to-linestring';
 import greatCircle from '@turf/great-circle';
@@ -1012,6 +1012,22 @@ export const makeBboxFromOWS = (lcOWS, ucOWS) => {
     return [lc[0], lc[1], uc[0], uc[1]];
 };
 
+/**
+ * helper use to create a geojson Feature with a Polygon geometry
+ * starting from circle data
+ * @see https://turfjs.org/docs/#circle
+ * @param {number[]} center in the form of [x, y]
+ * @param {number} radius
+ * @param {string} [units="degrees"] the unit measure
+ * @param {number} [steps=100] number of vertices of the polygon
+ */
+export const getPolygonFromCircle = (center, radius, units = "degrees", steps = 100) => {
+    if (!center || !radius) {
+        return null;
+    }
+    return turfCircle(center, radius, {steps, units});
+};
+
 
 CoordinatesUtils = {
     setCrsLabels,
@@ -1065,7 +1081,8 @@ CoordinatesUtils = {
     extractCrsFromURN,
     crsCodeTable,
     makeNumericEPSG,
-    makeBboxFromOWS
+    makeBboxFromOWS,
+    getPolygonFromCircle
 
 };
 export default CoordinatesUtils;

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import expect from 'expect';
+import { isNearlyEqual } from '../MapUtils';
 
 import CoordinatesUtils from '../CoordinatesUtils';
 import Proj4js from 'proj4';
@@ -762,5 +763,35 @@ describe('CoordinatesUtils', () => {
     it('makeNumericEPSG with invalid EPSG', () => {
         const epsg = 'EPSG:84';
         expect(CoordinatesUtils.makeNumericEPSG(epsg)).toBe(null);
+    });
+    it('creates a polygon with getPolygonFromCircle defaults', () => {
+        let polygon = CoordinatesUtils.getPolygonFromCircle();
+        expect(polygon).toBe(null);
+        polygon = CoordinatesUtils.getPolygonFromCircle([40, 15]);
+        expect(polygon).toBe(null);
+        polygon = CoordinatesUtils.getPolygonFromCircle(null, 6.13);
+        expect(polygon).toBe(null);
+        polygon = CoordinatesUtils.getPolygonFromCircle([40, 15], 6.13);
+        expect(polygon).toBeTruthy();
+    });
+    it('creates a polygon with getPolygonFromCircle, radius in degress', () => {
+        let polygon = CoordinatesUtils.getPolygonFromCircle([40, 15], 6.13, "degrees", 50);
+        expect(polygon.geometry.coordinates[0].length).toBe(50 + 1);
+        expect(polygon.geometry.coordinates[0][0][0]).toBe(40);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][0][1], 21.137162260837176)).toBe(true);
+        expect(polygon.geometry.coordinates[0][50][0]).toBe(40);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][50][1], 21.137162260837176)).toBe(true);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][20][0], 36.34143838801184)).toBe(true);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][20][1], 10.00834658343667)).toBe(true);
+    });
+    it('creates a polygon with getPolygonFromCircle, radius in meters', () => {
+        let polygon = CoordinatesUtils.getPolygonFromCircle([40, 15], 6000, "meters", 50);
+        expect(polygon.geometry.coordinates[0].length).toBe(50 + 1);
+        expect(polygon.geometry.coordinates[0][0][0]).toBe(40);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][0][1], 15.053959221823476)).toBe(true);
+        expect(polygon.geometry.coordinates[0][50][0]).toBe(40);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][50][1], 15.053959221823476)).toBe(true);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][20][0], 39.96717142640955)).toBe(true);
+        expect(isNearlyEqual(polygon.geometry.coordinates[0][20][1], 14.956343723081114)).toBe(true);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

add getPolygonFromCircle helper to CoordinatesUtils
with related tests


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
