### PR TITLE
#6524: Snap time on guide layer select

### DIFF
--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -16,7 +16,8 @@ import {
     setTimelineCurrentTime,
     updateRangeDataOnRangeChange,
     settingInitialOffsetValue,
-    syncTimelineGuideLayer
+    syncTimelineGuideLayer,
+    snapTimeGuideLayer
 } from '../timeline';
 
 import { changeMapView } from '../../actions/map';
@@ -151,7 +152,7 @@ describe('timeline Epics', () => {
             done();
         });
     });
-    describe('syncTimelineGuideLayer', () => {
+    describe('Timeline GuideLayer', () => {
         const doAssertion = (NUM_ACTIONS, actions, layerId) => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map(action=>{
@@ -159,14 +160,12 @@ describe('timeline Epics', () => {
                 case SELECT_LAYER:
                     expect(action.layerId).toBe(layerId);
                     break;
-                case SET_CURRENT_TIME:
-                    break;
                 default:
                     expect(true).toBe(false);
                 }
             });
         };
-        const NUM_ACTIONS = 2;
+        const NUM_ACTIONS = 1;
         const STATE_TIMELINE = {
             timeline: { settings: {autoSelect: true}},
             layers: { flat: [
@@ -218,10 +217,22 @@ describe('timeline Epics', () => {
             }, {...STATE_TIMELINE, timeline: { settings: {autoSelect: true, showHiddenLayers: true}}});
         });
         it('syncTimelineGuideLayer retain selection', done => {
-            testEpic(addTimeoutEpic(syncTimelineGuideLayer, 500), 1, [selectLayer('TEST_LAYER1'), removeNode('TEST_LAYER1', 'layers') ], ([action]) => {
+            testEpic(addTimeoutEpic(syncTimelineGuideLayer, 500), NUM_ACTIONS, [selectLayer('TEST_LAYER1'), removeNode('TEST_LAYER1', 'layers') ], ([action]) => {
                 expect(action.type).toBe(TEST_TIMEOUT); // Don't update selection when selected layer in timeline present
                 done();
             }, {...STATE_TIMELINE, timeline: { settings: {autoSelect: true, showHiddenLayers: true}}});
+        });
+        it('snapTimeGuideLayer', done => {
+            testEpic(snapTimeGuideLayer, NUM_ACTIONS, [selectLayer('TEST_LAYER')], ([action]) => {
+                expect(action.type).toBe(SET_CURRENT_TIME);
+                done();
+            }, {...STATE_TIMELINE, timeline: { settings: {autoSelect: true, showHiddenLayers: true}}});
+        });
+        it('snapTimeGuideLayer when autoselect disabled', done => {
+            testEpic(addTimeoutEpic(snapTimeGuideLayer, 500), NUM_ACTIONS, [selectLayer('TEST_LAYER')], ([action]) => {
+                expect(action.type).toBe(TEST_TIMEOUT); // Don't trigger a snap time when snap to guide layer settings is turned off
+                done();
+            }, {...STATE_TIMELINE, timeline: { settings: {autoSelect: false}}});
         });
     });
     describe('updateRangeDataOnRangeChange', () => {

--- a/web/client/epics/timeline.js
+++ b/web/client/epics/timeline.js
@@ -235,18 +235,25 @@ export const syncTimelineGuideLayer = (action$, { getState = () => { } } = {}) =
             const state = getState();
             const firstTimeLayer = get(timelineLayersSelector(state), "[0].id");
             if (isAutoSelectEnabled(state) && firstTimeLayer) {
-                return Rx.Observable.of(selectLayer(firstTimeLayer)) // Select the first guide layer from the list and snap time
-                    .concat(
-                        Rx.Observable.of(1)
-                            .switchMap( () =>
-                                snapTime(getState(), firstTimeLayer, currentTimeSelector(getState()) || new Date().toISOString()) // Get latest state to snap time
-                                    .filter( v => v)
-                                    .map(time => setCurrentTime(time))
-                            )
-                    );
+                return Rx.Observable.of(selectLayer(firstTimeLayer)); // Select the first guide layer from the list and snap time
             }
             return Rx.Observable.empty();
         });
+
+/**
+ * Snap time of the selected layer
+ * @memberof epics.timeline
+ * @param {observable} action$ manages `SELECT_LAYER`
+ * @param {function} getState to fetch the store object
+ * @return {observable}
+ */
+export const snapTimeGuideLayer = (action$, { getState = () => { } } = {}) =>
+    action$.ofType(SELECT_LAYER)
+        .filter((action)=> action?.layerId && isAutoSelectEnabled(getState()))
+        .switchMap(({layerId}) => snapTime(getState(), layerId, currentTimeSelector(getState()) || new Date().toISOString())
+            .filter(v => v)
+            .map(time => setCurrentTime(time))
+        );
 
 /**
  * When offset is initiated this epic sets both initial current time and offset if any does not exist
@@ -330,5 +337,6 @@ export default {
     setTimelineCurrentTime,
     settingInitialOffsetValue,
     updateRangeDataOnRangeChange,
-    syncTimelineGuideLayer
+    syncTimelineGuideLayer,
+    snapTimeGuideLayer
 };


### PR DESCRIPTION
## Description
This PR adds commit to snap time on selecting the guide layer when 'Snap to guide layer' option is enabled

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6524 

**What is the new behavior?**

- On selecting the guide layer with 'Snap to guide layer' on, the time slider automatically snap times in the Timeline

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
**Sample map**: https://dev.mapstore2.geo-solutions.it/mapstore/#/viewer/openlayers/33077