### PR TITLE
[Backreport 2021.01.xx] Failed password change attempts are not reported to the user #3245

### DIFF
--- a/web/client/actions/security.js
+++ b/web/client/actions/security.js
@@ -114,8 +114,15 @@ export function changePasswordFail(e) {
     };
 }
 
+export function changePasswordStart() {
+    return {
+        type: CHANGE_PASSWORD
+    };
+}
+
 export function changePassword(user, newPassword) {
     return (dispatch) => {
+        dispatch(changePasswordStart());
         AuthenticationAPI.changePassword(user, newPassword).then(() => {
             dispatch(changePasswordSuccess(user, newPassword));
         }).catch((e) => {

--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -173,10 +173,14 @@ const Api = {
     },
     changePassword: function(user, newPassword, options) {
         return axios.put(
-            "users/user/" + user.id, "<User><newPassword>" + newPassword + "</newPassword></User>",
+            "users/user/" + user.id, {
+                User: {
+                    newPassword
+                }
+            },
             this.addBaseUrl(merge({
                 headers: {
-                    'Content-Type': "application/xml"
+                    'Content-Type': "application/json"
                 }
             }, options)));
     },

--- a/web/client/components/security/modals/PasswordResetModal.jsx
+++ b/web/client/components/security/modals/PasswordResetModal.jsx
@@ -36,7 +36,8 @@ class PasswordResetModal extends React.Component {
         buttonSize: PropTypes.string,
         includeCloseButton: PropTypes.bool,
         changed: PropTypes.bool,
-        error: PropTypes.object
+        error: PropTypes.object,
+        loading: PropTypes.bool
     };
 
     static defaultProps = {
@@ -50,7 +51,8 @@ class PasswordResetModal extends React.Component {
         closeGlyph: "",
         style: {},
         buttonSize: "small",
-        includeCloseButton: true
+        includeCloseButton: true,
+        loading: false
     };
 
     state = {
@@ -83,7 +85,7 @@ class PasswordResetModal extends React.Component {
                 key="passwordChangeButton"
                 bsStyle="primary"
                 bsSize={this.props.buttonSize}
-                disabled={!this.state.passwordValid}
+                disabled={!this.state.passwordValid || this.props.loading}
                 onClick={() => {
                     this.setState({loading: true});
                     this.onPasswordChange();
@@ -97,7 +99,7 @@ class PasswordResetModal extends React.Component {
     };
 
     getBody = () => {
-        return (<PasswordReset role="body" ref="passwordResetForm"
+        return (<PasswordReset error={this.props.error} role="body" ref="passwordResetForm"
             changed={this.props.changed}
             onChange={(password, valid) => {
                 this.setState({passwordValid: valid, password});
@@ -105,7 +107,7 @@ class PasswordResetModal extends React.Component {
     };
 
     renderLoading = () => {
-        return this.state.loading ? <Spinner spinnerName="circle" key="loadingSpinner" noFadeIn overrideSpinnerClassName="spinner"/> : null;
+        return this.props.loading ? <Spinner spinnerName="circle" key="loadingSpinner" noFadeIn overrideSpinnerClassName="spinner"/> : null;
     };
 
     render() {

--- a/web/client/components/security/modals/__tests__/PasswordResetModal-test.jsx
+++ b/web/client/components/security/modals/__tests__/PasswordResetModal-test.jsx
@@ -54,4 +54,20 @@ describe("Test password reset modal", () => {
         ReactTestUtils.Simulate.click(button);
         expect(spy.calls.length).toEqual(1);
     });
+
+    it('test password show spinner on Submit', () => {
+        let callbacks = {
+            onPasswordChange: (user, pass) => {
+                expect(pass).toEqual("test");
+                expect(pass).toEqual("password");
+            }
+        };
+        expect.spyOn(callbacks, 'onPasswordChange');
+        ReactDOM.render(<PRModal loading={false} options={{animation: false}} show user={{name: "test"}} onPasswordChange={callbacks.onPasswordChange}/>, document.getElementById("container"));
+        let button = document.getElementsByTagName("button")[1];
+        ReactTestUtils.Simulate.click(button);
+        let spinner = document.getElementsByTagName("Spinner");
+        expect(spinner).toExist();
+    });
+
 });

--- a/web/client/plugins/login/index.js
+++ b/web/client/plugins/login/index.js
@@ -52,7 +52,8 @@ export const PasswordReset = connect((state) => ({
     user: state.security && state.security.user,
     show: state.controls.ResetPassword && state.controls.ResetPassword.enabled,
     changed: state.security && state.security.passwordChanged && true || false,
-    error: state.security && state.security.passwordError
+    error: state.security && state.security.passwordError,
+    loading: state.security && state.security.changePasswordLoading || false
 }), {
     onPasswordChange: (user, pass) => { return changePassword(user, pass); },
     onClose: setControlProperty.bind(null, "ResetPassword", "enabled", false, false)

--- a/web/client/reducers/__tests__/security-test.js
+++ b/web/client/reducers/__tests__/security-test.js
@@ -17,7 +17,8 @@ import {
     CHANGE_PASSWORD_SUCCESS,
     CHANGE_PASSWORD_FAIL,
     REFRESH_SUCCESS,
-    SESSION_VALID
+    SESSION_VALID,
+    CHANGE_PASSWORD
 } from '../../actions/security';
 
 import { SET_CONTROL_PROPERTY } from '../../actions/controls';
@@ -140,6 +141,13 @@ describe('Test the security reducer', () => {
         expect(state.user.name).toBe("user");
     });
 
+    it('change password start set changePasswordLoading', () => {
+        let state = security({user: testUser.User}, {type: CHANGE_PASSWORD});
+        expect(state).toExist();
+        expect(state.changePasswordLoading).toBeTruthy();
+        expect(state.passwordError).toBe(null);
+    });
+
     it('change password success', () => {
         let state = security({user: testUser.User}, {type: CHANGE_PASSWORD_SUCCESS, user: {
             id: 6,
@@ -148,12 +156,15 @@ describe('Test the security reducer', () => {
         expect(state).toExist();
         expect(state.user.password).toBe("newpassword");
         expect(state.passwordChanged).toBe(true);
+        expect(state.changePasswordLoading).toBeFalsy();
+
     });
 
     it('change password fail', () => {
         let state = security({user: testUser.User}, {type: CHANGE_PASSWORD_FAIL, error: {message: 'error'}});
         expect(state).toExist();
         expect(state.passwordError).toExist();
+        expect(state.changePasswordLoading).toBeFalsy();
     });
 
     it('reset password error', () => {

--- a/web/client/reducers/security.js
+++ b/web/client/reducers/security.js
@@ -14,7 +14,8 @@ import {
     CHANGE_PASSWORD_FAIL,
     RESET_ERROR,
     REFRESH_SUCCESS,
-    SESSION_VALID
+    SESSION_VALID,
+    CHANGE_PASSWORD
 } from '../actions/security';
 
 import { SET_CONTROL_PROPERTY } from '../actions/controls';
@@ -80,17 +81,25 @@ function security(state = {user: null, errorCause: null}, action) {
             authHeader: null,
             loginError: null
         });
+    case CHANGE_PASSWORD:
+        return  assign({}, state, {
+            passwordError: null,
+            changePasswordLoading: true
+        });
     case CHANGE_PASSWORD_SUCCESS:
         return assign({}, state, {
             user: assign({}, state.user, assign({}, action.user, {date: new Date().getTime()})),
             authHeader: action.authHeader,
             passwordChanged: true,
-            passwordError: null
+            passwordError: null,
+            changePasswordLoading: false
         });
     case CHANGE_PASSWORD_FAIL:
         return assign({}, state, {
             passwordError: action.error,
-            passwordChanged: false
+            passwordChanged: false,
+            changePasswordLoading: false
+
         });
     case SESSION_VALID:
     {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

#3245 

**What is the current behavior?**
Loading Spinner is not stopped when an error occurs while changing user password and no information is shown to the user
#3245 

**What is the new behavior?**
The spinner stops spinning and an error should be shown to the user

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
