### PR TITLE
Geodesic center fix

### DIFF
--- a/web/client/components/map/openlayers/DrawSupport.jsx
+++ b/web/client/components/map/openlayers/DrawSupport.jsx
@@ -435,7 +435,7 @@ export default class DrawSupport extends React.Component {
                     // TODO verify center is projected in 4326 and is an array
                     center = reproject(center, this.getMapCrs(), "EPSG:4326", false);
                     const originalId = newProps && newProps.features && newProps.features.length && newProps.features[0] && newProps.features[0].features && newProps.features[0].features.length && newProps.features[0].features.filter(f => f.properties.isDrawing)[0].properties.id || id;
-                    newFeature.setProperties({isCircle: true, radius, center: [center.x, center.y], id: originalId, crs: this.getMapCrs()});
+                    newFeature.setProperties({isCircle: true, radius, center: [center.x, center.y], id: originalId, crs: this.getMapCrs(), isGeodesic: this.props.options.geodesic});
                 } else if (drawMethod === "Polygon") {
                     newDrawMethod = this.props.drawMethod;
                     let coordinates = drawnGeom.getCoordinates();
@@ -847,7 +847,7 @@ export default class DrawSupport extends React.Component {
                     // TODO verify center is projected in 4326 and is an array
                     center = reproject(center, this.getMapCrs(), "EPSG:4326", false);
                     olFt.setProperties(omit(previousFt && previousFt.getProperties() || {}, "geometry"));
-                    olFt.setProperties({isCircle: true, radius, center: [center.x, center.y]});
+                    olFt.setProperties({isCircle: true, radius, center: [center.x, center.y], isGeodesic: this.props.options.geodesic});
                     break;
                 }
                 case "Text": {

--- a/web/client/components/map/openlayers/VectorStyle.js
+++ b/web/client/components/map/openlayers/VectorStyle.js
@@ -14,7 +14,7 @@ import head from 'lodash/head';
 import last from 'lodash/last';
 import find from 'lodash/find';
 import isObject from 'lodash/isObject';
-
+import {getCenter} from 'ol/extent';
 import {colorToRgbaStr} from '../../../utils/ColorUtils';
 import {reproject, transformLineToArcs} from '../../../utils/CoordinatesUtils';
 import Icons from '../../../utils/openlayers/Icons';
@@ -204,8 +204,9 @@ export const addDefaultStartEndPoints = (styles = [], startPointOptions = {radiu
 
 export const centerPoint = (feature) => {
     const geometry = feature.getGeometry();
+    const { isGeodesic = false } = feature.getProperties();
     const extent = geometry.getExtent();
-    let center = geometry.getCenter && geometry.getCenter() || [extent[2] - extent[0], extent[3] - extent[1]];
+    let center = isGeodesic ? getCenter(extent) : (geometry.getCenter && geometry.getCenter() || [extent[2] - extent[0], extent[3] - extent[1]]);
     return new Point(center);
 };
 export const lineToArc = (feature) => {

--- a/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
+++ b/web/client/components/map/openlayers/__tests__/VectorStyle-test.js
@@ -15,7 +15,8 @@ import {
     getGeometryTrasformation,
     getFilter,
     parseStyles,
-    getStyle
+    getStyle,
+    centerPoint
 } from '../VectorStyle';
 
 import isArray from 'lodash/isArray';
@@ -562,6 +563,20 @@ describe('Test VectorStyle', () => {
         const olStyles = parseStyles({style: [markerStyle]});
         expect(isArray(olStyles)).toBe(true);
         expect(olStyles.length).toBe(2);
+    });
+    it('centerPoint of a circle', () => {
+        let circleFt = new Feature({
+            geometry: new Polygon([[[1, 2], [2, 3], [3, 4], [5, 6], [1, 2]]])
+        });
+        // Geodesic circle
+        circleFt.setProperties({isGeodesic: true, isCircle: true});
+        let center = centerPoint(circleFt);
+        expect(center.getCoordinates()).toEqual([3, 4]);
+
+        // Non-geodesic circle
+        circleFt.setProperties({isGeodesic: false, isCircle: true});
+        center = centerPoint(circleFt);
+        expect(center.getCoordinates()).toEqual([4, 4]);
     });
     it('parseStyles of a feature, with a style [polygonStyle, markerStyle]', () => {
         const markerStyle = {

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -261,6 +261,8 @@ const conditionalToggle = on.bind(null, toggleControl('annotations', null), (sta
   * @prop {string} defaultShapeFillColor default symbol fill color
   * @prop {string} defaultShapeSize default symbol shape size in px
   * @prop {string} symbolsPath the relative path to the symbols folder where symbols.json and SVGs are located (starting from the index.html folder, i.e. the root) symbols.json can be structured like [this](https://github.com/geosolutions-it/MapStore2/blob/90fb33465fd3ff56c4bbaafb5ab0ed492826622c/web/client/product/assets/symbols/symbols.json)
+  * @prop {boolean} measurementAnnotationEdit flag for measurement specific annotation features. Enabling this will allow user to edit measurements saved as annotation
+  * @prop {boolean} geodesic draw geodesic annotation. By default geodesic is true (Currently applicable only for Circle annotation)
   * @class Annotations
   * @memberof plugins
   * @static
@@ -273,6 +275,16 @@ const conditionalToggle = on.bind(null, toggleControl('annotations', null), (sta
   *   {"name": "filename", "label": "label"},
   *   {"name": "square", "label": "Square"}
   * ]
+  *
+  * Typical configuration of the plugin
+  *
+  * {
+  *   "name": "Annotations",
+  *    "cfg": {
+  *        measurementAnnotationEdit: false,
+  *        geodesic: true
+  *    }
+  * }
   */
 
 const annotationsSelector = createSelector([


### PR DESCRIPTION
## Description
This PR adds a fix for incorrect calculation of center for geodesic circle while placing a center point from annotation

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/pull/6541#issuecomment-782039723

**What is the new behavior?**
- Center style will properly applied and the style will be displayed in the circle'center for geodesic circle
- Updated annotation plugin documentation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
