### PR TITLE
6748: Spinner is not displayed in the GFI panel between user requests

### DIFF
--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -81,7 +81,11 @@ function receiveResponse(state, action, type) {
             }
         }
 
-        let indexObj = {loaded: true, index: 0};
+        let indexObj = {index: 0};
+        // As long as we have a response stop the loaded
+        if (responses.filter((r) => r).length) {
+            indexObj = {...indexObj, loaded: true};
+        }
         // Set responses and index as first response is received
         return assign({}, state, {
             ...(isVector && {requests}),


### PR DESCRIPTION
## Description
The loader/spinner is not displayed in the GFI panel between user requests

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Spinner is not displayed between user requests of getting feature info

#6748 

**What is the new behavior?**
The spinner should be displayed until a valid response is received


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
