### PR TITLE
Add browserslist to modernize and reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,19 @@
 {
   "name": "mapstore2",
+  "browserslist": {
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all",
+      "not IE 11",
+      "not UCAndroid 12.12"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "version": "0.2.1",
   "description": "MapStore 2",
   "repository": "https://github.com/geosolutions-it/MapStore2",
@@ -24,11 +38,11 @@
   ],
   "devDependencies": {
     "@babel/core": "7.8.7",
-    "@babel/runtime": "7.11.2",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.8.7",
     "@babel/preset-react": "7.8.3",
+    "@babel/runtime": "7.11.2",
     "@geosolutions/acorn-jsx": "4.0.2",
     "@geosolutions/jsdoc": "3.4.4",
     "@geosolutions/mocha": "6.2.1-3",


### PR DESCRIPTION
## Description
Exluding old browsers support and browsers with no market share, we obtain: 

before:
```
mapstore2 (12.3 MiB)
      mapstore2.js
  embedded (3.28 MiB)
      embedded.js
  ms2-api (3.4 MiB)
      ms2-api.js
```

after:
```
mapstore2 (10.8 MiB)
      mapstore2.js
  embedded (2.97 MiB)
      embedded.js
  ms2-api (3.1 MiB)
      ms2-api.js
```

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
