### PR TITLE
#6361: fixes errors in console when removing an extension

### DIFF
--- a/web/client/components/app/withExtensions.js
+++ b/web/client/components/app/withExtensions.js
@@ -53,6 +53,14 @@ function withExtensions(AppComponent) {
             return false;
         }
 
+        /**
+         * Updates the internal list of dynamically loaded extensions.
+         * Also takes care of properly enabling the related assets (e.g. new translations paths)         * @param {*} plugins
+         *
+         * @param {object} plugins extensions definition object
+         * @param {array} translations list of extensions related translations paths
+         * @param {*} store application redux store, used to dispatch reloading localized messages if needed
+         */
         onPluginsLoaded = (plugins, translations, store) => {
             this.setState({
                 pluginsRegistry: plugins
@@ -74,7 +82,7 @@ function withExtensions(AppComponent) {
                         );
                     }
                     if (action.type === PLUGIN_UNINSTALLED) {
-                        this.removeExtension(action.plugin);
+                        this.removeExtension(action.plugin, action.cfg?.translations);
                     }
                 });
             }
@@ -106,10 +114,23 @@ function withExtensions(AppComponent) {
                 />);
         }
 
-        removeExtension = (plugin) => {
+        /**
+         * Removes the given extension from configuration, taking
+         * care of the related assets too.
+         *
+         * @param {string} name of the plugin to be removed
+         * @param {*} translations translations path used by the extension, if any
+         */
+        removeExtension = (plugin, translations) => {
             this.setState({
                 removedPlugins: [...this.state.removedPlugins, plugin + "Plugin"] // TODO: check
             });
+            if (translations) {
+                // remove extension's translation paths from the actual list
+                const translationsPath = ConfigUtils.getConfigProp("translationsPath");
+                ConfigUtils.setConfigProp("translationsPath",
+                    castArray(translationsPath).filter(p => p !== this.getAssetPath(translations)));
+            }
         };
 
         filterRemoved = (registry, removed) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6361 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
An error in console is thrown when removing an extension with custom translations, due to not removing the translations from the application configuration on removal.

**What is the new behavior?**
An error in console is NOT thrown when removing an extension with custom translations.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
I couldn't reproduce the other mentioned issue, related to a refresh need on extension installation instead.
