### PR TITLE
#6231: Next button is disabled when editing some existing context

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -252,7 +252,7 @@ export default class ContextCreator extends React.Component {
                     id: 'general-settings',
                     label: 'contextCreator.generalSettings.label',
                     extraToolbarButtons: extraToolbarButtons('general-settings'),
-                    disableNext: !this.props.resource.name || !this.props.resource.name.length ||
+                    disableNext: !this.props.resource.name ||
                         !this.props.newContext.windowTitle || !this.props.newContext.windowTitle.length ||
                         this.props.loading || !this.props.isValidContextName || !this.props.contextNameChecked,
                     component:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixes validation that doesn't recognize numbers as possible values for context resource names

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6231 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Next button enabled when context resource names are numbers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
