### PR TITLE
6687: improving default embedded maps configuration

### DIFF
--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -78,7 +78,7 @@ class ShareEmbed extends React.Component {
         const {sizeOptions, selectedOption} = this.state;
         const height = selectedOption === "Custom" ? sizeOptions.Custom.height : sizeOptions[selectedOption]?.height;
         const width = selectedOption === "Custom" ? sizeOptions.Custom.width : sizeOptions[selectedOption]?.width;
-        const codeEmbedded = `<iframe style=\"border: none;\" height=\"${height || 0}\" width=\"${width || 0}\" src=\"${this.generateUrl(this.props.shareUrl)}\"></iframe>`;
+        const codeEmbedded = `<iframe allowFullScreen style=\"border: none;\" height=\"${height || 0}\" width=\"${width || 0}\" src=\"${this.generateUrl(this.props.shareUrl)}\"></iframe>`;
         return (
             <div className="input-link">
                 <div className="input-link-head">

--- a/web/client/components/share/__tests__/ShareEmbed-test.jsx
+++ b/web/client/components/share/__tests__/ShareEmbed-test.jsx
@@ -33,7 +33,7 @@ describe("The ShareEmbed component", () => {
 
     it('should have the address url in the textarea field', () => {
         const url = location.href;
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"400\" width=\"600\" src=\"" + url + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + url + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(<ShareEmbed shareUrl={url}/>, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
 
@@ -46,7 +46,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/";
         const hashPart = "#/abc/def/1";
         let expectedParam = "?forceDrawer=true";
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"400\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(<ShareEmbed shareUrl={ host + hashPart }/>, document.getElementById("container"));
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "input");
         let checkbox = head(inputs.filter(i => i.type === "checkbox"));
@@ -69,7 +69,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"400\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 shareUrl={ host + hashPart }
@@ -89,7 +89,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe style=\"border: none;\" height=\"700\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"700\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 sizeOptions = {{Small: { width: 400, height: 700}}}

--- a/web/client/components/share/__tests__/ShareEmbed-test.jsx
+++ b/web/client/components/share/__tests__/ShareEmbed-test.jsx
@@ -33,7 +33,7 @@ describe("The ShareEmbed component", () => {
 
     it('should have the address url in the textarea field', () => {
         const url = location.href;
-        const iFrameStr = "<iframe style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + url + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"400\" width=\"600\" src=\"" + url + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(<ShareEmbed shareUrl={url}/>, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
 
@@ -46,7 +46,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/";
         const hashPart = "#/abc/def/1";
         let expectedParam = "?forceDrawer=true";
-        const iFrameStr = "<iframe style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"400\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(<ShareEmbed shareUrl={ host + hashPart }/>, document.getElementById("container"));
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "input");
         let checkbox = head(inputs.filter(i => i.type === "checkbox"));
@@ -69,7 +69,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"400\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 shareUrl={ host + hashPart }

--- a/web/client/embedded.html
+++ b/web/client/embedded.html
@@ -91,6 +91,11 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
     </head>
+    <style>
+        .leaflet-top {
+            top: 50px;
+        }
+    </style>
     <body>
         <div id="container">
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>


### PR DESCRIPTION
## Description
Fullscreen does not work when Iframe is embedded and The TOC button covers the zoom in/out button.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The TOC button covers the zoom in/out button
The map does not become fullscreen when iframe is embedded


#6687 

**What is the new behavior?**

- [ ] The TOC button covers the zoom in/out button
- [x] The map  full screen works

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
