### PR TITLE
backport  2021.01.xx - #6322 Fix draw of multiparts geom in attribute table (#6402)

### DIFF
--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -389,7 +389,7 @@ export const featureGridUpdateGeometryFilter = (action$, store) =>
                 // flag to see if virtualScroll page size has been modified
                 let virtualScrollSet = false;
                 return action$.ofType(UPDATE_FILTER)
-                    .filter(({ update = {} }) => update.type === 'geometry')
+                    .filter(({ update = {} }) => update.type === 'geometry' && update.enabled && !update.deactivated)
                     .switchMap((a, i) => {
                         if (i === 0) {
                             virtualScrollSet = true;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
backport  2021.01.xx - #6322 Fix draw of multiparts geom in attribute table (#6402)