### PR TITLE
[Backport 2021.01.xx] #6447: Wrong title for unsupported browser HTML page (#6446)

### DIFF
--- a/project/standard/templates/unsupportedBrowser.html
+++ b/project/standard/templates/unsupportedBrowser.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-        <title>MapStore Unsupported Browser</title>
+        <title>MapStore</title>
         <style>
             body {
                 margin: 0;

--- a/web/client/unsupportedBrowser.html
+++ b/web/client/unsupportedBrowser.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-        <title>MapStore Unsupported Browser</title>
+        <title>MapStore</title>
         <style>
             body {
                 margin: 0;


### PR DESCRIPTION
[Backport 2021.01.xx] #6447: Wrong title for unsupported browser HTML page (#6446)