### PR TITLE
#6569 Moved showMapInfoInPopup in app state to share with epics

### DIFF
--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -35,6 +35,9 @@ export const SET_CURRENT_EDIT_FEATURE_QUERY = 'IDENTIFY:CURRENT_EDIT_FEATURE_QUE
 export const SET_MAP_TRIGGER = 'IDENTIFY:SET_MAP_TRIGGER';
 
 export const TOGGLE_EMPTY_MESSAGE_GFI = "IDENTIFY:TOGGLE_EMPTY_MESSAGE_GFI";
+
+export const SET_SHOW_IN_MAP_POPUP = "IDENTIFY:SET_SHOW_IN_MAP_POPUP";
+
 export const toggleEmptyMessageGFI = () => ({type: TOGGLE_EMPTY_MESSAGE_GFI});
 
 /**
@@ -272,4 +275,13 @@ export const setCurrentEditFeatureQuery = (query) => ({
 export const setMapTrigger = (trigger) => ({
     type: SET_MAP_TRIGGER,
     trigger
+});
+
+/**
+ * Sets the 'showInMapPopup' value in the state.
+ * @param {boolean} value the value to set
+ */
+export const setShowInMapPopup = (value) => ({
+    type: SET_SHOW_IN_MAP_POPUP,
+    value
 });

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -69,9 +69,11 @@ export const identifyLifecycle = compose(
         componentDidMount() {
             const {
                 enabled,
+                showInMapPopup,
                 changeMousePointer = () => {},
                 disableCenterToMarker,
-                onEnableCenterToMarker = () => {}
+                onEnableCenterToMarker = () => {},
+                setShowInMapPopup = () => {}
             } = this.props;
 
             if (enabled) {
@@ -81,6 +83,7 @@ export const identifyLifecycle = compose(
             if (!disableCenterToMarker) {
                 onEnableCenterToMarker();
             }
+            setShowInMapPopup(showInMapPopup);
         },
         componentWillUnmount() {
             const {
@@ -105,6 +108,9 @@ export const identifyLifecycle = compose(
                 changeMousePointer('auto');
                 hideMarker();
                 purgeResults();
+            }
+            if (this.props.showInMapPopup !== newProps.showInMapPopup) {
+                newProps.setShowInMapPopup?.(newProps.showInMapPopup);
             }
         }
     })

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -22,6 +22,7 @@ import {
     changeMapInfoFormat,
     changePage,
     clearWarning,
+    setShowInMapPopup,
     closeIdentify,
     editLayerFeatures,
     hideMapinfoMarker,
@@ -84,7 +85,7 @@ const selector = createStructuredSelector({
     reverseGeocodeData: (state) => state.mapInfo && state.mapInfo.reverseGeocodeData,
     warning: (state) => state.mapInfo && state.mapInfo.warning,
     currentLocale: currentLocaleSelector,
-    dockStyle: state => mapLayoutValuesSelector(state, {height: true}),
+    dockStyle: state => mapLayoutValuesSelector(state, { height: true }),
     formatCoord: (state) => state.mapInfo && state.mapInfo.formatCoord || ConfigUtils.getConfigProp('defaultCoordinateFormat'),
     showCoordinateEditor: (state) => state.mapInfo && state.mapInfo.showCoordinateEditor,
     showEmptyMessageGFI: state => showEmptyMessageGFISelector(state),
@@ -99,7 +100,7 @@ const selector = createStructuredSelector({
  */
 const identifyIndex = compose(
     connect(
-        createSelector(indexSelector, isLoadedResponseSelector, (state) =>state.browser && state.browser.mobile, (index, loaded, isMobile) => ({ index, loaded, isMobile })),
+        createSelector(indexSelector, isLoadedResponseSelector, (state) => state.browser && state.browser.mobile, (index, loaded, isMobile) => ({ index, loaded, isMobile })),
         {
             setIndex: changePage
         }
@@ -109,7 +110,7 @@ const DefaultViewer = compose(
     identifyIndex,
     defaultViewerDefaultProps,
     defaultViewerHandlers,
-    loadingState(({loaded}) => isUndefined(loaded))
+    loadingState(({ loaded }) => isUndefined(loaded))
 )(DefaultViewerComp);
 
 
@@ -123,12 +124,12 @@ const identifyDefaultProps = defaultProps({
     responses: [],
     viewerOptions: {},
     viewer: DefaultViewer,
-    purgeResults: () => {},
-    hideMarker: () => {},
-    clearWarning: () => {},
-    changeMousePointer: () => {},
-    showRevGeocode: () => {},
-    hideRevGeocode: () => {},
+    purgeResults: () => { },
+    hideMarker: () => { },
+    clearWarning: () => { },
+    changeMousePointer: () => { },
+    showRevGeocode: () => { },
+    hideRevGeocode: () => { },
     containerProps: {
         continuous: false
     },
@@ -212,7 +213,6 @@ const identifyDefaultProps = defaultProps({
  * }
  *
  */
-
 const IdentifyPlugin = compose(
     connect(selector, {
         purgeResults: purgeMapInfoResults,
@@ -252,6 +252,9 @@ const IdentifyPlugin = compose(
     identifyDefaultProps,
     identifyIndex,
     defaultViewerHandlers,
+    connect(() => { }, {
+        setShowInMapPopup
+    }),
     identifyLifecycle
 )(IdentifyContainer);
 
@@ -275,8 +278,8 @@ export default {
             name: 'info',
             position: 6,
             tooltip: "info.tooltip",
-            icon: <Glyphicon glyph="map-marker"/>,
-            help: <Message msgId="helptexts.infoButton"/>,
+            icon: <Glyphicon glyph="map-marker" />,
+            help: <Message msgId="helptexts.infoButton" />,
             action: toggleMapInfoState,
             selector: (state) => ({
                 bsStyle: state.mapInfo && state.mapInfo.enabled ? "success" : "primary",
@@ -287,11 +290,11 @@ export default {
             tool: [<FeatureInfoFormatSelector
                 key="featureinfoformat"
                 label={<Message msgId="infoFormatLbl" />
-                }/>, <FeatureInfoTriggerSelector
+                } />, <FeatureInfoTriggerSelector
                 key="featureinfotrigger" />],
             position: 3
         }
     }),
-    reducers: {mapInfo},
+    reducers: { mapInfo },
     epics
 };

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -17,7 +17,8 @@ import {
     changeFormat,
     changePage,
     toggleHighlightFeature,
-    setMapTrigger
+    setMapTrigger,
+    setShowInMapPopup
 } from '../../actions/mapInfo';
 import {changeMapType} from '../../actions/maptype';
 
@@ -840,5 +841,11 @@ describe('Test the mapInfo reducer', () => {
         const initialState = {configuration: {trigger: "click"}};
         const state = mapInfo(initialState, action);
         expect(state.configuration.trigger).toBe("click");
+    });
+
+    it('setShowInMapPopup', () => {
+        const initialState = { configuration: {} };
+        const state = mapInfo(initialState, setShowInMapPopup(true));
+        expect(state.showInMapPopup).toBeTruthy();
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -30,7 +30,8 @@ import {
     CHANGE_FORMAT,
     TOGGLE_SHOW_COORD_EDITOR,
     SET_CURRENT_EDIT_FEATURE_QUERY,
-    SET_MAP_TRIGGER
+    SET_MAP_TRIGGER,
+    SET_SHOW_IN_MAP_POPUP
 } from '../actions/mapInfo';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -110,6 +111,7 @@ const initState = {
  * }
  * ```
  * @prop {object} configuration contains the configuration for getFeatureInfo tool.
+ * @prop {boolean} showInMapPopup if true, the results are always shown in a popup (if configuration.hover = true, they are by default)
  * @prop {array} requests the requests performed. Here a sample:
  * ```javascript
  * {
@@ -420,6 +422,12 @@ function mapInfo(state = initState, action) {
                 ...state.configuration,
                 trigger: action.trigger
             }
+        };
+    }
+    case SET_SHOW_IN_MAP_POPUP: {
+        return {
+            ...state,
+            showInMapPopup: action.value // this is global, actually not saved in map configuration (configuration part)
         };
     }
     case MAP_TYPE_CHANGED: {

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -16,6 +16,7 @@ import {
     generalInfoFormatSelector,
     stopGetFeatureInfoSelector,
     isMapInfoOpen,
+    isMapPopup,
     mapInfoConfigurationSelector,
     showEmptyMessageGFISelector,
     clickPointSelector,
@@ -356,5 +357,8 @@ describe('Test mapinfo selectors', () => {
         // when mapInfo is present
         expect(hoverEnabledSelector({maptype: {mapType: "openlayers"} })).toBe(true);
         expect(hoverEnabledSelector({maptype: {mapType: "cesium"} })).toBe(false);
+    });
+    it('isMapPopup', () => {
+        expect(isMapPopup({ mapInfo: {showInMapPopup: true} })).toBeTruthy();
     });
 });

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -14,7 +14,6 @@ import { isPluginInContext } from './context';
 import { currentLocaleSelector } from './locale';
 import {getValidator} from '../utils/MapInfoUtils';
 import { isCesium } from './maptype';
-import { pluginsSelectorCreator } from './localConfig';
 /**
  * selects mapinfo state
  * @name mapinfo
@@ -22,12 +21,10 @@ import { pluginsSelectorCreator } from './localConfig';
  * @static
  */
 
-export const isMapPopup =  createSelector(
-    (state) => pluginsSelectorCreator("desktop")(state) || {},
+export const isMapPopup = createSelector(
     isCesium,
-    (plugins, cesium) => {
-        return !cesium && !!((Object.values(plugins).filter(({name}) => name === "Identify").pop() || {}).cfg || {}).showInMapPopup;
-    }
+    state => !!state?.mapInfo?.showInMapPopup,
+    (cesium, showInMapPopup) => !cesium && showInMapPopup
 );
 /**
   * Get mapinfo requests from state


### PR DESCRIPTION
## Description
The selector of `mapInfoPopup` was getting the state for the original localConfig.json. To support contexts, all cfg must be in application state. In order to fix the bug I added the configuration to mapInfo reducer and sync with it.

Note: I didn't put this configuration in `configuration` section because this part is saved on maps. This configuration instead is intended to be context based. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6569

**What is the new behavior?**
Now it works in both use cases.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
