### PR TITLE
#6452: Custom plugin documentation url for plugin config

### DIFF
--- a/docs/developer-guide/context-editor-config.md
+++ b/docs/developer-guide/context-editor-config.md
@@ -28,7 +28,8 @@ The configuration file has this shape:
         "name": "TOCItemSettings",
         "...": "..."
     }, {
-        "name": "MyPlugin" // <-- this is typically an extension
+        "name": "MyPlugin", // <-- this is typically an extension,
+        "docUrl": "https://domain.com/documentation"  // <-- custom documentation url
     }, {
        "name": "Footer",
        "children": ["MousePosition", "CRSSelector",  "ScaleBox"]
@@ -53,6 +54,7 @@ These are the properties allowed for the plugin entry object:
 * `name`: `{string}` the name (ID) of the plugin
 * `title`: `{string}` the title string OR messageId (from localization file)
 * `description`: `{string}`: the description string OR messageId (from localization file)
+* `docUrl`: `{string}`: the plugin/extension specific documentation url
 * `symbol`: {string}`: icon (or image) symbol for the plugin
 * `defaultConfig` `{object}`: optional object containing the default configuration to pass to the context-creator.
 * `mandatory` `{boolean}`: if true, the plugin must be added to the map, so not possible to remove (but can be customized)

--- a/web/client/components/contextcreator/ConfigurePluginsStep.jsx
+++ b/web/client/components/contextcreator/ConfigurePluginsStep.jsx
@@ -60,12 +60,12 @@ const getEnabledTools = (plugin, isMandatory, editedPlugin, documentationBaseURL
         active: plugin.name === editedPlugin,
         onClick: () => onEditPlugin(plugin.name === editedPlugin ? undefined : plugin.name)
     }, {
-        visible: !!documentationBaseURL,
+        visible: !!(plugin.docUrl || documentationBaseURL),
         glyph: 'question-sign',
         tooltipId: 'contextCreator.configurePlugins.tooltips.pluginDocumentation',
         Element: (props) =>
             <a target="_blank" rel="noopener noreferrer"
-                href={documentationBaseURL && documentationBaseURL + '#plugins.' + (plugin.docName || plugin.name)}>
+                href={plugin.docUrl || documentationBaseURL && documentationBaseURL + '#plugins.' + (plugin.docName || plugin.name)}>
                 <ToolbarButton {...props}/>
             </a>
     }, {

--- a/web/client/components/contextcreator/__tests__/ConfigurePluginsStep-test.jsx
+++ b/web/client/components/contextcreator/__tests__/ConfigurePluginsStep-test.jsx
@@ -219,4 +219,24 @@ describe('ConfigurePluginsStep component', () => {
         expect(tooltip).toExist();
         expect(tooltip.getAttribute('role')).toBe('tooltip');
     });
+    it('ConfigurePluginsStep extensions with extension specific documentation url', () => {
+        const docUrl = 'https://domain.com/documentation';
+        const plugins = [{
+            title: "Extension",
+            isExtension: true,
+            enabled: true,
+            name: "Plugin_1",
+            description: "Test plugin",
+            docUrl
+        }, {
+            title: "Internal",
+            isExtension: false
+        }];
+        ReactDOM.render(<ConfigurePluginsStep allPlugins={plugins}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const docLink = container.querySelectorAll('a');
+        expect(container.querySelectorAll(".glyphicon-question-sign").length).toBe(1);
+        expect(docLink.length).toBe(1);
+        expect(docLink[0].href).toBe(docUrl);
+    });
 });

--- a/web/client/reducers/__tests__/contextcreator-test.js
+++ b/web/client/reducers/__tests__/contextcreator-test.js
@@ -105,7 +105,11 @@ const defaultPlugins = [{
     defaultOverride: {
         parameter: 'value2'
     }
-}];
+}, {
+    name: 'NewPlugin',
+    docUrl: 'https://domain.com/documentation'
+}
+];
 
 const pluginsConfig = {plugins: defaultPlugins};
 
@@ -184,7 +188,7 @@ describe('contextcreator reducer', () => {
         expect(mapConfigSelector(state)).toEqual(data.mapConfig);
         expect(resourceSelector(state)).toEqual(resource);
         expect(plugins).toExist();
-        expect(plugins.length).toBe(4);
+        expect(plugins.length).toBe(5);
         expect(plugins[0].name).toBe(defaultPlugins[0].name);
         expect(plugins[0].title).toBe(defaultPlugins[0].title);
         expect(plugins[0].enabled).toBe(false);
@@ -227,6 +231,13 @@ describe('contextcreator reducer', () => {
         expect(plugins[3].pluginConfig.name).toEqual(defaultPlugins[4].name);
         expect(plugins[3].pluginConfig.cfg).toNotExist();
         expect(plugins[3].pluginConfig.override).toEqual(defaultPlugins[4].defaultOverride);
+        expect(plugins[4].name).toBe(defaultPlugins[5].name);
+        expect(plugins[4].title).toBe(defaultPlugins[5].title);
+        expect(plugins[4].enabled).toBe(false);
+        expect(plugins[4].isUserPlugin).toBe(false);
+        expect(plugins[4].active).toBe(false);
+        expect(plugins[4].docUrl).toExist();
+        expect(plugins[4].docUrl).toEqual("https://domain.com/documentation");
     });
     it('setResource with context with templates inside MapTemplates config', () => {
         const contextResource = {
@@ -292,7 +303,7 @@ describe('contextcreator reducer', () => {
         expect(mapConfigSelector(state)).toEqual(data.mapConfig);
         expect(resourceSelector(state)).toEqual(resource);
         expect(plugins).toExist();
-        expect(plugins.length).toBe(5);
+        expect(plugins.length).toBe(6);
         expect(plugins[0].name).toBe(defaultPlugins[0].name);
         expect(plugins[0].title).toBe(defaultPlugins[0].title);
         expect(plugins[0].enabled).toBe(false);
@@ -335,14 +346,21 @@ describe('contextcreator reducer', () => {
         expect(plugins[3].pluginConfig.name).toEqual(defaultPlugins[4].name);
         expect(plugins[3].pluginConfig.cfg).toNotExist();
         expect(plugins[3].pluginConfig.override).toEqual(defaultPlugins[4].defaultOverride);
-        expect(plugins[4].name).toBe('MapTemplates');
+        expect(plugins[4].name).toBe(defaultPlugins[5].name);
+        expect(plugins[4].title).toBe(defaultPlugins[5].title);
         expect(plugins[4].enabled).toBe(false);
         expect(plugins[4].isUserPlugin).toBe(false);
         expect(plugins[4].active).toBe(false);
-        expect(plugins[4].pluginConfig).toExist();
-        expect(plugins[4].pluginConfig.cfg).toExist();
-        expect(plugins[4].pluginConfig.cfg.allowedTemplates).toExist();
-        expect(plugins[4].pluginConfig.cfg.allowedTemplates.length).toBe(1);
+        expect(plugins[4].docUrl).toExist();
+        expect(plugins[4].docUrl).toEqual("https://domain.com/documentation");
+        expect(plugins[5].name).toBe('MapTemplates');
+        expect(plugins[5].enabled).toBe(false);
+        expect(plugins[5].isUserPlugin).toBe(false);
+        expect(plugins[5].active).toBe(false);
+        expect(plugins[5].pluginConfig).toExist();
+        expect(plugins[5].pluginConfig.cfg).toExist();
+        expect(plugins[5].pluginConfig.cfg.allowedTemplates).toExist();
+        expect(plugins[5].pluginConfig.cfg.allowedTemplates.length).toBe(1);
     });
     it('setSelectedPlugins', () => {
         const pluginsToSelect = ['Catalog', 'ZoomIn'];
@@ -489,6 +507,15 @@ describe('contextcreator reducer', () => {
         const state = contextcreator(undefined, pluginUploaded([{ name: 'myplugin' }]));
         expect(state).toExist();
         expect(state.plugins.length).toBe(1);
+        expect(state.uploadResult).toExist();
+        expect(state.uploadResult.result).toBe("ok");
+    });
+    it('pluginUploaded with documentation url', () => {
+        const state = contextcreator(undefined, pluginUploaded([{ name: 'myplugin', docUrl: 'https://domain.com/documentation' }]));
+        expect(state).toExist();
+        expect(state.plugins.length).toBe(1);
+        expect(state.plugins[0].name).toBe('myplugin');
+        expect(state.plugins[0].docUrl).toBe('https://domain.com/documentation');
         expect(state.uploadResult).toExist();
         expect(state.uploadResult.result).toBe("ok");
     });

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -72,6 +72,7 @@ const makeNode = (plugin, parent = null, plugins = [], localPlugins = []) => ({
     name: plugin.name,
     title: plugin.title,
     description: plugin.description,
+    docUrl: plugin.docUrl, // custom documentation url (useful for plugin as extension with extension specific documentation)
     glyph: plugin.glyph,
     parent,
     mandatory: !!plugin.mandatory,


### PR DESCRIPTION
## Description
This commit adds possibility to specify custom documentation url for plugins/extensions imported in Context creator 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6452 

**What is the new behavior?**
The user can specific custom documentation url via **docUrl** props in plugin config. So the custom documentation url will be used in place of default Mapstore documentation url
```
plugins: [
 {
    title: "Plugin title",
    ....
    docUrl: "some_url",
    .....
 }
]
``` 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
