### PR TITLE
#6730 fix zoom to extent triggered by epic when hooks are not yet registered

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -82,7 +82,10 @@ class CesiumMap extends React.Component {
     }
 
     componentDidMount() {
-        var map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), assign({
+        if (this.props.registerHooks) {
+            this.registerHooks();
+        }
+        let map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), assign({
             baseLayerPicker: false,
             animation: false,
             fullscreenButton: false,
@@ -119,9 +122,6 @@ class CesiumMap extends React.Component {
             if (this.cesiumNavigation) {
                 this.cesiumNavigation.navigationInitialization(this.props.id, map);
             }
-        }
-        if (this.props.registerHooks) {
-            this.registerHooks();
         }
     }
 

--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -82,9 +82,6 @@ class CesiumMap extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.registerHooks) {
-            this.registerHooks();
-        }
         let map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), assign({
             baseLayerPicker: false,
             animation: false,
@@ -98,6 +95,9 @@ class CesiumMap extends React.Component {
             navigationHelpButton: false,
             navigationInstructionsInitiallyVisible: false
         }, this.getMapOptions(this.props.mapOptions)));
+        if (this.props.registerHooks) {
+            this.registerHooks();
+        }
         map.scene.globe.baseColor = Cesium.Color.WHITE;
         map.imageryLayers.removeAll();
         map.camera.moveEnd.addEventListener(this.updateMapInfoState);

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -102,6 +102,9 @@ class LeafletMap extends React.Component {
         }
     }
     componentDidMount() {
+        if (this.props.registerHooks) {
+            this.registerHooks();
+        }
         const {limits = {}} = this.props;
         const maxBounds = limits.restrictedExtent && limits.crs && reprojectBbox(limits.restrictedExtent, limits.crs, "EPSG:4326");
         let mapOptions = assign({}, this.props.interactive ? {} : {
@@ -247,10 +250,6 @@ class LeafletMap extends React.Component {
         });
 
         this.drawControl = null;
-
-        if (this.props.registerHooks) {
-            this.registerHooks();
-        }
     }
 
     UNSAFE_componentWillReceiveProps(newProps) {

--- a/web/client/components/map/leaflet/Map.jsx
+++ b/web/client/components/map/leaflet/Map.jsx
@@ -102,9 +102,6 @@ class LeafletMap extends React.Component {
         }
     }
     componentDidMount() {
-        if (this.props.registerHooks) {
-            this.registerHooks();
-        }
         const {limits = {}} = this.props;
         const maxBounds = limits.restrictedExtent && limits.crs && reprojectBbox(limits.restrictedExtent, limits.crs, "EPSG:4326");
         let mapOptions = assign({}, this.props.interactive ? {} : {
@@ -128,7 +125,9 @@ class LeafletMap extends React.Component {
             Math.round(this.props.zoom));
 
         this.map = map;
-
+        if (this.props.registerHooks) {
+            this.registerHooks();
+        }
         // store zoomControl in the class to target the right control while add/remove
         if (this.props.zoomControl) {
             this.mapZoomControl = L.control.zoom();

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -94,6 +94,9 @@ class OpenlayersMap extends React.Component {
     };
 
     componentDidMount() {
+        if (this.props.registerHooks) {
+            this.registerHooks();
+        }
         this.props.projectionDefs.forEach(p => {
             const projDef = proj4.defs(p.code);
             projUtils.addProjections(p.code, p.extent, p.worldExtent, p.axisOrientation || projDef.axis || 'enu', projDef.units || 'm');
@@ -241,9 +244,6 @@ class OpenlayersMap extends React.Component {
         this.forceUpdate();
 
         this.props.onResolutionsChange(this.getResolutions());
-        if (this.props.registerHooks) {
-            this.registerHooks();
-        }
     }
 
     UNSAFE_componentWillReceiveProps(newProps) {

--- a/web/client/components/map/openlayers/Map.jsx
+++ b/web/client/components/map/openlayers/Map.jsx
@@ -94,9 +94,6 @@ class OpenlayersMap extends React.Component {
     };
 
     componentDidMount() {
-        if (this.props.registerHooks) {
-            this.registerHooks();
-        }
         this.props.projectionDefs.forEach(p => {
             const projDef = proj4.defs(p.code);
             projUtils.addProjections(p.code, p.extent, p.worldExtent, p.axisOrientation || projDef.axis || 'enu', projDef.units || 'm');
@@ -157,6 +154,9 @@ class OpenlayersMap extends React.Component {
         });
 
         this.map = map;
+        if (this.props.registerHooks) {
+            this.registerHooks();
+        }
         this.map.disabledListeners = {};
         this.map.disableEventListener = (event) => {
             this.map.disabledListeners[event] = true;
@@ -237,7 +237,6 @@ class OpenlayersMap extends React.Component {
         const mouseMove = throttle(this.mouseMoveEvent, 100);
         // TODO support disableEventListener
         map.on('pointermove', mouseMove);
-
         this.updateMapInfoState();
         this.setMousePointer(this.props.mousePointer);
         // NOTE: this re-call render function after div creation to have the map initialized.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
this pr solves a problem with readQueryParamsOnMapEpic that was running an action used by zoomToExtentEpic
and the resolutions passed to MapUtils.getZoomForExtent where incorrect if some custom are defined 
because [here](https://github.com/geosolutions-it/MapStore2/blob/8c6490c4ddd110ef5846fb0b9b9b5e509b6c3825/web/client/utils/MapUtils.js#L198) the hooks were not yet defined

so moving up the registration of hooks made the trick

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6730

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
the zoomToExtent now calculates correctly the zoom level

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
