### PR TITLE
#3871: Openlayers cache glitch fix on updateParams

### DIFF
--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1730,18 +1730,18 @@ describe('Openlayers layer', () => {
 
         expect(layer).toExist();
         const source = layer.layer.getSource();
-        const spy = expect.spyOn(source, "refresh");
+        const spy = expect.spyOn(source.tileCache, "pruneExceptNewestZ");
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
 
-        expect(layer.layer.getSource()).toExist();
-        expect(layer.layer.getSource().getParams()).toExist();
-        expect(layer.layer.getSource().getParams().cql_filter).toBe("INCLUDE");
+        expect(source).toExist();
+        expect(source.getParams()).toExist();
+        expect(source.getParams().cql_filter).toBe("INCLUDE");
 
         layer = ReactDOM.render(
             <OpenlayersLayer type="wms" observables={["cql_filter"]}
                 options={assign({}, options, { params: { cql_filter: "EXCLUDE" } })} map={map} />, document.getElementById("container"));
-        expect(layer.layer.getSource().getParams().cql_filter).toBe("EXCLUDE");
+        expect(source.getParams().cql_filter).toBe("EXCLUDE");
 
         // this prevents old cache to be rendered while loading
         expect(spy).toHaveBeenCalled();
@@ -1764,10 +1764,9 @@ describe('Openlayers layer', () => {
         var layer = ReactDOM.render(
             <OpenlayersLayer type="wms" observables={["cql_filter"]}
                 options={options} map={map} />, document.getElementById("container"));
-
         expect(layer).toExist();
-        const source = layer.layer.getSource();
-        const spyRefresh = expect.spyOn(source, "refresh");
+        let source = layer.layer.getSource();
+        const spy = expect.spyOn(source.tileCache, "pruneExceptNewestZ");
         // count layers
         expect(map.getLayers().getLength()).toBe(1);
 
@@ -1779,8 +1778,8 @@ describe('Openlayers layer', () => {
             <OpenlayersLayer type="wms" observables={["cql_filter"]}
                 options={assign({}, options, { params: { time: "2019-01-01T00:00:00Z", ...options.params } })} map={map} />, document.getElementById("container"));
 
-        expect(spyRefresh).toHaveBeenCalled();
-        expect(layer.layer.getSource().getParams().time).toBe("2019-01-01T00:00:00Z");
+        expect(spy).toHaveBeenCalled();
+        expect(source.getParams().time).toBe("2019-01-01T00:00:00Z");
     });
     it('wms empty params not removed on update', () => {
         var options = {

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -347,19 +347,16 @@ Layers.registerType('wms', {
         if (oldOptions.maxResolution !== newOptions.maxResolution) {
             layer.setMaxResolution(newOptions.maxResolution === undefined ? Infinity : newOptions.maxResolution);
         }
-
         if (needsRefresh) {
             // forces tile cache drop
             // this prevents old cached tiles at lower zoom levels to be
-            // rendered during new params load, but causes a blink glitch.
-            // TODO: find out a way to refresh only once to clear lower zoom level cache.
-            if (wmsSource.refresh) {
-                wmsSource.refresh();
-            }
+            // rendered during new params load
+            wmsSource?.tileCache?.pruneExceptNewestZ?.();
             if (vectorSource) {
                 vectorSource.clear();
                 vectorSource.refresh();
             }
+
             if (changed) {
                 const params = assign(newParams, addAuthenticationToSLD(optionsToVendorParams(newOptions) || {}, newOptions));
 


### PR DESCRIPTION
## Description
This PR adds commit to fix the Openlayers cache glitch on updateParams

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#3871 

**What is the new behavior?**
- The blink issue will not occur when changing time from timeline
-  Also the fix of low level render tile cache should be unaffected

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
