### PR TITLE
[BackReport 2021.01.xx]: Not proper validation for HTML FeatureInfo response.

### DIFF
--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -32,7 +32,7 @@ const regexpBody = /^[\s\S]*<body[^>]*>([\s\S]*)<\/body>[\s\S]*$/i;
 const regexpStyle = /(<style[\s\=\w\/\"]*>[^<]*<\/style>)/i;
 
 export function parseHTMLResponse(res) {
-    if ( typeof res.response === "string" && res.response.indexOf("<?xml") !== 0 ) {
+    if ( typeof res.response === "string") {
         let match = res.response.match(regexpBody);
         if ( res.layerMetadata && res.layerMetadata.regex ) {
             return match && match[1] && match[1].match(res.layerMetadata.regex);

--- a/web/client/utils/__tests__/FeatureInfoUtils-test.js
+++ b/web/client/utils/__tests__/FeatureInfoUtils-test.js
@@ -67,6 +67,34 @@ describe('FeatureInfoUtils', () => {
 
     });
 
+    it('HTML valid html contained in xml',  () => {
+        const htmlInXML =  '<?xml version="1.0" encoding="ISO-8859-1"?>' + rowHTML;
+        const validResults = Validator.HTML.getValidResponses([{response: htmlInXML}]);
+        expect(validResults.length).toBe(1);
+    });
+
+    it("HTML should return invalid if html is not valid", () => {
+        const inValidXML = `<?xml version='1.0' encoding="ISO-8859-1"  standalone="no" ?>
+        <ServiceExceptionReport version="1.1.1">
+          <ServiceException code="InvalidFormat">
+            <![CDATA[
+            Parámetros erroneos:
+            formato = image/png
+            XMin = -412208.172942018
+            YMin =  4928258.28942967
+            XMax = -411725.664200968
+            YMax =  4928740.79817072
+            AnchoPixels =  101
+            AltoPixels =  101
+            Transparente = No
+            Descripción error:
+            layers (AD.ADDRESSA) No soportada.]]>
+           </ServiceException>
+        </ServiceExceptionReport>`;
+        const validResults = Validator.HTML.getNoValidResponses([{response: inValidXML}]);
+        expect(validResults.length).toBe(1);
+    });
+
     // **********************************
     // TEXT
     // **********************************


### PR DESCRIPTION
(cherry picked from commit 16b379e08fd1a43a5232bfe6b54843eae867885d)

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

#6539 

**What is the current behavior?**
MapStore tells "No feature found for any result.

#<issue>

**What is the new behavior?**
If the service replies with a valid HTML MapStore shows the HTML


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
I added a check response includes <xml> since the xml reponse can contain html. So with this the second check for `regexpBody` will verify if reponse contains html body