### PR TITLE
#6522: Pass format option from WMS service when adding layer to TOC 

### DIFF
--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -133,6 +133,14 @@ class RecordItem extends React.Component {
 
     };
 
+    getFormats = (type, record) => {
+        let formats;
+        if (type === 'wms') {
+            formats = this.props?.service?.format && [this.props.service.format];
+        }
+        return formats ? formats : record.format && [record.format] || record.formats;
+    }
+
     renderButtons = (record, disabled) => {
         if (!record || !record.references) {
             // we don't have a valid record so no buttons to add
@@ -173,7 +181,7 @@ class RecordItem extends React.Component {
                     bsStyle="primary"
                     bsSize={this.props.buttonSize}
                     onClick={() => {
-                        const layer = this.makeLayer(type, wms || wmts, record.format && [record.format] || record.formats);
+                        const layer = this.makeLayer(type, wms || wmts, this.getFormats(type, record));
                         if (layer) {
                             this.addLayer(layer, {record});
                         }

--- a/web/client/components/catalog/__tests__/RecordItem-test.jsx
+++ b/web/client/components/catalog/__tests__/RecordItem-test.jsx
@@ -293,9 +293,11 @@ describe('This test for RecordItem', () => {
 
             }
         };
+        const service = { format: "image/jpeg", title: "GeoServer WMS", type: "wms", url: 'fakeURL'};
         let actionsSpy = expect.spyOn(actions, "onLayerAdd");
         const item = ReactDOM.render(<RecordItem
             record={sampleRecord}
+            service={service}
             onLayerAdd={actions.onLayerAdd}
             catalogURL="fakeURL"
             catalogType="wms"
@@ -312,6 +314,8 @@ describe('This test for RecordItem', () => {
         expect(actionsSpy.calls.length).toBe(1);
         expect(actionsSpy.calls[0].arguments.length).toBe(2);
         expect(actionsSpy.calls[0].arguments[0].catalogURL).toNotExist();
+        expect(actionsSpy.calls[0].arguments[0].format).toBeTruthy();
+        expect(actionsSpy.calls[0].arguments[0].format).toBe(service.format);
         expect(actionsSpy.calls[0].arguments[1].zoomToLayer).toBeTruthy();
     });
     it('check wms default format', () => {


### PR DESCRIPTION
## Description
This PR adds fix for current service format option not passed to the layer when adding WMS layer to TOC from Catalog

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/issues/6522#issuecomment-827473111

**What is the new behavior?**
- Selected format option of WMS service is passed to layer when added to TOC

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
