### PR TITLE
[Backport 2021.01.xx] #6481 Implement rate control for the geolocation update frequency (#6…

### DIFF
--- a/web/client/components/mapcontrols/locate/LocateTool.jsx
+++ b/web/client/components/mapcontrols/locate/LocateTool.jsx
@@ -1,7 +1,7 @@
 import {useEffect, useRef} from 'react';
 import useMapTool from "../../../map/hooks/useMapTool";
 
-const LocateTool = ({map, mapType, status, messages, maxZoom, changeLocateState, onLocateError}) => {
+const LocateTool = ({map, mapType, status, messages, maxZoom, changeLocateState, onLocateError, rateControl}) => {
     const locateInstance = useRef();
     const [loaded, Impl, error] = useMapTool(mapType, 'locate');
     useEffect(() => {
@@ -23,7 +23,9 @@ const LocateTool = ({map, mapType, status, messages, maxZoom, changeLocateState,
     function getOptions() {
         return {
             locateOptions: {
-                ...(maxZoom !== undefined && { maxZoom })
+                ...(maxZoom !== undefined && { maxZoom }),
+                ...(rateControl !== undefined && { rateControl })
+
             }
         };
     }
@@ -49,4 +51,3 @@ const LocateTool = ({map, mapType, status, messages, maxZoom, changeLocateState,
 };
 
 export default LocateTool;
-

--- a/web/client/plugins/Locate.jsx
+++ b/web/client/plugins/Locate.jsx
@@ -32,6 +32,7 @@ import LocateTool from "../components/mapcontrols/locate/LocateTool";
   * @prop {string} cfg.text The button text, if any
   * @prop {number} cfg.maxZoom The maximum zoom for automatic view setting to the user location
   * @prop {string} cfg.className the class name for the button
+  * @prop {string} cfg.rateControl The rate control for the geolocation update frequency, value in milliseconds
   *
   */
 

--- a/web/client/utils/openlayers/OlLocate.js
+++ b/web/client/utils/openlayers/OlLocate.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define */
 /**
  * Copyright 2015, GeoSolutions Sas.
  * All rights reserved.
@@ -20,6 +21,8 @@ import {Point, Circle} from 'ol/geom';
 import GeometryCollection from 'ol/geom/GeometryCollection';
 import {Style, Fill, Stroke} from 'ol/style';
 import CircleStyle from 'ol/style/Circle';
+import throttle from 'lodash/throttle';
+
 
 const popUp = olPopUp();
 
@@ -59,7 +62,11 @@ const OlLocate = function(map, optOptions) {
         trackingOptions: this.options.locateOptions
     });
     this.updateHandler = this._updatePosFt.bind(this);
-    this.geolocate.on('change:position', this.updateHandler);
+
+    this.geolocate.on('change:position', (this.options.locateOptions.rateControl)
+        ? throttle( this.updateHandler, this.options.locateOptions.rateControl )
+        : this.updateHandler);
+
     this.popup = popUp;
     this.popup.hidden = true;
     this.popCnt = popUp.getElementsByClassName("ol-popup-cnt")[0];


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6481


Currently the update of geolocation positions follows the frequency dictated by the underlying Web Geolocation API

as you can see in the video, with an increment of 0.5 in latitude, the requests are 298

![screen-capture-_1_](https://user-images.githubusercontent.com/4085786/107660006-15154680-6c88-11eb-9679-b3561c1b189b.gif)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
We  introduce a configurable control rate, that will filter the position updates and only broadcast one update within the configured period 

as you can see in the video, with an increment of 0.5 in latitude and 1 second of rate control, the requests are less

![screen-capture-_2_](https://user-images.githubusercontent.com/4085786/107660531-ad133000-6c88-11eb-944f-f80d3228b76e.gif)

**How to enable Sensors tab in inspect element:**
Open inspect element / DevTools click on three vertical dots at the bottom left, and add sensors

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
