### PR TITLE
#6970: Resolved URL update issue on geostory.

### DIFF
--- a/web/client/actions/geostory.js
+++ b/web/client/actions/geostory.js
@@ -243,4 +243,10 @@ export const updateUrlOnScroll = value => ({type: SET_UPDATE_URL_SCROLL, value})
 
 export const updateMediaEditorSettings = mediaEditorSettings => ({ type: UPDATE_MEDIA_EDITOR_SETTINGS, mediaEditorSettings });
 
+/**
+ * This action can be used to disable/enable URL update during story load,
+ * to avoid conflicts due to the initial scroll when the user opens a link pointing to a section/column.
+ * @param {boolean} status true if the application is actually scrolling
+ * @returns the action
+ */
 export const geostoryScrolling = (status) => ({ type: GEOSTORY_SCROLLING, status});

--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -33,8 +33,7 @@ import {
     editWebPageComponent,
     handlePendingGeoStoryChanges,
     loadStoryOnHistoryPop,
-    scrollOnLoad,
-    urlUpdateOnScroll
+    scrollOnLoad
 } from '../geostory';
 import {
     ADD,
@@ -61,8 +60,7 @@ import {
     editWebPage,
     setResource,
     SET_PENDING_CHANGES,
-    LOAD_GEOSTORY,
-    updateCurrentPage
+    LOAD_GEOSTORY
 } from '../../actions/geostory';
 import { SET_CONTROL_PROPERTY } from '../../actions/controls';
 import {
@@ -1634,18 +1632,9 @@ describe('Geostory Epics', () => {
             });
         });
     });
-
-    it('urlUpdateOnScroll', (done) => {
-        const NUM_ACTIONS = 1;
-        testEpic(addTimeoutEpic(urlUpdateOnScroll, 100), NUM_ACTIONS, [updateCurrentPage({sectionId: "sectionId"})],
-            (actions) => {
-                expect(actions[0].type).toBe(TEST_TIMEOUT);
-                done();
-            }, {geostory: {mode: "view", updateUrlOnScroll: true, resource: {id: "1"}}});
-    });
     it('scrollOnLoad', (done) => {
         const NUM_ACTIONS = 2;
-        testEpic(scrollOnLoad, NUM_ACTIONS, setCurrentStory({}),
+        testEpic(scrollOnLoad, NUM_ACTIONS, {...setCurrentStory({}), delay: 0}, // replace default delay for testing
             (actions) => {
                 expect(actions[0].type).toBe(GEOSTORY_SCROLLING);
                 expect(actions[0].status).toBe(true);

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -521,7 +521,8 @@ export const urlUpdateOnScroll = (action$, {getState}) =>
     action$.ofType(UPDATE_CURRENT_PAGE)
         .let(semaphore(
             action$.ofType(GEOSTORY_SCROLLING)
-                .map(a => !a.value)
+                .map(a => !a.status)
+                .startWith(true)
         ))
         .debounceTime(50) // little delay if too many UPDATE_CURRENT_PAGE actions come
         .switchMap(({sectionId, columnId}) => {
@@ -544,10 +545,9 @@ export const urlUpdateOnScroll = (action$, {getState}) =>
  */
 export const scrollOnLoad = (action$) =>
     action$.ofType(SET_CURRENT_STORY)
-        .switchMap(({delay = 500}) => {
+        .switchMap(({delay = 2000}) => {
             const storyIds = window?.location?.hash?.split('/');
             return Observable.of(storyIds)
-                .delay(delay)
                 .do(() => {
                     if (window?.location?.hash?.includes('shared')) {
                             scrollToContent(storyIds[7] || storyIds[5], {block: "start", behavior: "auto"});


### PR DESCRIPTION
## Description
This should solve the issue with the share URL of geostory.

- The temporary disable while scrolling was not working because of the wrong value checked (`a.value` instead of `a.status`). Started this with a true event, to let always pass when scrolling is not going to be performed. 
- I increased the delay after scroll finish to 2 seconds, before reactivating the URL update (it's an acceptable time, IMHO, after the initial scroll). 
- I remove the test about it because it was not testing anything, so having it confuses only (increase coverage, but the test is not performed). A real testing the URL change should require a little refactor of the  handler, and this may be problematic at the moment. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6970

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
