### PR TITLE
[Backreport 2021.01.xx]  #6592: Compare tool Problem (#6612)

### DIFF
--- a/web/client/components/map/openlayers/swipe/EffectSupport.jsx
+++ b/web/client/components/map/openlayers/swipe/EffectSupport.jsx
@@ -26,7 +26,7 @@ const circleCut = (layer, circleCutPrecomposeCallback, postcomposeCallback) => {
 const EffectSupport = ({ map, layer: layerId, type, getWidth, getHeight, circleCutProp }) => {
     const verticalCutPrecomposeCallback = useCallback((event) => {
         let ctx = event.context;
-        const width = getWidth();
+        const width = getWidth() * map.pixelRatio_;
         ctx.save();
         ctx.beginPath();
         ctx.rect(width, 0, ctx.canvas.width - width, ctx.canvas.height);
@@ -41,7 +41,7 @@ const EffectSupport = ({ map, layer: layerId, type, getWidth, getHeight, circleC
 
     const horizontalCutPrecomposeCallback = useCallback((event) => {
         let ctx = event.context;
-        const height = getHeight();
+        const height = getHeight() * map.pixelRatio_;
         ctx.save();
         ctx.beginPath();
         ctx.rect(0, height, ctx.canvas.width, ctx.canvas.height - height);


### PR DESCRIPTION
(cherry picked from commit 1e6f4705f1f09b6ffdc457e1ed2eef793a9fcd16)
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

#6592 

**What is the current behavior?**
The default vertical and horizontal heights are not in inline with the slider and swipe height 
The slider map content and the swiper are not synced
#6592 

**What is the new behavior?**
The default vertical and horizontal heights are in inline with the slider and swipe height 

<!-- Describe here the new behavior based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
