### PR TITLE
#6728: Infobox viewer alignment fix

### DIFF
--- a/web/client/themes/default/less/details.less
+++ b/web/client/themes/default/less/details.less
@@ -23,6 +23,9 @@
 
 }
 
+// Workaround: This emulates the br tags inside p or h tags in the editor, when pressing enter,
+// that are not included in the output of draftToHtml(DraftJS converter)
+// see https://github.com/geosolutions-it/MapStore2/issues/6728
 .ms-details-preview {
     p{
         margin: 1em;

--- a/web/client/themes/default/less/details.less
+++ b/web/client/themes/default/less/details.less
@@ -23,6 +23,18 @@
 
 }
 
+.ms-details-preview {
+    p{
+        margin: 1em;
+    }
+    p, h1, h2, h3, h4, h5, h6, blockquote{
+        &:empty::after {
+            content: "\a";
+            white-space: pre;
+        }
+    }
+}
+
 /////////////////////
 // LIBRARIES FIX
 /////////////////////


### PR DESCRIPTION
## Description
This PR add commit to fix the detail viewer in handling the empty tag created from the editor which affects alignment (when manually pushing content by hitting "Enter") 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6728 

**What is the new behavior?**
The empty tags will have enough spacing such that it doesn't break the alignment and viewer will match the representation in the editor tool

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Map ref: https://dev.mapstore2.geo-solutions.it/mapstore/?debug=true#/viewer/openlayers/10358