### PR TITLE
#6340: Shape file polygon stroke fix

### DIFF
--- a/web/client/components/map/openlayers/LegacyVectorStyle.js
+++ b/web/client/components/map/openlayers/LegacyVectorStyle.js
@@ -376,7 +376,7 @@ const getValidStyle = (geomType, options = { style: defaultStyles}, isDrawing, t
             }),
             new Style({
                 stroke: new Stroke( tempStyle.stroke ? tempStyle.stroke : {
-                    color: options.style.useSelectedStyle ? blue : colorToRgbaStr(options.style && tempStyle.color || "#0000FF", tempStyle.opacity || 1),
+                    color: options.style.useSelectedStyle ? blue : colorToRgbaStr(options.style && tempStyle.color || "#0000FF", isNil(tempStyle.opacity) ? 1 : tempStyle.opacity),
                     lineDash: options.style.highlight ? [10] : [0],
                     width: tempStyle.weight || 1
                 }),

--- a/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
@@ -452,13 +452,15 @@ describe('Test LegacyVectorStyle', () => {
             expect(styleObject).toExist();
             let polygonStyle = styleObject[1];
             expect(polygonStyle.fill_.color_).toBe("rgba(255, 255, 255, 0.2)");
+            expect(polygonStyle.stroke_.color_).toBe("rgb(255, 204, 51)");
             styleObject = getStyle({
                 features: [ft],
-                style: {...STYLE_POLYGON, fillOpacity: 0}
+                style: {...STYLE_POLYGON, fillOpacity: 0, opacity: 0}
             }, false, []);
             expect(styleObject).toExist();
             polygonStyle = styleObject[1];
             expect(polygonStyle.fill_.color_).toBe("rgba(255, 255, 255, 0)");
+            expect(polygonStyle.stroke_.color_).toBe("rgba(255, 204, 51, 0)");
         });
     });
 });


### PR DESCRIPTION
## Description
This PR adds fix for user being unable to set stroke opacity to 0 for polygon and multipolygon geometry (When uploading shape file and from styles tab)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6340 

**What is the new behavior?**
User set stroke opacity will be applied properly along with 0 for shape file of type Polygon and MultiPolygon

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
