### PR TITLE
#6951: Custom option in label property of Text Symbolizer freezes the application

### DIFF
--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -6,13 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useState, useEffect } from 'react';
-import { FormGroup, FormControl as FormControlRB, Glyphicon } from 'react-bootstrap';
+import React, { useRef, useState } from 'react';
+import { FormGroup, FormControl as FormControlRB } from 'react-bootstrap';
 import isObject from 'lodash/isObject';
 import omit from 'lodash/omit';
 import isNil from 'lodash/isNil';
 import isNaN from 'lodash/isNaN';
-import castArray from 'lodash/castArray';
 import Toolbar from '../misc/toolbar/Toolbar';
 import ColorSelector from '../style/ColorSelector';
 import Slider from '../misc/Slider';
@@ -20,17 +19,14 @@ import ColorRamp from './ColorRamp';
 import DashArray from '../style/vector/DashArray';
 import ThemaClassesEditor from '../style/ThemaClassesEditor';
 import Message from '../I18N/Message';
-import Select from 'react-select';
 import localizedProps from '../misc/enhancers/localizedProps';
 import PropertyField from './PropertyField';
 import MarkSelector from './MarkSelector';
 import Band from './Band';
 import IconInput from './IconInput';
+import SelectInput from './SelectInput';
 
 const FormControl = localizedProps('placeholder')(FormControlRB);
-const ReactSelect = localizedProps(['placeholder', 'noResultsText'])(Select);
-
-const ReactSelectCreatable = localizedProps(['placeholder', 'noResultsText'])(Select.Creatable);
 
 export const fields = {
     color: ({
@@ -190,88 +186,23 @@ export const fields = {
             </PropertyField>
         );
     },
-    select: ({
-        label,
-        value,
-        config: {
-            getOptions = () => [],
-            selectProps = {},
-            isValid
-        },
-        onChange,
-        disabled,
-        visible = true,
-        ...props
-    }) => {
-        if (!visible) return null;
+    select: (props) => {
         const {
-            creatable,
-            clearable = false,
-            multi
-        } = selectProps;
-
-        function updateOptions(options = [], newValue) {
-            const optionsValues = options.map(option => option.value);
-            const isMissing = newValue?.value && optionsValues.indexOf(newValue.value) === -1;
-            return isMissing
-                ? [ newValue, ...options]
-                : options;
-        }
-
-        function initOptions(options) {
-            if (!value) {
-                return options;
-            }
-            // we get an array when using some properties
-            // eg. font-family
-            const values = castArray(value);
-            return values
-                .map(entry => ({ value: entry, label: entry }))
-                .reduce(updateOptions, options);
-        }
-
-        const options = getOptions(props);
-
-        const [newOptions, setNewOptions] = useState(initOptions(options));
-        useEffect(() => {
-            setNewOptions(initOptions(options));
-            // we should compare the previous and new options inside the dependencies
-            // we could try the stringify for now because we have a usually small and constant array
-            // this is to avoid infinite loop inside the style editor
-        }, [JSON.stringify(options)]);
-
-        const SelectInput = creatable
-            ? ReactSelectCreatable
-            : ReactSelect;
+            label,
+            value,
+            config: {
+                isValid
+            },
+            visible = true
+        } = props;
+        if (!visible) return null;
         const valid = !isValid || isValid({ value });
         return (
             <PropertyField
                 label={label}
                 invalid={!valid}>
                 <SelectInput
-                    disabled={disabled}
-                    clearable={clearable}
-                    placeholder="styleeditor.selectPlaceholder"
-                    noResultsText="styleeditor.noResultsSelectInput"
-                    {...selectProps}
-                    options={newOptions.map((option) => ({
-                        ...option,
-                        label: option.labelId
-                            ? <><Message msgId={option.labelId}/>
-                                {option.glyphId && <Glyphicon style={{ marginLeft: 10 }} glyph={option.glyphId}/>}
-                            </>
-                            : option.label
-                    }))}
-                    value={value}
-                    onChange={option => {
-                        if (multi) {
-                            return onChange(option.length > 0
-                                ? option.map((entry) => entry.value)
-                                : undefined);
-                        }
-                        setNewOptions(updateOptions(newOptions, option));
-                        return onChange(option.value);
-                    }}
+                    {...props}
                 />
             </PropertyField>
         );

--- a/web/client/components/styleeditor/Fields.jsx
+++ b/web/client/components/styleeditor/Fields.jsx
@@ -12,7 +12,7 @@ import isObject from 'lodash/isObject';
 import omit from 'lodash/omit';
 import isNil from 'lodash/isNil';
 import isNaN from 'lodash/isNaN';
-import isEqual from 'lodash/isEqual';
+import castArray from 'lodash/castArray';
 import Toolbar from '../misc/toolbar/Toolbar';
 import ColorSelector from '../style/ColorSelector';
 import Slider from '../misc/Slider';
@@ -222,19 +222,23 @@ export const fields = {
             if (!value) {
                 return options;
             }
-            return [{ value, label: value }].reduce(updateOptions, options);
+            // we get an array when using some properties
+            // eg. font-family
+            const values = castArray(value);
+            return values
+                .map(entry => ({ value: entry, label: entry }))
+                .reduce(updateOptions, options);
         }
 
         const options = getOptions(props);
 
         const [newOptions, setNewOptions] = useState(initOptions(options));
         useEffect(() => {
-            !multi && !isEqual(options, newOptions) && setNewOptions(initOptions(options));
-        }, [options]);
-
-        useEffect(() => {
-            multi && setNewOptions(initOptions(options));
-        }, [options?.length]);
+            setNewOptions(initOptions(options));
+            // we should compare the previous and new options inside the dependencies
+            // we could try the stringify for now because we have a usually small and constant array
+            // this is to avoid infinite loop inside the style editor
+        }, [JSON.stringify(options)]);
 
         const SelectInput = creatable
             ? ReactSelectCreatable

--- a/web/client/components/styleeditor/SelectInput.jsx
+++ b/web/client/components/styleeditor/SelectInput.jsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Glyphicon } from 'react-bootstrap';
+import castArray from 'lodash/castArray';
+import Message from '../I18N/Message';
+import Select from 'react-select';
+import localizedProps from '../misc/enhancers/localizedProps';
+
+const ReactSelect = localizedProps(['placeholder', 'noResultsText'])(Select);
+const ReactSelectCreatable = localizedProps(['placeholder', 'noResultsText'])(Select.Creatable);
+
+function SelectInput({
+    label,
+    value,
+    config: {
+        getOptions = () => [],
+        selectProps = {}
+    } = {},
+    onChange,
+    disabled,
+    ...props
+}) {
+
+    const {
+        creatable,
+        clearable = false,
+        multi
+    } = selectProps;
+
+    function updateOptions(options = [], newValue) {
+        const optionsValues = options.map(option => option.value);
+        const isMissing = newValue?.value && optionsValues.indexOf(newValue.value) === -1;
+        return isMissing
+            ? [ newValue, ...options]
+            : options;
+    }
+
+    function initOptions(options) {
+        if (!value) {
+            return options;
+        }
+        // we get an array when using some properties
+        // eg. font-family
+        const values = castArray(value);
+        return values
+            .map(entry => ({ value: entry, label: entry }))
+            .reduce(updateOptions, options);
+    }
+
+    const options = getOptions(props);
+
+    const [newOptions, setNewOptions] = useState(initOptions(options));
+    useEffect(() => {
+        setNewOptions(initOptions(options));
+        // we should compare the previous and new options inside the dependencies
+        // we could try the stringify for now because we have a usually small and constant array
+        // this is to avoid infinite loop inside the style editor
+    }, [JSON.stringify(options)]);
+
+    const SelectComponent = creatable
+        ? ReactSelectCreatable
+        : ReactSelect;
+
+    return (
+        <SelectComponent
+            disabled={disabled}
+            clearable={clearable}
+            placeholder="styleeditor.selectPlaceholder"
+            noResultsText="styleeditor.noResultsSelectInput"
+            {...selectProps}
+            options={newOptions.map((option) => ({
+                ...option,
+                label: option.labelId
+                    ? <><Message msgId={option.labelId}/>
+                        {option.glyphId && <Glyphicon style={{ marginLeft: 10 }} glyph={option.glyphId}/>}
+                    </>
+                    : option.label
+            }))}
+            value={value}
+            onChange={option => {
+                if (multi) {
+                    return onChange(option.length > 0
+                        ? option.map((entry) => entry.value)
+                        : undefined);
+                }
+                setNewOptions(updateOptions(newOptions, option));
+                return onChange(option.value);
+            }}
+        />
+    );
+}
+
+export default SelectInput;

--- a/web/client/components/styleeditor/__tests__/SelectInput-test.jsx
+++ b/web/client/components/styleeditor/__tests__/SelectInput-test.jsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+import SelectInput from '../SelectInput';
+import { act, Simulate } from 'react-dom/test-utils';
+import expect from 'expect';
+
+describe('SelectInput component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<SelectInput />, document.getElementById("container"));
+        const selectInputNode = document.querySelector('.Select');
+        expect(selectInputNode).toBeTruthy();
+    });
+    it('should not freeze after changing options', () => {
+        act(() => {
+            ReactDOM.render(<SelectInput
+                value={'a'}
+                config={{
+                    getOptions: () => [{ value: '1', label: '1' }]
+                }}
+            />, document.getElementById("container"));
+        });
+        let selectInputControlNode = document.querySelector('.Select-control');
+        expect(selectInputControlNode).toBeTruthy();
+        act(() => {
+            ReactDOM.render(<SelectInput
+                value={'a'}
+                config={{
+                    getOptions: () => [{ value: '1', label: '1' }, { value: '2', label: '2' }]
+                }}
+            />, document.getElementById("container"));
+        });
+        selectInputControlNode = document.querySelector('.Select-control');
+        act(() => {
+            Simulate.keyDown(selectInputControlNode, { keyCode: 40 });
+        });
+        const selectInputOptions = document.querySelectorAll('.Select-option');
+        expect(selectInputOptions.length).toBe(3);
+        expect([...selectInputOptions].map((node) => node.innerHTML)).toEqual([ 'a', '1', '2' ]);
+    });
+});


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The text symbolizer was triggering an infinite loop due to the options dependencies in a useEffec

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6951

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Using a string as dependency should prevent an infinite loop in the component. The options reference was changing on each rerender.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
