### PR TITLE
#5224: fixed build to include default db security settings also when a profile (e.g. printing) is activated

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -572,7 +572,9 @@
     <profile>
         <id>db-security</id>
         <activation>
-            <activeByDefault>true</activeByDefault>
+            <property>
+                <name>!disable.db.security</name>
+            </property>
         </activation>
         <build>
             <plugins>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The db-security profile (copying the default geostore security stuff) was not active when a specific set of profiles was included in build, so no security configuration was present, preventing mapstore to start.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#5224 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
