### PR TITLE
#5619: Classification url style service configuration

### DIFF
--- a/web/client/api/SLDService.js
+++ b/web/client/api/SLDService.js
@@ -220,10 +220,12 @@ const API = {
      * @method getStyleMetadataService
      * @param {object} layer layer configuration object
      * @param {object} params map of classification parameters: they will be used to build parameters for the SLDService classify service
+     * @param {object} styleService style service configuration object
      * @returns {string} url to get a classification metadata JSON
      */
-    getStyleMetadataService: (layer, params) => {
-        const parts = urlParts(getLayerUrl(layer));
+    getStyleMetadataService: (layer, params, styleService) => {
+        const { baseUrl = '', isStatic = false } = styleService || {};
+        const parts = urlParts(isStatic ? baseUrl : getLayerUrl(layer));
         return url.format(assign(getUrl(parts), {
             pathname: parts.applicationRootPath + "/rest/sldservice/" + layer.name + "/classify.json",
             query: params

--- a/web/client/api/StyleEditor.js
+++ b/web/client/api/StyleEditor.js
@@ -187,13 +187,15 @@ export function updateStyleService({ baseUrl, styleService }) {
  * @param {object} properties current properties of the rule that needs update
  * @param {array} rules rules of a style object
  * @param {object} layer layer configuration object
+ * @param {object} styleService style service configuration object
  * @returns {promise} return new rules with updated property and classification
  */
 export function classificationVector({
     values,
     properties,
     rules,
-    layer
+    layer,
+    styleService
 }) {
 
     let paramsKeys = [
@@ -254,7 +256,7 @@ export function classificationVector({
             attribute: params.attribute,
             intervalsForUnique: params.intervalsForUnique
         };
-        return axios.get(SLDService.getStyleMetadataService(layer, paramSLDService))
+        return axios.get(SLDService.getStyleMetadataService(layer, paramSLDService, styleService))
             .then(({ data }) => {
                 return updateRules(ruleId, rules, (rule) => ({
                     ...rule,
@@ -278,13 +280,15 @@ export function classificationVector({
  * @param {object} properties current properties of the rule that needs update
  * @param {array} rules rules of a style object
  * @param {object} layer layer configuration object
+ * @param {object} styleService style service configuration object
  * @returns {promise} return new rules with updated property and classification
  */
 export function classificationRaster({
     values,
     properties,
     rules,
-    layer
+    layer,
+    styleService
 }) {
 
     const paramsKeys = [
@@ -313,7 +317,7 @@ export function classificationRaster({
             method: params.method,
             reverse: params.reverse,
             ...rampParams
-        }))
+        }, styleService))
             .then(({ data }) => {
                 return updateRules(ruleId, rules, (rule) => ({
                     ...rule,

--- a/web/client/api/__tests__/SLDService-test.js
+++ b/web/client/api/__tests__/SLDService-test.js
@@ -304,6 +304,13 @@ describe('Test correctness of the SLDService APIs', () => {
         expect(result.indexOf('param1=value1') > 0).toBe(true);
         expect(result.indexOf('param2=value2') > 0).toBe(true);
     });
+    it('check getStyleMetadataService with static style service', () => {
+        const styleService = { baseUrl: 'http://localhost:8080/static/wms', isStatic: true };
+        const result = API.getStyleMetadataService(layer, params, styleService);
+        expect(result.indexOf('http://localhost:8080/static/rest/sldservice/mylayer/classify.json')).toBe(0);
+        expect(result.indexOf('param1=value1') > 0).toBe(true);
+        expect(result.indexOf('param2=value2') > 0).toBe(true);
+    });
     it('check getStyleParameters', () => {
         const result = API.getStyleParameters(layer, params);
         expect(result).toIncludeKey('SLD');

--- a/web/client/api/__tests__/StyleEditor-test.js
+++ b/web/client/api/__tests__/StyleEditor-test.js
@@ -33,7 +33,7 @@ describe('StyleEditor API', () => {
         });
         it('should send a classification request', (done) => {
 
-            mockAxios.onGet().reply(200, CLASSIFY_VECTOR_RESPONSE.SAMPLE1);
+            mockAxios.onGet(/geoserver/).reply(200, CLASSIFY_VECTOR_RESPONSE.SAMPLE1);
 
             const values = {
                 attribute: 'ATTRIBUTE'
@@ -66,6 +66,90 @@ describe('StyleEditor API', () => {
                 properties,
                 rules,
                 layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].classification).toEqual(
+                        [
+                            {
+                                title: ' >= 168839.0 AND <2211312.4',
+                                color: '#9e0142',
+                                type: 'Polygon',
+                                min: 168839,
+                                max: 2211312.4
+                            },
+                            {
+                                title: ' >= 2211312.4 AND <4253785.8',
+                                color: '#f98e52',
+                                type: 'Polygon',
+                                min: 2211312.4,
+                                max: 4253785.8
+                            },
+                            {
+                                title: ' >= 4253785.8 AND <6296259.2',
+                                color: '#ffffbf',
+                                type: 'Polygon',
+                                min: 4253785.8,
+                                max: 6296259.2
+                            },
+                            {
+                                title: ' >= 6296259.2 AND <8338732.6',
+                                color: '#89d0a5',
+                                type: 'Polygon',
+                                min: 6296259.2,
+                                max: 8338732.6
+                            },
+                            {
+                                title: ' >= 8338732.6 AND <=1.0381206E7',
+                                color: '#5e4fa2',
+                                type: 'Polygon',
+                                min: 8338732.6,
+                                max: 10381206
+                            }
+                        ]
+                    );
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should send a classification request with style service url when service is static', (done) => {
+
+            mockAxios.onGet(/static/).reply(200, CLASSIFY_VECTOR_RESPONSE.SAMPLE1);
+
+            const values = {
+                attribute: 'ATTRIBUTE'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                ramp: 'spectral',
+                type: 'classificationVector',
+                ...DEFAULT_CONFIG
+            };
+            const rules = [
+                {
+                    color: '#dddddd',
+                    fillOpacity: 1,
+                    kind: 'Classification',
+                    outlineColor: '#777777',
+                    outlineWidth: 1,
+                    symbolizerKind: 'Fill',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            const styleService = {baseUrl: '/static/wms', isStatic: true};
+            classificationVector({
+                values,
+                properties,
+                rules,
+                layer,
+                styleService
             }).then((newRules) => {
                 try {
                     expect(newRules[0].classification).toEqual(
@@ -609,7 +693,7 @@ describe('StyleEditor API', () => {
             setTimeout(done);
         });
         it('should send a classification request', (done) => {
-            mockAxios.onGet().reply(200, CLASSIFY_RASTER_RESPONSE);
+            mockAxios.onGet(/geoserver/).reply(200, CLASSIFY_RASTER_RESPONSE);
             const values = {
                 ramp: 'spectral'
             };
@@ -637,6 +721,79 @@ describe('StyleEditor API', () => {
                 properties,
                 rules,
                 layer
+            }).then((newRules) => {
+                try {
+                    expect(newRules[0].classification).toEqual(
+                        [
+                            {
+                                color: '#9E0142',
+                                opacity: 1,
+                                label: '0',
+                                quantity: 0
+                            },
+                            {
+                                color: '#F98E52',
+                                opacity: 1,
+                                label: '1789.75',
+                                quantity: 1789.75
+                            },
+                            {
+                                color: '#FFFFBF',
+                                opacity: 1,
+                                label: '3579.5',
+                                quantity: 3579.5
+                            },
+                            {
+                                color: '#89D0A5',
+                                opacity: 1,
+                                label: '5369.25',
+                                quantity: 5369.25
+                            },
+                            {
+                                color: '#5E4FA2',
+                                opacity: 1,
+                                label: '7159',
+                                quantity: 7159
+                            }
+                        ]
+                    );
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            });
+        });
+        it('should send a classification request with style service url when service is static', (done) => {
+            mockAxios.onGet(/static/).reply(200, CLASSIFY_RASTER_RESPONSE);
+            const values = {
+                ramp: 'spectral'
+            };
+            const properties = {
+                ruleId: 'rule0',
+                intervals: 5,
+                method: 'equalInterval',
+                reverse: false,
+                continuous: true,
+                type: 'classificationRaster'
+            };
+            const rules = [
+                {
+                    kind: 'Raster',
+                    opacity: 1,
+                    symbolizerKind: 'Raster',
+                    ...properties
+                }
+            ];
+            const layer = {
+                url: '/geoserver/wms'
+            };
+            const styleService = {baseUrl: '/static/wms', isStatic: true};
+            classificationRaster({
+                values,
+                properties,
+                rules,
+                layer,
+                styleService
             }).then((newRules) => {
                 try {
                     expect(newRules[0].classification).toEqual(

--- a/web/client/components/styleeditor/VisualStyleEditor.jsx
+++ b/web/client/components/styleeditor/VisualStyleEditor.jsx
@@ -61,6 +61,7 @@ const updateFunc = ({
     properties,
     rules,
     layer,
+    styleService,
     styleUpdateTypes = {}
 }) => {
 
@@ -81,7 +82,7 @@ const updateFunc = ({
     return new Promise((resolve) => {
         const request = properties.type && styleUpdateTypes[properties.type];
         return request
-            ? resolve(request({ values, properties, rules, layer }))
+            ? resolve(request({ values, properties, rules, layer, styleService }))
             : resolve(defaultUpdateRules());
     });
 };
@@ -145,6 +146,7 @@ function validateStyle(rules) {
  * @prop {object} error error object
  * @prop {function} getColors return colors for available ramps in classification
  * @prop {number} debounceTime debounce time for on change function, default 300
+ * @prop {object} styleService style service configuration object
  */
 function VisualStyleEditor({
     code,
@@ -165,7 +167,8 @@ function VisualStyleEditor({
     methods,
     getColors,
     styleUpdateTypes,
-    debounceTime
+    debounceTime,
+    styleService
 }) {
 
     const { symbolizerBlock, ruleBlock } = getBlocks(config);
@@ -365,6 +368,7 @@ function VisualStyleEditor({
                     properties,
                     layer,
                     rules: state.current.style.rules,
+                    styleService,
                     styleUpdateTypes
                 })
                     .then(newRules => handleUpdateStyle(newRules))

--- a/web/client/plugins/StyleEditor.jsx
+++ b/web/client/plugins/StyleEditor.jsx
@@ -103,8 +103,8 @@ class StyleEditorPanel extends React.Component {
  * @prop {array} cfg.styleService.formats supported formats, could be one of [ 'sld' ] or [ 'sld', 'css' ]
  * @prop {array} cfg.editingAllowedRoles all roles with edit permission eg: [ 'ADMIN' ], if null all roles have edit permission
  * @prop {array} cfg.enableSetDefaultStyle enable set default style functionality
- * @prop {array} cfg.editorConfig contains editor configurations
- * @prop {array} cfg.editorConfig.classification configuration of the classification symbolizer
+ * @prop {object} cfg.editorConfig contains editor configurations
+ * @prop {object} cfg.editorConfig.classification configuration of the classification symbolizer
  * For example adding default editor configuration to the classification
  * ```
  * "cfg": {

--- a/web/client/plugins/styleeditor/StyleCodeEditor.jsx
+++ b/web/client/plugins/styleeditor/StyleCodeEditor.jsx
@@ -103,7 +103,8 @@ const ConnectedVisualStyleEditor = connect(
             fonts: styleService.fonts || [],
             methods: (geometryType === 'raster'
                 ? styleService?.classificationMethods?.raster
-                : styleService?.classificationMethods?.vector) || SLDService.methods
+                : styleService?.classificationMethods?.vector) || SLDService.methods,
+            styleService: { baseUrl: styleService?.baseUrl, isStatic: styleService?.isStatic }
         })
     ),
     {


### PR DESCRIPTION
## Description
This PR add possibility of using style service base url for requesting style classification when style service is static

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#5619 

**What is the new behavior?**
- Uses style service base url for requesting classification rules instead of layer url when style service is static

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
