### PR TITLE
6723: Error creating circle annotation

### DIFF
--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -1514,6 +1514,49 @@ describe('Test the annotations reducer', () => {
         expect(round(firstPoint[0], 10)).toBe(1);
         expect(round(firstPoint[1], 10)).toBe(-27.8323353334);
     });
+
+    it('changeSelected, Selected Properties for Circle Feature with Radius and Radius Undefined', () => {
+        const selected = {
+            properties: {
+                canEdit: true,
+                center: [-6.576492309570317, 41.6007838467891],
+                id: "259d79d0-053e-11ea-b0b3-379d853a3ff4",
+                isCircle: true,
+                isValidFeature: true
+            },
+            geometry: {
+                type: "Circle",
+                coordinates: [-6.576492309570317, 41.6007838467891]
+            }
+        };
+        const featureColl = {
+            type: "FeatureCollection",
+            features: [selected],
+            tempFeatures: [],
+            properties: {
+                id: '1asdfads'
+            },
+            style: {}
+        };
+        const coordinates = [[1, 1]];
+        // with defined radius
+        const state = annotations({
+            editing: featureColl,
+            selected,
+            featureType: "Text",
+            unsavedGeometry: true
+        }, changeSelected(coordinates, 3567, null, "EPSG:3857"));
+
+        // with undefined radius
+        const state2 = annotations({
+            editing: featureColl,
+            selected: {...selected, properties: {...selected.properties}},
+            featureType: "Text",
+            unsavedGeometry: true
+        }, changeSelected(coordinates, undefined, null, "EPSG:4326"));
+
+        expect(state.selected.properties).toNotEqual(state2.selected.properties);
+    });
     it('UPDATE_SYMBOLS', () => {
         let annotationsState = annotations({}, updateSymbols());
         expect(annotationsState.symbolList.length).toBe(0);

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -155,11 +155,16 @@ function annotations(state = {validationErrors: {}}, action) {
             if (validateCoordsArray(selected.properties.center)) {
                 center = selected.properties.center;
                 // turf/circle by default use km unit hence we divide by 1000 the radius(in meters)
-                c = circle(
-                    center,
-                    action.crs === "EPSG:4326" ? action.radius : action.radius / 1000,
-                    { steps: 100, units: action.crs === "EPSG:4326" ? "degrees" : "kilometers" }
-                ).geometry;
+                // this try catch prevents the app from crashing when there is no radius maybe we can use a default value for radius incase action.radius === undefined
+                try {
+                    c = circle(
+                        center,
+                        action.crs === "EPSG:4326" ? action.radius : action.radius / 1000,
+                        { steps: 100, units: action.crs === "EPSG:4326" ? "degrees" : "kilometers" }
+                    ).geometry;
+                } catch (e) {
+                    console.log(e);
+                }
             } else {
                 selected = set("properties.center", [], selected);
             }

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -156,15 +156,12 @@ function annotations(state = {validationErrors: {}}, action) {
                 center = selected.properties.center;
                 // turf/circle by default use km unit hence we divide by 1000 the radius(in meters)
                 // this try catch prevents the app from crashing when there is no radius maybe we can use a default value for radius incase action.radius === undefined
-                try {
-                    c = circle(
-                        center,
-                        action.crs === "EPSG:4326" ? action.radius : action.radius / 1000,
-                        { steps: 100, units: action.crs === "EPSG:4326" ? "degrees" : "kilometers" }
-                    ).geometry;
-                } catch (e) {
-                    console.log(e);
-                }
+                const circleRadius = action.radius ?? 0.0001;
+                c = circle(
+                    center,
+                    action.crs === "EPSG:4326" ? circleRadius : circleRadius / 1000,
+                    { steps: 100, units: action.crs === "EPSG:4326" ? "degrees" : "kilometers" }
+                ).geometry;
             } else {
                 selected = set("properties.center", [], selected);
             }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## 6723

**What is the current behavior?**
MapStore crashes before having the chance to enter a radius while entering Lat and Lng

#6723

**What is the new behavior?**
It should be possible to enter coordinates before entering a radius without throwing an error.

#### how the issue was resolved
I found that the package https://www.npmjs.com/package/@turf/turf causes the app to crash at this line https://github.com/geosolutions-it/MapStore2/blob/master/web/client/reducers/annotations.js#L158. It's my guess that `circle` needs the radius. Without radius it causes the app to crash. So wrapping it a `try-catch solves the problem

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
