### PR TITLE
backport 2021.01.xx - #6992 reset to click method for mapInfo (#7001)

### DIFF
--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -265,8 +265,15 @@ describe('Test the mapInfo reducer', () => {
 
     it('should reset the state', () => {
         let state = mapInfo({showMarker: true}, {type: 'RESET_CONTROLS'});
-        expect(state).toExist();
-        expect(state.showMarker).toBe(false);
+        expect(state).toBeTruthy();
+        expect(state).toEqual({
+            showMarker: false,
+            responses: [],
+            requests: [],
+            configuration: {
+                trigger: "click"
+            }
+        });
     });
 
     it('should toggle mapinfo state', () => {

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -324,7 +324,11 @@ function mapInfo(state = initState, action) {
         return assign({}, state, {
             showMarker: false,
             responses: [],
-            requests: []
+            requests: [],
+            configuration: {
+                ...state.configuration,
+                trigger: "click"
+            }
         });
     }
     case GET_VECTOR_INFO: {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
backport 2021.01.xx - #6992 reset to click method for mapInfo (#7001)