### PR TITLE
6722:  Fix hide info marker on close share Panel

### DIFF
--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -24,6 +24,7 @@ import {
 } from '../../actions/search';
 
 import { resetControls } from '../../actions/controls';
+import { hideMapinfoMarker } from '../../actions/mapInfo';
 
 describe('Test the search reducer', () => {
     it('search results loading', () => {
@@ -183,5 +184,12 @@ describe('Test the search reducer', () => {
             color: "#ff0000"
         }}, resetControls());
         expect(state).toBe(null);
+    });
+
+    it('HIDE INFO MARKER', () => {
+        const state = search({markerPosition: {
+            latlng: {lat: 0, lng: 0}
+        }}, hideMapinfoMarker());
+        expect(JSON.stringify(state.markerPosition)).toBe(JSON.stringify({}));
     });
 });

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -24,6 +24,7 @@ import {
 } from '../actions/search';
 
 import { RESET_CONTROLS } from '../actions/controls';
+import { HIDE_MAPINFO_MARKER } from '../actions/mapInfo';
 import assign from 'object-assign';
 /**
  * Manages the state of the map search with it's results
@@ -131,6 +132,8 @@ function search(state = null, action) {
         return {...state, format: action.format};
     case CHANGE_COORD:
         return {...state, coordinate: {...state.coordinate, [action.coord]: action.val}};
+    case HIDE_MAPINFO_MARKER:
+        return assign({}, state, {markerPosition: state?.markerPosition?.latlng ? {} : state?.markerPosition});
     default:
         return state;
     }


### PR DESCRIPTION
## Description
The marker remains on the map once the share panel is closed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Marker does not disappear on close share panel.
See [comment](https://github.com/geosolutions-it/MapStore2/pull/6740#issuecomment-819545100)
![share_marker](https://user-images.githubusercontent.com/56537133/114723565-0bb56280-9d3b-11eb-9a81-eb4d49be3674.gif)

#6722

**What is the new behavior?**
Once the Share panel is closed, the marker disappears

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
