### PR TITLE
#6870 The Identify panel opens when it shouldn't in one use case

### DIFF
--- a/web/client/components/misc/FeatureInfoTriggerSelector.jsx
+++ b/web/client/components/misc/FeatureInfoTriggerSelector.jsx
@@ -21,12 +21,18 @@ class FeatureInfoTriggerSelector extends React.Component {
         hoverEnabled: PropTypes.bool
     }
     static defaultProps = {
-        hoverEnabled: true
+        hoverEnabled: true,
+        onSetMapTrigger: () => {},
+        onPurgeMapInfoResults: () => {}
     }
 
+    /* #6870 in the following, we clear results because when passing from hover to click
+        the identify panel gets opened
+        (because it has some responses in the current state) while it should not
+    */
     onChange = (event) => {
         this.props.onSetMapTrigger(event.target.value);
-        this.props.onPurgeMapInfoResults(event.target.value);
+        this.props.onPurgeMapInfoResults();
     }
 
     render() {

--- a/web/client/components/misc/FeatureInfoTriggerSelector.jsx
+++ b/web/client/components/misc/FeatureInfoTriggerSelector.jsx
@@ -17,6 +17,7 @@ class FeatureInfoTriggerSelector extends React.Component {
     static propTypes = {
         trigger: PropTypes.string,
         onSetMapTrigger: PropTypes.func,
+        onPurgeMapInfoResults: PropTypes.func,
         hoverEnabled: PropTypes.bool
     }
     static defaultProps = {
@@ -25,6 +26,7 @@ class FeatureInfoTriggerSelector extends React.Component {
 
     onChange = (event) => {
         this.props.onSetMapTrigger(event.target.value);
+        this.props.onPurgeMapInfoResults(event.target.value);
     }
 
     render() {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -270,7 +270,8 @@ const FeatureInfoTriggerSelector = connect((state) => ({
     trigger: isMouseMoveIdentifyActiveSelector(state) ? 'hover' : 'click',
     hoverEnabled: hoverEnabledSelector(state)
 }), {
-    onSetMapTrigger: setMapTrigger
+    onSetMapTrigger: setMapTrigger,
+    onPurgeMapInfoResults: purgeMapInfoResults
 })(FeatureInfoTriggerSelectorComp);
 
 export default {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR fixes the the status of identify panel by clearing mapinfo results when the trigger method is changed

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/M1apStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6870 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
it fixes the problems related to trigger event change in Settings Panel

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
