### PR TITLE
[Backport 2021.01.xx] #6635: Fix Issue with Virtual Scroll (#6647)

### DIFF
--- a/web/client/components/catalog/CompactCatalog.jsx
+++ b/web/client/components/catalog/CompactCatalog.jsx
@@ -72,7 +72,7 @@ const loadPage = ({text, catalog = {}}, page = 0) => Rx.Observable
     .fromPromise(API[catalog.type].textSearch(catalog.url, page * PAGE_SIZE + (catalog.type === "csw" ? 1 : 0), PAGE_SIZE, text))
     .map((result) => ({ result, records: getCatalogRecords(catalog.type, result || [], { url: catalog && catalog.url, service: catalog })}))
     .map(resToProps);
-const scrollSpyOptions = {querySelector: ".ms2-border-layout-body", pageSize: PAGE_SIZE};
+const scrollSpyOptions = {querySelector: ".ms2-border-layout-body .ms2-border-layout-content", pageSize: PAGE_SIZE};
 /**
  * Compat catalog : Reusable catalog component, with infinite scroll.
  * You can simply pass the catalog to browse and the handler onRecordSelected.

--- a/web/client/components/maps/enhancers/enhancers.js
+++ b/web/client/components/maps/enhancers/enhancers.js
@@ -53,7 +53,7 @@ const loadPage = ({ text = "*", options = {} }, page = 0) => getResources({
         items: [],
         total: 0
     }));
-const scrollSpyOptions = { querySelector: ".ms2-border-layout-body", pageSize: PAGE_SIZE };
+const scrollSpyOptions = { querySelector: ".ms2-border-layout-body .ms2-border-layout-content", pageSize: PAGE_SIZE };
 
 /**
  * transforms loadPage to add the empty map item on top


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

#6635 

**What is the current behavior?**
The lists loaders infinitely  even without the user scrolling
#6635 

**What is the new behavior?**
List should load when the user scrolls to the bottom of the list

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
