### PR TITLE
#6282: Annotation visibility sync fix

### DIFF
--- a/web/client/actions/__tests__/annotations-test.js
+++ b/web/client/actions/__tests__/annotations-test.js
@@ -207,8 +207,9 @@ describe('Test correctness of the annotations actions', () => {
         expect(result.unsavedStyle).toEqual(true);
     });
     it('cancel edit annotation', () => {
-        const result = cancelEditAnnotation();
+        const result = cancelEditAnnotation({id: 1});
         expect(result.type).toEqual(CANCEL_EDIT_ANNOTATION);
+        expect(result.properties).toEqual({id: 1});
     });
     it('startDrawing', () => {
         const result = startDrawing();
@@ -315,8 +316,9 @@ describe('Test correctness of the annotations actions', () => {
     });
 
     it('confirm close annotations', () => {
-        const result = confirmCloseAnnotations();
+        const result = confirmCloseAnnotations({id: 1});
         expect(result.type).toEqual(CONFIRM_CLOSE_ANNOTATIONS);
+        expect(result.properties).toEqual({id: 1});
     });
 
     it('changeRadius', () => {

--- a/web/client/actions/__tests__/measurement-test.js
+++ b/web/client/actions/__tests__/measurement-test.js
@@ -115,14 +115,14 @@ describe('Test correctness of measurement actions', () => {
         expect(retval.measures).toEqual({len: 0});
     });
     it('Test addAnnotation action creator', () => {
-        const retval = addAnnotation([{type: 'Feature'}], [{position: [1, 1], text: '1,111 m'}], {area: {}, length: {}}, false, 1);
+        const retval = addAnnotation([{type: 'Feature'}], [{position: [1, 1], text: '1,111 m'}], {area: {}, length: {}}, false, {id: 1});
         expect(retval).toExist();
         expect(retval.type).toBe(ADD_MEASURE_AS_ANNOTATION);
         expect(retval.features).toEqual([{type: 'Feature'}]);
         expect(retval.textLabels).toEqual([{position: [1, 1], text: '1,111 m'}]);
         expect(retval.uom).toEqual({area: {}, length: {}});
         expect(retval.save).toBe(false);
-        expect(retval.id).toBe(1);
+        expect(retval.properties.id).toBe(1);
     });
     it('Test setMeasurementConfig action creator', () => {
         const retval = setMeasurementConfig("prop", 'value');
@@ -132,10 +132,10 @@ describe('Test correctness of measurement actions', () => {
         expect(retval.value).toBe('value');
     });
     it('Test setAnnotationMeasurement action creator', () => {
-        const retval = setAnnotationMeasurement([{type: 'Feature'}], 1);
+        const retval = setAnnotationMeasurement([{type: 'Feature'}], {id: 1});
         expect(retval).toExist();
         expect(retval.type).toBe(SET_ANNOTATION_MEASUREMENT);
         expect(retval.features).toEqual([{type: 'Feature'}]);
-        expect(retval.id).toBe(1);
+        expect(retval.properties).toEqual({id: 1});
     });
 });

--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -168,10 +168,11 @@ export const addText = () => {
     };
 };
 
-export const toggleVisibilityAnnotation = (id) => {
+export const toggleVisibilityAnnotation = (id, visibility) => {
     return {
         type: TOGGLE_ANNOTATION_VISIBILITY,
-        id
+        id,
+        visibility
     };
 };
 
@@ -206,9 +207,10 @@ export const cancelRemoveAnnotation = () => {
         type: CANCEL_REMOVE_ANNOTATION
     };
 };
-export const cancelEditAnnotation = () => {
+export const cancelEditAnnotation = (properties) => {
     return {
-        type: CANCEL_EDIT_ANNOTATION
+        type: CANCEL_EDIT_ANNOTATION,
+        properties
     };
 };
 export const saveAnnotation = (id, fields, geometry, style, newFeature, properties) => {
@@ -292,9 +294,10 @@ export const closeAnnotations = () => {
         type: CLOSE_ANNOTATIONS
     };
 };
-export const confirmCloseAnnotations = () => {
+export const confirmCloseAnnotations = (properties) => {
     return {
-        type: CONFIRM_CLOSE_ANNOTATIONS
+        type: CONFIRM_CLOSE_ANNOTATIONS,
+        properties
     };
 };
 export const setUnsavedChanges = (unsavedChanges) => {

--- a/web/client/actions/measurement.js
+++ b/web/client/actions/measurement.js
@@ -24,14 +24,14 @@ export const SET_ANNOTATION_MEASUREMENT = 'MEASUREMENT:SET_ANNOTATION_MEASUREMEN
 /**
  * trigger the epic to add the measure feature into an annotation.
 */
-export function addAnnotation(features, textLabels, uom, save, id) {
+export function addAnnotation(features, textLabels, uom, save, properties) {
     return {
         type: ADD_MEASURE_AS_ANNOTATION,
         features,
         textLabels,
         uom,
         save,
-        id
+        properties
     };
 }
 
@@ -49,11 +49,11 @@ export function changeMeasurement(measurement) {
     };
 }
 
-export function setAnnotationMeasurement(features, id) {
+export function setAnnotationMeasurement(features, properties) {
     return {
         type: SET_ANNOTATION_MEASUREMENT,
         features,
-        id
+        properties
     };
 }
 

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -317,7 +317,7 @@ class AnnotationsEditor extends React.Component {
                                 tooltipId: "annotations.back",
                                 visible: this.props.showBack,
                                 onClick: () => {
-                                    this.props.onCancelEdit();
+                                    this.props.onCancelEdit(this.props?.feature?.properties);
                                     this.props.onCancel(); this.props.onCleanHighlight();
                                 }
                             }, {
@@ -373,7 +373,7 @@ class AnnotationsEditor extends React.Component {
                                         this.props.onToggleUnsavedChangesModal();
                                     } else {
                                         this.props.onResetCoordEditor();
-                                        this.props.onCancelEdit();
+                                        this.props.onCancelEdit(this.props.editing?.properties);
                                         // Reset geometry editor tab
                                         this.setState({...this.state, tabValue: 'coordinates'});
                                     }
@@ -512,7 +512,7 @@ class AnnotationsEditor extends React.Component {
                 show
                 modal
                 onClose={this.props.onCancelClose}
-                onConfirm={this.props.onConfirmClose}
+                onConfirm={()=> this.props.onConfirmClose(this.props.editing?.properties)}
                 confirmButtonBSStyle="default"
                 closeGlyph="1-close"
                 confirmButtonContent={<Message msgId="annotations.confirm" />}
@@ -526,7 +526,7 @@ class AnnotationsEditor extends React.Component {
                 onClose={this.props.onToggleUnsavedChangesModal}
                 onConfirm={() => {
                     this.props.selected && this.props.onResetCoordEditor();
-                    this.props.onCancelEdit(); this.props.onToggleUnsavedChangesModal();
+                    this.props.onCancelEdit(this.props.editing?.properties); this.props.onToggleUnsavedChangesModal();
                 }}
                 confirmButtonBSStyle="default"
                 closeGlyph="1-close"
@@ -851,7 +851,7 @@ class AnnotationsEditor extends React.Component {
 
     setAnnotationMeasurement = () => {
         // Excluding geometry types not supported by measurement
-        this.props.onSetAnnotationMeasurement(this.props.editing.features.filter(f=> f.geometry.type !== 'Point' && !f.properties.isCircle), this.props.editing?.properties.id);
+        this.props.onSetAnnotationMeasurement(this.props.editing.features.filter(f=> f.geometry.type !== 'Point' && !f.properties.isCircle), this.props.editing?.properties);
         this.hideWarning();
     }
 

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -214,7 +214,8 @@ describe("test the AnnotationsEditor Panel", () => {
         const feature = {
             id: "1",
             title: 'mytitle',
-            description: '<span><i>desc</i></span>'
+            description: '<span><i>desc</i></span>',
+            visibility: false
         };
 
         const testHandlers = {
@@ -240,6 +241,10 @@ describe("test the AnnotationsEditor Panel", () => {
 
         expect(spySave.calls.length).toEqual(0);
         expect(spyCancel.calls.length).toEqual(1);
+        const properties = spyCancel.calls[0].arguments[0];
+        expect(Object.keys(properties).length > 0).toBe(true);
+        expect(spyCancel.calls[0].arguments[0].id).toBe('1');
+        expect(spyCancel.calls[0].arguments[0].visibility).toBe(false);
     });
 
     it('test click cancel trigger UnsavedChangesModal', () => {
@@ -457,8 +462,11 @@ describe("test the AnnotationsEditor Panel", () => {
         expect(spyOnSetAnnotationMeasurement.calls[0].arguments).toBeTruthy();
         expect(spyOnSetAnnotationMeasurement.calls[0].arguments.length).toBe(2);
         const features = spyOnSetAnnotationMeasurement.calls[0].arguments[0];
+        const properties = spyOnSetAnnotationMeasurement.calls[0].arguments[1];
         expect(features.length).toBe(1);
         expect(features[0].geometry.type).toBe('LineString');
+        expect(properties).toBeTruthy();
+        expect(Object.keys(properties).length > 0).toBe(true);
     });
 
     it('test Measurement geometry', () => {

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -381,7 +381,10 @@ class MeasureComponent extends React.Component {
                                                     this.props.measurement.textLabels,
                                                     this.props.uom,
                                                     !exportToAnnotation,
-                                                    this.props.measurement.id
+                                                    {
+                                                        id: this.props.measurement.id,
+                                                        visibility: this.props.measurement.visibility
+                                                    }
                                                 );
                                             },
                                             disabled: (this.props.measurement.features || []).length === 0,

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -476,7 +476,7 @@ describe("test the MeasureComponent", () => {
         expect(spyOnAddAnnotation.calls[0].arguments[1]).toEqual(measurement.textLabels);
         expect(spyOnAddAnnotation.calls[0].arguments[2]).toEqual(uom);
         expect(spyOnAddAnnotation.calls[0].arguments[3]).toBe(false);
-        expect(spyOnAddAnnotation.calls[0].arguments[4]).toBe(1);
+        expect(spyOnAddAnnotation.calls[0].arguments[4].id).toBe(1);
     });
 
     it("test Measurement default", () =>{

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -42,7 +42,7 @@ import {
     LOADING,
     SET_DEFAULT_STYLE,
     toggleVisibilityAnnotation,
-    geometryHighlight, EDIT_ANNOTATION
+    geometryHighlight, EDIT_ANNOTATION, CLEAN_HIGHLIGHT
 } from '../../actions/annotations';
 
 import { TOGGLE_CONTROL, toggleControl, SET_CONTROL_PROPERTY } from '../../actions/controls';
@@ -635,6 +635,26 @@ describe('annotations Epics', () => {
         });
         const action = changeLayerProperties('annotations', {visibility: true});
         tempStore.dispatch(action);
+    });
+    it('test on close annotations panel', (done) => {
+        const state = {
+            controls: {annotations: {enabled: false}}
+        };
+        testEpic(addTimeoutEpic(closeAnnotationsEpic, 100), 2, toggleControl("annotations"), actions => {
+            expect(actions.length).toBe(2);
+            actions.map((action) => {
+                switch (action.type) {
+                case CLEAN_HIGHLIGHT:
+                    break;
+                case CHANGE_DRAWING_STATUS:
+                    expect(action.status).toBe("clean");
+                    break;
+                default:
+                    expect(false).toBe(true);
+                }
+            });
+            done();
+        }, state);
     });
     it('save annotation', (done) => {
         const state = {

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -629,7 +629,7 @@ describe('annotations Epics', () => {
             done();
         }, state);
     });
-    it('toggle annotation visibility to enable the annotation layer', (done) => {
+    it('toggle annotation visibility to set annotation layer visibility', (done) => {
         const tempStore = mockStore({
             layers: {
                 flat: [

--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -100,7 +100,7 @@ describe('measurement epics', () => {
         testEpic(
             addTimeoutEpic(addAnnotationFromMeasureEpic, 10),
             NUMBER_OF_ACTIONS, [
-                addAnnotation(features, textLabels, uom, false, 1)
+                addAnnotation(features, textLabels, uom, false, {id: 1})
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 expect(actions[0].type).toBe("TOGGLE_CONTROL");
@@ -115,6 +115,8 @@ describe('measurement epics', () => {
                 expect(actions[3].feature.features[1].geometry.type).toBe("Point");
                 expect(actions[3].feature.features[2].geometry.type).toBe("Point");
                 expect(actions[3].feature.features[3].geometry.type).toBe("Point");
+                expect(actions[3].feature.properties.id).toBe(1);
+                expect(actions[3].feature.visibility).toBe(true);
                 done();
             }, null);
     });
@@ -125,7 +127,7 @@ describe('measurement epics', () => {
         testEpic(
             addTimeoutEpic(addAnnotationFromMeasureEpic, 10),
             NUMBER_OF_ACTIONS, [
-                addAnnotation(features, textLabels, uom, true, 1)
+                addAnnotation(features, textLabels, uom, true, {id: 1, visibility: false})
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 const resultFeatures = actions[3].feature.features;
@@ -141,6 +143,7 @@ describe('measurement epics', () => {
                 expect(resultFeatures[0].geometry.textLabels[1].text).toBe("1,837,281.12 m | 140.72°");
                 expect(resultFeatures[0].properties).toExist();
                 expect(resultFeatures[0].properties.geometryGeodesic).toExist();
+                expect(actions[3].feature.visibility).toBe(false);
                 done();
             }, null);
     });
@@ -232,7 +235,7 @@ describe('measurement epics', () => {
             }, state);
     });
     it('test closeMeasureEpics', (done) => {
-        const NUMBER_OF_ACTIONS = 2;
+        const NUMBER_OF_ACTIONS = 1;
         const state = {
             controls: {
                 measure: {
@@ -249,9 +252,6 @@ describe('measurement epics', () => {
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 expect(actions[0].type).toBe("ANNOTATIONS:CLEAN_HIGHLIGHT");
-                expect(actions[1].type).toBe("CHANGE_LAYER_PROPERTIES");
-                expect(actions[1].newProperties).toEqual({"visibility": true});
-                expect(actions[1].layer).toBe("annotations");
                 done();
             }, state);
     });

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -205,9 +205,7 @@ export default (viewer) => ({
                 const {visibility = false, features: annotationFeatures = []} = annotationsLayer;
                 // parsing old style structure
                 let features = annotationFeatures.map(ftColl => {
-                    // Update visibility property of the annotation feature
-                    const properties = {...ftColl.properties, visibility};
-                    return {...ftColl,  properties, style: {}, features: (ftColl.features || []).map(ft => {
+                    return {...ftColl, style: {}, features: (ftColl.features || []).map(ft => {
                         let styleType = ft.properties.isCircle && "Circle" || ft.properties.isText && "Text" || ft.geometry.type;
                         let extraStyles = [];
                         if (styleType === "Circle") {
@@ -230,7 +228,8 @@ export default (viewer) => ({
                 return Rx.Observable.of(updateNode(ANNOTATIONS, 'layer', {
                     rowViewer: viewer,
                     features,
-                    style: {}
+                    style: {},
+                    visibility
                 }));
             }
             return Rx.Observable.empty();
@@ -503,8 +502,7 @@ export default (viewer) => ({
         .switchMap(() => {
             return Rx.Observable.from([
                 cleanHighlight(),
-                changeDrawingStatus("clean", store.getState().annotations.featureType || '', ANNOTATIONS, [], {}),
-                changeLayerProperties(ANNOTATIONS, {visibility: true})
+                changeDrawingStatus("clean", store.getState().annotations?.featureType || '', ANNOTATIONS, [], {})
             ]);
         }),
     confirmCloseAnnotationsEpic: (action$, store) => action$.ofType(CONFIRM_CLOSE_ANNOTATIONS)

--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -11,7 +11,7 @@ import uuidv1 from 'uuid/v1';
 
 import {convertMeasuresToGeoJSON, getGeomTypeSelected} from '../utils/MeasurementUtils';
 import {ADD_MEASURE_AS_ANNOTATION, ADD_AS_LAYER, SET_ANNOTATION_MEASUREMENT, setMeasurementConfig, changeMeasurement} from '../actions/measurement';
-import {addLayer, changeLayerProperties} from '../actions/layers';
+import {addLayer} from '../actions/layers';
 import {STYLE_TEXT} from '../utils/AnnotationsUtils';
 import {toggleControl, setControlProperty, SET_CONTROL_PROPERTY, TOGGLE_CONTROL} from '../actions/controls';
 import {closeFeatureGrid} from '../actions/featuregrid';
@@ -25,10 +25,12 @@ export const addAnnotationFromMeasureEpic = (action$) =>
         .switchMap((a) => {
             // transform measure feature into geometry collection
             // add feature property to manage text annotation with value and uom
-            const {features, textLabels, uom, save, id = uuidv1()} = a;
+            const {features, textLabels, uom, save, properties} = a;
+            const {id = uuidv1(), visibility = true} = properties || {};
             const newFeature = {
                 ...convertMeasuresToGeoJSON(features, textLabels, uom, id, 'Annotations created from measurements', STYLE_TEXT),
-                newFeature: save
+                newFeature: save,
+                visibility
             };
 
             return Rx.Observable.of(
@@ -66,7 +68,7 @@ export const closeMeasureEpics = (action$, store) =>
     action$.ofType(TOGGLE_CONTROL)
         .filter(action => action.control === "measure" && !measureSelector(store.getState()))
         .switchMap(() => {
-            return Rx.Observable.of(cleanHighlight(), changeLayerProperties('annotations', {visibility: true}));
+            return Rx.Observable.of(cleanHighlight());
         });
 
 export const setMeasureStateFromAnnotationEpic = (action$, store) =>

--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -142,12 +142,13 @@ describe('Test the measurement reducer', () => {
             bearingMeasureEnabled: false,
             len: 0,
             area: 700
-        }, setAnnotationMeasurement([{type: 'Feature', geometry: {type: 'LineString'}}], 1));
+        }, setAnnotationMeasurement([{type: 'Feature', geometry: {type: 'LineString'}}], {id: 1, visibility: true}));
         expect(state.features).toEqual([{type: 'Feature', geometry: {type: 'LineString'}}]);
         expect(state.geomTypeSelected).toEqual(['LineString']);
         expect(state.updatedByUI).toBe(true);
         expect(state.exportToAnnotation).toBe(true);
-        expect(state.id).toEqual(1);
+        expect(state.id).toBe(1);
+        expect(state.visibility).toBe(true);
         expect(state.geomType).toEqual("LineString");
     });
     it('SET_MEASUREMENT_CONFIG', () => {

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -150,7 +150,7 @@ function measurement(state = defaultState, action) {
         };
     }
     case SET_ANNOTATION_MEASUREMENT: {
-        let {features} = action;
+        let {features, properties} = action;
         const geomTypeSelected = getGeomTypeSelected(features);
         return {
             ...state,
@@ -159,7 +159,8 @@ function measurement(state = defaultState, action) {
             updatedByUI: true,
             isDrawing: false,
             exportToAnnotation: true,
-            id: action.id
+            id: properties.id,
+            visibility: properties.visibility
         };
     }
     case SET_TEXT_LABELS: {


### PR DESCRIPTION
## Description
This PR adds commits to fix annotation visibility sync issue. Also adds an enhancement where other annotations are not hidden when adding or editing an annotation unless changed from TOC or annotation panel by clicking on the visibility icon

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature

## Issue

**What is the current behavior?**
#6282 

**What is the new behavior?**
https://github.com/geosolutions-it/MapStore2/issues/6282#issuecomment-744456196

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
