### PR TITLE
#6482: updates react-pdf to latest to fix pdf.worker.js loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "react-nouislider": "2.0.1",
     "react-numeric-input": "2.2.3",
     "react-overlays": "1.2.0",
-    "react-pdf": "4.0.5",
+    "react-pdf": "5.1.0",
     "react-player": "1.15.3",
     "react-plotly.js": "2.5.0",
     "react-quill": "1.1.0",

--- a/web/client/components/print/PrintPreview.jsx
+++ b/web/client/components/print/PrintPreview.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Glyphicon } from 'react-bootstrap';
-import { Document, Page } from 'react-pdf';
+import { Document, Page } from 'react-pdf/dist/umd/entry.webpack';
 import Button from '../misc/Button';
 
 
@@ -53,32 +53,28 @@ class PrintPreview extends React.Component {
     };
 
     render() {
-        if (window.PDFJS) {
-            window.PDFJS.workerSrc = 'https://unpkg.com/pdfjs-dist@1.4.79/build/pdf.worker.js';
-            return (
-                <div>
-                    <div style={this.props.style}>
-                        <Document file={this.props.url}
-                            onLoadSuccess={this.onDocumentComplete}>
-                            <Page pageNumber={this.props.currentPage + 1} scale={this.props.scale}/>
-                        </Document>
-                    </div>
-                    <div style={{marginTop: "10px"}}>
-                        <Button bsStyle={this.props.buttonStyle} style={{marginRight: "10px"}} onClick={this.props.back}><Glyphicon glyph="arrow-left"/></Button>
-                        <Button bsStyle={this.props.buttonStyle} disabled={this.props.scale >= this.props.maxScale} onClick={this.zoomIn}><Glyphicon glyph="zoom-in"/></Button>
-                        <Button bsStyle={this.props.buttonStyle} disabled={this.props.scale <= this.props.minScale} onClick={this.zoomOut}><Glyphicon glyph="zoom-out"/></Button>
-                        <label style={{marginLeft: "10px", marginRight: "10px"}}>{this.props.scale}x</label>
-                        <div className={"print-download btn btn-" + this.props.buttonStyle}><a href={this.props.url} target="_blank"><Glyphicon glyph="save"/></a></div>
-                        <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === 0} onClick={this.firstPage}><Glyphicon glyph="step-backward"/></Button>
-                        <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === 0} onClick={this.prevPage}><Glyphicon glyph="chevron-left"/></Button>
-                        <label style={{marginLeft: "10px", marginRight: "10px"}}>{this.props.currentPage + 1} / {this.props.pages}</label>
-                        <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === this.props.pages - 1} onClick={this.nextPage}><Glyphicon glyph="chevron-right"/></Button>
-                        <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === this.props.pages - 1} onClick={this.lastPage}><Glyphicon glyph="step-forward"/></Button>
-                    </div>
+        return (
+            <div>
+                <div style={this.props.style}>
+                    <Document file={this.props.url}
+                        onLoadSuccess={this.onDocumentComplete}>
+                        <Page pageNumber={this.props.currentPage + 1} scale={this.props.scale}/>
+                    </Document>
                 </div>
-            );
-        }
-        return null;
+                <div style={{marginTop: "10px"}}>
+                    <Button bsStyle={this.props.buttonStyle} style={{marginRight: "10px"}} onClick={this.props.back}><Glyphicon glyph="arrow-left"/></Button>
+                    <Button bsStyle={this.props.buttonStyle} disabled={this.props.scale >= this.props.maxScale} onClick={this.zoomIn}><Glyphicon glyph="zoom-in"/></Button>
+                    <Button bsStyle={this.props.buttonStyle} disabled={this.props.scale <= this.props.minScale} onClick={this.zoomOut}><Glyphicon glyph="zoom-out"/></Button>
+                    <label style={{marginLeft: "10px", marginRight: "10px"}}>{this.props.scale}x</label>
+                    <div className={"print-download btn btn-" + this.props.buttonStyle}><a href={this.props.url} target="_blank"><Glyphicon glyph="save"/></a></div>
+                    <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === 0} onClick={this.firstPage}><Glyphicon glyph="step-backward"/></Button>
+                    <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === 0} onClick={this.prevPage}><Glyphicon glyph="chevron-left"/></Button>
+                    <label style={{marginLeft: "10px", marginRight: "10px"}}>{this.props.currentPage + 1} / {this.props.pages}</label>
+                    <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === this.props.pages - 1} onClick={this.nextPage}><Glyphicon glyph="chevron-right"/></Button>
+                    <Button bsStyle={this.props.buttonStyle} disabled={this.props.currentPage === this.props.pages - 1} onClick={this.lastPage}><Glyphicon glyph="step-forward"/></Button>
+                </div>
+            </div>
+        );
     }
 
     firstPage = () => {

--- a/web/client/plugins/Print.jsx
+++ b/web/client/plugins/Print.jsx
@@ -216,12 +216,6 @@ export default {
                     };
 
                     UNSAFE_componentWillMount() {
-                        if (this.props.usePreview && !window.PDFJS) {
-                            const s = document.createElement("script");
-                            s.type = "text/javascript";
-                            s.src = "https://unpkg.com/pdfjs-dist@1.4.79/build/pdf.combined.js";
-                            document.head.appendChild(s);
-                        }
                         this.configurePrintMap();
                     }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Updates react-pdf to latest version to fix loading pdfjs worker in production with webpack.
The new version allows loading pdfjs dependency from node_modules, so we can remove the dynamic script loading from CDN.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6482 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
In production, pdf.worker.js is not loaded from the correct location.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
In production, pdf.worker.js is loaded from the dist folder, where it is bundled by webpack.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
