### PR TITLE
#6300 fix layer info when layer name has changed

### DIFF
--- a/web/client/epics/layerinfo.js
+++ b/web/client/epics/layerinfo.js
@@ -83,16 +83,23 @@ export const layerInfoSyncLayersEpic = (action$, store) => action$
                     .map(caps => {
                         const title = caps.title ?? caps.dc?.title;
 
-                        return ['success', {
-                            ...layerObj,
-                            title: isObject(layerObj.title) ? {
-                                ...layerObj.title,
-                                'default': title
-                            } : title,
-                            description: caps._abstract ?? caps.dc?.abstract ?? caps.dc?.description
-                        }];
+                        if (title) {
+                            return ['success', {
+                                ...layerObj,
+                                title: isObject(layerObj.title) ? {
+                                    ...layerObj.title,
+                                    'default': title
+                                } : title,
+                                description: caps._abstract ?? caps.dc?.abstract ?? caps.dc?.description
+                            }];
+                        }
+                        return  ['error', layerObj];
                     })
-                    .catch(() => Observable.of(['error', layerObj])))
+                    .catch((e) => {
+                        console.error(e);
+                        return Observable.of(['error', layerObj]);
+                    }
+                    ))
             )
                 .flatMap(([syncStatus, layerObj]) => Observable.of(updateLayer({
                     layerObj,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

this is a fix when layer name has changed on Geoserver capabilities
and layerInfo does not recognize that causing problems.

the issue was mainly in the layerInfoSyncLayersEpic epic

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6300 


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
