### PR TITLE
#6494: added direct dependency for commons-pool jar, needed both by base profile and printing one

### DIFF
--- a/printing/assembly/mapstore-printing.xml
+++ b/printing/assembly/mapstore-printing.xml
@@ -19,7 +19,6 @@
                 <include>**/bcmail-*.jar</include>
                 <include>**/bcprov-*.jar</include>
                 <include>**/commons-lang3-*.jar</include>
-                <include>**/commons-pool-*.jar</include>
                 <include>**/ejml-*.jar</include>
                 <include>**/fontbox-*.jar</include>
                 <include>**/fop-*.jar</include>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -67,6 +67,12 @@
         <artifactId>ehcache-web</artifactId>
         <version>2.0.4</version>
     </dependency>
+    <!-- misc -->
+    <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>1.5.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -66,6 +66,12 @@
         <artifactId>ehcache-web</artifactId>
         <version>2.0.4</version>
     </dependency>
+    <!-- misc -->
+    <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>1.5.4</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The commons-pool java library is needed by both geostore and mapfish-print.
geostore uses the 1.3 version, while mapfish-print the 1.5.4 version.
We need to include the latest in the basic (default profile) so that is always included in the built war, for all building profiles.

I did the change both for the product build in web/pom.xml and the standard project.

Since now commons-pool,jar is always included in the standard war, I have removed it from the printing extension zip.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6494 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
When building without the printing profile, commons-pool is missing from the WEB-INF/lib folder of the webapp and mapstore fails to start.

**What is the new behavior?**
commons-pool is always copied in WEB-INF/lib, for every building profile, so the webapp is starting properly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
