### PR TITLE
Fixed style for timeline range values

### DIFF
--- a/web/client/themes/default/less/timeline.less
+++ b/web/client/themes/default/less/timeline.less
@@ -386,18 +386,18 @@
                             border-color: fade(@ms2-color-primary, 50%);
                         }
                         &.vis-range {
-                            border-color: transparent;
-                            background-color: fade(@ms2-color-primary, 50%);
-                            .vis-item-content {
-                                padding: 0 5px;
-                                margin: 5px 0;
-                                background-color: fade(@ms2-color-primary, 50%);
-                                border-color: darken(@ms2-color-primary, 10%);
-                            }
-
-                            background-color: transparent;
-                            border-color: transparent;
                             &.histogram-item {
+                                border-color: transparent;
+                                background-color: fade(@ms2-color-primary, 50%);
+                                .vis-item-content {
+                                    padding: 0 5px;
+                                    margin: 5px 0;
+                                    background-color: fade(@ms2-color-primary, 50%);
+                                    border-color: darken(@ms2-color-primary, 10%);
+                                }
+
+                                background-color: transparent;
+                                border-color: transparent;
                                 &.vis-item {
                                     top: 0 !important; // override inline offset due to auto-set
                                 }


### PR DESCRIPTION
## Description
Time values interval or interval/resolutions in `dimensions` attribute is already partially supported. Anyway the style doesn't show them properly. 
```json
{
        "id": "mapstore:Meteorite_Landings_from_NASA_Open_Data_Portal__6",
        "format": "image/png8",
        "search": {
          "url": "https://gs-stable.geo-solutions.it/geoserver/wfs",
          "type": "wfs"
        },
        "name": "mapstore:Meteorite_Landings_from_NASA_Open_Data_Portal",
        "opacity": 1,
        "description": "Meteorite_Landings_from_NASA_Open_Data_Portal",
        "title": "Meteorite Landings from NASA Open Data Portal",
        "type": "wms",
        "url": "https://gs-stable.geo-solutions.it/geoserver/wms",
        "bbox": {
          "crs": "EPSG:4326",
          "bounds": {
            "minx": "-180.0",
            "miny": "-90.0",
            "maxx": "180.0",
            "maxy": "90.0"
          }
        },
        "visibility": true,
        "singleTile": true,
        "allowedSRS": {
          "EPSG:3857": true,
          "EPSG:900913": true
        },
        "dimensions": [
          {
            "values": [
              "1900-03-01T13:00:00Z/2007-03-01T13:00:00Z/P2M10DT2H30M",
              "1800-03-01T13:00:00Z/1890-03-01T13:00:00Z",
              "1820-03-01T13:00:00Z/1890-03-01T13:00:00Z"
            ],
            "name": "time"
          }
        ],
        "hideLoading": false,
        "handleClickOnLayer": false,
        "catalogURL": null,
        "useForElevation": false,
        "hidden": false,
        "params": {
          "time": "1982-01-01T00:00:00.000Z"
        }
      }
    ],
```
This PR restores the previous style, like this:
![image](https://user-images.githubusercontent.com/1279510/108984018-c2785900-768f-11eb-91a3-228447b08968.png)

TODO
- [ ] The style should and the app should support better overlaps (now normal intervals overlap as in the image above, they should instead show a small line (same height and color of the single time value point). While interval resolution should not show decimal values.
- [ ] The ideal condition with many values is to show anyway a locally generated histogram, in any case, when more than n-values are present. Evaluate feasability.