### PR TITLE
[Backport for 2021.01.xx]: #6305: Map size doesn't fit the new widget size

### DIFF
--- a/web/client/components/misc/enhancers/withResizeSpy.js
+++ b/web/client/components/misc/enhancers/withResizeSpy.js
@@ -46,6 +46,7 @@ export default ({
         this.width = undefined;
         this.height = undefined;
         this.skipOnMount = props.skipOnMount;
+        this.div = null;
         this.onResize = debounce((...args) => this.props.onResize(...args), debounceTime !== undefined ? debounceTime : props.debounceTime || 1000);
         this.ro = new ResizeObserver((entries) => {
             entries.forEach((entry) => {
@@ -74,9 +75,15 @@ export default ({
     }
     componentDidMount() {
         this.isMounded = true;
-        const div = this.findDomNode();
-        if (div) {
-            this.ro.observe(div);
+        this.div = this.findDomNode();
+        if (this.div) {
+            this.ro.observe(this.div);
+        }
+    }
+    componentDidUpdate() {
+        this.div = this.findDomNode();
+        if (this.div) {
+            this.ro.observe(this.div);
         }
     }
     componentWillUnmount() {


### PR DESCRIPTION
[Backport for 2021.01.xx]: #6305: Map size doesn't fit the new widget size