### PR TITLE
Add autocomplete in cross layer filter #2972

### DIFF
--- a/web/client/actions/__tests__/queryform-test.js
+++ b/web/client/actions/__tests__/queryform-test.js
@@ -43,6 +43,7 @@ import {
     TOGGLE_AUTOCOMPLETE_MENU,
     SET_AUTOCOMPLETE_MODE,
     CHANGE_SPATIAL_FILTER_VALUE,
+    UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS,
     setAutocompleteMode,
     toggleMenu,
     changeDwithinValue,
@@ -77,7 +78,8 @@ import {
     addSimpleFilterField,
     removeSimpleFilterField,
     removeAllSimpleFilterFields,
-    changeSpatialFilterValue
+    changeSpatialFilterValue,
+    updateCrossLayerFilterFieldOptions
 } from '../queryform';
 
 describe('Test correctness of the queryform actions', () => {
@@ -170,6 +172,22 @@ describe('Test correctness of the queryform actions', () => {
         expect(retval.rowId).toBe(100);
         expect(retval.fieldName).toBe("fieldName");
         expect(retval.fieldValue).toBe("fieldValue");
+    });
+
+    it('updateCrossLayerFilterFieldOptions', () => {
+        let rowId = 100;
+        let fieldName = "fieldName";
+        let fieldValue = "fieldValue";
+        let fieldAttribute = 'NAME';
+
+        let retval = updateCrossLayerFilterFieldOptions({
+            rowId, fieldName, fieldValue, attribute: fieldAttribute, fieldOptions: {}
+        }, ['a', 'b, c'], 3);
+        expect(retval).toExist();
+        expect(retval.filterField.fieldValue).toBe(fieldValue);
+        expect(retval.type).toBe(UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS);
+        expect(retval.valuesCount).toEqual(3);
+        expect(retval.options).toEqual(['a', 'b, c']);
     });
 
     it('updateExceptionField', () => {

--- a/web/client/actions/queryform.js
+++ b/web/client/actions/queryform.js
@@ -50,6 +50,7 @@ export const LOADING_FILTER_FIELD_OPTIONS = 'LOADING_FILTER_FIELD_OPTIONS';
 export const ADD_CROSS_LAYER_FILTER_FIELD = 'QUERYFORM:ADD_CROSS_LAYER_FILTER_FIELD';
 export const UPDATE_CROSS_LAYER_FILTER_FIELD = 'QUERYFORM:UPDATE_CROSS_LAYER_FILTER_FIELD';
 export const REMOVE_CROSS_LAYER_FILTER_FIELD = 'QUERYFORM:REMOVE_CROSS_LAYER_FILTER_FIELD';
+export const UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS = 'QUERYFORM:UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS';
 export const SET_AUTOCOMPLETE_MODE = 'SET_AUTOCOMPLETE_MODE';
 export const TOGGLE_AUTOCOMPLETE_MENU = 'TOGGLE_AUTOCOMPLETE_MENU';
 export const LOAD_FILTER = 'QUERYFORM:LOAD_FILTER';
@@ -379,7 +380,6 @@ export function addCrossLayerFilterField(groupId) {
     };
 }
 export function updateCrossLayerFilterField(rowId, fieldName, fieldValue, fieldType, fieldOptions = {}) {
-    // TODO
     return {
         type: UPDATE_CROSS_LAYER_FILTER_FIELD,
         rowId,
@@ -412,6 +412,15 @@ export function loadingFilterFieldOptions(status, filterField) {
 export function updateFilterFieldOptions(filterField, options, valuesCount) {
     return {
         type: UPDATE_FILTER_FIELD_OPTIONS,
+        filterField,
+        options,
+        valuesCount
+    };
+}
+
+export function updateCrossLayerFilterFieldOptions(filterField, options, valuesCount) {
+    return {
+        type: UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS,
         filterField,
         options,
         valuesCount

--- a/web/client/actions/queryform.js
+++ b/web/client/actions/queryform.js
@@ -379,6 +379,7 @@ export function addCrossLayerFilterField(groupId) {
     };
 }
 export function updateCrossLayerFilterField(rowId, fieldName, fieldValue, fieldType, fieldOptions = {}) {
+    // TODO
     return {
         type: UPDATE_CROSS_LAYER_FILTER_FIELD,
         rowId,

--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -102,7 +102,7 @@ export default ({
             ? (<Row className="filter-field-fixed-row">
                 <Col xs={12}>
                     <GroupField
-                        autocompleteEnabled={false /* TODO make it work with stream enhancer */}
+                        autocompleteEnabled
                         withContainer={false}
                         attributes={attributes}
                         groupLevels={-1}

--- a/web/client/epics/autocomplete.js
+++ b/web/client/epics/autocomplete.js
@@ -128,4 +128,3 @@ export default {
     fetchAutocompleteOptionsEpic
 };
 
-// returns a promise of data, params

--- a/web/client/reducers/queryform.js
+++ b/web/client/reducers/queryform.js
@@ -46,7 +46,8 @@ import {
     RESET_CROSS_LAYER_FILTER,
     SET_AUTOCOMPLETE_MODE,
     TOGGLE_AUTOCOMPLETE_MENU,
-    LOAD_FILTER
+    LOAD_FILTER,
+    UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS
 } from '../actions/queryform';
 
 import { END_DRAWING, CHANGE_DRAWING_STATUS } from '../actions/draw';
@@ -258,6 +259,28 @@ function queryform(state = initialState, action) {
                 attribute: state.crossLayerFilter && state.crossLayerFilter.attribute
             }
         });
+    }
+    case UPDATE_CROSS_LAYER_FILTER_FIELD_OPTIONS: {
+        return set(
+            `crossLayerFilter.collectGeometries.queryCollection.filterFields`,
+            (get(state, 'crossLayerFilter.collectGeometries.queryCollection.filterFields') || [])
+                .map((field) => {
+                    if (field.rowId === action.filterField.rowId) {
+                        return {
+                            ...field,
+                            options: {
+                                ...field.options,
+                                [field.attribute]: action.options
+                            },
+                            fieldOptions: {
+                                ...field.fieldOptions,
+                                valuesCount: action.valuesCount
+                            }
+                        };
+                    }
+                    return field;
+                })
+            , state);
     }
     case SELECT_SPATIAL_METHOD: {
         return assign({}, state, {spatialField: assign({}, state.spatialField, {[action.fieldName]: action.method, geometry: null})});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Ehancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Attribute Filter in Cross layer filter doesnot allow autocomplete 

#2972 

**What is the new behavior?**
Attribute Filter in cross layer filter should allow autocomplete as for the Attribute Filter of the query panel

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
