### PR TITLE
backport 2021.01.xx - #6495 fix for widgets width when adding them on the map viewer (#6500)

### DIFF
--- a/web/client/components/widgets/enhancers/emptyTextState.js
+++ b/web/client/components/widgets/enhancers/emptyTextState.js
@@ -4,8 +4,12 @@ import emptyState from '../../misc/enhancers/emptyState';
 
 export default emptyState(
     ({text} = {}) => !text,
-    ({iconFit} = {}) => ({
-        iconFit,
-        tooltip: <Message msgId="widgets.errors.notext" />
+    () => ({
+        iconFit: false,
+        glyph: false,
+        style: {
+            margin: "auto"
+        },
+        title: <Message msgId="widgets.errors.notext" />
     })
 );

--- a/web/client/plugins/Widgets.jsx
+++ b/web/client/plugins/Widgets.jsx
@@ -78,18 +78,21 @@ compose(
                 breakpoints: { xxs: 0 },
                 cols: { xxs: 1 }
             } : {};
-
+            const viewWidth = width && width > 800 ? width - (500 + RIGHT_MARGIN) : width - RIGHT_MARGIN;
+            const widthOptions = width ? {width: viewWidth - 1} : {};
             return ({
                 rowHeight,
                 className: "on-map",
                 breakpoints: { md: 480, xxs: 0 },
                 cols: { md: 6, xxs: 1 },
+                ...widthOptions,
+                useDefaultWidthProvider: false,
                 style: {
                     left: (width && width > 800) ? "500px" : "0",
                     marginTop: 52,
                     bottom: 65,
                     height: Math.floor((height - 100) / (rowHeight + 10)) * (rowHeight + 10),
-                    width: width && width > 800 ? `calc(100% - ${500 + RIGHT_MARGIN}px)` : `calc(100% - ${RIGHT_MARGIN}px)`,
+                    width: viewWidth + 'px',
                     position: 'absolute',
                     zIndex: 50,
                     ...maximizedStyle


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2021.01.xx - #6495 fix for widgets width when adding them on the map viewer (#6500)