### PR TITLE
#6522 - Fetch formats of the service for use in layer settings

### DIFF
--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -69,7 +69,13 @@ import {
     CHANGE_METADATA_TEMPLATE,
     changeMetadataTemplate,
     SET_LOADING,
-    recordsNotFound
+    recordsNotFound,
+    FORMAT_OPTIONS_FETCH,
+    formatOptionsFetch,
+    FORMAT_OPTIONS_LOADING,
+    formatsLoading,
+    SET_FORMAT_OPTIONS,
+    setSupportedFormats
 } from '../catalog';
 
 import { CHANGE_LAYER_PROPERTIES, ADD_LAYER } from '../layers';
@@ -375,5 +381,22 @@ describe('Test correctness of the catalog actions', () => {
         expect(action.type).toBe(SHOW_NOTIFICATION);
         expect(action.message).toBe("catalog.notification.errorSearchingRecords");
         expect(action.values).toEqual({ records: "topp:states , topp:states-tasmania" });
+    });
+    it('test formatOptionsFetch', () => {
+        const action = formatOptionsFetch(url);
+        expect(action.type).toBe(FORMAT_OPTIONS_FETCH);
+        expect(action.url).toBe(url);
+    });
+    it('test formatsLoading', () => {
+        const action = formatsLoading(false);
+        expect(action.type).toBe(FORMAT_OPTIONS_LOADING);
+        expect(action.loading).toBe(false);
+    });
+    it('test setSupportedFormats', () => {
+        const formats = {imageFormats: ["image/png"], infoFormats: ["text/plain"]};
+        const action = setSupportedFormats(formats, url);
+        expect(action.type).toBe(SET_FORMAT_OPTIONS);
+        expect(action.formats).toEqual(formats);
+        expect(action.url).toEqual(url);
     });
 });

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -58,6 +58,9 @@ export const SET_LOADING = 'CATALOG:SET_LOADING';
 export const TOGGLE_TEMPLATE = 'CATALOG:TOGGLE_TEMPLATE';
 export const TOGGLE_THUMBNAIL = 'CATALOG:TOGGLE_THUMBNAIL';
 export const TOGGLE_ADVANCED_SETTINGS = 'CATALOG:TOGGLE_ADVANCED_SETTINGS';
+export const FORMAT_OPTIONS_FETCH = 'CATALOG:FORMAT_OPTIONS_FETCH';
+export const FORMAT_OPTIONS_LOADING = 'CATALOG:FORMAT_OPTIONS_LOADING';
+export const SET_FORMAT_OPTIONS = 'CATALOG:SET_FORMAT_OPTIONS';
 
 /**
  * Adds a list of layers from the given catalogs to the map
@@ -308,6 +311,9 @@ export const changeMetadataTemplate = (metadataTemplate) => ({type: CHANGE_METAD
 export const toggleAdvancedSettings = () => ({type: TOGGLE_ADVANCED_SETTINGS});
 export const toggleTemplate = () => ({type: TOGGLE_TEMPLATE});
 export const toggleThumbnail = () => ({type: TOGGLE_THUMBNAIL});
+export const formatOptionsFetch = (url) => ({type: FORMAT_OPTIONS_FETCH, url});
+export const formatsLoading = (loading) => ({type: FORMAT_OPTIONS_LOADING, loading});
+export const setSupportedFormats = (formats, url) => ({type: SET_FORMAT_OPTIONS, formats, url});
 
 import {error} from './notifications';
 

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -12,6 +12,8 @@ import PropTypes from 'prop-types';
 import Accordion from '../../../misc/panels/Accordion';
 import { Glyphicon } from 'react-bootstrap';
 import Message from '../../../I18N/Message';
+import includes from 'lodash/includes';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Component for rendering FeatureInfo an Accordion with current available format for get feature info
@@ -57,7 +59,7 @@ export default class extends React.Component {
 
     render() {
         // the selected value if missing on that layer should be set to the general info format value and not the first one.
-        const data = this.getInfoFormat(this.props.defaultInfoFormat);
+        const data = this.getInfoFormat(this.supportedInfoFormats());
         return (
             <span>
                 <Accordion
@@ -74,5 +76,15 @@ export default class extends React.Component {
                     }}/>
             </span>
         );
+    }
+
+    supportedInfoFormats = () => {
+        const availableInfoFormats =  this.props.element?.infoFormats || [];
+        const infoFormats = Object.assign({},
+            ...Object.entries(this.props.defaultInfoFormat)
+                .filter(([, value])=> includes(availableInfoFormats, value))
+                .map(([key, value])=> ({[key]: value}))
+        );
+        return isEmpty(infoFormats) ? this.props.defaultInfoFormat : infoFormats;
     }
 }

--- a/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
+++ b/web/client/components/TOC/fragments/settings/FeatureInfo.jsx
@@ -78,6 +78,11 @@ export default class extends React.Component {
         );
     }
 
+    /**
+     * Fetch the supported formats from the layer props if present
+     * else use the default info format
+     * @return {object} info formats
+     */
     supportedInfoFormats = () => {
         const availableInfoFormats =  this.props.element?.infoFormats || [];
         const infoFormats = Object.assign({},

--- a/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/FeatureInfo-test.jsx
@@ -77,4 +77,10 @@ describe("test FeatureInfo", () => {
         expect(sideCards.length).toBe(4);
         TestUtils.Simulate.click(sideCards[0]);
     });
+
+    it('test rendering with supported infoFormats from layer props', () => {
+        ReactDOM.render(<FeatureInfo element={{infoFormats: ["text/html", "text/plain"]}} formatCards={formatCards} defaultInfoFormat={defaultInfoFormat} />, document.getElementById("container"));
+        const testComponent = document.getElementsByClassName('test-preview');
+        expect(testComponent.length).toBe(2);
+    });
 });

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -30,6 +30,7 @@ import { getMessageById } from '../../utils/LocaleUtils';
 import Message from '../I18N/Message';
 import RecordGrid from './RecordGrid';
 import Loader from '../misc/Loader';
+import { DEFAULT_FORMAT_WMS, getUniqueInfoFormats } from "../../utils/CatalogUtils";
 
 class Catalog extends React.Component {
     static propTypes = {
@@ -78,7 +79,9 @@ class Catalog extends React.Component {
         layers: PropTypes.array,
         clearModal: PropTypes.func,
         formatOptions: PropTypes.array,
-        layerBaseConfig: PropTypes.object
+        infoFormatOptions: PropTypes.array,
+        layerBaseConfig: PropTypes.object,
+        service: PropTypes.object
     };
 
     static contextTypes = {
@@ -112,24 +115,10 @@ class Catalog extends React.Component {
         services: {},
         wrapOptions: false,
         zoomToLayer: true,
-        formatOptions: [{
-            label: 'image/png',
-            value: 'image/png'
-        }, {
-            label: 'image/png8',
-            value: 'image/png8'
-        }, {
-            label: 'image/jpeg',
-            value: 'image/jpeg'
-        }, {
-            label: 'image/vnd.jpeg-png',
-            value: 'image/vnd.jpeg-png'
-        }, {
-            label: 'image/gif',
-            value: 'image/gif'
-        }],
+        formatOptions: DEFAULT_FORMAT_WMS,
         layerBaseConfig: {},
-        crs: "EPSG:3857"
+        crs: "EPSG:3857",
+        service: {}
     };
 
     state = {
@@ -279,7 +268,8 @@ class Catalog extends React.Component {
                 hideExpand={this.props.hideExpand}
                 onAddBackground={this.props.onAddBackground}
                 defaultFormat={this.props.services[this.props.selectedService] && this.props.services[this.props.selectedService].format}
-                formatOptions={this.props.formatOptions}
+                formatOptions={this.props.services[this.props.selectedService]?.url === this.props.service?.url ? this.props.formatOptions : DEFAULT_FORMAT_WMS}
+                infoFormatOptions={this.props.services[this.props.selectedService]?.url === this.props.service?.url ? this.props.infoFormatOptions : getUniqueInfoFormats()}
                 layerBaseConfig={this.props.layerBaseConfig}
                 onAdd={() => {
                     this.search({ services: this.props.services, selectedService: this.props.selectedService });

--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -46,10 +46,12 @@ export default ({
     onAddService = () => {},
     onDeleteService = () => {},
     onChangeCatalogMode = () => {},
+    onFormatOptionsFetch = () => {},
     selectedService,
     isLocalizedLayerStylesEnabled,
     tileSizeOptions = [256],
-    layerOptions
+    layerOptions,
+    formatsLoading
 }) => {
     const [valid, setValid] = useState(true);
     return (<BorderLayout
@@ -84,6 +86,8 @@ export default ({
                 tileSizeOptions={tileSizeOptions}
                 currentWMSCatalogLayerSize={layerOptions.tileSize ? layerOptions.tileSize : 256}
                 selectedService={selectedService}
+                onFormatOptionsFetch={onFormatOptionsFetch}
+                formatsLoading={formatsLoading}
             />
             <FormGroup controlId="buttons" key="buttons">
                 <Col xs={12}>

--- a/web/client/components/catalog/RecordGrid.jsx
+++ b/web/client/components/catalog/RecordGrid.jsx
@@ -41,6 +41,7 @@ class RecordGrid extends React.Component {
         service: PropTypes.object,
         defaultFormat: PropTypes.string,
         formatOptions: PropTypes.array,
+        infoFormatOptions: PropTypes.array,
         layerBaseConfig: PropTypes.object
     };
 
@@ -87,6 +88,7 @@ class RecordGrid extends React.Component {
                     currentLocale={this.props.currentLocale}
                     defaultFormat={this.props.defaultFormat}
                     formatOptions={this.props.formatOptions}
+                    infoFormatOptions={this.props.infoFormatOptions}
                     layerBaseConfig={this.props.layerBaseConfig}
                 />
             </Col>

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -66,7 +66,8 @@ class RecordItem extends React.Component {
         service: PropTypes.service,
         showTemplate: PropTypes.bool,
         defaultFormat: PropTypes.string,
-        formatOptions: PropTypes.array
+        formatOptions: PropTypes.array,
+        infoFormatOptions: PropTypes.array
     };
 
     static defaultProps = {
@@ -363,7 +364,11 @@ class RecordItem extends React.Component {
                                 : null,
                         format: this.getLayerFormat(
                             formats.filter(f => f.indexOf("image/") === 0)
-                        )
+                        ),
+                        formats: {
+                            imageFormats: this.props.formatOptions,
+                            infoFormats: this.props.infoFormatOptions
+                        }
                     }
                     : {
                         format: this.getLayerFormat(

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -858,4 +858,32 @@ describe('This test for RecordItem', () => {
         expect(descDiv.hasChildNodes()).toBe(true);
         expect(descDiv.firstElementChild.tagName).toBe('SPAN');
     });
+    it('check formats are added to layer props (WMS)', () => {
+        const defaultFormat = 'image/jpeg';
+        const formatOptions = ["image/png", "image/png8"];
+        const infoFormatOptions = ["text/html", "text/plain"];
+        let actions = {
+            onLayerAdd: () => {}
+        };
+        let actionsSpy = expect.spyOn(actions, "onLayerAdd");
+        const item = ReactDOM.render(<RecordItem
+            defaultFormat={defaultFormat}
+            formatOptions={formatOptions}
+            infoFormatOptions={infoFormatOptions}
+            record={sampleRecord}
+            onLayerAdd={actions.onLayerAdd}/>, document.getElementById("container"));
+        expect(item).toExist();
+
+        const itemDom = ReactDOM.findDOMNode(item);
+        expect(itemDom).toExist();
+        let button = TestUtils.findRenderedDOMComponentWithTag(
+            item, 'button'
+        );
+        expect(button).toExist();
+        button.click();
+        expect(actionsSpy.calls.length).toBe(1);
+        expect(actionsSpy.calls[0].arguments[0].format).toBe(defaultFormat);
+        expect(actionsSpy.calls[0].arguments[0].imageFormats).toEqual(formatOptions);
+        expect(actionsSpy.calls[0].arguments[0].infoFormats).toBe(infoFormatOptions);
+    });
 });

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -6,9 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-import Select from "react-select";
 import { FormGroup, Col, ControlLabel } from "react-bootstrap";
 import CommonAdvancedSettings from './CommonAdvancedSettings';
+import RS from 'react-select';
+import localizedProps from '../../../misc/enhancers/localizedProps';
+const Select = localizedProps('noResultsText')(RS);
 
 /**
  * Generates an array of options in the form e.g. [{value: "256", label: "256x256"}]
@@ -26,6 +28,7 @@ export default ({
     tileSizeOptions,
     currentWMSCatalogLayerSize,
     selectedService,
+    onFormatOptionsFetch = () => {},
     ...props
 }) => {
     const tileSelectOptions = getTileSizeSelectOptions(tileSizeOptions);
@@ -36,9 +39,13 @@ export default ({
             </Col >
             <Col xs={6}>
                 <Select
+                    isLoading={props.formatsLoading}
+                    onOpen={() => onFormatOptionsFetch(service.url)}
                     value={service && service.format}
                     clearable
-                    options={formatOptions}
+                    noResultsText={props.formatsLoading
+                        ? "catalog.format.loading" : "catalog.format.noOption"}
+                    options={props.formatsLoading ? [] : formatOptions}
                     onChange={event => onChangeServiceFormat(event && event.value)} />
             </Col >
         </FormGroup>

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -21,7 +21,8 @@ const {
     getMetadataRecordById,
     autoSearchEpic,
     openCatalogEpic,
-    recordSearchEpic
+    recordSearchEpic,
+    getSupportedFormatsEpic
 } = catalog(API);
 import {SHOW_NOTIFICATION} from '../../actions/notifications';
 import {CLOSE_FEATURE_GRID} from '../../actions/featuregrid';
@@ -36,7 +37,10 @@ import {
     textSearch, TEXT_SEARCH,
     RECORD_LIST_LOADED,
     RECORD_LIST_LOAD_ERROR,
-    SET_LOADING
+    SET_LOADING,
+    formatOptionsFetch,
+    FORMAT_OPTIONS_LOADING,
+    SET_FORMAT_OPTIONS
 } from '../../actions/catalog';
 
 
@@ -311,6 +315,31 @@ describe('catalog Epics', () => {
                 },
                 pageSize: 2
             }
+        });
+    });
+    it('getSupportedFormatsEpic wms', (done) => {
+        const NUM_ACTIONS = 3;
+        const url = "base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml";
+        testEpic(addTimeoutEpic(getSupportedFormatsEpic, 0), NUM_ACTIONS, formatOptionsFetch(url), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case SET_FORMAT_OPTIONS:
+                    expect(action.formats).toBeTruthy();
+                    expect(action.formats.imageFormats).toEqual([{"label": "image/png", "value": "image/png"}, {"label": "image/gif", "value": "image/gif"}, {"label": "image/jpeg", "value": "image/jpeg"}, {"label": "image/png8", "value": "image/png8"}, {"label": "image/vnd.jpeg-png", "value": "image/vnd.jpeg-png"}]);
+                    expect(action.formats.infoFormats).toEqual(["text/plain", "text/html", "application/json"]);
+                    break;
+                case FORMAT_OPTIONS_LOADING:
+                    break;
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            catalog: {}
         });
     });
 });

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -19,6 +19,7 @@ import {
     GET_METADATA_RECORD_BY_ID,
     TEXT_SEARCH,
     CATALOG_CLOSE,
+    FORMAT_OPTIONS_FETCH,
     addCatalogService,
     setLoading,
     deleteCatalogService,
@@ -29,7 +30,9 @@ import {
     changeCatalogMode,
     resetCatalog,
     textSearch,
-    changeSelectedService
+    changeSelectedService,
+    formatsLoading,
+    setSupportedFormats
 } from '../actions/catalog';
 import { showLayerMetadata, addLayer } from '../actions/layers';
 import { error, success } from '../actions/notifications';
@@ -46,7 +49,8 @@ import {
     servicesSelector,
     selectedCatalogSelector,
     searchOptionsSelector,
-    catalogSearchInfoSelector
+    catalogSearchInfoSelector,
+    getFormatUrlUsedSelector
 } from '../selectors/catalog';
 import { metadataSourceSelector } from '../selectors/backgroundselector';
 import { currentMessagesSelector } from "../selectors/locale";
@@ -58,11 +62,12 @@ import {
     extractEsriReferences,
     extractOGCServicesReferences,
     getCatalogRecords,
-    recordToLayer
+    recordToLayer,
+    getSupportedFormat
 } from '../utils/CatalogUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
 import {getCapabilitiesUrl} from '../utils/LayersUtils';
-
+import { wrapStartStop } from '../observables/epics';
 
 /**
     * Epics for CATALOG
@@ -388,5 +393,25 @@ export default (API) => ({
                     resetCatalog()
                 ].concat(metadataSource === 'backgroundSelector' ?
                     [changeSelectedService(head(keys(services))), allowBackgroundsDeletion(true)] : [])));
+            }),
+
+    getSupportedFormatsEpic: (action$, {getState = ()=> {}} = {}) =>
+        action$.ofType(FORMAT_OPTIONS_FETCH)
+            .filter((action)=> getFormatUrlUsedSelector(getState()) !== action?.url)
+            .switchMap(({url = ''} = {})=> {
+                return Rx.Observable.defer(() => getSupportedFormat(url, true))
+                    .switchMap((supportedFormats) => Rx.Observable.of(setSupportedFormats(supportedFormats, url)))
+                    .let(
+                        wrapStartStop(
+                            formatsLoading(true),
+                            formatsLoading(false),
+                            () => {
+                                return Rx.Observable.of(
+                                    error({ title: "Error", message: "Failed to fetch format" }),
+                                    formatsLoading(false),
+                                );
+                            }
+                        )
+                    );
             })
 });

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -395,6 +395,14 @@ export default (API) => ({
                     [changeSelectedService(head(keys(services))), allowBackgroundsDeletion(true)] : [])));
             }),
 
+    /**
+     * Fetch all supported formats of a WMS service configured (infoFormats and imageFormats)
+     * Dispatches an action that sets the supported formats of the service.
+     * @param {Observable} action$ the actions triggered
+     * @param {object} getState store object
+     * @memberof epics.catalog
+     * @return {external:Observable}
+     */
     getSupportedFormatsEpic: (action$, {getState = ()=> {}} = {}) =>
         action$.ofType(FORMAT_OPTIONS_FETCH)
             .filter((action)=> getFormatUrlUsedSelector(getState()) !== action?.url)
@@ -407,7 +415,7 @@ export default (API) => ({
                             formatsLoading(false),
                             () => {
                                 return Rx.Observable.of(
-                                    error({ title: "Error", message: "Failed to fetch format" }),
+                                    error({ title: "layerProperties.format.error.title", message: 'layerProperties.format.error.message' }),
                                     formatsLoading(false),
                                 );
                             }

--- a/web/client/plugins/MetadataExplorer.jsx
+++ b/web/client/plugins/MetadataExplorer.jsx
@@ -35,6 +35,7 @@ import {
     changeUrl,
     deleteService,
     focusServicesList,
+    formatOptionsFetch,
     textSearch,
     toggleAdvancedSettings,
     toggleTemplate,
@@ -69,14 +70,17 @@ import {
     serviceListOpenSelector,
     servicesSelector,
     servicesSelectorWithBackgrounds,
-    tileSizeOptionsSelector
+    tileSizeOptionsSelector,
+    formatsLoadingSelector,
+    getSupportedFormatsSelector,
+    getSupportedGFIFormatsSelector
 } from '../selectors/catalog';
 import { layersSelector } from '../selectors/layers';
 import { currentLocaleSelector, currentMessagesSelector } from '../selectors/locale';
 import { isLocalizedLayerStylesEnabledSelector } from '../selectors/localizedLayerStyles';
 import { projectionSelector } from '../selectors/map';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
-import { getCatalogRecords } from '../utils/CatalogUtils';
+import {DEFAULT_FORMAT_WMS, getCatalogRecords} from '../utils/CatalogUtils';
 
 const DEFAULT_ALLOWED_PROVIDERS = ["OpenStreetMap", "OpenSeaMap", "Stamen"];
 
@@ -110,7 +114,10 @@ const metadataExplorerSelector = createStructuredSelector({
     pageSize: pageSizeSelector,
     loading: loadingSelector,
     crs: projectionSelector,
-    isLocalizedLayerStylesEnabled: isLocalizedLayerStylesEnabledSelector
+    isLocalizedLayerStylesEnabled: isLocalizedLayerStylesEnabledSelector,
+    formatsLoading: formatsLoadingSelector,
+    formatOptions: getSupportedFormatsSelector,
+    infoFormatOptions: getSupportedGFIFormatsSelector
 });
 
 
@@ -123,22 +130,7 @@ const Catalog = compose(
             marginBottom: "10px",
             marginRight: "5px"
         },
-        formatOptions: [{
-            label: 'image/png',
-            value: 'image/png'
-        }, {
-            label: 'image/png8',
-            value: 'image/png8'
-        }, {
-            label: 'image/jpeg',
-            value: 'image/jpeg'
-        }, {
-            label: 'image/vnd.jpeg-png',
-            value: 'image/vnd.jpeg-png'
-        }, {
-            label: 'image/gif',
-            value: 'image/gif'
-        }]
+        formatOptions: DEFAULT_FORMAT_WMS
     }),
     branch(
         ({mode}) => mode === "edit",
@@ -267,6 +259,7 @@ const MetadataExplorerPlugin = connect(metadataExplorerSelector, {
     onFocusServicesList: focusServicesList,
     onPropertiesChange: changeLayerProperties,
     onAddBackground: backgroundAdded,
+    onFormatOptionsFetch: formatOptionsFetch,
     onToggle: toggleControl.bind(null, 'backgroundSelector', null),
     onLayerChange: setControlProperty.bind(null, 'backgroundSelector'),
     onStartChange: setControlProperty.bind(null, 'backgroundSelector', 'start')

--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -53,7 +53,9 @@ import {
     addCatalogService,
     changeText,
     changeServiceFormat,
-    setLoading
+    setLoading,
+    formatsLoading,
+    setSupportedFormats
 } from '../../actions/catalog';
 
 import { MAP_CONFIG_LOADED } from '../../actions/config';
@@ -323,5 +325,19 @@ describe('Test the catalog reducer', () => {
             newService: {}
         }, {type: CHANGE_METADATA_TEMPLATE, metadataTemplate: ""});
         expect(state.newService.metadataTemplate).toBe("");
+    });
+    it('FORMAT_OPTIONS_LOADING ', () => {
+        const state = catalog({
+            newService: {}
+        }, formatsLoading(false));
+        expect(state.formatsLoading).toBe(false);
+    });
+    it('SET_FORMAT_OPTIONS ', () => {
+        const formats = {imageFormats: ["image/png"], infoFormats: ["text/html"]};
+        const state = catalog({
+            newService: {}
+        }, setSupportedFormats(formats, url));
+        expect(state.newService.formatUrlUsed).toBe(url);
+        expect(state.newService.supportedFormats).toEqual(formats);
     });
 });

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -28,7 +28,9 @@ import {
     SET_LOADING,
     TOGGLE_THUMBNAIL,
     TOGGLE_TEMPLATE,
-    TOGGLE_ADVANCED_SETTINGS
+    TOGGLE_ADVANCED_SETTINGS,
+    FORMAT_OPTIONS_LOADING,
+    SET_FORMAT_OPTIONS
 } from '../actions/catalog';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -204,6 +206,12 @@ function catalog(state = {
     }
     case TOGGLE_ADVANCED_SETTINGS: {
         return set("newService.showAdvancedSettings", !state.newService.showAdvancedSettings, state);
+    }
+    case FORMAT_OPTIONS_LOADING: {
+        return set("formatsLoading", action.loading, state);
+    }
+    case SET_FORMAT_OPTIONS: {
+        return set("newService.supportedFormats", action.formats, set("newService.formatUrlUsed", action.url, state));
     }
     default:
         return state;

--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -28,10 +28,15 @@ import {
     selectedServiceSelector,
     servicesSelector,
     serviceListOpenSelector,
-    tileSizeOptionsSelector
+    tileSizeOptionsSelector,
+    formatsLoadingSelector,
+    getSupportedFormatsSelector,
+    getSupportedGFIFormatsSelector,
+    getFormatUrlUsedSelector
 } from '../catalog';
 
 import { set } from '../../utils/ImmutableUtils';
+import {DEFAULT_FORMAT_WMS, getUniqueInfoFormats} from "../../utils/CatalogUtils";
 const url = "https://demo.geo-solutions.it/geoserver/wms";
 const state = {
     controls: {
@@ -244,5 +249,59 @@ describe('Test catalog selectors', () => {
         expect(tileSizes.length).toBe(2);
         expect(tileSizes[0]).toBe(256);
         expect(tileSizes[1]).toBe(512);
+    });
+    it('test formatsLoadingSelector with default value', () => {
+        const formatLoading = formatsLoadingSelector(state);
+        expect(formatLoading).toBe(false);
+    });
+    it('test formatsLoadingSelector', () => {
+        const formatLoading = formatsLoadingSelector({catalog: {formatsLoading: true}});
+        expect(formatLoading).toBe(true);
+    });
+    it('test getSupportedFormatsSelector with default value', () => {
+        const defaultImageFormats = getSupportedFormatsSelector(state);
+        expect(defaultImageFormats).toEqual(DEFAULT_FORMAT_WMS);
+    });
+    it('test getSupportedFormatsSelector ', () => {
+        const defaultImageFormats = getSupportedFormatsSelector({
+            catalog: {
+                newService: {
+                    supportedFormats: {
+                        imageFormats: ["image/png"]
+                    }
+                }
+            }
+        });
+        expect(defaultImageFormats).toEqual(["image/png"]);
+    });
+    it('test getSupportedGFIFormatsSelector with default value', () => {
+        const defaultInfoFormats = getSupportedGFIFormatsSelector(state);
+        expect(defaultInfoFormats).toEqual(getUniqueInfoFormats());
+    });
+    it('test getSupportedGFIFormatsSelector ', () => {
+        const defaultInfoFormats = getSupportedGFIFormatsSelector({
+            catalog: {
+                newService: {
+                    supportedFormats: {
+                        infoFormats: ["text/html"]
+                    }
+                }
+            }
+        });
+        expect(defaultInfoFormats).toEqual(["text/html"]);
+    });
+    it('test getFormatUrlUsedSelector with default value', () => {
+        const urlUsed = getFormatUrlUsedSelector(state);
+        expect(urlUsed).toBe('');
+    });
+    it('test getFormatUrlUsedSelector ', () => {
+        const urlUsed = getFormatUrlUsedSelector({
+            catalog: {
+                newService: {
+                    formatUrlUsed: url
+                }
+            }
+        });
+        expect(urlUsed).toBe(url);
     });
 });

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -10,6 +10,7 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import { get, pick } from 'lodash';
 
 import { projectionSelector } from './map';
+import { DEFAULT_FORMAT_WMS, getUniqueInfoFormats } from "../utils/CatalogUtils";
 
 export const staticServicesSelector = (state) => get(state, "catalog.default.staticServices");
 export const servicesSelector = (state) => get(state, "catalog.services");
@@ -49,3 +50,7 @@ export const delayAutoSearchSelector = (state) => get(state, "catalog.delayAutoS
 export const catalogSearchInfoSelector = createStructuredSelector({
     projection: projectionSelector
 });
+export const formatsLoadingSelector = (state) => get(state, "catalog.formatsLoading", false);
+export const getSupportedFormatsSelector = (state) => get(state, "catalog.newService.supportedFormats.imageFormats", DEFAULT_FORMAT_WMS);
+export const getSupportedGFIFormatsSelector = (state) => get(state, "catalog.newService.supportedFormats.infoFormats", getUniqueInfoFormats());
+export const getFormatUrlUsedSelector = (state) => get(state, "catalog.newService.formatUrlUsed", '');

--- a/web/client/themes/default/less/toc.less
+++ b/web/client/themes/default/less/toc.less
@@ -841,3 +841,10 @@
         margin-top: 8px;
     }
 }
+
+.ms-format-container {
+    display: flex;
+    .format-select {
+       width: 100%;
+    }
+}

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -71,7 +71,6 @@
             "styleCustom": "Stil \"{value}\" nutzen",
             "styleListLoadError": "Es gab einen Fehler beim Laden der Liste von Stilen",
             "stylesRefreshList": "Aktualisiere die Liste von Stilen",
-            "format": "Format",
             "delete": "Löschen",
             "deleteLayer":"Ebene löschen",
             "deleteLayerMessage": "Möchten Sie diese Ebene wirklich löschen?",
@@ -146,6 +145,12 @@
             "enableLocalizedLayerStyles": {
                 "label": "Lokalisierten Stil aktivieren",
                 "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"
+            },
+            "format": {
+                "title": "Format",
+                "refresh": "Unterstütztes Format abrufen",
+                "loading": "Wird geladen...",
+                "noOption": "Keine Option"
             }
         },
         "longitude": "Lon",
@@ -1426,6 +1431,10 @@
             "enableLocalizedLayerStyles": {
                 "label": "Lokalisierten Stil aktivieren",
                 "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"
+            },
+            "format": {
+                "noOption": "Keine Option",
+                "loading": "Wird geladen..."
             }
         },
         "uploader": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -150,7 +150,11 @@
                 "title": "Format",
                 "refresh": "Unterstütztes Format abrufen",
                 "loading": "Wird geladen...",
-                "noOption": "Keine Option"
+                "noOption": "Keine Option",
+                "error": {
+                    "title": "Error",
+                    "message": "Format konnte nicht abgerufen werden"
+                }
             }
         },
         "longitude": "Lon",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -150,7 +150,11 @@
                 "title": "Format",
                 "refresh": "Fetch supported format",
                 "loading": "Loading...",
-                "noOption": "No option"
+                "noOption": "No option",
+                "error": {
+                    "title": "Error",
+                    "message": "Failed to fetch format"
+                }
             }
         },
         "longitude": "Lon",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -71,7 +71,6 @@
             "styleCustom": "Use style named \"{value}\"",
             "styleListLoadError": "There was an error loading the styles list",
             "stylesRefreshList": "Refresh Styles List",
-            "format": "Format",
             "delete": "Delete",
             "deleteLayer":"Delete Layer",
             "deleteLayerMessage": "Do you really want to delete this layer?",
@@ -146,6 +145,12 @@
             "enableLocalizedLayerStyles": {
                 "label": "Enable localized style",
                 "tooltip": "Note: This parameter requires specific configurations on GeoServer"
+            },
+            "format": {
+                "title": "Format",
+                "refresh": "Fetch supported format",
+                "loading": "Loading...",
+                "noOption": "No option"
             }
         },
         "longitude": "Lon",
@@ -1426,6 +1431,10 @@
             "enableLocalizedLayerStyles": {
                 "label": "Enable localized styles",
                 "tooltip": "Note: This parameter requires specific configurations on GeoServer"
+            },
+            "format": {
+                "noOption": "No option",
+                "loading": "Loading..."
             }
         },
         "uploader": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -71,7 +71,6 @@
             "styleCustom": "Use un estilo llamado \"{value} \"",
             "styleListLoadError": "Se ha producido un error al cargar la lista de estilos",
             "stylesRefreshList": "Actualizar la lista de estilos",
-            "format": "Formato",
             "delete": "Borrar",
             "deleteLayer":"Borrar el mapa",
             "deleteLayerMessage": "¿Está totalmente seguro de querer borrar este mapa?",
@@ -146,6 +145,12 @@
             "enableLocalizedLayerStyles": {
                 "label": "Habilitar estilo localizado",
                 "tooltip": "Nota: este parámetro requiere configuraciones específicas en GeoServer"
+            },
+            "format": {
+                "title": "Formato",
+                "refresh": "Obtener formato compatible",
+                "loading": "Cargando...",
+                "noOption": "Sin opcion"
             }
         },
         "longitude": "Lon",
@@ -1426,6 +1431,10 @@
             "enableLocalizedLayerStyles": {
                 "label": "Habilitar estilos localizados",
                 "tooltip": "Nota: este parámetro requiere configuraciones específicas en GeoServer"
+            },
+            "format": {
+                "noOption": "Sin opcion",
+                "loading": "Cargando..."
             }
         },
         "uploader": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -150,7 +150,11 @@
                 "title": "Formato",
                 "refresh": "Obtener formato compatible",
                 "loading": "Cargando...",
-                "noOption": "Sin opcion"
+                "noOption": "Sin opcion",
+                "error": {
+                    "title": "Error",
+                    "message": "No se pudo recuperar el formato"
+                }
             }
         },
         "longitude": "Lon",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -150,7 +150,11 @@
                 "title": "Format",
                 "refresh": "Récupérer le format pris en charge",
                 "loading": "Chargement...",
-                "noOption": "Pas d'option"
+                "noOption": "Pas d'option",
+                "error": {
+                    "title": "Erreur",
+                    "message": "Échec de la récupération du format"
+                }
             }
         },
         "longitude": "Lon",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -71,7 +71,6 @@
             "styleCustom": "Utiliser un style nommé \"{value} \"",
             "styleListLoadError": "Une erreur s'est produite lors du chargement de la liste des styles",
             "stylesRefreshList": "Actualiser la liste des styles",
-            "format": "Format",
             "delete": "Supprimer",
             "deleteLayer": "Supprimer la couche",
             "deleteLayerMessage": "Voulez-vous vraiment supprimer cette couche ?",
@@ -146,6 +145,12 @@
             "enableLocalizedLayerStyles": {
                 "label": "Activer le style localisé",
                 "tooltip": "Remarque: ce paramètre nécessite des configurations spécifiques sur GeoServer"
+            },
+            "format": {
+                "title": "Format",
+                "refresh": "Récupérer le format pris en charge",
+                "loading": "Chargement...",
+                "noOption": "Pas d'option"
             }
         },
         "longitude": "Lon",
@@ -1427,6 +1432,10 @@
             "enableLocalizedLayerStyles": {
                 "label": "Activer les styles localisés",
                 "tooltip": "Remarque : ce paramètre nécessite des configurations spécifiques sur GeoServer"
+            },
+            "format": {
+                "noOption": "Pas d'option",
+                "loading": "Chargement..."
             }
         },
         "uploader": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -71,7 +71,6 @@
             "styleCustom": "Usa stile con nome \"{value}\"",
             "styleListLoadError": "Si è verificato un errore durante il caricamento della lista degli stili",
             "stylesRefreshList": "Aggiorna lista degli stili",
-            "format": "Formato",
             "delete": "Elimina",
             "deleteLayer":"Elimina Livello",
             "deleteLayerMessage": "Sei sicuro di voler eliminare questo livello?",
@@ -146,6 +145,12 @@
             "enableLocalizedLayerStyles": {
                 "label": "Abilita stile localizzato",
                 "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"
+            },
+            "format": {
+                "title": "Formato",
+                "refresh": "Recupera il formato supportato",
+                "loading": "Caricamento in corso...",
+                "noOption": "Nessuna opzione"
             }
         },
         "longitude": "Lon",
@@ -1426,6 +1431,10 @@
             "enableLocalizedLayerStyles": {
                 "label": "Abilita stili di livello localizzati",
                 "tooltip": "Nota: questo parametro richiede configurazioni specifiche su GeoServer"
+            },
+            "format": {
+                "noOption": "Nessuna opzione",
+                "loading": "Caricamento in corso..."
             }
         },
         "uploader": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -150,7 +150,11 @@
                 "title": "Formato",
                 "refresh": "Recupera il formato supportato",
                 "loading": "Caricamento in corso...",
-                "noOption": "Nessuna opzione"
+                "noOption": "Nessuna opzione",
+                "error": {
+                    "title": "Errore",
+                    "message": "Impossibile recuperare il formato"
+                }
             }
         },
         "longitude": "Lon",

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -18,7 +18,8 @@ import {
     uniq,
     includes,
     get,
-    isNil
+    isNil,
+    isEmpty
 } from 'lodash';
 
 import urlUtil from 'url';
@@ -29,6 +30,7 @@ import {getMessageById} from './LocaleUtils';
 import * as WMTSUtils from './WMTSUtils';
 import { cleanAuthParamsFromURL } from './SecurityUtils';
 import WMS from '../api/WMS';
+import { getAvailableInfoFormat } from "./MapInfoUtils";
 
 const getBaseCatalogUrl = (url) => {
     return url && url.replace(/\/csw$/, "/");
@@ -491,7 +493,7 @@ const toURLArray = (url) => {
  *  - `removeParameters` if you didn't provided an `url` option and you want to use record's one, you can remove some params (typically authkey params) using this.
  *  - `url`, if you already have the correct service URL (typically when you want to use you URL already stripped from some parameters, e.g. authkey params)
  */
-export const recordToLayer = (record, type = "wms", {removeParams = [], format, catalogURL, url} = {}, baseConfig = {}, localizedLayerStyles) => {
+export const recordToLayer = (record, type = "wms", {removeParams = [], format, catalogURL, url, formats = {}} = {}, baseConfig = {}, localizedLayerStyles) => {
     if (!record || !record.references) {
         // we don't have a valid record so no buttons to add
         return null;
@@ -553,7 +555,8 @@ export const recordToLayer = (record, type = "wms", {removeParams = [], format, 
         catalogURL,
         ...baseConfig,
         ...record.layerOptions,
-        localizedLayerStyles: !isNil(localizedLayerStyles) ? localizedLayerStyles : undefined
+        localizedLayerStyles: !isNil(localizedLayerStyles) ? localizedLayerStyles : undefined,
+        ...(type === 'wms' && !isEmpty(formats) && {imageFormats: formats.imageFormats, infoFormats: formats.infoFormats})
     };
 };
 export const getCatalogRecords = (format, records, options, locales) => {
@@ -669,4 +672,55 @@ export const tileProviderToLayer = (record) => {
         provider: record.provider, // "ProviderName.VariantName"
         name: record.provider
     };
+};
+
+export const DEFAULT_FORMAT_WMS = [{
+    label: 'image/png',
+    value: 'image/png'
+}, {
+    label: 'image/png8',
+    value: 'image/png8'
+}, {
+    label: 'image/jpeg',
+    value: 'image/jpeg'
+}, {
+    label: 'image/vnd.jpeg-png',
+    value: 'image/vnd.jpeg-png'
+}, {
+    label: 'image/vnd.jpeg-png8',
+    value: 'image/vnd.jpeg-png8'
+}, {
+    label: 'image/gif',
+    value: 'image/gif'
+}];
+
+export const getUniqueInfoFormats = () => {
+    return uniq(Object.values(getAvailableInfoFormat()));
+};
+
+export const getSupportedFormat = (url, includeGFIFormats = false) => {
+    return WMS.getCapabilities(url).then((caps) => {
+        let getMapFormats = get(caps, 'capability.request.getMap.format', []);
+        let imageFormats;
+        if (!isEmpty(getMapFormats)) {
+            const defaultFormats = DEFAULT_FORMAT_WMS.map(({value}) => value);
+            getMapFormats = getMapFormats.map(({value})=> ({label: value, value}));
+            imageFormats = getMapFormats.filter(({value})=> includes(defaultFormats, value)) || [];
+        } else {
+            imageFormats = DEFAULT_FORMAT_WMS;
+        }
+
+        let infoFormats;
+        if (includeGFIFormats) {
+            let getFeatureInfoFormats = get(caps, 'capability.request.getFeatureInfo.format', []);
+            const defaultFormats = getUniqueInfoFormats();
+            if (!isEmpty(getFeatureInfoFormats)) {
+                getFeatureInfoFormats = getFeatureInfoFormats.map(({value})=> value);
+                infoFormats = uniq(getFeatureInfoFormats.filter((value)=> includes(defaultFormats, value))) || [];
+            } else {
+                infoFormats = defaultFormats;
+            }
+        }
+        return includeGFIFormats ? {imageFormats, infoFormats} : imageFormats;
+    }).catch(()=> includeGFIFormats ? {imageFormats: DEFAULT_FORMAT_WMS, infoFormats: getUniqueInfoFormats()} : DEFAULT_FORMAT_WMS);
 };

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -694,10 +694,20 @@ export const DEFAULT_FORMAT_WMS = [{
     value: 'image/gif'
 }];
 
+/**
+ * Get unique array of supported info formats
+ * @return {array} info formats
+ */
 export const getUniqueInfoFormats = () => {
     return uniq(Object.values(getAvailableInfoFormat()));
 };
 
+/**
+ * Fetch the supported formats of the WMS service
+ * @param url
+ * @param includeGFIFormats
+ * @return {object|string} formats
+ */
 export const getSupportedFormat = (url, includeGFIFormats = false) => {
     return WMS.getCapabilities(url).then((caps) => {
         let getMapFormats = get(caps, 'capability.request.getMap.format', []);
@@ -722,5 +732,7 @@ export const getSupportedFormat = (url, includeGFIFormats = false) => {
             }
         }
         return includeGFIFormats ? {imageFormats, infoFormats} : imageFormats;
-    }).catch(()=> includeGFIFormats ? {imageFormats: DEFAULT_FORMAT_WMS, infoFormats: getUniqueInfoFormats()} : DEFAULT_FORMAT_WMS);
+    }).catch(()=>
+        // Fallback to default formats on exception
+        includeGFIFormats ? {imageFormats: DEFAULT_FORMAT_WMS, infoFormats: getUniqueInfoFormats()} : DEFAULT_FORMAT_WMS);
 };


### PR DESCRIPTION
## Description
This PR adds commits to fetch formats of the service (WMS) configured for to be used in the layer settings.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#6522 

**What is the new behavior?**
- If type is WMS and URL is valid, on list open, fetches the formats(image formats of getMap and info formats of GFI). If not available, use defaults
- When the record is created, the list of available formats are added to the layer when adding, to be used in layer settings.
- Format refresh button is available next to the formats select in _Display_ tab to refresh capabilities (Applicable to map widgets in Dashboard and in Geostory map configuration)
- Use the available formats of the layer props to be displayed in format select of _Display_ tab in layer settings. If not present the default is used
- Based on available formats for GetFeatureInfo, in layer props (if present) use it to display the possible allowed formats else use defaults

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
