### PR TITLE
[backport] #6394 FeatureGrid shows "id" attribute values as NaN (#6513)

### DIFF
--- a/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
+++ b/web/client/components/data/featuregrid/__tests__/FeatureGrid-test.jsx
@@ -125,6 +125,19 @@ describe('Test for FeatureGrid component', () => {
         TestUtils.Simulate.click(domNode);
         expect(events.onRowsDeselected).toHaveBeenCalled();
     });
+    it('Test the field values are rendered right way in grid cells', () => {
+        ReactDOM.render(<FeatureGrid virtualScroll={false}
+            describeFeatureType={describePois}
+            features={museam.features}/>, document.getElementById("container"));
+        let domNode = Array.prototype.filter.call(document.getElementsByClassName("react-grid-Cell"), (element) =>{
+            return element;
+        });
+        expect(domNode).toExist();
+        expect(domNode[0].getAttribute('value')).toBe('' + (museam.features[0].properties.NAME));
+        expect(domNode[1].getAttribute('value')).toBe('' + (museam.features[0].properties.THUMBNAIL));
+        expect(domNode[2].getAttribute('value')).toBe('' + (museam.features[0].properties.MAINPAGE));
+    });
+
     it('temporary changes on field edit', () => {
         const events = {
             onTemporaryChanges: () => {}

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -109,8 +109,9 @@ const featuresToGrid = compose(
                 .filter(props.focusOnEdit ? createNewAndEditingFilter(props.changes && Object.keys(props.changes).length > 0, props.newFeatures, props.changes) : () => true)
                 .map(orig => applyAllChanges(orig, props.changes)).map(result =>
                     ({...result,
+                        ["_!_id_!_"]: result.id,
                         get: key => {
-                            return (key === "id" || key === "geometry" || key === "_new") ? result[key] : result.properties && result.properties[key];
+                            return (key === "geometry" || key === "_new") ? result[key] : result.properties && result.properties[key];
                         }
                     }))
         })
@@ -192,7 +193,7 @@ const featuresToGrid = compose(
                     showCheckbox: props.mode === "EDIT",
                     selectBy: {
                         keys: {
-                            rowKey: 'id',
+                            rowKey: '_!_id_!_',
                             values: props.select.map(f => f.id)
                         }
                     },


### PR DESCRIPTION
## Description
The FeatureGrid treats values of feature propoerties named "id" as NaN. 
I suppose a property named "id" clashes somehow with the feature.id key, making the FeatureGrid go crazy.

## How to reproduce
You can see it live with [this GeoNode layer](https://master.demo.geonode.org/maps/new?layer=geonode:grid_50km&view=True). The original shapefile is [this](https://github.com/geosolutions-it/MapStore2/files/5813359/grid_50km.zip),

*Expected Result*
I expect to see the values for the "id" attribute

QGIS view:
![image](https://user-images.githubusercontent.com/571129/104567765-7af1bc80-564f-11eb-990f-c7b0cda3a1c2.png)

*Current Result*
In MapStore the values are NaN

MS2 view:
![image](https://user-images.githubusercontent.com/571129/104567779-80e79d80-564f-11eb-8d23-fae408827cd0.png)

