### PR TITLE
#6503: Geodesic circle annotation

### DIFF
--- a/web/client/actions/__tests__/annotations-test.js
+++ b/web/client/actions/__tests__/annotations-test.js
@@ -215,6 +215,12 @@ describe('Test correctness of the annotations actions', () => {
         const result = startDrawing();
         expect(result.type).toEqual(START_DRAWING);
     });
+    it('startDrawing with options', () => {
+        const options = {geodesic: false};
+        const result = startDrawing(options);
+        expect(result.type).toEqual(START_DRAWING);
+        expect(result.options).toEqual(options);
+    });
     it('toggleUnsavedChangesModal', () => {
         const result = toggleUnsavedChangesModal();
         expect(result.type).toEqual(TOGGLE_CHANGES_MODAL);

--- a/web/client/components/mapcontrols/annotations/Annotations.jsx
+++ b/web/client/components/mapcontrols/annotations/Annotations.jsx
@@ -89,6 +89,7 @@ import Button from '../../misc/Button';
  * @prop {string} defaultShapeSize default symbol shape size in px
  * @prop {object} defaultStyles object with default symbol styles
  * @prop {number} textRotationStep rotation step of text styler
+ * @prop {boolean} geodesic draw geodesic annotation (Currently applicable only for Circle annotation)
  *
  * the annotation's attributes.
  */
@@ -349,7 +350,7 @@ class Annotations extends React.Component {
         const annotation = this.props.annotations && head(this.props.annotations.filter(a => a.properties.id === this.props.current));
         const Editor = this.props.editor;
         if (this.props.mode === 'detail') {
-            return (<Editor feature={annotation} showBack id={this.props.current} config={this.props.config} width={this.props.width}
+            return (<Editor feature={annotation} geodesic={this.props.geodesic} showBack id={this.props.current} config={this.props.config} width={this.props.width}
                 {...annotation.properties}
             />);
         }

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -1276,4 +1276,38 @@ describe('annotations Epics', () => {
         const action = geometryHighlight("1");
         store.dispatch(action);
     });
+    it('edit circle annotation with geodesic property ', (done) => {
+        store = mockStore({...defaultState, annotations: {...defaultState.annotations, config: {...defaultState.annotations.config, geodesic: true}}} );
+
+        store.subscribe(() => {
+            const actions = store.getActions();
+            if (actions.length >= 2) {
+                expect(actions[0].type).toBe(DRAWING_FEATURE);
+                expect(actions[1].type).toBe(CHANGE_DRAWING_STATUS);
+                expect(actions[1].options).toContain({
+                    geodesic: true,
+                    editEnabled: true,
+                    transformToFeatureCollection: true,
+                    addClickCallback: true
+                });
+                done();
+            }
+        });
+        const circleGeom = {
+            type: "Polygon",
+            coordinates: [[1, 2], [2, 3]]
+        };
+        const feature = {
+            type: "Feature",
+            geometry: circleGeom,
+            properties: {
+                canEdit: true,
+                id: "12345",
+                isCircle: true
+            }
+        };
+        const action = drawingFeatures([feature]);
+        store.dispatch(action);
+
+    });
 });

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -73,7 +73,8 @@ import {
     initPlugin,
     hideMeasureWarning,
     toggleShowAgain,
-    unSelectFeature
+    unSelectFeature,
+    startDrawing
 } from '../../actions/annotations';
 
 import { PURGE_MAPINFO_RESULTS } from '../../actions/mapInfo';
@@ -1710,5 +1711,13 @@ describe('Test the annotations reducer', () => {
         const features = state.editing.features;
         expect(features[0].properties.canEdit).toBe(false);
         expect(features[1].properties.canEdit).toBe(false);
+    });
+    it('START_DRAWING', () => {
+        let annotationsState = annotations({
+            editing: null,
+            selected: null
+        }, startDrawing({geodesic: true}));
+        expect(annotationsState.config).toBeTruthy();
+        expect(annotationsState.config.geodesic).toBe(true);
     });
 });

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -60,7 +60,8 @@ import {
     HIDE_MEASURE_WARNING,
     TOGGLE_SHOW_AGAIN,
     INIT_PLUGIN,
-    UNSELECT_FEATURE
+    UNSELECT_FEATURE,
+    START_DRAWING
 } from '../actions/annotations';
 
 import {
@@ -733,6 +734,8 @@ function annotations(state = {validationErrors: {}}, action) {
     case HIDE_MEASURE_WARNING: {
         return {...state, showPopupWarning: false};
     }
+    case START_DRAWING:
+        return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
     default:
         return state;
 


### PR DESCRIPTION
## Description
This PR adds geodesic circle annotation enhancement 
Note: This enhancement has been already added to 2020.01.xx as part of a project fix request

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6503

**What is the new behavior?**

- Allow to configure geodesic property for Annotation plugin to draw geodesic circle annotation
- When geodesic = true, a geodesic circle of type Polygon is drawn which is not interactable but the center can be moved by clicking on the map
- When geodesic = false, a non-geodesic circle is drawn and it is interactable (i.e resize the circle, move the center by click-n-drag the center of the circle)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
