### PR TITLE
#6394 FeatureGrid shows "id" attribute values as NaN

### DIFF
--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -125,6 +125,19 @@ describe('Test for FeatureGrid component', () => {
         TestUtils.Simulate.click(domNode);
         expect(events.onRowsDeselected).toHaveBeenCalled();
     });
+    it('Test the field values are rendered right way', () => {
+        ReactDOM.render(<FeatureGrid virtualScroll={false}
+            describeFeatureType={describePois}
+            features={museam.features}/>, document.getElementById("container"));
+        let domNode = Array.prototype.filter.call(document.getElementsByClassName("react-grid-Cell"), (element) =>{
+            return element;
+        });
+        expect(domNode).toExist();
+        expect(domNode[0].getAttribute('value')).toBe('' + (museam.features[0].properties.NAME));
+        expect(domNode[1].getAttribute('value')).toBe('' + (museam.features[0].properties.THUMBNAIL));
+        expect(domNode[2].getAttribute('value')).toBe('' + (museam.features[0].properties.MAINPAGE));
+    });
+
     it('temporary changes on field edit', () => {
         const events = {
             onTemporaryChanges: () => {}

--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -125,7 +125,7 @@ describe('Test for FeatureGrid component', () => {
         TestUtils.Simulate.click(domNode);
         expect(events.onRowsDeselected).toHaveBeenCalled();
     });
-    it('Test the field values are rendered right way', () => {
+    it('Test the field values are rendered right way in grid cells', () => {
         ReactDOM.render(<FeatureGrid virtualScroll={false}
             describeFeatureType={describePois}
             features={museam.features}/>, document.getElementById("container"));

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -109,8 +109,9 @@ const featuresToGrid = compose(
                 .filter(props.focusOnEdit ? createNewAndEditingFilter(props.changes && Object.keys(props.changes).length > 0, props.newFeatures, props.changes) : () => true)
                 .map(orig => applyAllChanges(orig, props.changes)).map(result =>
                     ({...result,
+                        ["_!_id_!_"]: result.id,
                         get: key => {
-                            return (key === "id" || key === "geometry" || key === "_new") ? result[key] : result.properties && result.properties[key];
+                            return (key === "geometry" || key === "_new") ? result[key] : result.properties && result.properties[key];
                         }
                     }))
         })
@@ -192,7 +193,7 @@ const featuresToGrid = compose(
                     showCheckbox: props.mode === "EDIT",
                     selectBy: {
                         keys: {
-                            rowKey: 'id',
+                            rowKey: '_!_id_!_',
                             values: props.select.map(f => f.id)
                         }
                     },

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -342,17 +342,7 @@
                         "alwaysVisible": true
                     }
                 }
-            },
-            "Home",
-            {
-              "name": "FeatureEditor",
-              "cfg": {
-                "editingAllowedRoles": [
-                  "ADMIN",
-                  "USER"
-                ]
-              }
-            },
+            }, "Home", "FeatureEditor",
             "LayerDownload",
             {
               "name": "QueryPanel",

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -342,7 +342,17 @@
                         "alwaysVisible": true
                     }
                 }
-            }, "Home", "FeatureEditor",
+            },
+            "Home",
+            {
+              "name": "FeatureEditor",
+              "cfg": {
+                "editingAllowedRoles": [
+                  "ADMIN",
+                  "USER"
+                ]
+              }
+            },
             "LayerDownload",
             {
               "name": "QueryPanel",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6394
The FeatureGrid treats values of feature properties named "id" as NaN.

![104567779-80e79d80-564f-11eb-8d23-fae408827cd0](https://user-images.githubusercontent.com/4085786/107050136-2dd6b580-67cb-11eb-8228-af031884ce2c.png)


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
We expect to see the right values for the "id" attribute

![Schermata 2021-02-05 alle 15 54 54](https://user-images.githubusercontent.com/4085786/107049625-9cffda00-67ca-11eb-932a-ffff073d9d0b.png)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
