### PR TITLE
fix SEARCH_CANCEL_ITEM error when search state is null

### DIFF
--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -115,23 +115,23 @@ describe('Test the search reducer', () => {
         expect(state.selectedServices.length).toBe(1);
     });
     it('nested search cancel item', () => {
-        let itemToCacel = {text: "text2"};
+        let itemToCancel = {text: "text2"};
         let state = search({
             searchText: "",
-            selectedItems: [{text: "text1"}, itemToCacel]
+            selectedItems: [{text: "text1"}, itemToCancel]
         }, {
             type: TEXT_SEARCH_CANCEL_ITEM,
-            item: itemToCacel
+            item: itemToCancel
 
         });
         expect(state.searchText).toBe("text2");
         expect(state.selectedItems.length).toBe(1);
     });
     it('checks for valid state in TEXT_SEARCH_CANCEL_ITEM', () => {
-        let itemToCacel = {text: "text2"};
+        let itemToCancel = {text: "text2"};
         let state = search(null, {
             type: TEXT_SEARCH_CANCEL_ITEM,
-            item: itemToCacel
+            item: itemToCancel
 
         });
         expect(state).toBe(null);

--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -127,6 +127,15 @@ describe('Test the search reducer', () => {
         expect(state.searchText).toBe("text2");
         expect(state.selectedItems.length).toBe(1);
     });
+    it('checks for valid state in TEXT_SEARCH_CANCEL_ITEM', () => {
+        let itemToCacel = {text: "text2"};
+        let state = search(null, {
+            type: TEXT_SEARCH_CANCEL_ITEM,
+            item: itemToCacel
+
+        });
+        expect(state).toBe(null);
+    });
     it('update results style', () => {
         const style = {color: '#ff0000'};
         const state = search({}, {

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -118,10 +118,10 @@ function search(state = null, action) {
             selectedItems: (state.selectedItems || []).concat(action.items)
         });
     case TEXT_SEARCH_CANCEL_ITEM:
-        return assign({}, {
+        return state ? assign({}, {
             selectedItems: state.selectedItems && state.selectedItems.filter(item => item !== action.item),
             searchText: state.searchText === "" && action.item && action.item.text ? action.item.text.substring(0, action.item.text.length) : state.searchText
-        });
+        }) : state;
     case UPDATE_RESULTS_STYLE:
         return assign({}, state, {style: action.style});
     case CHANGE_SEARCH_TOOL:


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
porting in master branch a fix made for https://github.com/geosolutions-it/webmapper-halliburton/issues/1643
in https://github.com/geosolutions-it/MapStore2/tree/c039_identify_error