### PR TITLE
#6362: fix for new rootReducer not persisted on StateUtils augmentStore

### DIFF
--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -204,7 +204,7 @@ export const updateStore = ({ rootReducer, rootEpic, reducers = {}, epics = {} }
  */
 export const augmentStore = ({ reducers = {}, epics = {} } = {}, store) => {
     const rootReducer = fetchReducer();
-    const reducer = (state, action) => {
+    const reducer = persistReducer((state, action) => {
         const initialStoreKeys = Object.keys(rootReducer({}, {}));
         const newState = {...state, ...rootReducer(state, action)};
         return Object.keys(reducers)
@@ -217,8 +217,9 @@ export const augmentStore = ({ reducers = {}, epics = {} } = {}, store) => {
                     [current]: reducers[current](previous[current], action)
                 };
             }, newState);
-    };
+    });
     (store || getStore()).replaceReducer(reducer);
+
     const rootEpic = fetchEpic();
 
     wrapEpics(epics).forEach((epic) => {

--- a/web/client/utils/__tests__/StateUtils-test.js
+++ b/web/client/utils/__tests__/StateUtils-test.js
@@ -157,6 +157,29 @@ describe('StateUtils', () => {
         expect(spy2.calls.length > 0).toBe(true);
         expect(spy1.calls.length).toBe(beforeUpdateCalls);
     });
+    it('augmentStore should add all reducers if called many times', () => {
+        const rootReducer = () => ({});
+        let currentReducer = rootReducer;
+        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);
+        const store = {
+            replaceReducer: (reducer) => {
+                currentReducer = reducer;
+            }
+        };
+        augmentStore({ reducers: {
+            map: () => {
+                return {};
+            }
+        }}, store);
+        augmentStore({ reducers: {
+            controls: () => {
+                return {};
+            }
+        } }, store);
+        const newState = currentReducer({}, {});
+        expect(Object.keys(newState)).toEqual([ 'map', 'controls' ]);
+        setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', undefined);
+    });
     it('should use the new added reducers (augmentStore)', () => {
         const rootReducer = () => ({});
         setConfigProp(PERSISTED_STORE_NAME + '.rootReducer', rootReducer);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6362 

**What is the current behavior?**
Calling StateUtils.augmentStore many times will always use the original reducer stored at application start, so it cannot be called many times to add more reducers.

**What is the new behavior?**
Now every call to StateUtils.augmentStore persists the last reducer so that it can be called many times to add new reducers.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
