### PR TITLE
#6316: Set pom.xml versions for stable branch

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -97,7 +97,23 @@
                 </configuration>
             </plugin>
     </plugins>
-  </build>
+    <extensions>
+        <!--.............................................-->
+        <!--       GeoSolutions (using wagon ftp)       -->
+        <!--.............................................-->
+        <extension>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-ftp</artifactId>
+            <version>1.0-beta-2</version>
+        </extension>
+    </extensions>
+    </build>
+    <distributionManagement>
+    <repository>
+        <id>geosolutions</id>
+        <url>ftp://maven.geo-solutions.it/</url>
+    </repository>
+    </distributionManagement>
   <profiles>
   </profiles>
     <repositories>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-backend</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1</version>
   <name>MapStore 2 - Backend</name>
   <url>http://www.geo-solutions.it</url>
 

--- a/printing/pom.xml
+++ b/printing/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>geosolutions-2.0-SNAPSHOT</version>
+        <version>geosolutions-2.0</version>
     </dependency>
     <dependency>
         <groupId>org.mapfish.geo</groupId>

--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.1.0</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.5-SNAPSHOT</version>
+      <version>1.6.0</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.1.0</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.5-SNAPSHOT</version>
+      <version>1.6.0</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -540,7 +540,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>geosolutions-2.0-SNAPSHOT</version>
+                    <version>geosolutions-2.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.mapfish.geo</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.1.0</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -523,7 +523,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>geosolutions-2.0-SNAPSHOT</version>
+            <version>geosolutions-2.0</version>
         </dependency>
         <dependency>
             <groupId>org.mapfish.geo</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.6-SNAPSHOT</version>
+      <version>1.6.0</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
sets versions: 
- print-lib geosolutions-2.0
- http_proxy 1.1.0
- geostore 1.6.0
- mapstore-backend 1.1 

Also included distributionManagement, that is missing on Master
https://github.com/geosolutions-it/MapStore2/pull/5990/files#diff-34049c3bc6deee4bbf269544338e0450399140da63fec684096d1ae0ce70b4bbR100
