### PR TITLE
make endianess configurable for the elevation layer

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -266,6 +266,7 @@ in `localConfig.json`
             "format": "application/bil16",
             ...
             "name": "elevation",
+            "littleendian": false,
             "visibility": true,
             "useForElevation": true
         }]

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -127,6 +127,7 @@ function wmsToCesiumOptionsBIL(options) {
     }
     return assign({
         url,
+        littleEndian: options.littleendian || false,
         layerName: options.name
     });
 }

--- a/web/client/components/map/leaflet/plugins/WMSLayer.js
+++ b/web/client/components/map/leaflet/plugins/WMSLayer.js
@@ -110,9 +110,10 @@ L.tileLayer.multipleUrlWMS = function(urls, options) {
 
 
 L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
-    initialize: function(urls, options, nodata) {
+    initialize: function(urls, options, nodata, littleendian) {
         this._tiles = {};
         this._nodata = nodata;
+        this._littleendian = littleendian;
         L.TileLayer.MultipleUrlWMS.prototype.initialize.apply(this, arguments);
     },
     _addTile: function(coords) {
@@ -124,7 +125,8 @@ L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
         try {
             const tilePoint = this._getTileFromCoords(latLng);
             const elevation = getElevation(this._tileCoordsToKey(tilePoint),
-                this._getTileRelativePixel(tilePoint, containerPoint), this.getTileSize().x, this._nodata);
+                this._getTileRelativePixel(tilePoint, containerPoint), this.getTileSize().x,
+                this._nodata, this._littleendian);
             if (elevation.available) {
                 return elevation.value;
             }
@@ -146,8 +148,8 @@ L.TileLayer.ElevationWMS = L.TileLayer.MultipleUrlWMS.extend({
     _abortLoading: function() {}
 });
 
-L.tileLayer.elevationWMS = function(urls, options, nodata) {
-    return new L.TileLayer.ElevationWMS(urls, options, nodata);
+L.tileLayer.elevationWMS = function(urls, options, nodata, littleendian) {
+    return new L.TileLayer.ElevationWMS(urls, options, nodata, littleendian);
 };
 
 const removeNulls = (obj = {}) => {
@@ -192,7 +194,7 @@ Layers.registerType('wms', {
         const queryParameters = removeNulls(wmsToLeafletOptions(options) || {});
         urls.forEach(url => addAuthenticationParameter(url, queryParameters, options.securityToken));
         if (options.useForElevation) {
-            return L.tileLayer.elevationWMS(urls, queryParameters, options.nodata || -9999);
+            return L.tileLayer.elevationWMS(urls, queryParameters, options.nodata || -9999, options.littleendian || false);
         }
         if (options.singleTile) {
             return L.nonTiledLayer.wmsCustom(urls[0], queryParameters);

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -162,7 +162,7 @@ function getElevation(pos) {
     try {
         const tilePoint = getTileFromCoords(this, pos);
         const tileSize = this.getSource().getTileGrid().getTileSize();
-        const elevation = getElevationFunc(tileCoordsToKey(tilePoint), getTileRelativePixel(this, pos, tilePoint), tileSize, this.get('nodata'));
+        const elevation = getElevationFunc(tileCoordsToKey(tilePoint), getTileRelativePixel(this, pos, tilePoint), tileSize, this.get('nodata'), this.get('littleEndian'));
         if (elevation.available) {
             return elevation.value;
         }
@@ -251,6 +251,7 @@ const createLayer = (options, map) => {
     }
     if (options.useForElevation) {
         layer.set('nodata', options.nodata);
+        layer.set('littleEndian', options.littleendian ?? false);
         layer.set('getElevation', getElevation.bind(layer));
     }
     return layer;

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -176,6 +176,7 @@ import pluginsCreator from "./map/index";
  *         "format": "application/bil16",
  *         "useForElevation": true,
  *         "nodata": -9999,
+ *         "littleendian": false,
  *         "hidden": true
  *      }]
  *   }

--- a/web/client/utils/ElevationUtils.js
+++ b/web/client/utils/ElevationUtils.js
@@ -31,10 +31,10 @@ const addErroredElevationTile = (error, coords, key) => {
     });
 };
 
-const getValueAtXY = (ncols, tile, x, y, nodata = -9999) => {
+const getValueAtXY = (ncols, tile, x, y, nodata = -9999, littleendian = false) => {
     const index = (y * ncols) + x;
     try {
-        const result = tile.dataView.getInt16(index * 2, false);
+        const result = tile.dataView.getInt16(index * 2, littleendian);
         if (result !== nodata && result !== 32767 && result !== -32768) {
             return result;
         }
@@ -77,17 +77,18 @@ export const loadTile = (url, coords, key) => {
  * @param tilePixelPosition a pixel position inside the tile (x, y)
  * @param tileSize in pixels (e.g. 256)
  * @param nodata value to be used for nodata (no elevation available)
+ * @param littleendian whether or not the BIL data is in little endian or big endian
  * @returns an object with the following properties:
  *   * available: true / false
  *   * value: elevation value if available is true
  *   * message: an error message if available is false
  */
-export const getElevation = (key, tilePixelPosition, tileSize, nodata = -9999) => {
+export const getElevation = (key, tilePixelPosition, tileSize, nodata = -9999, littleendian = false) => {
     const tile = elevationTiles.get(key);
     if (tile && tile.status === "success") {
         return {
             available: true,
-            value: getValueAtXY(tileSize, tile, tilePixelPosition.x, tilePixelPosition.y, nodata)
+            value: getValueAtXY(tileSize, tile, tilePixelPosition.x, tilePixelPosition.y, nodata, littleendian)
         };
     } else if (tile && tile.status === "loading") {
         return {


### PR DESCRIPTION
cf georchestra/mapstore2-georchestra#331 for the rationale

## Description
the idea is to be able to configure the endianess of the BIL data sent by the WMS server - this way the client code knows how to decode it.

I've successfully tested this with a DEM layer coming from mapserver, which seems to encode BIL as little-endian, with no way to configure it. Should be easily testable with a geoserver layer configured to serve BIL as little endian too. I've also tested it with a geoserver layer in BE mode, still works.


tested both with `MousePosition` and the cesium 3d view, but more testing is welcome !

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
georchestra/mapstore2-georchestra#331

**What is the new behavior?**
Ability to use a DEM layer provided as little-endian BIL.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

No breaking change, as if not defined `littleendian` defaults to `false`, eg the current behaviour.

## Other useful information
