### PR TITLE
#6291: Small issue in measure panel while editing a measure annotation

### DIFF
--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -19,7 +19,8 @@ import {
     init,
     setAnnotationMeasurement,
     setMeasurementConfig,
-    setCurrentFeature
+    setCurrentFeature,
+    changeGeometry
 } from '../../actions/measurement';
 
 import { RESET_CONTROLS, setControlProperty } from '../../actions/controls';
@@ -173,5 +174,17 @@ describe('Test the measurement reducer', () => {
             currentFeature: 4
         }, setCurrentFeature());
         expect(state.currentFeature).toBe(2);
+    });
+    it('CHANGED_GEOMETRY', () => {
+        let state = measurement({
+            geomType: "LineString",
+            lineMeasureEnabled: true,
+            areaMeasureEnabled: false,
+            bearingMeasureEnabled: false,
+            len: 0,
+            area: 700,
+            features: []
+        }, changeGeometry([{type: "Feature", geometry: {type: "LineString"}}]));
+        expect(state.currentFeature).toBe(0); // current feature index in the features array
     });
 });

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -137,6 +137,7 @@ function measurement(state = defaultState, action) {
             ...state,
             features,
             geomTypeSelected,
+            currentFeature: features.length - 1, // current feature is the last feature added
             updatedByUI: false,
             isDrawing: false,
             ...(isEmpty(features) && {exportToAnnotation: false})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
As soon as the user creates a new measurement in the above situation, the last created one must be selected in the dropdown list

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6291 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
As soon as the user creates a new measurement in the above situation, the last created one must be selected in the dropdown list

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
