### PR TITLE
[Backport 2021.01.xx] #6369  The GFI highlighting feature is not disabled after closing the panel

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -35,7 +35,7 @@ export default props => {
     const {
         enabled,
         requests = [],
-        onClose,
+        onClose = () => {},
         responses = [],
         index,
         viewerOptions = {},
@@ -68,7 +68,8 @@ export default props => {
         onChangeFormat,
         formatCoord,
         loaded,
-        validator = () => null
+        validator = () => null,
+        toggleHighlightFeature = () => {}
     } = props;
     const latlng = point && point.latlng || null;
     const targetResponse = validResponses[index]; // the index is calculated on the valid responses hence using all responses leads to wrong results
@@ -112,7 +113,10 @@ export default props => {
                 fluid={fluid}
                 position={position}
                 draggable={draggable}
-                onClose={onClose}
+                onClose={() => {
+                    onClose();
+                    toggleHighlightFeature(false);
+                }}
                 dock={dock}
                 style={dockStyle}
                 showFullscreen={showFullscreen}

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -252,8 +252,38 @@ describe("test IdentifyContainer", () => {
             showCoordinateEditor={false}
         />, document.getElementById("container"));
         let glyphIcons = document.querySelectorAll('.glyphicon');
-        expect(glyphIcons.length).toBe(4);
+        expect(glyphIcons.length).toBe(5);
         expect(glyphIcons.forEach(glyph => glyph.className) !== 'zoom-to').toBeTruthy();
+    });
+
+    it('test call toggleHighlightFeature on Close', () => {
+        const requests = [{reqId: 1}, {reqId: 2}];
+        const callbacks = {
+            toggleHighlightFeature: () => {}
+        };
+        const toggleHighlightFeatureSpy = expect.spyOn(callbacks, 'toggleHighlightFeature');
+        const responses = [{layerMetadata: {title: "Layer 1"}}, {layerMetadata: {title: "Layer 2"}}];
+        const CMP = (<IdentifyContainer
+            enabled
+            index={0}
+            requests={requests}
+            responses={responses}
+            getFeatureButtons={getFeatureButtons}
+            point={{latlng: {lat: 1, lng: 1}}}
+            showCoordinateEditor={false}
+            toggleHighlightFeature={callbacks.toggleHighlightFeature}
+        />);
+        ReactDOM.render(CMP, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const closeIcon = container.querySelectorAll('.ms-close');
+        TestUtils.Simulate.click(closeIcon[0]);
+        TestUtils.act(() => {
+            ReactDOM.render(CMP, document.getElementById("container"));
+        });
+        expect(toggleHighlightFeatureSpy).toHaveBeenCalled();
+        // Test since when the highlight feature is disabled the zoom Icon is not shown
+        const zoomIcon = document.querySelector('.glyphicon-zoom-to');
+        expect(zoomIcon).toNotExist();
     });
 
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

#6369 

**What is the current behavior?**
By enabling the highlight feature from the GFI panel and after enabling mouse hover, the highlight feature toll is still active.
#6369 

**What is the new behavior?**
The feature is not highlighted after closing panel

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
