### PR TITLE
#6892 Fix geometry type bug in wfs layer style panel

### DIFF
--- a/web/client/plugins/tocitemssettings/SimpleVectorStyleEditor.jsx
+++ b/web/client/plugins/tocitemssettings/SimpleVectorStyleEditor.jsx
@@ -157,7 +157,7 @@ const SimpleVectorStyleEditor = compose(
         </React.Fragment>);
     } else {
         // Fail gracefully if the geometry type is not supported for styling
-        editorComponent = (<div style={{padding: 20}}>
+        editorComponent = (<div style={{padding: 20, color: "red"}}>
             <Message msgId={'layerProperties.styleWarning'} msgParams={{geometryType}} />
         </div>);
     }

--- a/web/client/plugins/tocitemssettings/SimpleVectorStyleEditor.jsx
+++ b/web/client/plugins/tocitemssettings/SimpleVectorStyleEditor.jsx
@@ -145,13 +145,22 @@ const SimpleVectorStyleEditor = compose(
     emptyState(({ geometryType }) => !geometryType)
 )(({ geometryType, element = {}, onChange = () => { } }) => {
     const CMP = stylers[geometryType];
-    return (<React.Fragment>
-        <h4>&nbsp;&nbsp;&nbsp;&nbsp;<Message msgId="layerProperties.style"/></h4>
-        <CMP
-            styleName={element.styleName}
-            style={element.style}
-            onChange={onChange}
-        />
-    </React.Fragment>);
+    let editorComponent;
+    if (CMP) {
+        editorComponent = (<React.Fragment>
+            <h4>&nbsp;&nbsp;&nbsp;&nbsp;<Message msgId="layerProperties.style"/></h4>
+            <CMP
+                styleName={element.styleName}
+                style={element.style}
+                onChange={onChange}
+            />
+        </React.Fragment>);
+    } else {
+        // Fail gracefully if the geometry type is not supported for styling
+        editorComponent = (<div style={{padding: 20}}>
+            <Message msgId={'layerProperties.styleWarning'} msgParams={{geometryType}} />
+        </div>);
+    }
+    return editorComponent;
 });
 export default SimpleVectorStyleEditor;

--- a/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
+++ b/web/client/plugins/tocitemssettings/__tests__/deafaultSettingsTabs-test.js
@@ -6,17 +6,52 @@
  * LICENSE file in the root directory of this source tree.
  */
 import expect from 'expect';
+import MockAdapter from "axios-mock-adapter";
+import axios from "../../../libs/ajax";
 
 import defaultSettingsTabs, { getStyleTabPlugin } from '../defaultSettingsTabs';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { act } from "react-dom/test-utils";
+
+import SimpleVectorStyleEditor from "../SimpleVectorStyleEditor";
 
 const BASE_STYLE_TEST_DATA = {
     settings: {},
     items: [],
     loadedPlugins: {}
 };
+let mockAxios;
 
+const getQueryParam = (param, url) => {
+    let href = url;
+    // this expression is to get the query strings
+    let reg = new RegExp("[?&]" + param + "=([^&#]*)", "i");
+    let queryString = reg.exec(href);
+    return queryString ? decodeURIComponent(queryString[1]) : null;
+};
+
+const mockFeatureRequestWithGeometryType = (geometryType) => {
+    mockAxios.onGet().reply((req) => {
+        const request = getQueryParam("request", req.url);
+        if (request === "DescribeFeatureType") {
+            let mockResponse = {
+                "featureTypes": [
+                    {
+                        "properties": [
+                            {
+                                "name": "the_geom",
+                                "type": `gml:${geometryType}`
+                            }
+                        ]
+                    }
+                ]
+            };
+            return [200, mockResponse];
+        }
+        return [404, "NOT FOUND"];
+    });
+};
 
 describe('TOCItemsSettings - getStyleTabPlugin', () => {
     it('getStyleTabPlugin', () => {
@@ -117,5 +152,145 @@ describe('TOCItemsSettings - getStyleTabPlugin rendered items', () => {
         expect(toolbarNode).toBeTruthy();
         expect(toolbarNode.innerHTML).toBe('enableSetDefaultStyle');
 
+    });
+});
+
+describe('TOCItemsSettings - SimpleVectorStyleEditor rendered items', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = "";
+        if (mockAxios) {
+            mockAxios.restore();
+        }
+        mockAxios = null;
+        setTimeout(done);
+    });
+
+    it("SimpleVectorStyleEditor displays an error message if the geometry is type GEOMETRY and the layer is wfs", async() => {
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                type: "wfs",
+                search: {
+                    url: "something"
+                }
+            }
+        };
+
+        mockFeatureRequestWithGeometryType("Geometry");
+
+        await act(async() => {
+            ReactDOM.render(<SimpleVectorStyleEditor {...PROPS}/>, document.querySelector('#container'));
+        });
+
+        // Check if an error message is rendered
+        const messageComponent = document.querySelector("#container");
+        expect(messageComponent.innerHTML).toContain("layerProperties.styleWarning");
+    });
+
+    it("SimpleVectorStyleEditor renders editor if the geometry is not of type GEOMETRY and the layer is wfs", async() => {
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                type: "wfs",
+                search: {
+                    url: "something"
+                }
+            }
+        };
+
+        mockFeatureRequestWithGeometryType("MultiPolygon");
+
+        await act(async() => {
+            ReactDOM.render(<SimpleVectorStyleEditor {...PROPS}/>, document.querySelector('#container'));
+        });
+
+        // Check if the editor is rendered
+        const messageComponent = document.querySelector("#container");
+        expect(messageComponent.innerHTML).toContain("layerProperties.style");
+    });
+
+    it("SimpleVectorStyleEditor renders an empty component if the geometry is not defined and the layer is wfs", async() => {
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                type: "wfs",
+                search: {
+                    url: "something"
+                }
+            }
+        };
+
+        mockFeatureRequestWithGeometryType("");
+
+        await act(async() => {
+            ReactDOM.render(<SimpleVectorStyleEditor {...PROPS}/>, document.querySelector('#container'));
+        });
+
+        // Check if an empty container has been rendered
+        const messageComponent = document.querySelector(".empty-state-container");
+        expect(messageComponent).toBeTruthy();
+    });
+
+    it("SimpleVectorStyleEditor displays an error message if the geometry is type GEOMETRY and the layer is not wfs", async() => {
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                features: [
+                    {geometry: {
+                        type: "Geometry"
+                    }}
+                ]
+            }
+        };
+
+        await act(async() => {
+            ReactDOM.render(<SimpleVectorStyleEditor {...PROPS}/>, document.querySelector('#container'));
+        });
+
+        // Check if an error message is rendered
+        const messageComponent = document.querySelector("#container");
+        expect(messageComponent.innerHTML).toContain("layerProperties.styleWarning");
+    });
+
+    it("SimpleVectorStyleEditor renders editor if the geometry is not of type GEOMETRY and the layer is not wfs", async() => {
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA,
+            element: {
+                features: [
+                    {geometry: {
+                        type: "MultiPolygon"
+                    }}
+                ]
+            }
+        };
+
+        await act(async() => {
+            ReactDOM.render(<SimpleVectorStyleEditor {...PROPS}/>, document.querySelector('#container'));
+        });
+
+        // Check if the editor is rendered
+        const messageComponent = document.querySelector("#container");
+        expect(messageComponent.innerHTML).toContain("layerProperties.style");
+    });
+
+    it("SimpleVectorStyleEditor renders an empty component if the geometry is not set and the layer is not wfs", async() => {
+        const PROPS = {
+            ...BASE_STYLE_TEST_DATA
+        };
+
+        await act(async() => {
+            ReactDOM.render(<SimpleVectorStyleEditor {...PROPS}/>, document.querySelector('#container'));
+        });
+
+        // Check if an empty container has been rendered
+        const messageComponent = document.querySelector(".empty-state-container");
+        expect(messageComponent).toBeTruthy();
     });
 });

--- a/web/client/plugins/tocitemssettings/__tests__/defaultSettingsTabs-test.js
+++ b/web/client/plugins/tocitemssettings/__tests__/defaultSettingsTabs-test.js
@@ -276,8 +276,8 @@ describe('TOCItemsSettings - SimpleVectorStyleEditor rendered items', () => {
             element: {
                 features: [
                     {geometry: {
-                            type: "Geometry"
-                        }}
+                        type: "Geometry"
+                    }}
                 ]
             }
         };
@@ -298,8 +298,8 @@ describe('TOCItemsSettings - SimpleVectorStyleEditor rendered items', () => {
             element: {
                 features: [
                     {geometry: {
-                            type: "MultiPolygon"
-                        }}
+                        type: "MultiPolygon"
+                    }}
                 ]
             }
         };

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -99,6 +99,7 @@
             "templateFormatDescription": "Passen Sie das Ergebnis der Feature-Informationen an",
             "hideFormatTitle": "IDENTIFIZIERUNG DEAKTIVIEREN",
             "hideFormatDescription": "Deaktivieren Sie die Funktionsinformationen für diese Ebene",
+            "styleWarning": "Ebenenstil-Editor für Geometrietyp '{geometryType}' wird nicht unterstützt.",
             "templateFormatInfoAlert1": "Klicken Sie auf Bearbeiten, um eine neue Vorlage hinzuzufügen.",
             "templateFormatInfoAlert2": "Verwenden Sie ${ attribute }, um Attribut-Werte anzuzeigen",
             "templateFormatInfoAlertExample": "Die ID des Features lautet ${ properties }",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -99,6 +99,7 @@
             "templateFormatDescription": "Customize feature info results format",
             "hideFormatTitle": "DISABLE IDENTIFY",
             "hideFormatDescription": "Disable the feature info for this layer",
+            "styleWarning": "Layer style editor for geometry type '{geometryType}' is not supported.",
             "templateFormatInfoAlert1": "Click on edit button to add a new template.",
             "templateFormatInfoAlert2": "Use ${ attribute } to wrap the properties you need to display",
             "templateFormatInfoAlertExample": "The id of the feature is ${ properties }",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -99,6 +99,7 @@
             "templateFormatDescription": "Personalizar el formato de resultados de información de la capa",
             "hideFormatTitle": "DESACTIVAR IDENTIFICAR",
             "hideFormatDescription": "Deshabilite la información de la entidad para esta capa",
+            "styleWarning": "El editor de estilo de capa para el tipo de geometría '{geometryType}' no es compatible.",
             "templateFormatInfoAlert1": "Haga clic en el botón Editar para agregar una nueva plantilla.",
             "templateFormatInfoAlert2": "Use ${ attribute } para ajustar las propiedades que necesita visualizar",
             "visibilityLimits": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -99,6 +99,7 @@
             "templateFormatDescription": "Personnaliser le format des résultats d'interrogation des attributs",
             "hideFormatTitle": "DÉSACTIVER L'IDENTIFICATION",
             "hideFormatDescription": "Désactiver les informations sur les caractéristiques de cette couche",
+            "styleWarning": "L'éditeur de style de calque pour le type de géométrie '{geometryType}' n'est pas pris en charge.",
             "templateFormatInfoAlert1": "Cliquez sur le bouton d'édition pour ajouter un nouveau modèle.",
             "templateFormatInfoAlert2": "Utilisez ${ attribut } pour envelopper les propriétés que vous devez afficher",
             "templateFormatInfoAlertExample": "L'ID de la fonctionnalité est ${ properties }",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -99,6 +99,7 @@
             "templateFormatDescription": "Personalizza il formato di risposta",
             "hideFormatTitle": "DISABILITA IDENTIFICA",
             "hideFormatDescription": "Disabilita le informazioni sulla funzionalità per questo livello",
+            "styleWarning": "L'editore dello stile di livello per il tipo di geometria '{geometryType}' non è supportato.",
             "templateFormatInfoAlert1": "Click sul bottone di modifica per aggiungere un nuovo template.",
             "templateFormatInfoAlert2": "Usa ${ attribute } per aggiungere gli attributi da visualizzare",
             "templateFormatInfoAlertExample": "id della feature è ${ properties }",


### PR DESCRIPTION
## Description
Adds a conditional to the `SimpleVectorTileEditor` to fail gracefully with an error message when the geometry type is not supported.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6892

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Rather than crashing the application a message is shown to the user saying that the style editor is not supported for the geometry type.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
