### PR TITLE
#6758 add customEditorsOptions to state initialization of FeatureEditor

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -13,7 +13,7 @@ import { get, pick } from 'lodash';
 import {compose, lifecycle} from 'recompose';
 import ReactDock from 'react-dock';
 
-import { createPlugin } from '../utils/PluginsUtils';
+import { createPlugin, connect as connectPlugin } from '../utils/PluginsUtils';
 
 import * as epics from '../epics/featuregrid';
 import featuregrid from '../reducers/featuregrid';
@@ -152,7 +152,7 @@ const FeatureDock = (props = {
     dialogs: EMPTY_OBJ,
     select: EMPTY_ARR
 }) => {
-    const { maxZoom } = props.pluginCfg;
+    const maxZoom  = props?.pluginCfg?.maxZoom;
     const dockProps = {
         dimMode: "none",
         defaultSize: 0.35,
@@ -261,7 +261,7 @@ const selector = createSelector(
     })
 );
 const EditorPlugin = compose(
-    connect(selector,
+    connectPlugin(selector,
         (dispatch) => ({
             onMount: bindActionCreators(setUp, dispatch),
             gridEvents: bindActionCreators(gridEvents, dispatch),
@@ -281,8 +281,7 @@ const EditorPlugin = compose(
             this.props.onMount(pick(this.props, [
                 'showFilteredObject',
                 'showTimeSync',
-                'timeSync',
-                'customEditorsOptions'
+                'timeSync'
             ]));
         }
     })

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -261,9 +261,18 @@ const selector = createSelector(
     })
 );
 const EditorPlugin = compose(
-    connectPlugin(selector,
+    connect(() => ({}),
         (dispatch) => ({
-            onMount: bindActionCreators(setUp, dispatch),
+            onMount: bindActionCreators(setUp, dispatch)
+        })),
+    lifecycle({
+        componentDidMount() {
+            // only the passed properties will be picked
+            this.props.onMount(pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']));
+        }
+    }),
+    connect(selector,
+        (dispatch) => ({
             gridEvents: bindActionCreators(gridEvents, dispatch),
             pageEvents: bindActionCreators(pageEvents, dispatch),
             initPlugin: bindActionCreators((options) => initPlugin(options), dispatch),
@@ -274,17 +283,7 @@ const EditorPlugin = compose(
             })),
             onSizeChange: (...params) => dispatch(sizeChange(...params))
         })
-    ),
-    lifecycle({
-        componentDidMount() {
-            // only the passed properties will be picked
-            this.props.onMount(pick(this.props, [
-                'showFilteredObject',
-                'showTimeSync',
-                'timeSync'
-            ]));
-        }
-    })
+    )
 )(FeatureDock);
 
 export default createPlugin('FeatureEditor', {

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -13,7 +13,7 @@ import { get, pick } from 'lodash';
 import {compose, lifecycle} from 'recompose';
 import ReactDock from 'react-dock';
 
-import { createPlugin, connect as connectPlugin } from '../utils/PluginsUtils';
+import { createPlugin } from '../utils/PluginsUtils';
 
 import * as epics from '../epics/featuregrid';
 import featuregrid from '../reducers/featuregrid';

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -278,7 +278,12 @@ const EditorPlugin = compose(
     lifecycle({
         componentDidMount() {
             // only the passed properties will be picked
-            this.props.onMount(pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync']));
+            this.props.onMount(pick(this.props, [
+                'showFilteredObject',
+                'showTimeSync',
+                'timeSync',
+                'customEditorsOptions'
+            ]));
         }
     })
 )(FeatureDock);

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -252,7 +252,7 @@ const IdentifyPlugin = compose(
     identifyDefaultProps,
     identifyIndex,
     defaultViewerHandlers,
-    connect(() => { }, {
+    connect(() => ({}), {
         setShowInMapPopup
     }),
     identifyLifecycle

--- a/web/client/plugins/featuregrid/panels/index.jsx
+++ b/web/client/plugins/featuregrid/panels/index.jsx
@@ -135,7 +135,7 @@ const ClearDialog = connect(
         onClose: () => toggleTool("clearConfirm", false),
         onConfirm: () => clearChangeConfirmed()
     })(ConfirmClearComp);
-const FeatureCloseDialog = connect(() => {}
+const FeatureCloseDialog = connect(() => ({})
     , {
         onClose: () => closeFeatureGridConfirmed(),
         onConfirm: () => closeFeatureGrid()


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
this pr allows customEditorsOptions to be passed from config --> plugin  bypassing state

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6758

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
customEditorsOptions is being now passed to the FeatureEditor

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
