### PR TITLE
backport 2021.01.xx - #6494: added direct dependency for commons-pool jar, needed both by base profile and printing one (#6496)

### DIFF
--- a/printing/assembly/mapstore-printing.xml
+++ b/printing/assembly/mapstore-printing.xml
@@ -19,7 +19,6 @@
                 <include>**/bcmail-*.jar</include>
                 <include>**/bcprov-*.jar</include>
                 <include>**/commons-lang3-*.jar</include>
-                <include>**/commons-pool-*.jar</include>
                 <include>**/ejml-*.jar</include>
                 <include>**/fontbox-*.jar</include>
                 <include>**/fop-*.jar</include>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -67,6 +67,12 @@
         <artifactId>ehcache-web</artifactId>
         <version>2.0.4</version>
     </dependency>
+    <!-- misc -->
+    <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>1.5.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -66,6 +66,12 @@
         <artifactId>ehcache-web</artifactId>
         <version>2.0.4</version>
     </dependency>
+    <!-- misc -->
+    <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>1.5.4</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
backport 2021.01.xx - #6494: added direct dependency for commons-pool jar, needed both by base profile and printing one (#6496)