### PR TITLE
#6503: Enhance draw support for geodesic circle annotation

### DIFF
--- a/web/client/actions/__tests__/annotations-test.js
+++ b/web/client/actions/__tests__/annotations-test.js
@@ -193,6 +193,12 @@ describe('Test correctness of the annotations actions', () => {
         const result = startDrawing();
         expect(result.type).toEqual(START_DRAWING);
     });
+    it('startDrawing with options', () => {
+        const options = {geodesic: false};
+        const result = startDrawing(options);
+        expect(result.type).toEqual(START_DRAWING);
+        expect(result.options).toEqual(options);
+    });
     it('toggleUnsavedChangesModal', () => {
         const result = toggleUnsavedChangesModal();
         expect(result.type).toEqual(TOGGLE_CHANGES_MODAL);

--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -298,9 +298,10 @@ function cancelCloseAnnotations() {
         type: CANCEL_CLOSE_ANNOTATIONS
     };
 }
-function startDrawing() {
+function startDrawing(options = {}) {
     return {
-        type: START_DRAWING
+        type: START_DRAWING,
+        options
     };
 }
 function toggleUnsavedChangesModal() {

--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -914,7 +914,7 @@ export default class DrawSupport extends React.Component {
         }
         if (newProps.options.editEnabled) {
 
-            !newProps.options.geodesic && newProps.drawMethod !== "Circle" && this.addModifyInteraction(newProps);
+            !newProps.options.geodesic && this.addModifyInteraction(newProps);
             // removed for polygon because of the issue https://github.com/geosolutions-it/MapStore2/issues/2378
             if (newProps.options.translateEnabled !== false) {
                 this.addTranslateInteraction();

--- a/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/DrawSupport-test.jsx
@@ -1816,6 +1816,44 @@ describe('Test DrawSupport', () => {
             drawMethod: "Circle"
         });
         expect(support).toExist();
+        expect(support.drawSource.getFeatures()[0].getGeometry().getType()).toBe("Circle");
+        expect(spyOnDrawingFeatures).toHaveBeenCalled();
+        done();
+    });
+    it('test click callbacks in edit mode with Circle feature with geodesic', (done) => {
+        const feature = {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: [13, 43]
+            },
+            properties: {
+                name: "some name",
+                id: "a-unique-id",
+                valueText: "a text",
+                canEdit: true,
+                radius: 1111,
+                isCircle: true
+            },
+            style: [{
+                id: "style-id",
+                color: "#FF0000",
+                opacity: 1
+            }]
+        };
+        const spyOnDrawingFeatures = expect.spyOn(testHandlers, "onDrawingFeatures");
+        let support = renderAndClick({
+            feature,
+            drawMethod: "Circle",
+            options: {
+                drawEnabled: false,
+                editEnabled: true,
+                addClickCallback: true,
+                geodesic: true
+            }
+        });
+        expect(support.drawSource.getFeatures()[0].getGeometry().getType()).toBe("Polygon");
+        expect(support).toExist();
         expect(spyOnDrawingFeatures).toHaveBeenCalled();
         done();
     });
@@ -1860,6 +1898,54 @@ describe('Test DrawSupport', () => {
         expect(ArgsGeometryChanged[0][0]).toEqual(ArgsEndDrawing[0]);
 
         done();
+    });
+    it('test drawend callbacks with Circle with geodesic, transformed into feature collection', () => {
+        const fakeMap = {
+            addLayer: () => {},
+            disableEventListener: () => {},
+            addInteraction: () => {},
+            getInteractions: () => ({
+                getLength: () => 0
+            }),
+            getView: () => ({
+                getProjection: () => ({
+                    getCode: () => 'EPSG:3857'
+                })
+            })
+        };
+        const simplifiedCircle = new Feature({
+            geometry: new Polygon([[
+                [1260844.6064174946, 5858067.29727681],
+                [1260960.7874218025, 5857951.114737838],
+                [1260844.6064174946, 5857834.9352681665],
+                [1260728.4254131867, 5857951.114737838],
+                [1260844.6064174946, 5858067.29727681]
+            ]])
+        });
+        const features = JSON.parse(`[{"type":"FeatureCollection","id":"1","geometry":null,"features":[{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]},"properties":{"id":"1","isValidFeature":false,"canEdit":true,"isCircle":true,"isDrawing":true}}],"newFeature":true,"properties":{"id":"1"},"tempFeatures":[]}]`);
+        const spyEnd = expect.spyOn(testHandlers, "onEndDrawing");
+        const support = ReactDOM.render(
+            <DrawSupport features={features} map={fakeMap}/>, document.getElementById("container"));
+        expect(support).toExist();
+        ReactDOM.render(
+            <DrawSupport features={features} map={fakeMap} drawStatus="drawOrEdit" drawMethod="Circle" options={{
+                stopAfterDrawing: true,
+                geodesic: true,
+                drawEnabled: true,
+                transformToFeatureCollection: true
+            }}
+            onEndDrawing={testHandlers.onEndDrawing} onChangeDrawingStatus={testHandlers.onStatusChange}/>, document.getElementById("container"));
+        support.drawInteraction.dispatchEvent({
+            type: 'drawstart',
+            feature: simplifiedCircle
+        });
+        support.drawInteraction.dispatchEvent({
+            type: 'drawend',
+            feature: simplifiedCircle
+        });
+        expect(spyEnd).toHaveBeenCalled();
+        const [feature] = spyEnd.calls[0].arguments[0].features;
+        expect(feature.properties.radius).toBe(79.91);
     });
 
     it('test drawend callbacks with Text, transformed int feature collection', (done) => {
@@ -2213,6 +2299,22 @@ describe('Test DrawSupport', () => {
         expect(spyOnGeometryChanged).toHaveBeenCalled();
         expect(spyOnDrawingFeatures).toNotHaveBeenCalled();
 
+        done();
+    });
+    it('test modifyInteraction of Circle with geodesic', (done) => {
+        let support = renderDrawSupport();
+        support = renderDrawSupport({
+            drawMethod: "Circle",
+            drawStatus: "drawOrEdit",
+            features: [geomCollFeature],
+            options: {
+                transformToFeatureCollection: true,
+                editEnabled: true,
+                geodesic: true
+            }
+        });
+        expect(support).toExist();
+        expect(support.modifyInteraction).toBeFalsy();
         done();
     });
     it('test drawPropertiesForGeometryType for BBOX', (done) => {

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -83,6 +83,7 @@ const defaultConfig = require('./AnnotationsConfig');
  * @prop {string} symbolsPath path to the svg folder
  * @prop {object[]} symbolList list of symbols
  * @prop {string} defaultShape default Shape
+ * @prop {boolean} geodesic draw geodesic annotation (Currently applicable only for Circle annotation)
  *
  * the annotation's attributes.
  */
@@ -129,7 +130,8 @@ class Annotations extends React.Component {
         lineDashOptions: PropTypes.array,
         symbolList: PropTypes.array,
         defaultShape: PropTypes.string,
-        symbolsPath: PropTypes.string
+        symbolsPath: PropTypes.string,
+        geodesic: PropTypes.bool
     };
 
     static contextTypes = {
@@ -229,10 +231,10 @@ class Annotations extends React.Component {
         const annotation = this.props.annotations && head(this.props.annotations.filter(a => a.properties.id === this.props.current));
         const Editor = this.props.editor;
         if (this.props.mode === 'detail') {
-            return <Editor feature={annotation} showBack id={this.props.current} config={this.props.config} width={this.props.width} {...annotation.properties}/>;
+            return <Editor geodesic={this.props.geodesic} feature={annotation} showBack id={this.props.current} config={this.props.config} width={this.props.width} {...annotation.properties}/>;
         }
         // mode = editing
-        return this.props.editing && <Editor feature={annotation} id={this.props.editing.properties && this.props.editing.properties.id || uuidv1()} width={this.props.width} config={this.props.config} {...this.props.editing.properties} lineDashOptions={this.props.lineDashOptions}
+        return this.props.editing && <Editor geodesic={this.props.geodesic} feature={annotation} id={this.props.editing.properties && this.props.editing.properties.id || uuidv1()} width={this.props.width} config={this.props.config} {...this.props.editing.properties} lineDashOptions={this.props.lineDashOptions}
             symbolsPath={this.props.symbolsPath}
             onUpdateSymbols={this.props.onUpdateSymbols}
             onSetErrorSymbol={this.props.onSetErrorSymbol}

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -189,7 +189,8 @@ class AnnotationsEditor extends React.Component {
         symbolErrors: PropTypes.array,
         lineDashOptions: PropTypes.array,
         symbolList: PropTypes.array,
-        defaultShape: PropTypes.string
+        defaultShape: PropTypes.string,
+        geodesic: PropTypes.bool
     };
 
     static defaultProps = {
@@ -312,7 +313,7 @@ class AnnotationsEditor extends React.Component {
                             onAddText: this.props.onAddText,
                             onSetStyle: this.props.onSetStyle,
                             style: this.props.selected && this.props.selected.style || this.props.editing.style,
-                            onStartDrawing: this.props.onStartDrawing,
+                            onStartDrawing: ()=> this.props.onStartDrawing({geodesic: this.props.geodesic}),
                             disabled: !this.props.config.multiGeometry && this.props.editing && this.props.editing.features && this.props.editing.features.length,
                             drawing: this.props.drawing,
                             titles: {

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -897,4 +897,39 @@ describe('annotations Epics', () => {
         store.dispatch(action);
     });
 
+    it('edit circle annotation with geodesic property ', (done) => {
+        store = mockStore({...defaultState, annotations: {...defaultState.annotations, config: {...defaultState.annotations.config, geodesic: true}}} );
+
+        store.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 2) {
+                expect(actions[0].type).toBe(DRAWING_FEATURE);
+                expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[1].options).toContain({
+                    geodesic: true,
+                    editEnabled: true,
+                    transformToFeatureCollection: true,
+                    addClickCallback: true
+                });
+                done();
+            }
+        });
+        const circleGeom = {
+            type: "Polygon",
+            coordinates: [[1, 2], [2, 3]]
+        };
+        const feature = {
+            type: "Feature",
+            geometry: circleGeom,
+            properties: {
+                canEdit: true,
+                id: "12345",
+                isCircle: true
+            }
+        };
+        const action = drawingFeatures([feature]);
+        store.dispatch(action);
+
+    });
+
 });

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -31,7 +31,7 @@ const uuidv1 = require('uuid/v1');
 const {FEATURES_SELECTED, GEOMETRY_CHANGED, DRAWING_FEATURE} = require('../actions/draw');
 const {PURGE_MAPINFO_RESULTS} = require('../actions/mapInfo');
 
-const {head, findIndex, castArray, isArray, find} = require('lodash');
+const {head, findIndex, castArray, isArray, find, get} = require('lodash');
 const assign = require('object-assign');
 const {annotationsLayerSelector, multiGeometrySelector} = require('../selectors/annotations');
 const {normalizeAnnotation, removeDuplicate, validateCoordsArray, getStartEndPointsForLinestring, DEFAULT_ANNOTATIONS_STYLES} = require('../utils/AnnotationsUtils');
@@ -67,6 +67,16 @@ const validateFeatureCollection = (feature) => {
     return set("features", features, feature);
 };
 
+/**
+ * Get geodesic property from the annotation config
+ * @param state
+ * @param drawMethod
+ * @return {boolean}
+ */
+const getGeodesicProperty = (state, drawMethod = "Circle") => {
+    return drawMethod === "Circle" && get(state.annotations, "config.geodesic", false);
+};
+
 const getSelectDrawStatus = (state) => {
     let feature = state.annotations.editing;
     const multiGeom = multiGeometrySelector(state);
@@ -77,7 +87,8 @@ const getSelectDrawStatus = (state) => {
         selectEnabled: true,
         drawEnabled: false,
         translateEnabled: false,
-        transformToFeatureCollection: true
+        transformToFeatureCollection: true,
+        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
     };
 
     feature = validateFeatureCollection(feature);
@@ -93,7 +104,8 @@ const getReadOnlyDrawStatus = (state) => {
         selectEnabled: false,
         translateEnabled: false,
         drawEnabled: false,
-        transformToFeatureCollection: true
+        transformToFeatureCollection: true,
+        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
     };
     feature = validateFeatureCollection(feature);
     return changeDrawingStatus("drawOrEdit", state.draw.drawMethod, "annotations", [feature], drawOptions, feature.style);
@@ -111,7 +123,8 @@ const getEditingGeomDrawStatus = (state) => {
         translateEnabled: false,
         addClickCallback: true,
         useSelectedStyle: true,
-        transformToFeatureCollection: true
+        transformToFeatureCollection: true,
+        geodesic: getGeodesicProperty(state, state.draw.drawMethod)
     };
     feature = validateFeatureCollection(feature);
     return changeDrawingStatus("drawOrEdit", state.draw.drawMethod, "annotations", [feature], drawOptions, feature.style);
@@ -197,7 +210,8 @@ module.exports = (viewer) => ({
                 editEnabled: false,
                 selectEnabled: true,
                 drawEnabled: false,
-                transformToFeatureCollection: true
+                transformToFeatureCollection: true,
+                geodesic: getGeodesicProperty(state, type)
             };
             // parsing styles searching for missing symbols, therefore updating it with a missing symbol
             return Rx.Observable.from([
@@ -337,7 +351,8 @@ module.exports = (viewer) => ({
                 editFilter: (f) => f.getProperties().canEdit,
                 defaultTextAnnotation,
                 transformToFeatureCollection: true,
-                addClickCallback: true
+                addClickCallback: true,
+                geodesic: getGeodesicProperty(state, type)
             };
             return Rx.Observable.of(changeDrawingStatus("drawOrEdit", type, "annotations", [feature], drawOptions, assign({}, feature.style, {highlight: false})));
         }),
@@ -550,7 +565,8 @@ module.exports = (viewer) => ({
                 useSelectedStyle: true,
                 drawEnabled: false,
                 transformToFeatureCollection: true,
-                addClickCallback: true
+                addClickCallback: true,
+                geodesic: getGeodesicProperty(state, method)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of(action);
         }),
@@ -646,7 +662,8 @@ module.exports = (viewer) => ({
                 drawEnabled: false,
                 useSelectedStyle: true,
                 transformToFeatureCollection: true,
-                addClickCallback: true
+                addClickCallback: true,
+                geodesic: getGeodesicProperty(state)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of(action);
         }),
@@ -674,7 +691,8 @@ module.exports = (viewer) => ({
                 drawEnabled: false,
                 useSelectedStyle: true,
                 transformToFeatureCollection: true,
-                addClickCallback: true
+                addClickCallback: true,
+                geodesic: getGeodesicProperty(state, method)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of( changeDrawingStatus("clean"), action);
         }),
@@ -696,7 +714,8 @@ module.exports = (viewer) => ({
                 drawEnabled: false,
                 useSelectedStyle: true,
                 transformToFeatureCollection: true,
-                addClickCallback: true
+                addClickCallback: true,
+                geodesic: getGeodesicProperty(state)
             }, assign({}, style, {highlight: false}));
             return Rx.Observable.of(action);
         })

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -294,7 +294,12 @@
                 }
               }
             }
-          }, "AutoMapUpdate", "HelpLink", "Share", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
+          }, "AutoMapUpdate", "HelpLink", "Share", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", {
+            "name": "Annotations",
+            "cfg": {
+              "geodesic": true
+            }
+          },
             {
                 "name": "Identify",
                 "cfg": {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -294,12 +294,7 @@
                 }
               }
             }
-          }, "AutoMapUpdate", "HelpLink", "Share", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", {
-            "name": "Annotations",
-            "cfg": {
-              "geodesic": true
-            }
-          },
+          }, "AutoMapUpdate", "HelpLink", "Share", "DrawerMenu", "Version", "Notifications", "BackgroundSelector", "Annotations",
             {
                 "name": "Identify",
                 "cfg": {

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -41,7 +41,8 @@ const {
     toggleStyle,
     setStyle,
     updateSymbols,
-    setEditingFeature
+    setEditingFeature,
+    startDrawing
 } = require('../../actions/annotations');
 const {PURGE_MAPINFO_RESULTS} = require('../../actions/mapInfo');
 const {drawingFeatures, selectFeatures} = require('../../actions/draw');
@@ -1589,5 +1590,13 @@ describe('Test the annotations reducer', () => {
         expect(annotationsState.editing.features[0].style[2].filtering).toBe(false);
         expect(annotationsState.editing.features[1].style[1].filtering).toBe(false);
         expect(annotationsState.editing.features[1].style[2].filtering).toBe(false);
+    });
+    it('START_DRAWING', () => {
+        let annotationsState = annotations({
+            editing: null,
+            selected: null
+        }, startDrawing({geodesic: true}));
+        expect(annotationsState.config).toBeTruthy();
+        expect(annotationsState.config.geodesic).toBe(true);
     });
 });

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -21,12 +21,12 @@ const {REMOVE_ANNOTATION, CONFIRM_REMOVE_ANNOTATION, CANCEL_REMOVE_ANNOTATION, C
     UNSAVED_CHANGES, TOGGLE_GEOMETRY_MODAL, TOGGLE_CHANGES_MODAL, CHANGED_PROPERTIES, TOGGLE_STYLE_MODAL, UNSAVED_STYLE,
     ADD_TEXT, CHANGED_SELECTED, RESET_COORD_EDITOR, CHANGE_RADIUS, CHANGE_TEXT,
     ADD_NEW_FEATURE, SET_EDITING_FEATURE, SET_INVALID_SELECTED, TOGGLE_DELETE_FT_MODAL, CONFIRM_DELETE_FEATURE, HIGHLIGHT_POINT,
-    CHANGE_FORMAT, UPDATE_SYMBOLS, ERROR_SYMBOLS
+    CHANGE_FORMAT, UPDATE_SYMBOLS, ERROR_SYMBOLS, START_DRAWING
 } = require('../actions/annotations');
 
 const {validateCoordsArray, getAvailableStyler, DEFAULT_ANNOTATIONS_STYLES, convertGeoJSONToInternalModel, addIds, validateFeature, getComponents, updateAllStyles, getBaseCoord} = require('../utils/AnnotationsUtils');
 const {set} = require('../utils/ImmutableUtils');
-const {head, findIndex, isNil, slice, castArray} = require('lodash');
+const {head, findIndex, isNil, slice, castArray, get} = require('lodash');
 
 const uuid = require('uuid');
 
@@ -624,6 +624,8 @@ function annotations(state = { validationErrors: {} }, action) {
         });
     case ERROR_SYMBOLS:
         return {...state, symbolErrors: action.symbolErrors};
+    case START_DRAWING:
+        return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
     default:
         return state;
 


### PR DESCRIPTION
## Description
This PR enhances the drawsupport to create a geodesic circle annotation via configuration option from Annotation plugin

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6503 

**What is the new behavior?**
- Allow to configure geodesic property for Annotation plugin to draw geodesic circle annotation
- When geodesic = true, a geodesic circle of type Polygon is drawn which is not interactable but only move the center by clicking on the map
- When geodesic = false, a non-geodesic circle is drawn and it is interactable (i.e resize the circle, move the center by click-n-drag the center of the circle) 

**Annotation Plugin - Config**
```
{
  "name": "Annotations",
  "cfg": {
    "geodesic": true
  }
}
```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
