### PR TITLE
5111: Tooltips on map widget TOC

### DIFF
--- a/web/client/components/widgets/builder/wizard/map/TOC.jsx
+++ b/web/client/components/widgets/builder/wizard/map/TOC.jsx
@@ -47,6 +47,7 @@ export default enhanceTOC(({
         layerElement={<DefaultLayer
             selectedNodes={selectedNodes}
             onSelect={onSelect}
+            titleTooltip
             propertiesChangeHandler={(layer, changes) => Object.keys(changes).map(k => changeLayerProperty(layer, k, changes[k]))}
             onUpdateNode={(layer, _, changes) => Object.keys(changes).map(k => changeLayerProperty(layer, k, changes[k]))}
             onToggle={(id, expanded) => changeLayerProperty(id, "expanded", !expanded)} />} />


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The tooltips are not activated on layers

#5111 

**What is the new behavior?**
The layers' tooltips are visible when hover oven the layers as follows:

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
