### PR TITLE
#6537: Measurement panel improvement (III)

### DIFF
--- a/web/client/components/I18N/IntlNumberFormControl.jsx
+++ b/web/client/components/I18N/IntlNumberFormControl.jsx
@@ -46,9 +46,6 @@ class IntlNumberFormControl extends React.Component {
                 {...formProps}
                 {...value !== undefined ? {value: this.format(value) } : {defaultValue: this.format(defaultValue)}}
                 format={this.format}
-                onKeyUp={ev=>{
-                    ev.target.setSelectionRange(-1, -1);
-                }}
                 onChange={(val) => {
                     val === null ? this.props.onChange("") : this.props.onChange(val.toString());
                 }}

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -71,11 +71,13 @@ export default class MeasurementSupport extends React.Component {
         startEndPoint: {
             startPointOptions: {
                 radius: 3,
-                fillColor: "green"
+                fillColor: "green",
+                applyToPolygon: true
             },
             endPointOptions: {
                 radius: 3,
-                fillColor: "red"
+                fillColor: "red",
+                applyToPolygon: true
             }
         },
         updateOnMouseMove: false
@@ -163,8 +165,8 @@ export default class MeasurementSupport extends React.Component {
     /**
      * Update the draw interaction when feature in edit
      */
-    updateInteraction = (props) => {
-        const disableInteraction = props.measurement.features.some(ft=> get(ft, 'properties.disabled'));
+    updateInteraction = (props, features) => {
+        const disableInteraction = features.some(ft=> get(ft, 'properties.disabled'));
         if (disableInteraction) {
             // Disable interaction (To allow add coordinate points by click on map)
             this.removeDrawInteraction();
@@ -175,20 +177,73 @@ export default class MeasurementSupport extends React.Component {
         }
     }
 
-    updateFeatures = (props) => {
-        const oldFeatures = this.source.getFeatures();
+    /**
+     * Create LineString geometry for Polygon to display the feature
+     * when polygon is not fully formed
+     */
+    convertPolyToLineFeature = (coordinates = []) => {
+        let reprojectedCoords = [];
+        const firstIndexValid = validateCoord(coordinates[0]);
+        if (firstIndexValid && validateCoord(coordinates[1])) {
+            reprojectedCoords = this.reprojectedCoordinatesFrom4326([coordinates[0], coordinates[1]]);
+        } else if (firstIndexValid) {
+            reprojectedCoords = this.reprojectedCoordinatesFrom4326([coordinates[0]]);
+        }
+        if (reprojectedCoords.length) {
+            return new LineString(reprojectedCoords);
+        }
+        return null;
+    }
 
+    /**
+     * Modify feature based on the geometries validity
+     */
+    modifyFeatures = (props) => {
+        let {currentFeature, features} = props.measurement || {};
+        let coordinates = features[currentFeature]?.geometry?.coordinates || [];
+        let type = features[currentFeature]?.geometry?.type || '';
+        if (type === "Polygon") {
+            coordinates = coordinates?.[0] || [];
+        }
+        const coordinatesLength = coordinates.length;
+        const hasInvalidCoords = coordinates.some(c=> !validateCoord(c));
+        let geometryObj;
+        // Modify only when LineString or Polygon is not fully formed
+        if (!hasInvalidCoords && type === 'LineString' && coordinatesLength < 2) {
+            const reprojectedCoords = this.reprojectedCoordinatesFrom4326(coordinates);
+            geometryObj = new LineString(reprojectedCoords);
+            features[currentFeature] = set("properties.disabled", true, set("geometry.coordinates", [...coordinates, ["", ""]], features[currentFeature]));
+        } else if (!hasInvalidCoords && type === "Polygon" && coordinatesLength <= 4
+            && isEqual(coordinates[coordinatesLength - 1], coordinates[coordinatesLength - 2])) {
+            coordinates.splice(2, 0, ["", ""]);
+            coordinates.pop();
+            features[currentFeature] = set("properties.disabled", true, set("geometry.coordinates", [coordinates], features[currentFeature]));
+        }
+        if (type === "Polygon" && coordinatesLength <= 4) {
+            geometryObj = this.convertPolyToLineFeature(coordinates);
+        }
+        let currentOlFt;
+        if (geometryObj) {
+            this.source.clear();
+            currentOlFt = new Feature({geometry: geometryObj}); // Add feature with new geometry
+        }
+        return [features, currentOlFt];
+    }
+
+    updateFeatures = (props) => {
+        const [features, currentOlFt] = this.modifyFeatures(props) || [];
+        const oldFeatures = this.source.getFeatures();
         this.removeMeasureTooltips();
         this.removeSegmentLengthOverlays();
         this.source.clear();
         this.textLabels = [];
         this.segmentLengths = [];
         let indexOfFeatureInEdit = null;
-        this.updateInteraction(props);
-        const results = props.measurement.features.map((feature, index) => {
+        this.updateInteraction(props, features);
+        const results = features.map((feature, index) => {
             if (get(feature, 'properties.disabled')) {
                 indexOfFeatureInEdit = index;
-                return [feature, oldFeatures && oldFeatures[index] && oldFeatures[index].getGeometry()];
+                return [feature, oldFeatures && oldFeatures[index] && oldFeatures[index].getGeometry() || currentOlFt?.getGeometry()];
             }
 
             const geomType = feature.geometry.type;
@@ -196,8 +251,12 @@ export default class MeasurementSupport extends React.Component {
             const isBearing = (featureValues[0] || {}).type === 'bearing' ||
                 (!(featureValues[0] || {}).type && props.measurement.bearingMeasureEnabled);
             const coords = geomType === 'Polygon' ? feature.geometry.coordinates[0] : feature.geometry.coordinates;
-            const reprojectedCoords = this.reprojectedCoordinatesFrom4326(coords);
-            const geometryObj = geomType === 'Polygon' ? new Polygon([reprojectedCoords]) : new LineString(reprojectedCoords);
+            let newCoords = coords;
+            if (geomType === 'LineString' && coords.length >= 2 && !isBearing) {
+                newCoords = transformLineToArcs(coords); // Maintain the arc when updating features
+            }
+            const newReprojectedCoords = this.reprojectedCoordinatesFrom4326(newCoords);
+            const geometryObj = geomType === 'Polygon' ? new Polygon([newReprojectedCoords]) : new LineString(newReprojectedCoords);
 
             const getMeasureValue = {
                 'Point': () => coords,
@@ -217,6 +276,7 @@ export default class MeasurementSupport extends React.Component {
                 'Polygon': () => this.formatAreaValue(this.getArea(geometryObj), props.uom)
             };
 
+            const reprojectedCoords = this.reprojectedCoordinatesFrom4326(coords);
             // recalculate segments
             if (!isBearing) {
                 for (let i = 0; i < coords.length - 1; ++i) {
@@ -227,10 +287,22 @@ export default class MeasurementSupport extends React.Component {
                     const bearingText = this.props.measurement && this.props.measurement.showLengthAndBearingLabel && " | " + getFormattedBearingValue(segmentLengthBearing, this.props.measurement.trueBearing) || "";
                     const overlayText = this.formatLengthValue(segmentLengthDistance, props.uom, isBearing) + bearingText;
                     last(this.segmentOverlayElements).innerHTML = overlayText;
-                    last(this.segmentOverlays).setPosition(midpoint(reprojectedCoords[i], reprojectedCoords[i + 1], true));
+                    let textLabelPosition = midpoint(coords[i], coords[i + 1], true);
+                    let segmentOverlayPosition = midpoint(reprojectedCoords[i], reprojectedCoords[i + 1], true);
+
+                    // Generate correct textLabels and update segment overlays
+                    if (geomType === 'LineString') {
+                        const middlePoint = newCoords[100 * i + 50];
+                        if (middlePoint) {
+                            textLabelPosition = middlePoint;
+                            segmentOverlayPosition = pointObjectToArray(reproject(middlePoint, 'EPSG:4326', getProjectionCode(this.props.map)));
+                        }
+                    }
+
+                    last(this.segmentOverlays).setPosition(segmentOverlayPosition);
                     this.textLabels[this.segmentOverlays.length - 1] = {
                         text: overlayText,
-                        position: midpoint(coords[i], coords[i + 1], true)
+                        position: textLabelPosition
                     };
                     this.segmentLengths[this.segmentOverlays.length - 1] = {
                         value: segmentLengthDistance,
@@ -313,11 +385,10 @@ export default class MeasurementSupport extends React.Component {
                 newFeature.geometry.textLabels =  tempTextLabels.splice(0, currentCoordinateLength - sliceVal) || [];
             }
             if (isPolygon && !hasInvalidCoords && coordinates.length && isEqual(coordinates[currentCoordinateLength], coordinates[currentCoordinateLength - 1])) {
-                newFeature.geometry.coordinates[0].pop(); // Pop last coordinate of a Polygon to prevent extra rows in Measure panel
+                newFeature.geometry.coordinates[0].pop(); // Pop last duplicate coordinate of a Polygon to prevent extra rows in Measure panel
             }
             return newFeature;
         });
-
         this.props.changeGeometry(newFeatures);
         this.props.setTextLabels([...this.textLabels]);
 

--- a/web/client/components/map/openlayers/MeasurementSupport.jsx
+++ b/web/client/components/map/openlayers/MeasurementSupport.jsx
@@ -222,6 +222,9 @@ export default class MeasurementSupport extends React.Component {
         if (type === "Polygon" && coordinatesLength <= 4) {
             geometryObj = this.convertPolyToLineFeature(coordinates);
         }
+        if (!hasInvalidCoords && isEqual(coordinates[coordinatesLength - 1], coordinates[coordinatesLength - 2])) {
+            features[currentFeature]?.geometry?.coordinates?.[0]?.pop(); // Pop last duplicate coordinate of a Polygon to prevent extra rows in Measure panel
+        }
         let currentOlFt;
         if (geometryObj) {
             this.source.clear();
@@ -383,9 +386,6 @@ export default class MeasurementSupport extends React.Component {
                 newFeature.geometry.textLabels = newFeature.geometry.textLabels.concat([{text: "0"}]); // Add empty label when coordinate row is empty
             } else {
                 newFeature.geometry.textLabels =  tempTextLabels.splice(0, currentCoordinateLength - sliceVal) || [];
-            }
-            if (isPolygon && !hasInvalidCoords && coordinates.length && isEqual(coordinates[currentCoordinateLength], coordinates[currentCoordinateLength - 1])) {
-                newFeature.geometry.coordinates[0].pop(); // Pop last duplicate coordinate of a Polygon to prevent extra rows in Measure panel
             }
             return newFeature;
         });

--- a/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
@@ -12,7 +12,7 @@ import expect from 'expect';
 
 import MeasurementSupport from '../MeasurementSupport';
 
-import { LineString } from 'ol/geom';
+import { LineString, Polygon } from 'ol/geom';
 import { Map, View, Feature } from 'ol';
 
 describe('Openlayers MeasurementSupport', () => {
@@ -923,5 +923,75 @@ describe('Openlayers MeasurementSupport', () => {
         });
         // Restore drawInteraction when feature is valid
         expect(cmp.drawInteraction).toBeTruthy();
+    });
+
+    it('test modify features when geometry in edit is not fully formed', () => {
+        const spyOnchangeGeometry = expect.spyOn(testHandlers, 'changeGeometry');
+        let cmp = renderMeasurement();
+        cmp = renderMeasurement({
+            measurement: {
+                geomType: "LineString",
+                lineMeasureEnabled: true,
+                updatedByUI: false,
+                showLabel: true
+            },
+            uom
+        });
+
+        cmp.drawInteraction.dispatchEvent({
+            type: 'drawstart',
+            feature: new Feature({
+                geometry: new Polygon([[10.0, 15.0], [10.0, 15.0]])
+            })
+        });
+
+        // LineString
+        let ftLineString = {
+            type: "Feature",
+            geometry: {type: "LineString", coordinates: [[1, 2]], textLabels: []}
+        };
+        cmp = renderMeasurement({
+            measurement: {
+                geomType: "LineString",
+                lineMeasureEnabled: true,
+                updatedByUI: true,
+                features: [ftLineString],
+                currentFeature: 0
+            },
+            uom
+        });
+        expect(cmp.source.getFeatures().length).toBe(1);
+        let feature = cmp.source.getFeatures()[0];
+        expect(feature.getGeometry().getType()).toBe('LineString');
+        expect(spyOnchangeGeometry).toHaveBeenCalled();
+        let updatedFeatures = spyOnchangeGeometry.calls[0].arguments[0];
+        expect(updatedFeatures[0].geometry.coordinates).toEqual([[1, 2], ["", ""]]);
+        expect(updatedFeatures[0].geometry.textLabels).toEqual([{text: "0"}]);
+        expect(updatedFeatures[0].properties.disabled).toBe(true);
+
+        // Polygon
+        cmp = renderMeasurement({
+            measurement: {
+                geomType: "Polygon",
+                areaMeasureEnabled: true,
+                currentFeature: 1,
+                updatedByUI: true,
+                features: [{...ftLineString, geometry: {...ftLineString.geometry, coordinates: [[1, 2], [2, 3]]}}, {
+                    type: "Feature",
+                    geometry: {type: "Polygon", coordinates: [[[1, 2], ["", ""], [1, 2]]], textLabels: [{text: "0"}, {text: "0"}]},
+                    properties: {disabled: true}
+                }]
+            },
+            uom
+        });
+
+        // Generate Linestring geometry for unformed Polygon
+        expect(cmp.source.getFeatures().length).toBe(2);
+        feature = cmp.source.getFeatures()[1];
+        expect(feature.getGeometry().getType()).toBe('LineString');
+        updatedFeatures = spyOnchangeGeometry.calls[1].arguments[0];
+        expect(updatedFeatures[1].geometry.coordinates).toEqual([[[1, 2], ["", ""], [1, 2]]]);
+        expect(updatedFeatures[1].geometry.textLabels.length).toBe(3);
+        expect(updatedFeatures[1].properties.disabled).toBe(true);
     });
 });

--- a/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/MeasurementSupport-test.jsx
@@ -389,7 +389,8 @@ describe('Openlayers MeasurementSupport', () => {
                 updatedByUI: true,
                 showLabel: true,
                 showLengthAndBearingLabel: true,
-                features
+                features,
+                currentFeature: 0
             },
             uom
         });
@@ -397,7 +398,7 @@ describe('Openlayers MeasurementSupport', () => {
         expect(cmp.outputValues).toExist();
         expect(cmp.outputValues.length).toBe(2);
         expect(cmp.textLabels).toExist();
-        expect(cmp.textLabels.length).toBe(4);
+        expect(cmp.textLabels.length).toBe(3);
 
         expect(spyOnChangeGeometry).toHaveBeenCalled();
         const resultFeature = spyOnChangeGeometry.calls[0].arguments[0];
@@ -406,7 +407,7 @@ describe('Openlayers MeasurementSupport', () => {
         expect(resultFeature[0].geometry).toBeTruthy();
         expect(resultFeature[0].geometry.type).toBe('Polygon');
         expect(resultFeature[0].geometry.coordinates[0].length).toBe(4);
-        expect(resultFeature[0].geometry.textLabels.length).toBe(4);
+        expect(resultFeature[0].geometry.textLabels.length).toBe(3);
     });
     it('test drawing (LineString)', () => {
         const spyOnChangeGeometry = expect.spyOn(testHandlers, "changeGeometry");

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -8,7 +8,7 @@
 
 import 'react-quill/dist/quill.snow.css';
 
-import { head, isEmpty, isFunction } from 'lodash';
+import { head, isEmpty, isFunction, isUndefined } from 'lodash';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -831,7 +831,13 @@ class AnnotationsEditor extends React.Component {
             if (Object.keys(errors).length === 0) {
                 this.props.onError({});
                 this.props.onSave(this.props.id, assign({}, this.props.editedFields),
-                    this.props.editing.features, this.props.editing.style, this.props.editing.newFeature || false, this.props.editing.properties);
+                    this.props.editing.features, this.props.editing.style, this.props.editing.newFeature || false, {
+                        ...this.props.editing.properties,
+                        visibility: !isUndefined(this.props.editing.properties.visibility)
+                            ? this.props.editing.properties.visibility
+                            : this.props.editing.visibility
+                    }
+                );
             } else {
                 this.props.onError(errors);
             }

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -370,7 +370,9 @@ class CoordinatesEditor extends React.Component {
     addCoordPolygon = (components) => {
         if (this.props.type === "Polygon") {
             const validComponents = components.filter(validateCoords);
-            return components.concat([validComponents.length ? validComponents[0] : {lat: "", lon: ""}]);
+            const coordinates = this.props.features[this.props.currentFeature]?.geometry?.coordinates?.[0] || [];
+            const invalidCoordinateIndex = coordinates !== undefined ? coordinates.findIndex(c=> !validateCoords({lon: c[0], lat: c[1]})) : -1;
+            return components.concat([validComponents.length && invalidCoordinateIndex !== 0 ? validComponents[0] : {lat: "", lon: ""}]);
         }
         return components;
     }

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -162,7 +162,8 @@ describe("test the AnnotationsEditor Panel", () => {
             selected={null}
             editing={{
                 properties: feature,
-                features: [{}]
+                features: [{}],
+                visibility: true
             }}
             onSave={testHandlers.onSaveHandler}
             onCancelEdit={testHandlers.onCancelHandler}/>, document.getElementById("container"));
@@ -173,6 +174,8 @@ describe("test the AnnotationsEditor Panel", () => {
         expect(saveButton).toExist();
         TestUtils.Simulate.click(saveButton);
         expect(spySave.calls.length).toEqual(1);
+        expect(spySave.calls[0].arguments[0]).toEqual(1);
+        expect(spySave.calls[0].arguments[5]).toEqual({...feature, visibility: true});
         expect(spyCancel.calls.length).toEqual(0);
     });
 

--- a/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/CoordinatesEditor-test.js
@@ -159,7 +159,7 @@ describe("test the CoordinatesEditor Panel", () => {
             {type: 'Feature',
                 geometry: {
                     type: 'Polygon',
-                    coordinates: [[10, 10], [6, 6], [6, 6]],
+                    coordinates: [[[10, 10], [6, 6], [6, 6]]],
                     textLabels: [
                         {text: '2 m | 060°', position: [10, 10]},
                         {text: '3 m | 078°', position: [6, 6]},

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -765,6 +765,8 @@ describe('annotations Epics', () => {
             actions.map((action) => {
                 switch (action.type) {
                 case UPDATE_NODE:
+                    expect(action.options.features).toBeTruthy();
+                    expect(action.options.visibility).toBe(false);
                     break;
                 case CHANGE_DRAWING_STATUS:
                     expect(action.owner).toBe('annotations');

--- a/web/client/epics/__tests__/measurement-test.jsx
+++ b/web/client/epics/__tests__/measurement-test.jsx
@@ -209,7 +209,7 @@ describe('measurement epics', () => {
             }, state);
     });
     it('test setMeasureStateFromAnnotationEpic', (done) => {
-        const NUMBER_OF_ACTIONS = 3;
+        const NUMBER_OF_ACTIONS = 4;
         const state = {
             controls: {
                 measure: {
@@ -232,6 +232,8 @@ describe('measurement epics', () => {
                 expect(actions[2].control).toBe("annotations");
                 expect(actions[2].property).toBe("enabled");
                 expect(actions[2].value).toBe(false);
+                expect(actions[3].type).toBe("ANNOTATIONS:VISIBILITY");
+                expect(actions[3].visibility).toBe(false);
                 done();
             }, state);
     });

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -348,7 +348,7 @@ export default (viewer) => ({
                     features: f.properties.id === action.id ? featureCollection : f.features,
                     style: f.properties.id === action.id ? action.style : f.style
                 })).concat(action.newFeature ? [createNewFeature(action)] : []),
-                visibility: !!annotationsLayer.features?.filter(f => f.properties.visibility)?.length
+                visibility: !isUndefined(action?.properties?.visibility) ? action.properties.visibility : false
             })] : [
                 addLayer({
                     type: 'vector',

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -347,7 +347,8 @@ export default (viewer) => ({
                     properties: f.properties.id === action.id ? assign({}, f.properties, action.properties, action.fields) : f.properties,
                     features: f.properties.id === action.id ? featureCollection : f.features,
                     style: f.properties.id === action.id ? action.style : f.style
-                })).concat(action.newFeature ? [createNewFeature(action)] : [])
+                })).concat(action.newFeature ? [createNewFeature(action)] : []),
+                visibility: !!annotationsLayer.features?.filter(f => f.properties.visibility)?.length
             })] : [
                 addLayer({
                     type: 'vector',

--- a/web/client/epics/measurement.js
+++ b/web/client/epics/measurement.js
@@ -20,7 +20,7 @@ import {purgeMapInfoResults, hideMapinfoMarker} from '../actions/mapInfo';
 import {showCoordinateEditorSelector, measureSelector} from '../selectors/controls';
 import {geomTypeSelector} from '../selectors/measurement';
 import { CLICK_ON_MAP } from '../actions/map';
-import {newAnnotation, setEditingFeature, cleanHighlight} from '../actions/annotations';
+import {newAnnotation, setEditingFeature, cleanHighlight, toggleVisibilityAnnotation} from '../actions/annotations';
 
 export const addAnnotationFromMeasureEpic = (action$) =>
     action$.ofType(ADD_MEASURE_AS_ANNOTATION)
@@ -75,11 +75,12 @@ export const closeMeasureEpics = (action$, store) =>
 
 export const setMeasureStateFromAnnotationEpic = (action$, store) =>
     action$.ofType(SET_ANNOTATION_MEASUREMENT)
-        .switchMap(({features}) => {
+        .switchMap(({features, properties}) => {
             const isGeomSelected = geomTypeSelector(store.getState()) === getGeomTypeSelected(features)?.[0];
             return Rx.Observable.of( !isGeomSelected && changeMeasurement({geomType: getGeomTypeSelected(features)?.[0]}),
                 setControlProperty("measure", "enabled", true),
-                setControlProperty("annotations", "enabled", false));
+                setControlProperty("annotations", "enabled", false),
+                toggleVisibilityAnnotation(properties.id, false));
         });
 
 export const addCoordinatesEpic = (action$, {getState = () => {}}) =>

--- a/web/client/utils/MeasurementUtils.js
+++ b/web/client/utils/MeasurementUtils.js
@@ -66,6 +66,7 @@ const STYLE_TEXT_LABEL_BIGGER = {
 
 const convertGeometryToGeoJSON = (feature, uom, measureValueStyle) => {
     const actualMeasureValueStyle = measureValueStyle || STYLE_TEXT_LABEL_BIGGER;
+    const isBearing = !!feature.properties?.values?.find(val=>val.type === 'bearing');
     return [{
         type: 'Feature',
         geometry: {
@@ -76,15 +77,16 @@ const convertGeometryToGeoJSON = (feature, uom, measureValueStyle) => {
         properties: {
             id: uuidv1(),
             isValidFeature: true,
-            geometryGeodesic: feature.geometry.type === 'LineString' ? {type: "LineString", coordinates: transformLineToArcs(feature.geometry.coordinates)} : null,
-            useGeodesicLines: feature.geometry.type === 'LineString',
+            // Transform only the linestring of type not bearing
+            geometryGeodesic: feature.geometry.type === 'LineString' && !isBearing ? {type: "LineString", coordinates: transformLineToArcs(feature.geometry.coordinates)} : null,
+            useGeodesicLines: feature.geometry.type === 'LineString' && !isBearing,
             values: feature.properties?.values || []
         },
         style: [{
             ...DEFAULT_ANNOTATIONS_STYLES[feature.geometry.type],
             type: feature.geometry.type,
             id: uuidv1(),
-            geometry: feature.geometry.type === 'LineString' ? "lineToArc" : null,
+            geometry: feature.geometry.type === 'LineString' && !isBearing ? "lineToArc" : null,
             title: `${feature.geometry.type} Style`,
             filtering: true
         }].concat(feature.geometry.type === "LineString" ? getStartEndPointsForLinestring() : [])


### PR DESCRIPTION
## Description
This PR adds more improvements to the measurement panel

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Enhancement

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/pull/6545#issuecomment-781278947

**What is the new behavior?**
Measurement panel with coordinates editor
- Upon clicking the **+** button, the coordinate row is added and either by clicking on the map or entering the valid coordinate and submitting, the coordinate editor will automatically add coordinates row until the geometry is valid (LineString & Bearing - 2 row, Polygon - 3 rows)
- Upon adding the vertices, the vertex points of the coordinate is highlighted with a point (To guide the user in visualizing the position while the geometry is drawn) 
- The Linestring arc will be maintained while updating the features (if any).
- When saving the measurement to annotation, the 'Bearing' will not be transformed to arc line (if any).
- User should be able to use left/right arrow keys to move cursor position in the coordinates editor input fields

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
https://github.com/geosolutions-it/austrocontrol-C125/issues/268
https://github.com/geosolutions-it/austrocontrol-C125/issues/269