### PR TITLE
[Backport 2021.01.xx] #6172: Embedded do not work in standard projects (#6529)

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -22,6 +22,37 @@ This is a list of things to check if you want to update from a previous version 
 
 ## Migration from 2021.01.00 to 2021.01.01
 
+### Update embedded entry to load the correct configuration
+
+Existing MapStore project could have an issue with the loading of map embedded page due to the impossibility to change some configuration such as localConfig.json or translations path in the javascript entry.
+This issue can be solved following these steps:
+1 - add a custom entry named `embedded.jsx` in the `js/` directory of the project with the content:
+```js
+import {
+    setConfigProp,
+    setLocalConfigurationFile
+} from '@mapstore/utils/ConfigUtils';
+
+// Add custom (overriding) translations
+// example for additional translations in the project folder
+// setConfigProp('translationsPath', ['./MapStore2/web/client/translations', './translations']);
+setConfigProp('translationsPath', './MapStore2/web/client/translations');
+// __PROJECTNAME__ is the name of the project used in the creation process 
+setConfigProp('themePrefix', '__PROJECTNAME__');
+
+// Use a custom plugins configuration file
+// example if localConfig.json is located in the root of the project
+// setLocalConfigurationFile('localConfig.json');
+setLocalConfigurationFile('MapStore2/web/client/localConfig.json');
+
+// async load of the standard embedded bundle
+import('@mapstore/product/embedded');
+```
+2 - update the path of the embedded entry inside the `webpack.config.js` and `prod-webpack.config.js` files with:
+```js
+// __PROJECTNAME__ is the name of the project used in the creation process 
+'__PROJECTNAME__-embedded': path.join(__dirname, "js", "embedded"),
+```
 ### Locate plugin configuration
 
 Configuration for Locate plugin has changed and it is not needed anymore inside the Map plugin

--- a/project/standard/templates/js/embedded.jsx
+++ b/project/standard/templates/js/embedded.jsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+    setConfigProp,
+    setLocalConfigurationFile
+} from '@mapstore/utils/ConfigUtils';
+/**
+ * Add custom (overriding) translations with:
+ *
+ * setConfigProp('translationsPath', ['./MapStore2/web/client/translations', './translations']);
+ */
+setConfigProp('translationsPath', './MapStore2/web/client/translations');
+setConfigProp('themePrefix', '__PROJECTNAME__');
+
+/**
+ * Use a custom plugins configuration file with:
+ *
+ * setLocalConfigurationFile('localConfig.json');
+ */
+setLocalConfigurationFile('MapStore2/web/client/localConfig.json');
+
+import('@mapstore/product/embedded');

--- a/project/standard/templates/prod-webpack.config.js
+++ b/project/standard/templates/prod-webpack.config.js
@@ -15,7 +15,7 @@ const paths = {
 module.exports = require('./MapStore2/build/buildConfig')(
     {
         '__PROJECTNAME__': path.join(__dirname, "js", "app"),
-        '__PROJECTNAME__-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
+        '__PROJECTNAME__-embedded': path.join(__dirname, "js", "embedded"),
         '__PROJECTNAME__-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
         'geostory-embedded': path.join(__dirname, "js", "geostoryEmbedded"),
         "dashboard-embedded": path.join(__dirname, "js", "dashboardEmbedded")

--- a/project/standard/templates/webpack.config.js
+++ b/project/standard/templates/webpack.config.js
@@ -7,7 +7,7 @@ const ModuleFederationPlugin = require('./MapStore2/build/moduleFederation').plu
 module.exports = require('./MapStore2/build/buildConfig')(
     {
         '__PROJECTNAME__': path.join(__dirname, "js", "app"),
-        '__PROJECTNAME__-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
+        '__PROJECTNAME__-embedded': path.join(__dirname, "js", "embedded"),
         '__PROJECTNAME__-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
         'geostory-embedded': path.join(__dirname, "js", "geostoryEmbedded"),
         "dashboard-embedded": path.join(__dirname, "js", "dashboardEmbedded")


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
backport of #6529

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6172

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
New embedded entry for the create script of standard project and related documentation

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
