### PR TITLE
Dynamic load of rules grid to split code for react-data-grid-addons

### DIFF
--- a/web/client/plugins/RulesDataGrid.jsx
+++ b/web/client/plugins/RulesDataGrid.jsx
@@ -7,7 +7,9 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Suspense } from 'react';
+import LoadingView from '../components/misc/LoadingView';
+
 import ContainerDimensions from 'react-container-dimensions';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
@@ -16,10 +18,9 @@ import { createSelector } from 'reselect';
 import { error } from '../actions/notifications';
 import { rulesSelected, setFilter, setLoading } from '../actions/rulesmanager';
 import rulesgridComp from '../components/manager/rulesmanager/rulesgrid/enhancers/rulesgrid';
-import RulesGridComp from '../components/manager/rulesmanager/rulesgrid/RulesGrid';
 import rulesmanager from '../reducers/rulesmanager';
 import { filterSelector, isEditorActive, selectedRules, triggerLoadSel } from '../selectors/rulesmanager';
-
+const RulesGridComp = React.lazy(() => import('../components/manager/rulesmanager/rulesgrid/RulesGrid'));
 const ruelsSelector = createSelector([selectedRules, filterSelector, triggerLoadSel], (rules, filters, triggerLoad) => {
     return {
         selectedIds: rules.map(r => r.id),
@@ -58,7 +59,9 @@ class RulesDataGrid extends React.Component {
          return (<ContainerDimensions>{({width, height}) =>
              (<div className={`rules-data-gird ${this.props.enabled ? "" : "hide-locked-cell"}`}>
                  {!this.props.enabled && (<div className="ms-overlay"/>)}
-                 <RulesGrid width={width} height={height}/>
+                 <Suspense fallback={<LoadingView />}>
+                     <RulesGrid width={width} height={height}/>
+                 </Suspense>
              </div>)
          }
          </ContainerDimensions>);


### PR DESCRIPTION
## Description
`react-data-grid-addons` is used only by `RulesDataGrid`. Doing a dynamic import using suspanse allows to defer loading of this lib (~800kb uncompressed) only when necessary. 

![image](https://user-images.githubusercontent.com/1279510/112177461-39eec900-8bf9-11eb-8629-e6f2aeaa887f.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#4297 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
