### PR TITLE
#6732: Map decentering on scale zoom fix

### DIFF
--- a/web/client/epics/__tests__/maplayout-test.js
+++ b/web/client/epics/__tests__/maplayout-test.js
@@ -14,6 +14,7 @@ import { closeIdentify, purgeMapInfoResults, noQueryableLayers } from '../../act
 import { updateMapLayoutEpic } from '../maplayout';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import ConfigUtils from '../../utils/ConfigUtils';
+import { openFeatureGrid } from "../../actions/featuregrid";
 
 describe('map layout epics', () => {
     afterEach(() => {
@@ -25,8 +26,8 @@ describe('map layout epics', () => {
                 expect(actions.length).toBe(1);
                 actions.map((action) => {
                     expect(action.type).toBe(UPDATE_MAP_LAYOUT);
-                    expect(action.layout).toEqual({ left: 600, right: 658, bottom: 30, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
-                        bottom: 30,
+                    expect(action.layout).toEqual({ left: 600, right: 658, bottom: 0, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
+                        bottom: 0,
                         left: 600,
                         right: 658
                     }});
@@ -52,8 +53,8 @@ describe('map layout epics', () => {
                 actions.map((action) => {
                     expect(action.type).toBe(UPDATE_MAP_LAYOUT);
                     expect(action.layout).toEqual({
-                        left: 600, right: 330, bottom: 120, transform: 'none', height: 'calc(100% - 120px)', boundingMapRect: {
-                            bottom: 120,
+                        left: 600, right: 330, bottom: 0, transform: 'none', height: 'calc(100% - 120px)', boundingMapRect: {
+                            bottom: 0,
                             left: 600,
                             right: 330
                         }
@@ -127,10 +128,10 @@ describe('map layout epics', () => {
                 actions.map((action) => {
                     expect(action.type).toBe(UPDATE_MAP_LAYOUT);
                     expect(action.layout).toEqual({
-                        left: 512, right: 0, bottom: 30, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
+                        left: 512, right: 0, bottom: 0, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
                             left: 512,
                             right: 0,
-                            bottom: 30
+                            bottom: 0
                         }
                     });
                 });
@@ -150,8 +151,8 @@ describe('map layout epics', () => {
                 actions.map((action) => {
                     expect(action.type).toBe(UPDATE_MAP_LAYOUT);
                     expect(action.layout).toEqual({
-                        left: 0, right, bottom: 30, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
-                            bottom: 30,
+                        left: 0, right, bottom: 0, transform: 'none', height: 'calc(100% - 30px)', boundingMapRect: {
+                            bottom: 0,
                             left: 0,
                             right
                         }
@@ -194,5 +195,25 @@ describe('map layout epics', () => {
             done();
         };
         testEpic(updateMapLayoutEpic, 1, noQueryableLayers(), epicResult, {});
+    });
+
+    it('tests when feature grid open', (done) => {
+        const epicResult = actions => {
+            try {
+                expect(actions.length).toBe(1);
+                actions.map((action) => {
+                    expect(action.type).toBe(UPDATE_MAP_LAYOUT);
+                    expect(action.layout).toEqual({
+                        left: 0, right: 0, bottom: '100%', dockSize: 100, transform: "translate(0, -30px)", height: "calc(100% - 30px)",
+                        boundingMapRect: {bottom: "100%", dockSize: 100, left: 0, right: 0}
+                    });
+                });
+            } catch (e) {
+                done(e);
+            }
+            done();
+        };
+        const state = {featuregrid: {open: true, dockSize: 1}};
+        testEpic(updateMapLayoutEpic, 1, openFeatureGrid(), epicResult, state);
     });
 });

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -112,7 +112,8 @@ export const updateMapLayoutEpic = (action$, store) =>
             ].filter(panel => panel)) || {right: 0};
 
             const dockSize = getDockSize(state) * 100;
-            const bottom = isFeatureGridOpen(state) && {bottom: dockSize + '%', dockSize} || {bottom: mapLayout.bottom.sm};
+            const bottom = isFeatureGridOpen(state) && {bottom: dockSize + '%', dockSize}
+                || {bottom: 0}; // To avoid map from de-centering when performing scale zoom
 
             const transform = isFeatureGridOpen(state) && {transform: 'translate(0, -' + mapLayout.bottom.sm + 'px)'} || {transform: 'none'};
             const height = {height: 'calc(100% - ' + mapLayout.bottom.sm + 'px)'};

--- a/web/client/reducers/maplayout.js
+++ b/web/client/reducers/maplayout.js
@@ -10,6 +10,13 @@ import { UPDATE_MAP_LAYOUT } from '../actions/maplayout';
 
 import assign from 'object-assign';
 
+/**
+ * Manages the map layout state. Determines and manages the placement of the components on the screen
+ * @prop {object} [layout] property helps in organizing the components on the screen (ex. Leaves space for the footer, move the navBar or the background selector when the Catalog or the TOC panel is open, respectively)
+ * @prop {object} [boundingMapRect] property treated as "padding" of the map that allows to zoom taking into account the panels that overlaps (ex. Catalog, Feature Grid)
+ *
+ * @memberof reducers
+ */
 function mapLayout(state = { layout: {}, boundingMapRect: {} }, action) {
     switch (action.type) {
     case UPDATE_MAP_LAYOUT: {


### PR DESCRIPTION
## Description
This PR attempts to fix the map from decentering on scale zoom fix (_Backport from **c125_search_gfi** branch_)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6732 

**What is the new behavior?**
- The map doesn't decenters on using scale to zoom
- Other panels/components in the map screen renders without any issue (i.e TOC, Featuregrid, Background selector, Identify panel) 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
