### PR TITLE
#6282: Annotation layer visibility sync

### DIFF
--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -358,11 +358,11 @@ describe('annotations Epics', () => {
     it('edit annotation', (done) => {
         store.subscribe(() => {
             const actions = store.getActions();
-            if (actions.length >= 6) {
-                expect(actions[2].type).toBe(CHANGE_LAYER_PROPERTIES);
-                expect(actions[3].type).toBe(UPDATE_NODE);
-                expect(actions[4].type).toBe(CHANGE_DRAWING_STATUS);
-                expect(actions[5].type).toBe(HIDE_MAPINFO_MARKER);
+            if (actions.length >= 8) {
+                expect(actions[4].type).toBe(CHANGE_LAYER_PROPERTIES);
+                expect(actions[5].type).toBe(UPDATE_NODE);
+                expect(actions[6].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[7].type).toBe(HIDE_MAPINFO_MARKER);
                 done();
             }
         });
@@ -384,6 +384,8 @@ describe('annotations Epics', () => {
             const actions = store.getActions();
             if (actions.length >= 2) {
                 expect(actions[1].type).toBe(UPDATE_NODE);
+                const features = actions[1].options.features[0];
+                expect(features.features[0].style.length).toBe(2);
                 done();
             }
         });
@@ -582,6 +584,25 @@ describe('annotations Epics', () => {
         });
         const action = toggleVisibilityAnnotation('1');
         tempStore.dispatch(action);
+    });
+    it('test showHideAnnotationEpic on non-annotation layer', (done) => {
+        store = mockStore({
+            layers: {
+                flat: [
+                    {id: "1", features: [{properties: {id: '1'}}]}
+                ]
+            }
+        });
+        store.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 1) {
+                const types = actions.map(a=>a.type);
+                expect(types.includes(UPDATE_NODE)).toBe(false);
+                done();
+            }
+        });
+        const action = changeLayerProperties('1', {visibility: true});
+        store.dispatch(action);
     });
     it('toggle annotation visibility on CHANGE_LAYER_PROPERTIES', (done) => {
         const tempStore = mockStore({

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -443,6 +443,8 @@ export default (viewer) => ({
             );
         }),
     showHideAnnotationEpic: (action$, store) => action$.ofType(TOGGLE_ANNOTATION_VISIBILITY, CHANGE_LAYER_PROPERTIES)
+        .filter(action=>
+            (action.type === CHANGE_LAYER_PROPERTIES && action.layer === ANNOTATIONS) || (action.type === TOGGLE_ANNOTATION_VISIBILITY))
         .switchMap((action) => {
             const feature = (f, visibility = false) => assign({}, f, {
                 properties: {...f.properties, visibility}
@@ -451,7 +453,7 @@ export default (viewer) => ({
             const annotationLayers = annotationsLayerSelector(store.getState());
 
             // Update visibility of annotations from TOC or annotation panel
-            if (!isEmpty(annotationLayers) && (isLayerPropertyChange || action.id)) {
+            if (!isEmpty(annotationLayers)) {
                 const features = (annotationLayers.features || []).map(f => isLayerPropertyChange ? feature(f, action?.newProperties?.visibility)
                     : (f.properties.id === action.id) ? feature(f, !f.properties?.visibility) : f);
                 const layerVisibility = !!features?.filter(f => f.properties.visibility)?.length;

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -449,8 +449,9 @@ export default (viewer) => ({
             });
             let isLayerPropertyChange = action.layer === ANNOTATIONS;
             const annotationLayers = annotationsLayerSelector(store.getState());
-            // Update visibility based on layer property change from TOC or annotation panel
-            if (!isEmpty(annotationLayers)) {
+
+            // Update visibility of annotations from TOC or annotation panel
+            if (!isEmpty(annotationLayers) && (isLayerPropertyChange || action.id)) {
                 const features = (annotationLayers.features || []).map(f => isLayerPropertyChange ? feature(f, action?.newProperties?.visibility)
                     : (f.properties.id === action.id) ? feature(f, !f.properties?.visibility) : f);
                 const layerVisibility = !!features?.filter(f => f.properties.visibility)?.length;

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -90,6 +90,11 @@ export const DEFAULT_ANNOTATIONS_STYLES = {
 export const ANNOTATION_TYPE = "ms2-annotations";
 
 /**
+ * The constant for annotations
+ */
+export const ANNOTATIONS = "annotations";
+
+/**
  * return two styles object for start and end point.
  * usually added to a LineString
  * @return {object[]} the two styles


### PR DESCRIPTION
## Description
This PR adds commits to sync the visibility of annotation layer in TOC with that of annotations panel 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#6282

**What is the new behavior?**
- As soon as I hide all annotations in the annotation panel, also the layer in TOC changes his state.
- If then I show one annotation in the annotation panel, also the layer in TOC changes his state accordingly
- As soon as I hide the annotation layer in TOC all the annotations are hidden accordingly

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
