### PR TITLE
6817: Hide allowFullScreen on dashboard and geostory

### DIFF
--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -78,7 +78,7 @@ class ShareEmbed extends React.Component {
         const {sizeOptions, selectedOption} = this.state;
         const height = selectedOption === "Custom" ? sizeOptions.Custom.height : sizeOptions[selectedOption]?.height;
         const width = selectedOption === "Custom" ? sizeOptions.Custom.width : sizeOptions[selectedOption]?.width;
-        const codeEmbedded = `<iframe allowFullScreen style=\"border: none;\" height=\"${height || 0}\" width=\"${width || 0}\" src=\"${this.generateUrl(this.props.shareUrl)}\"></iframe>`;
+        const codeEmbedded = `<iframe ${!this.hideAllowFullScreen() ? 'allowFullScreen' : ''} style=\"border: none;\" height=\"${height || 0}\" width=\"${width || 0}\" src=\"${this.generateUrl(this.props.shareUrl)}\"></iframe>`;
         return (
             <div className="input-link">
                 <div className="input-link-head">
@@ -140,6 +140,9 @@ class ShareEmbed extends React.Component {
         return url.format(parsed);
 
     };
+    hideAllowFullScreen = () => {
+        return window.location.hash?.includes("geostory") || window.location.hash?.includes("dashboard");
+    }
 }
 
 export default ShareEmbed;


### PR DESCRIPTION
## Description
The allowFullScreen attribute has been added also on the embed snippet of dashboard and geostory but it is not needed there so it should be removed for them.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The allowFullScreen attribute is included in embed snippet of the dashboard and geostory 

**What is the new behavior?**
The allowFullScreen attribute is not included in the embed snippet of the dashboard and geostory 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
