### PR TITLE
#6838 Changed cesium URL with the one with valid certificates

### DIFF
--- a/project/custom/templates/index.html
+++ b/project/custom/templates/index.html
@@ -13,8 +13,8 @@
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
-        <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
-        <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+        <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
+        <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
         <script src="libs/cesium-navigation/cesium-navigation.js"></script>
         <link rel="stylesheet" href="libs/cesium-navigation/cesium-navigation.css" />
     </head>

--- a/project/standard/templates/index.html
+++ b/project/standard/templates/index.html
@@ -92,8 +92,8 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
         <!--<script src="https://www.mapquestapi.com/sdk/leaflet/v2.2/mq-map.js?key=__API_KEY_MAPQUEST__"></script>-->
-        <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
-        <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+        <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
+        <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
         <script src="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.js"></script>
         <link rel="stylesheet" href="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.css" />
 

--- a/project/standard/templates/indexTemplate.html
+++ b/project/standard/templates/indexTemplate.html
@@ -91,8 +91,8 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
-      <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
-      <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+      <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
+      <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
       <script src="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.js"></script>
       <link rel="stylesheet" href="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.css" />
       <script type="text/javascript" src="https://unpkg.com/bowser@2.7.0/es5.js"></script>

--- a/web/client/examples/api/index.html
+++ b/web/client/examples/api/index.html
@@ -17,8 +17,8 @@
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
-        <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
-        <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+        <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
+        <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
         <style>
             #container {
                 position: absolute;

--- a/web/client/index.html
+++ b/web/client/index.html
@@ -92,8 +92,8 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
         <!--<script src="https://www.mapquestapi.com/sdk/leaflet/v2.2/mq-map.js?key=__API_KEY_MAPQUEST__"></script>-->
-        <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
-        <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+        <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
+        <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
         <script src="libs/cesium-navigation/cesium-navigation.js"></script>
         <link rel="stylesheet" href="libs/cesium-navigation/cesium-navigation.css" />
 

--- a/web/client/indexTemplate.html
+++ b/web/client/indexTemplate.html
@@ -90,8 +90,8 @@
     <script src="https://maps.google.com/maps/api/js?v=3"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
-    <script src="https://cesiumjs.org/releases/1.17/Build/Cesium/Cesium.js"></script>
-    <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Cesium.js"></script>
+    <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.17/Build/Cesium/Widgets/widgets.css" />
     <script src="libs/cesium-navigation/cesium-navigation.js"></script>
     <link rel="stylesheet" href="libs/cesium-navigation/cesium-navigation.css" />
     <script type="text/javascript" src="https://unpkg.com/bowser@2.7.0/es5.js"></script>


### PR DESCRIPTION
## Description
Changed URLs  of cesium to new ones. The old ones redirect to this URL, anyway the certificates for cesiumjs.org has expired.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6838  

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
