### PR TITLE
#6417 add globe switcher to context and support switching from there

### DIFF
--- a/project/standard/templates/pluginsConfig.json
+++ b/project/standard/templates/pluginsConfig.json
@@ -414,6 +414,15 @@
       "dependencies": ["MapFooter"]
     },
     {
+      "name": "GlobeViewSwitcher",
+      "glyph": "globe",
+      "title": "plugins.Globe.title",
+      "description": "plugins.Globe.description",
+      "dependencies": [
+        "Toolbar"
+      ]
+    },
+    {
       "name": "ZoomAll",
       "glyph": "resize-full",
       "title": "plugins.ZoomAll.title",

--- a/web/client/components/buttons/GlobeViewSwitcherButton.jsx
+++ b/web/client/components/buttons/GlobeViewSwitcherButton.jsx
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 /*
  * Copyright 2017, GeoSolutions Sas.
  * All rights reserved.
@@ -9,6 +7,7 @@ import PropTypes from 'prop-types';
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import ToggleButton from './ToggleButton';
 import { Tooltip } from 'react-bootstrap';

--- a/web/client/epics/__tests__/globeswitcher-test.js
+++ b/web/client/epics/__tests__/globeswitcher-test.js
@@ -11,9 +11,50 @@ import expect from 'expect';
 import { toggle3d, UPDATE_LAST_2D_MAPTYPE } from '../../actions/globeswitcher';
 import { localConfigLoaded } from '../../actions/localConfig';
 import assign from 'object-assign';
-import { updateRouteOn3dSwitch, updateLast2dMapTypeOnChangeEvents } from '../globeswitcher';
+import { replaceMapType, updateRouteOn3dSwitch, updateLast2dMapTypeOnChangeEvents } from '../globeswitcher';
 import { testEpic } from './epicTestUtils';
+import { MAP_TYPE_CHANGED } from './../../actions/maptype';
+
 describe('globeswitcher Epics', () => {
+
+    it('toggle to 3d for context maps', (done) => {
+        const NUM_ACTIONS = 1;
+        testEpic(updateRouteOn3dSwitch, NUM_ACTIONS, assign({}, toggle3d(true, "openlayers"), { hash: "/context/3dmap/123" }), actions => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case MAP_TYPE_CHANGED:
+                    expect(action.mapType).toBe("cesium");
+                    break;
+                default:
+                    expect(true).toBe(false);
+
+                }
+            });
+            done();
+        }, {
+            globeswitcher: {last2dMapType: "openlayers"}
+        });
+    });
+    it('toggle from 3d for context maps', (done) => {
+        const NUM_ACTIONS = 1;
+        testEpic(updateRouteOn3dSwitch, NUM_ACTIONS, assign({ hash: "/context/3dmap/123" }, toggle3d(false, "cesium")), actions => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case MAP_TYPE_CHANGED:
+                    expect(action.mapType).toBe("leaflet");
+                    break;
+                default:
+                    expect(true).toBe(false);
+
+                }
+            });
+            done();
+        }, {
+            globeswitcher: {last2dMapType: "leaflet"}
+        });
+    });
     it('updates maptype toggling to 3D', (done) => {
         testEpic(updateRouteOn3dSwitch, 1, assign({hash: "/viewer/leaflet/2"}, toggle3d(true, "leaflet")), actions => {
             expect(actions.length).toBe(1);
@@ -104,6 +145,44 @@ describe('globeswitcher Epics', () => {
             maptype: {
                 mapType: 'openlayers'
             }
+        });
+
+    });
+    it('testing replaceMapType with viewer regex', () => {
+        const urls = [
+            {
+                url: "/viewer/openlayers/123",
+                newMapType: "cesium",
+                expected: "/viewer/cesium/123"
+            },
+            {
+                url: "/viewer/openlayers/new/context/123",
+                newMapType: "cesium",
+                expected: "/viewer/cesium/new/context/123"
+            },
+            {
+                url: "/viewer/cesium/123",
+                newMapType: "openlayers",
+                expected: "/viewer/openlayers/123"
+            },
+            {
+                url: "/viewer/123",
+                newMapType: "cesium",
+                expected: "/viewer/cesium/123"
+            },
+            {
+                url: "/viewer/123",
+                newMapType: "openlayers",
+                expected: "/viewer/openlayers/123"
+            },
+            {
+                url: "/context/ctxName/123",
+                newMapType: "openlayers",
+                expected: "/context/ctxName/123"
+            }
+        ];
+        urls.forEach(({url, newMapType, expected}) => {
+            expect(replaceMapType(url, newMapType)).toBe(expected);
         });
 
     });

--- a/web/client/epics/globeswitcher.js
+++ b/web/client/epics/globeswitcher.js
@@ -7,17 +7,28 @@
  */
 import { TOGGLE_3D, updateLast2dMapType } from '../actions/globeswitcher';
 
-import { MAP_TYPE_CHANGED } from '../actions/maptype';
+import { changeMapType, MAP_TYPE_CHANGED } from '../actions/maptype';
 import { mapTypeSelector } from '../selectors/maptype';
 import { LOCAL_CONFIG_LOADED } from '../actions/localConfig';
 import Rx from 'rxjs';
-import { get } from 'lodash';
-
-const defaultRegexes = [/\/viewer\/\w+\/(\w+)/, /\/viewer\/(\w+)/];
 import { push } from 'connected-react-router';
+import { last2dMapTypeSelector } from './../selectors/globeswitcher';
 
-const replaceMapType = (path, newMapType) => {
-    const match = defaultRegexes.reduce((previous, regex) => {
+const VIEWERS_REGEX = [
+    /\/viewer\/\w+\/(\w+)/,
+    /\/viewer\/(\w+)/
+];
+const CONTEXT_NEW_MAP_REGEX = /\/viewer\/\w+\/(\w+)\/context\/(\w+)/;
+const CONTEXT_REGEX = /\/context\/(\w+)/;
+
+export const replaceMapType = (path, newMapType) => {
+    // check context new regex  first
+    const contextMatch = path.match(CONTEXT_NEW_MAP_REGEX);
+    if (contextMatch) {
+        return `/viewer/${newMapType}/${contextMatch[1]}/context/${contextMatch[2]}`;
+    }
+    // check normal viewer regex after
+    const match = VIEWERS_REGEX.reduce((previous, regex) => {
         return previous || path.match(regex);
     }, null);
     if (match) {
@@ -34,7 +45,13 @@ const replaceMapType = (path, newMapType) => {
 export const updateRouteOn3dSwitch = (action$, store) =>
     action$.ofType(TOGGLE_3D)
         .switchMap( (action) => {
-            const newPath = replaceMapType(action.hash || location.hash, action.enable ? "cesium" : get(store.getState(), "globeswitcher.last2dMapType") || 'leaflet');
+            const last2dMapType = last2dMapTypeSelector(store.getState());
+            const hash = action.hash || location.hash;
+            if (hash.match(CONTEXT_REGEX) && !hash.match(CONTEXT_NEW_MAP_REGEX)) {
+                // hash can be "#/context/3d"
+                return Rx.Observable.of(changeMapType(action.originalMapType !== "cesium" ? "cesium" : last2dMapType ));
+            }
+            const newPath = replaceMapType(hash, action.enable ? "cesium" : last2dMapType);
             if (newPath) {
                 return Rx.Observable.from([push(newPath)]);
             }

--- a/web/client/pluginsConfig.json
+++ b/web/client/pluginsConfig.json
@@ -414,6 +414,15 @@
       "dependencies": ["MapFooter"]
     },
     {
+      "name": "GlobeViewSwitcher",
+      "glyph": "globe",
+      "title": "plugins.Globe.title",
+      "description": "plugins.Globe.description",
+      "dependencies": [
+        "Toolbar"
+      ]
+    },
+    {
       "name": "ZoomAll",
       "glyph": "resize-full",
       "title": "plugins.ZoomAll.title",

--- a/web/client/selectors/globeswitcher.js
+++ b/web/client/selectors/globeswitcher.js
@@ -1,0 +1,3 @@
+import {get} from 'lodash';
+
+export const last2dMapTypeSelector = state => get(state, "globeswitcher.last2dMapType") || 'leaflet';

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2759,6 +2759,10 @@
             "description": "Eine Taskleiste zum Ausblenden und Erweitern von Widgets auf der Karte.",
             "title": "Widgets-Fach"
           },
+          "Globe": {
+            "description": "Sidebar-Taste zum Ein- und Ausschalten des 3D-Modus",
+            "title": "3D"
+          },
           "ZoomAll": {
             "description": "Sidebar-Schaltfläche, um den Kartenausschnitt der Karte zu vergrößern",
             "title": "Maximal zoomen"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2770,6 +2770,10 @@
             "description": "A tray to collapse and expand widgets on map. ",
             "title": "Widgets Tray"
           },
+          "Globe": {
+            "description": "Sidebar button to toggle 3D mode on/off",
+            "title": "3D"
+          },
           "ZoomAll": {
             "description": "Sidebar button to zoom to the map extent of the map",
             "title": "Zoom To Max Extent"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2759,6 +2759,10 @@
             "description": "Una bandeja para colapsar, expandir widgets en el mapa.",
             "title": "Bandeja de widgets"
           },
+          "Globe": {
+            "description": "otón de la barra lateral para activar / desactivar el modo 3D",
+            "title": "3D"
+          },
           "ZoomAll": {
             "description": "Botón de barra lateral para acercar a la extensión del mapa",
             "title": "Zoom a la extensión máxima"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2760,6 +2760,10 @@
             "description": "Une barre d'outils pour réduire et développer les widgets sur la carte.",
             "title": "Barre de widgets"
           },
+          "Globe": {
+            "description": "Bouton de la barre latérale pour activer / désactiver le mode 3D",
+            "title": "3D"
+          },
           "ZoomAll": {
             "description": "Bouton de la barre latérale pour zoomer sur l'étendue de la carte",
             "title": "Zoom jusqu'à l'étendue maximale"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2759,6 +2759,10 @@
             "description": "Un vassoio per comprimere ed espandere i widget sulla mappa.",
             "title": "Vassoio widget"
           },
+          "Globe": {
+            "description": "Pulsante della barra laterale per attivare/disattivare la modalità 3D",
+            "title": "3D"
+          },
           "ZoomAll": {
             "description": "Pulsante della barra laterale per ingrandire l'estensione della mappa della mappa",
             "title": "Zoom al massima Estensione"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
add globe switcher to context and support switching from there
Notice that the path of a context is #/context/ctxName
and when we click on 3D button we update the local state instead of the pathname

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6417

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
add globe switcher to context and support switching from there

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
