### PR TITLE
#6682 Fix infinite loading in map templates

### DIFF
--- a/web/client/components/maptemplates/__tests__/MapTemplatesPanel-test.jsx
+++ b/web/client/components/maptemplates/__tests__/MapTemplatesPanel-test.jsx
@@ -27,4 +27,16 @@ describe('MapTemplatesPanel component', () => {
         const container = document.getElementById('container');
         expect(container.getElementsByClassName('map-templates-panel')[0]).toExist();
     });
+    it('MapTemplatesPanel with template with format', () => {
+        const template = {
+            id: 1,
+            format: 'wmc'
+        };
+
+        ReactDOM.render(<MapTemplatesPanel templates={[template]}/>, document.getElementById("container"));
+        const sideCards = document.getElementsByClassName('mapstore-side-card');
+        expect(sideCards.length).toBe(1);
+        const formatIcon = document.getElementsByClassName('glyphicon-ext-wmc')[0];
+        expect(formatIcon).toExist();
+    });
 });

--- a/web/client/epics/__tests__/maptemplates-test.js
+++ b/web/client/epics/__tests__/maptemplates-test.js
@@ -98,14 +98,29 @@ describe('maptemplates epics', () => {
                     }]
                 }
             },
-            maptemplates: {},
-            localConfig: {
-                plugins: {
-                    desktop: [
-                        {name: "MapTemplates", cfg: {allowedTemplates: [{ id: 1 }]}}
-                    ]
-                }
+            maptemplates: {}
+        }, done);
+    });
+    it('setAllowedTemplatesEpic with no allowed templates', (done) => {
+        mockAxios.onPost('/resources/search/list').reply(config => get(config, 'params.includeAttributes', false) ? [200, {
+            ResourceList: {
+                Resource: []
             }
+        }] : [404, {}]);
+        testEpic(setAllowedTemplatesEpic, 2, setAllowedTemplates(), actions => {
+            expect(actions.length).toBe(2);
+            expect(actions[0].type).toBe(SET_TEMPLATES);
+            expect(actions[0].templates).toExist();
+            expect(actions[0].templates.length).toBe(0);
+            expect(actions[1].type).toBe(SET_MAP_TEMPLATES_LOADED);
+            expect(actions[1].loaded).toBe(true);
+        }, {
+            context: {
+                currentContext: {
+                    templates: []
+                }
+            },
+            maptemplates: {}
         }, done);
     });
 });

--- a/web/client/epics/maptemplates.js
+++ b/web/client/epics/maptemplates.js
@@ -72,23 +72,23 @@ export const setAllowedTemplatesEpic = (action$, store) => action$
             }), {});
         };
 
-        return templates.length > 0 ? Observable.defer(
-            () => Api.searchListByAttributes(makeFilter(), {params: { includeAttributes: true }}, '/resources/search/list')
-        ).switchMap(
-            (data) => {
-                const resourceObj = get(data, 'ResourceList.Resource', []);
-                const resources = isArray(resourceObj) ? resourceObj : [resourceObj];
-                const newTemplates = resources.map(resource => ({
-                    ...pick(resource, 'id', 'name', 'description'),
-                    ...extractAttributes(resource),
-                    dataLoaded: false,
-                    loading: false
-                }));
-                return Observable.of(setTemplates(newTemplates), setMapTemplatesLoaded(true));
-            }
-        ).catch(
-            err => Observable.of(setMapTemplatesLoaded(true, err))
-        ) : Observable.empty();
+        return templates.length > 0
+            ? Observable
+                .defer(() => Api.searchListByAttributes(makeFilter(), {params: { includeAttributes: true }}, '/resources/search/list'))
+                .switchMap(
+                    (data) => {
+                        const resourceObj = get(data, 'ResourceList.Resource', []);
+                        const resources = isArray(resourceObj) ? resourceObj : [resourceObj];
+                        const newTemplates = resources.map(resource => ({
+                            ...pick(resource, 'id', 'name', 'description'),
+                            ...extractAttributes(resource),
+                            dataLoaded: false,
+                            loading: false
+                        }));
+                        return Observable.of(setTemplates(newTemplates), setMapTemplatesLoaded(true));
+                    })
+                .catch( err => Observable.of(setMapTemplatesLoaded(true, err)))
+            : Observable.of(setTemplates([]), setMapTemplatesLoaded(true));
     });
 
 export const mergeTemplateEpic = (action$, store) => action$

--- a/web/client/epics/maptemplates.js
+++ b/web/client/epics/maptemplates.js
@@ -72,23 +72,23 @@ export const setAllowedTemplatesEpic = (action$, store) => action$
             }), {});
         };
 
-        return templates.length > 0
-            ? Observable
-                .defer(() => Api.searchListByAttributes(makeFilter(), {params: { includeAttributes: true }}, '/resources/search/list'))
-                .switchMap(
-                    (data) => {
-                        const resourceObj = get(data, 'ResourceList.Resource', []);
-                        const resources = isArray(resourceObj) ? resourceObj : [resourceObj];
-                        const newTemplates = resources.map(resource => ({
-                            ...pick(resource, 'id', 'name', 'description'),
-                            ...extractAttributes(resource),
-                            dataLoaded: false,
-                            loading: false
-                        }));
-                        return Observable.of(setTemplates(newTemplates), setMapTemplatesLoaded(true));
-                    })
-                .catch( err => Observable.of(setMapTemplatesLoaded(true, err)))
-            : Observable.of(setTemplates([]), setMapTemplatesLoaded(true));
+        return templates.length > 0 ? Observable.defer(
+            () => Api.searchListByAttributes(makeFilter(), {params: { includeAttributes: true }}, '/resources/search/list')
+        ).switchMap(
+            (data) => {
+                const resourceObj = get(data, 'ResourceList.Resource', []);
+                const resources = isArray(resourceObj) ? resourceObj : [resourceObj];
+                const newTemplates = resources.map(resource => ({
+                    ...pick(resource, 'id', 'name', 'description'),
+                    ...extractAttributes(resource),
+                    dataLoaded: false,
+                    loading: false
+                }));
+                return Observable.of(setTemplates(newTemplates), setMapTemplatesLoaded(true));
+            }
+        ).catch(
+            err => Observable.of(setMapTemplatesLoaded(true, err))
+        ) : Observable.empty();
     });
 
 export const mergeTemplateEpic = (action$, store) => action$

--- a/web/client/plugins/__tests__/MapTemplates-test.jsx
+++ b/web/client/plugins/__tests__/MapTemplates-test.jsx
@@ -11,7 +11,6 @@ import ReactDOM from 'react-dom';
 
 import MapTemplates from '../MapTemplates';
 import { getPluginForTest } from './pluginsTestUtils';
-
 describe('MapTemplates Plugins', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -27,15 +26,16 @@ describe('MapTemplates Plugins', () => {
             controls: {
                 mapTemplates: {
                     enabled: true
+                },
+                maptemplates: {
+                    mapTemplatesLoaded: false
                 }
             }
         });
         ReactDOM.render(<Plugin/>, document.getElementById("container"));
-        expect(document.getElementsByClassName('ms-side-panel')[0]).toExist();
         expect(document.getElementsByClassName('map-templates-loader')[0]).toExist();
-        expect(document.getElementsByClassName('map-templates-panel')[0]).toNotExist();
     });
-    it('shows MapTemplates loaded', () => {
+    it('shows MapTemplates loaded, empty', () => {
         const { Plugin } = getPluginForTest(MapTemplates, {
             controls: {
                 mapTemplates: {
@@ -46,37 +46,16 @@ describe('MapTemplates Plugins', () => {
                 mapTemplatesLoaded: true
             }
         });
-        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        ReactDOM.render(<Plugin templates={[{id: 1}]}/>, document.getElementById("container"));
+        const sideCards = document.getElementsByClassName('mapstore-side-card');
+        expect(sideCards.length).toBe(0);
         expect(document.getElementsByClassName('ms-side-panel')[0]).toExist();
         expect(document.getElementsByClassName('map-templates-loader')[0]).toNotExist();
         expect(document.getElementsByClassName('map-templates-panel')[0]).toExist();
     });
-    it('MapTemplatesPanel with template with format', () => {
+    it('MapTemplatesPanel with favourite template', () => {
         const template = {
             id: 1,
-            format: 'wmc'
-        };
-        const { Plugin } = getPluginForTest(MapTemplates, {
-            controls: {
-                mapTemplates: {
-                    enabled: true
-                }
-            },
-            maptemplates: {
-                mapTemplatesLoaded: true,
-                templates: [template]
-            }
-        });
-        ReactDOM.render(<Plugin/>, document.getElementById("container"));
-        const sideCards = document.getElementsByClassName('mapstore-side-card');
-        expect(sideCards.length).toBe(1);
-        const formatIcon = document.getElementsByClassName('glyphicon-ext-wmc')[0];
-        expect(formatIcon).toExist();
-    });
-    it('MapTemplatesPanel with favourite template with format', () => {
-        const template = {
-            id: 1,
-            format: 'wmc',
             favourite: true,
             name: 'Map Template',
             description: 'This is a map template.'
@@ -92,13 +71,10 @@ describe('MapTemplates Plugins', () => {
                 templates: [template]
             }
         });
-        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+
+        ReactDOM.render(<Plugin allowedTemplates={[template]}/>, document.getElementById("container"));
         const sideCards = document.getElementsByClassName('mapstore-side-card');
         expect(sideCards.length).toBe(2);
-        const formatIcons = document.getElementsByClassName('glyphicon-ext-wmc');
-        expect(formatIcons.length).toBe(2);
-        const favouriteIcon = document.getElementsByClassName('glyphicon-star');
-        expect(favouriteIcon).toExist();
         const favouriteIconEmpty = document.getElementsByClassName('glyphicon-star-empty');
         expect(favouriteIconEmpty).toExist();
         const favouriteCard = document.querySelector('.mapstore-side-card.ms-sm');

--- a/web/client/plugins/__tests__/MapTemplates-test.jsx
+++ b/web/client/plugins/__tests__/MapTemplates-test.jsx
@@ -33,7 +33,7 @@ describe('MapTemplates Plugins', () => {
             }
         });
         ReactDOM.render(<Plugin/>, document.getElementById("container"));
-        expect(document.getElementsByClassName('map-templates-loader')[0]).toExist();
+        expect(document.getElementsByClassName('map-templates-panel')[0]).toExist();
     });
     it('shows MapTemplates loaded, empty', () => {
         const { Plugin } = getPluginForTest(MapTemplates, {


### PR DESCRIPTION
## Description
When the list of allowed templates is empty, the UI doesn't turn off loading spinner. This fix loads the empty results array and turn off loading spinner, when no template is allowed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6682

**What is the new behavior?**
The users see an empty view instead of an infinite loading spinner

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
