### PR TITLE
#6321 fix editing of features with "type" in properties that was causing problems

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -253,7 +253,7 @@ export default class DrawSupport extends React.Component {
                         });
                     } else {
                         feature = new Feature({
-                            geometry: this.createOLGeometry(geometry.geometry ? geometry.geometry : {...geometry, ...omit(geometry.properties, "type"), center })
+                            geometry: this.createOLGeometry(geometry.geometry ? geometry.geometry : {...geometry, radius: geometry.properties?.radius, center })
                         });
                     }
                     feature.setProperties(f.properties);

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -253,7 +253,7 @@ export default class DrawSupport extends React.Component {
                         });
                     } else {
                         feature = new Feature({
-                            geometry: this.createOLGeometry(geometry.geometry ? geometry.geometry : {...geometry, ...geometry.properties, center })
+                            geometry: this.createOLGeometry(geometry.geometry ? geometry.geometry : {...geometry, ...omit(geometry.properties, "type"), center })
                         });
                     }
                     feature.setProperties(f.properties);

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -1360,6 +1360,33 @@ describe('Test DrawSupport', () => {
         expect(coords[0].length).toBe(101);
 
     });
+    it('test createOLGeometry with type in properties', () => {
+        const features = [{"type": "Feature", "id": "protected_areas.1", "geometry": {"type": "MultiPolygon", "coordinates": [[[[15.5436, 40.1345], [15.5439, 40.1358], [15.5448, 40.1376], [15.5456, 40.1397], [15.5444, 40.1419], [15.5443, 40.1439], [15.5462, 40.1446], [15.5473, 40.1455], [15.5485, 40.1464], [15.5496, 40.1482], [15.5506, 40.1483], [15.5514, 40.1473], [15.552, 40.1459], [15.5526, 40.1448], [15.5529, 40.1443], [15.5529, 40.1424], [15.552, 40.1414], [15.553, 40.1389], [15.5536, 40.137], [15.5527, 40.136], [15.5511, 40.1373], [15.5498, 40.1361], [15.5476, 40.1345], [15.5449, 40.1339], [15.5436, 40.1345]]]]}, "geometry_name": "the_geom", "properties": {"fid_1": 1, "fid": 1, "id": "214710630", "type": "protected_area", "name": "Oasi del Bussento"}, "bbox": [15.5436, 40.1339, 15.5536, 40.1483]}];
+        const fakeMap = {
+            addLayer: () => {},
+            removeLayer: () => {},
+            disableEventListener: () => {},
+            enableEventListener: () => {},
+            addInteraction: () => {},
+            updateOnlyFeatureStyles: () => {},
+            on: () => {},
+            removeInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:4326'
+                })
+            })
+        };
+
+        let support = ReactDOM.render(<DrawSupport options={{geodesic: true}} map={fakeMap}/>, document.getElementById("container"));
+        support = ReactDOM.render(<DrawSupport options={{geodesic: true}} map={fakeMap} projection={"EPSG:900913"} features={features} method="MultiPolygon" drawStatus="drawOrEdit"/>, document.getElementById("container"));
+
+        const geomType = support.drawSource.getFeatures()[0].getGeometry().getType();
+        expect(geomType).toBe("MultiPolygon");
+    });
     it('test createOLGeometry type Circle geodesic', () => {
         const support = ReactDOM.render(<DrawSupport options={{geodesic: true}}/>, document.getElementById("container"));
         const type = 'Circle';


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The type coming from properties was overriding the geom type and it was drawing the wrong geom type

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6321 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
selecting the geom it works
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
