### PR TITLE
[ Backport 2021.01.xx ]6556 Configure fixed scales for MapStore scale widget (#6577)

### DIFF
--- a/web/client/components/map/enhancers/__tests__/withScalesDenominators-test.js
+++ b/web/client/components/map/enhancers/__tests__/withScalesDenominators-test.js
@@ -1,0 +1,64 @@
+
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import withScalesDenominators from '../withScalesDenominators';
+import { getResolutionsForScales } from '../../../../utils/MapUtils';
+
+function MockApp({ map }) {
+
+    return (
+        <div className="MockApp">
+            <ul> { map.mapOptions.view.resolutions.map((res) => <li key={res}>{res}</li>) } </ul>
+        </div>
+    );
+
+}
+export default MockApp;
+
+const mapMockConf = { mapOptions: { view: { scales: [ 50000, 25000, 10000 ] } }};
+const resolutions = getResolutionsForScales(mapMockConf.mapOptions.view.scales, 'EPSG:3857');
+let MockComp = withScalesDenominators(MockApp);
+
+describe('Test get resolutions from scales', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('Test componet is rendered', () => {
+        ReactDOM.render(<MockComp map={mapMockConf} />
+            , document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelector('.MockApp');
+        expect(el).toExist();
+    });
+
+
+    it('Test component props', () => {
+        ReactDOM.render(<MockComp map={mapMockConf} />, document.getElementById("container"));
+        const el = document.getElementsByClassName('MockApp');
+        expect(el).toExist();
+        const text = el[0].childNodes[0];
+        expect(text).toExist();
+        expect(text.childNodes[1].innerHTML).toBe('' + resolutions[0]);
+        expect(text.childNodes[2].innerHTML).toBe('' + resolutions[1]);
+        expect(text.childNodes[3].innerHTML).toBe('' + resolutions[2]);
+
+    });
+
+
+});

--- a/web/client/components/map/enhancers/withScalesDenominators.js
+++ b/web/client/components/map/enhancers/withScalesDenominators.js
@@ -1,0 +1,55 @@
+
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { getResolutionsForScales } from '../../../utils/MapUtils';
+
+/**
+ * Get the Scales, by configuration and use it to compute the map resolutions
+ * if scales and resolutions props are declared the scales prop has priority
+ * @name withScalesDenominators
+ * @memberof components.map.enhancers
+ * @param {Component} Component this component is used to render the map, in the application contents: Maps, Dashboard, Geostory
+ * @returns the map component with the resolutions calculated by fixed scales
+ * @example
+ * withScalesDenominators(MapPlugin);
+ */
+
+
+const withScalesDenominators = (Component) => {
+
+    return (props) => {
+        const projection = props?.map?.projection || 'EPSG:3857';
+        // if null the getResolutionsForScales will use DEFAULT_SCREEN_DPI automatically
+        const dpi = props?.map?.mapOptions?.view?.DPI || null;
+        const scales = props?.map?.mapOptions?.view?.scales;
+        const resolutions = useMemo(() => (scales) ? getResolutionsForScales(scales, projection, dpi) : null, [scales, projection, dpi]);
+        const mapProps = (resolutions) ? {
+            ...props,
+            map: {
+                ...props.map,
+                mapOptions: {
+                    ...props.map.mapOptions,
+                    view: {
+                        ...props.map.mapOptions.view,
+                        resolutions: resolutions
+                    }
+                }
+            }
+        } : props;
+
+        return <Component {...mapProps} />;
+    };
+};
+
+withScalesDenominators.propTypes = {
+    Component: PropTypes.element
+};
+export default withScalesDenominators;

--- a/web/client/components/widgets/widget/MapView.jsx
+++ b/web/client/components/widgets/widget/MapView.jsx
@@ -14,15 +14,16 @@ import mapType from '../../map/enhancers/mapType';
 import onMapViewChanges from '../../map/enhancers/onMapViewChanges';
 import {withOnClick, withPopupSupport} from '../../common/enhancers/withIdentifyPopup';
 import BaseMap from '../../map/BaseMap';
+import withScalesDenominators from "../../../components/map/enhancers/withScalesDenominators";
 
 export default compose(
     onMapViewChanges,
     autoResize(0),
     autoMapType,
+    withScalesDenominators,
     mapType,
     withPopupSupport,
     withOnClick,
     getProjectionDefs,
     handlingUnsupportedProjection
 )(BaseMap);
-

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -27,6 +27,7 @@ import mapTypeReducer from "../reducers/maptype";
 import additionalLayersReducer from "../reducers/additionallayers";
 import mapEpics from "../epics/map";
 import pluginsCreator from "./map/index";
+import withScalesDenominators from "../components/map/enhancers/withScalesDenominators";
 
 /**
  * The Map plugin allows adding mapping library dependent functionality using support tools.
@@ -438,7 +439,7 @@ export default createPlugin('Map', {
     component: connect(selector, {
         onFontError: errorLoadingFont,
         onResolutionsChange: setMapResolutions
-    })(MapPlugin),
+    })(withScalesDenominators(MapPlugin)),
     reducers: {
         map: mapReducer,
         layers: layersReducer,

--- a/web/client/plugins/geostory/MediaViewer.js
+++ b/web/client/plugins/geostory/MediaViewer.js
@@ -20,6 +20,7 @@ import { resourcesSelector } from '../../selectors/geostory';
 import { SectionTypes } from '../../utils/GeoStoryUtils';
 import withMediaVisibilityContainer from '../../components/geostory/common/enhancers/withMediaVisibilityContainer';
 import autoMapType from '../../components/map/enhancers/autoMapType';
+import withScalesDenominators from "../../components/map/enhancers/withScalesDenominators";
 
 const image = branch(
     ({resourceId}) => resourceId,
@@ -46,6 +47,7 @@ const map = compose(
         connectMap,
     ),
     autoMapType,
+    withScalesDenominators,
     withLocalMapState,
     withMapEditingAndLocalMapState
 )(withMediaVisibilityContainer(Map));


### PR DESCRIPTION
* render comp and test

* mock test

* functional compoent

* change props

* implement logic

* rename file HOC comp

* mock class comp for HOC unit test

* import renamed HOC comp

* rm console

* rename comp and PropTypes

* rename file HOC

* class component in test file

* comp in to test file rm import file

* rename imported component

* remove DEFAULT DPI

* rename imported component

* rename imported component

* add useMemo

* fix spread in mapProps

* add with scales denominators

* add scales denomitor HOC

* rename file

* add info jsdoc

* add info jsdoc

* rename file tets

* Update web/client/components/map/enhancers/withScalesDenominators.js

* add info in doc

* conditional inside hook

Co-authored-by: stefano bovio <stefano.bovio@geo-solutions.it>

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6556 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
