### PR TITLE
6592: Compare tool Problem

### DIFF
--- a/web/client/components/map/openlayers/swipe/EffectSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/EffectSupport.jsx
@@ -26,7 +26,7 @@ const circleCut = (layer, circleCutPrecomposeCallback, postcomposeCallback) => {
 const EffectSupport = ({ map, layer: layerId, type, getWidth, getHeight, circleCutProp }) => {
     const verticalCutPrecomposeCallback = useCallback((event) => {
         let ctx = event.context;
-        const width = getWidth();
+        const width = getWidth() * map.pixelRatio_;
         ctx.save();
         ctx.beginPath();
         ctx.rect(width, 0, ctx.canvas.width - width, ctx.canvas.height);

--- a/web/client/components/map/openlayers/swipe/EffectSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/EffectSupport.jsx
@@ -41,7 +41,7 @@ const EffectSupport = ({ map, layer: layerId, type, getWidth, getHeight, circleC
 
     const horizontalCutPrecomposeCallback = useCallback((event) => {
         let ctx = event.context;
-        const height = getHeight();
+        const height = getHeight() * map.pixelRatio_;
         ctx.save();
         ctx.beginPath();
         ctx.rect(0, height, ctx.canvas.width, ctx.canvas.height - height);

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -36,7 +36,13 @@ const VSlider = ({ type, map, widthRef }) => {
     }, [ type ]);
 
     useEffect(() => {
-        widthRef.current = map.getProperties().size[0] / 2;
+        const callback = (event) => {
+            let ctx = event.context;
+            widthRef.current = ctx.canvas.width / 2;
+            map.un('precompose', callback);
+        };
+        map.on('precompose', callback);
+        return () => map.un('precompose', callback);
     }, [ type ]);
 
     return (
@@ -95,7 +101,13 @@ const HSlider = ({ type, map, heightRef }) => {
     }, [ type ]);
 
     useEffect(() => {
-        heightRef.current = map.getProperties().size[1] / 2;
+        const callback = event => {
+            let ctx = event.context;
+            heightRef.current = ctx.canvas.height / 2;
+            map.un('precompose', callback);
+        };
+        map.on('precompose', callback);
+        return () => map.un('precompose', callback);
     }, [ type ]);
 
     return (<Draggable

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -36,13 +36,7 @@ const VSlider = ({ type, map, widthRef }) => {
     }, [ type ]);
 
     useEffect(() => {
-        const callback = (event) => {
-            let ctx = event.context;
-            widthRef.current = ctx.canvas.width / 2;
-            map.un('precompose', callback);
-        };
-        map.on('precompose', callback);
-        return () => map.un('precompose', callback);
+        widthRef.current = map.getProperties().size[0] / 2;
     }, [ type ]);
 
     return (
@@ -84,11 +78,11 @@ const HSlider = ({ type, map, heightRef }) => {
 
     const onWindowResize = () => {
         setPos({x: 0, y: 0});
-        heightRef.current = map.getProperties().size[1] / 2;
+        heightRef.current = map.getProperties().size[1];
     };
 
     const onDragHorizontalHandler = (e, ui) => {
-        heightRef.current += ui.deltaY;
+        heightRef.current += ui.deltaY * map.pixelRatio_;
         setPos({x: ui.x, y: ui.y});
         map.render();
     };
@@ -101,13 +95,7 @@ const HSlider = ({ type, map, heightRef }) => {
     }, [ type ]);
 
     useEffect(() => {
-        const callback = event => {
-            let ctx = event.context;
-            heightRef.current = ctx.canvas.height / 2;
-            map.un('precompose', callback);
-        };
-        map.on('precompose', callback);
-        return () => map.un('precompose', callback);
+        heightRef.current = map.getProperties().size[1];
     }, [ type ]);
 
     return (<Draggable
@@ -118,7 +106,7 @@ const HSlider = ({ type, map, heightRef }) => {
         onStop={() => setShowArrows(true)}>
         <div className="mapstore-swipe-slider" style={{
             height: "8px",
-            top: `${map.getProperties().size[1] / 2}px`,
+            top: `${map.getProperties().size[1] / map.pixelRatio_}px`,
             left: "0px",
             width: '100%',
             cursor: "row-resize"

--- a/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/SliderSwipeSupport.jsx
@@ -78,11 +78,11 @@ const HSlider = ({ type, map, heightRef }) => {
 
     const onWindowResize = () => {
         setPos({x: 0, y: 0});
-        heightRef.current = map.getProperties().size[1];
+        heightRef.current = map.getProperties().size[1] / 2;
     };
 
     const onDragHorizontalHandler = (e, ui) => {
-        heightRef.current += ui.deltaY * map.pixelRatio_;
+        heightRef.current += ui.deltaY;
         setPos({x: ui.x, y: ui.y});
         map.render();
     };
@@ -95,7 +95,7 @@ const HSlider = ({ type, map, heightRef }) => {
     }, [ type ]);
 
     useEffect(() => {
-        heightRef.current = map.getProperties().size[1];
+        heightRef.current = map.getProperties().size[1] / 2;
     }, [ type ]);
 
     return (<Draggable
@@ -106,7 +106,7 @@ const HSlider = ({ type, map, heightRef }) => {
         onStop={() => setShowArrows(true)}>
         <div className="mapstore-swipe-slider" style={{
             height: "8px",
-            top: `${map.getProperties().size[1] / map.pixelRatio_}px`,
+            top: `${map.getProperties().size[1] / 2}px`,
             left: "0px",
             width: '100%',
             cursor: "row-resize"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

#6592 

**What is the current behavior?**
The default vertical and horizontal heights are not in inline with the slider and swipe height 
The slider map content and the swiper are not synced
#6592 

**What is the new behavior?**
The default vertical and horizontal heights are in inline with the slider and swipe height 

<!-- Describe here the new behavior based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
