### PR TITLE
6664: Catalog service selector for dashboards Fixes

### DIFF
--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -49,7 +49,7 @@ export default ({
     onFormatOptionsFetch = () => {},
     selectedService,
     isLocalizedLayerStylesEnabled,
-    tileSizeOptions = [256],
+    tileSizeOptions = [256, 512],
     formatsLoading,
     layerOptions = {},
     services

--- a/web/client/components/catalog/CompactCatalog.jsx
+++ b/web/client/components/catalog/CompactCatalog.jsx
@@ -58,12 +58,12 @@ const getIdentifier = (r) =>
 /*
  * converts record item into a item for SideGrid
  */
-const resToProps = ({records, result = {}}) => ({
+const resToProps = ({records, result = {}, catalog = {}}) => ({
     items: (records || []).map((record = {}) => ({
         title: record.title && isObject(record.title) && record.title.default || record.title,
         caption: getIdentifier(record),
         description: record.description,
-        preview: record.thumbnail ? <img src="thumbnail" /> : defaultPreview,
+        preview: !catalog.hideThumbnail ? record.thumbnail ? <img src="thumbnail" /> : defaultPreview : null,
         record: {
             ...record, identifier: getIdentifier(record)
         }
@@ -77,7 +77,7 @@ const PAGE_SIZE = 10;
 const loadPage = ({text, catalog = {}}, page = 0) => Rx.Observable
     .fromPromise(API[catalog.type].textSearch(catalog.url, page * PAGE_SIZE + (catalog.type === "csw" ? 1 : 0), PAGE_SIZE, text, catalog.type === 'tms' ? {options: {service: catalog}} : {}))
     .map((result) => ({ result, records: getCatalogRecords(catalog.type, result || [], { url: catalog && catalog.url, service: catalog })}))
-    .map(resToProps);
+    .map(({records, result}) => resToProps({records, result, catalog}));
 const scrollSpyOptions = {querySelector: ".ms2-border-layout-body .ms2-border-layout-content", pageSize: PAGE_SIZE};
 /**
  * Compat catalog : Reusable catalog component, with infinite scroll.

--- a/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
@@ -52,7 +52,7 @@ export default ({
                 </Checkbox>
             </Col>
         </FormGroup>)}
-        {(!isNil(service.type) ? service.type === "csw" : false) && (<FormGroup controlId="metadata-template" key="metadata-template" className="metadata-template-editor">
+        {(!isNil(service.type) ? (service.type === "csw" && !service.excludeShowTemplate) : false) && (<FormGroup controlId="metadata-template" key="metadata-template" className="metadata-template-editor">
             <Col xs={12}>
                 <Checkbox
                     onChange={() => onToggleTemplate()}

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import { FormGroup, Col, ControlLabel } from "react-bootstrap";
 import RS from 'react-select';
+import { DEFAULT_FORMAT_WMS } from '../../../../utils/CatalogUtils';
 import localizedProps from '../../../misc/enhancers/localizedProps';
 const Select = localizedProps('noResultsText')(RS);
 
@@ -22,22 +23,7 @@ const getTileSizeSelectOptions = (opts) => {
 
 export default ({
     service,
-    formatOptions =  [{
-        label: 'image/png',
-        value: 'image/png'
-    }, {
-        label: 'image/png8',
-        value: 'image/png8'
-    }, {
-        label: 'image/jpeg',
-        value: 'image/jpeg'
-    }, {
-        label: 'image/vnd.jpeg-png',
-        value: 'image/vnd.jpeg-png'
-    }, {
-        label: 'image/gif',
-        value: 'image/gif'
-    }],
+    formatOptions =  DEFAULT_FORMAT_WMS,
     onChangeServiceFormat = () => { },
     onChangeServiceProperty = () => {},
     currentWMSCatalogLayerSize,

--- a/web/client/plugins/widgetbuilder/CatalogServiceEditor.jsx
+++ b/web/client/plugins/widgetbuilder/CatalogServiceEditor.jsx
@@ -13,7 +13,8 @@ const emptyService = {
     showAdvancedSettings: false,
     showTemplate: false,
     hideThumbnail: false,
-    metadataTemplate: "<p>${description}</p>"
+    metadataTemplate: "<p>${description}</p>",
+    excludeShowTemplate: true
 };
 
 export default ({service: defaultService, catalogServices,
@@ -21,8 +22,9 @@ export default ({service: defaultService, catalogServices,
     dashboardSelectedService, ...props}) => {
     const [service, setService] = useState(isNew ? emptyService :
         isEmpty(dashboardSelectedService) ? {...defaultServices[defaultSelectedService],
-            old: defaultServices[defaultSelectedService], key: defaultSelectedService} :
-            {...dashboardServices[dashboardSelectedService], old: dashboardServices[dashboardSelectedService], key: dashboardSelectedService} );
+            old: defaultServices[defaultSelectedService], key: defaultSelectedService, excludeShowTemplate: true} :
+            {...dashboardServices[dashboardSelectedService], old: dashboardServices[dashboardSelectedService],
+                key: dashboardSelectedService, excludeShowTemplate: true} );
 
     const existingServices = isEmpty(dashboardServices) ? defaultServices : dashboardServices;
 

--- a/web/client/reducers/dashboard.js
+++ b/web/client/reducers/dashboard.js
@@ -65,7 +65,8 @@ function dashboard(state = {
             ...state,
             originalData: undefined,
             resource: undefined,
-            mode: "view"
+            mode: "view",
+            services: undefined
         };
     }
     case SAVE_ERROR: {
@@ -106,6 +107,7 @@ function dashboard(state = {
     case DASHBOARD_ADD_NEW_SERVICE: {
         let { services, service } = action;
         service.isNew = false;
+        service.showAdvancedSettings = false;
         delete service.old;
         services[service.key] = service;
         const selectedService = service.key;


### PR DESCRIPTION
## Description

See [Issue comment](https://github.com/geosolutions-it/MapStore2/issues/6664#issuecomment-832787358)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Fix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
See [Issue comment](https://github.com/geosolutions-it/MapStore2/issues/6664#issuecomment-832787358)

#6664 

**What is the new behavior?**

- [ ]  Missing 512 x 512 Tile options
- [ ] Missing `image/vnd.jpeg-png8` Format Option
- [ ] Exclude Show Meta Template for CSW
- [ ] New dashboard in the service list there are also services added in other dashboards instead of only those configured in localConfig.json
- [ ] Hide Preview for Layers
- [ ]  The panel returns to the previous page (Configure Map Options page) instead of opening the list of layers of the service just saved

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
