### PR TITLE
#6941 Fix issue with context manager and user session

### DIFF
--- a/web/client/actions/config.js
+++ b/web/client/actions/config.js
@@ -24,6 +24,7 @@ export const RESET_MAP_SAVE_ERROR = 'MAP:RESET_MAP_SAVE_ERROR';
  * @param {object} conf map config
  * @param {number} mapId map resource id
  * @param {boolean} zoomToExtent if provided, zooms to this extent after the map is configured
+ * @memberof actions.config
  */
 export function configureMap(conf, mapId, zoomToExtent) {
     return {
@@ -52,12 +53,13 @@ export function loadNewMap(configName, contextId) {
 }
 
 /**
- * Loads map configuration
+ * Loads map configuration for passed `configName` and `mapId`.
  * @param {string} configName map config url
  * @param {number} mapId resource id of the map on a server
  * @param {object} config full config, overrides configName if not null or undefined
  * @param {object} mapInfo map info override
- * @param {object} overrideConfig config override
+ * @param {object} overrideConfig config override, to provide overrides to apply to the configuration. Use an empty object`{}` to skip session loading.
+ * @memberof actions.config
  */
 export function loadMapConfig(configName, mapId, config, mapInfo, overrideConfig) {
     return {

--- a/web/client/epics/__tests__/config-test.js
+++ b/web/client/epics/__tests__/config-test.js
@@ -115,6 +115,34 @@ describe('config epics', () => {
                 }
             );
         });
+        // this option is used by contexts (for loading their own session) and for context-manager (empty object, to not use a session at all)
+        it('don\'t use the user session if the localConfig.json includes it\'s own overrides', (done) => {
+            ConfigUtils.setConfigProp("userSessions", {
+                enabled: true
+            });
+            mockAxios.onGet("/base/web/client/test-resources/testConfig.json").reply(() => ([ 200, {} ]));
+            mockAxios.onGet("/base/web/client/test-resources/testConfig.json").reply(() => ([ 200, {} ]));
+            const checkActions = ([a, b, c]) => {
+                expect(a).toExist();
+                expect(a.type).toNotEqual(LOAD_USER_SESSION);
+                expect(b.type).toNotEqual(LOAD_USER_SESSION);
+                expect(c.type).toNotEqual(LOAD_USER_SESSION);
+                done();
+            };
+            testEpic(loadMapConfigAndConfigureMap,
+                3,
+                [loadMapConfig('base/web/client/test-resources/testConfig.json', 1398, undefined, undefined, {})],
+                checkActions,
+                {
+                    security: {
+                        user: {
+                            role: "ADMIN",
+                            name: "Saitama"
+                        }
+                    }
+                }
+            );
+        });
         it('does not load a missing configuration file', (done) => {
             mockAxios.onGet("missingConfig.json").reply(() => ([ 404, {} ]));
             const checkActions = ([a]) => {

--- a/web/client/epics/__tests__/contextcreator-test.js
+++ b/web/client/epics/__tests__/contextcreator-test.js
@@ -18,7 +18,8 @@ import {
     saveTemplateEpic,
     saveContextResource,
     checkIfContextExists,
-    editTemplateEpic
+    editTemplateEpic,
+    mapViewerLoadEpic
 } from '../contextcreator';
 import {
     editPlugin,
@@ -31,6 +32,7 @@ import {
     saveTemplate,
     saveNewContext,
     editTemplate,
+    mapViewerLoad,
     SET_EDITED_PLUGIN,
     SET_EDITED_CFG,
     SET_CFG_ERROR,
@@ -51,6 +53,8 @@ import {
     SET_PARSED_TEMPLATE,
     SET_FILE_DROP_STATUS
 } from '../../actions/contextcreator';
+import {INIT_MAP} from '../../actions/map';
+import {LOAD_MAP_CONFIG} from '../../actions/config';
 import {
     SHOW_NOTIFICATION
 } from '../../actions/notifications';
@@ -941,5 +945,13 @@ describe('contextcreator epics', () => {
                 }
             }
         }, done);
+    });
+    it('mapViewerLoadEpic loads a map with empty context, to skip session', (done) => {
+        testEpic(mapViewerLoadEpic, 2, mapViewerLoad(), ([a, b]) => {
+            expect(a.type).toEqual(INIT_MAP);
+            expect(b.type).toEqual(LOAD_MAP_CONFIG);
+            expect(b.overrideConfig).toEqual({});
+            done();
+        });
     });
 });

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -108,6 +108,12 @@ const mapFlowWithOverride = (configName, mapId, config, mapInfo, state, override
         .catch((e) => Observable.of(configureError(e, mapId)));
 };
 
+/**
+ * Intercepts the LOAD_MAP_CONFIG action and loads the Map configuration for the given configName and mapId.
+ * This epic loads also the user session, if enabled. The session load is skipped if `overrideConfig` is passed (e.g. for context loading it is delegated to it)
+ * Hint: Use `overrideConfig={}` in the action to skip the session loading at all.
+ * @memberof epics.config
+ */
 export const loadMapConfigAndConfigureMap = (action$, store) =>
     action$.ofType(LOAD_MAP_CONFIG)
         .switchMap(({configName, mapId, config, mapInfo, overrideConfig}) => {

--- a/web/client/epics/config.js
+++ b/web/client/epics/config.js
@@ -55,6 +55,7 @@ export const loadNewMapEpic = (action$) =>
  * @param {Object} overrideConfig override object of the given or loaded config, allows to apply a
  * partial override of the main configuration (e.g. for sessions management)
  * @returns {Observable} map configuration flow
+ * @ignore
  */
 const mapFlowWithOverride = (configName, mapId, config, mapInfo, state, overrideConfig = {}) => {
     // delay here is to postpone map load to ensure that

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -492,7 +492,7 @@ export const mapViewerLoadEpic = (action$, store) => action$
             Rx.Observable.merge(
                 Rx.Observable.of(
                     initMap(true),
-                    loadMapConfig(configUrl, null, cloneDeep(mapConfig)),
+                    loadMapConfig(configUrl, null, cloneDeep(mapConfig), undefined, {}),
                     mapViewerLoaded(true)
                 )
             );


### PR DESCRIPTION
## Description
In order to skip loading of user session when using the context-manager, I passed an empty object to the context load.
This prevent the loading of sessions. 
I also added documentation to suggest this.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6941

**What is the new behavior?**
Context Manager map viewer doesn't use the session anymore.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
