### PR TITLE
[Backport 2021.01.xx] #6729: Limit user input of max value (#6876)

### DIFF
--- a/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/AeronauticalCoordinateEditor.jsx
@@ -124,7 +124,7 @@ class AeronauticalCoordinateEditor extends React.Component {
         } else {
             const parsedVal = type === SECONDS ? parseFloat(val) : parseInt(val, 10);
             const maxValue = type === DEGREES ? this.props.maxDegrees : 60;
-            newValue = Math.round(parsedVal * 10) / 10 < maxValue ? parsedVal : maxValue - 1;
+            newValue = Math.round(parsedVal * 10) / 10 < maxValue ? parsedVal : this.props[type];
         }
         return newValue;
     }
@@ -228,6 +228,7 @@ class AeronauticalCoordinateEditor extends React.Component {
         if (event.keyCode === 69) {
             event.preventDefault();
         }
+        if (event?.target?.value === "0") event.target.setSelectionRange(-1, -1);
         if (event.keyCode === 13 ) {
             event.preventDefault();
             event.stopPropagation();

--- a/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
+++ b/web/client/components/misc/coordinateeditors/editors/__tests__/AeronauticalCoordinateEditor-test.jsx
@@ -137,7 +137,7 @@ describe('AeronauticalCoordinateEditor enhancer', () => {
         expect(+minutes.value).toBeLessThan(testValue);
         expect(+seconds.value).toBeLessThan(testValue);
         expect(spyOnChange).toHaveBeenCalled();
-        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(89);
+        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(20);
     });
     it('Test AeronauticalCoordinateEditor LON fields onChange not exceed max field values', () => {
         const actions = {
@@ -173,6 +173,6 @@ describe('AeronauticalCoordinateEditor enhancer', () => {
         expect(+seconds.value).toBeLessThan(testValue);
         expect(+seconds.value).toNotEqual(0);
         expect(spyOnChange).toHaveBeenCalled();
-        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(179);
+        expect(parseFloat(spyOnChange.calls[0].arguments[0])).toBe(160);
     });
 });


### PR DESCRIPTION
[Backport 2021.01.xx] #6729: Limit user input of max value (#6876)