### PR TITLE
#6385: fix for mime-type detection in ConfigController

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,25 @@ dist: xenial
 language: node_js
 node_js:
   - 12.13.0
-script:
-  - npm run travis
-addons:
-  firefox: latest
-before_install:
-    # Fixes an issue where the max file watch count is exceeded, triggering ENOSPC
-    - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-    - node -v
-    - npm -v
+
+jobs:
+  include:
+    - language: node_js
+      node_js: 12.13.0
+      script:
+        - npm run travis
+      addons:
+        firefox: latest
+      before_install:
+        # Fixes an issue where the max file watch count is exceeded, triggering ENOSPC
+        - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+        - node -v
+        - npm -v
+
+    - language: java
+      jdk: openjdk8
+      script:
+        - mvn clean install
 branches:
   only:
     - master

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,6 +21,13 @@
         <version>2.1</version>
     </dependency>
 
+    <!-- Mime-Util -->
+    <dependency>
+        <groupId>eu.medsea.mimeutil</groupId>
+        <artifactId>mime-util</artifactId>
+        <version>2.1.3</version>
+    </dependency>
+
     <!-- Spring -->
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->
     <dependency>

--- a/backend/src/main/java/it/geosolutions/mapstore/ConfigController.java
+++ b/backend/src/main/java/it/geosolutions/mapstore/ConfigController.java
@@ -47,6 +47,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.fge.jsonpatch.JsonPatchException;
 
+import eu.medsea.mimeutil.MimeType;
+import eu.medsea.mimeutil.MimeUtil;
 import it.geosolutions.mapstore.utils.ResourceUtils;
 
 /**
@@ -70,6 +72,10 @@ public class ConfigController {
         String data;
         String type;
         File file;
+    }
+    
+    static {
+    	MimeUtil.registerMimeDetector("eu.medsea.mimeutil.detector.ExtensionMimeDetector");
     }
 
     private ObjectMapper jsonMapper = new ObjectMapper();
@@ -168,7 +174,9 @@ public class ConfigController {
     private Resource readResourceFromFile(File file, boolean applyOverrides, Optional<File> patch) throws IOException {
     	Resource resource = new Resource();
         resource.file = file;
-        resource.type = Files.probeContentType(Paths.get(file.getAbsolutePath()));
+        
+        MimeType type = MimeUtil.getMostSpecificMimeType(MimeUtil.getMimeTypes(file));
+        resource.type = type != null ? type.toString() : null;
         try (Stream<String> stream =
                 Files.lines( Paths.get(file.getAbsolutePath()), StandardCharsets.UTF_8); ) {
             Properties props = readOverrides();

--- a/backend/src/main/resources/mime-types.properties
+++ b/backend/src/main/resources/mime-types.properties
@@ -1,0 +1,13 @@
+css=text/css
+gif=image/gif
+html=text/html
+htm=text/html
+jpe=image/jpeg
+jpeg=image/jpeg
+jpg=image/jpeg
+js=application/javascript
+json=application/json
+png=image/png
+svg=image/svg+xml
+txt=text/plain
+


### PR DESCRIPTION
## Description
Replaces Files.probeContentType with the mime-util library, using a configurable, file extension based, mime recognition for ConfigController loadAsset entrypoint.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6385 

**What is the current behavior?**
Mime type recognition based on  Files.probeContentType is very OS and environment dependent, so the result is not consistent, and tests can fail on some environment.

**What is the new behavior?**
Mime type recognition is guardanteed to be consistent for all the registered files extensions. It is possible to configure new extensions, if needed in the future. Currently html, css, js, json, png, jpeg, gif and svg files are registered. More come from the library itself.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
