### PR TITLE
#6469: fixed printing dependencies to use latest print-lib and fixed loading of pdf.worker.js

### DIFF
--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -41,62 +41,6 @@
       <scope>runtime</scope>
     </dependency>
 
-
-    <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-epsg-hsql</artifactId>
-      <version>8.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jyaml</groupId>
-      <artifactId>jyaml</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vividsolutions</groupId>
-      <artifactId>jts</artifactId>
-      <version>1.8</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_codec</artifactId>
-      <version>1.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pdfbox</groupId>
-      <artifactId>pdfbox</artifactId>
-      <version>1.6.0</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_imageio</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-transcoder</artifactId>
-      <version>1.7</version>
-    </dependency>
-    <dependency>
-      <groupId>com.lowagie</groupId>
-      <artifactId>itext</artifactId>
-      <version>2.1.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20080701</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_core</artifactId>
-      <version>1.1.3</version>
-    </dependency>
     <!-- JUnit -->
     <dependency>
       <groupId>junit</groupId>
@@ -587,11 +531,6 @@
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
                     <version>geosolutions-2.0-SNAPSHOT</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.mapfish.geo</groupId>
-                    <artifactId>mapfish-geo-lib</artifactId>
-                    <version>1.2.0</version>
                 </dependency>
             </dependencies>
             </profile>

--- a/web/client/components/print/PrintPreview.jsx
+++ b/web/client/components/print/PrintPreview.jsx
@@ -54,6 +54,7 @@ class PrintPreview extends React.Component {
 
     render() {
         if (window.PDFJS) {
+            window.PDFJS.workerSrc = 'https://unpkg.com/pdfjs-dist@1.4.79/build/pdf.worker.js';
             return (
                 <div>
                     <div style={this.props.style}>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -40,61 +40,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-epsg-hsql</artifactId>
-      <version>8.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jyaml</groupId>
-      <artifactId>jyaml</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vividsolutions</groupId>
-      <artifactId>jts</artifactId>
-      <version>1.8</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_codec</artifactId>
-      <version>1.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.pdfbox</groupId>
-      <artifactId>pdfbox</artifactId>
-      <version>1.6.0</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_imageio</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-transcoder</artifactId>
-      <version>1.7</version>
-    </dependency>
-    <dependency>
-      <groupId>com.lowagie</groupId>
-      <artifactId>itext</artifactId>
-      <version>2.1.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20080701</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_core</artifactId>
-      <version>1.1.3</version>
-    </dependency>
     <!-- JUnit -->
     <dependency>
       <groupId>junit</groupId>
@@ -562,11 +507,6 @@
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
             <version>geosolutions-2.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mapfish.geo</groupId>
-            <artifactId>mapfish-geo-lib</artifactId>
-            <version>1.2.0</version>
         </dependency>
        </dependencies>
     </profile>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The master branch was using a wrong SNAPSHOT of the mapfish print-lib library.
This PR updates the version to geosolutions-2.0-SNAPSHOT and removes old dependencies of mapfish-print so the right ones are inerithed directly from the print-lib pom.

The dependency to mapfish-geo-lib has been removed too, since this has been integrated in print-lib in latest releases. This was causing the following error when printing vector stuff (e.g. Annotations):

```
Exception in thread "tilesReader3" java.lang.NoSuchMethodError: org.mapfish.geo.MfGeometry.getInternalGeometry()Lorg/locationtech/jts/geom/Geometry
```

Also a client side dependency to pdf.worker.js not resolved in production has been fixed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6469 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
