### PR TITLE
[Backport 2021.01.xx] #6561: SearchServicesConfig toggle button is visible in the search bar even if the plugin is not in localConfig (#6562)

### DIFF
--- a/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
+++ b/web/client/components/mapcontrols/search/__tests__/SearchBar-test.jsx
@@ -16,7 +16,11 @@ import SearchBar from '../SearchBar';
 import TestUtils from 'react-dom/test-utils';
 
 describe("test the SearchBar", () => {
-    const items = [{bookmarkConfig: () =>({glyph: "cog", visible: true}), menuItem: () => <MenuItem>Search by bookmark</MenuItem>}];
+    const items = [{
+        name: 'SearchByBookmark',
+        bookmarkConfig: () =>({glyph: "cog", visible: true}),
+        menuItem: () => <MenuItem>Search by bookmark</MenuItem>
+    }];
 
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -445,7 +449,11 @@ describe("test the SearchBar", () => {
         const actions = {
             onToggleControl: () =>{}
         };
-        const itemsProps = [{bookmarkConfig: (toggleConfig) =>({onClick: () => toggleConfig("searchBookmarkConfig"), glyph: "cog", visible: true}), menuItem: () => <MenuItem>Search by bookmark</MenuItem>}];
+        const itemsProps = [{
+            name: 'SearchByBookmark',
+            bookmarkConfig: (toggleConfig) =>({onClick: () => toggleConfig("searchBookmarkConfig"), glyph: "cog", visible: true}),
+            menuItem: () => <MenuItem>Search by bookmark</MenuItem>
+        }];
         const spyOnToggleControl = expect.spyOn(actions, 'onToggleControl');
         const props = {
             showOptions: true,

--- a/web/client/plugins/Search.jsx
+++ b/web/client/plugins/Search.jsx
@@ -53,12 +53,10 @@ import ToggleButton from './searchbar/ToggleButton';
 
 const searchSelector = createSelector([
     state => state.search || null,
-    state => state.controls && state.controls.searchservicesconfig || null,
     state => state.controls && state.controls.searchBookmarkConfig || null,
     state=> state.mapConfigRawData || {},
     state => state?.searchbookmarkconfig || ''
-], (searchState, searchservicesconfigControl, searchBookmarkConfigControl, mapInitial, bookmarkConfig) => ({
-    enabledSearchServicesConfig: searchservicesconfigControl && searchservicesconfigControl.enabled || false,
+], (searchState, searchBookmarkConfigControl, mapInitial, bookmarkConfig) => ({
     enabledSearchBookmarkConfig: searchBookmarkConfigControl && searchBookmarkConfigControl.enabled || false,
     error: searchState && searchState.error,
     coordinate: searchState && searchState.coordinate || {},


### PR DESCRIPTION
## Description

This PR makes pluggable the toggle button of SearchServicesConfig.

<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6561

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The toggle button is removed together with the plugin

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
