### PR TITLE
#6960: Map error when default_map_backgrounds is missing.

### DIFF
--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -141,6 +141,10 @@ describe('Test catalog selectors', () => {
         const bgService = retVal.default_map_backgrounds;
         expect(bgService.readOnly).toBe(true);
     });
+    it('test servicesSelectorWithBackgrounds with empty state', () => {
+        const retVal = servicesSelectorWithBackgrounds({});
+        expect(retVal).toBeFalsy();
+    });
     it('test newServiceTypeSelector', () => {
         const retVal = newServiceTypeSelector(state);
         expect(retVal).toExist();

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -15,7 +15,7 @@ import { DEFAULT_FORMAT_WMS, getUniqueInfoFormats } from "../utils/CatalogUtils"
 export const staticServicesSelector = (state) => get(state, "catalog.default.staticServices");
 export const servicesSelector = (state) => get(state, "catalog.services");
 export const servicesSelectorWithBackgrounds = createSelector(staticServicesSelector, servicesSelector, (staticServices, services) => {
-    const backgroundService = staticServices.default_map_backgrounds;
+    const backgroundService = staticServices?.default_map_backgrounds;
     if (backgroundService) {
         // static services are readOnly by default
         backgroundService.readOnly = true;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR introduces a control to static services to ensure the selector does not crash the app if `state.catalog.default.staticServices` is undefined

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6960

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
add an optional chain operator to the backgroundServices selection

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
This should not add changes to the mapstore application because mapstore has that part of state always populated