### PR TITLE
Backport 2021.01.xx - #6102: support for multiple string and number values in attribute filter (#6315)

### DIFF
--- a/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
+++ b/web/client/components/data/featuregrid/filterRenderers/NumberFilter.jsx
@@ -8,9 +8,10 @@
 
 import AttributeFilter from './AttributeFilter';
 
-import { trim } from 'lodash';
+import { trim, identity } from 'lodash';
 import { compose, withHandlers, withState, defaultProps } from 'recompose';
-const EXPRESSION_REGEX = /\s*(!==|!=|<>|<=|>=|===|==|=|<|>)?\s*(-?\d*\.?\d*)\s*/;
+const COMMA_REGEX = /\,/;
+import { getOperatorAndValue } from '../../../../utils/FeatureGridUtils';
 
 export default compose(
     defaultProps({
@@ -20,34 +21,36 @@ export default compose(
     withHandlers({
         onChange: props => ({value, attribute} = {}) => {
             props.onValueChange(value);
-            let operator = "=";
-            let newVal;
-            const match = EXPRESSION_REGEX.exec(value);
-            if (match) {
-                operator = match[1] || "=";
-                // replace with standard opeartors
-                if (operator === "!==" | operator === "!=") {
-                    operator = "<>";
-                } else if (operator === "===" | operator === "==") {
-                    operator = "=";
+            if (!COMMA_REGEX.exec(value)) {
+                let {operator, newVal} = getOperatorAndValue(value, "number");
+                if (isNaN(newVal) && trim(value) !== "") {
+                    props.setValid(false);
+                } else {
+                    props.setValid(true);
                 }
-                newVal = parseFloat(match[2]);
+                props.onChange({
+                    value: isNaN(newVal) ? undefined : newVal,
+                    rawValue: value,
+                    operator,
+                    type: 'number',
+                    attribute
+                });
             } else {
-                newVal = parseFloat(value, 10);
+                const multipleValues = value?.split(",").filter(identity) || [];
+                const isValid = multipleValues.reduce((valid, v) => {
+                    let {newVal} = getOperatorAndValue(v);
+                    return valid && !(isNaN(newVal) && trim(v) !== "");
+                }, true);
+                props.setValid(isValid);
+                props.onChange({
+                    value: value,
+                    rawValue: value,
+                    operator: "=",
+                    type: 'number',
+                    attribute
+                });
             }
 
-            if (isNaN(newVal) && trim(value) !== "") {
-                props.setValid(false);
-            } else {
-                props.setValid(true);
-            }
-            props.onChange({
-                value: isNaN(newVal) ? undefined : newVal,
-                rawValue: value,
-                operator,
-                type: 'number',
-                attribute
-            });
         }
     }),
     defaultProps({

--- a/web/client/utils/FeatureGridUtils.js
+++ b/web/client/utils/FeatureGridUtils.js
@@ -6,7 +6,7 @@
   * LICENSE file in the root directory of this source tree.
   */
 
-import { fill, findIndex, get, isArray, isNil } from 'lodash';
+import { identity, trim, fill, findIndex, get, isArray, isNil, isString } from 'lodash';
 
 import {
     findGeometryProperty,
@@ -174,14 +174,77 @@ export const createNewAndEditingFilter = (hasChanges, newFeatures, changes) => f
 export const hasValidNewFeatures = (newFeatures = [], describeFeatureType) => newFeatures.map(f => isValid(f, describeFeatureType)).reduce((acc, cur) => cur && acc, true);
 export const applyAllChanges = (orig, changes = {}) => applyChanges(orig, changes[orig.id] || {});
 
+export const EXPRESSION_REGEX = /\s*(!==|!=|<>|<=|>=|===|==|=|<|>)?\s*(-?\d*\.?\d*)\s*/;
+
+/**
+ * handle parsing of raw values for string and number types
+ * @param {string} value the value in string form, with operator in case of number
+ * @param {string} type the type of the value, number or string
+ */
+export const getOperatorAndValue = (value, type) => {
+    if (type === "string") {
+        return {newVal: trim(value), operator: "ilike"};
+    }
+    const match = EXPRESSION_REGEX.exec(value);
+    let operator = "=";
+    let newVal;
+    if (match) {
+        operator = match[1] || "=";
+        // replace with standard operators
+        if (operator === "!==" | operator === "!=") {
+            operator = "<>";
+        } else if (operator === "===" | operator === "==") {
+            operator = "=";
+        }
+        newVal = parseFloat(match[2]);
+    } else {
+        newVal = parseFloat(value, 10);
+    }
+    return {newVal, operator};
+};
+
+
 export const gridUpdateToQueryUpdate = ({attribute, operator, value, type} = {}, oldFilterObj = {}) => {
+
+    const cleanGroupFields = oldFilterObj.groupFields?.filter((group) => attribute !== group.id && group.id !== 1 ) || [];
+    if ((type === 'string' || type === 'number') && isString(value) && value?.indexOf(",") !== -1) {
+        const multipleValues = value?.split(",").filter(identity) || [];
+        const cleanFilterFields = oldFilterObj.filterFields?.filter((field) => attribute !== field.attribute) || [];
+        return {
+            ...oldFilterObj,
+            groupFields: cleanGroupFields.concat([
+                {
+                    id: attribute,
+                    logic: "OR",
+                    groupId: 1,
+                    index: 0
+                }]),
+            filterFields: cleanFilterFields.concat(multipleValues.map((v) => {
+                let {operator: op, newVal} = getOperatorAndValue(v, type);
+
+                return {
+                    attribute,
+                    rowId: Date.now(),
+                    type: type,
+                    groupId: attribute,
+                    operator: op,
+                    value: newVal
+                };
+            })),
+            spatialField: oldFilterObj.spatialField,
+            spatialFieldOperator: oldFilterObj.spatialFieldOperator
+        };
+    }
+
     return {
         ...oldFilterObj,
-        groupFields: [{
-            id: 1,
-            logic: "AND",
-            index: 0
-        }],
+        groupFields: cleanGroupFields.concat([
+            {
+                id: 1,
+                logic: "AND",
+                groupId: 1,
+                index: 0
+            }]),
         filterFields: type === 'geometry' ? oldFilterObj.filterFields : !isNil(value)
             ? upsertFilterField((oldFilterObj.filterFields || []), {attribute: attribute}, {
                 attribute,

--- a/web/client/utils/__tests__/FeatureGridUtils-test.js
+++ b/web/client/utils/__tests__/FeatureGridUtils-test.js
@@ -55,7 +55,7 @@ describe('FeatureGridUtils', () => {
         const gridUpdate1 = {
             type: "geometry",
             attribute: "ATTRIBUTE",
-            opeartor: "OPERATOR",
+            operator: "OPERATOR",
             value: {attribute: "ATTRIBUTE", method: "METHOD_1"},
             rawValue: "RAWVAL"
         };
@@ -72,5 +72,89 @@ describe('FeatureGridUtils', () => {
         expect(queryUpdateFilter2.spatialField).toEqual(gridUpdate2.value);
         expect(queryUpdateFilter2.filterFields).toBe(undefined);
         expect(queryUpdateFilter2.spatialFieldOperator).toBe("OR");
+    });
+    it('gridUpdateToQueryUpdate with multiple strings', () => {
+        const gridUpdate1 = {
+            type: "string",
+            attribute: "ATTRIBUTE",
+            operator: "ilike",
+            value: "str1, str2",
+            rawValue: "str1, str2"
+        };
+        const queryUpdateFilter = gridUpdateToQueryUpdate(gridUpdate1, {});
+        expect(queryUpdateFilter.filterFields.length).toBe(2);
+        expect(queryUpdateFilter.groupFields.length).toBe(1);
+        expect(queryUpdateFilter.groupFields[0].logic).toBe("OR");
+        expect(queryUpdateFilter.filterFields[0].value).toBe("str1");
+        expect(queryUpdateFilter.filterFields[0].operator).toBe("ilike");
+        expect(queryUpdateFilter.filterFields[1].value).toBe("str2");
+        expect(queryUpdateFilter.filterFields[1].operator).toBe("ilike");
+    });
+    it('gridUpdateToQueryUpdate with multiple numbers', () => {
+        const gridUpdate1 = {
+            type: "number",
+            attribute: "ATTRIBUTE",
+            operator: null,
+            value: "> 300, 69, < 10",
+            rawValue: "> 300, 69, < 10"
+        };
+        const queryUpdateFilter = gridUpdateToQueryUpdate(gridUpdate1, {});
+        expect(queryUpdateFilter.filterFields.length).toBe(3);
+        expect(queryUpdateFilter.groupFields.length).toBe(1);
+        expect(queryUpdateFilter.groupFields[0].logic).toBe("OR");
+        expect(queryUpdateFilter.filterFields[0].value).toBe(300);
+        expect(queryUpdateFilter.filterFields[0].operator).toBe(">");
+        expect(queryUpdateFilter.filterFields[1].value).toBe(69);
+        expect(queryUpdateFilter.filterFields[1].operator).toBe("=");
+        expect(queryUpdateFilter.filterFields[2].value).toBe(10);
+        expect(queryUpdateFilter.filterFields[2].operator).toBe("<");
+
+    });
+    it('gridUpdateToQueryUpdate with multiple numbers and multiple strings', () => {
+        const gridUpdate1 = {
+            type: "number",
+            attribute: "ATTR_2_NUMERIC",
+            operator: null,
+            value: "> 300, 69, < 10",
+            rawValue: "> 300, 69, < 10"
+        };
+
+        const oldFilterObject = {
+            "groupFields": [{"id": "ATTR_1_STRING", "logic": "OR", "groupId": 1, "index": 0}],
+            "filterFields": [
+                {
+                    "attribute": "ATTR_1_STRING",
+                    "rowId": 1608204971082,
+                    "type": "string",
+                    "groupId": "ATTR_1_STRING",
+                    "operator": "ilike",
+                    "value": "cat"
+                },
+                {"attribute": "ATTR_1_STRING",
+                    "rowId": 1608204971082,
+                    "type": "string",
+                    "groupId": "ATTR_1_STRING",
+                    "operator": "ilike",
+                    "value": "to"
+                }
+            ]};
+
+        const queryUpdateFilter = gridUpdateToQueryUpdate(gridUpdate1, oldFilterObject);
+        expect(queryUpdateFilter.filterFields.length).toBe(5);
+        expect(queryUpdateFilter.groupFields.length).toBe(2);
+        expect(queryUpdateFilter.groupFields[0].id).toBe("ATTR_1_STRING");
+        expect(queryUpdateFilter.groupFields[0].logic).toBe("OR");
+        expect(queryUpdateFilter.groupFields[0].id).toBe("ATTR_1_STRING");
+        expect(queryUpdateFilter.groupFields[1].logic).toBe("OR");
+        expect(queryUpdateFilter.filterFields[0].value).toBe("cat");
+        expect(queryUpdateFilter.filterFields[0].operator).toBe("ilike");
+        expect(queryUpdateFilter.filterFields[1].value).toBe("to");
+        expect(queryUpdateFilter.filterFields[1].operator).toBe("ilike");
+        expect(queryUpdateFilter.filterFields[2].value).toBe(300);
+        expect(queryUpdateFilter.filterFields[2].operator).toBe(">");
+        expect(queryUpdateFilter.filterFields[3].value).toBe(69);
+        expect(queryUpdateFilter.filterFields[3].operator).toBe("=");
+        expect(queryUpdateFilter.filterFields[4].value).toBe(10);
+        expect(queryUpdateFilter.filterFields[4].operator).toBe("<");
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Backport 2021.01.xx - #6102: support for multiple string and number values in attribute filter (#6315)