### PR TITLE
[Backport for 2021.01.xx]: #6318: Shape upload polygon fill opacity fix

### DIFF
--- a/web/client/components/map/openlayers/LegacyVectorStyle.js
+++ b/web/client/components/map/openlayers/LegacyVectorStyle.js
@@ -382,7 +382,7 @@ const getValidStyle = (geomType, options = { style: defaultStyles}, isDrawing, t
                 }),
                 image: isDrawing ? image : null,
                 fill: new Fill(tempStyle.fill ? tempStyle.fill : {
-                    color: colorToRgbaStr(options.style && tempStyle.fillColor || "#0000FF", tempStyle.fillOpacity || 1)
+                    color: colorToRgbaStr(options.style && tempStyle.fillColor || "#0000FF", isNil(tempStyle.fillOpacity) ? 1 : tempStyle.fillOpacity)
                 })
             })
         ];

--- a/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
@@ -8,8 +8,8 @@
 import expect from 'expect';
 import { getStyle, styleFunction, firstPointOfPolylineStyle, lastPointOfPolylineStyle, startEndPolylineStyle } from '../LegacyVectorStyle';
 
-import {geomCollFeature, multipointFt, lineStringFt} from '../../../../test-resources/drawsupport/features';
-import {DEFAULT_ANNOTATIONS_STYLES, STYLE_CIRCLE} from '../../../../utils/AnnotationsUtils';
+import {geomCollFeature, multipointFt, lineStringFt, polygonFt, multipolygonFt} from '../../../../test-resources/drawsupport/features';
+import {DEFAULT_ANNOTATIONS_STYLES, STYLE_CIRCLE, STYLE_POLYGON} from '../../../../utils/AnnotationsUtils';
 
 import Feature from 'ol/Feature';
 import {Point, LineString, MultiLineString, Polygon, MultiPolygon} from 'ol/geom';
@@ -445,5 +445,20 @@ describe('Test LegacyVectorStyle', () => {
         }, false, []);
         expect(styleObject).toExist();
         expect(styleObject.image_).toExist();
+    });
+    it('test getStyle with Polygon & MultiPolygon', () => {
+        [polygonFt, multipolygonFt].forEach(ft=> {
+            let styleObject = getStyle({ features: [ft], style: {...STYLE_POLYGON}}, false, []);
+            expect(styleObject).toExist();
+            let polygonStyle = styleObject[1];
+            expect(polygonStyle.fill_.color_).toBe("rgba(255, 255, 255, 0.2)");
+            styleObject = getStyle({
+                features: [ft],
+                style: {...STYLE_POLYGON, fillOpacity: 0}
+            }, false, []);
+            expect(styleObject).toExist();
+            polygonStyle = styleObject[1];
+            expect(polygonStyle.fill_.color_).toBe("rgba(255, 255, 255, 0)");
+        });
     });
 });


### PR DESCRIPTION
**[Backport for 2021.01.xx]**: #6318