### PR TITLE
#6456 reset maptype when changing url outside viewer

### DIFF
--- a/web/client/epics/__tests__/maptype-test.js
+++ b/web/client/epics/__tests__/maptype-test.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import { onLocationChanged } from 'connected-react-router';
+
+import { syncMapType } from '../maptype';
+import { MAP_TYPE_CHANGED } from '../../actions/maptype';
+import { testEpic } from './epicTestUtils';
+
+const NUM_ACTIONS = 1;
+
+
+describe('maptype epics', () => {
+
+    it('test to switch to cesium when passing to 3d mode', (done) => {
+        const STATE = {
+            maptype: {
+                mapType: "openlayers"
+            },
+            globeswitcher: {
+                last2dMapType: "openlayers"
+            }
+        };
+        testEpic(syncMapType, NUM_ACTIONS, onLocationChanged({pathname: "/viewer/cesium/10358"}, "PUSH" ), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            expect(actions[0].type).toBe(MAP_TYPE_CHANGED);
+            expect(actions[0].mapType).toBe("cesium");
+            done();
+        }, STATE);
+    });
+    it('test to switch to last2d cesium when passing to 3d mode', (done) => {
+        const STATE_3D = {
+            maptype: {
+                mapType: "cesium"
+            },
+            globeswitcher: {
+                last2dMapType: "openlayers"
+            }
+        };
+        testEpic(syncMapType, NUM_ACTIONS, onLocationChanged({pathname: "/"}, "PUSH" ), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            expect(actions[0].type).toBe(MAP_TYPE_CHANGED);
+            expect(actions[0].mapType).toBe("openlayers");
+            done();
+        }, STATE_3D);
+    });
+
+});

--- a/web/client/epics/maptype.js
+++ b/web/client/epics/maptype.js
@@ -19,7 +19,8 @@ import { mapTypeSelector } from './../selectors/maptype';
 
 
 /**
- * restore mapType to last mapType for a 2d mode when the URL is changed
+ * Keep in sync mapType in state with mapType in URL.
+ * Restores mapType to last mapType for a 2d mode when the URL is changed
  * @memberof epics.maptype
  * @param  {external:Observable} action$ the stream of actions, acts on `LOCATION_CHANGE`
  * @param  {object} store   the store middleware API from redux `createMiddleware`


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The problem caused by having cesium in the state as maptype when switching to geostory or dashboard is fixed by preventing this to happen and restore maptype to latest 2d maptype

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6456

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
crash it does not occur when switching from 3d map to a geostory or dashboard because cesium maptype is removed in favor of latest 2d maptype (ol or leaflet)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
