### PR TITLE
[Backreport 2021.01.xx] #2973: Cross Layer Filter limits should be well notified to the user

### DIFF
--- a/web/client/components/data/query/CrossLayerFilter.jsx
+++ b/web/client/components/data/query/CrossLayerFilter.jsx
@@ -15,7 +15,7 @@ import Select from 'react-select';
 import GeometricOperationSelector from './GeometricOperationSelector';
 import GroupField from './GroupField';
 import { isSameUrl } from '../../../utils/URLUtils';
-
+import InfoPopover from '../../widgets/widget/InfoPopover';
 
 const isSameOGCServiceRoot = (origSearchUrl, {search, url} = {}) => isSameUrl(origSearchUrl, url) || isSameUrl(origSearchUrl, (search && search.url));
 // bbox make not sense with cross layer filter
@@ -47,6 +47,15 @@ export default ({
         index: 0
     }]} = queryCollection;
 
+    const unMatchingLayerOptions = layers
+        .filter( l => !isSameOGCServiceRoot(searchUrl, l));
+
+    const renderUnMatchingLayersInfo = () => {
+        if (layers.length && unMatchingLayerOptions.length) {
+            return (<InfoPopover bsStyle="link" text={<Message msgId="queryform.crossLayerFilter.errors.layersExcluded" />}/>);
+        }
+        return null;
+    };
     return (<SwitchPanel
         loading={loadingCapabilities}
         expanded={crossLayerExpanded && !loadingCapabilities && !errorObj}
@@ -63,7 +72,11 @@ export default ({
         title={<Message msgId="queryform.crossLayerFilter.title" />} >
         <Row className="inline-form filter-field-fixed-row">
             <Col xs={6}>
-                <div><Message msgId="queryform.crossLayerFilter.targetLayer"/></div>
+                <div>
+                    <Message msgId="queryform.crossLayerFilter.targetLayer"/>&nbsp;
+                    { renderUnMatchingLayersInfo() }
+                </div>
+
             </Col>
             <Col xs={6}>
                 <Select

--- a/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
+++ b/web/client/components/data/query/__tests__/CrossLayerFilter-test.jsx
@@ -116,4 +116,42 @@ describe('CrossLayerFilter component', () => {
         expect(expected).toEqual('false');
     });
 
+    it('Test CrossLayerFilter show tooltip for non matching layer source', () => {
+        const container = document.getElementById('container');
+        ReactDOM.render(<CrossLayerFilter
+            layers={[{name: "test", url: "https://google.com"}, {name: 'test2', url: 'https://example.com'}]}
+            queryCollection={{
+                typeName: "test",
+                geometryName: "geometry"
+            }}
+            searchUrl="https://google.com"
+            operation="WITHIN"
+            spatialOperations={[{
+                id: "WITHIN",
+                name: "Within"
+            }]}
+        />, document.getElementById("container"));
+        const infoIcon = container.querySelector('.mapstore-info-popover');
+        expect(infoIcon).toExist();
+    });
+
+    it('Test CrossLayerFilter not show tooltip for matching layer source', () => {
+        const container = document.getElementById('container');
+        ReactDOM.render(<CrossLayerFilter
+            layers={[{name: "test", url: "https://google.com"}, {name: 'test2', url: 'https://google.com'}]}
+            queryCollection={{
+                typeName: "test",
+                geometryName: "geometry"
+            }}
+            searchUrl="https://google.com"
+            operation="WITHIN"
+            spatialOperations={[{
+                id: "WITHIN",
+                name: "Within"
+            }]}
+        />, document.getElementById("container"));
+        const infoIcon = container.querySelector('.mapstore-info-popover');
+        expect(infoIcon).toNotExist();
+    });
+
 });

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1075,7 +1075,8 @@
                 "operation": "Geometrische Operation",
                 "placeholder": "Wählen Sie eine Ebene aus",
                 "errors": {
-                    "noCrossLayerAvailable": "Ebenenfilter ist für die ausgewählte Ebene nicht verfügbar"
+                    "noCrossLayerAvailable": "Ebenenfilter ist für die ausgewählte Ebene nicht verfügbar",
+                    "layersExcluded": "Für diesen Ebenenfilter können nur Ebenen ausgewählt werden, die von derselben Quelle stammen"
                 }
             },
             "changedFilter": "Filter geändert",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1074,7 +1074,8 @@
                 "operation": "Operation",
                 "placeholder": "Select layer",
                 "errors": {
-                    "noCrossLayerAvailable": "Cross layer filtering is not available for the selected layer"
+                    "noCrossLayerAvailable": "Cross layer filtering is not available for the selected layer",
+                    "layersExcluded": "Only layers coming from the same source can be selected as target layer for this layer filter"
                 }
             },
             "changedFilter": "Filter Changed",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1074,7 +1074,8 @@
                 "operation": "Operación",
                 "placeholder": "Selecciona una capa",
                 "errors": {
-                    "noCrossLayerAvailable": "El filtro de capa no está disponible para la capa seleccionada"
+                    "noCrossLayerAvailable": "El filtro de capa no está disponible para la capa seleccionada",
+                    "layersExcluded": "Solo las capas que provienen de la misma fuente se pueden seleccionar como capa de destino para este filtro de capa"
                 }
             },
             "changedFilter": "Filtro cambiado",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -900,7 +900,8 @@
         "operation": "Toiminto",
         "placeholder": "Valitse taso",
         "errors": {
-          "noCrossLayerAvailable": "Ristiinsuodatus ei ole käytettävissä valitulle tasolle"
+          "noCrossLayerAvailable": "Ristiinsuodatus ei ole käytettävissä valitulle tasolle",
+          "layersExcluded": "Vain kerrokset, jotka tulevat samasta lähteestä, voidaan valita tämän kerroksen suodattimen kohdekerrokseksi"
         }
       },
       "changedFilter": "Suodatin vaihdettu",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1074,7 +1074,8 @@
                 "operation": "Opération",
                 "placeholder": "Sélectionner une couche",
                 "errors": {
-                    "noCrossLayerAvailable": "Le filtrage croisé n'est pas disponible pour la couche sélectionné"
+                    "noCrossLayerAvailable": "Le filtrage croisé n'est pas disponible pour la couche sélectionné",
+                    "layersExcluded": "Seuls les calques provenant de la même source peuvent être sélectionnés comme calque cible pour ce filtre de calque"
                 }
             },
             "changedFilter": "Filtre modifié",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -880,7 +880,8 @@
                 "operation": "Operacija",
                 "placeholder": "Odaberi sloj",
                 "errors": {
-                    "noCrossLayerAvailable": "Unakrsni filter više slojeva nije omogućen za odabrani sloj"
+                    "noCrossLayerAvailable": "Unakrsni filter više slojeva nije omogućen za odabrani sloj",
+                    "layersExcluded": "Kao ciljni sloj za ovaj filtar slojeva mogu se odabrati samo slojevi koji dolaze iz istog izvora"
                 }
             },
             "changedFilter": "Filter prominjenjen",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1074,7 +1074,8 @@
                 "operation": "Operazione",
                 "placeholder": "Seleziona il livello",
                 "errors": {
-                    "noCrossLayerAvailable": "L'operazione di filtraggio usando un livello non è supportata per il layer selezionato"
+                    "noCrossLayerAvailable": "L'operazione di filtraggio usando un livello non è supportata per il layer selezionato",
+                    "layersExcluded": "Solo i layer provenienti dalla stessa sorgente possono essere selezionati come layer di destinazione per questo filtro layer"
                 }
             },
             "changedFilter": "Filtero modificato",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1075,7 +1075,8 @@
                 "operation": "Operatie",
                 "placeholder": "Selecteer laag",
                 "errors": {
-                    "noCrossLayerAvailable": "Tussen lagen filteren is niet beschikbaar voor de geselecteerde laag"
+                    "noCrossLayerAvailable": "Tussen lagen filteren is niet beschikbaar voor de geselecteerde laag",
+                    "layersExcluded": "Alleen lagen die uit dezelfde bron komen, kunnen als doellaag voor dit laagfilter worden geselecteerd"
                 }
             },
             "changedFilter": "Filter gewijzigd",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -864,7 +864,8 @@
                 "clear": "Clear filter",
                 "operation": "Operation",
                 "errors": {
-                    "noCrossLayerAvailable": "Cross Layer Filtering is not available for the selected layer"
+                    "noCrossLayerAvailable": "Cross Layer Filtering is not available for the selected layer",
+                    "layersExcluded": "Apenas as camadas provenientes da mesma origem podem ser selecionadas como camada de destino para este filtro de camada"
                 }
             }
         },

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -1028,7 +1028,8 @@
             "crossLayerFilter": {
                 "clear": "Xóa bộ lọc",
                 "errors": {
-                    "noCrossLayerAvailable": "Lọc lớp chéo không khả dụng cho lớp đã chọn"
+                    "noCrossLayerAvailable": "Lọc lớp chéo không khả dụng cho lớp đã chọn",
+                    "layersExcluded": "Chỉ các lớp đến từ cùng một nguồn mới có thể được chọn làm lớp đích cho bộ lọc lớp này"
                 },
                 "operation": "Hoạt động",
                 "placeholder": "Chọn lớp",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -842,7 +842,8 @@
                 "clear": "Clear filter",
                 "operation": "Operation",
                 "errors": {
-                    "noCrossLayerAvailable": "Cross Layer Filtering is not available for the selected layer"
+                    "noCrossLayerAvailable": "Cross Layer Filtering is not available for the selected layer",
+                    "layersExcluded": "只能选择来自同一来源的图层作为此图层过滤器的目标图层"
                 }
             }
         },


### PR DESCRIPTION
(cherry picked from commit 68019ce53f92b0fb889cc156faa34c58d47d708e)

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

#2973 

**What is the current behavior?**
No user information is provided to the user if a layer is excluded from the cross-layer filter
#2973 

**What is the new behavior?**
Info Icon is shown if layers not from the same source are excluded from the cross-layer filter list
<img width="600" alt="Screenshot 2021-03-03 at 14 56 20" src="https://user-images.githubusercontent.com/39124174/109802280-a72dc080-7c30-11eb-8d0e-d7419ad2515f.png">

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
