### PR TITLE
[Backport 2021.01.xx] #6768: GFI Panel - Graphical bug #6775

### DIFF
--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -144,7 +144,7 @@ export default props => {
                     </Row>,
                     <Row className="coordinates-edit-row">
                         <span className="identify-icon glyphicon glyphicon-point"/>
-                        <div className={"coordinate-editor"}>
+                        <div style={showCoordinateEditor ? {zIndex: 1} : {}} className={"coordinate-editor"}>
                             <Coordinate
                                 key="coordinate-editor"
                                 formatCoord={formatCoord}

--- a/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
+++ b/web/client/components/data/identify/__tests__/IdentifyContainer-test.jsx
@@ -286,4 +286,19 @@ describe("test IdentifyContainer", () => {
         expect(zoomIcon).toNotExist();
     });
 
+    it('test z index to 1 for coordinate-editor if editor is active ', () => {
+        const requests = [{reqId: 1}, {reqId: 2}];
+        const responses = [{layerMetadata: {title: "Layer 1"}}, {layerMetadata: {title: "Layer 2"}}];
+        ReactDOM.render(<IdentifyContainer
+            enabled
+            index={0}
+            requests={requests}
+            responses={responses}
+            getFeatureButtons={getFeatureButtons}
+            point={{latlng: {lat: 1, lng: 1}}}
+            showCoordinateEditor
+        />, document.getElementById("container"));
+        let coordinateEditorContainer = document.querySelectorAll('.coordinate-editor');
+        expect(coordinateEditorContainer[0].style['z-index']).toBe('1');
+    });
 });


### PR DESCRIPTION
## Description
Graphical bug: when the coordinate editor in the GFI window is activated, the arrows of the input fields are overlapping the content of the dropdown box

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


## Issue

**What is the current behavior?**
the arrows of the input fields are overlapping the content of the dropdown menu

#6768

**What is the new behavior?**
The DD menu must properly cover the input field behind


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
