### PR TITLE
#6727: Details update fix

### DIFF
--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -211,5 +211,33 @@ describe('geostore observables for resources management', () => {
                 e => done(e)
             );
         });
+        it('updateResource linked resource is updated', done => {
+            const testResource = {
+                id: 10,
+                data: {},
+                category: "TEST",
+                metadata: {
+                    name: "RES2"
+                },
+                linkedResources: {
+                    details: { category: "DETAILS", data: "<p>Test</p>"}
+                }
+            };
+
+            const DummyAPI = {
+                getResourceAttributes: () => Promise.resolve([{
+                    name: 'details',
+                    type: 'STRING',
+                    value: 'rest/geostore/data/134'
+                }]),
+                putResourceMetadataAndAttributes: () => Promise.resolve(10),
+                putResource: () => Promise.resolve(10),
+                updateResourceAttribute: () => Promise.resolve(11)
+            };
+            updateResource(testResource, DummyAPI).subscribe(
+                () => done(),
+                e => done(e)
+            );
+        });
     });
 });

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -68,7 +68,7 @@ const updateOrDeleteLinkedResource = (id, attributeName, linkedResource = {}, re
             .switchMap( () => Observable.fromPromise( API.updateResourceAttribute(id, attributeName, "NODATA")))
         // update flow.
         : Observable.forkJoin([
-            API.putResource(resourceId, linkedResource.data)
+            Observable.defer(() => API.putResource(resourceId, linkedResource.data))
                 .switchMap(() => Observable.defer(() => API.updateResourceAttribute(id, attributeName, createLinkedResourceURL(resourceId, linkedResource.tail)))),
             ...(permission ? [updateResourcePermissions(resourceId, permission, API)] : [])
         ]);


### PR DESCRIPTION
## Description
This PR adds commit to fix, the duplication resource when updating the existing resource.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6727 

**What is the new behavior?**
When updating the details resource, the specific resource will only get updated and no duplicate creation of the same resource.
**i.e** Only one entry specific to the resource will be available in the DB (tables - gs_stored_data, gs_resource, gs_security) 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
