### PR TITLE
[Backport 2021.01.xx] #6722: Wrong GFI Behaviour using the Share tool (#6740 and #6778)

### DIFF
--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -87,7 +87,8 @@ class SharePanel extends React.Component {
         formatCoords: PropTypes.string,
         point: PropTypes.object,
         isScrollPosition: PropTypes.bool,
-        hideMarker: PropTypes.func
+        hideMarker: PropTypes.func,
+        addMarker: PropTypes.func
     };
 
     static defaultProps = {
@@ -105,7 +106,8 @@ class SharePanel extends React.Component {
         onUpdateSettings: () => {},
         formatCoords: "decimal",
         isScrollPosition: false,
-        hideMarker: () => {}
+        hideMarker: () => {},
+        addMarker: () => {}
     };
 
     state = {
@@ -136,11 +138,11 @@ class SharePanel extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        const {settings = {}, isVisible,  onSubmitClickPoint: showMarker, hideMarker} = this.props || {};
+        const {settings = {}, isVisible, hideMarker, addMarker} = this.props || {};
         if (!isEqual(settings.markerEnabled, prevProps.settings.markerEnabled) && isVisible) {
             const [lng, lat] = this.state.coordinate;
             let newPoint = set('latlng.lng', lng, set('latlng.lat', lat, this.props.point));
-            settings.markerEnabled ? showMarker(newPoint) : hideMarker();
+            settings.markerEnabled ? addMarker(newPoint) : hideMarker();
         }
     }
 
@@ -344,7 +346,7 @@ class SharePanel extends React.Component {
                                 const lat = !isNil(val.lat) && !isNaN(val.lat) ? parseFloat(val.lat) : 0;
                                 const lng = !isNil(val.lon) && !isNaN(val.lon) ? parseFloat(val.lon) : 0;
                                 let newPoint = set('latlng.lng', lng, set('latlng.lat', lat, this.props.point));
-                                this.props.onSubmitClickPoint(newPoint);
+                                this.props.addMarker(newPoint);
                             }}
                             onChangeFormat={this.props.onChangeFormat}
                         />

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -126,19 +126,19 @@ describe("The SharePanel component", () => {
     it('test panel with enable default ', () => {
         const actions = {
             onUpdateSettings: () => {},
-            onSubmitClickPoint: () => {}
+            addMarker: () => {}
         };
         const spyOnUpdateSettings = expect.spyOn(actions, "onUpdateSettings");
-        const spyOnSubmitClickPoint = expect.spyOn(actions, "onSubmitClickPoint");
+        const spyAddMarker = expect.spyOn(actions, "addMarker");
         let panel = ReactDOM.render(
             <SharePanel onUpdateSettings={actions.onUpdateSettings} settings={{markerEnabled: false}} shareUrl="www.geo-solutions.it" isVisible={false} />, document.getElementById("container"));
         expect(panel).toBeTruthy();
-        panel = ReactDOM.render(<SharePanel settings={{markerEnabled: true}} advancedSettings={{centerAndZoom: true, defaultEnabled: "markerAndZoom"}} onUpdateSettings={actions.onUpdateSettings} onSubmitClickPoint={actions.onSubmitClickPoint} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
+        panel = ReactDOM.render(<SharePanel settings={{markerEnabled: true}} advancedSettings={{centerAndZoom: true, defaultEnabled: "markerAndZoom"}} onUpdateSettings={actions.onUpdateSettings} addMarker={actions.addMarker} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
         expect(panel).toBeTruthy();
         const cmpDom = ReactDOM.findDOMNode(panel);
         expect(cmpDom).toBeTruthy();
         expect(spyOnUpdateSettings).toHaveBeenCalled();
         expect(spyOnUpdateSettings.calls[0].arguments[0]).toEqual({ markerEnabled: true, centerAndZoomEnabled: true, bboxEnabled: false });
-        expect(spyOnSubmitClickPoint).toHaveBeenCalled();
+        expect(spyAddMarker).toHaveBeenCalled();
     });
 });

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -99,9 +99,8 @@ describe('queryparam epics', () => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
                     expect(actions[0].type).toBe("TEXT_SEARCH_RESET");
-                    expect(actions[1].type).toBe("FEATURE_INFO_CLICK");
-                    expect(actions[1].point).toEqual({"latlng": {"lat": 39.01, "lng": -89.97}});
-                    expect(actions[1].layer).toBe("layer01");
+                    expect(actions[1].type).toBe("TEXT_SEARCH_ADD_MARKER");
+                    expect(actions[1].markerPosition).toEqual(point);
                 } catch (e) {
                     done(e);
                 }

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -19,7 +19,7 @@ import { warning } from '../actions/notifications';
 
 import { isValidExtent } from '../utils/CoordinatesUtils';
 import { getConfigProp, getCenter } from '../utils/ConfigUtils';
-import {featureInfoClick, hideMapinfoMarker, purgeMapInfoResults, toggleMapInfoState } from "../actions/mapInfo";
+import { hideMapinfoMarker, purgeMapInfoResults, toggleMapInfoState } from "../actions/mapInfo";
 import {getBbox} from "../utils/MapUtils";
 import {mapSelector} from '../selectors/map';
 
@@ -146,10 +146,10 @@ export const readQueryParamsOnMapEpic = (action$, store) =>
  */
 export const onMapClickForShareEpic = (action$, { getState = () => { } }) =>
     action$.ofType(CLICK_ON_MAP).
-        switchMap(({point, layer}) =>{
+        switchMap(({point}) =>{
             const allowClick = get(getState(), 'controls.share.settings.centerAndZoomEnabled');
             return allowClick
-                ? Rx.Observable.of(resetSearch(), featureInfoClick(point, layer))
+                ? Rx.Observable.of(resetSearch(), addMarker({latlng: point?.latlng || {}}))
                 : Rx.Observable.empty();
         });
 

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -24,7 +24,7 @@ import { currentContextSelector } from '../selectors/context';
 import { get } from 'lodash';
 import controls from '../reducers/controls';
 import {featureInfoClick, changeFormat, hideMapinfoMarker} from '../actions/mapInfo';
-import { clickPointSelector} from '../selectors/mapInfo';
+import { addMarker } from '../actions/search';
 import { updateUrlOnScrollSelector } from '../selectors/geostory';
 /**
  * Share Plugin allows to share the current URL (location.href) in some different ways.
@@ -66,7 +66,7 @@ const Share = connect(createSelector([
     currentContextSelector,
     state => get(state, 'controls.share.settings', {}),
     (state) => state.mapInfo && state.mapInfo.formatCoord || ConfigUtils.getConfigProp("defaultCoordinateFormat"),
-    clickPointSelector,
+    state => state.search && state.search.markerPosition || {},
     updateUrlOnScrollSelector
 ], (isVisible, version, map, context, settings, formatCoords, point, isScrollPosition) => ({
     isVisible,
@@ -88,13 +88,13 @@ const Share = connect(createSelector([
     },
     formatCoords: formatCoords,
     point,
-    isScrollPosition
-})), {
+    isScrollPosition})), {
     onClose: toggleControl.bind(null, 'share', null),
     hideMarker: hideMapinfoMarker,
     onUpdateSettings: setControlProperty.bind(null, 'share', 'settings'),
     onSubmitClickPoint: featureInfoClick,
-    onChangeFormat: changeFormat
+    onChangeFormat: changeFormat,
+    addMarker: addMarker
 })(SharePanel);
 
 export const SharePlugin = assign(Share, {

--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -24,6 +24,7 @@ import {
 } from '../../actions/search';
 
 import { resetControls } from '../../actions/controls';
+import { hideMapinfoMarker } from '../../actions/mapInfo';
 
 describe('Test the search reducer', () => {
     it('search results loading', () => {
@@ -174,5 +175,12 @@ describe('Test the search reducer', () => {
             color: "#ff0000"
         }}, resetControls());
         expect(state).toBe(null);
+    });
+
+    it('HIDE INFO MARKER', () => {
+        const state = search({markerPosition: {
+            latlng: {lat: 0, lng: 0}
+        }}, hideMapinfoMarker());
+        expect(JSON.stringify(state.markerPosition)).toBe(JSON.stringify({}));
     });
 });

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -24,6 +24,7 @@ import {
 } from '../actions/search';
 
 import { RESET_CONTROLS } from '../actions/controls';
+import { HIDE_MAPINFO_MARKER } from '../actions/mapInfo';
 import assign from 'object-assign';
 /**
  * Manages the state of the map search with it's results
@@ -130,6 +131,8 @@ function search(state = null, action) {
         return {...state, format: action.format};
     case CHANGE_COORD:
         return {...state, coordinate: {...state.coordinate, [action.coord]: action.val}};
+    case HIDE_MAPINFO_MARKER:
+        return assign({}, state, {markerPosition: state?.markerPosition?.latlng ? {} : state?.markerPosition});
     default:
         return state;
     }

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -105,7 +105,8 @@ function search(state = null, action) {
     case TEXT_SEARCH_RESULTS_PURGE:
         return assign({}, state, { results: null, error: null});
     case TEXT_SEARCH_ADD_MARKER:
-        return assign({}, state, { markerPosition: action.markerPosition, markerLabel: action.markerLabel });
+        const latlng = action.markerPosition.latlng ? {latlng: action.markerPosition.latlng, lat: action.markerPosition.latlng.lat,  lng: action.markerPosition.latlng.lng} : action.markerPosition;
+        return assign({}, state, { markerPosition: latlng, markerLabel: action.markerLabel });
     case TEXT_SEARCH_SET_HIGHLIGHTED_FEATURE:
         return assign({}, state, {highlightedFeature: action.highlightedFeature});
     case TEXT_SEARCH_RESET:


### PR DESCRIPTION
## Description
The marker remains on the map once the share panel is closed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Marker does not disappear on close share panel.
See [comment](https://github.com/geosolutions-it/MapStore2/pull/6740#issuecomment-819545100)
![share_marker](https://user-images.githubusercontent.com/56537133/114723565-0bb56280-9d3b-11eb-9a81-eb4d49be3674.gif)

#6722

**What is the new behavior?**
Once the Share panel is closed, the marker disappears

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
