### PR TITLE
#6305: Map size doesn't fit the new widget size

### DIFF
--- a/web/client/components/misc/enhancers/withResizeSpy.js
+++ b/web/client/components/misc/enhancers/withResizeSpy.js
@@ -46,6 +46,7 @@ export default ({
         this.width = undefined;
         this.height = undefined;
         this.skipOnMount = props.skipOnMount;
+        this.div = null;
         this.onResize = debounce((...args) => this.props.onResize(...args), debounceTime !== undefined ? debounceTime : props.debounceTime || 1000);
         this.ro = new ResizeObserver((entries) => {
             entries.forEach((entry) => {
@@ -74,9 +75,15 @@ export default ({
     }
     componentDidMount() {
         this.isMounded = true;
-        const div = this.findDomNode();
-        if (div) {
-            this.ro.observe(div);
+        this.div = this.findDomNode();
+        if (this.div) {
+            this.ro.observe(this.div);
+        }
+    }
+    componentDidUpdate() {
+        this.div = this.findDomNode();
+        if (this.div) {
+            this.ro.observe(this.div);
         }
     }
     componentWillUnmount() {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
When the map widget is adjusted the map also updates its size

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6305 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When the map widget is adjusted the map also updates its size

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
