### PR TITLE
[Backport Mapstore2] #6906: FeatureList default prop updated (#6908)

### DIFF
--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -220,7 +220,8 @@ FeaturesList.defaultProps = {
     onSelectFeature: () => {},
     setTabValue: () => {},
     isMeasureEditDisabled: true,
-    defaultPointType: 'marker'
+    defaultPointType: 'marker',
+    defaultStyles: {}
 };
 
 export default FeaturesList;

--- a/web/client/components/mapcontrols/annotations/__tests__/FeatureList-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/FeatureList-test.js
@@ -295,4 +295,15 @@ describe("test FeatureList component", () => {
         TestUtils.Simulate.mouseLeave(featureCard[0]);
         expect(spyOnGeometryHighlight).toNotHaveBeenCalled();
     });
+
+    it('test render defaults with defaultPointType as symbol', () => {
+        ReactDOM.render(<FeaturesList defaultPointType={'symbol'}/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        expect(container).toBeTruthy();
+        const labels = container.querySelectorAll(".control-label");
+        expect(labels[0].innerText).toBe('annotations.geometries');
+        const buttons = container.querySelectorAll("button");
+        expect(buttons.length).toBe(5);
+        expect(container.innerText).toContain('annotations.addGeometry');
+    });
 });


### PR DESCRIPTION
## Description
This PR is a backport that fixes the app crash when adding measurement as annotation when annotation plugin is configured with defaultPointType as `symbol`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6906 

**What is the new behavior?**
- With defaultPointType as `symbol`, adding measurement as annotation will not cause app crash and allows user to add annotation and modify them accordingly

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Issue ref: https://github.com/geosolutions-it/austrocontrol-C125/issues/288