### PR TITLE
#6289: Shape file style fix for MultiPoint

### DIFF
--- a/web/client/components/map/openlayers/LegacyVectorStyle.js
+++ b/web/client/components/map/openlayers/LegacyVectorStyle.js
@@ -454,7 +454,7 @@ export function getStyle(options, isDrawing = false, textValues = []) {
             })
         };
 
-        if (geomType === "Point") {
+        if (geomType === "Point" || geomType === "MultiPoint") {
             style = {
                 image: new Circle(assign({}, style, {radius: options.style.radius || 5}))
             };

--- a/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
@@ -8,8 +8,8 @@
 import expect from 'expect';
 import { getStyle, styleFunction, firstPointOfPolylineStyle, lastPointOfPolylineStyle, startEndPolylineStyle } from '../LegacyVectorStyle';
 
-import {geomCollFeature} from '../../../../test-resources/drawsupport/features';
-import {DEFAULT_ANNOTATIONS_STYLES} from '../../../../utils/AnnotationsUtils';
+import {geomCollFeature, multipointFt, lineStringFt} from '../../../../test-resources/drawsupport/features';
+import {DEFAULT_ANNOTATIONS_STYLES, STYLE_CIRCLE} from '../../../../utils/AnnotationsUtils';
 
 import Feature from 'ol/Feature';
 import {Point, LineString, MultiLineString, Polygon, MultiPolygon} from 'ol/geom';
@@ -415,5 +415,35 @@ describe('Test LegacyVectorStyle', () => {
         }));
         expect(styleGenerated).toExist();
     });
+    it('test getStyle with FeatureCollection', () => {
+        const styleFunc = getStyle({
+            features: [{...lineStringFt, type: "FeatureCollection"}],
+            style: {
+                color: "ff0000",
+                opacity: 0.5,
+                ...DEFAULT_ANNOTATIONS_STYLES
+            }
+        }, false, ["textValue"]);
+        expect(styleFunc).toExist();
 
+        const styleGenerated = styleFunc(new Feature({
+            geometry: new LineString([
+                [100.0, 0.0], [101.0, 1.0]
+            ])
+        })
+        );
+        expect(styleGenerated).toExist();
+    });
+    it('test getStyle with MultiPoint', () => {
+        const styleObject = getStyle({
+            features: [multipointFt],
+            style: {
+                color: "ff0000",
+                opacity: 0.5,
+                ...STYLE_CIRCLE
+            }
+        }, false, []);
+        expect(styleObject).toExist();
+        expect(styleObject.image_).toExist();
+    });
 });


### PR DESCRIPTION
## Description
This PR adds fix to style not getting applied when uploaded a shape file of type 'MultiPoint'

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6289 

**What is the new behavior?**
Default/user specified style will be applied upon uploading the shape file of type 'MulitPoint'

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
