### PR TITLE
6796: Identify Popup as default for Embedded Maps

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -6,6 +6,7 @@ const moduleFederationPlugin = require('./moduleFederation.js').plugin;
 
 module.exports = require('./buildConfig')(
     {
+        "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded"),
         [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app")
     },
     { ["themes/default"]: themeEntries["themes/" + (process.env.theme || "default")]},

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -6,7 +6,6 @@ const moduleFederationPlugin = require('./moduleFederation.js').plugin;
 
 module.exports = require('./buildConfig')(
     {
-        "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded"),
         [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app")
     },
     { ["themes/default"]: themeEntries["themes/" + (process.env.theme || "default")]},

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -523,10 +523,7 @@
               }, {
                 "name": "Identify",
                 "cfg": {
-                    "showFullscreen": true,
-                    "position": "bottom",
-                    "size": 0.5,
-                    "fluid": true,
+                    "showInMapPopup":true,
                     "viewerOptions": {
                         "container": "{context.ReactSwipe}"
                     }

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -46,6 +46,7 @@ import FeatureInfoFormatSelectorComp from '../components/misc/FeatureInfoFormatS
 import FeatureInfoTriggerSelectorComp from '../components/misc/FeatureInfoTriggerSelector';
 import epics from '../epics/identify';
 import mapInfo from '../reducers/mapInfo';
+import mapPopups from '../reducers/mapPopups';
 import { isEditingAllowedSelector } from '../selectors/featuregrid';
 import { layersSelector } from '../selectors/layers';
 import { currentLocaleSelector } from '../selectors/locale';
@@ -295,6 +296,6 @@ export default {
             position: 3
         }
     }),
-    reducers: { mapInfo },
+    reducers: { mapInfo, mapPopups },
     epics
 };


### PR DESCRIPTION
## Description
Enable the Identify tool as a popup for embedded maps.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Embedded Maps uses a modal to show info
#6796 

**What is the new behavior?**
FeatureInfo is shown in a pop

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
