### PR TITLE
#6127 fixed regression for URLs without FQDN

### DIFF
--- a/web/client/components/catalog/editor/MainForm.jsx
+++ b/web/client/components/catalog/editor/MainForm.jsx
@@ -16,7 +16,7 @@ import InfoPopover from '../../widgets/widget/InfoPopover';
 import { FormControl as FC, Form, Col, FormGroup, ControlLabel, Alert } from "react-bootstrap";
 
 import localizedProps from '../../misc/enhancers/localizedProps';
-import {defaultPlaceholder, isHttps} from "./MainFormUtils";
+import {defaultPlaceholder, isValidURL} from "./MainFormUtils";
 
 const FormControl = localizedProps('placeholder')(FC);
 
@@ -129,7 +129,7 @@ export default ({
     function handleProtocolValidity(url) {
         onChangeUrl(url);
         if (url) {
-            const isInvalidProtocol = !isHttps(url);
+            const isInvalidProtocol = !isValidURL(url);
             setInvalidProtocol(isInvalidProtocol);
             setValid(!isInvalidProtocol);
         }

--- a/web/client/components/catalog/editor/MainFormUtils.js
+++ b/web/client/components/catalog/editor/MainFormUtils.js
@@ -16,10 +16,16 @@ export const defaultPlaceholder = (service) => {
     return true;
 };
 
-export const isHttps = (catalogUrl = '') => {
-    const { protocol: mapStoreProtocol } = url.parse(window.location.href);
+/**
+ * Check if the URL typed is valid or not
+ * @param {string} catalogUrl The URL of the catalog
+ * @param {string} currentLocation The current location, by default `window.location.href`
+ * @returns {boolean} true if the URL is valid
+ */
+export const isValidURL = (catalogUrl = '', currentLocation) => {
+    const { protocol: mapStoreProtocol } = url.parse(currentLocation ?? window.location.href);
     const { protocol: catalogProtocol } = url.parse(catalogUrl);
-    if (mapStoreProtocol === 'https:') {
+    if (mapStoreProtocol === 'https:' && !!catalogProtocol) {
         return mapStoreProtocol === catalogProtocol;
     }
     return true;

--- a/web/client/components/catalog/editor/__tests__/MainFormUtils-test.js
+++ b/web/client/components/catalog/editor/__tests__/MainFormUtils-test.js
@@ -1,0 +1,31 @@
+import expect from "expect";
+
+import { isValidURL } from '../MainFormUtils';
+
+describe('Catalog Main Form Editor Utils', () => {
+    it('isValidURL', () => {
+        const URLS = [
+            // http
+            ['http://myDomain.com/geoserver/wms', 'https://myMapStore.com/geoserver/wms', false],
+            ['http://myDomain.com/geoserver/wms', 'http://myMapStore.com/geoserver/wms', true],
+            // https
+            ['https://myDomain.com/geoserver/wms', 'http://myMapStore.com/geoserver/wms', true],
+            ['https://myDomain.com/geoserver/wms', 'https://myMapStore.com/geoserver/wms', true],
+            // protocol relative URL
+            ['//myDomain.com/geoserver/wms', 'http://myMapStore.com/geoserver/wms', true],
+            ['//myDomain.com/geoserver/wms', 'https://myMapStore.com/geoserver/wms', true],
+            // absolute path
+            ['/geoserver/wms', 'http://myMapStore.com/geoserver/wms', true],
+            ['/geoserver/wms', 'https://myMapStore.com/geoserver/wms', true],
+            // relative path
+            ["geoserver/wms", "http://myMapStore.com/geoserver/wms", true],
+            ["geoserver/wms", "https://myMapStore.com/geoserver/wms", true]
+
+
+        ];
+        URLS.forEach(([catalogURL, locationURL, valid]) => {
+            const result = isValidURL(catalogURL, locationURL);
+            expect(!!result).toEqual(!!valid, `${catalogURL} - added when location is ${locationURL} should be ${valid}, but it is ${result}`);
+        });
+    });
+});


### PR DESCRIPTION
## Description
This PR comes to fix https://github.com/georchestra/mapstore2-georchestra/issues/374 adding the condition that if no protocol is found (parsing the URL can happen when adding protocol relative URLs, absolute paths or relative paths) the check passes anyway.

**One note about #6127 and it's solution**  
Checking  I notice that the requirement here is not properly correct. 
Here we are assuming that the protocol of the catalog is the protocol of the relative layer, that is not properly correct. The catalog can be any object on the web (CSW service, WMTS Capabilities xml file online, GeoServer).

Anyway, because the access to HTTP URL from HTTPS is allowed **only** because we have the proxy (otherwise it is be denied by the browser) this check can make sense. 
Take into account that, anyway, the fix applied in the previous [PR](https://github.com/geosolutions-it/MapStore2/pull/6674) and improved here can cause some issues to customers that use indifferently http and https with the same domain name (e.g. internal network v.s. public ones) but enforces them somehow to stay strict for the future.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6127

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
for testers : 

In many installation MapStore are published under the same domain of GeoServer, and catalog URLs like  `/geosever/wms` should be allowed. In dev instance, we don't have a local geoserver so I don't know if it is testable. It is testable instead in georchestra test env.
I added some unit tests.