### PR TITLE
https://github.com/geosolutions-it/internal/issues/61: prevent loadin…

### DIFF
--- a/backend/src/main/java/it/geosolutions/mapstore/ConfigController.java
+++ b/backend/src/main/java/it/geosolutions/mapstore/ConfigController.java
@@ -32,10 +32,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -76,7 +73,7 @@ public class ConfigController {
     }
 
     private ObjectMapper jsonMapper = new ObjectMapper();
-
+    
     @ResponseStatus(value = HttpStatus.NOT_FOUND)
     public class ResourceNotFoundException extends RuntimeException {
         public ResourceNotFoundException(String message) {
@@ -136,7 +133,9 @@ public class ConfigController {
     public void loadAsset(HttpServletRequest request, HttpServletResponse response) throws IOException {
     	String resourcePath = ((String) request.getAttribute(
     	        HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).split("/loadasset/")[0];
-        // TODO: prevent directory traversing
+    	if (Paths.get(resourcePath).isAbsolute()) {
+    		throw new IOException("Absolute paths are not allowed!");
+    	}
         Resource resource = readResource(resourcePath, false, "");
         response.setContentType(resource.type); 
         IOUtils.copy(toStream(resource), response.getOutputStream());

--- a/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
@@ -103,12 +103,31 @@ public class ConfigControllerTest {
         controller.setContext(context);
     	MockHttpServletRequest request = new MockHttpServletRequest("GET", "/index.js");
     	MockHttpServletResponse response = new MockHttpServletResponse();
-    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/index.js");
+    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "index.js");
         controller.loadAsset(request, response);
         assertEquals(response.getContentType(), "application/javascript");
         assertEquals("console.log('hello')\n", response.getContentAsString()); // \n should not be there, but is not a mess
         tempResource.delete();
     }
+    @Test
+    public void testLoadAssetFromAbsolutePathIsNotAllowed() throws IOException {
+    	ServletContext context = Mockito.mock(ServletContext.class);
+        File tempResource = TestUtils.copyToTemp(ConfigControllerTest.class, "/index.js");
+        Mockito.when(context.getRealPath(Mockito.anyString())).thenReturn(tempResource.getAbsolutePath());
+        controller.setContext(context);
+    	MockHttpServletRequest request = new MockHttpServletRequest("GET", "/index.js");
+    	MockHttpServletResponse response = new MockHttpServletResponse();
+    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, new File("index.js").getAbsolutePath());
+    	Exception found = null;
+    	try {
+    		controller.loadAsset(request, response);
+    	} catch(Exception e) {
+    		found = e;
+    	} finally {
+    		tempResource.delete();
+    	}
+    	assertNotNull(found);
+    }    
     @Test
     public void testLoadJpegAsset() throws IOException {
     	ServletContext context = Mockito.mock(ServletContext.class);
@@ -117,7 +136,7 @@ public class ConfigControllerTest {
         controller.setContext(context);
     	MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test.jpg");
     	MockHttpServletResponse response = new MockHttpServletResponse();
-    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/test.jpg");
+    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "test.jpg");
         controller.loadAsset(request, response);
         assertEquals(response.getContentType(), "image/jpeg");
         byte[] expected = FileUtils.readFileToByteArray(tempResource);
@@ -137,7 +156,7 @@ public class ConfigControllerTest {
         controller.setContext(context);
     	MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test.jpg");
     	MockHttpServletResponse response = new MockHttpServletResponse();
-    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/test.png");
+    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "test.png");
         controller.loadAsset(request, response);
         assertEquals(response.getContentType(), "image/png");
         byte[] expected = FileUtils.readFileToByteArray(tempResource);
@@ -156,7 +175,7 @@ public class ConfigControllerTest {
         controller.setContext(context);
     	MockHttpServletRequest request = new MockHttpServletRequest("GET", "/style.css");
     	MockHttpServletResponse response = new MockHttpServletResponse();
-    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/style.css");
+    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "style.css");
         controller.loadAsset(request, response);
         assertEquals(response.getContentType(), "text/css");
         assertEquals(".test{background: none}\n", response.getContentAsString()); // \n should not be there, but is not a mess
@@ -173,7 +192,7 @@ public class ConfigControllerTest {
         controller.setContext(context);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/index.js");
     	MockHttpServletResponse response = new MockHttpServletResponse();
-    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/index.js");
+    	request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "index.js");
         controller.loadAsset(request, response);
         assertEquals(response.getContentType(), "application/javascript");
         assertEquals("console.log('hello')\n", response.getContentAsString()); // \n should not be there, but is not a mess

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-backend</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </dependency>
 
     <!-- ================================================================ -->


### PR DESCRIPTION
…g assets from absolute paths

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
https://github.com/geosolutions-it/internal/issues/61

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/internal/issues/61

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Absolute paths are not allowed by /rest/config/loadasset/**path** anymore

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
