### PR TITLE
6938: Add toolbar icons are not visible when a GeoStory is empty

### DIFF
--- a/web/client/components/geostory/common/ToolbarPopover.jsx
+++ b/web/client/components/geostory/common/ToolbarPopover.jsx
@@ -35,7 +35,7 @@ class ToolbarPopover extends React.Component {
     getContainerNode = () => {
         // The overlay contain should always have a target root container to ensure all mapstore2 styles can be applied.
         // The parentNode is the default and fallback is got from the themePrefix
-        return this.parentNode || document.querySelector('.' + (ConfigUtils.getConfigProp('themePrefix') || 'ms2') + " > div") || document.body
+        return this.parentNode || document.querySelector('.' + (ConfigUtils.getConfigProp('themePrefix') || 'ms2') + " > div") || document.body;
     }
 
     render() {

--- a/web/client/components/geostory/common/ToolbarPopover.jsx
+++ b/web/client/components/geostory/common/ToolbarPopover.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
+import ConfigUtils from '../../../utils/ConfigUtils';
 
 /**
  * Toolbar for AddBar.
@@ -31,6 +32,12 @@ class ToolbarPopover extends React.Component {
         id: ''
     };
 
+    getContainerNode = () => {
+        // The overlay contain should always have a target root container to ensure all mapstore2 styles can be applied.
+        // The parentNode is the default and fallback is got from the themePrefix
+        return this.parentNode || document.querySelector('.' + (ConfigUtils.getConfigProp('themePrefix') || 'ms2') + " > div") || document.body
+    }
+
     render() {
         return (
             <div
@@ -39,7 +46,7 @@ class ToolbarPopover extends React.Component {
                 <OverlayTrigger
                     ref={trigger => { this.trigger = trigger; }}
                     trigger={['click']}
-                    container={this.parentNode}
+                    container={this.getContainerNode()}
                     placement={this.props.placement}
                     rootClose
                     overlay={


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
icons of the add toolbar are not visible
#6938 

**What is the new behavior?**
icons are visible and aligned on the plus button

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
