### PR TITLE
6817: Hide full screen when sharing links

### DIFF
--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -141,7 +141,8 @@ class ShareEmbed extends React.Component {
 
     };
     hideAllowFullScreen = () => {
-        return window.location.hash?.includes("geostory") || window.location.hash?.includes("dashboard");
+        return window.location.hash?.includes("geostory") || window.location.hash?.includes("dashboard") ||
+            this.props.shareUrl.includes("dashboard") || this.props.shareUrl.includes("geostory");
     }
 }
 

--- a/web/client/components/share/ShareEmbed.jsx
+++ b/web/client/components/share/ShareEmbed.jsx
@@ -28,12 +28,14 @@ class ShareEmbed extends React.Component {
         showTOCToggle: PropTypes.bool,
         showConnectionsParamToggle: PropTypes.bool,
         sizeOptions: PropTypes.object,
-        selectedOption: PropTypes.string
+        selectedOption: PropTypes.string,
+        allowFullScreen: PropTypes.bool
     };
 
     static defaultProps = {
         showTOCToggle: true,
-        shareUrl: ''
+        shareUrl: '',
+        allowFullScreen: true
     };
 
     state = {
@@ -78,7 +80,7 @@ class ShareEmbed extends React.Component {
         const {sizeOptions, selectedOption} = this.state;
         const height = selectedOption === "Custom" ? sizeOptions.Custom.height : sizeOptions[selectedOption]?.height;
         const width = selectedOption === "Custom" ? sizeOptions.Custom.width : sizeOptions[selectedOption]?.width;
-        const codeEmbedded = `<iframe ${!this.hideAllowFullScreen() ? 'allowFullScreen' : ''} style=\"border: none;\" height=\"${height || 0}\" width=\"${width || 0}\" src=\"${this.generateUrl(this.props.shareUrl)}\"></iframe>`;
+        const codeEmbedded = `<iframe ${this.props.allowFullScreen ? 'allowFullScreen' : ''} style=\"border: none;\" height=\"${height || 0}\" width=\"${width || 0}\" src=\"${this.generateUrl(this.props.shareUrl)}\"></iframe>`;
         return (
             <div className="input-link">
                 <div className="input-link-head">
@@ -140,10 +142,6 @@ class ShareEmbed extends React.Component {
         return url.format(parsed);
 
     };
-    hideAllowFullScreen = () => {
-        return window.location.hash?.includes("geostory") || window.location.hash?.includes("dashboard") ||
-            this.props.shareUrl.includes("dashboard") || this.props.shareUrl.includes("geostory");
-    }
 }
 
 export default ShareEmbed;

--- a/web/client/components/share/__tests__/ShareEmbed-test.jsx
+++ b/web/client/components/share/__tests__/ShareEmbed-test.jsx
@@ -69,7 +69,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 shareUrl={ host + hashPart }
@@ -89,7 +89,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"700\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe style=\"border: none;\" height=\"700\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 sizeOptions = {{Small: { width: 400, height: 700}}}

--- a/web/client/components/share/__tests__/ShareEmbed-test.jsx
+++ b/web/client/components/share/__tests__/ShareEmbed-test.jsx
@@ -69,7 +69,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"500\" width=\"600\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 shareUrl={ host + hashPart }
@@ -89,7 +89,7 @@ describe("The ShareEmbed component", () => {
         const host = "http://localhost:8081/dashboard-embedded.html";
         const hashPart = "#/1";
         const expectedParam = "?connections=true";
-        const iFrameStr = "<iframe style=\"border: none;\" height=\"700\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
+        const iFrameStr = "<iframe allowFullScreen style=\"border: none;\" height=\"700\" width=\"400\" src=\"" + host + expectedParam + hashPart + "\"></iframe>";
         const cmpSharePanel = ReactDOM.render(
             <ShareEmbed
                 sizeOptions = {{Small: { width: 400, height: 700}}}
@@ -104,7 +104,7 @@ describe("The ShareEmbed component", () => {
         expect(codeEmbed.innerText).toEqual(iFrameStr);
     });
 
-    it("should remove allowFullScreen for dashboard", () => {
+    it("should show allowFullScreen if prop allowFullScreen doesnot exist", () => {
         Object.defineProperty(window.location.constructor.prototype, 'hash', {configurable: true, writable: true});
         window.location.hash = "#/dashboard/5728";
         const host = "http://localhost:8081/embedded.html";
@@ -116,10 +116,10 @@ describe("The ShareEmbed component", () => {
                 showConnectionsParamToggle
             />, document.getElementById("container"));
         const codeEmbed = ReactDOM.findDOMNode(ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "code")[0]);
-        expect(codeEmbed.innerText.includes("allowFullScreen")).toBe(false);
+        expect(codeEmbed.innerText.includes("allowFullScreen")).toBe(true);
     });
 
-    it("should remove allowFullScreen for geostory", () => {
+    it("should not show allowFullScreen is prop.allowFullScreen is false", () => {
         Object.defineProperty(window.location.constructor.prototype, 'hash', {configurable: true, writable: true});
         window.location.hash = "#/geostory/5728";
         const host = "http://localhost:8081/embedded.html";
@@ -129,23 +129,9 @@ describe("The ShareEmbed component", () => {
                 sizeOptions = {{Small: { width: 400, height: 700}}}
                 shareUrl={ host + hashPart }
                 showConnectionsParamToggle
+                allowFullScreen={false}
             />, document.getElementById("container"));
         const codeEmbed = ReactDOM.findDOMNode(ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "code")[0]);
         expect(codeEmbed.innerText.includes("allowFullScreen")).toBe(false);
-    });
-
-    it("should add allowFullScreen for maps", () => {
-        Object.defineProperty(window.location.constructor.prototype, 'hash', {configurable: true, writable: true});
-        window.location.hash = "#/viewer/openlayers/5728";
-        const host = "http://localhost:8081/embedded.html";
-        const hashPart = "#";
-        const cmpSharePanel = ReactDOM.render(
-            <ShareEmbed
-                sizeOptions = {{Small: { width: 400, height: 700}}}
-                shareUrl={ host + hashPart }
-                showConnectionsParamToggle
-            />, document.getElementById("container"));
-        const codeEmbed = ReactDOM.findDOMNode(ReactTestUtils.scryRenderedDOMComponentsWithTag(cmpSharePanel, "code")[0]);
-        expect(codeEmbed.innerText.includes("allowFullScreen")).toBe(true);
     });
 });

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -664,6 +664,7 @@
             "embedOptions": {
               "showTOCToggle": false,
               "showConnectionsParamToggle": true,
+              "allowFullScreen": false,
               "sizeOptions": {
                 "Small": { "width": 600, "height": 500 },
                 "Medium": { "width": 800, "height": 600},
@@ -797,7 +798,8 @@
               "embedPanel": true,
               "showAPI": false,
               "embedOptions": {
-                "showTOCToggle": false
+                "showTOCToggle": false,
+                "allowFullScreen":false
               },
               "shareUrlRegex": "(h[^#]*)#\\/geostory\\/([^\\/]*)\\/([A-Za-z0-9]*)",
               "shareUrlReplaceString": "$1geostory-embedded.html#/$3",

--- a/web/client/utils/ShareUtils.js
+++ b/web/client/utils/ShareUtils.js
@@ -19,14 +19,15 @@ export const DASHBOARD_DEFAULT_SHARE_OPTIONS = {
     shareUrlReplaceString: "$1dashboard-embedded.html#/$2",
     embedOptions: {
         showTOCToggle: false,
-        showConnectionsParamToggle: true
+        showConnectionsParamToggle: true,
+        allowFullScreen: false
     }
 };
 
 export const GEOSTORY_DEFAULT_SHARE_OPTIONS = {
     embedPanel: true,
     showAPI: false,
-    embedOptions: { showTOCToggle: false },
+    embedOptions: { showTOCToggle: false, allowFullScreen: false },
     shareUrlRegex: "(h[^#]*)#\\/geostory\\/([^\\/]*)\\/([A-Za-z0-9]*)",
     shareUrlReplaceString: "$1geostory-embedded.html#/$3",
     advancedSettings: {


### PR DESCRIPTION
## Description
See issue [comment](https://github.com/geosolutions-it/MapStore2/issues/6817#event-4681857812) 

Hide allowFullScreen when sharing on the home screen.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
See issue [comment](https://github.com/geosolutions-it/MapStore2/issues/6817#event-4681857812) 
#6817 

**What is the new behavior?**

allowFullScreen is not present 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
