### PR TITLE
Backport 2021.01.xx - #6338 - fix thematic layer color ramps not applied correctly (#6341)

### DIFF
--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -70,7 +70,9 @@ const standardColors = [{
 
 const getColor = (layer, name, intervals, customRamp) => {
     const chosenColors = layer
-        ? head((layer.thematic.colors || layer.thematic.additionalColors || []).filter(c => c.name === name))
+        ? head((layer.thematic.colors || layer.thematic.additionalColors || [])
+            .filter(c => c.name === name)
+        ) || head(standardColors.filter(c => c.name === name))
         : customRamp
             ? head([ customRamp, ...standardColors].filter(c => c.name === name))
             : head(standardColors.filter(c => c.name === name));

--- a/web/client/api/__tests__/SLDService-test.js
+++ b/web/client/api/__tests__/SLDService-test.js
@@ -396,6 +396,35 @@ describe('Test correctness of the SLDService APIs', () => {
         expect(result.length).toBe(2);
         expect(result[0].values).toExist();
     });
+    it('check getColor with layer with thematic.colors', () => {
+        const result = API.getColor({thematic: {colors: [{
+            name: 'green',
+            colors: ['#000', '#008000', '#0f0']
+        }]}}, "green", 5);
+        expect(result.ramp).toBe("custom");
+        expect(result.colors).toBeTruthy();
+        expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
+    });
+    it('check getColor with layer with thematic.additionalColors', () => {
+        const result = API.getColor({thematic: {additionalColors: [{
+            name: 'green',
+            colors: ['#000', '#008000', '#0f0']
+        }]}}, "green", 5);
+        expect(result.ramp).toBe("custom");
+        expect(result.colors).toBeTruthy();
+        expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
+    });
+    it('check getColor with layer with thematic.additionalColors', () => {
+        const result = API.getColor({thematic: {}}, "notdefined", 5);
+        expect(result.ramp).toBe("notdefined");
+        expect(result.colors).toBeFalsy();
+    });
+    it('check getColor with standard color transformed in custom ramp', () => {
+        const result = API.getColor({thematic: {}}, "green", 5);
+        expect(result.ramp).toBe("custom");
+        expect(result.colors).toBeTruthy();
+        expect(result.colors).toEqual("#000000,#004000,#008000,#00c000,#00ff00");
+    });
     it('check getColors only standard', () => {
         const result = API.getColors(undefined, layer, 10);
         expect(result.length).toBe(5 + 36 /* 36 color brewer ramps */);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Backport 2021.01.xx - #6338 - fix thematic layer color ramps not applied correctly (#6341)