### PR TITLE
[Backport 2021.01.xx] : Ensure Http urls added in Catalog conform to Mapstore Http protocol

### DIFF
--- a/web/client/components/catalog/editor/MainForm.jsx
+++ b/web/client/components/catalog/editor/MainForm.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import {get, find} from 'lodash';
 import Message from '../../I18N/Message';
 import HTML from '../../I18N/HTML';
@@ -13,10 +13,10 @@ import HTML from '../../I18N/HTML';
 import {getConfigProp} from '../../../utils/ConfigUtils';
 
 import InfoPopover from '../../widgets/widget/InfoPopover';
-import { FormControl as FC, Form, Col, FormGroup, ControlLabel } from "react-bootstrap";
+import { FormControl as FC, Form, Col, FormGroup, ControlLabel, Alert } from "react-bootstrap";
 
 import localizedProps from '../../misc/enhancers/localizedProps';
-import {defaultPlaceholder} from "./MainFormUtils";
+import {defaultPlaceholder, isHttps} from "./MainFormUtils";
 
 const FormControl = localizedProps('placeholder')(FC);
 
@@ -122,8 +122,18 @@ export default ({
     onChangeTitle,
     onChangeUrl,
     onChangeServiceProperty,
-    onChangeType
+    onChangeType,
+    setValid = () => {}
 }) => {
+    const [invalidProtocol, setInvalidProtocol] = useState(false);
+    function handleProtocolValidity(url) {
+        onChangeUrl(url);
+        if (url) {
+            const isInvalidProtocol = !isHttps(url);
+            setInvalidProtocol(isInvalidProtocol);
+            setValid(!isInvalidProtocol);
+        }
+    }
     const URLEditor = service.type === "tms" ? TmsURLEditor : DefaultURLEditor;
     return (
         <Form horizontal >
@@ -149,6 +159,11 @@ export default ({
                         onChange={(e) => onChangeTitle(e.target.value)} />
                 </Col>
             </FormGroup>
-            <URLEditor key="url-row" serviceTypes={serviceTypes} service={service} onChangeUrl={onChangeUrl} onChangeTitle={onChangeTitle} onChangeServiceProperty={onChangeServiceProperty} />
+            <URLEditor key="url-row" serviceTypes={serviceTypes} service={service} onChangeUrl={handleProtocolValidity} onChangeTitle={onChangeTitle} onChangeServiceProperty={onChangeServiceProperty} />
+
+            {invalidProtocol ? <Alert bsStyle="danger">
+                <Message msgId="catalog.invalidUrlHttpProtocol" />
+            </Alert> : null}
+
         </Form>);
 };

--- a/web/client/components/catalog/editor/MainFormUtils.js
+++ b/web/client/components/catalog/editor/MainFormUtils.js
@@ -1,3 +1,5 @@
+import url from 'url';
+
 export const defaultPlaceholder = (service) => {
     let urlPlaceholder = {
         wfs: "e.g. https://mydomain.com/geoserver/wfs",
@@ -10,6 +12,15 @@ export const defaultPlaceholder = (service) => {
         if ( key === service.type) {
             return value;
         }
+    }
+    return true;
+};
+
+export const isHttps = (catalogUrl = '') => {
+    const { protocol: mapStoreProtocol } = url.parse(window.location.href);
+    const { protocol: catalogProtocol } = url.parse(catalogUrl);
+    if (mapStoreProtocol === 'https:') {
+        return mapStoreProtocol === catalogProtocol;
     }
     return true;
 };

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1413,6 +1413,7 @@
             "showPreview": "Vorschau zeigen",
             "advancedSettings": "Erweiterte Einstellungen",
             "templateMetadataAvailable": "Metadaten im Dublin Core-Format verfügbar: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "invalidUrlHttpProtocol": "Dieser Katalog kann nicht zu den verfügbaren hinzugefügt werden, da er ein http-Protokoll verwendet. Bitte geben Sie eine Katalog-URL an, die das https-Protokoll verwendet.",
             "notification": {
                 "errorTitle": "Error",
                 "errorSearchingRecords": "Einige Datensätze wurden nicht gefunden: {records} . Bitte überprüfen Sie die URL des Abfrageparameters",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1413,6 +1413,7 @@
             "showPreview": "Show preview",
             "advancedSettings": "Advanced settings",
             "templateMetadataAvailable": "Metadata available from Dublin Core format: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "invalidUrlHttpProtocol": "Thìs catalog cannot be added to the available ones because it uses an http protocol. Please provide a catalog url that uses https protocol",
             "notification": {
                 "errorTitle": "Error",
                 "errorSearchingRecords": "Some records have not been found: {records} Please check the query URL and its parameters.",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1413,6 +1413,7 @@
             "showPreview": "Mostrar vista previa",
             "advancedSettings": "Ajustes avanzados",
             "templateMetadataAvailable": "Metadatos disponibles en formato Dublin Core: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "invalidUrlHttpProtocol": "Este catálogo no se puede agregar a los disponibles porque usa un protocolo http. Proporcione una URL del catálogo que utilice el protocolo https",
             "notification": {
                 "errorTitle": "Error",
                 "errorSearchingRecords": "No se han encontrado algunos registros: {records} . Por favor revise la consulta param url",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1414,6 +1414,7 @@
             "showPreview": "Afficher l'aperçu",
             "advancedSettings": "Réglages avancés",
             "templateMetadataAvailable": "Métadonnées disponibles pour le format Dublin Core : abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "invalidUrlHttpProtocol": "Ce catalogue ne peut pas être ajouté à ceux disponibles car il utilise un protocole http. Veuillez fournir une URL de catalogue qui utilise le protocole https.",
             "notification": {
                 "errorTitle": "Erreur",
                 "errorSearchingRecords": "Certains enregistrements n'ont pas été trouvés: {records} . Veuillez vérifier l'URL de la requête et ses paramètres.",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1413,6 +1413,7 @@
             "showPreview": "Mostra la preview",
             "advancedSettings": "Impostazioni avanzate",
             "templateMetadataAvailable": "Metadati disponibili del formato Dublin Core: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "invalidUrlHttpProtocol": "Questo catalogo non può essere aggiunto a quelli disponibili perché utilizza un protocollo http. Fornisci un URL di catalogo che utilizzi il protocollo https",
             "notification": {
                 "errorTitle": "Errore",
                 "errorSearchingRecords": "Alcuni record non sono stati trovati: {records} . Controlla la lista dei parametri nella barra degli indirizzi",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -1116,6 +1116,7 @@
                 "duplicatedServiceTitle": "A service with that title already exists. Please, change title",
                 "serviceDeletedCorrectly": "The service was deleted correctly",
                 "errorServiceUrl": "Service not available. Please, check the provided url"
+
             }
         },
         "uploader": {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bug

<!-- add here the ReadTheDocs link (if needed) -->

#6127 

**What is the current behavior?**
If a map with HTTPS URL has the services in HTTP the service requests must remain in HTTP and not in HTTPS as it happens now.
#<issue>

**What is the new behavior?**
URLs will be allowed to be input if they match the protocol of mapstore for example. if mapstore is on HTTP then only URLs with `http://` will be allowed
<img width="581" alt="Screenshot 2021-03-10 at 15 58 12" src="https://user-images.githubusercontent.com/39124174/110641389-022c5e00-81c3-11eb-82ae-50dbce783f59.png">

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
