### PR TITLE
[2021.01.xx backport] #6367 Save as button for story (#6544)

### DIFF
--- a/web/client/plugins/GeoStorySave.jsx
+++ b/web/client/plugins/GeoStorySave.jsx
@@ -88,7 +88,7 @@ export const GeoStorySave = createPlugin('GeoStorySave', {
                 isLoggedIn,
                 resourceSelector,
                 (loggedIn, {canEdit, id} = {}) => ({
-                    style: loggedIn && (!id || id && canEdit) ? {} : { display: "none" }// the resource is new (no resource) or if present, is editable
+                    style: loggedIn && (id && canEdit) ? {} : { display: "none" } // save is present only if the resource already exists and you can save
                 })
             ),
             position: 1,
@@ -123,8 +123,8 @@ export const GeoStorySaveAs = createPlugin('GeoStorySaveAs', {
             selector: createSelector(
                 isLoggedIn,
                 resourceSelector,
-                (loggedIn, {id} = {}) => ({
-                    style: loggedIn && id ? {} : { display: "none" }// save as is present only if the resource already exists and you can save
+                (loggedIn ) => ({
+                    style: loggedIn ? {} : { display: "none" } // the  resource is new (no resource) or if present, is editable
                 })
             ),
             position: 2,

--- a/web/client/plugins/__tests__/GeoStorySave-test.jsx
+++ b/web/client/plugins/__tests__/GeoStorySave-test.jsx
@@ -44,8 +44,8 @@ describe('GeoStorySave Plugins (GeoStorySave, GeoStorySaveAs)', () => {
             // check log-in logout properties selector for button in burger menu
             // hide when not logged in
             expect(containers.BurgerMenu.selector({ security: {} }).style.display).toBe("none");
-            // show when logged in
-            expect(containers.BurgerMenu.selector({security: {user: {}}}).style.display).toNotExist();
+            // hide when logged in if resource is not set
+            expect(containers.BurgerMenu.selector({security: {user: {}}}).style.display).toBe("none");
             // hide if you don't have permissions
             expect(containers.BurgerMenu.selector({ security: { user: {} }, geostory: { resource: { id: 1234, canEdit: false } } }).style.display ).toBe("none");
         });
@@ -79,8 +79,8 @@ describe('GeoStorySave Plugins (GeoStorySave, GeoStorySaveAs)', () => {
             // check log-in logout properties selector for button in burger menu
             // hide when not logged in
             expect(containers.BurgerMenu.selector({ security: {} }).style.display).toBe("none");
-            // hide when logged in if resource is not set
-            expect(containers.BurgerMenu.selector({ security: { user: {} } }).style.display).toBe("none");
+            // show when logged in
+            expect(containers.BurgerMenu.selector({ security: { user: {} } }).style.display).toNotExist();
             // show if resource is available for clone
             expect(containers.BurgerMenu.selector({
                 security: { user: {} },


### PR DESCRIPTION
## Description
<!-- Add here a few sentences describing the bug. -->
Saving a new story the button shows Save instead of Save as

## How to reproduce
<!-- A list of steps to reproduce the bug -->
- Open a new story
- Click on Burger Menu

*Expected Result*
<!-- Describe here the expected result  -->
Save button shows the word Save As

*Current Result*
<!-- Describe here the current behavior -->
Save button shows the word Save instead of Save As

- [x] Not browser related

<details><summary> <b>Browser info</b> </summary>
<!-- If browser related, please compile the following table -->
<!-- If your browser is not in the list please add a new row to the table with the version -->
(use this site: <a href="https://www.whatsmybrowser.org/">https://www.whatsmybrowser.org/</a> for non expert users)

| Browser Affected | Version |
|---|---|
|Internet Explorer| |
|Edge| |
|Chrome| |
|Firefox| |
|Safari| |
</details>

## Other useful information
<!-- error stack trace, screenshot, videos, or link to repository code are welcome -->
