### PR TITLE
#6722: Wrong GFI Behaviour using the Share tool

### DIFF
--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web/client/components/share', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/build/tests.webpack.js
+++ b/build/tests.webpack.js
@@ -1,3 +1,3 @@
-var context = require.context('../web', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
+var context = require.context('../web/client/components/share', true, /(-test\.jsx?)|(-test-chrome\.jsx?)$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -87,7 +87,8 @@ class SharePanel extends React.Component {
         formatCoords: PropTypes.string,
         point: PropTypes.object,
         isScrollPosition: PropTypes.bool,
-        hideMarker: PropTypes.func
+        hideMarker: PropTypes.func,
+        selectedLayer: PropTypes.object
     };
 
     static defaultProps = {
@@ -105,7 +106,8 @@ class SharePanel extends React.Component {
         onUpdateSettings: () => {},
         formatCoords: "decimal",
         isScrollPosition: false,
-        hideMarker: () => {}
+        hideMarker: () => {},
+        selectedLayer: {}
     };
 
     state = {
@@ -277,6 +279,16 @@ class SharePanel extends React.Component {
         return markerSetting;
     }
 
+    renderActiveLayerNotVisible = () => {
+        if (this.props.selectedLayer.visibility !== undefined && !this.props.selectedLayer.visibility) {
+            return (<OverlayTrigger  placement="top"
+                overlay={<Tooltip id="no-active-queryable-layer"><Message msgId="share.noActiveQueryableLayer"/></Tooltip>}>
+                <Glyphicon style={{marginLeft: 5}} glyph="info-sign" />
+            </OverlayTrigger>);
+        }
+        return null;
+    }
+
     renderAdvancedSettings = () => {
         return (
             <SwitchPanel
@@ -366,6 +378,7 @@ class SharePanel extends React.Component {
                             }}/>
                     </FormGroup>
                     <Checkbox
+                        disabled={this.props.selectedLayer.visibility !== undefined ? !this.props.selectedLayer.visibility : false}
                         checked={this.props.settings && this.props.settings.markerEnabled}
                         onChange={() => {
                             this.props.onUpdateSettings({
@@ -374,7 +387,7 @@ class SharePanel extends React.Component {
                             });
                         }
                         }>
-                        <Message msgId="share.marker" />
+                        <Message msgId="share.marker" /> { this.renderActiveLayerNotVisible()}
                     </Checkbox>
                 </div>
                 }

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -123,6 +123,24 @@ describe("The SharePanel component", () => {
         expect(spyOnUpdateSettings.calls[1].arguments[0]).toEqual({markerEnabled: false, centerAndZoomEnabled: false, bboxEnabled: false});
         expect(spyOnHideMarker).toHaveBeenCalled();
     });
+
+    it('test disable Add marker options in the panel is selectedLayer visibility is off', () => {
+        const actions = {
+            onUpdateSettings: () => {},
+            hideMarker: () => {}
+        };
+        let panel = ReactDOM.render(<SharePanel selectedLayer={{name: 'ny_roads', visibility: false}} hideMarker={actions.hideMarker} onUpdateSettings={actions.onUpdateSettings} settings={{markerEnabled: false, centerAndZoomEnabled: true}} advancedSettings={{centerAndZoom: true, defaultEnabled: "centerAndZoom"}} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
+        expect(panel).toBeTruthy();
+        const cmpDom = ReactDOM.findDOMNode(panel);
+        expect(cmpDom).toBeTruthy();
+        const checkBoxes = document.querySelectorAll("input[type=checkbox]");
+        const checkBoxCenterAndZoom = checkBoxes[1];
+        const checkBoxAddMarker = checkBoxes[2];
+        expect(checkBoxCenterAndZoom).toBeTruthy();
+        expect(checkBoxCenterAndZoom.checked).toBe(true);
+        expect(checkBoxAddMarker).toBeTruthy();
+        expect(checkBoxAddMarker.disabled).toBe(true);
+    });
     it('test panel with enable default ', () => {
         const actions = {
             onUpdateSettings: () => {},

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -26,6 +26,7 @@ import controls from '../reducers/controls';
 import {featureInfoClick, changeFormat, hideMapinfoMarker} from '../actions/mapInfo';
 import { clickPointSelector} from '../selectors/mapInfo';
 import { updateUrlOnScrollSelector } from '../selectors/geostory';
+import { getSelectedLayer } from '../selectors/layers';
 /**
  * Share Plugin allows to share the current URL (location.href) in some different ways.
  * You can share it on socials networks(facebook,twitter,google+,linkedIn)
@@ -67,8 +68,9 @@ const Share = connect(createSelector([
     state => get(state, 'controls.share.settings', {}),
     (state) => state.mapInfo && state.mapInfo.formatCoord || ConfigUtils.getConfigProp("defaultCoordinateFormat"),
     clickPointSelector,
-    updateUrlOnScrollSelector
-], (isVisible, version, map, context, settings, formatCoords, point, isScrollPosition) => ({
+    updateUrlOnScrollSelector,
+    getSelectedLayer
+], (isVisible, version, map, context, settings, formatCoords, point, isScrollPosition, selectedLayer) => ({
     isVisible,
     shareUrl: location.href,
     shareApiUrl: getApiUrl(location.href),
@@ -88,7 +90,8 @@ const Share = connect(createSelector([
     },
     formatCoords: formatCoords,
     point,
-    isScrollPosition
+    isScrollPosition,
+    selectedLayer
 })), {
     onClose: toggleControl.bind(null, 'share', null),
     hideMarker: hideMapinfoMarker,

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1299,7 +1299,8 @@
             "coordTooltip": "Klicken Sie auf die Karte, um die Koordinaten zu ändern / festzulegen",
             "zoomToolTip": "Min: 1 und Max: 35",
             "showSectionId": "Bildlaufposition einschließen",
-            "showConnections": "Verbindungen anzeigen"
+            "showConnections": "Verbindungen anzeigen",
+            "noActiveQueryableLayer": "Deaktiviert, da die Sichtbarkeit der ausgewählten Ebene deaktiviert ist"
         },
         "snapshot": {
             "title": "Snapshot Vorschau",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1298,7 +1298,8 @@
             "wrongBboxParamMessage": "Bounding box params must be in EPSG:4326 and wrote as bbox=minx,miny,maxx,maxy",
             "showHomeButton": "Link to MapStore home",
             "showSectionId": "Include scroll position",
-            "showConnections": "Show connections"
+            "showConnections": "Show connections",
+            "noActiveQueryableLayer": "Disabled because the selected layer visibility is off"
         },
         "snapshot": {
             "title": "Snapshot Preview",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1298,7 +1298,8 @@
             "coordTooltip": "Haga clic en el mapa para tomar las coordenadas.",
             "zoomToolTip": "Min: 1 y Max: 35",
             "showSectionId": "Incluir posición de desplazamiento",
-            "showConnections": "Mostrar conexiones"
+            "showConnections": "Mostrar conexiones",
+            "noActiveQueryableLayer": "Desactivado porque la visibilidad de la capa seleccionada está desactivada"
         },
         "snapshot": {
             "title": "Previsualización de la captura del mapa",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1299,7 +1299,8 @@
             "wrongBboxParamTitle": "Paramètre de rectangle englobant invalide",
             "wrongBboxParamMessage": "Les paramètres du rectangle englobant doivent être en EPSG:4326 et écrit de cette façon : bbox=minx,miny,maxx,maxy",
             "showSectionId": "Inclure la position de défilement",
-            "showConnections": "Afficher les connexions"
+            "showConnections": "Afficher les connexions",
+            "noActiveQueryableLayer": "Désactivé car la visibilité du calque sélectionné est désactivée"
         },
         "snapshot": {
             "title": "Prévisualisation de la capture de la carte",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1298,7 +1298,8 @@
             "coordTooltip": "Clicca sulla mappa per ottenere le coordinate del centro",
             "zoomToolTip": "Min: 1 e Max: 35",
             "showSectionId": "Includi posizione di scorrimento",
-            "showConnections": "Mostra connessioni"
+            "showConnections": "Mostra connessioni",
+            "noActiveQueryableLayer": "Disattivato perché la visibilità del livello selezionato è disattivata"
         },
         "snapshot": {
             "title": "Istantanea",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The share function triggers a GFI request and therefore the message "No active queryable layer" is visualized.
#6722

**What is the new behavior?**
All GFI requests should be disabled while using the share function.

<img width="688" alt="Screenshot 2021-04-02 at 14 33 47" src="https://user-images.githubusercontent.com/39124174/113413715-f3048e80-93c3-11eb-8df7-173bd417448f.png">

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
