### PR TITLE
#6758 Fixed default custom editors and FeatureEditor config in context

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, {useEffect} from 'react';
 import {connect} from 'react-redux';
 import {createSelector, createStructuredSelector} from 'reselect';
 import {bindActionCreators} from 'redux';
@@ -269,6 +269,16 @@ const EditorPlugin = compose(
         componentDidMount() {
             // only the passed properties will be picked
             this.props.onMount(pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']));
+        },
+        // TODO: fix this in contexts
+        // due to multiple renders of plugins in contexts (one with default props, then with context props)
+        // the options have to be updated when change.
+        componentDidUpdate(oldProps) {
+            const newOptions = pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']);
+            const oldOptions = pick(oldProps, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']);
+            if (JSON.stringify(newOptions) !== JSON.stringify(oldOptions) ) {
+                this.props.onMount(newOptions);
+            }
         }
     }),
     connect(selector,

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, {useEffect} from 'react';
+import React from 'react';
 import {connect} from 'react-redux';
 import {createSelector, createStructuredSelector} from 'reselect';
 import {bindActionCreators} from 'redux';

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {createSelector, createStructuredSelector} from 'reselect';
 import {bindActionCreators} from 'redux';
-import { get, pick } from 'lodash';
+import { get, pick, isEqual } from 'lodash';
 import {compose, lifecycle} from 'recompose';
 import ReactDock from 'react-dock';
 
@@ -276,7 +276,7 @@ const EditorPlugin = compose(
         componentDidUpdate(oldProps) {
             const newOptions = pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']);
             const oldOptions = pick(oldProps, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']);
-            if (JSON.stringify(newOptions) !== JSON.stringify(oldOptions) ) {
+            if (!isEqual(newOptions, oldOptions) ) {
                 this.props.onMount(newOptions);
             }
         }

--- a/web/client/utils/featuregrid/EditorRegistry.jsx
+++ b/web/client/utils/featuregrid/EditorRegistry.jsx
@@ -8,7 +8,7 @@
 
 const find = require('lodash/find');
 const assign = require('object-assign');
-let Editors = assign({}, require('../../components/data/featuregrid/editors/customEditors'));
+let Editors = assign({}, require('../../components/data/featuregrid/editors/customEditors').default);
 
 const isPresent = (editorName) => {
     return Object.keys(Editors).indexOf(editorName) !== -1;
@@ -35,6 +35,7 @@ const getEditor = (type, name, props) => {
 };
 module.exports = {
     get: () => Editors,
+    set: (e) => {Editors = e;},
     register: ({name, editors}) => {
         if (!!editors) {
             Editors[name] = editors;

--- a/web/client/utils/featuregrid/__tests__/EditorRegistry-test.js
+++ b/web/client/utils/featuregrid/__tests__/EditorRegistry-test.js
@@ -5,19 +5,20 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-const ReactDOM = require('react-dom');
-const React = require('react');
-const expect = require('expect');
-const DropDownEditor = require('../../../components/data/featuregrid/editors/DropDownEditor');
+import ReactDOM from 'react-dom';
+import React from 'react';
+import expect from 'expect';
+import DropDownEditor from '../../../components/data/featuregrid/editors/DropDownEditor';
 
-const assign = require('object-assign');
-const {
+import assign from 'object-assign';
+import {
     register,
     clean,
     get,
+    set,
     getCustomEditor,
     remove
-} = require('../EditorRegistry');
+} from '../EditorRegistry';
 const attribute = "STATE_NAME";
 const url = "https://demo.geo-solutions.it/geoserver/wfs";
 const typeName = "topp:states";
@@ -31,8 +32,8 @@ const rules = [{
         "forceSelection": true
     }
 }];
-const Editor = require('../../../components/data/featuregrid/editors/AttributeEditor');
-const NumberEditor = require('../../../components/data/featuregrid/editors/NumberEditor');
+import Editor from '../../../components/data/featuregrid/editors/AttributeEditor';
+import NumberEditor from '../../../components/data/featuregrid/editors/NumberEditor';
 const testEditors = {
     "defaultEditor": (props) => <Editor {...props}/>,
     "string": (props) => <DropDownEditor dataType="string" {...props}/>,
@@ -40,13 +41,22 @@ const testEditors = {
     "number": (props) => <NumberEditor dataType="number" inputProps={{step: 1, type: "number"}} {...props}/>
 };
 describe('EditorRegistry tests ', () => {
+    let original;
     beforeEach(() => {
+        original = get();
         document.body.innerHTML = '<div id="container"></div>';
         clean();
     });
     afterEach(() => {
         ReactDOM.unmountComponentAtNode(document.getElementById("container"));
         document.body.innerHTML = '';
+        set(original);
+    });
+    it('check custom editors by default', () => {
+        ["DropDownEditor", "NumberEditor", "FormatEditor"].map((v) => {
+            expect(original[v]).toBeTruthy();
+            expect(Object.keys(original[v].length > 0)).toBeTruthy();
+        });
     });
     it('clean', () => {
         let Editors = get();


### PR DESCRIPTION
**Draft for tests that have to be refined/checked**
## Description
This PR solves the 2 points in this comment https://github.com/geosolutions-it/MapStore2/issues/6758#issuecomment-833683251

1. Fix wrong import for default custom editors
2. Fix feature grid options callback issue due to multiple renders of plugins with different properties.
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6758

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

### For testing: 
The problems that caused this PR are 2:
 - The default custom editors "DropDownEditor", "NumberEditor" was not working anymore. (see https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.FeatureEditor) 
 - FeatureEditor (FeatureGrid) plugin wasn't able to load some custom configurations (expecially `customEditorsOptions`) in contexts (they work in localConfig)

So to test this you can create a **context** with the `DropDownEditor` and `NumberEditor` configured and check ([example on dev](http://localhost:8081/#/context/CustomEditorContext) ). 

Trying to open the feature grid in edit mode (logged in as admin) you should be able to 
- edit the attribute `type` ONLY with the values "FOREST", "MOUNTAIN", "DESERT", "LAKE", "SECRET" without possibility to keep it empty or any pagination in the dropdown.
- `land` attribute can not be a negative number

for a complete information and to replicate in other contexts. 
The map in the example context contains the layer `atlantis:landmarks` and has this configuration of Attribute table:
```json
{
 "cfg": {
      "customEditorsOptions": {
        "rules": [{
          "regex": {
            "attribute": "type",
            "typeName": "atlantis:landmarks"
          },
          "editor": "DropDownEditor",
          "editorProps": {
            "values": ["FOREST", "MOUNTAIN", "DESERT", "LAKE", "SECRET"],
            "forceSelection": true,
            "defaultOption": "FOREST",
            "allowEmpty": false
          }
        }, {
          "regex": {
            "attribute": "land",
            "typeName": "atlantis:landmarks"
          },
          "editor": "NumberEditor",
          "editorProps": {
            "minValue": 0
          }
        }]
      }
}
```



