### PR TITLE
Add embedded to local dev environment by default

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -7,7 +7,9 @@ const moduleFederationPlugin = require('./moduleFederation.js').plugin;
 module.exports = require('./buildConfig')(
     {
         [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app"),
-        "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded")
+        "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded"),
+        "dashboard-embedded": path.join(__dirname, "..", "web", "client", "product", "dashboardEmbedded"),
+        "geostory-embedded": path.join(__dirname, "..", "web", "client", "product", "geostoryEmbedded")
     },
     { ["themes/default"]: themeEntries["themes/" + (process.env.theme || "default")]},
     {

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -6,7 +6,8 @@ const moduleFederationPlugin = require('./moduleFederation.js').plugin;
 
 module.exports = require('./buildConfig')(
     {
-        [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app")
+        [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app"),
+        "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded")
     },
     { ["themes/default"]: themeEntries["themes/" + (process.env.theme || "default")]},
     {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This pr adds back the embedded to the webpack build of the main product 
with or without there is a small difference in terms of compiling time, which on my pc is around 2s (42 vs 44)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
you had to remember to add it :)

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
just including embedded js files when running npm start

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
