### PR TITLE
#6666: MousePosition plugins returns and error with lazy loading

### DIFF
--- a/web/client/plugins/MousePosition.jsx
+++ b/web/client/plugins/MousePosition.jsx
@@ -46,7 +46,7 @@ const selector = createSelector([
     mapSelector,
     (state) => isMouseMoveCoordinatesActiveSelector(state),
     (state) => get(state, 'mousePosition.position') || {},
-    (state) => get(state, 'mousePosition.crs', 'EPSG:4326'),
+    (state) => get(state, 'mousePosition.crs') || 'EPSG:4326',
     (state) => state.mapInfo || {}
 ], (state, map, enabled, mousePosition, crs, mapInfo) => ({
     enabled,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR moves the default value of crs outside of the lodash get function because in case of null the get function returns null. The lodash get function return the default only if the value is undefined

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: small improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6666

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

geonode-mapstore-client does not load correctly the MousePosition plugin if imported dynamically.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Cannot be tested on MapStore2 product we should only check if the application is working as usual