### PR TITLE
Backport 6488: The options menu is not fully visible if it contains many items

### DIFF
--- a/web/client/themes/default/less/dropdown-menu.less
+++ b/web/client/themes/default/less/dropdown-menu.less
@@ -92,6 +92,8 @@
 
 #mapstore-burger-menu {
     .dropdown-menu {
-        z-index: 1040;
+		z-index: 1040;
+		overflow-y: auto;
+        max-height: 80vh;
     }
 }


### PR DESCRIPTION
(cherry picked from commit f3fc81fc7dd140ef7c51f2c66db5515c3bdcc1f3)

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
The options menu is not fully visible if it contains many items
#6488

![4438e6fa-728d-4c1b-a5b4-8a8d7971fc91](https://user-images.githubusercontent.com/4085786/106739230-2ff91280-6619-11eb-946e-5bb8bc975d41.png)


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Include a scrollbar in the options menu, to enable the user to view all items
![106627093-b7427980-6578-11eb-90e7-6b4995131152](https://user-images.githubusercontent.com/4085786/106739240-34bdc680-6619-11eb-8188-21796b86cbf7.png)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
