### PR TITLE
[Backport #6818] 6813: Filter request layers only

### DIFF
--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -25,6 +25,71 @@ const parseUrl = (url) => {
     }));
 };
 
+export const constructXMLBody = (startPosition, maxRecords, searchText) => {
+    if (!searchText) {
+        return `<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+        xmlns:ogc="http://www.opengis.net/ogc"
+        xmlns:gml="http://www.opengis.net/gml"
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:dct="http://purl.org/dc/terms/"
+        xmlns:gmd="http://www.isotc211.org/2005/gmd"
+        xmlns:gco="http://www.isotc211.org/2005/gco"
+        xmlns:gmi="http://www.isotc211.org/2005/gmi"
+        xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="${startPosition}" maxRecords="${maxRecords}">
+        <csw:Query typeNames="csw:Record">
+            <csw:ElementSetName>full</csw:ElementSetName>
+            <csw:Constraint version="1.1.0">
+        <ogc:Filter>
+            <ogc:Or>
+            <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>dc:type</ogc:PropertyName>
+                <ogc:Literal>dataset</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+            <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>dc:type</ogc:PropertyName>
+                <ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+           </ogc:Or>
+        </ogc:Filter>
+            </csw:Constraint>
+        </csw:Query>
+    </csw:GetRecords>`;
+    }
+    return `<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:gco="http://www.isotc211.org/2005/gco"
+    xmlns:gmi="http://www.isotc211.org/2005/gmi"
+    xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="${startPosition}" maxRecords="${maxRecords}">
+    <csw:Query typeNames="csw:Record">
+        <csw:ElementSetName>full</csw:ElementSetName>
+        <csw:Constraint version="1.1.0">
+            <ogc:Filter>
+            <ogc:And>
+                <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\">
+                    <ogc:PropertyName>csw:AnyText</ogc:PropertyName>
+                    <ogc:Literal>%${searchText}%</ogc:Literal>
+                </ogc:PropertyIsLike>
+                <ogc:Or>
+                <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>dc:type</ogc:PropertyName>
+                    <ogc:Literal>dataset</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>dc:type</ogc:PropertyName>
+                    <ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+               </ogc:Or>
+            </ogc:And>
+            </ogc:Filter>
+        </csw:Constraint>
+    </csw:Query>
+</csw:GetRecords>`;
+};
+
 /**
  * API for local config
  */
@@ -86,11 +151,14 @@ var Api = {
     getRecords: function(url, startPosition, maxRecords, filter) {
         return new Promise((resolve) => {
             require.ensure(['../utils/ogc/CSW', '../utils/ogc/Filter'], () => {
-                const {CSW, marshaller, unmarshaller} = require('../utils/ogc/CSW');
+                const {CSW, marshaller, unmarshaller } = require('../utils/ogc/CSW');
                 let body = marshaller.marshalString({
                     name: "csw:GetRecords",
-                    value: CSW.getRecords(startPosition, maxRecords, filter)
+                    value: CSW.getRecords(startPosition, maxRecords, typeof filter !== "string" && filter)
                 });
+                if (!filter || typeof filter === "string") {
+                    body = constructXMLBody(startPosition, maxRecords, filter);
+                }
                 resolve(axios.post(parseUrl(url), body, { headers: {
                     'Content-Type': 'application/xml'
                 }}).then(
@@ -215,17 +283,7 @@ var Api = {
     },
     textSearch: function(url, startPosition, maxRecords, text) {
         return new Promise((resolve) => {
-            require.ensure(['../utils/ogc/CSW', '../utils/ogc/Filter'], () => {
-                const {Filter} = require('../utils/ogc/Filter');
-                // creates a request like this:
-                // <ogc:PropertyName>apiso:AnyText</ogc:PropertyName><ogc:Literal>%a%</ogc:Literal></ogc:PropertyIsLike>
-                let filter = null;
-                if (text) {
-                    let ops = Filter.propertyIsLike("csw:AnyText", "%" + text + "%");
-                    filter = Filter.filter(ops);
-                }
-                resolve(Api.getRecords(url, startPosition, maxRecords, filter));
-            });
+            resolve(Api.getRecords(url, startPosition, maxRecords, text));
         });
     },
     workspaceSearch: function(url, startPosition, maxRecords, text, workspace) {

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -8,7 +8,7 @@
 
 import expect from 'expect';
 
-import API from '../CSW';
+import API, { constructXMLBody } from '../CSW';
 
 describe('Test correctness of the CSW APIs', () => {
     it('getRecords ISO Metadata Profile', (done) => {
@@ -83,5 +83,25 @@ describe('Test correctness of the CSW APIs', () => {
                 done(ex);
             }
         });
+    });
+});
+
+describe("constructXMLBody", () => {
+    it("construct body without PropertyIsLike when there is no search text", () => {
+        const body = constructXMLBody(1, 5, null);
+        expect(body.indexOf("PropertyIsLike")).toBe(-1);
+    });
+
+    it("construct body with PropertyIsLike when there is search text", () => {
+        const body = constructXMLBody(1, 5, "text");
+        expect(body.indexOf("PropertyIsLike")).toNotBe(-1);
+    });
+
+    it("construct body with PropertyIsEqualTo always", () => {
+        const body = constructXMLBody(1, 5, "text");
+        expect(body.indexOf("PropertyIsEqualTo")).toNotBe(-1);
+
+        const body2 = constructXMLBody(1, 5, null);
+        expect(body2.indexOf("PropertyIsEqualTo")).toNotBe(-1);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Record Items that are not Layers are shown
#6813 

**What is the new behavior?**
 Record Items that are not Layers are hidden

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
