### PR TITLE
[Backport Mapstore2] #6911: Share coordinates fix (#6912)

### DIFF
--- a/web/client/actions/__tests__/search-test.js
+++ b/web/client/actions/__tests__/search-test.js
@@ -32,7 +32,9 @@ import {
     selectSearchItem,
     selectNestedService,
     cancelSelectedItem,
-    updateResultsStyle
+    updateResultsStyle,
+    hideMarker,
+    HIDE_MARKER
 } from '../search';
 
 describe('Test correctness of the search actions', () => {
@@ -131,5 +133,10 @@ describe('Test correctness of the search actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(CHANGE_FORMAT);
         expect(retval.format).toEqual(format);
+    });
+    it('hide marker', () => {
+        const retval = hideMarker();
+        expect(retval).toExist();
+        expect(retval.type).toBe(HIDE_MARKER);
     });
 });

--- a/web/client/actions/search.js
+++ b/web/client/actions/search.js
@@ -25,6 +25,7 @@ export const CHANGE_SEARCH_TOOL = 'CHANGE_SEARCH_TOOL';
 export const ZOOM_ADD_POINT = 'SEARCH:ZOOM_ADD_POINT';
 export const CHANGE_FORMAT = 'SEARCH:CHANGE_FORMAT';
 export const CHANGE_COORD = 'SEARCH:CHANGE_COORD';
+export const HIDE_MARKER = 'SEARCH:HIDE_MARKER';
 
 /**
  * change the format for coordinate editor tool
@@ -163,6 +164,15 @@ export function addMarker(itemPosition, itemText) {
     };
 }
 
+/**
+ * Hide a marker
+ * @memberof actions.search
+ */
+export function hideMarker() {
+    return {
+        type: HIDE_MARKER
+    };
+}
 /**
  * perform a text search
  * @memberof actions.search

--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -28,6 +28,7 @@ import {
 import Message from '../../components/I18N/Message';
 import { join, isNil, isEqual, inRange } from 'lodash';
 import { removeQueryFromUrl, getSharedGeostoryUrl, CENTERANDZOOM, BBOX, MARKERANDZOOM, SHARE_TABS } from '../../utils/ShareUtils';
+import { getLonLatFromPoint } from '../../utils/CoordinatesUtils';
 import SwitchPanel from '../misc/switch/SwitchPanel';
 import Editor from '../data/identify/coordinates/Editor';
 import {set} from '../../utils/ImmutableUtils';
@@ -172,26 +173,6 @@ class SharePanel extends React.Component {
         });
     }
 
-    /**
-     * Generates longitude and latitude value from the point prop
-     * @param {object} point with latlng data
-     * @return {array} corrected longitude and latitude
-     */
-    getLonLat = (point) =>{
-        const latlng = point && point.latlng || null;
-        let lngCorrected = null;
-        /* lngCorrected is the converted longitude in order to have the value between
-             * the range (-180 / +180).
-             * Precision has to be >= than the coordinate editor precision
-             * especially in the case of aeronautical degree editor which is 12
-        */
-        if (latlng) {
-            lngCorrected = latlng && Math.round(latlng.lng * 100000000000000000) / 100000000000000000;
-            lngCorrected = lngCorrected - 360 * Math.floor(lngCorrected / 360 + 0.5);
-        }
-        return  [lngCorrected, latlng && latlng.lat];
-    }
-
     getShareUrl = () => {
         const { settings, advancedSettings } = this.props;
         const shouldRemoveSectionId = !settings.showSectionId && advancedSettings && advancedSettings.sectionId;
@@ -261,7 +242,7 @@ class SharePanel extends React.Component {
     }
 
     getCoordinates = (props) => {
-        const lonLat = this.getLonLat(props.point);
+        const lonLat = getLonLatFromPoint(props.point);
         const {x, y} = props.center || {x: "", y: ""};
         const isValidLatLng = lonLat.filter(coord=> coord !== null);
         return isValidLatLng.length > 0 ? lonLat : [x, y];

--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -128,6 +128,27 @@ describe('queryparam epics', () => {
                 done();
             }, state);
     });
+    it('test disableGFIForShareEpic, on share panel open with mapInfo enabled and mapInfo open', (done)=>{
+
+        const NUMBER_OF_ACTIONS = 2;
+        const state = {controls: {share: {enabled: true}}, mapInfo: {enabled: true, clickPoint: {latlng: {lat: 40, lng: -80}}, requests: ["test"]}};
+
+        testEpic(
+            addTimeoutEpic(disableGFIForShareEpic, 10),
+            NUMBER_OF_ACTIONS, [
+                toggleControl('share', null)
+            ], actions => {
+                expect(actions.length).toBe(NUMBER_OF_ACTIONS);
+                try {
+                    expect(actions[0].type).toBe("TOGGLE_MAPINFO_STATE");
+                    expect(actions[1].type).toBe("TEXT_SEARCH_ADD_MARKER");
+                    expect(actions[1].markerPosition).toEqual({"latlng": {"lat": 40, "lng": -80}});
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }, state);
+    });
     it('test disableGFIForShareEpic, on share panel close', (done)=>{
         const state = {controls: {share: { enabled: false }}};
         const NUMBER_OF_ACTIONS = 4;

--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -22,7 +22,7 @@ import {
 } from '../actions/mapInfo';
 
 import { SHOW_SETTINGS, HIDE_SETTINGS } from '../actions/layers';
-import { isMapInfoOpen } from '../selectors/mapInfo';
+import {isMapInfoOpen, mapInfoEnabledSelector} from '../selectors/mapInfo';
 import { showCoordinateEditorSelector } from '../selectors/controls';
 import ConfigUtils from '../utils/ConfigUtils';
 import { mapInfoDetailsSettingsFromIdSelector, isMouseMoveIdentifyActiveSelector } from '../selectors/map';
@@ -108,7 +108,7 @@ export const updateMapLayoutEpic = (action$, store) =>
                 get(state, "controls.userExtensions.enabled") && { right: mapLayout.right.md } || null,
                 get(state, "controls.mapTemplates.enabled") && { right: mapLayout.right.md } || null,
                 get(state, "controls.mapCatalog.enabled") && { right: mapLayout.right.md } || null,
-                get(state, "mapInfo.enabled") && isMapInfoOpen(state) && !isMouseMoveIdentifyActiveSelector(state) && {right: mapLayout.right.md} || null
+                mapInfoEnabledSelector(state) && isMapInfoOpen(state) && !isMouseMoveIdentifyActiveSelector(state) && {right: mapLayout.right.md} || null
             ].filter(panel => panel)) || {right: 0};
 
             const dockSize = getDockSize(state) * 100;

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -13,15 +13,17 @@ import url from 'url';
 
 import { CHANGE_MAP_VIEW, zoomToExtent, ZOOM_TO_EXTENT, CLICK_ON_MAP, changeMapView } from '../actions/map';
 import { ADD_LAYERS_FROM_CATALOGS } from '../actions/catalog';
-import { SEARCH_LAYER_WITH_FILTER, addMarker, resetSearch } from '../actions/search';
+import { SEARCH_LAYER_WITH_FILTER, addMarker, resetSearch, hideMarker } from '../actions/search';
 import { TOGGLE_CONTROL, setControlProperty } from '../actions/controls';
 import { warning } from '../actions/notifications';
 
-import { isValidExtent } from '../utils/CoordinatesUtils';
+import {getLonLatFromPoint, isValidExtent} from '../utils/CoordinatesUtils';
 import { getConfigProp, getCenter } from '../utils/ConfigUtils';
 import { hideMapinfoMarker, purgeMapInfoResults, toggleMapInfoState } from "../actions/mapInfo";
-import {getBbox} from "../utils/MapUtils";
-import {mapSelector} from '../selectors/map';
+import { getBbox } from "../utils/MapUtils";
+import { mapSelector } from '../selectors/map';
+import { clickPointSelector, isMapInfoOpen, mapInfoEnabledSelector } from '../selectors/mapInfo';
+import { shareSelector } from "../selectors/controls";
 
 /*
 it maps params key to function.
@@ -164,16 +166,30 @@ export const disableGFIForShareEpic = (action$, { getState = () => { } }) =>
     action$.ofType(TOGGLE_CONTROL)
         .filter(({control}) => control === "share")
         .switchMap(() => {
-            const shareEnabled = get(getState(), 'controls.share.enabled');
-            const mapInfoEnabled = get(getState(), 'mapInfo.enabled');
+            const state = getState();
+            const shareEnabled = shareSelector(state);
+            const mapInfoEnabled = mapInfoEnabledSelector(state);
             const shareParams = {bboxEnabled: false, centerAndZoomEnabled: false};
             if (!isUndefined(shareEnabled) && shareEnabled) {
-                return mapInfoEnabled ? Rx.Observable.of(toggleMapInfoState()) : Rx.Observable.empty();
+                let $observable = Rx.Observable.empty();
+                if (mapInfoEnabled) {
+                    let actions = [toggleMapInfoState()];
+                    if (isMapInfoOpen(state)) {
+                        const clickedPoint = clickPointSelector(state);
+                        const [lng, lat] = getLonLatFromPoint(clickedPoint);
+                        const newPoint = {latlng: {lat, lng}};
+                        actions = actions.concat(addMarker(newPoint)); // Retain marker position set by GFI for Share position marker
+                    }
+                    $observable = Rx.Observable.from(actions);
+                }
+                return $observable;
             }
             return Rx.Observable.of(hideMapinfoMarker(),
                 purgeMapInfoResults(),
                 toggleMapInfoState(),
-                setControlProperty("share", "settings", shareParams));
+                setControlProperty("share", "settings", shareParams),
+                hideMarker()
+            );
         });
 
 export default {

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -63,7 +63,8 @@ import {
     responsesSelector,
     showEmptyMessageGFISelector,
     validResponsesSelector,
-    hoverEnabledSelector
+    hoverEnabledSelector,
+    mapInfoEnabledSelector
 } from '../selectors/mapInfo';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
 import { isCesium, mapTypeSelector } from '../selectors/maptype';
@@ -74,7 +75,7 @@ import getToolButtons from './identify/toolButtons';
 import Message from './locale/Message';
 
 const selector = createStructuredSelector({
-    enabled: (state) => state.mapInfo && state.mapInfo.enabled || state.controls && state.controls.info && state.controls.info.enabled || false,
+    enabled: (state) => mapInfoEnabledSelector(state) || state.controls && state.controls.info && state.controls.info.enabled || false,
     responses: responsesSelector,
     validResponses: validResponsesSelector,
     requests: requestsSelector,

--- a/web/client/plugins/Share.jsx
+++ b/web/client/plugins/Share.jsx
@@ -23,9 +23,10 @@ import { mapSelector } from '../selectors/map';
 import { currentContextSelector } from '../selectors/context';
 import { get } from 'lodash';
 import controls from '../reducers/controls';
-import {featureInfoClick, changeFormat, hideMapinfoMarker} from '../actions/mapInfo';
-import { addMarker } from '../actions/search';
+import { changeFormat } from '../actions/mapInfo';
+import { addMarker, hideMarker } from '../actions/search';
 import { updateUrlOnScrollSelector } from '../selectors/geostory';
+import { shareSelector } from "../selectors/controls";
 /**
  * Share Plugin allows to share the current URL (location.href) in some different ways.
  * You can share it on socials networks(facebook,twitter,google+,linkedIn)
@@ -60,7 +61,7 @@ import { updateUrlOnScrollSelector } from '../selectors/geostory';
  */
 
 const Share = connect(createSelector([
-    state => state.controls && state.controls.share && state.controls.share.enabled,
+    shareSelector,
     versionSelector,
     mapSelector,
     currentContextSelector,
@@ -90,9 +91,8 @@ const Share = connect(createSelector([
     point,
     isScrollPosition})), {
     onClose: toggleControl.bind(null, 'share', null),
-    hideMarker: hideMapinfoMarker,
+    hideMarker,
     onUpdateSettings: setControlProperty.bind(null, 'share', 'settings'),
-    onSubmitClickPoint: featureInfoClick,
     onChangeFormat: changeFormat,
     addMarker: addMarker
 })(SharePanel);

--- a/web/client/plugins/__tests__/Share-test.jsx
+++ b/web/client/plugins/__tests__/Share-test.jsx
@@ -15,6 +15,8 @@ import { getPluginForTest } from './pluginsTestUtils';
 import ReactTestUtils from 'react-dom/test-utils';
 import { TOGGLE_CONTROL } from '../../actions/controls';
 import { PURGE_MAPINFO_RESULTS, HIDE_MAPINFO_MARKER } from '../../actions/mapInfo';
+import mapInfo from '../../reducers/mapInfo';
+import search from '../../reducers/search';
 
 describe('Share Plugin', () => {
     beforeEach(() => {
@@ -438,5 +440,47 @@ describe('Share Plugin', () => {
         expect(toNumber(inputLinks[2].value)).toBe(-89.01);
         done();
     });
+    it('test Share plugin with markerAndZoom', () => {
+        let storeState = {
+            map: {
+                center: {
+                    crs: "EPSG:4326",
+                    x: -86.25,
+                    y: 38.07
+                },
+                zoom: 5
+            },
+            controls: {
+                share: {
+                    enabled: true,
+                    settings: {
+                        centerAndZoomEnabled: true
+                    }
+                }
+            },
+            search: {
+                markerPosition: {latlng: {lat: 40, lng: -80}}
+            }
+        };
+        const props = {
+            advancedSettings: {
+                centerAndZoom: true,
+                defaultEnabled: "markerAndZoom"
+            }
+        };
+        const {Plugin} = getPluginForTest({...SharePlugin, reducers: {
+            mapInfo,
+            search
+        }}, storeState);
+        ReactDOM.render(<Plugin {...props}/>, document.getElementById("container"));
 
+        expect(document.getElementById('share-panel-dialog')).toExist();
+        let inputLink = document.querySelectorAll('input.form-control');
+        let lat = inputLink[1];
+        let lon = inputLink[2];
+        let zoom = inputLink[3];
+        expect(toNumber(lat.value)).toBe(40);
+        expect(toNumber(lon.value)).toBe(-80);
+        expect(toNumber(zoom.value)).toBe(5);
+    });
 });

--- a/web/client/reducers/__tests__/search-test.js
+++ b/web/client/reducers/__tests__/search-test.js
@@ -20,11 +20,11 @@ import {
     resetSearch,
     changeFormat,
     changeCoord,
-    changeActiveSearchTool
+    changeActiveSearchTool,
+    hideMarker
 } from '../../actions/search';
 
 import { resetControls } from '../../actions/controls';
-import { hideMapinfoMarker } from '../../actions/mapInfo';
 
 describe('Test the search reducer', () => {
     it('search results loading', () => {
@@ -186,10 +186,10 @@ describe('Test the search reducer', () => {
         expect(state).toBe(null);
     });
 
-    it('HIDE INFO MARKER', () => {
+    it('HIDE MARKER', () => {
         const state = search({markerPosition: {
             latlng: {lat: 0, lng: 0}
-        }}, hideMapinfoMarker());
+        }}, hideMarker());
         expect(JSON.stringify(state.markerPosition)).toBe(JSON.stringify({}));
     });
 });

--- a/web/client/reducers/search.js
+++ b/web/client/reducers/search.js
@@ -20,11 +20,11 @@ import {
     UPDATE_RESULTS_STYLE,
     CHANGE_SEARCH_TOOL,
     CHANGE_FORMAT,
-    CHANGE_COORD
+    CHANGE_COORD,
+    HIDE_MARKER
 } from '../actions/search';
 
 import { RESET_CONTROLS } from '../actions/controls';
-import { HIDE_MAPINFO_MARKER } from '../actions/mapInfo';
 import assign from 'object-assign';
 /**
  * Manages the state of the map search with it's results
@@ -132,7 +132,7 @@ function search(state = null, action) {
         return {...state, format: action.format};
     case CHANGE_COORD:
         return {...state, coordinate: {...state.coordinate, [action.coord]: action.val}};
-    case HIDE_MAPINFO_MARKER:
+    case HIDE_MARKER:
         return assign({}, state, {markerPosition: state?.markerPosition?.latlng ? {} : state?.markerPosition});
     default:
         return state;

--- a/web/client/selectors/__tests__/controls-test.js
+++ b/web/client/selectors/__tests__/controls-test.js
@@ -18,7 +18,8 @@ import {
     originalSettingsSelector,
     activeTabSettingsSelector,
     drawerEnabledControlSelector,
-    showCoordinateEditorSelector
+    showCoordinateEditorSelector,
+    shareSelector
 } from '../controls';
 
 const state = {
@@ -114,6 +115,11 @@ describe('Test controls selectors', () => {
     });
     it('test showCoordinateEditorSelector', () => {
         const retVal = showCoordinateEditorSelector({controls: {measure: {showCoordinateEditor: true}}});
+        expect(retVal).toExist();
+        expect(retVal).toBe(true);
+    });
+    it('test shareSelector', () => {
+        const retVal = shareSelector({controls: {share: {enabled: true}}});
         expect(retVal).toExist();
         expect(retVal).toBe(true);
     });

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -27,7 +27,9 @@ import {
     overrideParamsSelector,
     mapTriggerSelector,
     hoverEnabledSelector,
-    currentFeatureSelector
+    currentFeatureSelector,
+    mapInfoEnabledSelector,
+    mapInfoDisabledSelector
 } from '../mapInfo';
 
 const QUERY_PARAMS = {
@@ -375,5 +377,15 @@ describe('Test mapinfo selectors', () => {
         const [feature] = currentFeatureSelector(state);
         expect(feature).toBeTruthy();
         expect(feature.id).toBe('poi.4');
+    });
+    it('test mapInfoEnabledSelector ', () => {
+        const state = { mapInfo: { enabled: true}};
+        const mapInfoEnabled = mapInfoEnabledSelector(state);
+        expect(mapInfoEnabled).toBeTruthy();
+    });
+    it('test mapInfoDisabledSelector ', () => {
+        const state = { mapInfo: { enabled: true}};
+        const mapInfoEnabled = mapInfoDisabledSelector(state);
+        expect(mapInfoEnabled).toBeFalsy();
     });
 });

--- a/web/client/selectors/controls.js
+++ b/web/client/selectors/controls.js
@@ -18,7 +18,7 @@ export const createControlEnabledSelector = name => createControlVariableSelecto
  * @return {boolean} the showCoordinateEditor in the state
  */
 export const showCoordinateEditorSelector = (state) => get(state, "controls.measure.showCoordinateEditor");
-
+export const shareSelector = (state) => get(state, "controls.share.enabled");
 export const measureSelector = (state) => get(state, "controls.measure.enabled");
 export const queryPanelSelector = (state) => get(state, "controls.queryPanel.enabled");
 export const printSelector = (state) => get(state, "controls.print.enabled");

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -67,7 +67,8 @@ export const drawSupportActiveSelector = (state) => {
     return drawStatus && drawStatus !== 'clean' && drawStatus !== 'stop';
 };
 export const annotationsEditingSelector = (state) => get(state, "annotations.editing");
-export const mapInfoDisabledSelector = (state) => !get(state, "mapInfo.enabled", false);
+export const mapInfoEnabledSelector = (state) => get(state, "mapInfo.enabled", false);
+export const mapInfoDisabledSelector = (state) => !mapInfoEnabledSelector(state);
 
 /**
  * selects stopGetFeatureInfo from state

--- a/web/client/utils/CoordinatesUtils.js
+++ b/web/client/utils/CoordinatesUtils.js
@@ -1065,6 +1065,26 @@ export const checkIfLayerFitsExtentForProjection = (layer = {}) => {
     return ((minx >= crsMinX) && (minY >= crsMinY) && (maxX <= crsMaxX) && (maxY <= crsMaxY));
 };
 
+/**
+ * Generates longitude and latitude value from the point
+ * @param {object} point with latlng data
+ * @return {array} corrected longitude and latitude
+ */
+export const getLonLatFromPoint = (point) => {
+    const latlng = point && point.latlng || null;
+    let lngCorrected = null;
+    /* lngCorrected is the converted longitude in order to have the value between
+         * the range (-180 / +180).
+         * Precision has to be >= than the coordinate editor precision
+         * especially in the case of aeronautical degree editor which is 12
+    */
+    if (latlng) {
+        lngCorrected = latlng && Math.round(latlng.lng * 100000000000000000) / 100000000000000000;
+        lngCorrected = lngCorrected - 360 * Math.floor(lngCorrected / 360 + 0.5);
+    }
+    return [lngCorrected, latlng && latlng.lat];
+};
+
 CoordinatesUtils = {
     setCrsLabels,
     getUnits,
@@ -1119,7 +1139,7 @@ CoordinatesUtils = {
     makeNumericEPSG,
     makeBboxFromOWS,
     getPolygonFromCircle,
-    checkIfLayerFitsExtentForProjection
-
+    checkIfLayerFitsExtentForProjection,
+    getLonLatFromPoint
 };
 export default CoordinatesUtils;

--- a/web/client/utils/__tests__/CoordinatesUtils-test.js
+++ b/web/client/utils/__tests__/CoordinatesUtils-test.js
@@ -38,7 +38,8 @@ import {
     getPolygonFromCircle,
     getProjections,
     getExtentForProjection,
-    checkIfLayerFitsExtentForProjection
+    checkIfLayerFitsExtentForProjection,
+    getLonLatFromPoint
 } from '../CoordinatesUtils';
 import { setConfigProp, removeConfigProp } from '../ConfigUtils';
 import Proj4js from 'proj4';
@@ -923,5 +924,18 @@ describe('CoordinatesUtils', () => {
         };
         const canFitWithBounds = checkIfLayerFitsExtentForProjection({name: "test", ...geoJson});
         expect(canFitWithBounds).toBe(true);
+    });
+    it('test getLonLatFromPoint', ()=> {
+        const [lon, lat] = getLonLatFromPoint({latlng: {lat: 40, lng: -80}});
+        expect(lat).toBe(40);
+        expect(lon).toBe(-80);
+    });
+    it('test getLonLatFromPoint with lng > +-180', ()=> {
+        let [lon, lat] = getLonLatFromPoint({latlng: {lat: 40, lng: -280}});
+        expect(lat).toBe(40);
+        expect(lon).toBe(80);
+        [lon, lat] = getLonLatFromPoint({latlng: {lat: 40, lng: 280}});
+        expect(lat).toBe(40);
+        expect(lon).toBe(-80);
     });
 });


### PR DESCRIPTION
## Description
This PR is **backport** that fixes Share plugin always places marker in the center of the map when defaultEnabled prop is `markerAndZoom` and opened from floating toolbar which point marked by GFI

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#6911 

**What is the new behavior?**
- Share function will retain the position of marker of GFI when opened from toolbar (floating toolbar)
- Share function will behave as is for other scenarios
Config for share plugin
```
{
  "name": "Share",
  "cfg": {
    "advancedSettings": {
      "bbox": true,
      "centerAndZoom": true,
      "defaultEnabled": "markerAndZoom"
    }
  },
  "override": {
    "Toolbar": {
      "priority": 1
    },
    "BurgerMenu": {
      "priority": 1
    }
  }
}
```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Issue ref: https://github.com/geosolutions-it/austrocontrol-C125/issues/287