### PR TITLE
backport_2021.01.xx - #6870 The Identify panel opens when it shouldn't in one use case (#6880)

### DIFF
--- a/web/client/components/misc/FeatureInfoTriggerSelector.jsx
+++ b/web/client/components/misc/FeatureInfoTriggerSelector.jsx
@@ -17,14 +17,22 @@ class FeatureInfoTriggerSelector extends React.Component {
     static propTypes = {
         trigger: PropTypes.string,
         onSetMapTrigger: PropTypes.func,
+        onPurgeMapInfoResults: PropTypes.func,
         hoverEnabled: PropTypes.bool
     }
     static defaultProps = {
-        hoverEnabled: true
+        hoverEnabled: true,
+        onSetMapTrigger: () => {},
+        onPurgeMapInfoResults: () => {}
     }
 
+    /* #6870 in the following, we clear results because when passing from hover to click
+        the identify panel gets opened
+        (because it has some responses in the current state) while it should not
+    */
     onChange = (event) => {
         this.props.onSetMapTrigger(event.target.value);
+        this.props.onPurgeMapInfoResults();
     }
 
     render() {

--- a/web/client/components/misc/FeatureInfoTriggerSelector.jsx
+++ b/web/client/components/misc/FeatureInfoTriggerSelector.jsx
@@ -18,12 +18,14 @@ class FeatureInfoTriggerSelector extends React.Component {
         trigger: PropTypes.string,
         onSetMapTrigger: PropTypes.func,
         onPurgeMapInfoResults: PropTypes.func,
+        onHideMapinfoMarker: PropTypes.func,
         hoverEnabled: PropTypes.bool
     }
     static defaultProps = {
         hoverEnabled: true,
         onSetMapTrigger: () => {},
-        onPurgeMapInfoResults: () => {}
+        onPurgeMapInfoResults: () => {},
+        onHideMapinfoMarker: () => {}
     }
 
     /* #6870 in the following, we clear results because when passing from hover to click
@@ -33,6 +35,7 @@ class FeatureInfoTriggerSelector extends React.Component {
     onChange = (event) => {
         this.props.onSetMapTrigger(event.target.value);
         this.props.onPurgeMapInfoResults();
+        this.props.onHideMapinfoMarker();
     }
 
     render() {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -270,7 +270,8 @@ const FeatureInfoTriggerSelector = connect((state) => ({
     hoverEnabled: hoverEnabledSelector(state)
 }), {
     onSetMapTrigger: setMapTrigger,
-    onPurgeMapInfoResults: purgeMapInfoResults
+    onPurgeMapInfoResults: purgeMapInfoResults,
+    onHideMapinfoMarker: hideMapinfoMarker
 })(FeatureInfoTriggerSelectorComp);
 
 export default {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -269,7 +269,8 @@ const FeatureInfoTriggerSelector = connect((state) => ({
     trigger: isMouseMoveIdentifyActiveSelector(state) ? 'hover' : 'click',
     hoverEnabled: hoverEnabledSelector(state)
 }), {
-    onSetMapTrigger: setMapTrigger
+    onSetMapTrigger: setMapTrigger,
+    onPurgeMapInfoResults: purgeMapInfoResults
 })(FeatureInfoTriggerSelectorComp);
 
 export default {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport_2021.01.xx - #6870 The Identify panel opens when it shouldn't in one use case (#6880)