### PR TITLE
#6255: Extra whitespace on details

### DIFF
--- a/web/client/components/resources/modals/fragments/DetailsSheet.jsx
+++ b/web/client/components/resources/modals/fragments/DetailsSheet.jsx
@@ -25,16 +25,24 @@ export default ({
     onClose = () => {},
     onSave = () => {}
 }) => {
+    const viewer = (<DetailsViewer
+        className="ms-details-preview-container"
+        textContainerClassName="ms-details-preview"
+        loading={loading}
+        detailsText={detailsText}/>);
     return (
         <Portal>
             {readOnly ? (
-                <ResizableModal size="lg"
+                <ResizableModal
+                    size="lg"
+                    bodyClassName="details-viewer-modal"
                     showFullscreen
+                    fitContent
                     onClose={() => onClose()}
                     title={<Message msgId="map.details.title" msgParams={{ name: title }} />}
                     show={show}
                 >
-                    <DetailsViewer className="ms-detail-body" textContainerClassName="ql-editor" loading={loading} detailsText={detailsText}/>
+                    {viewer}
                 </ResizableModal>
             ) : (<ResizableModal
                 show={show}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fix extra white space when details Modal is opened from Home page

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6255 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
 No extra white space when details Modal is opened from Home page

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
