### PR TITLE
5138: Exported measurements issues with import/styling #5138

### DIFF
--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -67,11 +67,13 @@ class StylePanel extends React.Component {
         useDefaultStyle: false,
         zoomOnShapefiles: true,
         overrideAnnotation: false,
-        initialLayers: []
+        initialLayers: [],
+        disableStyleCustomization: false
     };
 
     componentDidMount() {
         this.setState({initialLayers: [...this.props.layers]});
+        this.checkAndDisableStyleCustomization();
     }
 
     getGeometryType = (geometry) => {
@@ -138,6 +140,17 @@ class StylePanel extends React.Component {
         </Row>);
     };
 
+    renderDisableStyleCustomization = () => {
+        if (this.state.disableStyleCustomization) {
+            return (
+                <div className="alert alert-info mb-2 style-customisation-disabled-container">
+                    <Message msgId="shapefile.styleCustomizationDisabled"/>
+                </div>
+            );
+        }
+        return null;
+    }
+
     render() {
         return (
             <Grid role="body" style={{width: "400px"}} fluid>
@@ -151,13 +164,14 @@ class StylePanel extends React.Component {
                 <Row key="styler" style={{marginBottom: 10}}>
                     {this.state.useDefaultStyle ? null : this.props.stylers[this.getGeomType(this.props.selected)]}
                 </Row>
+                {this.renderDisableStyleCustomization()}
                 <Row key="options">
                     {isAnnotation(this.props.selected) ?
                         this.annotationOptions()
                         :
                         <>
                             <Col xs={2}>
-                                <input aria-label="..." type="checkbox" defaultChecked={this.state.useDefaultStyle} onChange={(e) => { this.setState({ useDefaultStyle: e.target.checked }); }} />
+                                <input aria-label="..." type="checkbox" disabled={this.state.disableStyleCustomization} checked={this.state.useDefaultStyle} defaultChecked={this.state.useDefaultStyle} onChange={(e) => { this.setState({ useDefaultStyle: e.target.checked }); }} />
                             </Col>
                             <Col style={{ paddingLeft: 0, paddingTop: 1 }} xs={10}>
                                 <label><Message msgId="shapefile.defaultStyle" /></label>
@@ -239,6 +253,30 @@ class StylePanel extends React.Component {
             </Col>
         </>
     );
+
+    checkAndDisableStyleCustomization = () => {
+        if (this.props.layers[0]) {
+            const [layer] = this.props.layers;
+            if (layer.features.length) {
+                for (let i = 0; i < layer.features.length; i++) {
+                    const feature = layer.features[i];
+                    if (feature.style) {
+                        if (Array.isArray(feature.style)) {
+                            if (feature.style.length) {
+                                this.setState({disableStyleCustomization: true, useDefaultStyle: true});
+                                break;
+                            }
+                        } else {
+                            if (Object.keys(feature.style).length) {
+                                this.setState({disableStyleCustomization: true, useDefaultStyle: true});
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -150,7 +150,6 @@ class StylePanel extends React.Component {
         if (this.state.disableStyleCustomization) {
             return (
                 <div className="alert alert-info mb-2 style-customisation-disabled-container">
-                    {/* TODO update translation message */}
                     <Message msgId="shapefile.styleCustomizationDisabled"/>
                 </div>
             );

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -73,6 +73,7 @@ class StylePanel extends React.Component {
 
     componentDidMount() {
         this.setState({initialLayers: [...this.props.layers]});
+        this.setState({currentActiveLayer: this.props.selected});
         this.checkAndDisableStyleCustomization();
     }
 
@@ -144,6 +145,7 @@ class StylePanel extends React.Component {
         if (this.state.disableStyleCustomization) {
             return (
                 <div className="alert alert-info mb-2 style-customisation-disabled-container">
+                    {/* TODO update translation message */}
                     <Message msgId="shapefile.styleCustomizationDisabled"/>
                 </div>
             );
@@ -229,7 +231,6 @@ class StylePanel extends React.Component {
             this.props.onSuccess(this.props.layers.length > 1
                 ? isAnnotationLayer ? "Annotation" : this.props.layers[0].name + getMessageById(this.context.messages, "shapefile.success")
                 : undefined);
-
             this.props.onLayerAdded(this.props.selected);
         }).catch(e => {
             this.props.onError({ type: "error", name: isAnnotationLayer ? "Annotation" : this.props.layers[0].name, error: e, message: 'shapefile.error.genericLoadError'});
@@ -255,8 +256,9 @@ class StylePanel extends React.Component {
     );
 
     checkAndDisableStyleCustomization = () => {
-        if (this.props.layers[0]) {
-            const [layer] = this.props.layers;
+        this.setState({disableStyleCustomization: false, useDefaultStyle: false});
+        const layer =  this.props.selected;
+        if (layer) {
             if (layer.features.length) {
                 for (let i = 0; i < layer.features.length; i++) {
                     const feature = layer.features[i];

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -73,7 +73,6 @@ class StylePanel extends React.Component {
 
     componentDidMount() {
         this.setState({initialLayers: [...this.props.layers]});
-        this.setState({currentActiveLayer: this.props.selected});
     }
 
     getGeometryType = (geometry) => {

--- a/web/client/components/import/style/StylePanel.jsx
+++ b/web/client/components/import/style/StylePanel.jsx
@@ -76,6 +76,11 @@ class StylePanel extends React.Component {
         this.setState({currentActiveLayer: this.props.selected});
         this.checkAndDisableStyleCustomization();
     }
+    componentDidUpdate(prevProps) {
+        if (prevProps.selected.name !== this.props.selected.name) {
+            this.checkAndDisableStyleCustomization();
+        }
+    }
 
     getGeometryType = (geometry) => {
         if (geometry && geometry.type === 'GeometryCollection') {

--- a/web/client/components/import/style/__tests__/StylePanel-test.jsx
+++ b/web/client/components/import/style/__tests__/StylePanel-test.jsx
@@ -136,4 +136,36 @@ describe('StylePanel component', () => {
         const btn = document.querySelectorAll('button')[2];
         ReactTestUtils.Simulate.click(btn); // <-- trigger event callback
     });
+
+    it("Test StylePanel show Style customization information if layer.features has styles", (done) => {
+        const layers = [{name: "Feature", features: [{
+            type: "Feature",
+            id: "poi.1",
+            geometry: {
+                type: "Point",
+                coordinates: [
+                    -74.0104611,
+                    40.70758763
+                ]
+            },
+            geometry_name: "the_geom",
+            properties: {
+                NAME: "museam",
+                THUMBNAIL: "pics/22037827-Ti.jpg",
+                MAINPAGE: "pics/22037827-L.jpg"
+            },
+            style: [{color: 'red'}]
+        }]}];
+        const cmp = ReactDOM.render(<StylePanel
+            errors={[W1]}
+            layers={layers}
+            selected={L1}
+            stylers={{ "Point": <div></div> }}
+        />, document.getElementById("container"));
+        expect(cmp).toExist();
+        const container = document.getElementById('container');
+        const el = container.querySelector('.style-customisation-disabled-container');
+        expect(el).toExist();
+        done();
+    });
 });

--- a/web/client/components/import/style/__tests__/StylePanel-test.jsx
+++ b/web/client/components/import/style/__tests__/StylePanel-test.jsx
@@ -159,7 +159,7 @@ describe('StylePanel component', () => {
         const cmp = ReactDOM.render(<StylePanel
             errors={[W1]}
             layers={layers}
-            selected={L1}
+            selected={layers[0]}
             stylers={{ "Point": <div></div> }}
         />, document.getElementById("container"));
         expect(cmp).toExist();

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1325,7 +1325,7 @@
             "skip": "springen",
             "finish": "Fertig",
             "layerOf": "Ebene {count} von {total}:",
-            "styleCustomizationDisabled":"Diese Ebene hat einen Stil, der in einem Stil inline definiert ist, und kann nicht angepasst werden."
+            "styleCustomizationDisabled":"Diese Ebene hat bereits einen Stil definiert und kann nicht angepasst werden."
         },
         "mapImport": {
                 "title": "Importieren",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1324,7 +1324,8 @@
             "next": "Nächster",
             "skip": "springen",
             "finish": "Fertig",
-            "layerOf": "Ebene {count} von {total}:"
+            "layerOf": "Ebene {count} von {total}:",
+            "styleCustomizationDisabled":"Diese Ebene hat einen Stil, der in einem Stil inline definiert ist, und kann nicht angepasst werden."
         },
         "mapImport": {
                 "title": "Importieren",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1323,7 +1323,8 @@
             "next": "Next",
             "skip": "Skip",
             "finish": "Finish",
-            "layerOf": "Layer {count} of {total}:"
+            "layerOf": "Layer {count} of {total}:",
+            "styleCustomizationDisabled": "This layer has a style defined at an style inline and its not possible to customize it."
         },
         "mapImport": {
             "title": "Import",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1324,7 +1324,7 @@
             "skip": "Skip",
             "finish": "Finish",
             "layerOf": "Layer {count} of {total}:",
-            "styleCustomizationDisabled": "This layer has a style defined at an style inline and its not possible to customize it."
+            "styleCustomizationDisabled": "This layer has already a style defined and is not possible to customize it."
         },
         "mapImport": {
             "title": "Import",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1323,7 +1323,8 @@
             "next": "Siguiente",
             "skip": "Saltar",
             "finish": "Terminar",
-            "layerOf": "Capa {count} de {total}:"
+            "layerOf": "Capa {count} de {total}:",
+            "styleCustomizationDisabled":"Esta capa tiene un estilo definido en un estilo en línea y no es posible personalizarlo."
         },
         "mapImport": {
             "title": "Importar",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1324,7 +1324,7 @@
             "skip": "Saltar",
             "finish": "Terminar",
             "layerOf": "Capa {count} de {total}:",
-            "styleCustomizationDisabled":"Esta capa tiene un estilo definido en un estilo en línea y no es posible personalizarlo."
+            "styleCustomizationDisabled":"Esta capa ya tiene un estilo definido y no es posible personalizarlo."
         },
         "mapImport": {
             "title": "Importar",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1324,7 +1324,8 @@
             "next": "Suivant",
             "skip": "Passer",
             "finish": "Terminer",
-            "layerOf": "Couche {count} sur {total} :"
+            "layerOf": "Couche {count} sur {total} :",
+            "styleCustomizationDisabled":"Ce calque a un style défini à un style en ligne et il n'est pas possible de le personnaliser."
         },
         "mapImport": {
             "title": "Importer",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1325,7 +1325,7 @@
             "skip": "Passer",
             "finish": "Terminer",
             "layerOf": "Couche {count} sur {total} :",
-            "styleCustomizationDisabled":"Ce calque a un style défini à un style en ligne et il n'est pas possible de le personnaliser."
+            "styleCustomizationDisabled":"Ce calque a déjà un style défini et il n'est pas possible de le personnaliser."
         },
         "mapImport": {
             "title": "Importer",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1324,7 +1324,7 @@
             "skip": "Salta",
             "finish": "Fine",
             "layerOf": "Strato {count} dei {total}:",
-            "styleCustomizationDisabled":"Questo livello ha uno stile definito in uno stile in linea e non è possibile personalizzarlo."
+            "styleCustomizationDisabled":"Questo livello ha già uno stile definito e non è possibile personalizzarlo."
         },
         "mapImport": {
             "title": "Importa",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1323,7 +1323,8 @@
             "next": "Avanti",
             "skip": "Salta",
             "finish": "Fine",
-            "layerOf": "Strato {count} dei {total}:"
+            "layerOf": "Strato {count} dei {total}:",
+            "styleCustomizationDisabled":"Questo livello ha uno stile definito in uno stile in linea e non è possibile personalizzarlo."
         },
         "mapImport": {
             "title": "Importa",

--- a/web/client/utils/ImporterUtils.js
+++ b/web/client/utils/ImporterUtils.js
@@ -28,3 +28,18 @@ export const getbsStyleForState = function(state) {
 
     }
 };
+
+/**
+ * @param {*} layer
+ * @returns {boolean}
+ */
+
+export const checkFeaturesStyle = (layer = {}) => {
+    return layer && layer.features.length ?
+        layer.features.reduce((hasCustomStyle, feature ) => {
+            const isCustomStylePresent = feature.style &&
+            (Array.isArray(feature.style) && feature.style.length ) ||
+            (Object.keys(feature.style || {}).length);
+            return hasCustomStyle || !!isCustomStylePresent;
+        }, false) : false;
+};

--- a/web/client/utils/__tests__/ImportUtils-test.js
+++ b/web/client/utils/__tests__/ImportUtils-test.js
@@ -1,0 +1,22 @@
+import expect from 'expect';
+import {checkFeaturesStyle} from '../ImporterUtils';
+
+describe('ImporterUtils', () => {
+    it('should return false if layer features donot have styles', () => {
+        const layer = {name: 'Layer', features: [{name: 'Feature'}]};
+        const hasStyles = checkFeaturesStyle(layer);
+        expect(hasStyles).toBeFalsy();
+    });
+
+    it('should return true if layer features have style array with an item', () => {
+        const layer = {name: 'Layer', features: [{name: 'Feature', style: [{color: 'red'}]}]};
+        const hasStyles = checkFeaturesStyle(layer);
+        expect(hasStyles).toBeTruthy();
+    });
+
+    it('should return true if layer features have style Object with atleast one item', () => {
+        const layer = {name: 'Layer', features: [{name: 'Feature', style: {color: 'red'}}]};
+        const hasStyles = checkFeaturesStyle(layer);
+        expect(hasStyles).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Others Describe. Enhancement

## Issue

**What is the current behavior?**
The style is not applied.
#5138 

**What is the new behavior?**
If the imported map has inline styles defined. Check and Disable Default Style checkbox and notify the user with a message.
![Screenshot 2021-03-17 at 16 10 26](https://user-images.githubusercontent.com/39124174/111490416-108ef280-874c-11eb-9e19-1f8ac2c0c51d.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


## Other useful information
