### PR TITLE
#6460 fix layer refresh when layer filter toggled on/off

### DIFF
--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -15,7 +15,7 @@ const {
     needProxy
 } = require('../../../../utils/ProxyUtils');
 const assign = require('object-assign');
-const {isArray} = require('lodash');
+const {isArray, isEqual} = require('lodash');
 const WMSUtils = require('../../../../utils/cesium/WMSUtils');
 const {getAuthenticationParam, getURLs} = require('../../../../utils/LayersUtils');
 const { optionsToVendorParams } = require('../../../../utils/VendorParamsUtils');
@@ -160,9 +160,12 @@ const updateLayer = (layer, newOptions, oldOptions) => {
         .filter((key) => {
             const oldOption = oldOptions[key] === undefined ? oldParams && oldParams[key] : oldOptions[key];
             const newOption = newOptions[key] === undefined ? newParams && newParams[key] : newOptions[key];
-            return oldOption !== newOption;
+            return !isEqual(oldOption, newOption);
         });
-    if (newParameters.length > 0 || newOptions.securityToken !== oldOptions.securityToken || newOptions.tileSize !== oldOptions.tileSize) {
+    if (newParameters.length > 0 ||
+        newOptions.securityToken !== oldOptions.securityToken ||
+        !isEqual(newOptions.layerFilter, oldOptions.layerFilter) ||
+        newOptions.tileSize !== oldOptions.tileSize) {
         return createLayer(newOptions);
     }
     return null;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
add condition to update layer when layerFilter changes

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6460

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it updates correctly the layer in the map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
