### PR TITLE
#6665: getConfiguredPlugin fails due to lazy loading

### DIFF
--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -446,7 +446,7 @@ export const getConfiguredPlugin = (pluginDef, loadedPlugins = {}, loaderCompone
             !pluginDef.plugin.loadPlugin && pluginDef.plugin;
         const id = isObject(pluginDef) ? pluginDef.id : null;
         const stateSelector = isObject(pluginDef) ? pluginDef.stateSelector : id || undefined;
-        const Plugin = getPluginImplementation(impl.?component || impl, stateSelector);
+        const Plugin = getPluginImplementation(impl?.component || impl, stateSelector);
         const result = (props) => {
             return Plugin ? (<Plugin key={pluginDef.id}
                 {...props} {...pluginDef.cfg} pluginCfg={pluginDef.cfg} items={pluginDef.items || []} />) : loaderComponent;

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -446,7 +446,7 @@ export const getConfiguredPlugin = (pluginDef, loadedPlugins = {}, loaderCompone
             !pluginDef.plugin.loadPlugin && pluginDef.plugin;
         const id = isObject(pluginDef) ? pluginDef.id : null;
         const stateSelector = isObject(pluginDef) ? pluginDef.stateSelector : id || undefined;
-        const Plugin = getPluginImplementation(impl, stateSelector);
+        const Plugin = getPluginImplementation(impl.component || impl, stateSelector);
         const result = (props) => {
             return Plugin ? (<Plugin key={pluginDef.id}
                 {...props} {...pluginDef.cfg} pluginCfg={pluginDef.cfg} items={pluginDef.items || []} />) : loaderComponent;

--- a/web/client/utils/PluginsUtils.js
+++ b/web/client/utils/PluginsUtils.js
@@ -446,7 +446,7 @@ export const getConfiguredPlugin = (pluginDef, loadedPlugins = {}, loaderCompone
             !pluginDef.plugin.loadPlugin && pluginDef.plugin;
         const id = isObject(pluginDef) ? pluginDef.id : null;
         const stateSelector = isObject(pluginDef) ? pluginDef.stateSelector : id || undefined;
-        const Plugin = getPluginImplementation(impl.component || impl, stateSelector);
+        const Plugin = getPluginImplementation(impl.?component || impl, stateSelector);
         const result = (props) => {
             return Plugin ? (<Plugin key={pluginDef.id}
                 {...props} {...pluginDef.cfg} pluginCfg={pluginDef.cfg} items={pluginDef.items || []} />) : loaderComponent;

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -439,4 +439,33 @@ describe('PluginsUtils', () => {
         ReactDOM.render(<LoadedPlugin/>, document.getElementById('container'));
         expect(document.querySelector('.selector')).toBeTruthy();
     });
+
+    it.only('should not throw an error if the loaded plugin is an object with component key', () => {
+
+        function MockStyleEditor() {
+            return <div></div>;
+        }
+        const pluginDef = {
+            ToolbarComponent: () => null,
+            cfg: {},
+            items: [],
+            name: 'StyleEditor',
+            plugin: MockStyleEditor,
+            priority: 1,
+            target: 'style'
+        };
+
+        const loadedPlugins = {
+            StyleEditor: {
+                component: MockStyleEditor,
+                containers: {},
+                epics: {},
+                name: 'StyleEditor',
+                reducers: {}
+            }
+        };
+        const result = PluginsUtils.getConfiguredPlugin(pluginDef, loadedPlugins);
+        expect(result.loaded).toBe(true);
+
+    });
 });

--- a/web/client/utils/__tests__/PluginsUtils-test.js
+++ b/web/client/utils/__tests__/PluginsUtils-test.js
@@ -440,7 +440,7 @@ describe('PluginsUtils', () => {
         expect(document.querySelector('.selector')).toBeTruthy();
     });
 
-    it.only('should not throw an error if the loaded plugin is an object with component key', () => {
+    it('should not throw an error if the loaded plugin is an object with component key', () => {
 
         function MockStyleEditor() {
             return <div></div>;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR adds a similar check as in [includeLoaded](https://github.com/allyoucanmap/MapStore2/blob/d06f2f59e477a8db7943474f679e153721b7ad4e/web/client/utils/PluginsUtils.js#L223) function to check if the implementation contains a component key.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: small improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6665

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

[geonode-mapstore-client](https://github.com/GeoNode/geonode-mapstore-client) does not load correctly the StyleEditor and TOCItemsSettings plugins if imported dynamically.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Cannot be tested on MapStore2 product we should only check if the application is working as usual