### PR TITLE
#6366 Reset filter selection when feature grid is closed

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -11,6 +11,8 @@ import expect from 'expect';
 import { isEmpty, isEqual } from 'lodash';
 
 import {
+    launchUpdateFilterFunc,
+    LAUNCH_UPDATE_FILTER_FUNC,
     SELECT_FEATURES,
     selectFeatures,
     changePage,
@@ -111,6 +113,12 @@ describe('Test correctness of featurgrid actions', () => {
         expect(retval.features).toExist();
         expect(retval.features.length).toBe(features.length);
         expect(retval.type).toBe(DELETE_GEOMETRY_FEATURE);
+    });
+    it('Test deleteGeometryFeature action creator', () => {
+        const retval = launchUpdateFilterFunc({});
+        expect(retval).toBeTruthy();
+        expect(retval.updateFilterAction).toBeTruthy();
+        expect(retval.type).toBe(LAUNCH_UPDATE_FILTER_FUNC);
     });
     it('Test deleteGeometry action creator', () => {
         const retval = deleteGeometry();

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -51,6 +51,7 @@ export const SIZE_CHANGE = 'FEATUREGRID:SIZE_CHANGE';
 export const TOGGLE_SHOW_AGAIN_FLAG = 'FEATUREGRID:TOGGLE_SHOW_AGAIN_FLAG';
 export const HIDE_SYNC_POPOVER = 'FEATUREGRID:HIDE_SYNC_POPOVER';
 export const UPDATE_EDITORS_OPTIONS = 'FEATUREGRID:UPDATE_EDITORS_OPTIONS';
+export const LAUNCH_UPDATE_FILTER_FUNC = 'FEATUREGRID:LAUNCH_UPDATE_FILTER_FUNC';
 
 export const MODES = {
     EDIT: "EDIT",
@@ -374,4 +375,8 @@ export const setTimeSync = value => ({
 export const setPagination = (size) => ({
     type: SET_PAGINATION,
     size
+});
+export const launchUpdateFilterFunc = (updateFilterAction) => ({
+    type: LAUNCH_UPDATE_FILTER_FUNC,
+    updateFilterAction
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This pr introduces a reset of the filter geom selection if you close the feature grid because you are opening the advanced search
The previous updateFilterFunc was executed before the reducer in featured happened for resetFilter

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6366

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it resets the filter geom selection if open advanced search and if you back from it is cleared 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
