### PR TITLE
backport 2021.01.xx - #6366 Reset filter selection when feature grid is closed (#6399)

### DIFF
--- a/web/client/actions/__tests__/featuregrid-test.js
+++ b/web/client/actions/__tests__/featuregrid-test.js
@@ -11,6 +11,8 @@ import expect from 'expect';
 import { isEmpty, isEqual } from 'lodash';
 
 import {
+    launchUpdateFilterFunc,
+    LAUNCH_UPDATE_FILTER_FUNC,
     SELECT_FEATURES,
     selectFeatures,
     changePage,
@@ -111,6 +113,12 @@ describe('Test correctness of featurgrid actions', () => {
         expect(retval.features).toExist();
         expect(retval.features.length).toBe(features.length);
         expect(retval.type).toBe(DELETE_GEOMETRY_FEATURE);
+    });
+    it('Test deleteGeometryFeature action creator', () => {
+        const retval = launchUpdateFilterFunc({});
+        expect(retval).toBeTruthy();
+        expect(retval.updateFilterAction).toBeTruthy();
+        expect(retval.type).toBe(LAUNCH_UPDATE_FILTER_FUNC);
     });
     it('Test deleteGeometry action creator', () => {
         const retval = deleteGeometry();

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -51,6 +51,7 @@ export const SIZE_CHANGE = 'FEATUREGRID:SIZE_CHANGE';
 export const TOGGLE_SHOW_AGAIN_FLAG = 'FEATUREGRID:TOGGLE_SHOW_AGAIN_FLAG';
 export const HIDE_SYNC_POPOVER = 'FEATUREGRID:HIDE_SYNC_POPOVER';
 export const UPDATE_EDITORS_OPTIONS = 'FEATUREGRID:UPDATE_EDITORS_OPTIONS';
+export const LAUNCH_UPDATE_FILTER_FUNC = 'FEATUREGRID:LAUNCH_UPDATE_FILTER_FUNC';
 
 export const MODES = {
     EDIT: "EDIT",
@@ -374,4 +375,8 @@ export const setTimeSync = value => ({
 export const setPagination = (size) => ({
     type: SET_PAGINATION,
     size
+});
+export const launchUpdateFilterFunc = (updateFilterAction) => ({
+    type: LAUNCH_UPDATE_FILTER_FUNC,
+    updateFilterAction
 });

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -101,7 +101,9 @@ import {
     FEATURES_MODIFIED,
     deactivateGeometryFilter as  deactivateGeometryFilterAction,
     setSelectionOptions,
-    setPagination
+    setPagination,
+    launchUpdateFilterFunc,
+    LAUNCH_UPDATE_FILTER_FUNC
 } from '../actions/featuregrid';
 
 import { TOGGLE_CONTROL, resetControls, setControlProperty, toggleControl } from '../actions/controls';
@@ -437,13 +439,23 @@ export const featureGridUpdateGeometryFilter = (action$, store) =>
                             });
                             // if closed for other causes, need to restore anyway the pagination
                             if (virtualScrollSet) {
-                                return Rx.Observable.of(setPagination(originalSize), resetFilter, updateFilterFunc(store)(resetFilter));
+                                return Rx.Observable.of(setPagination(originalSize), resetFilter, launchUpdateFilterFunc(resetFilter));
                             }
-                            return Rx.Observable.of(resetFilter, updateFilterFunc(store)(resetFilter));
+                            return Rx.Observable.of(resetFilter, launchUpdateFilterFunc(resetFilter));
                         })
                     );
             });
     });
+
+/**
+ * @memberof epics.featuregrid
+ * this epic has been created because there was a non correct sequence of actions dispatched by featureGridUpdateGeometryFilter when CLOSE_FEATURE_GRID was triggered
+ * the resetFilter action is now dispatched before executing updateFilterFunc that is now using the correct data from the store
+ * see #6366
+  */
+export const launchUpdateFilterEpic = (action$, store) => action$.ofType(LAUNCH_UPDATE_FILTER_FUNC).switchMap((a) => {
+    return Rx.Observable.of(updateFilterFunc(store)(a.updateFilterAction));
+});
 /**
  * Performs the query when the text filters are updated
  * @memberof epics.featuregrid
@@ -991,9 +1003,8 @@ export const autoReopenFeatureGridOnFeatureInfoClose = (action$) =>
         );
 export const onOpenAdvancedSearch = (action$, store) =>
     action$.ofType(OPEN_ADVANCED_SEARCH).switchMap(() => {
-        const selected = selectedFeaturesSelector(store.getState());
         return Rx.Observable.of(
-            // temporarily hide selected features from map
+            // hide selected features from map
             selectFeatures([]),
             loadFilter(get(store.getState(), `featuregrid.advancedFilters["${selectedLayerIdSelector(store.getState())}"]`)),
             closeFeatureGrid(),
@@ -1014,8 +1025,8 @@ export const onOpenAdvancedSearch = (action$, store) =>
                         .filter(({control, property} = {}) => control === "queryPanel" && (!property || property === "enabled"))
                         .mergeMap(() => {
                             const {drawStatus} = (store.getState()).draw || {};
-                            const acts = (drawStatus !== 'clean' && selected.length === 0) ? [changeDrawingStatus("clean", "", "featureGrid", [], {})] : [];
-                            return Rx.Observable.from(acts.concat(selectFeatures(selected, true), openFeatureGrid()));
+                            const acts = (drawStatus !== 'clean') ? [changeDrawingStatus("clean", "", "featureGrid", [], {})] : [];
+                            return Rx.Observable.from(acts.concat(openFeatureGrid()));
                         }
                         )
                 ).takeUntil(action$.ofType(OPEN_FEATURE_GRID, LOCATION_CHANGE))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2021.01.xx - #6366 Reset filter selection when feature grid is closed (#6399)