### PR TITLE
Increment package.json and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2021.01.00](https://github.com/geosolutions-it/MapStore2/tree/v2021.01.00) (2021-01-21)
+
+- **[Full Changelog](https://github.com/geosolutions-it/MapStore2/compare/v2020.02.02...v2021.01.00)**
+
+- **[Implemented enhancements](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222021.01.00%22+is%3Aclosed+label%3Aenhancement)**
+
+- **[Fixed bugs](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222021.01.00%22+is%3Aclosed+label%3Abug)**
+
+- **[Closed issues](https://github.com/geosolutions-it/MapStore2/issues?q=is%3Aissue+milestone%3A%222021.01.00%22+is%3Aclosed)**
+
 ## [2020.02.02](https://github.com/geosolutions-it/MapStore2/tree/v2020.02.02) (2020-10-26)
 
 - **[Full Changelog](https://github.com/geosolutions-it/MapStore2/compare/v2020.02.01...v2020.02.02)**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapstore2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MapStore 2",
   "repository": "https://github.com/geosolutions-it/MapStore2",
   "main": "index.js",


### PR DESCRIPTION
## Description
As for the release 2021.01.xx steps in #6312 : 
- Increment the package.json to version 0.2.0 (following https://semver.org/lang/it/)
- update changelog

**note** this is a part of #6312, It doesn't close it after merge and back-port.

