### PR TITLE
[Backport 2021.01.xx]  #6528 fix polygon external internal (#6554)

### DIFF
--- a/web/client/utils/ogc/GML/index.js
+++ b/web/client/utils/ogc/GML/index.js
@@ -41,7 +41,7 @@ const polygonElement = (coordinates, srsName, version) => {
             return coordinate[0] + (gml2 ? "," : " ") + coordinate[1];
         });
         const exterior = (gml2 ? "outerBoundaryIs" : "exterior");
-        const interior = (gml2 ? "innerBoundaryIs" : "exterior");
+        const interior = (gml2 ? "innerBoundaryIs" : "interior");
         gmlPolygon +=
             (index < 1 ? '<gml:' + exterior + '>' : '<gml:' + interior + '>') +
                     '<gml:LinearRing>' +

--- a/web/client/utils/ogc/__tests__/GML-test.js
+++ b/web/client/utils/ogc/__tests__/GML-test.js
@@ -7,8 +7,9 @@
  */
 
 const expect = require('expect');
-const {processOGCGeometry} = require('../GML');
+const {processOGCGeometry, polygonElement} = require('../GML');
 const V1_1_0 = "1.1.0";
+const srsName = "EPSG:3857";
 const point = {"type": "Point", "coordinates": [100.0, 0.0] };
 const lineString = { "type": "LineString",
     "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]
@@ -17,6 +18,12 @@ const polygon = {
     "type": "Polygon",
     "coordinates": [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]]
 };
+
+const polygonExternalInternal = {
+    "type": "Polygon",
+    "coordinates": [[[-13837894.938769765, 6152246.765038833], [-13870573.06472578, 5167186.555807996], [-13885246.404215768, 5141882.531585468], [-13060956.58557037, 3836666.5247580605], [-10834726.501826838, 2986698.362005187], [-10494170.270500567, 3494875.037811458], [-9336249.138400448, 3489971.447318631], [-8715477.041201625, 4086300.4560303073], [-8433239.847950352, 4713623.15121573], [-7624933.488392262, 5936526.215342932], [-9247909.64555257, 5111113.43704269], [-10569782.887260191, 6277905.950416091], [-13822622.687463861, 6276333.806899306]], [[-13082405.114977926, 5738510.996205103], [-12975574.219813585, 4728558.514625181], [-11716961.038662285, 4179094.355509075], [-9922209.486299047, 4394852.33719347], [-9935385.546249239, 5499208.293757439]]]
+};
+
 const multiPolygon = {
     "type": "MultiPolygon",
     "coordinates": [
@@ -73,14 +80,27 @@ const EXPECTED_RESULTS = {
                                         + '<gml:posList>100 0 101 0 101 1 100 1 100 0</gml:posList>'
                                     + '</gml:LinearRing>'
                                 + '</gml:exterior>'
-                                + '<gml:exterior>'
+                                + '<gml:interior>'
                                     + '<gml:LinearRing>'
                                         + '<gml:posList>100.2 0.2 100.8 0.2 100.8 0.8 100.2 0.8 100.2 0.2</gml:posList>'
                                     + '</gml:LinearRing>'
-                                + '</gml:exterior>'
+                                + '</gml:interior>'
                             + '</gml:Polygon>'
                         + '</gml:polygonMember>'
-                    + '</gml:MultiPolygon>'
+                    + '</gml:MultiPolygon>',
+        exteriorInterior: '<gml:Polygon srsName="EPSG:3857">'
+                            + '<gml:exterior>'
+                            +    '<gml:LinearRing>'
+                            +        '<gml:posList>-13837894.938769765 6152246.765038833 -13870573.06472578 5167186.555807996 -13885246.404215768 5141882.531585468 -13060956.58557037 3836666.5247580605 -10834726.501826838 2986698.362005187 -10494170.270500567 3494875.037811458 -9336249.138400448 3489971.447318631 -8715477.041201625 4086300.4560303073 -8433239.847950352 4713623.15121573 -7624933.488392262 5936526.215342932 -9247909.64555257 5111113.43704269 -10569782.887260191 6277905.950416091 -13822622.687463861 6276333.806899306 -13837894.938769765 6152246.765038833</gml:posList>'
+                            +    '</gml:LinearRing>'
+                            + '</gml:exterior>'
+                            + '<gml:interior>'
+                            +    '<gml:LinearRing>'
+                            +        '<gml:posList>-13082405.114977926 5738510.996205103 -12975574.219813585 4728558.514625181 -11716961.038662285 4179094.355509075 -9922209.486299047 4394852.33719347 -9935385.546249239 5499208.293757439 -13082405.114977926 5738510.996205103</gml:posList>'
+                            +    '</gml:LinearRing>'
+                            + '</gml:interior>'
+                        + '</gml:Polygon>'
+
     }
 };
 describe('Test GeoJSON/GML geometry conversion', () => {
@@ -104,5 +124,10 @@ describe('Test GeoJSON/GML geometry conversion', () => {
     it('MultiPolygon to GML 1.1.0', () => {
         const gmlMultiPolygon = processOGCGeometry(V1_1_0, multiPolygon);
         expect(gmlMultiPolygon).toBe(EXPECTED_RESULTS.V1_1_0.multiPolygon);
+    });
+
+    it('Polygon with holes to GML external internal', () => {
+        const gmlMultiPolygon = polygonElement(polygonExternalInternal.coordinates, srsName, V1_1_0);
+        expect(gmlMultiPolygon).toBe(EXPECTED_RESULTS.V1_1_0.exteriorInterior);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6528
uncorrect gml

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Valid gml
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
How to test:
Please upload this file in map (before unzip it):
[map.json.zip](https://github.com/geosolutions-it/MapStore2/files/6011097/map.json.zip)

you have see the US layer with a hole, open the TOC:

- click on US layer
- open table data grid 

these states: 

- Kansas
- Nebraska
- Wyoming
- Colorado

must be missing in the table




 


