### PR TITLE
#6537 - Measure panel improvement

### DIFF
--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -283,6 +283,7 @@ export default class MeasurementSupport extends React.Component {
 
         this.source.addFeatures(geometries.filter(g => !!g).map(geometry => new Feature({geometry})));
         let tempTextLabels = [...this.textLabels];
+        // Add segment length labels to the feature
         newFeatures.map((newFeature, index) => {
             const isBearing = !!newFeature.properties?.values?.find(val=>val.type === 'bearing');
             const isPolygon = newFeature.geometry.type === "Polygon";
@@ -295,7 +296,7 @@ export default class MeasurementSupport extends React.Component {
             } else {
                 newFeature.geometry.textLabels =  tempTextLabels.splice(0, currentCoordinateLength - sliceVal) || [];
             }
-            if (isEqual(coordinates[coordinates.length - 1], coordinates[coordinates.length - 2]) && !hasInvalidCoords && isPolygon) {
+            if (isPolygon && !hasInvalidCoords && coordinates.length && isEqual(coordinates[currentCoordinateLength], coordinates[currentCoordinateLength - 1])) {
                 newFeature.geometry.coordinates[0].pop(); // Pop last coordinate of a Polygon to prevent extra rows in Measure panel
             }
             return newFeature;

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {round, get, isEqual, dropRight, last, isEmpty} from 'lodash';
+import {round, get, isEqual, dropRight, last} from 'lodash';
 
 import {
     reprojectGeoJson,
@@ -19,7 +19,7 @@ import {
     transformLineToArcs,
     midpoint
 } from '../../../utils/CoordinatesUtils';
-import {convertUom, getFormattedBearingValue} from '../../../utils/MeasureUtils';
+import {convertUom, getFormattedBearingValue, validateCoord} from '../../../utils/MeasureUtils';
 import {set} from '../../../utils/ImmutableUtils';
 import {startEndPolylineStyle} from './VectorStyle';
 import {getMessageById} from '../../../utils/LocaleUtils';
@@ -160,9 +160,6 @@ export default class MeasurementSupport extends React.Component {
         return null;
     }
 
-    validateCoords = (coords) => {
-        return !isNaN(parseFloat(coords[0])) && !isNaN(parseFloat(coords[1]));
-    }
     updateFeatures = (props) => {
         const oldFeatures = this.source.getFeatures();
 
@@ -291,15 +288,15 @@ export default class MeasurementSupport extends React.Component {
             const isPolygon = newFeature.geometry.type === "Polygon";
             const sliceVal = (isPolygon || isBearing) ? 0 : 1;
             const coordinates = isPolygon ? newFeature.geometry.coordinates[0] : newFeature.geometry.coordinates;
-            const hasInvalidCoords = coordinates.some(c=> !this.validateCoords(c));
-            const tempCoordinateLengthCurr = isPolygon ? coordinates.length - 1 : isBearing ? 0 : coordinates.length;
+            const hasInvalidCoords = coordinates.some(c=> !validateCoord(c));
+            const currentCoordinateLength = isPolygon ? coordinates.length - 1 : isBearing ? 0 : coordinates.length;
             if (indexOfFeatureInEdit !== null && indexOfFeatureInEdit === index && hasInvalidCoords) {
-                newFeature.geometry.textLabels = newFeature.geometry.textLabels.concat([""]);
+                newFeature.geometry.textLabels = newFeature.geometry.textLabels.concat([{text: "0"}]); // Add empty label when coordinate row is empty
             } else {
-                newFeature.geometry.textLabels =  tempTextLabels.splice(0, tempCoordinateLengthCurr - sliceVal) || [];
+                newFeature.geometry.textLabels =  tempTextLabels.splice(0, currentCoordinateLength - sliceVal) || [];
             }
             if (isEqual(coordinates[coordinates.length - 1], coordinates[coordinates.length - 2]) && !hasInvalidCoords && isPolygon) {
-                newFeature.geometry.coordinates[0].pop();
+                newFeature.geometry.coordinates[0].pop(); // Pop last coordinate of a Polygon to prevent extra rows in Measure panel
             }
             return newFeature;
         });
@@ -529,13 +526,6 @@ export default class MeasurementSupport extends React.Component {
         draw.on('drawstart', (evt) => {
             // preserve the sketch feature of the draw controller
             // to update length/area on drawing a new vertex
-            // if (this.props.measurement.features.length && get(this.props.measurement.feature, 'properties.disabled')) {
-            //     draw.dispatchEvent({
-            //         type: 'drawend',
-            //         feature: evt.feature,
-            //         update: true
-            //     });
-            // }
             this.sketchFeature = evt.feature;
             this.drawing = true;
 
@@ -675,113 +665,98 @@ export default class MeasurementSupport extends React.Component {
             const geometry = evt.feature.getGeometry();
             const coords = geometry.getCoordinates();
             const geojsonFormat = new GeoJSON();
+
+            const getMeasureValue = {
+                'Point': () => reproject(coords, getProjectionCode(this.props.map), 'EPSG:4326'),
+                'LineString': () => this.getLength(coords, this.props),
+                'Polygon': () => this.getArea(geometry),
+                'Bearing': () => calculateAzimuth(coords[0], coords[1], getProjectionCode(this.props.map))
+            };
+
+            const getFormattedValue = {
+                'LineString': () => this.formatLengthValue(this.getLength(coords, this.props), this.props.uom, false),
+                'Polygon': () => this.formatAreaValue(this.getArea(geometry), this.props.uom),
+                'Bearing': () => this.formatLengthValue(
+                    calculateAzimuth(coords[0], coords[1], getProjectionCode(this.props.map)),
+                    this.props.uom,
+                    true,
+                    this.props.measurement.trueBearing
+                )
+            };
+
             let newFeature = reprojectGeoJson(geojsonFormat.writeFeatureObject(evt.feature.clone()), getProjectionCode(this.props.map), "EPSG:4326");
-            if (evt.update) {
-                const {currentFeature, features} = this.props.measurement;
-                let feature = currentFeatures[currentFeature];
-                let coordinates = feature.geometry.coordinates || [];
-                coordinates[feature.geometry.coordinates.length - 1] = newFeature.geometry.coordinates[0];
-                feature = {...feature, geometry: {...feature.geometry, coordinates}, properties: {disabled: false}};
-                let tempFeatures = features;
-                tempFeatures[currentFeature] = feature;
-                this.updateFeatures({...this.props, measurement: {...this.props.measurement, features: tempFeatures}});
-                this.drawInteraction.finishDrawing();
-            } else {
-                const getMeasureValue = {
-                    'Point': () => reproject(coords, getProjectionCode(this.props.map), 'EPSG:4326'),
-                    'LineString': () => this.getLength(coords, this.props),
-                    'Polygon': () => this.getArea(geometry),
-                    'Bearing': () => calculateAzimuth(coords[0], coords[1], getProjectionCode(this.props.map))
-                };
-
-                const getFormattedValue = {
-                    'LineString': () => this.formatLengthValue(this.getLength(coords, this.props), this.props.uom, false),
-                    'Polygon': () => this.formatAreaValue(this.getArea(geometry), this.props.uom),
-                    'Bearing': () => this.formatLengthValue(
-                        calculateAzimuth(coords[0], coords[1], getProjectionCode(this.props.map)),
-                        this.props.uom,
-                        true,
-                        this.props.measurement.trueBearing
-                    )
-                };
-
-                newFeature.properties = newFeature.properties || {};
-                newFeature.properties.values = [{
-                    value: (getMeasureValue[this.props.measurement.geomType] || (() => null))(),
-                    formattedValue: (getFormattedValue[this.props.measurement.geomType] || (() => null))(),
-                    position: pointObjectToArray(reproject(this.props.measurement.geomType === 'Polygon' ?
-                        geometry.getInteriorPoint().getCoordinates() :
-                        last(coords),
-                    getProjectionCode(this.props.map), 'EPSG:4326')),
-                    type: this.props.measurement.pointMeasureEnabled ? 'point' :
-                        this.props.measurement.lineMeasureEnabled ? 'length' :
-                            this.props.measurement.areaMeasureEnabled ? 'area' :
-                                this.props.measurement.bearingMeasureEnabled ? 'bearing' : undefined
-                }, ...(this.props.measurement.geomType === 'Polygon' ? [{
-                    value: (this.outputValues[this.measureTooltipElements.length - 2] || {}).value || 0,
-                    formattedValue: this.formatLengthValue(
-                        (this.outputValues[this.measureTooltipElements.length - 2] || {}).value || 0, this.props.uom, false),
-                    position: pointObjectToArray(reproject(last(coords[0]), getProjectionCode(this.props.map), 'EPSG:4326')),
-                    uom: this.props.uom,
-                    type: 'length'
-                }] : [])];
+            newFeature.properties = newFeature.properties || {};
+            newFeature.properties.values = [{
+                value: (getMeasureValue[this.props.measurement.geomType] || (() => null))(),
+                formattedValue: (getFormattedValue[this.props.measurement.geomType] || (() => null))(),
+                position: pointObjectToArray(reproject(this.props.measurement.geomType === 'Polygon' ?
+                    geometry.getInteriorPoint().getCoordinates() :
+                    last(coords),
+                getProjectionCode(this.props.map), 'EPSG:4326')),
+                type: this.props.measurement.pointMeasureEnabled ? 'point' :
+                    this.props.measurement.lineMeasureEnabled ? 'length' :
+                        this.props.measurement.areaMeasureEnabled ? 'area' :
+                            this.props.measurement.bearingMeasureEnabled ? 'bearing' : undefined
+            }, ...(this.props.measurement.geomType === 'Polygon' ? [{
+                value: (this.outputValues[this.measureTooltipElements.length - 2] || {}).value || 0,
+                formattedValue: this.formatLengthValue(
+                    (this.outputValues[this.measureTooltipElements.length - 2] || {}).value || 0, this.props.uom, false),
+                position: pointObjectToArray(reproject(last(coords[0]), getProjectionCode(this.props.map), 'EPSG:4326')),
+                uom: this.props.uom,
+                type: 'length'
+            }] : [])];
 
 
-                let clonedNewFeature = {...newFeature};
-                if (this.props.measurement.lineMeasureEnabled) {
-                    // Calculate arc
-                    let oldCoords = clonedNewFeature.geometry.coordinates;
-                    let newCoords = transformLineToArcs(oldCoords);
+            let clonedNewFeature = {...newFeature};
+            if (this.props.measurement.lineMeasureEnabled) {
+                // Calculate arc
+                let oldCoords = clonedNewFeature.geometry.coordinates;
+                let newCoords = transformLineToArcs(oldCoords);
 
-                    if (!this.props.measurement.disableLabels) {
-                        // the last overlay is a dummy
-                        this.removeLastSegment();
+                if (!this.props.measurement.disableLabels) {
+                    // the last overlay is a dummy
+                    this.removeLastSegment();
 
-                        // Generate correct textLabels and update segment overlays
-                        for (let i = 0; i < oldCoords.length - 1; ++i) {
-                            const middlePoint = newCoords[100 * i + 50];
-                            if (middlePoint) {
-                                this.textLabels[this.segmentOverlays.length - oldCoords.length + 1 + i].position = middlePoint;
-                                this.segmentOverlays[this.segmentOverlays.length - oldCoords.length + 1 + i].setPosition(
-                                    pointObjectToArray(reproject(middlePoint, 'EPSG:4326', getProjectionCode(this.props.map)))
-                                );
-                            }
+                    // Generate correct textLabels and update segment overlays
+                    for (let i = 0; i < oldCoords.length - 1; ++i) {
+                        const middlePoint = newCoords[100 * i + 50];
+                        if (middlePoint) {
+                            this.textLabels[this.segmentOverlays.length - oldCoords.length + 1 + i].position = middlePoint;
+                            this.segmentOverlays[this.segmentOverlays.length - oldCoords.length + 1 + i].setPosition(
+                                pointObjectToArray(reproject(middlePoint, 'EPSG:4326', getProjectionCode(this.props.map)))
+                            );
                         }
                     }
-
-                    clonedNewFeature = set("geometry.coordinates", newCoords, clonedNewFeature);
-                } else if (!this.props.measurement.disableLabels && this.props.measurement.areaMeasureEnabled) {
-                    // the one before the last is a dummy
-                    this.textLabels.splice(this.segmentOverlays.length - 2, 1);
-                    this.props.map.removeOverlay(this.segmentOverlays[this.segmentOverlays.length - 2]);
-                    this.segmentOverlayElements[this.segmentOverlays.length - 2].parentNode.removeChild(
-                        this.segmentOverlayElements[this.segmentOverlays.length - 2]
-                    );
-                    this.segmentOverlayElements.splice(this.segmentOverlays.length - 2, 1);
-                    this.segmentOverlays.splice(this.segmentOverlays.length - 2, 1);
                 }
-                const geomType = newFeature.properties.values[0]?.type === 'bearing' ? "Bearing" : newFeature.geometry.type;
-                newFeature.geometry.textLabels = this.textLabels.filter(label => label.type === geomType && label.textId === this.textId).map(({
-                    textId,
-                    type,
-                    ...textLabel
-                }) => textLabel);
-                this.props.changeGeometry([...currentFeatures, newFeature]);
-                this.props.setTextLabels([...this.textLabels]);
 
-                this.addFeature(clonedNewFeature);
-                if (!this.props.measurement.disableLabels) {
-                    last(this.measureTooltipElements).className = 'tooltip tooltip-static';
-                    last(this.measureTooltips).setOffset([0, -7]);
-                    if (this.props.measurement.geomType === 'Polygon') {
-                        this.measureTooltipElements[this.measureTooltipElements.length - 2].className = 'tooltip tooltip-static';
-                        this.measureTooltips[this.measureTooltipElements.length - 2].setOffset([0, -7]);
-                    }
-                    if (this.segmentOverlayElements) {
-                        for (let i = 0; i < this.segmentOverlayElements.length; ++i) {
-                            if (this.segmentOverlayElements[i]) {
-                                this.segmentOverlayElements[i].className = 'segment-overlay segment-overlay-static';
-                            }
+                clonedNewFeature = set("geometry.coordinates", newCoords, clonedNewFeature);
+            } else if (!this.props.measurement.disableLabels && this.props.measurement.areaMeasureEnabled) {
+                // the one before the last is a dummy
+                this.textLabels.splice(this.segmentOverlays.length - 2, 1);
+                this.props.map.removeOverlay(this.segmentOverlays[this.segmentOverlays.length - 2]);
+                this.segmentOverlayElements[this.segmentOverlays.length - 2].parentNode.removeChild(
+                    this.segmentOverlayElements[this.segmentOverlays.length - 2]
+                );
+                this.segmentOverlayElements.splice(this.segmentOverlays.length - 2, 1);
+                this.segmentOverlays.splice(this.segmentOverlays.length - 2, 1);
+            }
+            const geomType = newFeature.properties.values[0]?.type === 'bearing' ? "Bearing" : newFeature.geometry.type;
+            newFeature.geometry.textLabels = this.textLabels.filter(label => label.type === geomType && label.textId === this.textId).map(({textId, type, ...textLabel})=> textLabel);
+            this.props.changeGeometry([...currentFeatures, newFeature]);
+            this.props.setTextLabels([...this.textLabels]);
+
+            this.addFeature(clonedNewFeature);
+            if (!this.props.measurement.disableLabels) {
+                last(this.measureTooltipElements).className = 'tooltip tooltip-static';
+                last(this.measureTooltips).setOffset([0, -7]);
+                if (this.props.measurement.geomType === 'Polygon') {
+                    this.measureTooltipElements[this.measureTooltipElements.length - 2].className = 'tooltip tooltip-static';
+                    this.measureTooltips[this.measureTooltipElements.length - 2].setOffset([0, -7]);
+                }
+                if (this.segmentOverlayElements) {
+                    for (let i = 0; i < this.segmentOverlayElements.length; ++i) {
+                        if (this.segmentOverlayElements[i]) {
+                            this.segmentOverlayElements[i].className = 'segment-overlay segment-overlay-static';
                         }
                     }
                 }
@@ -790,6 +765,7 @@ export default class MeasurementSupport extends React.Component {
 
             this.curPolygonLength = undefined;
             this.curLineStringLength = undefined;
+
             this.discardDrawState();
         });
 

--- a/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
@@ -326,7 +326,7 @@ describe('Openlayers MeasurementSupport', () => {
         expect(resultFeature.length).toBe(0);
     });
     it('test add coordinates manually when no existing coordinates', () => {
-        const features = [{"type": "Feature", "properties": {"disabled": true}, "geometry": {"type": "LineString", "coordinates": [["", ""]]}}];
+        const features = [{"type": "Feature", "properties": {"disabled": true}, "geometry": {"type": "LineString", "coordinates": [["", ""]], "textLabels": []}}];
         const spyOnChangeGeometry = expect.spyOn(testHandlers, "changeGeometry");
         let cmp = renderMeasurement();
         cmp = renderMeasurement({
@@ -363,6 +363,50 @@ describe('Openlayers MeasurementSupport', () => {
         expect(resultFeature[0].properties.disabled).toBe(true);
         expect(resultFeature[0].geometry).toBeTruthy();
         expect(resultFeature[0].geometry).toEqual(features[0].geometry);
+        // Add empty label when empty coordinate (edit)
+        expect(resultFeature[0].geometry.textLabels).toEqual([{text: "0"}]);
+    });
+    it('test remove last coordinates when updating polygon', () => {
+        const features = [{"type": "Feature", "properties": {"disabled": false}, "geometry": {"type": "Polygon",
+            "coordinates": [[[1, 2], [2, 3], [3, 4], [1, 2], [1, 2]]], "textLabels": [{text: "1m"}, {text: "2m"}, {text: "3m"}, {text: "4m"}]}}];
+        const spyOnChangeGeometry = expect.spyOn(testHandlers, "changeGeometry");
+        let cmp = renderMeasurement();
+        cmp = renderMeasurement({
+            measurement: {
+                geomType: "LineString",
+                lineMeasureEnabled: true,
+                updatedByUI: false,
+                showLabel: true,
+                showLengthAndBearingLabel: true,
+                features: []
+            },
+            uom
+        });
+        cmp = renderMeasurement({
+            measurement: {
+                geomType: "Polygon",
+                lineMeasureEnabled: true,
+                updatedByUI: true,
+                showLabel: true,
+                showLengthAndBearingLabel: true,
+                features
+            },
+            uom
+        });
+
+        expect(cmp.outputValues).toExist();
+        expect(cmp.outputValues.length).toBe(2);
+        expect(cmp.textLabels).toExist();
+        expect(cmp.textLabels.length).toBe(4);
+
+        expect(spyOnChangeGeometry).toHaveBeenCalled();
+        const resultFeature = spyOnChangeGeometry.calls[0].arguments[0];
+        expect(resultFeature.length).toBe(1);
+        expect(resultFeature[0].properties.disabled).toBe(false);
+        expect(resultFeature[0].geometry).toBeTruthy();
+        expect(resultFeature[0].geometry.type).toBe('Polygon');
+        expect(resultFeature[0].geometry.coordinates[0].length).toBe(4);
+        expect(resultFeature[0].geometry.textLabels.length).toBe(4);
     });
     it('test drawing (LineString)', () => {
         const spyOnChangeGeometry = expect.spyOn(testHandlers, "changeGeometry");

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -80,8 +80,7 @@ class CoordinatesEditor extends React.Component {
         isMouseEnterEnabled: PropTypes.bool,
         isMouseLeaveEnabled: PropTypes.bool,
         showLengthAndBearingLabel: PropTypes.bool,
-        renderer: PropTypes.string,
-        isFeatureInvalid: PropTypes.bool
+        renderer: PropTypes.string
     };
 
     static contextTypes = {
@@ -117,8 +116,7 @@ class CoordinatesEditor extends React.Component {
         isMouseEnterEnabled: false,
         isMouseLeaveEnabled: false,
         properties: {},
-        type: "Point",
-        isFeatureInvalid: false
+        type: "Point"
     };
 
     getValidationStateRadius = (radius) => {
@@ -208,7 +206,7 @@ class CoordinatesEditor extends React.Component {
             {
                 glyph: 'plus',
                 tooltipId: 'annotations.editor.add',
-                disabled: this.props.isFeatureInvalid,
+                disabled: this.props.properties.disabled,
                 visible: componentsValidation[type].add && componentsValidation[type].max ? this.props.components.length !== componentsValidation[type].max : true,
                 onClick: () => {
                     let tempComps = [...this.props.components];
@@ -223,7 +221,7 @@ class CoordinatesEditor extends React.Component {
                     <div>
                         {this.props.showFeatureSelector ? <Select
                             value={this.props.currentFeature}
-                            disabled={this.props.isFeatureInvalid}
+                            disabled={this.props.properties.disabled}
                             options={[
                                 ...this.props.features.map((f, i) => {
                                     const values = get(f, 'properties.values', []);
@@ -275,10 +273,10 @@ class CoordinatesEditor extends React.Component {
                             aeronauticalOptions={this.props.aeronauticalOptions}
                             sortId={idx}
                             key={idx + " key"}
-                            disabled={this.props.isFeatureInvalid && validateCoords(component)}
+                            disabled={this.props.properties.disabled && validateCoords(component)}
                             renderer={this.props.renderer}
                             isDraggable={this.props.isDraggable}
-                            isDraggableEnabled={this.props.isDraggable && this[componentsValidation[type].validation]() && !this.props.isFeatureInvalid}
+                            isDraggableEnabled={this.props.isDraggable && this[componentsValidation[type].validation]() && !this.props.properties.disabled}
                             showDraggable={this.props.isDraggable && !(this.props.type === "Point" || this.props.type === "Text" || this.props.type === "Circle")}
                             formatVisible={false}
                             removeVisible={componentsValidation[type].remove}

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -80,7 +80,8 @@ class CoordinatesEditor extends React.Component {
         isMouseEnterEnabled: PropTypes.bool,
         isMouseLeaveEnabled: PropTypes.bool,
         showLengthAndBearingLabel: PropTypes.bool,
-        renderer: PropTypes.string
+        renderer: PropTypes.string,
+        isFeatureInvalid: PropTypes.bool
     };
 
     static contextTypes = {
@@ -116,7 +117,8 @@ class CoordinatesEditor extends React.Component {
         isMouseEnterEnabled: false,
         isMouseLeaveEnabled: false,
         properties: {},
-        type: "Point"
+        type: "Point",
+        isFeatureInvalid: false
     };
 
     getValidationStateRadius = (radius) => {
@@ -206,6 +208,7 @@ class CoordinatesEditor extends React.Component {
             {
                 glyph: 'plus',
                 tooltipId: 'annotations.editor.add',
+                disabled: this.props.isFeatureInvalid,
                 visible: componentsValidation[type].add && componentsValidation[type].max ? this.props.components.length !== componentsValidation[type].max : true,
                 onClick: () => {
                     let tempComps = [...this.props.components];
@@ -220,6 +223,7 @@ class CoordinatesEditor extends React.Component {
                     <div>
                         {this.props.showFeatureSelector ? <Select
                             value={this.props.currentFeature}
+                            disabled={this.props.isFeatureInvalid}
                             options={[
                                 ...this.props.features.map((f, i) => {
                                     const values = get(f, 'properties.values', []);
@@ -271,9 +275,10 @@ class CoordinatesEditor extends React.Component {
                             aeronauticalOptions={this.props.aeronauticalOptions}
                             sortId={idx}
                             key={idx + " key"}
+                            disabled={this.props.isFeatureInvalid && validateCoords(component)}
                             renderer={this.props.renderer}
                             isDraggable={this.props.isDraggable}
-                            isDraggableEnabled={this.props.isDraggable && this[componentsValidation[type].validation]()}
+                            isDraggableEnabled={this.props.isDraggable && this[componentsValidation[type].validation]() && !this.props.isFeatureInvalid}
                             showDraggable={this.props.isDraggable && !(this.props.type === "Point" || this.props.type === "Text" || this.props.type === "Circle")}
                             formatVisible={false}
                             removeVisible={componentsValidation[type].remove}

--- a/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
@@ -828,7 +828,7 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(invalidLineString).toBeTruthy();
     });
     it('CoordinatesEditor as Polygon, 5 rows, warning on invalid rows', () => {
-        const components = [{
+        let components = [{
             lat: 5,
             lon: ""
         }, {
@@ -846,15 +846,16 @@ describe("test the CoordinatesEditor Panel", () => {
             lon: ""
         }];
 
-        const editor = ReactDOM.render(
+        let editor = ReactDOM.render(
             <CoordinatesEditor
                 {...testHandlers}
                 isMouseEnterEnabled
                 isMouseLeaveEnabled
                 type="Polygon"
                 format="decimal"
-                properties={{isValidFeature: true}}
+                properties={{isValidFeature: true, disabled: true}}
                 components={components}
+                showFeatureSelector
             />, document.getElementById("container")
         );
         expect(editor).toExist();
@@ -865,5 +866,28 @@ describe("test the CoordinatesEditor Panel", () => {
         expect(buttons.length).toBe(18);
         const invalidPolygon = buttons[0].getElementsByClassName('glyphicon-exclamation-mark');
         expect(invalidPolygon).toBeTruthy();
+        const addButton = buttons[2];
+        expect(addButton.className).toContain('disabled');
+        const selectFeature = TestUtils.scryRenderedDOMComponentsWithClass(editor, "Select");
+        expect(selectFeature[0].className).toContain('is-disabled');
+        components[0] = {lat: 1, lon: 5};
+        editor = ReactDOM.render(
+            <CoordinatesEditor
+                {...testHandlers}
+                isMouseEnterEnabled
+                isMouseLeaveEnabled
+                type="Polygon"
+                format="decimal"
+                properties={{isValidFeature: true, disabled: true}}
+                components={components}
+                showFeatureSelector
+            />, document.getElementById("container")
+        );
+        // Coordinate rows
+        const formControl = TestUtils.scryRenderedDOMComponentsWithClass(editor, "form-control");
+        expect(formControl.length).toBe(10);
+        formControl.forEach((fc, i)=>
+            (i <= 7) ? expect(fc.disabled).toBe(true) : expect(fc.disabled).toBe(false));
+
     });
 });

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -309,7 +309,7 @@ class MeasureComponent extends React.Component {
                                             bsStyle: this.props.lineMeasureEnabled ? 'success' : 'primary',
                                             tooltip: this.renderText(this.props.inlineGlyph && this.props.lineGlyph, "measureComponent.MeasureLength"),
                                             onClick: () => this.onGeomClick('LineString'),
-                                            disabled: isFeatureInvalid
+                                            disabled: !this.props.lineMeasureEnabled && isFeatureInvalid
                                         },
                                         {
                                             active: !!this.props.areaMeasureEnabled,
@@ -317,7 +317,7 @@ class MeasureComponent extends React.Component {
                                             glyph: this.props.areaGlyph,
                                             tooltip: this.renderText(this.props.inlineGlyph && this.props.areaGlyph, "measureComponent.MeasureArea"),
                                             onClick: () => this.onGeomClick('Polygon'),
-                                            disabled: isFeatureInvalid
+                                            disabled: !this.props.areaMeasureEnabled && isFeatureInvalid
                                         },
                                         {
                                             visible: !this.props.disableBearing,
@@ -326,7 +326,7 @@ class MeasureComponent extends React.Component {
                                             glyph: this.props.bearingGlyph,
                                             tooltip: this.renderText(this.props.inlineGlyph && this.props.bearingGlyph, this.isTrueBearing() ? "measureComponent.MeasureTrueBearing" : "measureComponent.MeasureBearing"),
                                             onClick: () => this.onGeomClick('Bearing'),
-                                            disabled: isFeatureInvalid
+                                            disabled: !this.props.bearingMeasureEnabled && isFeatureInvalid
                                         }
                                     ]
                                 }/>
@@ -423,7 +423,7 @@ class MeasureComponent extends React.Component {
                                 type={this.props.geomType}
                                 showLengthAndBearingLabel={this.props.showLengthAndBearingLabel}
                                 components={!this.props.useSingleFeature && geomType.indexOf('polygon') !== -1 ? dropRight(coords) : coords}
-                                isFeatureInvalid={isFeatureInvalid}
+                                properties={feature?.properties || {}}
                             />
                         </Row> :
                         <Row>

--- a/web/client/components/mapcontrols/measure/MeasureComponent.jsx
+++ b/web/client/components/mapcontrols/measure/MeasureComponent.jsx
@@ -184,7 +184,7 @@ class MeasureComponent extends React.Component {
         };
     };
 
-    renderMeasurements = () => {
+    renderMeasurements = (disabled = false) => {
         let decimalFormat = {style: "decimal", minimumIntegerDigits: 1, maximumFractionDigits: 2, minimumFractionDigits: 2};
         return (
             <Grid fluid style={{maxHeight: 400}}>
@@ -200,6 +200,7 @@ class MeasureComponent extends React.Component {
                         </Col>}
                         <Col xs={6}>
                             <DropdownList
+                                disabled={disabled}
                                 value={this.props.uom.length.label}
                                 onChange={(value) => {
                                     this.props.onChangeUom("length", value, this.props.uom);
@@ -223,6 +224,7 @@ class MeasureComponent extends React.Component {
                         </Col>}
                         <Col xs={6}>
                             <DropdownList
+                                disabled={disabled}
                                 value={this.props.uom.area.label}
                                 onChange={(value) => {
                                     this.props.onChangeUom("area", value, this.props.uom);
@@ -245,9 +247,9 @@ class MeasureComponent extends React.Component {
         );
     };
 
-    renderPanel = () => {
+    renderPanel = (disabled) => {
         if (this.props.showResults) {
-            return this.renderMeasurements();
+            return this.renderMeasurements(disabled);
         }
         return null;
     };
@@ -275,7 +277,8 @@ class MeasureComponent extends React.Component {
         let coords;
         const features = get(this.props.measurement, 'features', []);
         const feature = features[this.props.measurement.currentFeature || 0];
-
+        const isFeatureInvalid = feature?.properties?.disabled || false;
+        const toolbarDisabled = (this.props.measurement.features || []).length === 0 || isFeatureInvalid;
         if (this.props.useSingleFeature) {
             geomType = (get(this.props.measurement, 'feature.geometry.type') || '').toLowerCase();
             coords = (get(this.props.measurement, geomType.indexOf('polygon') !== -1 ? 'feature.geometry.coordinates[0]' : 'feature.geometry.coordinates') || []).map(coordinate => ({lon: coordinate[0], lat: coordinate[1]}));
@@ -305,14 +308,16 @@ class MeasureComponent extends React.Component {
                                             active: !!this.props.lineMeasureEnabled,
                                             bsStyle: this.props.lineMeasureEnabled ? 'success' : 'primary',
                                             tooltip: this.renderText(this.props.inlineGlyph && this.props.lineGlyph, "measureComponent.MeasureLength"),
-                                            onClick: () => this.onGeomClick('LineString')
+                                            onClick: () => this.onGeomClick('LineString'),
+                                            disabled: isFeatureInvalid
                                         },
                                         {
                                             active: !!this.props.areaMeasureEnabled,
                                             bsStyle: this.props.areaMeasureEnabled ? 'success' : 'primary',
                                             glyph: this.props.areaGlyph,
                                             tooltip: this.renderText(this.props.inlineGlyph && this.props.areaGlyph, "measureComponent.MeasureArea"),
-                                            onClick: () => this.onGeomClick('Polygon')
+                                            onClick: () => this.onGeomClick('Polygon'),
+                                            disabled: isFeatureInvalid
                                         },
                                         {
                                             visible: !this.props.disableBearing,
@@ -320,7 +325,8 @@ class MeasureComponent extends React.Component {
                                             bsStyle: this.props.bearingMeasureEnabled ? 'success' : 'primary',
                                             glyph: this.props.bearingGlyph,
                                             tooltip: this.renderText(this.props.inlineGlyph && this.props.bearingGlyph, this.isTrueBearing() ? "measureComponent.MeasureTrueBearing" : "measureComponent.MeasureBearing"),
-                                            onClick: () => this.onGeomClick('Bearing')
+                                            onClick: () => this.onGeomClick('Bearing'),
+                                            disabled: isFeatureInvalid
                                         }
                                     ]
                                 }/>
@@ -348,7 +354,7 @@ class MeasureComponent extends React.Component {
                                     [
                                         {
                                             glyph: 'ext-json',
-                                            disabled: (this.props.measurement.features || []).length === 0,
+                                            disabled: toolbarDisabled,
                                             visible: !!(this.props.bearingMeasureEnabled || this.props.areaMeasureEnabled || this.props.lineMeasureEnabled) && this.props.showExportToGeoJSON,
                                             tooltip: <Message msgId="measureComponent.exportToGeoJSON"/>,
                                             onClick: () => {
@@ -364,7 +370,7 @@ class MeasureComponent extends React.Component {
                                         {
                                             glyph: '1-layer',
                                             visible: !!(this.props.bearingMeasureEnabled || this.props.areaMeasureEnabled || this.props.lineMeasureEnabled) && this.props.showAddAsLayer,
-                                            disabled: (this.props.measurement.features || []).length === 0 || exportToAnnotation,
+                                            disabled: toolbarDisabled || exportToAnnotation,
                                             tooltip: <Message msgId="measureComponent.addAsLayer"/>,
                                             onClick: () => this.props.onAddAsLayer(
                                                 this.props.measurement.features,
@@ -387,13 +393,13 @@ class MeasureComponent extends React.Component {
                                                     }
                                                 );
                                             },
-                                            disabled: (this.props.measurement.features || []).length === 0,
+                                            disabled: toolbarDisabled,
                                             visible: !!(this.props.bearingMeasureEnabled || this.props.areaMeasureEnabled || this.props.lineMeasureEnabled) && this.props.showAddAsAnnotation
                                         }
                                     ]
                                 }/>
                         </ButtonToolbar>
-                        {this.renderPanel()}
+                        {this.renderPanel(isFeatureInvalid)}
                     </div>
                 }>
                 {this.props.showCoordinateEditor && (<Grid fluid style={{maxHeight: 400, borderTop: '1px solid #ddd'}}>
@@ -416,7 +422,9 @@ class MeasureComponent extends React.Component {
                                 isDraggable
                                 type={this.props.geomType}
                                 showLengthAndBearingLabel={this.props.showLengthAndBearingLabel}
-                                components={!this.props.useSingleFeature && geomType.indexOf('polygon') !== -1 ? dropRight(coords) : coords}/>
+                                components={!this.props.useSingleFeature && geomType.indexOf('polygon') !== -1 ? dropRight(coords) : coords}
+                                isFeatureInvalid={isFeatureInvalid}
+                            />
                         </Row> :
                         <Row>
                             <Col xs={12} className="text-center" style={{padding: 15}}>

--- a/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
+++ b/web/client/components/mapcontrols/measure/__tests__/MeasureComponent-test.jsx
@@ -521,4 +521,50 @@ describe("test the MeasureComponent", () => {
         TestUtils.Simulate.click(buttons[0]);
         expect(buttons[0].className).toContain('active');
     });
+    it("test Measurement with invalid features", () =>{
+        let measurement = {
+            lineMeasureEnabled: true,
+            features: [{
+                type: "Feature",
+                geometry: {
+                    type: "LineString",
+                    coordinates: [[1, 2], [2, 5], ["", ""]]
+                },
+                properties: {
+                    disabled: true
+                }
+            }],
+            textLabels: [{position: [1, 2], text: "1,714 m"},
+                {position: [1, 1], text: "1,723 m"}],
+            id: 1,
+            len: 0,
+            area: 0,
+            bearing: 0
+        };
+        let cmp = ReactDOM.render(
+            <MeasureComponent
+                measurement={measurement}
+                format="decimal"
+                isDraggable
+                useSingleFeature
+                lineMeasureEnabled
+                showAddAsAnnotation
+            />, document.getElementById("container")
+        );
+        expect(cmp).toExist();
+        const toolbar = TestUtils.scryRenderedDOMComponentsWithClass(cmp, "btn-toolbar");
+        const toolBarGroup = TestUtils.scryRenderedDOMComponentsWithClass(cmp, "btn-group");
+        expect(toolbar).toExist();
+        expect(toolBarGroup.length).toBe(3);
+        const geomTypeButtons = toolBarGroup[0].querySelectorAll('button');
+        expect(geomTypeButtons.length).toBe(3);
+        geomTypeButtons.forEach((btn, i)=> {
+            if (i === 0) return expect(btn.className).toContain('active');
+            return expect(btn.className).toContain('disabled');
+        });
+
+        const exportTools = toolBarGroup[2].querySelectorAll('button');
+        expect(exportTools.length).toBe(3);
+        exportTools.forEach((btn)=> expect(btn.className).toContain('disabled'));
+    });
 });

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -40,7 +40,8 @@ class CoordinatesRow extends React.Component {
         removeVisible: PropTypes.bool,
         formatVisible: PropTypes.bool,
         removeEnabled: PropTypes.bool,
-        renderer: PropTypes.string
+        renderer: PropTypes.string,
+        disabled: PropTypes.bool
     };
 
     static defaultProps = {
@@ -48,7 +49,8 @@ class CoordinatesRow extends React.Component {
         formatVisible: false,
         onMouseEnter: () => {},
         onMouseLeave: () => {},
-        showToolButtons: true
+        showToolButtons: true,
+        disabled: false
     };
 
     constructor(props) {
@@ -88,7 +90,7 @@ class CoordinatesRow extends React.Component {
         const toolButtons = [
             {
                 visible: this.props.removeVisible,
-                disabled: !this.props.removeEnabled,
+                disabled: !this.props.removeEnabled || this.props.disabled,
                 glyph: 'trash',
                 onClick: () => {
                     this.props.onRemove(idx);
@@ -112,12 +114,13 @@ class CoordinatesRow extends React.Component {
                         text: <Message msgId="search.aeronautical"/>
                     }
                 ],
+                disabled: this.props.disabled,
                 visible: this.props.formatVisible,
                 Element: DropdownToolbarOptions
             },
             {
                 glyph: "ok",
-                disabled: this.state.disabledApplyChange,
+                disabled: this.state.disabledApplyChange || this.props.disabled,
                 tooltipId: 'identifyCoordinateApplyChanges',
                 onClick: this.onSubmit,
                 visible: this.props.renderer !== "annotations"
@@ -150,10 +153,11 @@ class CoordinatesRow extends React.Component {
                     {this.props.showDraggable ? this.props.isDraggable ? this.props.connectDragSource(dragButton) : dragButton : null}
                 </div>
                 <div className="coordinate">
-                    <div>
+                    <div className="input-group-container">
                         <InputGroup>
                             <InputGroup.Addon><Message msgId="latitude"/></InputGroup.Addon>
                             <CoordinateEntry
+                                disabled={this.props.disabled}
                                 format={this.props.format}
                                 aeronauticalOptions={this.props.aeronauticalOptions}
                                 coordinate="lat"
@@ -176,10 +180,11 @@ class CoordinatesRow extends React.Component {
                             />
                         </InputGroup>
                     </div>
-                    <div>
+                    <div className="input-group-container">
                         <InputGroup>
                             <InputGroup.Addon><Message msgId="longitude"/></InputGroup.Addon>
                             <CoordinateEntry
+                                disabled={this.props.disabled}
                                 format={this.props.format}
                                 aeronauticalOptions={this.props.aeronauticalOptions}
                                 coordinate="lon"

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -34,7 +34,8 @@ class AeronauticalCoordinateEditor extends React.Component {
         aeronauticalOptions: PropTypes.object,
         coordinate: PropTypes.string,
         onChange: PropTypes.func,
-        onKeyDown: PropTypes.func
+        onKeyDown: PropTypes.func,
+        disabled: PropTypes.bool
     };
     static defaultProps = {
         coordinate: "lat",
@@ -46,7 +47,8 @@ class AeronauticalCoordinateEditor extends React.Component {
                 step: 0.0001
             }
         },
-        onKeyDown: () => {}
+        onKeyDown: () => {},
+        disabled: false
     }
 
     onChange = (part, newValue) => {
@@ -133,6 +135,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                     <IntlNumberFormControl
                         key={this.props.coordinate + "degree"}
                         value={this.props.degrees}
+                        disabled={this.props.disabled}
                         placeholder="d"
                         onChange={val => this.onChange("degrees", parseInt(val, 10))}
                         step={1}
@@ -150,6 +153,7 @@ class AeronauticalCoordinateEditor extends React.Component {
 
                 <div className={"minutes"} style={{width: 40, display: 'flex' }}>
                     <IntlNumberFormControl
+                        disabled={this.props.disabled}
                         key={this.props.coordinate + "minutes"}
                         placeholder={"m"}
                         size={3}
@@ -170,6 +174,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                 </div>
                 <div className="seconds" style={{display: 'flex'}}>
                     <IntlNumberFormControl
+                        disabled={this.props.disabled}
                         key={this.props.coordinate + "seconds"}
                         value={this.props.seconds}
                         placeholder="s"
@@ -189,6 +194,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                 <div className={"direction-select"}>
 
                     <FormControl
+                        disabled={this.props.disabled}
                         componentClass="select" placeholder="select"
                         value={this.props.direction}
                         onChange={e => this.onChange("direction", e.target.value)}

--- a/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/DecimalCoordinateEditor.jsx
@@ -26,7 +26,8 @@ class DecimalCoordinateEditor extends React.Component {
         coordinate: PropTypes.string,
         onChange: PropTypes.func,
         onKeyDown: PropTypes.func,
-        onSubmit: PropTypes.func
+        onSubmit: PropTypes.func,
+        disabled: PropTypes.bool
     };
     static defaultProps = {
         format: "decimal",
@@ -43,17 +44,19 @@ class DecimalCoordinateEditor extends React.Component {
                 }
             }
         },
-        onKeyDown: () => {}
+        onKeyDown: () => {},
+        disabled: false
     }
 
 
     render() {
-        const {coordinate, value, onChange} = this.props;
+        const {coordinate, value, onChange, disabled} = this.props;
         const validateNameFunc = "validateDecimal" + capitalize(coordinate);
         return (
             <FormGroup
                 validationState={this[validateNameFunc](value)}>
                 <IntlNumberFormControl
+                    disabled={disabled}
                     key={coordinate}
                     value={value}
                     placeholder={coordinate}

--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -90,17 +90,22 @@ describe('Test the measurement reducer', () => {
     });
     it('CHANGE_COORDINATES', () => {
         const coordinates = [{lon: 3, lat: 1}, {lon: 5, lat: 5}];
-        let state = measurement({
-            feature: {
-                geometry: {
-                    type: "LineString",
-                    coordinates: [[1, 3], [5, 4]]
-                }
+        const feature = {
+            geometry: {
+                type: "LineString",
+                coordinates: [[1, 3], [5, 4]],
+                textLabels: [{text: "1m"}]
             }
+        };
+        let state = measurement({
+            feature,
+            features: [feature],
+            currentFeature: 0
         }, changeCoordinates(coordinates));
         expect(state.feature.geometry.coordinates).toEqual([[3, 1], [5, 5]]);
         expect(state.feature.properties.disabled).toEqual(false);
         expect(state.updatedByUI).toBe(true);
+        expect(state.features[0].geometry.textLabels).toEqual([{text: "1m"}]);
     });
     it('SET_CONTROL_PROPERTY closing measure tool', () => {
         let state = measurement({
@@ -177,15 +182,32 @@ describe('Test the measurement reducer', () => {
         expect(state.currentFeature).toBe(2);
     });
     it('CHANGED_GEOMETRY', () => {
+        const feature = {type: "Feature", geometry: {type: "LineString"}};
         let state = measurement({
-            geomType: "LineString",
+            geomType: "Bearing",
             lineMeasureEnabled: true,
             areaMeasureEnabled: false,
             bearingMeasureEnabled: false,
             len: 0,
             area: 700,
-            features: []
-        }, changeGeometry([{type: "Feature", geometry: {type: "LineString"}}]));
-        expect(state.currentFeature).toBe(0); // current feature index in the features array
+            features: [],
+            updatedByUI: true,
+            isDrawing: true
+        }, changeGeometry([feature]));
+        expect(state.features).toEqual([feature]);
+        expect(state.updatedByUI).toBe(false);
+        expect(state.isDrawing).toBe(false);
+        expect(state.geomTypeSelected).toEqual(["LineString"]);
+    });
+    it('CHANGED_GEOMETRY', () => {
+        let state = measurement({
+            features: [],
+            updatedByUI: true,
+            isDrawing: true
+        }, changeGeometry([]));
+        expect(state.features).toEqual([]);
+        expect(state.updatedByUI).toBe(false);
+        expect(state.isDrawing).toBe(false);
+        expect(state.exportToAnnotation).toBe(false);
     });
 });

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -137,7 +137,7 @@ function measurement(state = defaultState, action) {
             ...state,
             features,
             geomTypeSelected,
-            currentFeature: features.length - 1, // current feature is the last feature added
+            // currentFeature: features.length - 1, // current feature is the last feature added
             updatedByUI: false,
             isDrawing: false,
             ...(isEmpty(features) && {exportToAnnotation: false})
@@ -273,7 +273,8 @@ function measurement(state = defaultState, action) {
                     },
                     geometry: {
                         type: state.bearingMeasureEnabled ? "LineString" : state.geomType,
-                        coordinates: state.areaMeasureEnabled ? [[...coordinates, coordinates[0]]] : coordinates
+                        coordinates: state.areaMeasureEnabled ? [[...coordinates, coordinates[0]]] : coordinates,
+                        textLabels: currentFeatureObj.geometry.textLabels || []
                     }
                 },
                 ...features.slice(state.currentFeature + 1, features.length)

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -25,6 +25,7 @@ import {
 import { TOGGLE_CONTROL, RESET_CONTROLS, SET_CONTROL_PROPERTY } from '../actions/controls';
 import { set } from '../utils/ImmutableUtils';
 import { getGeomTypeSelected } from '../utils/MeasurementUtils';
+import { validateCoord } from '../utils/MeasureUtils';
 import { isPolygon } from '../utils/openlayers/DrawUtils';
 import { dropRight, isEmpty, findIndex, isNumber } from 'lodash';
 import assign from 'object-assign';
@@ -56,7 +57,7 @@ const defaultState = {
 function measurement(state = defaultState, action) {
     switch (action.type) {
     case CHANGE_MEASUREMENT_TOOL: {
-        const currentFeatureIndex = findIndex(state.features, (f)=> ((f.properties.values[0] || {}).type === 'bearing' ? 'Bearing' : f.geometry.type) === action.geomType);
+        const currentFeatureIndex = action.geomType !== null && findIndex(state.features, (f)=> ((f.properties.values[0] || {}).type === 'bearing' ? 'Bearing' : f.geometry.type) === action.geomType);
         return assign({}, state, {
             lineMeasureEnabled: action.geomType !== state.geomType && action.geomType === 'LineString',
             areaMeasureEnabled: action.geomType !== state.geomType && action.geomType === 'Polygon',
@@ -137,7 +138,6 @@ function measurement(state = defaultState, action) {
             ...state,
             features,
             geomTypeSelected,
-            // currentFeature: features.length - 1, // current feature is the last feature added
             updatedByUI: false,
             isDrawing: false,
             ...(isEmpty(features) && {exportToAnnotation: false})
@@ -244,8 +244,7 @@ function measurement(state = defaultState, action) {
         const features = state.features || [];
         const currentFeatureObj = features[state.currentFeature] || {};
         const invalidCoordinates = coordinates.filter((c) => {
-            const isValid = !isNaN(parseFloat(c[0])) && !isNaN(parseFloat(c[1]));
-            return isValid;
+            return validateCoord(c);
         }).length !== coordinates.length;
 
         return {
@@ -254,8 +253,7 @@ function measurement(state = defaultState, action) {
                 type: "Feature",
                 properties: {
                     disabled: coordinates.filter((c) => {
-                        const isValid = !isNaN(parseFloat(c[0])) && !isNaN(parseFloat(c[1]));
-                        return isValid;
+                        return validateCoord(c);
                     }).length !== coordinates.length
                 },
                 geometry: {
@@ -274,7 +272,7 @@ function measurement(state = defaultState, action) {
                     geometry: {
                         type: state.bearingMeasureEnabled ? "LineString" : state.geomType,
                         coordinates: state.areaMeasureEnabled ? [[...coordinates, coordinates[0]]] : coordinates,
-                        textLabels: currentFeatureObj.geometry.textLabels || []
+                        textLabels: currentFeatureObj?.geometry?.textLabels || [] // Persist labels on edit
                     }
                 },
                 ...features.slice(state.currentFeature + 1, features.length)

--- a/web/client/themes/default/less/measure.less
+++ b/web/client/themes/default/less/measure.less
@@ -24,8 +24,8 @@
         margin-bottom: 8px;
         justify-content: space-between;
         padding: 12px 0 12px 18px;
-        .Select-input > input {
-            width: 100%!important;
+        .Select-input {
+            width: 200px !important;
         }
         .Select-menu-outer{
             z-index: 3;
@@ -41,21 +41,36 @@
             vertical-align: middle;
         }
     }
+    .coordinateRow.aeronautical {
+        .coordinate {
+            flex-direction: column;
+            flex-wrap: wrap;
+        }
+    }
+    .coordinateRow.decimal {
+        .coordinate {
+            flex-wrap: nowrap;
+        }
+    }
     .coordinateRow {
         .coordinate {
             display: flex;
             flex: 1 1 0%;
             justify-content: space-between;
-            flex-wrap: wrap;
+            .input-group-container{
+                width: 100%;
+            }
             .input-group {
                 flex: 1 1 0%;
                 padding: 4px 0px;
                 margin-right: 8px;
                 .form-group {
                     .react-numeric-input{
+                        width: 100%;
                         font-size: @font-size-small;
                         #intl-numeric{
                           float: unset;
+                          width: 100%;
                         }
                     }
                     .degrees, .minutes {

--- a/web/client/themes/default/less/measure.less
+++ b/web/client/themes/default/less/measure.less
@@ -28,7 +28,7 @@
             width: 200px !important;
         }
         .Select-menu-outer{
-            z-index: 3;
+            z-index: 10;
         }
     }
     .coordinates-row-container {
@@ -66,6 +66,9 @@
                 margin-right: 8px;
                 .form-group {
                     .react-numeric-input{
+                        b {
+                            z-index: 2;
+                        }
                         width: 100%;
                         font-size: @font-size-small;
                         #intl-numeric{

--- a/web/client/utils/MeasureUtils.js
+++ b/web/client/utils/MeasureUtils.js
@@ -188,3 +188,4 @@ export const isValidGeometry = ({coordinates, type} = {}) => {
     validatedCoords = type === "Polygon" ? head(validatedCoords) : validatedCoords;
     return validatedCoords.length > 0;
 };
+


### PR DESCRIPTION
## Description
This PR adds improvements to the measure panel requested as part of Austrocontrol.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6537 

**What is the new behavior?**
1. Empty segment length labels will be displayed as **0** when editing (adding coordinate manually)
2. Additional coordinate rows will not displayed in Polygon coordinates editor
3. Labels will be retained in edit mode in both Length and area measurement
4. When in edit mode, the other update operations are disabled, except the coordinate row in edit.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**Ref**: https://github.com/geosolutions-it/austrocontrol-C125/issues/268