### PR TITLE
6639: Can not close Filter panel when WFS services are not available

### DIFF
--- a/web/client/components/data/query/QueryBuilder.jsx
+++ b/web/client/components/data/query/QueryBuilder.jsx
@@ -18,6 +18,7 @@ import crossLayerFilterEnhancer from './enhancers/crossLayerFilter';
 import GroupField from './GroupField';
 import QueryToolbar from './QueryToolbar';
 import SpatialFilter from './SpatialFilter';
+import QueryPanelHeader from './QueryPanelHeader';
 
 const CrossLayerFilter = crossLayerFilterEnhancer(CrossLayerFilterComp);
 
@@ -75,7 +76,8 @@ class QueryBuilder extends React.Component {
         appliedFilter: PropTypes.object,
         storedFilter: PropTypes.object,
         advancedToolbar: PropTypes.bool,
-        loadingError: PropTypes.bool
+        loadingError: PropTypes.bool,
+        controlActions: PropTypes.object
     };
 
     static defaultProps = {
@@ -145,12 +147,18 @@ class QueryBuilder extends React.Component {
             onSaveFilter: () => {},
             onRestoreFilter: () => {}
         },
-        toolsOptions: {}
+        toolsOptions: {},
+        controlActions: {
+            onToggleQuery: () => {}
+        }
     };
 
     render() {
         if (this.props.featureTypeError !== "") {
-            return <div style={{margin: "0 auto", "text-align": "center"}}>{this.props.featureTypeErrorText}</div>;
+            return (<div>
+                <QueryPanelHeader onToggleQuery={this.props.controlActions.onToggleQuery}/>
+                <div style={{margin: "0 auto", "text-align": "center"}}>{this.props.featureTypeErrorText}</div>
+            </div>);
         }
 
         const header = (<div className="m-header">{this.props.header}

--- a/web/client/components/data/query/__tests__/QueryBuilder-test.jsx
+++ b/web/client/components/data/query/__tests__/QueryBuilder-test.jsx
@@ -9,6 +9,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
 
 import QueryBuilder from '../QueryBuilder';
 
@@ -197,6 +198,41 @@ describe('QueryBuilder', () => {
         document.getElementById("container"));
 
         expect(querybuilder).toExist();
+    });
+
+    it('shows the QueryPanelHeader component in error state', () => {
+
+        const querybuilder = ReactDOM.render(<QueryBuilder
+            featureTypeError={"true"}
+            featureTypeErrorText={"bla bla"}
+            featureTypeConfigUrl={"randomurl"} />,
+        document.getElementById("container"));
+
+        expect(querybuilder).toExist();
+        const closeButton = document.getElementById("toc-query-close-button");
+        expect(closeButton).toExist();
+    });
+
+    it('calls onToggleQuery in error state on click closeButton', () => {
+        const controlActions = {onToggleQuery: () => {}};
+        const spy =  expect.spyOn(controlActions, 'onToggleQuery');
+        let querybuilder;
+        TestUtils.act(() => {
+            querybuilder =  ReactDOM.render(<QueryBuilder
+                controlActions={controlActions}
+                featureTypeError={"true"}
+                featureTypeErrorText={"bla bla"}
+                featureTypeConfigUrl={"randomurl"} />,
+            document.getElementById("container"));
+
+        });
+
+        expect(querybuilder).toExist();
+        const closeButton = document.getElementById("toc-query-close-button");
+        TestUtils.act(() => {
+            TestUtils.Simulate.click(closeButton);
+        });
+        expect(spy).toHaveBeenCalled();
     });
 
     it('creates the QueryBuilder component with empty filter support', () => {

--- a/web/client/plugins/QueryPanel.jsx
+++ b/web/client/plugins/QueryPanel.jsx
@@ -173,7 +173,8 @@ const SmartQueryForm = connect((state) => {
             updateCrossLayerFilterField,
             removeCrossLayerFilterField,
             resetCrossLayerFilter
-        }, dispatch)
+        }, dispatch),
+        controlActions: bindActionCreators({onToggleQuery: toggleControl.bind(null, 'queryPanel', null)}, dispatch)
     };
 })(QueryBuilder);
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Filter Panel cannot be closed in case there is an error.

![attribute_filter](https://user-images.githubusercontent.com/1279510/111158850-cf0a1600-8598-11eb-9ee6-1ad45f2d98b0.gif)

#6639

**What is the new behavior?**
When there is an error User can close the panel
<img width="609" alt="Screenshot 2021-03-25 at 15 09 22" src="https://user-images.githubusercontent.com/39124174/112471044-77c82a80-8d7c-11eb-879c-6384880b9267.png">

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
