### PR TITLE
#6721 avoid errors for localized titles in splitMapAndLayers function

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -53,10 +53,10 @@ const initialReorderLayers = (groups, allLayers) => {
 const reorderLayers = (groups, allLayers) => {
     return initialReorderLayers(groups, allLayers);
 };
-const createGroup = (groupId, groupName, layers, addLayers) => {
+const createGroup = (groupId, groupTitle, groupName, layers, addLayers) => {
     return assign({}, {
         id: groupId,
-        title: (groupName || "").replace(/\${dot}/g, "."),
+        title: groupTitle ?? (groupName || "").replace(/\${dot}/g, "."),
         name: groupName,
         nodes: addLayers ? getLayersId(groupId, layers) : [],
         expanded: true
@@ -343,7 +343,7 @@ export const getLayersByGroup = (configLayers, configGroups) => {
             const addLayers = idx === array.length - 1;
             if (!group) {
                 const groupTitle = getNestedGroupTitle(groupId, configGroups);
-                group = createGroup(groupId, groupTitle || groupName, mapLayers, addLayers);
+                group = createGroup(groupId, groupTitle || groupName, groupName, mapLayers, addLayers);
                 subGroups.push(group);
             } else if (addLayers) {
                 group.nodes = group.nodes.concat(getLayersId(groupId, mapLayers));

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1239,8 +1239,8 @@ describe('LayersUtils', () => {
         };
         it('localized titles for default group', () => {
             const {map, layers} = splitMapAndLayers(localizedGroupMap);
-            expect(map).toExist();
-            expect(layers).toExist();
+            expect(map).toBeTruthy();
+            expect(layers).toBeTruthy();
             expect(layers.groups[0].title).toEqual(localizedGroupMap.groups[0].title);
         });
     });

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -9,7 +9,7 @@ import expect from 'expect';
 
 import assign from 'object-assign';
 import * as LayersUtils from '../LayersUtils';
-const {extractTileMatrixSetFromLayers} = LayersUtils;
+const { extractTileMatrixSetFromLayers, splitMapAndLayers} = LayersUtils;
 const typeV1 = "empty";
 const emptyBackground = {
     type: typeV1
@@ -1172,5 +1172,76 @@ describe('LayersUtils', () => {
             maxResolution: 1000,
             minResolution: 100
         }, 1000)).toBe(false);
+    });
+    describe('splitMapAndLayers', () => {
+        const localizedGroupMap = {
+            "map": {
+                "center": {
+                    "x": 17.360751857301523,
+                    "y": 40.51921950782912,
+                    "crs": "EPSG:4326"
+                },
+                "maxExtent": [
+                    -20037508.34,
+                    -20037508.34,
+                    20037508.34,
+                    20037508.34
+                ],
+                "projection": "EPSG:900913",
+                "units": "m",
+                "zoom": 6,
+                "mapOptions": {},
+                "backgrounds": [],
+                "bookmark_search_config": {},
+                "mapId": null,
+                "size": null,
+                "version": 2
+            },
+            "layers": [
+                {
+                    "id": "test:Linea_costa__5",
+                    "format": "image/png",
+                    "search": {
+                        "url": "https://test/geoserver/wfs",
+                        "type": "wfs"
+                    },
+                    "name": "test:Linea_costa",
+                    "opacity": 1,
+                    "description": "",
+                    "title": {
+                        "default": "Linea_costa",
+                        "it-IT": "test",
+                        "en-US": "test",
+                        "fr-FR": "test",
+                        "de-DE": "test",
+                        "es-ES": "test"
+                    },
+                    "type": "wms",
+                    "url": "https://test/geoserver/wms",
+
+
+                    "useForElevation": false,
+                    "hidden": false,
+                    "params": {}
+                }
+            ],
+            "groups": [
+                {
+                    "id": "Default",
+                    "title": {
+                        "default": "Default",
+                        "it-IT": "test ",
+                        "en-US": "test"
+                    },
+                    "expanded": true
+                }
+            ]
+        };
+        it('localized titles for default group', () => {
+            const {map, layers} = splitMapAndLayers(localizedGroupMap);
+            expect(map).toExist();
+            expect(layers).toExist();
+            expect(layers.groups[0].title).toEqual(localizedGroupMap.groups[0].title);
+        });
     });
 });


### PR DESCRIPTION
## Description
The issue was cause by a `replace` function called on an object. the issue can be solved by modifying a little the function to avoid this error.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6721

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
