### PR TITLE
#6365 - fix highlight in GFI panel

### DIFF
--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -85,6 +85,9 @@ describe('Test the mapInfo reducer', () => {
             type: 'LOAD_FEATURE_INFO',
             data: "data",
             requestParams: "params",
+            layer: {
+                id: "layer_id"
+            },
             layerMetadata: "meta",
             reqId: 10
         };
@@ -132,7 +135,8 @@ describe('Test the mapInfo reducer', () => {
                         "prop0": "value0",
                         "prop1": {"this": "that"}
                     }
-                }]
+                }],
+                id: "layer_id"
             },
             request: {
                 lng: 10.0,

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -102,9 +102,17 @@ function receiveResponse(state, action, type) {
 
         let indexObj;
         if (isHover) {
-            indexObj = {loaded: true, index: 0};
+            indexObj = {
+                loaded: true,
+                index: 0,
+                requestId: responses[requestIndex].layer.id // TODO check if this is needed
+            };
         } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
-            indexObj = {loaded: true, index: requestIndex};
+            indexObj = {
+                loaded: true,
+                index: requestIndex,
+                requestId: responses[requestIndex].layer.id
+            };
         }
 
         // Set responses and index as first response is received
@@ -382,6 +390,9 @@ function mapInfo(state = initState, action) {
                 features: intersected,
                 totalFeatures: "unknown",
                 type: "FeatureCollection"
+            },
+            layer: {
+                id: action.layer.id
             },
             queryParams: action.request,
             layerMetadata: action.metadata,

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -66,6 +66,9 @@ const RESPONSE_STATE = {
                     title: 'Manhattan (NY) points of interest',
                     viewer: {},
                     featureInfo: {}
+                },
+                layer: {
+                    id: "layer_id"
                 }
             }
         ],
@@ -92,7 +95,8 @@ const RESPONSE_STATE = {
             }
         },
         clickLayer: null,
-        index: 0
+        index: 0,
+        requestId: "layer_id"
     }
 };
 const RESPONSE_STATE_WITH_FEATURES_METADATA = set('mapInfo.responses[0].layerMetadata', {

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -107,6 +107,8 @@ export const isHighlightEnabledSelector = (state = {}) => state.mapInfo && state
 
 export const indexSelector = (state = {}) => state && state.mapInfo && state.mapInfo.index;
 
+export const requestIdSelector = (state = {}) => state && state.mapInfo && state.mapInfo.requestId;
+
 export const responsesSelector = state => state.mapInfo && state.mapInfo.responses || [];
 
 export const requestsSelector = state => state?.mapInfo?.requests || [];
@@ -126,8 +128,10 @@ export const validResponsesSelector = createSelector(
     });
 
 export const currentResponseSelector = createSelector(
-    validResponsesSelector, indexSelector,
-    (responses = [], index = 0) => responses[index]
+    validResponsesSelector, requestIdSelector,
+    (responses = [], reqId) => {
+        return responses && responses.filter(r => r.layer.id === reqId)[0];
+    }
 );
 export const currentFeatureSelector = state => {
     const currentResponse = currentResponseSelector(state) || {};


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
there was a problem with the index because it was 4, (if you are using the map in the issue) but then the response was filtered so the original index become no longer valid

responses: [statesResponse],
index: 4

hence [this](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/selectors/mapInfo.js#L130) line was returning nothing

i'm using the layer id not fetch the correct response, please @offtherailz tell me if this is fine

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6365

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
