### PR TITLE
6688: Update default width and height configurations for Share Embed

### DIFF
--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -41,9 +41,9 @@ class ShareEmbed extends React.Component {
         forceDrawer: false,
         connections: false,
         sizeOptions: {
-            Small: { width: 400, height: 300 },
-            Medium: { width: 600, height: 450},
-            Large: { width: 800, height: 600},
+            Small: { width: 600, height: 500 },
+            Medium: { width: 800, height: 600},
+            Large: { width: 1000, height: 800},
             Custom: {width: 0, height: 0}
         },
         selectedOption: 'Small'

--- a/web/client/components/share/__tests__/ShareEmbed-test.jsx
+++ b/web/client/components/share/__tests__/ShareEmbed-test.jsx
@@ -33,7 +33,7 @@ describe("The ShareEmbed component", () => {
 
     it('should have the address url in the textarea field', () => {
         const url = location.href;
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + url + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + url + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(<ShareEmbed shareUrl={url}/>, document.getElementById("container"));
         expect(cmpSharePanel).toExist();
 
@@ -46,7 +46,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/";
         const hashPart = "#/abc/def/1";
         let expectedParam = "?forceDrawer=true";
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(<ShareEmbed shareUrl={ host + hashPart }/>, document.getElementById("container"));
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "input");
         let checkbox = head(inputs.filter(i => i.type === "checkbox"));
@@ -69,7 +69,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"300\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 shareUrl={ host + hashPart }

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -667,9 +667,9 @@
               "showTOCToggle": false,
               "showConnectionsParamToggle": true,
               "sizeOptions": {
-                "Small": { "width": 400, "height": 300 },
-                "Medium": { "width": 600, "height": 450},
-                "Large": { "width": 800, "height": 600},
+                "Small": { "width": 600, "height": 500 },
+                "Medium": { "width": 800, "height": 600},
+                "Large": { "width": 1000, "height": 800},
                 "Custom": {"width": 0, "height": 0}
             },
             "selectedOption": "Small"


### PR DESCRIPTION
## Description
Update defaults for share drop-down height and width. 
`Small: 600x500
Medium: 800x600
Large: 1000x800`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The defaults are not equal to `Small: 600x500
Medium: 800x600
Large: 1000x800`
#6688 

**What is the new behavior?**

Default height and width for the ShareEmbbed dropdown should be `Small: 600x500
Medium: 800x600
Large: 1000x800`

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
