### PR TITLE
#6338 - fix thematic layer color ramps not applied correctly

### DIFF
--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -70,7 +70,9 @@ const standardColors = [{
 
 const getColor = (layer, name, intervals, customRamp) => {
     const chosenColors = layer
-        ? head((layer.thematic.colors || layer.thematic.additionalColors || []).filter(c => c.name === name))
+        ? head((layer.thematic.colors || layer.thematic.additionalColors || [])
+            .filter(c => c.name === name)
+        ) || head(standardColors.filter(c => c.name === name))
         : customRamp
             ? head([ customRamp, ...standardColors].filter(c => c.name === name))
             : head(standardColors.filter(c => c.name === name));

--- a/web/client/api/__tests__/SLDService-test.js
+++ b/web/client/api/__tests__/SLDService-test.js
@@ -397,7 +397,7 @@ describe('Test correctness of the SLDService APIs', () => {
         expect(result[0].values).toExist();
     });
     it('check getColor with layer with thematic.colors', () => {
-        const result = API.getColor({thematic: {colors:[{
+        const result = API.getColor({thematic: {colors: [{
             name: 'green',
             colors: ['#000', '#008000', '#0f0']
         }]}}, "green", 5);
@@ -406,7 +406,7 @@ describe('Test correctness of the SLDService APIs', () => {
         expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
     });
     it('check getColor with layer with thematic.additionalColors', () => {
-        const result = API.getColor({thematic: {additionalColors:[{
+        const result = API.getColor({thematic: {additionalColors: [{
             name: 'green',
             colors: ['#000', '#008000', '#0f0']
         }]}}, "green", 5);

--- a/web/client/api/__tests__/SLDService-test.js
+++ b/web/client/api/__tests__/SLDService-test.js
@@ -396,6 +396,35 @@ describe('Test correctness of the SLDService APIs', () => {
         expect(result.length).toBe(2);
         expect(result[0].values).toExist();
     });
+    it('check getColor with layer with thematic.colors', () => {
+        const result = API.getColor({thematic: {colors:[{
+            name: 'green',
+            colors: ['#000', '#008000', '#0f0']
+        }]}}, "green", 5);
+        expect(result.ramp).toBe("custom");
+        expect(result.colors).toBeTruthy();
+        expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
+    });
+    it('check getColor with layer with thematic.additionalColors', () => {
+        const result = API.getColor({thematic: {additionalColors:[{
+            name: 'green',
+            colors: ['#000', '#008000', '#0f0']
+        }]}}, "green", 5);
+        expect(result.ramp).toBe("custom");
+        expect(result.colors).toBeTruthy();
+        expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
+    });
+    it('check getColor with layer with thematic.additionalColors', () => {
+        const result = API.getColor({thematic: {}}, "notdefined", 5);
+        expect(result.ramp).toBe("notdefined");
+        expect(result.colors).toBeFalsy();
+    });
+    it('check getColor with standard color transformed in custom ramp', () => {
+        const result = API.getColor({thematic: {}}, "green", 5);
+        expect(result.ramp).toBe("custom");
+        expect(result.colors).toBeTruthy();
+        expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
+    });
     it('check getColors only standard', () => {
         const result = API.getColors(undefined, layer, 10);
         expect(result.length).toBe(5 + 36 /* 36 color brewer ramps */);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
fix thematic layer color ramps not applied correctly

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6338

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
old behaviour by sending custom ramps works again

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
@allyoucanmap i did not covered all use cases with getColor with unit tests, maybe you can help me addressing them when customRamp is used
