### PR TITLE
#6281: Share plugin render fix

### DIFF
--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -100,6 +100,7 @@ export const SharePlugin = assign(Share, {
         name: 'share',
         position: 1000,
         priority: 1,
+        doNotHide: true,
         text: <Message msgId="share.title"/>,
         icon: <Glyphicon glyph="share-alt"/>,
         action: toggleControl.bind(null, 'share', null)
@@ -109,6 +110,7 @@ export const SharePlugin = assign(Share, {
         alwaysVisible: true,
         position: 2,
         priority: 0,
+        doNotHide: true,
         tooltip: "share.title",
         icon: <Glyphicon glyph="share-alt"/>,
         action: toggleControl.bind(null, 'share', null)

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -52,9 +52,13 @@ describe('Share Plugin', () => {
             }
         };
         const { containers } = getPluginForTest(SharePlugin, { controls }, {
-            ToolbarPlugin: {}
+            ToolbarPlugin: {},
+            BurgerMenuPlugin: {}
         });
-        expect(Object.keys(containers)).toContain('Toolbar');
+        expect(Object.keys(containers).length).toBe(2);
+        expect(Object.keys(containers)).toEqual(['BurgerMenu', 'Toolbar']);
+        expect(containers.Toolbar).toContain({alwaysVisible: true, doNotHide: true});
+        expect(containers.BurgerMenu).toContain({position: 1000, priority: 1, doNotHide: true});
     });
 
     it('test Share plugin on close', (done) => {


### PR DESCRIPTION
## Description
This PR contains fix for Share plugin render issue

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6281 

**What is the new behavior?**
The Share plugin will render with Share panel contents upon clicking the "Share" menu from burger menu

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
