### PR TITLE
#6469: fixed printingbundle profile to align with the printing profile fixes

### DIFF
--- a/printing/assembly/mapstore-printing.xml
+++ b/printing/assembly/mapstore-printing.xml
@@ -14,7 +14,32 @@
             <includes>
                 <include>**/*.xml</include>
                 <include>**/print-lib*.jar</include>
-                <include>**/mapfish-geo-lib*.jar</include>
+                <include>**/avalon-*.jar</include>
+                <include>**/batik-*.jar</include>
+                <include>**/bcmail-*.jar</include>
+                <include>**/bcprov-*.jar</include>
+                <include>**/commons-lang3-*.jar</include>
+                <include>**/commons-pool-*.jar</include>
+                <include>**/ejml-*.jar</include>
+                <include>**/fontbox-*.jar</include>
+                <include>**/fop-*.jar</include>
+                <include>**/GeographicLib-*.jar</include>
+                <include>**/gt-*.jar</include>
+                <include>**/hsqldb-*.jar</include>
+                <include>**/itext-*.jar</include>
+                <include>**/jai*.jar</include>
+                <include>**/jempbox-*.jar</include>
+                <include>**/jgridshift-*.jar</include>
+                <include>**/json-2008*.jar</include>
+                <include>**/jts-core-*.jar</include>
+                <include>**/jyaml-*.jar</include>
+                <include>**/pdfbox-*.jar</include>
+                <include>**/si-*.jar</include>
+                <include>**/systems-common-*.jar</include>
+                <include>**/unit-*.jar</include>
+                <include>**/uom-*.jar</include>
+                <include>**/xml-apis-ext-*.jar</include>
+                <include>**/xmlgraphics-commons-*.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/printing/pom.xml
+++ b/printing/pom.xml
@@ -20,11 +20,6 @@
         <artifactId>print-lib</artifactId>
         <version>geosolutions-2.0-SNAPSHOT</version>
     </dependency>
-    <dependency>
-        <groupId>org.mapfish.geo</groupId>
-        <artifactId>mapfish-geo-lib</artifactId>
-        <version>1.2.0</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fix for the printingbundle profile so that:
 * mapfish-geolib is not included anymore
 * all the dependencies jars of print-lib not included in the standard mapstore build are included in the mapstore-printing.zip

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6469 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
