### PR TITLE
[2021.01.xx backport] #6221 Add support for disabled flag in layer filter for widget (#6542)#6544

### DIFF
--- a/web/client/components/TOC/fragments/__tests__/ToggleFilter-test.jsx
+++ b/web/client/components/TOC/fragments/__tests__/ToggleFilter-test.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ToggleFilter from '../ToggleFilter';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import * as TestUtils from 'react-dom/test-utils';
+import { layerFilter, emptyLayerFilter }  from '../../../../test-resources/widgets/dependenciesToFiltersData';
+
+describe('Test Toggle filter', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('render component', () => {
+
+        const tf = ReactDOM.render(
+            <ToggleFilter node={layerFilter} propertiesChangeHandler={() => {}} />,
+            document.getElementById("container"));
+        expect(tf).toExist();
+        const tfNode = ReactDOM.findDOMNode(tf);
+        expect(tfNode.className.indexOf('toc-filter-icon') >= 0).toBe(true);
+    });
+
+    it('test cannot render component', () => {
+        const propertiesChangeHandler = {
+            callBack: () => {}
+        };
+        const tf = ReactDOM.render(<ToggleFilter  node={emptyLayerFilter} propertiesChangeHandler={propertiesChangeHandler.callBack} />,
+            document.getElementById("container"));
+
+        expect(tf).toExist();
+        const tfNode = ReactDOM.findDOMNode(tf);
+        expect(tfNode).toNotExist();
+    });
+
+    it('test click handler', () => {
+        const propertiesChangeHandler = {
+            callBack: () => {}
+        };
+        const propertiesChangeHandlerSpy = expect.spyOn(propertiesChangeHandler, 'callBack');
+        const tf = ReactDOM.render(
+            <ToggleFilter node={layerFilter}
+                propertiesChangeHandler={propertiesChangeHandler.callBack} />,
+            document.getElementById("container"));
+        expect(tf).toExist();
+
+        const tfNode = ReactDOM.findDOMNode(tf);
+        TestUtils.Simulate.click(tfNode);
+        expect(propertiesChangeHandlerSpy).toHaveBeenCalled();
+
+    });
+
+});

--- a/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
+++ b/web/client/components/widgets/enhancers/__tests__/dependenciesToFilter-test.jsx
@@ -18,6 +18,8 @@ import {
     spatialFilterMultiple,
     resultSpatialFilterMultiple,
     inputLayerFilterSTATENAME,
+    layerFilter,
+    emptyLayerFilter,
     resultFilterOnly,
     resultFilterObjRes1,
     resultMergeFilterRes,
@@ -25,10 +27,12 @@ import {
     resultQuickFilters,
     resultQuickFiltersAndDependenciesQF,
     resultQuickFiltersAndDependenciesFilter,
-    resultSpatialAndQuickFilters
+    resultSpatialAndQuickFilters,
+    resultLayerFilter
 } from '../../../../test-resources/widgets/dependenciesToFiltersData';
 
 describe('widgets dependenciesToFilter enhancer', () => {
+
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
         setTimeout(done);
@@ -164,6 +168,35 @@ describe('widgets dependenciesToFilter enhancer', () => {
                 }}],
                 viewport: { "bounds": { "minx": "-1", "miny": "-1", "maxx": "1", "maxy": "1" }, "crs": "EPSG:4326", "rotation": 0 }
             }} filter={inputFilterObjSpatial} />, document.getElementById("container"));
+
+    });
+
+    it('dependenciesToFilter with layerFilter', (done) => {
+
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.filter).toBe(resultLayerFilter);
+            expect(props.layer.layerFilter.disabled).toBe(false);
+            done();
+        }));
+        ReactDOM.render(<Sink
+            mapSync
+            layer={layerFilter}
+        />, document.getElementById("container"));
+
+    });
+
+    it('dependenciesToFilter with empty layerFilter', (done) => {
+
+        const Sink = dependenciesToFilter(createSink(props => {
+            expect(props).toExist();
+            expect(props.layer.layerFilter).toBe(undefined);
+            done();
+        }));
+        ReactDOM.render(<Sink
+            mapSync
+            layer={emptyLayerFilter}
+        />, document.getElementById("container"));
 
     });
 });

--- a/web/client/components/widgets/enhancers/dependenciesToFilter.js
+++ b/web/client/components/widgets/enhancers/dependenciesToFilter.js
@@ -54,7 +54,7 @@ export default compose(
             if (!mapSync) {
                 return {
                     filter: !isEmpty(newFilterObj) || layerFilter ? filter(and(
-                        ...(layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
+                        ...(layerFilter && !layerFilter.disabled ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
                         ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : [])
                     )) : undefined
                 };
@@ -81,7 +81,7 @@ export default compose(
                 return {
                     filter: filter(and(
                         ...cqlFilterRules,
-                        ...(layerFilter ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
+                        ...(layerFilter  && !layerFilter.disabled ? toOGCFilterParts(layerFilter, "1.1.0", "ogc") : []),
                         ...(newFilterObj ? toOGCFilterParts(newFilterObj, "1.1.0", "ogc") : []),
                         property(geomProp).intersects(geom)))
                 };

--- a/web/client/test-resources/widgets/dependenciesToFiltersData.js
+++ b/web/client/test-resources/widgets/dependenciesToFiltersData.js
@@ -99,6 +99,60 @@ export const inputLayerFilterSTATENAME = {
     hits: false
 };
 
+export const layerFilter = {
+    "layerFilter": {
+        "searchUrl": null,
+        "featureTypeConfigUrl": null,
+        "showGeneratedFilter": false,
+        "attributePanelExpanded": true,
+        "spatialPanelExpanded": true,
+        "crossLayerExpanded": true,
+        "showDetailsPanel": false,
+        "groupLevels": 5,
+        "useMapProjection": false,
+        "toolbarEnabled": true,
+        "groupFields": [
+            {
+                "id": 1,
+                "logic": "OR",
+                "index": 0
+            }
+        ],
+        "maxFeaturesWPS": 5,
+        "filterFields": [
+            {
+                "rowId": 1613414722261,
+                "groupId": 1,
+                "attribute": "STATE_NAME",
+                "operator": "=",
+                "value": "Arizona",
+                "type": "string",
+                "fieldOptions": {
+                    "valuesCount": 0,
+                    "currentPage": 1
+                },
+                "exception": null,
+                "loading": false,
+                "openAutocompleteMenu": false,
+                "options": {
+                    "STATE_NAME": []
+                }
+            }
+        ],
+        "spatialField": {
+            "method": null,
+            "operation": "INTERSECTS",
+            "geometry": null,
+            "attribute": "the_geom"
+        },
+        "simpleFilterFields": [],
+        "crossLayerFilter": null,
+        "autocompleteEnabled": true,
+        "disabled": false
+    }
+};
+
+export const emptyLayerFilter = {}
 /**
  * output data for filters
  */
@@ -145,3 +199,4 @@ export const resultSpatialFilterMultiple =
     + "</ogc:Intersects>"
     + "</ogc:Or></ogc:And></ogc:Filter>";
 
+export const resultLayerFilter = `<ogc:Filter><ogc:And><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>STATE_NAME</ogc:PropertyName><ogc:Literal>Arizona</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or></ogc:And></ogc:Filter>`;


### PR DESCRIPTION
## Description
If you generate a widget on the map starting from a layer (or from the featuregrid) where the layer has a filter saved, but disabled, the layer generates anyway the widget with the filter applied. Instead it should ignore the filter if the filter is disabled.

## How to reproduce
-  Add to the map a vector layer
- Create a filter for it
- disable de filter from the TOC
- create a chart from the layer in order to see if the filter is applied or not

*Expected Result*
- The filter is not applied to the results of the widget because the filter is disabled,

*Current Result*
- The filter is applied anyway to the widget's data.


- [x] Not browser related

<details><summary> <b>Browser info</b> </summary>
<!-- If browser related, please compile the following table -->
<!-- If your browser is not in the list please add a new row to the table with the version -->
(use this site: <a href="https://www.whatsmybrowser.org/">https://www.whatsmybrowser.org/</a> for non expert users)

| Browser Affected | Version |
|---|---|
|Internet Explorer| |
|Edge| |
|Chrome| |
|Firefox| |
|Safari| |
</details>

## Other useful information
<!-- error stack trace, screenshot, videos, or link to repository code are welcome -->
