### PR TITLE
[Backport for 2021.01.xx]: #6340: Shape file polygon stroke fix

### DIFF
--- a/web/client/components/map/openlayers/LegacyVectorStyle.js
+++ b/web/client/components/map/openlayers/LegacyVectorStyle.js
@@ -376,7 +376,7 @@ const getValidStyle = (geomType, options = { style: defaultStyles}, isDrawing, t
             }),
             new Style({
                 stroke: new Stroke( tempStyle.stroke ? tempStyle.stroke : {
-                    color: options.style.useSelectedStyle ? blue : colorToRgbaStr(options.style && tempStyle.color || "#0000FF", tempStyle.opacity || 1),
+                    color: options.style.useSelectedStyle ? blue : colorToRgbaStr(options.style && tempStyle.color || "#0000FF", isNil(tempStyle.opacity) ? 1 : tempStyle.opacity),
                     lineDash: options.style.highlight ? [10] : [0],
                     width: tempStyle.weight || 1
                 }),

--- a/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/LegacyVectorStyle-test.js
@@ -452,13 +452,15 @@ describe('Test LegacyVectorStyle', () => {
             expect(styleObject).toExist();
             let polygonStyle = styleObject[1];
             expect(polygonStyle.fill_.color_).toBe("rgba(255, 255, 255, 0.2)");
+            expect(polygonStyle.stroke_.color_).toBe("rgb(255, 204, 51)");
             styleObject = getStyle({
                 features: [ft],
-                style: {...STYLE_POLYGON, fillOpacity: 0}
+                style: {...STYLE_POLYGON, fillOpacity: 0, opacity: 0}
             }, false, []);
             expect(styleObject).toExist();
             polygonStyle = styleObject[1];
             expect(polygonStyle.fill_.color_).toBe("rgba(255, 255, 255, 0)");
+            expect(polygonStyle.stroke_.color_).toBe("rgba(255, 204, 51, 0)");
         });
     });
 });


### PR DESCRIPTION
[Backport for 2021.01.xx]: #6340: Shape file polygon stroke fix #6346