### PR TITLE
#6651: memoryStorage fallback when localStorage not available

### DIFF
--- a/web/client/api/userPersistedStorage/index.js
+++ b/web/client/api/userPersistedStorage/index.js
@@ -12,11 +12,25 @@ import set from 'lodash/set';
 import unset from 'lodash/unset';
 
 let UserPersistedSession = {
-    api: localStorage
 };
+let ls;
+/*
+ * This API provides a wrapper for local persistance. By default uses localStorage and implements the same API.
+ * Anyway, when localStorage is not accessible for security settings, it falls back to a dummy local memory.
+ * One example of 'localStorage not available' is when 3rd party cookies are disabled, the JS code is running in an iframe and you are in incognito mode.
+ */
+try {
+    // test localStorage access
+    ls = window.localStorage;
+    UserPersistedSession.api = "localStorage";
+} catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("localStorage is not accessible, using local memory storage instead", e);
+    UserPersistedSession.api = "memoryStorage";
+}
 let MemoryStorage = {};
 const ApiProviders = {
-    localStorage: window.localStorage,
+    localStorage: ls,
     memoryStorage: {
         accessDenied: false,
         getItem: (path) => {
@@ -42,7 +56,7 @@ const ApiProviders = {
         }
     }
 };
-export const api = "localStorage";
+export const api = UserPersistedSession.api;
 /**
 * Add a new API implementation
 * @param {string} name the key of the added api implementation
@@ -55,7 +69,7 @@ export const addApi = (name, apiName) => {
 * Set the current API
 * @param {string} name the key of the api implementation to be used
 */
-export const setApi = (name = "localStorage") => {
+export const setApi = (name = api) => {
     UserPersistedSession.api = name;
 };
 /**


### PR DESCRIPTION
## Description
Current implementation provides a wrapper for localStorage, but the error in #6651 is still present because "localStorage" is read anyway. 
This fix provides a soft and automatic fallback to `memoryStorage` when `localStorage` is not available.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6651

**What is the new behavior?**
Now the iframe loads correctly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
