### PR TITLE
#6800: exclude commons-codec 1.2 inherited from mapfish-print when pr…

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -448,6 +448,12 @@
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
             <version>geosolutions-2.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
        </dependencies>
     </profile>


### PR DESCRIPTION
…inting profile is enabled, conflicting with mapstore 1.4 version

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Removes commons-codec 1.2 from the product war when the printing profile is enabled. This is an inherited dependency of mapfish-print that conflicts with the 1.4 version used by MapStore for base64 decoding of home page thumbnails.

This was introduced from moving the printing profile build in the product module. The exclusion was only present in the framework java build, but the printing profile is applied later, when building the product, so an additional exclusion is needed.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [x] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#6800 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6800 thumbnails base64 decoding was failing due to a wrong version of the commons-codec library

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
thumbnails should now load perfectly fine

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
