### PR TITLE
#6729: Limit user input to max field value (Aeronautical)

### DIFF
--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -124,7 +124,7 @@ class AeronauticalCoordinateEditor extends React.Component {
         } else {
             const parsedVal = type === SECONDS ? parseFloat(val) : parseInt(val, 10);
             const maxValue = type === DEGREES ? this.props.maxDegrees : 60;
-            newValue = Math.round(parsedVal * 10) / 10 < maxValue ? parsedVal : maxValue - 1;
+            newValue = Math.round(parsedVal * 10) / 10 < maxValue ? parsedVal : this.props[type];
         }
         return newValue;
     }
@@ -228,6 +228,7 @@ class AeronauticalCoordinateEditor extends React.Component {
         if (event.keyCode === 69) {
             event.preventDefault();
         }
+        if (event?.target?.value === "0") event.target.setSelectionRange(-1, -1);
         if (event.keyCode === 13 ) {
             event.preventDefault();
             event.stopPropagation();

--- a/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
@@ -137,7 +137,7 @@ describe('AeronauticalCoordinateEditor enhancer', () => {
         expect(+minutes.value).toBeLessThan(testValue);
         expect(+seconds.value).toBeLessThan(testValue);
         expect(spyOnChange).toHaveBeenCalled();
-        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(89);
+        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(20);
     });
     it('Test AeronauticalCoordinateEditor LON fields onChange not exceed max field values', () => {
         const actions = {
@@ -173,6 +173,6 @@ describe('AeronauticalCoordinateEditor enhancer', () => {
         expect(+seconds.value).toBeLessThan(testValue);
         expect(+seconds.value).toNotEqual(0);
         expect(spyOnChange).toHaveBeenCalled();
-        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(179);
+        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(160);
     });
 });


### PR DESCRIPTION
## Description
This PR adds commit to limit the user input to max field value of Aeronautical fields same as decimal 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/issues/6729#issuecomment-841154628

**What is the new behavior?**

- User cannot enter value >= fields max value (Same as decimal fields)
- Upon clearing the fields and entering new value, the user input should not be append with 0 (i.e clearing 10 and entering 2 should not result in 20)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
