### PR TITLE
6730: Share by bounding box shows wrong result

### DIFF
--- a/web/client/actions/__tests__/map-test.js
+++ b/web/client/actions/__tests__/map-test.js
@@ -134,13 +134,15 @@ describe('Test correctness of the map actions', () => {
     });
 
     it('zoom to extent', () => {
-        const retval = zoomToExtent([-30, -30, 30, 30], 'EPSG:4326', 18);
+        const options = {nearest: true};
+        const retval = zoomToExtent([-30, -30, 30, 30], 'EPSG:4326', 18, options);
 
         expect(retval).toExist();
         expect(retval.type).toBe(ZOOM_TO_EXTENT);
         expect(retval.extent).toExist();
         expect(retval.crs).toBe('EPSG:4326');
         expect(retval.maxZoom).toBe(18);
+        expect(retval.options).toEqual(options);
     });
 
     it('changes map crs', () => {

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -126,13 +126,15 @@ export function panTo(center) {
  * @param {number[]} extent in the form of [minx, miny, maxx, maxy]
  * @param {string} crs related the extent
  * @param {number} maxZoom the max zoom limit
-*/
-export function zoomToExtent(extent, crs, maxZoom) {
+ * @param {object} options additional options {nearest: true}
+ */
+export function zoomToExtent(extent, crs, maxZoom, options) {
     return {
         type: ZOOM_TO_EXTENT,
         extent,
         crs,
-        maxZoom
+        maxZoom,
+        options
     };
 }
 

--- a/web/client/actions/map.js
+++ b/web/client/actions/map.js
@@ -126,7 +126,8 @@ export function panTo(center) {
  * @param {number[]} extent in the form of [minx, miny, maxx, maxy]
  * @param {string} crs related the extent
  * @param {number} maxZoom the max zoom limit
- * @param {object} options additional options {nearest: true}
+ * @param {object} options additional options `{nearest: true}`is the only supported
+ * (See {@link https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit| Openlayers View, fit method} )
  */
 export function zoomToExtent(extent, crs, maxZoom, options) {
     return {

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -625,7 +625,7 @@ class OpenlayersMap extends React.Component {
         this.props.hookRegister.registerHook(mapUtils.GET_COORDINATES_FROM_PIXEL_HOOK, (pixel) => {
             return this.map.getCoordinateFromPixel(pixel);
         });
-        this.props.hookRegister.registerHook(mapUtils.ZOOM_TO_EXTENT_HOOK, (extent, { padding, crs, maxZoom: zoomLevel, duration} = {}) => {
+        this.props.hookRegister.registerHook(mapUtils.ZOOM_TO_EXTENT_HOOK, (extent, { padding, crs, maxZoom: zoomLevel, duration, nearest} = {}) => {
             let bounds = reprojectBbox(extent, crs, this.props.projection);
             // if EPSG:4326 with max extent (-180, -90, 180, 90) bounds are 0,0,0,0. In this case zoom to max extent
             // TODO: improve this to manage all degenerated bounding boxes.
@@ -642,7 +642,8 @@ class OpenlayersMap extends React.Component {
                 size: this.map.getSize(),
                 padding: padding && [padding.top || 0, padding.right || 0, padding.bottom || 0, padding.left || 0],
                 maxZoom,
-                duration
+                duration,
+                nearest
             });
         });
     };

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -69,6 +69,7 @@ describe('queryparam epics', () => {
                     expect(Math.floor(actions[0].extent[2])).toBe(10);
                     expect(Math.floor(actions[0].extent[3])).toBe(46);
                     expect(actions[0].crs).toBe('EPSG:4326');
+                    expect(actions[0].options.nearest).toBe(true);
                 } catch (e) {
                     done(e);
                 }

--- a/web/client/epics/map.js
+++ b/web/client/epics/map.js
@@ -193,11 +193,12 @@ export const zoomToExtentEpic = (action$, {getState = () => {} }) =>
         const hook = MapUtils.getHook(MapUtils.ZOOM_TO_EXTENT_HOOK);
         const padding = mapPaddingSelector(getState());
         if (hook) {
-            const { crs, maxZoom } = action;
+            const { crs, maxZoom, options = {} } = action;
             hook(extent, {
                 crs,
                 padding,
-                maxZoom
+                maxZoom,
+                ...options
             });
             return Rx.Observable.empty();
         }

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -37,7 +37,7 @@ const paramActions = {
             .filter(val => !isNaN(val));
         if (extent && extent.length === 4 && isValidExtent(extent)) {
             return [
-                zoomToExtent(extent, 'EPSG:4326')
+                zoomToExtent(extent, 'EPSG:4326', undefined,  {nearest: true})
             ];
         }
         return [


### PR DESCRIPTION
## Description
Share by bounding box shows the wrong result which seems to use the correct box for the shown map, results in opening a map to a different extent, although using the same browser window size (switching to a different browser has the same result).
When creating a new sharing link from this map, the link is created opens a map at a higher zoom level.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
It seems a different zoom level is chosen by MS/OL for the provided BBOX

#6730 

**What is the new behavior?**
The zoom level is almost similar but always less by 1 than the original

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
