### PR TITLE
Fix directory traversal with no data dir set

### DIFF
--- a/backend/src/main/java/it/geosolutions/mapstore/utils/ResourceUtils.java
+++ b/backend/src/main/java/it/geosolutions/mapstore/utils/ResourceUtils.java
@@ -44,8 +44,20 @@ public class ResourceUtils {
 	 * @return
 	 */
 	public static Optional<File> findResource(String baseFolders, ServletContext context, String resourceName) {
-		String[] candidates = Stream.concat(Stream.of(baseFolders.split(",")).map(new Function<String, String>() {
+		String[] candidates = Stream.concat(Stream.of(baseFolders.split(","))
+				// remove empty string, to avoid to add "/" to the allowed paths
+				.filter(new Predicate<String>() {
 
+					@Override
+					public boolean test(String string) {
+						if(string == null || "".equals(string)) {
+							return false;
+						}
+						return true;
+					}
+					
+				})
+				.map(new Function<String, String>() {
 			@Override
 			public String apply(String f) {
 				return f + "/" + resourceName;

--- a/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
@@ -216,6 +216,7 @@ public class ConfigControllerTest {
         File tempProperties = TestUtils.copyToTemp(ConfigControllerTest.class, "/mapstore.properties");
         ServletContext context = Mockito.mock(ServletContext.class);
         Mockito.when(context.getRealPath(Mockito.endsWith(".json"))).thenReturn(tempResource.getAbsolutePath());
+        Mockito.when(context.getRealPath(Mockito.endsWith(".properties"))).thenReturn(tempProperties.getAbsolutePath());
         controller.setContext(context);
         controller.setOverrides(tempProperties.getAbsolutePath());
         controller.setMappings("header.height=headerHeight,header.url=headerUrl");

--- a/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/ConfigControllerTest.java
@@ -224,6 +224,22 @@ public class ConfigControllerTest {
         assertEquals("{\"header\":{\"height\":\"200\",\"url\":\"https://mapstore2.geo-solutions.it\"}}", resource.trim());
         tempResource.delete();
     }
+    @Test
+    public void testOverridesWithDataDir() throws IOException {
+    	File dataDir = TestUtils.getDataDir();
+        controller.setDataDir(dataDir.getAbsolutePath());
+        File tempResource = TestUtils.copyToTemp(ConfigControllerTest.class, "/localConfigFull.json");
+        ServletContext context = Mockito.mock(ServletContext.class);
+        Mockito.when(context.getRealPath(Mockito.endsWith(".json"))).thenReturn(tempResource.getAbsolutePath());
+        TestUtils.copyTo(ConfigControllerTest.class.getResourceAsStream("/mapstore.properties"), dataDir,
+        		"/mapstore.properties");
+        controller.setContext(context);
+        controller.setOverrides("mapstore.properties");
+        controller.setMappings("header.height=headerHeight,header.url=headerUrl");
+        String resource = new String(controller.loadResource("localConfig", true), "UTF-8");
+        assertEquals("{\"header\":{\"height\":\"200\",\"url\":\"https://mapstore2.geo-solutions.it\"}}", resource.trim());
+        tempResource.delete();
+    }
 
     @Test
     public void testPatch() throws IOException {

--- a/backend/src/test/java/it/geosolutions/mapstore/utils/ResourceUtilsTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/utils/ResourceUtilsTest.java
@@ -16,10 +16,10 @@ import java.io.IOException;
 import java.util.Optional;
 
 import javax.servlet.ServletContext;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 
 import it.geosolutions.mapstore.ConfigControllerTest;
 import it.geosolutions.mapstore.TestUtils;

--- a/backend/src/test/java/it/geosolutions/mapstore/utils/ResourceUtilsTest.java
+++ b/backend/src/test/java/it/geosolutions/mapstore/utils/ResourceUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+package it.geosolutions.mapstore.utils;
+
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import javax.servlet.ServletContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+import it.geosolutions.mapstore.ConfigControllerTest;
+import it.geosolutions.mapstore.TestUtils;
+
+public class ResourceUtilsTest {
+    
+    @Before
+    public void setUp() {
+        
+    }
+    
+    @Test
+    public void testFindResource() throws IOException {
+    	ServletContext context = Mockito.mock(ServletContext.class);
+    	File tempConfig = TestUtils.copyToTemp(ConfigControllerTest.class, "/pluginsConfig.json");
+        Mockito.when(context.getRealPath(Mockito.endsWith("pluginsConfig.json"))).thenReturn(tempConfig.getAbsolutePath());
+    	Optional<File> f1 = ResourceUtils.findResource("", context, "pluginsConfig.json");
+    	Optional<File> f2 = ResourceUtils.findResource("", context, "otherFile.json");
+    	assertTrue(f1.isPresent());
+    	assertFalse(f2.isPresent());
+    }
+    @Test
+    public void testFindResourceDoNotAllowAbsolutePaths() throws IOException {
+    	ServletContext context = Mockito.mock(ServletContext.class);
+    	File tempConfig = TestUtils.copyToTemp(ConfigControllerTest.class, "/pluginsConfig.json");
+    	Optional<File> f1 = ResourceUtils.findResource("", context, tempConfig.getAbsolutePath()); // "/tmp/something"
+    	Optional<File> f2 = ResourceUtils.findResource("", context, tempConfig.getAbsolutePath().substring(1)); // "tmp/something"
+    	assertFalse(f1.isPresent());
+    	assertFalse(f2.isPresent());
+    }
+    
+   
+}


### PR DESCRIPTION
## Description
This PR fix a bug when a data dir is not set, that uses "" as base dir, and so concatenates "" + "/" + "<path>" creating and absolute path.

@mbarto fixing it, a test with overrides from mapstore.properties failed. because it uses the same system to get resources. Do you think we can have problem with it?
I think I've fixed it:
-  `mapstore.properties`  must be relative to the data dir (I see from doc). So I added also a test to check that the file is correctly used from the data-dir.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
https://github.com/geosolutions-it/internal/issues/61

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
