### PR TITLE
Measure additional check when overriding default state

### DIFF
--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -216,7 +216,7 @@ describe('Test the measurement reducer', () => {
         expect(state.exportToAnnotation).toBe(false);
         expect(state.currentFeature).toBe(0);
     });
-    it('CHANGED_GEOMETRY', () => {
+    it('CHANGED_GEOMETRY - do not fail if features array is missing in the initial state', () => {
         let state = measurement({
             updatedByUI: true,
             isDrawing: true

--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -79,6 +79,7 @@ describe('Test the measurement reducer', () => {
         expect(state.areaMeasureEnabled).toBe(false);
         expect(state.bearingMeasureEnabled).toBe(false);
         expect(state.geomType).toEqual("");
+        expect(state.features).toEqual([]);
     });
     it('INIT', () => {
         let state = measurement( {feature: {}}, init({showAddAsAnnotation: true}));
@@ -213,6 +214,17 @@ describe('Test the measurement reducer', () => {
         expect(state.isDrawing).toBe(false);
         expect(state.isDrawing).toBe(false);
         expect(state.exportToAnnotation).toBe(false);
+        expect(state.currentFeature).toBe(0);
+    });
+    it('CHANGED_GEOMETRY', () => {
+        let state = measurement({
+            updatedByUI: true,
+            isDrawing: true
+        }, changeGeometry([]));
+        expect(state.features).toEqual([]);
+        expect(state.updatedByUI).toBe(false);
+        expect(state.isDrawing).toBe(false);
+        expect(state.isDrawing).toBe(false);
         expect(state.currentFeature).toBe(0);
     });
 });

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -132,9 +132,9 @@ function measurement(state = defaultState, action) {
         });
     }
     case CHANGED_GEOMETRY: {
-        let {features} = action;
+        let {features = []} = action;
         const geomTypeSelected = getGeomTypeSelected(features);
-        const currentFeature = state.features.length === features.length ? state.currentFeature : features.length - 1;
+        const currentFeature = state.features?.length === features.length ? state.currentFeature : features.length ? features.length - 1 : 0;
         return {
             ...state,
             features,
@@ -231,7 +231,8 @@ function measurement(state = defaultState, action) {
             feature: { properties: {
                 disabled: true
             }},
-            geomType: ""
+            geomType: "",
+            features: []
         };
     }
     case CHANGE_FORMAT: {


### PR DESCRIPTION
## Description
This PR adds additional check when default features props is missing

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/austrocontrol-C125/issues/272

**What is the new behavior?**
When project overrides the default state via localconfig, in this case measurement, the features props is missed which causes issue when drawing. Instead of adding the missing props via the project's localconfig, a additional check is implemented

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
