### PR TITLE
6772: The different decimal separator between FeatureGrid and Chart causes an error in the charts

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -114,9 +114,9 @@ function getLayoutOptions({ series = [], cartesian, type, yAxis, xAxisAngle, xAx
 }
 
 /**
- * Returns Decimal places
- * @param {number} value to check
- * @return {number} of decimal places
+ * Returns number of Decimal places
+ * @param {number} value to check 1.2
+ * @return {number} of decimal places 0
  */
 function countDecimals(value = 0) {
     if (Math.floor(value) === value) return 0;

--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -9,7 +9,6 @@
 import React, { Suspense } from 'react';
 import { sameToneRangeColors } from '../../utils/ColorUtils';
 import { parseExpression } from '../../utils/ExpressionUtils';
-import isEmpty from 'lodash/isEmpty';
 import LoadingView from '../misc/LoadingView';
 
 const Plot = React.lazy(() => import('./PlotlyChart'));
@@ -78,14 +77,6 @@ function getMargins({ type, isModeBarVisible}) {
         };
     }
 }
-
-// function determineFormat(props) {
-//     const prepData = getData(props);
-//     // if (!isEmpty(yAxisOpts.format)) return yAxisOpts;
-//     // const timesToCheck = data.length > 5 ? 5 : data.length;
-
-//     // // data.forEach(())
-// }
 
 function getLayoutOptions({ series = [], cartesian, type, yAxis, xAxisAngle, xAxisOpts = {}, yAxisOpts = {}, data = [], autoColorOptions = COLOR_DEFAULTS} ) {
     switch (type) {

--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -153,8 +153,8 @@ export const toPlotly = (props) => {
         // limit the loop to try the first 5 items for performance reasons
         // optionally check if only the first item
         const [{y}] = data;
-        const numberOfTimes = y.length > 5 ? 4 : y.length;
-        for (let i = 0; i < numberOfTimes; i++) {
+        const numberOfTimesToLoop = y.length > 5 ? 4 : y.length;
+        for (let i = 0; i < numberOfTimesToLoop; i++) {
             const num = y[i];
             // stop if item is not a number
             if (typeof num !== "number") { break; }

--- a/web/client/components/charts/__tests__/WidgetChart-test.js
+++ b/web/client/components/charts/__tests__/WidgetChart-test.js
@@ -223,6 +223,25 @@ describe('Widget Chart: data conversions ', () => {
                 expect(layout.yaxis.ticksuffix).toBe("W/h");
             });
         });
+        it('check yAxis tickformat calcuated', () => {
+            const DATASET_2 = {
+                data: [
+                    { name: 'Page A', value: 1.0332 },
+                    { name: 'Page B', value: 1.0332 },
+                    { name: 'Page C', value: 1.0332 },
+                    { name: 'Page D', value: 1.0332 }
+                ],
+                name: "bar",
+                type: "bar",
+                xAxis: { dataKey: "name" },
+                series: [{ dataKey: "value" }]
+            };
+            const { layout } = toPlotly({
+                type: 'pie',
+                ...DATASET_2
+            });
+            expect(layout.yaxis.tickformat).toBe('.4f');
+        });
         it('check formula', () => {
             testAllTypes({
                 ...DATASET_1,


### PR DESCRIPTION
## Description
When the feature grid uses the Anglo-Saxon decimal separator the charts report a wrong value

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The value is 294,3335k but in the FeatureGrid is reported the following value 294,333.46

#6772

**What is the new behavior?**
The value is 294,3335k but in the FeatureGrid is reported the following value 294,333.46

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
