### PR TITLE
#6819: Enhance SLD parser for IconSymbolizer

### DIFF
--- a/web/client/components/styleeditor/ClassificationSymbolizer.jsx
+++ b/web/client/components/styleeditor/ClassificationSymbolizer.jsx
@@ -38,7 +38,8 @@ function ClassificationSymbolizer({
         intervals,
         intervalsForUnique = config?.intervalsForUnique || 100,
         reverse,
-        continuous
+        continuous,
+        format
     } = props;
 
     // needed for slider
@@ -94,6 +95,7 @@ function ClassificationSymbolizer({
             />}>
             <Fields
                 properties={props}
+                format={format}
                 config={{
                     attributes,
                     methods,

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -88,7 +88,8 @@ const RulesEditor = forwardRef(({
         fonts,
         methods,
         getColors,
-        classification
+        classification,
+        format
     } = config;
 
     // needed for slider
@@ -337,6 +338,7 @@ const RulesEditor = forwardRef(({
                                     onUpdate={onUpdate}
                                     onChange={(values) => handleChanges({ values, ruleId }, true)}
                                     onReplace={handleReplaceRule}
+                                    format={format}
                                 />
                                 : symbolizers.map(({ kind = '', symbolizerId, ...properties }) => {
                                     const { params, glyph } = symbolizerBlock[kind] || {};
@@ -360,6 +362,7 @@ const RulesEditor = forwardRef(({
                                             }>
                                             <Fields
                                                 properties={properties}
+                                                format={format}
                                                 params={params}
                                                 config={{
                                                     bands,

--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -21,7 +21,8 @@ import getBlocks from './config/blocks';
 
 import {
     parseJSONStyle,
-    formatJSONStyle
+    formatJSONStyle,
+    updateExternalGraphicNode
 } from '../../utils/StyleEditorUtils';
 
 import undoable from 'redux-undo';
@@ -244,7 +245,11 @@ function VisualStyleEditor({
             if (parser) {
                 return parser.writeStyle(parseJSONStyle(options.style))
                     .then((newCode) => {
-                        onChange(newCode, options.style);
+                        // This is a workaround for geostyler-sld-parser not able to identify and parse
+                        // the format of ExternalGraphic (IconSymbolizer) when image url doesn't mentions the format/extension explicitly.
+                        // An issue has been opened in library for native support of a similar feature. (Ref: https://github.com/geostyler/geostyler/issues/1453)
+                        const { parsedCode, errorObj } = updateExternalGraphicNode(options, newCode);
+                        errorObj ?  onError(errorObj) : onChange(parsedCode, options.style);
                     })
                     .catch((err) => {
                         onError({
@@ -343,6 +348,7 @@ function VisualStyleEditor({
                 attributes,
                 methods,
                 getColors,
+                format,
                 ...config
             }}
             // reverse rules order to show top rendered style

--- a/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
+++ b/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
@@ -138,6 +138,7 @@ describe('RulesEditor', () => {
         const symbolizerFields = symbolizersNode[0].querySelectorAll('.ms-symbolizer-label > span');
         expect([...symbolizerFields].map(field => field.innerHTML)).toEqual([
             'styleeditor.image',
+            'styleeditor.format',
             'styleeditor.opacity',
             'styleeditor.size',
             'styleeditor.rotation'
@@ -596,6 +597,7 @@ describe('RulesEditor', () => {
         const symbolizerFields = symbolizersNode[0].querySelectorAll('.ms-symbolizer-label > span');
         expect([...symbolizerFields].map(field => field.innerHTML)).toEqual([
             'styleeditor.image',
+            'styleeditor.format',
             'styleeditor.size',
             'styleeditor.strokeWidth',
             'styleeditor.lineStyle',
@@ -616,6 +618,14 @@ describe('RulesEditor', () => {
 
     it('should trigger on change callback', (done) => {
         TestUtils.act(() => {
+            const Image = global.Image;
+            global.Image = class {
+                constructor() {
+                    setTimeout(() => {
+                        this.onload(); // simulate success
+                    }, 100);
+                }
+            };
             ReactDOM.render(
                 <RulesEditor
                     rules={[
@@ -635,8 +645,10 @@ describe('RulesEditor', () => {
                         try {
                             expect(newRules[0].symbolizers[0].image).toBe('new-url');
                         } catch (e) {
+                            global.Image = Image;
                             done(e);
                         }
+                        global.Image = Image;
                         done();
                     }}
                 />, document.getElementById('container'));
@@ -651,7 +663,7 @@ describe('RulesEditor', () => {
         expect(symbolizersNode.length).toBe(1);
 
         const inputNodes = symbolizersNode[0].querySelectorAll('input');
-        expect(inputNodes.length).toBe(1);
+        expect(inputNodes.length).toBe(2);
         TestUtils.act(() => {
             TestUtils.Simulate.change(inputNodes[0], { target: { value: 'new-url' }});
         });

--- a/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
+++ b/web/client/components/styleeditor/__tests__/VisualStyleEditor-test.js
@@ -237,4 +237,41 @@ describe('VisualStyleEditor', () => {
             />, document.getElementById('container'));
         });
     });
+    it('should throw an error when icon symbolizer has image with no format', (done) => {
+        const DEBOUNCE_TIME = 1;
+        act(() => {
+            ReactDOM.render(<VisualStyleEditor
+                format="sld"
+                code={"<?xml"}
+                defaultStyleJSON={{
+                    name: "Base SLD1",
+                    rules: [
+                        {
+                            name: "",
+                            ruleId: "1",
+                            symbolizers: [
+                                {
+                                    kind: "Icon",
+                                    image: "https://test.com/linktoImage",
+                                    opacity: 1,
+                                    size: 32,
+                                    rotate: 0,
+                                    symbolizerId: "2"
+                                }
+                            ]
+                        }
+                    ]
+                }}
+                debounceTime={DEBOUNCE_TIME}
+                onError={(error) => {
+                    try {
+                        expect(error).toEqual({ messageId: 'styleeditor.imageFormatEmpty', status: 400 });
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                }}
+            />, document.getElementById('container'));
+        });
+    });
 });

--- a/web/client/components/styleeditor/config/blocks.js
+++ b/web/client/components/styleeditor/config/blocks.js
@@ -9,6 +9,8 @@
 import property from './property';
 import omit from 'lodash/omit';
 import includes from 'lodash/includes';
+import isObject from 'lodash/isObject';
+import {SUPPORTED_MIME_TYPES} from "../../../utils/StyleEditorUtils";
 
 const getBlocks = (/* config = {} */) => {
     const symbolizerBlock = {
@@ -67,6 +69,16 @@ const getBlocks = (/* config = {} */) => {
                 image: property.image({
                     label: 'styleeditor.image',
                     key: 'image'
+                }),
+                format: property.select({
+                    label: 'styleeditor.format',
+                    key: 'format',
+                    isVisible: (value, { image } = {}, format) => {
+                        return format !== 'css'
+                        && !isObject(image)
+                        && !['png', 'jpg', 'svg', 'gif', 'jpeg'].includes(image.split('.').pop());
+                    },
+                    getOptions: () => SUPPORTED_MIME_TYPES
                 }),
                 opacity: property.opacity({
                     label: 'styleeditor.opacity'

--- a/web/client/components/styleeditor/config/property.js
+++ b/web/client/components/styleeditor/config/property.js
@@ -357,7 +357,7 @@ const property = {
             };
         }
     }),
-    select: ({ label, key = '', getOptions = () => [], selectProps, isValid, isDisabled }) => ({
+    select: ({ label, key = '', getOptions = () => [], selectProps, isValid, isDisabled, isVisible }) => ({
         type: 'select',
         label,
         config: {
@@ -370,7 +370,8 @@ const property = {
                 [key]: value
             };
         },
-        isDisabled
+        isDisabled,
+        isVisible
     }),
     colorRamp: ({ label, key = '', getOptions = () => [] }) => ({
         type: 'colorRamp',

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2233,7 +2233,7 @@
             "imageSrcLoadError": "Die angegebene Bildquelle konnte nicht geladen werden. Versuchen Sie es mit einer anderen URL oder stellen Sie sicher, dass die Quelle über MapStore erreichbar ist.",
             "imageSrcInvalidBase64": "Dies ist kein gültiges base64-Image. Einige Style-Renderer unterstützen diesen Quelltyp nicht. Sie können stattdessen eine externe URL-Quelle verwenden.",
             "imageSrcNotSupportedBase64Image": "Einige Style-Renderer unterstützen Base64-Images nicht, selbst wenn die aktuelle Quelle gültig ist",
-            "imageFormatEmpty": "Der Parser kann das Format des Bildes nicht identifizieren, selbst wenn die Quelle gültig ist. Bitte wählen Sie das Format des bereitgestellten Bildes aus der Dropdown-Liste",
+            "imageFormatEmpty": "Das Bildformat kann nicht identifiziert werden. Bitte wählen Sie das Bildformat aus den verfügbaren in der Dropdown-Liste 'Format' aus",
             "warningTextOrderTitle": "Warnung",
             "warningTextOrder": "Die Reihenfolge der Regeln, die den Textstil enthalten, konnte nicht mit der Renderreihenfolge auf der Karte übereinstimmen. Dieses Verhalten hängt mit einigen Rendering-Engines zusammen, die Beschriftungen über andere Regeln ziehen"
         },

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2118,6 +2118,7 @@
             "addIconSymbolizer": "Symbol-Symbolisierer hinzufügen",
             "addIconRule": "Symbolregel hinzufügen",
             "image": "Bild",
+            "format": "Format",
             "opacity": "Deckkraft",
             "size": "Größe",
             "addLineSymbolizer": "Liniensymbolisierer hinzufügen",
@@ -2232,6 +2233,7 @@
             "imageSrcLoadError": "Die angegebene Bildquelle konnte nicht geladen werden. Versuchen Sie es mit einer anderen URL oder stellen Sie sicher, dass die Quelle über MapStore erreichbar ist.",
             "imageSrcInvalidBase64": "Dies ist kein gültiges base64-Image. Einige Style-Renderer unterstützen diesen Quelltyp nicht. Sie können stattdessen eine externe URL-Quelle verwenden.",
             "imageSrcNotSupportedBase64Image": "Einige Style-Renderer unterstützen Base64-Images nicht, selbst wenn die aktuelle Quelle gültig ist",
+            "imageFormatEmpty": "Der Parser kann das Format des Bildes nicht identifizieren, selbst wenn die Quelle gültig ist. Bitte wählen Sie das Format des bereitgestellten Bildes aus der Dropdown-Liste",
             "warningTextOrderTitle": "Warnung",
             "warningTextOrder": "Die Reihenfolge der Regeln, die den Textstil enthalten, konnte nicht mit der Renderreihenfolge auf der Karte übereinstimmen. Dieses Verhalten hängt mit einigen Rendering-Engines zusammen, die Beschriftungen über andere Regeln ziehen"
         },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2244,7 +2244,7 @@
             "imageSrcLoadError": "The provided image source could not be loaded. Try with a different url or ensure the source is reachable by MapStore",
             "imageSrcInvalidBase64": "This is not a valid base64 image. Some style renderer does not support this type of source, you could use an external url source instead",
             "imageSrcNotSupportedBase64Image": "Some style renderer does not support base64 images even if the current source is valid",
-            "imageFormatEmpty": "Parser unable to identify format of the image even when the source is valid. Please select the format of the image provided from the dropdown",
+            "imageFormatEmpty": "The image format cannot be identified. Please select the image format from the available ones in the 'Format' dropdown",
             "warningTextOrderTitle": "Warning",
             "warningTextOrder": "The order of rule containing text style could not match the rendering order on map. This behaviour is related to some rendering engine that draw label on top of other rules"
         },

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2121,6 +2121,7 @@
             "addIconSymbolizer": "Add icon symbolizer",
             "addIconRule": "Add icon rule",
             "image": "Image",
+            "format": "Format",
             "opacity": "Opacity",
             "size": "Size",
             "addLineSymbolizer": "Add line symbolizer",
@@ -2243,6 +2244,7 @@
             "imageSrcLoadError": "The provided image source could not be loaded. Try with a different url or ensure the source is reachable by MapStore",
             "imageSrcInvalidBase64": "This is not a valid base64 image. Some style renderer does not support this type of source, you could use an external url source instead",
             "imageSrcNotSupportedBase64Image": "Some style renderer does not support base64 images even if the current source is valid",
+            "imageFormatEmpty": "Parser unable to identify format of the image even when the source is valid. Please select the format of the image provided from the dropdown",
             "warningTextOrderTitle": "Warning",
             "warningTextOrder": "The order of rule containing text style could not match the rendering order on map. This behaviour is related to some rendering engine that draw label on top of other rules"
         },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2118,6 +2118,7 @@
             "addIconSymbolizer": "Agregar simbolizador de icono",
             "addIconRule": "Agregar regla de icono",
             "image": "Imagen",
+            "format": "Formato",
             "opacity": "Opacidad",
             "size": "Tamaño",
             "addLineSymbolizer": "Agregar símbolo de línea",
@@ -2232,6 +2233,7 @@
             "imageSrcLoadError": "No se pudo cargar la fuente de la imagen proporcionada. Pruebe con una URL diferente o asegúrese de que MapStore pueda acceder a la fuente",
             "imageSrcInvalidBase64": "Esta no es una imagen base64 válida. Algunos procesadores de estilo no son compatibles con este tipo de fuente; en su lugar, puede utilizar una fuente de URL externa",
             "imageSrcNotSupportedBase64Image": "Algunos procesadores de estilo no admiten imágenes en base64 incluso si la fuente actual es válida",
+            "imageFormatEmpty": "El analizador no puede identificar el formato de la imagen incluso cuando la fuente es válida. Seleccione el formato de la imagen proporcionada en el menú desplegable",
             "warningTextOrderTitle": "Advertencia",
             "warningTextOrder": "El orden de la regla que contiene el estilo de texto no pudo coincidir con el orden de representación en el mapa. Este comportamiento está relacionado con algún motor de renderizado que dibuja la etiqueta sobre otras reglas"
         },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2233,7 +2233,7 @@
             "imageSrcLoadError": "No se pudo cargar la fuente de la imagen proporcionada. Pruebe con una URL diferente o asegúrese de que MapStore pueda acceder a la fuente",
             "imageSrcInvalidBase64": "Esta no es una imagen base64 válida. Algunos procesadores de estilo no son compatibles con este tipo de fuente; en su lugar, puede utilizar una fuente de URL externa",
             "imageSrcNotSupportedBase64Image": "Algunos procesadores de estilo no admiten imágenes en base64 incluso si la fuente actual es válida",
-            "imageFormatEmpty": "El analizador no puede identificar el formato de la imagen incluso cuando la fuente es válida. Seleccione el formato de la imagen proporcionada en el menú desplegable",
+            "imageFormatEmpty": "No se puede identificar el formato de la imagen. Seleccione el formato de imagen de los disponibles en el menú desplegable 'Formato'",
             "warningTextOrderTitle": "Advertencia",
             "warningTextOrder": "El orden de la regla que contiene el estilo de texto no pudo coincidir con el orden de representación en el mapa. Este comportamiento está relacionado con algún motor de renderizado que dibuja la etiqueta sobre otras reglas"
         },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2234,7 +2234,7 @@
             "imageSrcLoadError": "La source d'image fournie n'a pas pu être chargée. Essayez avec une URL différente ou assurez-vous que la source est accessible par MapStore",
             "imageSrcInvalidBase64": "Ceci n'est pas une image base64 valide. Certains rendus de style ne prennent pas en charge ce type de source, vous pouvez utiliser une source d'url externe à la place",
             "imageSrcNotSupportedBase64Image": "Certains rendus de style ne prennent pas en charge les images base64 même si la source actuelle est valide",
-            "imageFormatEmpty": "L'analyseur ne parvient pas à identifier le format de l'image même lorsque la source est valide. Veuillez sélectionner le format de l'image fournie dans la liste déroulante",
+            "imageFormatEmpty": "Le format d'image ne peut pas être identifié. Veuillez sélectionner le format d'image parmi ceux disponibles dans la liste déroulante 'Format'",
             "warningTextOrderTitle": "Avertissement",
             "warningTextOrder": "L'ordre de la règle contenant le style de texte ne pouvait pas correspondre à l'ordre de rendu sur la carte. Ce comportement est lié à certains moteurs de rendu qui dessinent une étiquette au-dessus d'autres règles"
         },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2119,6 +2119,7 @@
             "addIconSymbolizer": "Ajouter un symboliseur d'icône",
             "addIconRule": "Ajouter une règle d'icône",
             "image": "Image",
+            "format": "Format",
             "opacity": "Opacity",
             "size": "Taille",
             "addLineSymbolizer": "Ajouter un symboliseur de ligne",
@@ -2233,6 +2234,7 @@
             "imageSrcLoadError": "La source d'image fournie n'a pas pu être chargée. Essayez avec une URL différente ou assurez-vous que la source est accessible par MapStore",
             "imageSrcInvalidBase64": "Ceci n'est pas une image base64 valide. Certains rendus de style ne prennent pas en charge ce type de source, vous pouvez utiliser une source d'url externe à la place",
             "imageSrcNotSupportedBase64Image": "Certains rendus de style ne prennent pas en charge les images base64 même si la source actuelle est valide",
+            "imageFormatEmpty": "L'analyseur ne parvient pas à identifier le format de l'image même lorsque la source est valide. Veuillez sélectionner le format de l'image fournie dans la liste déroulante",
             "warningTextOrderTitle": "Avertissement",
             "warningTextOrder": "L'ordre de la règle contenant le style de texte ne pouvait pas correspondre à l'ordre de rendu sur la carte. Ce comportement est lié à certains moteurs de rendu qui dessinent une étiquette au-dessus d'autres règles"
         },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2119,6 +2119,7 @@
             "addIconSymbolizer": "Aggiungi stile icona",
             "addIconRule": "Aggiungi regola icona",
             "image": "Image",
+            "format": "Formato",
             "opacity": "Opacità",
             "size": "Dimensione",
             "addLineSymbolizer": "Aggiungi stile linea",
@@ -2233,6 +2234,7 @@
             "imageSrcLoadError": "Impossibile caricare l'origine dell'immagine fornita. Prova con un URL diverso o assicurati che la fonte sia raggiungibile da MapStore",
             "imageSrcInvalidBase64": "Questa non è un'immagine base64 valida. Alcuni renderer di stili non supportano questo tipo di risorsa, potresti invece utilizzare una immagine con URL esterno",
             "imageSrcNotSupportedBase64Image": "Alcuni renderer di stili non supportano le immagini base64 anche se la risorsa è valida",
+            "imageFormatEmpty": "Il parser non è in grado di identificare il formato dell'immagine anche quando l'origine è valida. Seleziona il formato dell'immagine fornita dal menu a discesa",
             "warningTextOrderTitle": "Attenzione",
             "warningTextOrder": "L'ordine delle regole che contengono etichette potrebbe non corrispondere all'ordine di disegno sulla mappa. Questo comportamento è correlato ad alcuni motori di rendering che disegnano etichette sopra alle altre regole"
         },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2234,7 +2234,7 @@
             "imageSrcLoadError": "Impossibile caricare l'origine dell'immagine fornita. Prova con un URL diverso o assicurati che la fonte sia raggiungibile da MapStore",
             "imageSrcInvalidBase64": "Questa non è un'immagine base64 valida. Alcuni renderer di stili non supportano questo tipo di risorsa, potresti invece utilizzare una immagine con URL esterno",
             "imageSrcNotSupportedBase64Image": "Alcuni renderer di stili non supportano le immagini base64 anche se la risorsa è valida",
-            "imageFormatEmpty": "Il parser non è in grado di identificare il formato dell'immagine anche quando l'origine è valida. Seleziona il formato dell'immagine fornita dal menu a discesa",
+            "imageFormatEmpty": "Non è possibile identificare il formato dell'immagine. Seleziona il formato dell'immagine fra quelli disponibili nel campo 'Formato'",
             "warningTextOrderTitle": "Attenzione",
             "warningTextOrder": "L'ordine delle regole che contengono etichette potrebbe non corrispondere all'ordine di disegno sulla mappa. Questo comportamento è correlato ad alcuni motori di rendering che disegnano etichette sopra alle altre regole"
         },

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -14,7 +14,7 @@
  */
 
 import expect from 'expect';
-
+import xml2js from 'xml2js';
 import {
     generateTemporaryStyleId,
     STYLE_ID_SEPARATOR,
@@ -27,7 +27,8 @@ import {
     stringifyNameParts,
     parseJSONStyle,
     formatJSONStyle,
-    validateImageSrc
+    validateImageSrc,
+    updateExternalGraphicNode
 } from '../StyleEditorUtils';
 
 describe('StyleEditorUtils test', () => {
@@ -854,5 +855,134 @@ describe('StyleEditorUtils test', () => {
                 expect(response.src).toBe(validBase64Src);
                 done();
             });
+    });
+    describe('test updateExternalGraphicNode', ()=>{
+        it('should return an valid parsed SLD with format specified', () => {
+            const format = 'image/png';
+            const style = {
+                name: "Base SLD1",
+                rules: [
+                    {
+                        name: "",
+                        ruleId: "1",
+                        symbolizers: [
+                            {
+                                kind: "Icon",
+                                format,
+                                image: "https://test.com/linktoImage",
+                                opacity: 1,
+                                size: 32,
+                                rotate: 0,
+                                symbolizerId: "2"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const parsedSLD = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><StyledLayerDescriptor version=\"1.0.0\" xsi:schemaLocation=\"http://www.opengis.net/sld StyledLayerDescriptor.xsd\" xmlns=\"http://www.opengis.net/sld\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><NamedLayer><Name>icon dev</Name><UserStyle><Name>icon dev</Name><Title>icon dev</Title><FeatureTypeStyle><Rule><Name/><PointSymbolizer><Graphic><ExternalGraphic><OnlineResource xlink:type=\"simple\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xlink:href=\"https://www.pngix.com/pngfile/middle/92-926820_test-logo-png-transparent-png.png\"/></ExternalGraphic><Opacity>1</Opacity><Size>32</Size></Graphic></PointSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>";
+            const {parsedCode, errorObj} = updateExternalGraphicNode({format: 'sld', style}, parsedSLD);
+            expect(errorObj).toBe(false);
+            expect(parsedCode).toBeTruthy();
+            expect(parsedCode).toContain(format);
+
+        });
+        it('should skip parsing when style format is css', () => {
+            const format = 'image/png';
+            const style = {
+                name: "Base SLD1",
+                rules: [
+                    {
+                        name: "",
+                        ruleId: "1",
+                        symbolizers: [
+                            {
+                                kind: "Icon",
+                                format,
+                                image: "https://test.com/linktoImage",
+                                opacity: 1,
+                                size: 32,
+                                rotate: 0,
+                                symbolizerId: "2"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const parsedSLD = "@mode 'Flat';\n" +
+                "@styleTitle 'Base CSS1';\n" +
+                "\n" +
+                "* {\n" +
+                "  mark: url('https://master.demo.geonode.org/documents/1623/link');\n" +
+                "  mark-opacity: 1;\n" +
+                "  mark-size: 32;\n" +
+                "  mark-rotation: 0;\n" +
+                "}";
+            const {parsedCode, errorObj} = updateExternalGraphicNode({format: 'css', style}, parsedSLD);
+            expect(errorObj).toBe(false);
+            expect(parsedCode).toBeTruthy();
+            expect(parsedCode).toEqual(parsedSLD);
+
+        });
+        it('should skip parsing when parsed SLD has format in external graphic of Icon symbolizer', () => {
+            const style = {
+                name: "Base SLD1",
+                rules: [
+                    {
+                        name: "",
+                        ruleId: "1",
+                        symbolizers: [
+                            {
+                                kind: "Icon",
+                                image: "https://test.com/linktoImage.png",
+                                opacity: 1,
+                                size: 32,
+                                rotate: 0,
+                                symbolizerId: "2"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const oldSLD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><NamedLayer><Name>icon dev</Name><UserStyle><Name>icon dev</Name><Title>icon dev</Title><FeatureTypeStyle><Rule><Name/><PointSymbolizer><Graphic><ExternalGraphic><OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.pngix.com/pngfile/middle/92-926820_test-logo-png-transparent-png.png"/><Format>image/png</Format></ExternalGraphic><Opacity>1</Opacity><Size>32</Size></Graphic></PointSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>`;
+            let oldSLDJSON;
+            xml2js.parseString(oldSLD, { explicitArray: false }, (_, res)=>{
+                oldSLDJSON = res;
+            });
+            const {parsedCode, errorObj} = updateExternalGraphicNode({format: 'sld', style}, oldSLD);
+            expect(errorObj).toBeFalsy();
+            expect(parsedCode).toBeTruthy();
+            let parsedCodeJSON;
+            xml2js.parseString(parsedCode, { explicitArray: false }, (_, res)=>{
+                parsedCodeJSON = res;
+            });
+            expect(parsedCodeJSON).toEqual(oldSLDJSON);
+        });
+        it('should return error when image and user specified format is not present', () => {
+            const style = {
+                name: "Base SLD1",
+                rules: [
+                    {
+                        name: "",
+                        ruleId: "1",
+                        symbolizers: [
+                            {
+                                kind: "Icon",
+                                image: "https://test.com/linktoImage",
+                                opacity: 1,
+                                size: 32,
+                                rotate: 0,
+                                symbolizerId: "2"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const parsedSLD = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><StyledLayerDescriptor version=\"1.0.0\" xsi:schemaLocation=\"http://www.opengis.net/sld StyledLayerDescriptor.xsd\" xmlns=\"http://www.opengis.net/sld\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><NamedLayer><Name>icon dev</Name><UserStyle><Name>icon dev</Name><Title>icon dev</Title><FeatureTypeStyle><Rule><Name/><PointSymbolizer><Graphic><ExternalGraphic><OnlineResource xlink:type=\"simple\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xlink:href=\"https://www.pngix.com/pngfile/middle/92-926820_test-logo-png-transparent-png.png\"/></ExternalGraphic><Opacity>1</Opacity><Size>32</Size></Graphic></PointSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>";
+            const {parsedCode, errorObj} = updateExternalGraphicNode({format: 'sld', style}, parsedSLD);
+            expect(errorObj).toBeTruthy();
+            expect(errorObj.messageId).toEqual('styleeditor.imageFormatEmpty');
+            expect(errorObj.status).toEqual(400);
+            expect(parsedCode).toBeFalsy();
+        });
     });
 });


### PR DESCRIPTION
## Description
This PR enhances the identification and parsing of format for image with no extension/format for the geostyler-sld-parser to use to generate `Format` node in `ExternalGraphic` for IconSymbolizer

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6819 

**What is the new behavior?**
- When image input is missing format, then user is presented with format selector to choose from
- When style editor is of CSS, then format selector is not shown, as the css parses the url correctly and updates the style regardless of whether format present or not
- When image input has extension/format or when the image source is not valid or when error, the format selector is not shown

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
