### PR TITLE
#6871 - Auto-opening of details panel

### DIFF
--- a/web/client/epics/__tests__/details-test.js
+++ b/web/client/epics/__tests__/details-test.js
@@ -32,7 +32,7 @@ import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
 import ConfigUtils from '../../utils/ConfigUtils';
 import { EMPTY_RESOURCE_VALUE } from '../../utils/MapInfoUtils';
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
-import { TOGGLE_CONTROL } from '../../actions/controls';
+import { TOGGLE_CONTROL, SET_CONTROL_PROPERTY } from '../../actions/controls';
 
 const baseUrl = "base/web/client/test-resources/geostore/";
 const mapId = 1;
@@ -98,7 +98,7 @@ describe('details epics tests', () => {
         ConfigUtils.getDefaults = oldGetDefaults;
     });
 
-    it('test closeDetailsPanel', (done) => {
+    it.('test closeDetailsPanel', (done) => {
 
         store.dispatch(closeDetailsPanel());
 
@@ -107,7 +107,7 @@ describe('details epics tests', () => {
                 const actions = store.getActions();
                 expect(actions.length).toBe(2);
                 expect(actions[0].type).toBe(CLOSE_DETAILS_PANEL);
-                expect(actions[1].type).toBe(TOGGLE_CONTROL);
+                expect(actions[1].type).toBe(SET_CONTROL_PROPERTY);
             } catch (e) {
                 done(e);
             }

--- a/web/client/epics/__tests__/details-test.js
+++ b/web/client/epics/__tests__/details-test.js
@@ -98,7 +98,7 @@ describe('details epics tests', () => {
         ConfigUtils.getDefaults = oldGetDefaults;
     });
 
-    it.('test closeDetailsPanel', (done) => {
+    it('test closeDetailsPanel', (done) => {
 
         store.dispatch(closeDetailsPanel());
 

--- a/web/client/epics/details.js
+++ b/web/client/epics/details.js
@@ -19,7 +19,7 @@ import {
 } from '../actions/details';
 import { MAP_INFO_LOADED } from '../actions/config';
 import { closeFeatureGrid } from '../actions/featuregrid';
-import { toggleControl } from '../actions/controls';
+import { toggleControl, setControlProperty } from '../actions/controls';
 
 import {
     mapIdSelector, mapInfoDetailsUriFromIdSelector
@@ -56,7 +56,7 @@ export const fetchDataForDetailsPanel = (action$, store) =>
 export const closeDetailsPanelEpic = (action$) =>
     action$.ofType(CLOSE_DETAILS_PANEL)
         .switchMap(() => Rx.Observable.from( [
-            toggleControl("details", "enabled")
+            setControlProperty("details", "enabled", false)
         ])
         );
 


### PR DESCRIPTION
## Description
solves the auto-opening of details panel when toggling 3D

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6871 

**What is the new behavior?**
See the description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
