### PR TITLE
#6449 fix hover crash on cesium

### DIFF
--- a/web/client/components/misc/FeatureInfoTriggerSelector.jsx
+++ b/web/client/components/misc/FeatureInfoTriggerSelector.jsx
@@ -16,7 +16,11 @@ import { FormControl, FormGroup, ControlLabel } from 'react-bootstrap';
 class FeatureInfoTriggerSelector extends React.Component {
     static propTypes = {
         trigger: PropTypes.string,
-        onSetMapTrigger: PropTypes.func
+        onSetMapTrigger: PropTypes.func,
+        hoverEnabled: PropTypes.bool
+    }
+    static defaultProps = {
+        hoverEnabled: true
     }
 
     onChange = (event) => {
@@ -28,11 +32,11 @@ class FeatureInfoTriggerSelector extends React.Component {
             <FormGroup bsSize="small">
                 <ControlLabel>{<Message msgId="infoTriggerLabel" />}</ControlLabel>
                 <FormControl
-                    value={this.props.trigger}
+                    value={this.props.hoverEnabled ? this.props.trigger : "click"}
                     componentClass="select"
                     onChange={this.onChange}>
                     <option value="click" key="click">Click</option>
-                    <option value="hover" key="hover">Hover</option>
+                    <option disabled={!this.props.hoverEnabled} value="hover" key="hover">Hover</option>
                 </FormControl>
             </FormGroup>
         );

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -71,6 +71,7 @@ import {
 import { setControlProperties } from '../../actions/controls';
 import { BROWSE_DATA } from '../../actions/layers';
 import { configureMap } from '../../actions/config';
+import { changeMapType } from './../../actions/maptype';
 
 const TEST_MAP_STATE = {
     present: {
@@ -1094,6 +1095,19 @@ describe('identify Epics', () => {
                 done();
             };
             testEpic(setMapTriggerEpic, 1, configureMap(), epicResponse, {});
+        });
+        it('should unregister identifyFloatingTool event if mapType is changed to cesium', (done) => {
+            const epicResponse = actions => {
+                expect(actions[0].type).toBe(UNREGISTER_EVENT_LISTENER);
+                done();
+            };
+            testEpic(setMapTriggerEpic, 1, changeMapType("cesium"), epicResponse, {
+                mapInfo: {
+                    configuration: {
+                        trigger: "click"
+                    }
+                }
+            });
         });
     });
 });

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -59,6 +59,7 @@ const gridGeometryQuickFilter = state => get(find(getAttributeFilters(state), f 
 const stopFeatureInfo = state => stopGetFeatureInfoSelector(state) || isFeatureGridOpen(state) && (gridEditingSelector(state) || gridGeometryQuickFilter(state));
 
 import {getFeatureInfo} from '../api/identify';
+import { MAP_TYPE_CHANGED } from './../actions/maptype';
 
 /**
  * Recalculates pixel and geometric filter to allow also GFI emulation for WFS.
@@ -431,7 +432,7 @@ export const removeMapInfoMarkerOnRemoveMapPopupEpic = (action$, {getState}) =>
 * Sets which trigger to use on the map
 */
 export const setMapTriggerEpic = (action$, store) =>
-    action$.ofType(SET_MAP_TRIGGER, MAP_CONFIG_LOADED)
+    action$.ofType(SET_MAP_TRIGGER, MAP_CONFIG_LOADED, MAP_TYPE_CHANGED)
         .switchMap(() => {
             return Rx.Observable.of(
                 mapTriggerSelector(store.getState()) === 'hover' ? registerEventListener('mousemove', 'identifyFloatingTool') : unRegisterEventListener('mousemove', 'identifyFloatingTool')

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -60,7 +60,8 @@ import {
     requestsSelector,
     responsesSelector,
     showEmptyMessageGFISelector,
-    validResponsesSelector
+    validResponsesSelector,
+    hoverEnabledSelector
 } from '../selectors/mapInfo';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
 import { isCesium, mapTypeSelector } from '../selectors/maptype';
@@ -262,7 +263,8 @@ const FeatureInfoFormatSelector = connect((state) => ({
 })(FeatureInfoFormatSelectorComp);
 
 const FeatureInfoTriggerSelector = connect((state) => ({
-    trigger: isMouseMoveIdentifyActiveSelector(state) ? 'hover' : 'click'
+    trigger: isMouseMoveIdentifyActiveSelector(state) ? 'hover' : 'click',
+    hoverEnabled: hoverEnabledSelector(state)
 }), {
     onSetMapTrigger: setMapTrigger
 })(FeatureInfoTriggerSelectorComp);

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -19,6 +19,7 @@ import {
     toggleHighlightFeature,
     setMapTrigger
 } from '../../actions/mapInfo';
+import {changeMapType} from '../../actions/maptype';
 
 import { MAP_CONFIG_LOADED } from '../../actions/config';
 import assign from 'object-assign';
@@ -827,5 +828,19 @@ describe('Test the mapInfo reducer', () => {
         const action = setMapTrigger('hover');
         const state = mapInfo(undefined, action);
         expect(state.configuration.trigger).toBe('hover');
+    });
+    it('test the result of changeMapType action - MAP_TYPE_CHANGED when passing to cesium', () => {
+        const action = changeMapType('cesium');
+        const initialState = {configuration: {hoverEnabled: true}};
+        const state = mapInfo(initialState, action);
+        expect(state.configuration.hoverEnabled).toBe(false);
+        expect(state.configuration.trigger).toBe("click");
+    });
+    it('test the result of changeMapType action - MAP_TYPE_CHANGED when passing to 2d maptype', () => {
+        const action = changeMapType('openlayers');
+        const initialState = {configuration: {hoverEnabled: false, trigger: "click"}};
+        const state = mapInfo(initialState, action);
+        expect(state.configuration.hoverEnabled).toBe(true);
+        expect(state.configuration.trigger).toBe("click");
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -37,6 +37,7 @@ import { MAP_CONFIG_LOADED } from '../actions/config';
 import { RESET_CONTROLS } from '../actions/controls';
 import assign from 'object-assign';
 import { findIndex, isUndefined } from 'lodash';
+import { MAP_TYPE_CHANGED } from './../actions/maptype';
 
 /**
  * Handles responses based on the type ["data"|"exceptions","error","vector"] of the responses received
@@ -91,6 +92,7 @@ function receiveResponse(state, action, type) {
 }
 const initState = {
     enabled: true,
+    hoverEnabled: true,
     configuration: {}
 };
 
@@ -418,6 +420,25 @@ function mapInfo(state = initState, action) {
             configuration: {
                 ...state.configuration,
                 trigger: action.trigger
+            }
+        };
+    }
+    case MAP_TYPE_CHANGED: {
+        if (action.mapType === "cesium") {
+            return {
+                ...state,
+                configuration: {
+                    ...state.configuration,
+                    trigger: "click",
+                    hoverEnabled: false
+                }
+            };
+        }
+        return {
+            ...state,
+            configuration: {
+                ...state.configuration,
+                hoverEnabled: true
             }
         };
     }

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -24,7 +24,8 @@ import {
     itemIdSelector,
     filterNameListSelector,
     overrideParamsSelector,
-    mapTriggerSelector
+    mapTriggerSelector,
+    hoverEnabledSelector
 } from '../mapInfo';
 
 const QUERY_PARAMS = {
@@ -348,5 +349,13 @@ describe('Test mapinfo selectors', () => {
         expect(mapTriggerSelector({mapInfo: { configuration: {} }})).toBe('click');
         // when mapInfo is present
         expect(mapTriggerSelector({mapInfo: { configuration: { trigger: 'hover' } }})).toBe('hover');
+    });
+    it('test hoverEnabledSelector', () => {
+        // when no mapInfo object is not present in state
+        expect(hoverEnabledSelector({})).toBe(true);
+        // when no trigger in the configuration
+        expect(hoverEnabledSelector({mapInfo: { configuration: {} }})).toBe(true);
+        // when mapInfo is present
+        expect(hoverEnabledSelector({mapInfo: { configuration: { hoverEnabled: false } }})).toBe(false);
     });
 });

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -199,3 +199,4 @@ export const mapTriggerSelector = state => {
     }
     return state.mapInfo.configuration.trigger;
 };
+export const hoverEnabledSelector = state => get(state, "mapInfo.configuration.hoverEnabled", true);

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -193,10 +193,5 @@ export const clickedPointWithFeaturesSelector = createSelector(
 
 export const currentEditFeatureQuerySelector = state => state.mapInfo?.currentEditFeatureQuery;
 
-export const mapTriggerSelector = state => {
-    if (state.mapInfo?.configuration?.trigger === undefined) {
-        return 'click';
-    }
-    return state.mapInfo.configuration.trigger;
-};
+export const mapTriggerSelector = state => get(state, "mapInfo.configuration.trigger", "click");
 export const hoverEnabledSelector = state => get(state, "mapInfo.configuration.hoverEnabled", true);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
the crash has been fixed by forcing click method on cesium map and avoiding to hover to be selected

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6449

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
see description 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
