### PR TITLE
[Backreport 2021.01.xx] #6115 Widget tool button should be hidden when a raster layer is selected #6115

### DIFF
--- a/web/client/components/TOC/Toolbar.jsx
+++ b/web/client/components/TOC/Toolbar.jsx
@@ -296,7 +296,7 @@ class Toolbar extends React.Component {
                         </Button>
                     </OverlayTrigger>
                     : null}
-                {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && this.props.selectedLayers[0].search !== 'vector' && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.layerdownload.expanded ?
+                {this.props.activateTool.activateWidgetTool && (status === 'LAYER') && this.props.selectedLayers.length === 1 && this.props.selectedLayers[0].search && this.props.selectedLayers[0].search !== 'vector' && !this.props.settings.expanded && !this.props.layerMetadata.expanded && !this.props.layerdownload.expanded ?
                     <OverlayTrigger
                         key="widgets"
                         placement="top"

--- a/web/client/components/TOC/__tests__/Toolbar-test.jsx
+++ b/web/client/components/TOC/__tests__/Toolbar-test.jsx
@@ -530,6 +530,10 @@ describe('TOC Toolbar', () => {
                         minx: -10,
                         miny: -9
                     }, crs: 'EPSG:3003'
+                },
+                search: {
+                    type: "wfs",
+                    url: "/geoserver/wfs"
                 }
             }];
             const activateTool = {
@@ -567,12 +571,36 @@ describe('TOC Toolbar', () => {
                         minx: -10,
                         miny: -9
                     }, crs: 'EPSG:3003'
+                },
+                search: {
+                    type: "wfs",
+                    url: "/geoserver/wfs"
                 }
             }];
             ReactDOM.render(<Toolbar activateTool={{ activateWidgetTool: true }} selectedLayers={selectedLayers} />, document.getElementById("container"));
             const widgetButton = document.querySelector(WIDGET_TOOL_SELECTOR);
             expect(widgetButton).toNotExist();
 
+        });
+
+        it('deactivate layers without search property(Raster Layers)', () => {
+            const selectedLayers = [{
+                id: 'l002',
+                title: 'layer002',
+                type: 'wms',
+                name: 'layer001name',
+                bbox: {
+                    bounds: {
+                        maxx: 10,
+                        maxy: 9,
+                        minx: -10,
+                        miny: -9
+                    }, crs: 'EPSG:3003'
+                }
+            }];
+            ReactDOM.render(<Toolbar activateTool={{ activateWidgetTool: true }} selectedLayers={selectedLayers} />, document.getElementById("container"));
+            const widgetButton = document.querySelector(WIDGET_TOOL_SELECTOR);
+            expect(widgetButton).toNotExist();
         });
     });
 


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

#6115 

**What is the current behavior?**
When a raster layer is selected inside the TOC the widget button is available.

**What is the new behavior?**
When a raster layer is selected inside the TOC, the widget button is unavailable.

#6115 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
Raster layers do not have a search property so I added a check to verify that a search property exists or if it's not `undefined`