### PR TITLE
6770:  DefaultPointType property not properly applied for all annotation types

### DIFF
--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -117,7 +117,7 @@ const FeaturesList = (props) => {
                             onClick: () => {
                                 const style = [
                                     {...DEFAULT_ANNOTATIONS_STYLES.Circle, highlight: true, type: "Circle", title: "Circle Style", id: uuidv1()},
-                                    {...DEFAULT_ANNOTATIONS_STYLES.Point, highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "Center Style", filtering: false, geometry: "centerPoint", id: uuidv1()}
+                                    {...DEFAULT_ANNOTATIONS_STYLES.Point, ...defaultStyles.POINT?.[defaultPointType], highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "Center Style", filtering: false, geometry: "centerPoint", id: uuidv1()}
                                 ];
                                 onClickGeometry("Circle", style);
                             },

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -49,6 +49,11 @@ const FeaturesList = (props) => {
         onStartDrawing({geodesic});
         setTabValue('coordinates');
     };
+    const circleCenterStyles = defaultPointType === "symbol" ? defaultStyles.POINT?.[defaultPointType] : DEFAULT_ANNOTATIONS_STYLES.Point;
+
+    const linePointStyles = defaultPointType === "symbol" ?  [{...defaultStyles.POINT?.[defaultPointType], highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "StartPoint Style", geometry: "startPoint", filtering: false, id: uuidv1()},
+        {...defaultStyles.POINT?.[defaultPointType], highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "EndPoint Style", geometry: "endPoint", filtering: false, id: uuidv1()}] : getStartEndPointsForLinestring();
+
     return (
         <>
             <div className={'geometries-toolbar'}>
@@ -83,7 +88,7 @@ const FeaturesList = (props) => {
                             disabled: !isValidFeature,
                             onClick: () => {
                                 const style = [{ ...DEFAULT_ANNOTATIONS_STYLES.LineString, highlight: true, id: uuidv1()}]
-                                    .concat(getStartEndPointsForLinestring());
+                                    .concat(linePointStyles);
                                 onClickGeometry("LineString", style);
                             },
                             tooltip: <Message msgId="annotations.titles.line" />
@@ -117,7 +122,7 @@ const FeaturesList = (props) => {
                             onClick: () => {
                                 const style = [
                                     {...DEFAULT_ANNOTATIONS_STYLES.Circle, highlight: true, type: "Circle", title: "Circle Style", id: uuidv1()},
-                                    {...DEFAULT_ANNOTATIONS_STYLES.Point, ...defaultStyles.POINT?.[defaultPointType], highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "Center Style", filtering: false, geometry: "centerPoint", id: uuidv1()}
+                                    { ...circleCenterStyles, highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "Center Style", filtering: false, geometry: "centerPoint", id: uuidv1()}
                                 ];
                                 onClickGeometry("Circle", style);
                             },

--- a/web/client/components/style/vector/Manager.jsx
+++ b/web/client/components/style/vector/Manager.jsx
@@ -87,7 +87,7 @@ class Manager extends React.Component {
         const expanded = styles.map((s, i) => i === 0 || s.filtering );
         const locked = styles.map((s, i) => i === 0 );
         this.setState({expanded, locked});
-        styles.forEach(style => {
+        styles.filter(({type}) => type === 'Point').forEach(style => {
             this.checkSymbolUrl({...this.props, style});
         });
     }

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -61,12 +61,9 @@
       "defaultState": {
         "annotations": {
           "config": {
-            "geometryEditorOptions": { "measureOptions": {"displayUom": "nm"}},
             "multiGeometry": true,
-            "validationErrors": {},
-            "defaultPointType": "symbol"
+            "validationErrors": {}
           },
-          "format": "aeronautical",
           "defaultTextAnnotation": "New"
         },
         "maptype": {

--- a/web/client/localConfig.json
+++ b/web/client/localConfig.json
@@ -61,9 +61,12 @@
       "defaultState": {
         "annotations": {
           "config": {
+            "geometryEditorOptions": { "measureOptions": {"displayUom": "nm"}},
             "multiGeometry": true,
-            "validationErrors": {}
+            "validationErrors": {},
+            "defaultPointType": "symbol"
           },
+          "format": "aeronautical",
           "defaultTextAnnotation": "New"
         },
         "maptype": {


### PR DESCRIPTION
## Description
This configuration property is properly applied in the case of Point annotations but not for other annotations types (Circle center point, Line start/end points) and it should be.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
defaultPointType is applied only for Point annotations

#6770 

**What is the new behavior?**
defaultPointType is applied for all types of points features in annotations

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
