### PR TITLE
#6531: Load of lazy plugin with stateSelector

### DIFF
--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -420,4 +420,23 @@ describe('PluginsUtils', () => {
             done();
         });
     });
+    it('should load lazy plugins with stateSelector', () => {
+
+        const pluginDef = {
+            name: 'StateSelectorLazy',
+            stateSelector: 'selector'
+        };
+        const pluginWithSelectorState = (stateSelector) => function Plugin() { return <div className={stateSelector}></div>; };
+        const plugins = {
+            StateSelectorLazyPlugin: {
+                loadPlugin: (resolve) => resolve(pluginWithSelectorState)
+            }
+        };
+        const loadedPlugins = {
+            StateSelectorLazy: pluginWithSelectorState
+        };
+        const { impl: LoadedPlugin } = PluginsUtils.getPluginDescriptor({}, plugins, [], pluginDef, loadedPlugins);
+        ReactDOM.render(<LoadedPlugin/>, document.getElementById('container'));
+        expect(document.querySelector('.selector')).toBeTruthy();
+    });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds the possibility to load lazy plugin with stateSelector

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6531

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
It's possible to load lazy plugin with stateSelector

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
