### PR TITLE
#6729: Aeronautical field limit max input for fields

### DIFF
--- a/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
+++ b/web/client/components/mapcontrols/searchcoordinates/CoordinatesSearch.js
@@ -130,9 +130,7 @@ const CoordinatesSearch = ({
     const {zoomToPoint, areValidCoordinates} = CoordinateOptions;
 
     const changeCoordinates = (coord, value) => {
-        let val = isNaN(parseFloat(value)) ? "" : parseFloat(value);
-
-        onChangeCoord(coord, val);
+        onChangeCoord(coord, parseFloat(value));
         if (!areValidCoordinates()) {
             onClearCoordinatesSearch({owner: "search"});
         }

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -17,10 +17,13 @@ import coordinateTypePreset from '../enhancers/coordinateTypePreset';
 import decimalToAeronautical from '../enhancers/decimalToAeronautical';
 import tempAeronauticalValue from '../enhancers/tempAeronauticalValue';
 
-/**
- * This component renders a coordiante inpout for aetronautical degrees
-*/
+const DEGREES = "degrees";
+const SECONDS = "seconds";
+const MINUTES = "minutes";
 
+/**
+ * This component renders a coordinate input for aeronautical degrees
+*/
 class AeronauticalCoordinateEditor extends React.Component {
 
     static propTypes = {
@@ -62,7 +65,7 @@ class AeronauticalCoordinateEditor extends React.Component {
                 minutes: this.props.minutes,
                 seconds: this.props.seconds,
                 direction: this.props.direction,
-                [part]: part === "degrees" ? Math.min(newValue, this.props.maxDegrees) : newValue
+                [part]: part === DEGREES ? Math.min(newValue, this.props.maxDegrees) : newValue
             };
             let seconds = newValues.seconds;
             let minutes = newValues.minutes + this.getSexagesimalStep(seconds);
@@ -114,6 +117,18 @@ class AeronauticalCoordinateEditor extends React.Component {
         return (isNaN(val) || val === "") ? {borderColor: "#a94442"} : {};
     }
 
+    getNewValue = (val, type = DEGREES) => {
+        let newValue;
+        if (val === "") {
+            newValue = "";
+        } else {
+            const parsedVal = type === SECONDS ? parseFloat(val) : parseInt(val, 10);
+            const maxValue = type === DEGREES ? this.props.maxDegrees : 60;
+            newValue = parsedVal < maxValue ? parsedVal : maxValue - 1;
+        }
+        return newValue;
+    }
+
     render() {
         const inputStyle = { padding: 0, textAlign: "center", borderRight: 'none' };
         const degreesInvalidStyle = this.getInputStyle(this.props.degrees);
@@ -131,13 +146,13 @@ class AeronauticalCoordinateEditor extends React.Component {
         const {step: stepSeconds} = this.props.aeronauticalOptions.seconds;
         return (
             <FormGroup style={{display: "inline-flex"}}>
-                <div className={"degrees"} style={{width: 40, display: 'flex'}}>
+                <div className={DEGREES} style={{width: 40, display: 'flex'}}>
                     <IntlNumberFormControl
-                        key={this.props.coordinate + "degree"}
+                        key={this.props.coordinate + DEGREES}
                         value={this.props.degrees}
                         disabled={this.props.disabled}
                         placeholder="d"
-                        onChange={val => this.onChange("degrees", parseInt(val, 10))}
+                        onChange={val => this.onChange(DEGREES, this.getNewValue(val))}
                         step={1}
                         size={3}
                         max={this.props.maxDegrees}
@@ -151,16 +166,14 @@ class AeronauticalCoordinateEditor extends React.Component {
                     <span style={labelStyle}>&deg;</span>
                 </div>
 
-                <div className={"minutes"} style={{width: 40, display: 'flex' }}>
+                <div className={MINUTES} style={{width: 40, display: 'flex' }}>
                     <IntlNumberFormControl
                         disabled={this.props.disabled}
-                        key={this.props.coordinate + "minutes"}
+                        key={this.props.coordinate + MINUTES}
                         placeholder={"m"}
                         size={3}
                         value={this.props.minutes}
-                        onChange={val => {
-                            this.onChange("minutes", parseInt(val, 10));
-                        }}
+                        onChange={val => this.onChange(MINUTES, this.getNewValue(val, MINUTES))}
                         max={60}
                         min={-1}
                         onKeyDown={(event) => {
@@ -172,13 +185,13 @@ class AeronauticalCoordinateEditor extends React.Component {
                     />
                     <span style={labelStyle}>&prime;</span>
                 </div>
-                <div className="seconds" style={{display: 'flex'}}>
+                <div className={SECONDS} style={{display: 'flex'}}>
                     <IntlNumberFormControl
                         disabled={this.props.disabled}
-                        key={this.props.coordinate + "seconds"}
+                        key={this.props.coordinate + SECONDS}
                         value={this.props.seconds}
                         placeholder="s"
-                        onChange={val => this.onChange("seconds", parseFloat(val))}
+                        onChange={val => this.onChange(SECONDS, this.getNewValue(val, SECONDS))}
                         step={stepSeconds}
                         max={60}
                         // size={5}

--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -124,7 +124,7 @@ class AeronauticalCoordinateEditor extends React.Component {
         } else {
             const parsedVal = type === SECONDS ? parseFloat(val) : parseInt(val, 10);
             const maxValue = type === DEGREES ? this.props.maxDegrees : 60;
-            newValue = parsedVal < maxValue ? parsedVal : maxValue - 1;
+            newValue = Math.round(parsedVal * 10) / 10 < maxValue ? parsedVal : maxValue - 1;
         }
         return newValue;
     }

--- a/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
@@ -164,13 +164,14 @@ describe('AeronauticalCoordinateEditor enhancer', () => {
         ReactTestUtils.Simulate.blur(elements[0]);
         ReactTestUtils.Simulate.change(elements[1], { target: { value: testValue } });
         ReactTestUtils.Simulate.blur(elements[1]);
-        ReactTestUtils.Simulate.change(elements[2], { target: { value: testValue } });
+        ReactTestUtils.Simulate.change(elements[2], { target: { value: 59.99999 } });
         ReactTestUtils.Simulate.blur(elements[2]);
 
         // Result
         expect(+degrees.value).toBeLessThan(195);
         expect(+minutes.value).toBeLessThan(testValue);
         expect(+seconds.value).toBeLessThan(testValue);
+        expect(+seconds.value).toNotEqual(0);
         expect(spyOnChange).toHaveBeenCalled();
         expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(179);
     });

--- a/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
@@ -103,4 +103,75 @@ describe('AeronauticalCoordinateEditor enhancer', () => {
             }
         });
     });
+    it('Test AeronauticalCoordinateEditor LAT fields onChange not exceed max field values', () => {
+        const actions = {
+            onChange: () => { }
+        };
+        const spyOnChange = expect.spyOn(actions, 'onChange');
+        ReactDOM.render(<AeronauticalCoordinateEditor
+            coordinate="lat"
+            value={20}
+            onChange={actions.onChange}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        let elements = container.querySelectorAll('input');
+        const degrees = elements[0];
+        const minutes = elements[1];
+        const seconds = elements[2];
+
+        expect(elements.length).toBe(3);
+        expect(degrees.value).toBe('20');
+        expect(minutes.value).toBe('0');
+        expect(seconds.value).toBe('0');
+
+        const testValue = 61;
+        // Simulate input
+        ReactTestUtils.Simulate.change(elements[0], { target: { value: "95" } });
+        ReactTestUtils.Simulate.blur(elements[0]);
+        ReactTestUtils.Simulate.change(elements[1], { target: { value: testValue } });
+        ReactTestUtils.Simulate.blur(elements[1]);
+        ReactTestUtils.Simulate.change(elements[2], { target: { value: testValue } });
+        ReactTestUtils.Simulate.blur(elements[2]);
+
+        // Result
+        expect(+degrees.value).toBeLessThan(95);
+        expect(+minutes.value).toBeLessThan(testValue);
+        expect(+seconds.value).toBeLessThan(testValue);
+        expect(spyOnChange).toHaveBeenCalled();
+        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(89);
+    });
+    it('Test AeronauticalCoordinateEditor LON fields onChange not exceed max field values', () => {
+        const actions = {
+            onChange: () => { }
+        };
+        const spyOnChange = expect.spyOn(actions, 'onChange');
+        ReactDOM.render(<AeronauticalCoordinateEditor
+            coordinate="lon"
+            value={160} onChange={actions.onChange} />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        let elements = container.querySelectorAll('input');
+        const degrees = elements[0];
+        const minutes = elements[1];
+        const seconds = elements[2];
+
+        expect(elements.length).toBe(3);
+        expect(degrees.value).toBe('160');
+        expect(minutes.value).toBe('0');
+        expect(seconds.value).toBe('0');
+
+        const testValue = 61;
+        // Simulate input
+        ReactTestUtils.Simulate.change(elements[0], { target: { value: "195" } });
+        ReactTestUtils.Simulate.blur(elements[0]);
+        ReactTestUtils.Simulate.change(elements[1], { target: { value: testValue } });
+        ReactTestUtils.Simulate.blur(elements[1]);
+        ReactTestUtils.Simulate.change(elements[2], { target: { value: testValue } });
+        ReactTestUtils.Simulate.blur(elements[2]);
+
+        // Result
+        expect(+degrees.value).toBeLessThan(195);
+        expect(+minutes.value).toBeLessThan(testValue);
+        expect(+seconds.value).toBeLessThan(testValue);
+        expect(spyOnChange).toHaveBeenCalled();
+        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(179);
+    });
 });

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -125,7 +125,7 @@
             display: flex;
             flex: 1 1 0%;
             justify-content: space-between;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             .input-group {
                 flex: 1 1 0%;
                 padding: 4px 0;


### PR DESCRIPTION
## Description
This PR limits the aeronautical fields to max value of each field, so the auto formatting of the fields won't happen on typing values greater than the respective fields' max limit

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6729 

**What is the new behavior?**
- Each field in the aeronautical coordinates is limited to its max field value. (ex: Degrees - 89/179, minutes and seconds to 59), such that it prevents auto formatting of the fields value on typing
- The auto format happens when user switches from decimal to aeronautical to allow conversion

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
