### PR TITLE
#6610: Fixed proxy configuration. Disabled unnecessary functionalities

### DIFF
--- a/project/custom/templates/web/src/main/resources/proxy.properties
+++ b/project/custom/templates/web/src/main/resources/proxy.properties
@@ -16,7 +16,7 @@ defaultStreamByteSize=1024
 # ###########
 #hostnameWhitelist = localhost,demo1.geo-solutions.it,demo.geo-solutions.it
 
-mimetypeWhitelist = application/force-download,text/html,text/plain,application/xml,text/xml,application/vnd.ogc.sld+xml,application/vnd.ogc.gml,application/json,application/vnd.ogc.wms_xml,application/x-www-form-urlencoded,image/png,application/pdf,text/csv,application/zip,text/csv;charset=UTF-8
+mimetypeWhitelist = application/force-download,text/html,text/plain,application/xml,text/xml,application/vnd.ogc.sld+xml,application/vnd.ogc.gml,application/json,application/vnd.ogc.wms_xml,application/x-www-form-urlencoded,image/png,application/pdf,text/csv,image/bil,application/bil16,application/zip,text/csv;charset=UTF-8
 
 methodsWhitelist = GET,POST,PUT
 

--- a/project/standard/templates/web/src/main/resources/proxy.properties
+++ b/project/standard/templates/web/src/main/resources/proxy.properties
@@ -16,7 +16,7 @@ defaultStreamByteSize=1024
 # ###########
 #hostnameWhitelist = localhost,demo1.geo-solutions.it,demo.geo-solutions.it
 
-mimetypeWhitelist = application/force-download,text/html,text/plain,application/xml,text/xml,application/vnd.ogc.sld+xml,application/vnd.ogc.gml,application/json,application/vnd.ogc.wms_xml,application/x-www-form-urlencoded,image/png,application/pdf,text/csv,application/zip,text/csv;charset=UTF-8
+mimetypeWhitelist = application/force-download,text/html,text/plain,application/xml,text/xml,application/vnd.ogc.sld+xml,application/vnd.ogc.gml,application/json,application/vnd.ogc.wms_xml,application/x-www-form-urlencoded,image/png,application/pdf,text/csv,image/bil,application/bil16,application/zip,text/csv;charset=UTF-8
 
 methodsWhitelist = GET,POST,PUT
 

--- a/web/client/utils/cesium/BILTerrainProvider.js
+++ b/web/client/utils/cesium/BILTerrainProvider.js
@@ -47,7 +47,8 @@ const createBilTerrainProvider = function(Cesium) {
 	 * static array where image formats available for OGCHelper are
 	 * defined
 	 */
-	OGCHelper.FormatImage = [ {
+	OGCHelper.FormatImage = []; // edit: disabled to avoid unnecessary requests. MapStore only supports WMS "image/bil"
+    /* [ {
 		format : "image/png",
 		extension: "png"
 	}, {
@@ -63,6 +64,7 @@ const createBilTerrainProvider = function(Cesium) {
 		format : "image/png; mode=8bit",
 		extension: "png"
 	} ];
+    */
 
 	/**
 	 * static array where data array availables for OGCHelper are defined

--- a/web/src/main/resources/proxy.properties
+++ b/web/src/main/resources/proxy.properties
@@ -16,7 +16,7 @@ defaultStreamByteSize=1024
 # ###########
 #hostnameWhitelist = localhost,demo1.geo-solutions.it,demo.geo-solutions.it
 
-mimetypeWhitelist = application/force-download,text/html,text/plain,application/xml,text/xml,application/vnd.ogc.sld+xml,application/vnd.ogc.gml,application/json,application/vnd.ogc.wms_xml,application/x-www-form-urlencoded,image/png,application/pdf,text/csv,application/bil16,application/zip,text/csv;charset=UTF-8
+mimetypeWhitelist = application/force-download,text/html,text/plain,application/xml,text/xml,application/vnd.ogc.sld+xml,application/vnd.ogc.gml,application/json,application/vnd.ogc.wms_xml,application/x-www-form-urlencoded,image/png,application/pdf,text/csv,image/bil,application/bil16,application/zip,text/csv;charset=UTF-8
 
 methodsWhitelist = GET,POST,PUT
 


### PR DESCRIPTION
## Description
This PR add fixes to #6610 after tests.

- Proxy requires to handle both `image/bil` and  `application/bil16` formats, because OL and Cesium use both.

This caused this issue https://github.com/geosolutions-it/MapStore2/pull/6617#issuecomment-795165287 , solved adding the proper formats to the proxy.properties. I added the formats to the template files too.

- Disabled elevation from image.

Due to these failures i noticed that `BILTerrainProvider` tries also to use an image to generate the terrain. Because the bil terrain has no result, these images take priority returning an undesired result
![image](https://user-images.githubusercontent.com/1279510/110623967-dcd92900-819d-11eb-861c-6d73c3560a2d.png)

Use PNG is not supported at the moment, and so I commented the list of the available format for image.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6610

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
We can check in the future if is really necessary to support both `image/bil` and  `application/bil16` or if we can force to use one.