### PR TITLE
[Backport 2021.01.xx] #6589 - Measure draw fail fix when overriding default state #6600

### DIFF
--- a/web/client/reducers/__tests__/measurement-test.js
+++ b/web/client/reducers/__tests__/measurement-test.js
@@ -79,6 +79,7 @@ describe('Test the measurement reducer', () => {
         expect(state.areaMeasureEnabled).toBe(false);
         expect(state.bearingMeasureEnabled).toBe(false);
         expect(state.geomType).toEqual("");
+        expect(state.features).toEqual([]);
     });
     it('INIT', () => {
         let state = measurement( {feature: {}}, init({showAddAsAnnotation: true}));
@@ -213,6 +214,17 @@ describe('Test the measurement reducer', () => {
         expect(state.isDrawing).toBe(false);
         expect(state.isDrawing).toBe(false);
         expect(state.exportToAnnotation).toBe(false);
+        expect(state.currentFeature).toBe(0);
+    });
+    it('CHANGED_GEOMETRY - do not fail if features array is missing in the initial state', () => {
+        let state = measurement({
+            updatedByUI: true,
+            isDrawing: true
+        }, changeGeometry([]));
+        expect(state.features).toEqual([]);
+        expect(state.updatedByUI).toBe(false);
+        expect(state.isDrawing).toBe(false);
+        expect(state.isDrawing).toBe(false);
         expect(state.currentFeature).toBe(0);
     });
 });

--- a/web/client/reducers/measurement.js
+++ b/web/client/reducers/measurement.js
@@ -132,9 +132,9 @@ function measurement(state = defaultState, action) {
         });
     }
     case CHANGED_GEOMETRY: {
-        let {features} = action;
+        let {features = []} = action;
         const geomTypeSelected = getGeomTypeSelected(features);
-        const currentFeature = state.features.length === features.length ? state.currentFeature : features.length - 1;
+        const currentFeature = state.features?.length === features.length ? state.currentFeature : features.length ? features.length - 1 : 0;
         return {
             ...state,
             features,
@@ -231,7 +231,8 @@ function measurement(state = defaultState, action) {
             feature: { properties: {
                 disabled: true
             }},
-            geomType: ""
+            geomType: "",
+            features: []
         };
     }
     case CHANGE_FORMAT: {


### PR DESCRIPTION
[Backport 2021.01.xx] #6589 - Measure draw fail fix when overriding default state #6600