### PR TITLE
a fix for coordinate editor layout on safari (#234)

### DIFF
--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -149,55 +149,59 @@ class CoordinatesRow extends React.Component {
                 <div style={{cursor: this.props.isDraggableEnabled ? 'grab' : "not-allowed"}}>
                     {this.props.showDraggable ? this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton : null}
                 </div>
-                <div className="coordinate lat">
-                    <InputGroup>
-                        <InputGroup.Addon><Message msgId="latitude"/></InputGroup.Addon>
-                        <CoordinateEntry
-                            format={this.props.format}
-                            aeronauticalOptions={this.props.aeronauticalOptions}
-                            coordinate="lat"
-                            idx={idx}
-                            value={this.state.lat}
-                            onChange={(dd) => this.onChangeLatLon("lat", dd)}
-                            constraints={{
-                                decimal: {
-                                    lat: {
-                                        min: -90,
-                                        max: 90
-                                    },
-                                    lon: {
-                                        min: -180,
-                                        max: 180
+                <div className="coordinate">
+                    <div>
+                        <InputGroup>
+                            <InputGroup.Addon><Message msgId="latitude"/></InputGroup.Addon>
+                            <CoordinateEntry
+                                format={this.props.format}
+                                aeronauticalOptions={this.props.aeronauticalOptions}
+                                coordinate="lat"
+                                idx={idx}
+                                value={this.state.lat}
+                                onChange={(dd) => this.onChangeLatLon("lat", dd)}
+                                constraints={{
+                                    decimal: {
+                                        lat: {
+                                            min: -90,
+                                            max: 90
+                                        },
+                                        lon: {
+                                            min: -180,
+                                            max: 180
+                                        }
                                     }
-                                }
-                            }}
-                            onKeyDown={this.onSubmit}
-                        />
-                    </InputGroup>
-                    <InputGroup>
-                        <InputGroup.Addon><Message msgId="longitude"/></InputGroup.Addon>
-                        <CoordinateEntry
-                            format={this.props.format}
-                            aeronauticalOptions={this.props.aeronauticalOptions}
-                            coordinate="lon"
-                            idx={idx}
-                            value={this.state.lon}
-                            onChange={(dd) => this.onChangeLatLon("lon", dd)}
-                            constraints={{
-                                decimal: {
-                                    lat: {
-                                        min: -90,
-                                        max: 90
-                                    },
-                                    lon: {
-                                        min: -180,
-                                        max: 180
+                                }}
+                                onKeyDown={this.onSubmit}
+                            />
+                        </InputGroup>
+                    </div>
+                    <div>
+                        <InputGroup>
+                            <InputGroup.Addon><Message msgId="longitude"/></InputGroup.Addon>
+                            <CoordinateEntry
+                                format={this.props.format}
+                                aeronauticalOptions={this.props.aeronauticalOptions}
+                                coordinate="lon"
+                                idx={idx}
+                                value={this.state.lon}
+                                onChange={(dd) => this.onChangeLatLon("lon", dd)}
+                                constraints={{
+                                    decimal: {
+                                        lat: {
+                                            min: -90,
+                                            max: 90
+                                        },
+                                        lon: {
+                                            min: -180,
+                                            max: 180
+                                        }
                                     }
-                                }
-                            }}
-                            onKeyDown={this.onSubmit}
-                        />
-                    </InputGroup>
+                                }}
+                                onKeyDown={this.onSubmit}
+                            />
+                        </InputGroup>
+                    </div>
                 </div>
                 {this.props.showToolButtons && <div key="tools">
                     <Toolbar

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -462,10 +462,13 @@
                 flex: 1;
                 justify-content: space-between;
                 flex-wrap: wrap;
-                .input-group {
+                > div {
                     flex: 1;
                     padding: 4px 0;
                     margin-right: 2px;
+                }
+                .input-group {
+                    width: 100%;
                     .form-group{
                         input#intl-numeric{
                             float: unset;

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -70,13 +70,16 @@
             flex: 1 1 0%;
             justify-content: space-between;
             flex-wrap: wrap;
+            > div {
+                flex: 1 1 0%;
+                padding: 4px 0px;
+                margin-right: 8px;
+            }
             .input-group {
                 .input-group-addon {
                     min-width: 45px;
                 }
-                flex: 1 1 0%;
-                padding: 4px 0px;
-                margin-right: 8px;
+                width: 100%;
                 .form-group{
                     width: 100%;
                     position: relative;


### PR DESCRIPTION
## Description
Safari on desktop and mobile incorrectly renders flex layouts with elements that are `display: table` (which input-groups are in B3)
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Coordinate editor does not render correctly in Safari - Longitude is not visible because Latitude takes up all space.

**What is the new behavior?**
Both input groups are shown.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
