### PR TITLE
#6832: Catalog CSW crs fix

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -125,12 +125,6 @@ var Api = {
                                                 el = rawRec.boundingBox;
                                             }
                                             if (el && el.value) {
-                                                // EPSG:4326 is defined as (lat,lon) but mapping frameworks usually expect (lon,lat) as it is
-                                                // more natural (because (lon,lat) is basically (x,y))
-                                                // so internally EPSG:4326 is assumed to be (lon,lat) but when we import from external services
-                                                // we assume that EPSG:4326 is (lat,lon) and CRS84 is (lon,lat) as by their definition
-                                                // after conversion to (lon,lat) we set crs to EPSG:4326
-
                                                 const crsValue = el.value?.crs ?? '';
                                                 const urn = crsValue.match(/[\w-]*:[\w-]*:[\w-]*:[\w-]*:[\w-]*:[^:]*:(([\w-]+\s[\w-]+)|[\w-]*)/)?.[0];
                                                 const epsg = makeNumericEPSG(crsValue.match(/EPSG:[0-9]+/)?.[0]);
@@ -144,14 +138,8 @@ var Api = {
                                                     crs = 'EPSG:4326';
                                                 } else if (extractedCrs.slice(0, 5) === 'EPSG:') {
                                                     crs = makeNumericEPSG(extractedCrs);
-                                                    if (!crs) {
-                                                        throw new Error(`No suitable EPSG numeric conversion found for "${extractedCrs}"`);
-                                                    }
                                                 } else {
                                                     crs = makeNumericEPSG(`EPSG:${extractedCrs}`);
-                                                    if (!crs) {
-                                                        throw new Error(`No suitable EPSG numeric conversion found for "${extractedCrs}"`);
-                                                    }
                                                 }
 
                                                 if (crs === 'EPSG:4326' && extractedCrs !== 'CRS84' && extractedCrs !== 'OGC:CRS84') {
@@ -162,7 +150,7 @@ var Api = {
                                             }
                                             obj.boundingBox = {
                                                 extent: bbox,
-                                                crs
+                                                crs: 'EPSG:4326'
                                             };
                                         }
                                         let dcElement = rawRec.dcElement;

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -142,6 +142,7 @@ var Api = {
                                                     crs = makeNumericEPSG(`EPSG:${extractedCrs}`);
                                                 }
 
+                                                // Usually switched, GeoServer sometimes doesn't. See https://docs.geoserver.org/latest/en/user/services/wfs/axis_order.html#axis-ordering
                                                 if (crs === 'EPSG:4326' && extractedCrs !== 'CRS84' && extractedCrs !== 'OGC:CRS84') {
                                                     lc = [lc[1], lc[0]];
                                                     uc = [uc[1], uc[0]];

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -39,7 +39,7 @@ describe('Test correctness of the CSW APIs', () => {
             try {
                 expect(result).toExist();
                 expect(result.records).toExist();
-                expect(result.records.length).toBe(2);
+                expect(result.records.length).toBe(4);
                 let rec0 = result.records[0];
                 expect(rec0.dc).toExist();
                 expect(rec0.dc.URI).toExist();
@@ -55,6 +55,14 @@ describe('Test correctness of the CSW APIs', () => {
                 expect(rec1.boundingBox).toExist();
                 expect(rec1.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec1.boundingBox.extent).toEqual([12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                let rec2 = result.records[2];
+                expect(rec2.boundingBox).toExist();
+                expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec2.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
+                let rec3 = result.records[3];
+                expect(rec3.boundingBox).toExist();
+                expect(rec3.boundingBox.crs).toBe('EPSG:4326');
+                expect(rec3.boundingBox.extent).toEqual([ 12.56, 47.46, 13.27, 48.13 ]);
                 done();
             } catch (ex) {
                 done(ex);

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -40,26 +40,27 @@ describe('Test correctness of the CSW APIs', () => {
                 expect(result).toExist();
                 expect(result.records).toExist();
                 expect(result.records.length).toBe(4);
-                let rec0 = result.records[0];
+                const [rec0, rec1, rec2, rec3] = result.records;
+
                 expect(rec0.dc).toExist();
                 expect(rec0.dc.URI).toExist();
                 expect(rec0.dc.URI[0]);
                 expect(rec0.boundingBox).toExist();
                 expect(rec0.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
-                let uri = rec0.dc.URI[0];
+                const uri = rec0.dc.URI[0];
                 expect(uri.name).toExist();
                 expect(uri.value).toExist();
                 expect(uri.description).toExist();
-                let rec1 = result.records[1];
+
                 expect(rec1.boundingBox).toExist();
                 expect(rec1.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec1.boundingBox.extent).toEqual([12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
-                let rec2 = result.records[2];
+
                 expect(rec2.boundingBox).toExist();
                 expect(rec2.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec2.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
-                let rec3 = result.records[3];
+
                 expect(rec3.boundingBox).toExist();
                 expect(rec3.boundingBox.crs).toBe('EPSG:4326');
                 expect(rec3.boundingBox.extent).toEqual([ 12.56, 47.46, 13.27, 48.13 ]);

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -114,15 +114,20 @@ describe('catalog Epics', () => {
                     expect(action.loading).toBe(true);
                     break;
                 case RECORD_LIST_LOADED:
-                    expect(action.result.records.length).toBe(2);
-                    const rec0 = action.result.records[0];
+                    expect(action.result.records.length).toBe(4);
+                    const [rec0, rec1, rec2, rec3] = action.result.records;
                     expect(rec0.boundingBox).toExist();
                     expect(rec0.boundingBox.crs).toBe('EPSG:4326');
                     expect(rec0.boundingBox.extent).toEqual([45.542, 11.874, 46.026, 12.718]);
-                    const rec1 = action.result.records[1];
                     expect(rec1.boundingBox).toExist();
                     expect(rec1.boundingBox.crs).toBe('EPSG:4326');
                     expect(rec1.boundingBox.extent).toEqual([12.002717999999996, 45.760718, 12.429282000000002, 46.187282]);
+                    expect(rec2.boundingBox).toExist();
+                    expect(rec2.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec2.boundingBox.extent).toEqual([ -4.14168, 47.93257, -4.1149, 47.959353362144 ]);
+                    expect(rec3.boundingBox).toExist();
+                    expect(rec3.boundingBox.crs).toBe('EPSG:4326');
+                    expect(rec3.boundingBox.extent).toEqual([ 12.56, 47.46, 13.27, 48.13 ]);
                     break;
                 case TEST_TIMEOUT:
                     break;

--- a/web/client/test-resources/csw/getRecordsResponseDC.xml
+++ b/web/client/test-resources/csw/getRecordsResponseDC.xml
@@ -36,5 +36,39 @@
       <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name2" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
       <dc:URI protocol="image/png" name="thumbnail">resources.get?id=187049&amp;fname=d698f693-6e7e-47a9-a138-918068d0b082_s.png&amp;access=public</dc:URI>
     </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:dct="http://purl.org/dc/terms/">
+      <dc:identifier>urn:isogeo:metadata:uuid:01ca64b3-6d69-43b7-b953-7743e11daafe</dc:identifier>
+      <dc:title>Title3</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>infoMapAccessService</dc:subject>
+      <dc:format />
+      <dct:abstract />
+      <dc:language />
+      <dc:source />
+      <dc:format />
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::RGF93 / Lambert-93 (EPSG:2154)">
+        <ows:LowerCorner>-4.1149 47.93257</ows:LowerCorner>
+        <ows:UpperCorner>-4.14168 47.959353362144</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name3" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png">http://geowww.agrocampus-ouest.fr/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
+    <csw:Record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ows="http://www.opengis.net/ows" xmlns:geonet="http://www.fao.org/geonetwork">
+      <dc:identifier>9df78858-ade9-4591-badf-63934f1afffc</dc:identifier>
+      <dc:date>2020-10-06T11:52:43.9635506</dc:date>
+      <dc:title>Title 4</dc:title>
+      <dc:type>dataset</dc:type>
+      <dc:subject>Air Transport Network</dc:subject>
+      <dc:format>PDF</dc:format>
+      <dc:format>PNG</dc:format>
+      <dc:format>JPEG</dc:format>
+      <dc:language>eng</dc:language>
+      <ows:BoundingBox crs="urn:ogc:def:crs:INSPIRE RS registry::http://www.opengis.net/def/crs/EPSG/0/3857">
+          <ows:LowerCorner>13.27 47.46</ows:LowerCorner>
+          <ows:UpperCorner>12.56 48.13</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:URI protocol="OGC:WMS-1.1.1-http-get-map" name="workspace:layer_name4" description="desc2">http://ows.domain.it:80/geoserver/wms?SERVICE=WMS&amp;</dc:URI>
+      <dc:URI protocol="image/png">https://test-geoserver.at/img/metadata/KBZ.png</dc:URI>
+    </csw:Record>
   </csw:SearchResults>
 </csw:GetRecordsResponse>


### PR DESCRIPTION
## Description
This PR adds commits to fix parsing CSW service url for crs 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6832 

**What is the new behavior?**
- When crs is not parsed from crs string, use the coordinates as is
- CRS of the bounding box is always EPSG:4326

**Service URLs to be tested:**
-  https://sdimdt-free.austrocontrol.at/geonetwork/csw-free/eng/csw
-  https://geobretagne.fr/geonetwork/srv/fre/csw
-  https://gs-stable.geo-solutions.it/geoserver/csw
- https://master.demo.geonode.org/catalogue/csw

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
