### PR TITLE
#6724 & #6748: GFI response index and loader fix

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -75,7 +75,7 @@ class DefaultViewer extends React.Component {
     getResponseProperties = () => {
         const validator = this.props.validator(this.props.format);
         const responses = this.props.responses.map(res => res === undefined ? {} : res); // Replace any undefined responses
-        const validResponses = validator.getValidResponses(responses);
+        const validResponses = this.props.renderEmpty ? validator.getValidResponses(responses) : responses;
         const invalidResponses = validator.getNoValidResponses(this.props.responses);
         const emptyResponses = this.props.requests.length === invalidResponses.length;
         const currResponse = this.getCurrentResponse(validResponses[this.props.index]);

--- a/web/client/components/data/identify/IdentifyContainer.jsx
+++ b/web/client/components/data/identify/IdentifyContainer.jsx
@@ -72,7 +72,9 @@ export default props => {
         toggleHighlightFeature = () => {}
     } = props;
     const latlng = point && point.latlng || null;
-    const targetResponse = validResponses[index]; // the index is calculated on the valid responses hence using all responses leads to wrong results
+
+    // Layer selector allows only selection of valid response's index, so target response will always be valid.
+    const targetResponse = responses[index];
     const {layer} = targetResponse || {};
 
     let lngCorrected = null;
@@ -126,7 +128,7 @@ export default props => {
                         <div className="layer-col">
                             <span className="identify-icon glyphicon glyphicon-1-layer"/>
                             <LayerSelector
-                                responses={validResponses}
+                                responses={responses}
                                 index={index}
                                 loaded={loaded}
                                 setIndex={setIndex}

--- a/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
@@ -127,7 +127,7 @@ describe('DefaultViewer', () => {
         expect(viewer).toExist();
         const dom = ReactDOM.findDOMNode(viewer);
         expect(dom.getElementsByClassName("alert").length).toBe(1);
-        expect(dom.getElementsByClassName("panel").length).toBe(1);
+        expect(dom.getElementsByClassName("panel").length).toBe(2);
 
         // Desktop view
         const gfiViewer = document.querySelector('.mapstore-identify-viewer');

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -114,7 +114,7 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].response).toBe("data");
         expect(state.responses[1].queryParams).toBe("params");
         expect(state.responses[1].layerMetadata).toBe("meta");
-        expect(state.index).toBe(0);
+        expect(state.index).toBe(1);
     });
 
     it('creates a feature info data from vector info request', () => {
@@ -146,7 +146,7 @@ describe('Test the mapInfo reducer', () => {
         let state = mapInfo({requests: [{}], configuration: {}}, testAction);
         expect(state.responses).toExist();
         expect(state.loaded).toBe(true);
-        expect(state.index).toBe(0);
+        expect(state.index).toBe(1);
         expect(state.responses.length).toBe(2);
         expect(state.responses[1].response).toExist();
         expect(state.responses[1].response.features.length).toBe(1);

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -37,9 +37,30 @@ import {
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import { RESET_CONTROLS } from '../actions/controls';
 import assign from 'object-assign';
-import { findIndex, isUndefined } from 'lodash';
+import { findIndex, isUndefined, isEmpty } from 'lodash';
 import { MAP_TYPE_CHANGED } from './../actions/maptype';
 
+import { getValidator } from '../utils/MapInfoUtils';
+
+/**
+ * Identifies when to update a index when the display information trigger is click (GFI panel)
+ * @param {object} state current state of the reducer
+ * @param {array} responses the responses received so far
+ * @param {number} requestIndex index position of the current request
+ * @param {boolean} isVector type of the response received is vector or not
+ */
+const isIndexValid = (state, responses, requestIndex, isVector) => {
+    const {configuration, requests, queryableLayers = [], index} = state;
+    const {infoFormat} = configuration || {};
+
+    // Index when first response received is valid
+    const validResponse = getValidator(infoFormat)?.getValidResponses([responses[requestIndex]]);
+    const inValidResponse = getValidator(infoFormat)?.getNoValidResponses(responses);
+    return ((isUndefined(index) && !!validResponse.length)
+        || (!isVector && requests.length === inValidResponse.filter(res=>res).length)
+        || (isUndefined(index) && isVector && requests.filter(r=>isEmpty(r)).length === queryableLayers.length) // Check if all requested layers are vector
+    );
+};
 /**
  * Handles responses based on the type ["data"|"exceptions","error","vector"] of the responses received
  * @param {object} state current state of the reducer
@@ -81,7 +102,12 @@ function receiveResponse(state, action, type) {
             }
         }
 
-        let indexObj = {loaded: true, index: 0};
+        let indexObj;
+        if (isHover) {
+            indexObj = {loaded: true, index: 0};
+        } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
+            indexObj = {loaded: true, index: requestIndex};
+        }
         // Set responses and index as first response is received
         return assign({}, state, {
             ...(isVector && {requests}),

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -26,7 +26,8 @@ import {
     filterNameListSelector,
     overrideParamsSelector,
     mapTriggerSelector,
-    hoverEnabledSelector
+    hoverEnabledSelector,
+    currentFeatureSelector
 } from '../mapInfo';
 
 const QUERY_PARAMS = {
@@ -360,5 +361,19 @@ describe('Test mapinfo selectors', () => {
     });
     it('isMapPopup', () => {
         expect(isMapPopup({ mapInfo: {showInMapPopup: true} })).toBeTruthy();
+    });
+
+    it('test currentFeatureSelector with default index', () => {
+        const state = { mapInfo: {...RESPONSE_STATE_WITH_FEATURES_METADATA.mapInfo, highlight: true}};
+        const [feature] = currentFeatureSelector(state);
+        expect(feature).toBeTruthy();
+        expect(feature.id).toBe('poi.4');
+    });
+    it('test currentFeatureSelector with derived index', () => {
+        const mapInfo = RESPONSE_STATE_WITH_FEATURES_METADATA.mapInfo;
+        const state = { mapInfo: {...mapInfo, responses: [{response: "no features were found"}, {...mapInfo.responses[0]}], highlight: true, index: 1}};
+        const [feature] = currentFeatureSelector(state);
+        expect(feature).toBeTruthy();
+        expect(feature.id).toBe('poi.4');
     });
 });

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -123,7 +123,7 @@ export const validResponsesSelector = createSelector(
     });
 
 export const currentResponseSelector = createSelector(
-    validResponsesSelector, indexSelector,
+    responsesSelector, indexSelector,
     (responses = [], index = 0) => responses[index]
 );
 export const currentFeatureSelector = state => {


### PR DESCRIPTION
## Description
This PR adds commit to fix the GFI response index and loader

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6724 & #6748 

**What is the new behavior?**
- On GetFeatureInfo, the first response received is the first one selected in the layer selector of GFI panel
- Spinner will be displayed when loading responses
- Existing functionalities should work as expected (Edit, zoom, highlight feature, etc.)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
