### PR TITLE
Fixed translations for catalog, history and map templates

### DIFF
--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -711,8 +711,8 @@
         "noInfoForLayers": "Für die folgenden Ebenen gibt es keine Objekte: ",
         "history":{
             "barLabel": "Kartenverlauf",
-            "undoBtnTooltip": "Vorheriger Zoom",
-            "redoBtnTooltip": "Nächster Zoom"
+            "undoBtnTooltip": "Gehe zurück",
+            "redoBtnTooltip": "Gehe vorwärts"
         },
         "infoFormatLbl": "Antwortformat festlegen",
         "infoTriggerLabel": "Auslöseereignis für Info-Box",
@@ -1382,8 +1382,8 @@
             "start": "Startdatum ",
             "end": "Enddatum ",
             "notAvailable": "Nicht verfügbar",
-            "title": "Fügen Sie Daten hinzu",
-            "tooltip": "Fügen Sie Daten aus einem Metadatenkatalog oder einem geografischen Datenserver hinzu",
+            "title": "Katalog",
+            "tooltip": "Fügen Sie der Karte Ebenen hinzu",
             "autoload": "Suche in Serviceauswahl",
             "clearValueText": "Auswahl aufheben",
             "noResultsText": "keine Ergebnisse gefunden",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1359,7 +1359,7 @@
             },
         "mapExport": {
             "title": "Karte exportieren",
-            "tooltip": "Exportieren Sie Ihre Karte",
+            "tooltip": "Exportieren Sie die aktuelle Karte",
             "exportPanel": {
                 "title": "<p><h4>Wählen Sie ein Format</h4></p>",
                 "exportButtonLabel": "Export"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1358,7 +1358,7 @@
         },
         "mapExport": {
             "title": "Export",
-            "tooltip": "Export your map",
+            "tooltip": "Export the current map",
             "exportPanel": {
                 "title": "<p><h4>Select your format</h4></p>",
                 "exportButtonLabel": "Export"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -710,8 +710,8 @@
         "noInfoForLayers": "There are no features for the following layers: ",
         "history":{
             "barLabel": "Map history",
-            "undoBtnTooltip": "Previous zoom",
-            "redoBtnTooltip": "Next zoom"
+            "undoBtnTooltip": "Go back",
+            "redoBtnTooltip": "Go forward"
         },
         "infoFormatLbl": "Information sheet format",
         "infoTriggerLabel": "Trigger event for the display of the information sheet",
@@ -1381,8 +1381,8 @@
             "start": "Start date ",
             "end": "End date ",
             "notAvailable": "Not Available",
-            "title": "Add a data",
-            "tooltip": "Add data from a metadata catalog or a geographic data server",
+            "title": "Catalog",
+            "tooltip": "Add layers to the map",
             "autoload": "Search on service selection",
             "clearValueText": "Clear selection",
             "noResultsText": "No Result",
@@ -2914,7 +2914,7 @@
                     "pluginDocumentation": "Open plugin configuration documentation",
                     "uploadPlugin": "Add an extension to MapStore",
                     "removePlugin": "Remove this extension from MapStore",
-                    "mapTemplatesConfig": "Configure the maps templates"
+                    "mapTemplatesConfig": "Configure the map templates"
                 },
                 "tutorialPlugins": {
                     "availableTitle": "Available Plugin",
@@ -2928,13 +2928,13 @@
                 }
             },
             "configureTemplates": {
-                "title": "Configure maps templates",
-                "availableTemplates": "Available maps templates",
-                "enabledTemplates": "Enabled maps templates",
-                "templatesFilterPlaceholder": "Filter  maps templates by name...",
-                "availableTemplatesEmpty": "All available  maps templates are enabled",
-                "enabledTemplatesEmpty": "Add  maps templates to configuration from list of available templates",
-                "searchResultsEmpty": "No  maps templates found that satisfy the search criteria",
+                "title": "Configure map templates",
+                "availableTemplates": "Available map templates",
+                "enabledTemplates": "Enabled map templates",
+                "templatesFilterPlaceholder": "Filter  map templates by name...",
+                "availableTemplatesEmpty": "All available  map templates are enabled",
+                "enabledTemplatesEmpty": "Add  map templates to configuration from list of available templates",
+                "searchResultsEmpty": "No  map templates found that satisfy the search criteria",
                 "fileDrop": {
                     "label": "Map template",
                     "clear": "Drop or click to select a map file (exported JSON MapStore maps or WMC files are supported)"
@@ -2995,15 +2995,15 @@
             "title": "Map templates",
             "favouritesTitle": "Favourites",
             "allTitle": "All",
-            "filterPlaceholder": "Filter map templates...",
+            "filterPlaceholder": "Filter map template...",
             "transfer": "Replace map with this map template",
             "merge": "Add this map template to the map",
             "favouriteAdd": "Add to favourites",
             "favouriteRemove": "Remove from favourites",
             "emptyTitle": "No Result",
             "emptyDescription": "Entered filter does not match name or description of any of map template",
-            "noTemplatesTitle": "No map templates found",
-            "noTemplatesDescription": "Current context contains no map templates",
+            "noTemplatesTitle": "No map template found",
+            "noTemplatesDescription": "Current context contains no map template",
             "confirmReplaceTitle": "Replace map content",
             "confirmReplaceMessage": "You will replace all layers and map configuration with the selected map template by clicking on the 'Replace' button",
             "confirmReplaceConfirmButton": "Replace"
@@ -3261,7 +3261,7 @@
                     },
                     "mapTemplatesTool": {
                         "title": "Plugin Tools: Map Templates",
-                        "text": "<p>'Map templates' plugin also has a special tool that allows you to configure map templates that will be accessible within the context.</p>"
+                        "text": "<p>'Map templates' plugin also has a special tool that allows you to configure map template that will be accessible within the context.</p>"
                     },
                     "extensions": {
                         "title": "Extensions",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -710,8 +710,8 @@
         "noInfoForLayers": "No hay características para las siguientes capas: ",
         "history":{
             "barLabel": "Histórico  del mapa",
-            "undoBtnTooltip": "Zoom anterior",
-            "redoBtnTooltip": "Siguiente zoom"
+            "undoBtnTooltip": "Ir hacia atrás",
+            "redoBtnTooltip": "Ir hacia adelante"
         },
         "infoFormatLbl": "Identificar el formato de respuesta",
         "infoTriggerLabel": "Evento desencadenante para identificar",
@@ -1381,8 +1381,8 @@
             "start": "Fecha de inicio ",
             "end": "Fecha de finalización ",
             "notAvailable": "No disponible",
-            "title": "Agregar un dato",
-            "tooltip": "Add datas from a metadata catalog or a geographic datas server",
+            "title": "Catálogo",
+            "tooltip": "agregar capas al mapa",
             "autoload": "Buscar en la selección de servicios",
             "clearValueText": "Borrar selección",
             "noResultsText": "No se encontraron resultados",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1358,7 +1358,7 @@
         },
         "mapExport": {
             "title": "Exportar",
-            "tooltip": "Exporta tu mapa",
+            "tooltip": "Exportar el mapa actual",
             "exportPanel": {
                 "title": "<p><h4>Seleccione su formato</h4></p>",
                 "exportButtonLabel": "Exportar"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -710,8 +710,8 @@
         "noInfoForLayers": "Il n'y a aucun objet pour les couches suivantes : ",
         "history": {
             "barLabel": "Historique de la carte",
-            "undoBtnTooltip": "Zoom précédent",
-            "redoBtnTooltip": "Zoom suivant"
+            "undoBtnTooltip": "Aller en arrière",
+            "redoBtnTooltip": "Aller en avant"
         },
         "infoFormatLbl": "Format de la fiche d'information",
         "infoTriggerLabel": "Événement déclencheur de l'affichage de la fiche d'information",
@@ -1382,8 +1382,8 @@
             "start": "Date de début ",
             "end": "Date de fin ",
             "notAvailable": "Indisponible",
-            "title": "Ajouter des données",
-            "tooltip": "Ajouter des données depuis un catalogue de métadonnées ou un serveur de données géographiques.",
+            "title": "Catalogue",
+            "tooltip": "Ajouter des couches à la carte",
             "autoload": "Recherche sur la sélection du service",
             "clearValueText": "Effacer la sélection",
             "noResultsText": "Aucun résultat trouvé",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1359,7 +1359,7 @@
         },
         "mapExport": {
             "title": "Exporter",
-            "tooltip": "Exporter votre carte.",
+            "tooltip": "Exporter la carte actuelle",
             "exportPanel": {
                 "title": "<p><h4>Sélectionnez votre format</h4></p>",
                 "exportButtonLabel": "Exporter"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -710,8 +710,8 @@
         "noInfoForLayers": "Non ci sono features per i seguenti layers: ",
         "history":{
             "barLabel": "Storia Mappa",
-            "undoBtnTooltip": "Zoom precedente",
-            "redoBtnTooltip": "Zoom successivo"
+            "undoBtnTooltip": "Torna indietro",
+            "redoBtnTooltip": "Vai avanti"
         },
         "infoFormatLbl": "Formato risposte interrogazioni su mappa",
         "infoTriggerLabel": "Evento trigger interrogazioni su mappa",
@@ -1381,8 +1381,8 @@
             "start": "Data d'inizio ",
             "end": "Data di fine ",
             "notAvailable": "Non disponibile",
-            "title": "Aggiungi un dato",
-            "tooltip": "Aggiungi dati da un catalogo di metadati o da un server di dati geografici",
+            "title": "Catalogo",
+            "tooltip": "Aggiungi livelli alla mappa",
             "autoload": "Ricerca alla selezione del servizio",
             "clearValueText": "Cancella selezione",
             "noResultsText": "Nessun risultato trovato",
@@ -2981,10 +2981,10 @@
           "removeExtension": "Rimuovi Estensione"
         },
         "mapTemplates": {
-            "title": "Modelli di mappe",
+            "title": "Modelli di mappa",
             "favouritesTitle": "Preferiti",
             "allTitle": "Tutti",
-            "filterPlaceholder": "Filtra i modelli di mappe...",
+            "filterPlaceholder": "Filtra i modelli di mappa...",
             "transfer": "Sostituisci mappa con questo modello",
             "merge": "Aggiungi questo modello alla mappa",
             "favouriteAdd": "Aggiungi ai preferiti",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1358,7 +1358,7 @@
         },
         "mapExport": {
             "title": "Esporta",
-            "tooltip": "Esporta la tua mappa",
+            "tooltip": "Esporta la mappa corrente",
             "exportPanel": {
                 "title": "<p><h4>Seleziona il tuo formato</h4></p>",
                 "exportButtonLabel": "Esportare"


### PR DESCRIPTION
## Description
This PR fixes some translations changed in #6845 to be coherent with the general MapStore semantics and documentation, plus some syntax minor fix.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: i18n fix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Translation for catalog, map catalog and history buttons are not consistent with their role and references in documentation.

**What is the new behavior?**
The strings has been adjusted

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
