### PR TITLE
#6296: Share tool not working in MS home

### DIFF
--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -85,7 +85,8 @@ class SharePanel extends React.Component {
         selectedTab: PropTypes.string,
         formatCoords: PropTypes.string,
         point: PropTypes.object,
-        isScrollPosition: PropTypes.bool
+        isScrollPosition: PropTypes.bool,
+        hideMarker: PropTypes.func
     };
 
     static defaultProps = {
@@ -102,7 +103,8 @@ class SharePanel extends React.Component {
         settings: {},
         onUpdateSettings: () => {},
         formatCoords: "decimal",
-        isScrollPosition: false
+        isScrollPosition: false,
+        hideMarker: () => {}
     };
 
     state = {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#6296
SharePanel for resources is broken (reproduce? 1) go to [https://dev.mapstore.geo-solutions.it/mapstore/#/](https://dev.mapstore.geo-solutions.it/mapstore/#/) 2) Share a resource)

**What is the new behavior?**

SharePanel is working again for resources.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
I'd say adding hideMarker can be set as default prop & withShareTool.jsx can stay as is, yet if my fix is not up-to-standard, please provide a better fix (and let me learn :) )
