### PR TITLE
Revert "#7013 removed console statements warnings"

### DIFF
--- a/web/client/api/usersession/browser.js
+++ b/web/client/api/usersession/browser.js
@@ -22,7 +22,7 @@ export default {
             const id = session && name;
             return Promise.resolve([id, session]);
         } catch (e) {
-            console.error(e); // eslint-disable-line
+            console.error(e);
             return Promise.resolve([0, null]);
         }
     }),
@@ -30,7 +30,7 @@ export default {
         try {
             getApi().setItem(getSessionName(id || name), JSON.stringify(session));
         } catch (e) {
-            console.error(e); // eslint-disable-line
+            console.error(e);
         }
         return Promise.resolve(id || name);
     }),

--- a/web/client/components/cookie/Cookie.jsx
+++ b/web/client/components/cookie/Cookie.jsx
@@ -133,7 +133,7 @@ class Cookie extends React.Component {
         try {
             getApi().setItem("cookies-policy-approved", true);
         } catch (e) {
-            console.error(e); // eslint-disable-line
+            console.error(e);
         }
         this.props.onSetCookieVisibility(false);
     }

--- a/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
+++ b/web/client/components/data/featuregrid/toolbars/Toolbar.jsx
@@ -201,7 +201,7 @@ export default ({
                                 try {
                                     getApi().setItem("showPopoverSync", false);
                                 } catch (e) {
-                                    console.error(e); // eslint-disable-line
+                                    console.error(e);
                                 }
                             }
                             events.hideSyncPopover();

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -68,7 +68,7 @@ const loadFunction = (options) => function(image, src) {
                 }
             }
         }).catch(e => {
-            console.error(e); // eslint-disable-line
+            console.error(e);
         });
 
     } else {

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -871,7 +871,7 @@ class AnnotationsEditor extends React.Component {
             try {
                 getApi().setItem("showPopupWarning", false);
             } catch (e) {
-                console.error(e); // eslint-disable-line
+                console.error(e);
             }
             this.props.onHideMeasureWarning();
         }

--- a/web/client/epics/cookies.js
+++ b/web/client/epics/cookies.js
@@ -29,7 +29,7 @@ export const cookiePolicyChecker = (action$) =>
             try {
                 return !getApi().getItem("cookies-policy-approved");
             } catch (e) {
-                console.error(e); // eslint-disable-line
+                console.error(e);
                 return false;
             }
         })

--- a/web/client/epics/layerinfo.js
+++ b/web/client/epics/layerinfo.js
@@ -96,7 +96,7 @@ export const layerInfoSyncLayersEpic = (action$, store) => action$
                         return  ['error', layerObj];
                     })
                     .catch((e) => {
-                        console.error(e); // eslint-disable-line
+                        console.error(e);
                         return Observable.of(['error', layerObj]);
                     }
                     ))

--- a/web/client/epics/tutorial.js
+++ b/web/client/epics/tutorial.js
@@ -110,7 +110,7 @@ export const switchGeostoryTutorialEpic = (action$, store) =>
             try {
                 isGeostoryTutorialDisabled = getApi().getItem("mapstore.plugin.tutorial.geostory.disabled") === "true";
             } catch (e) {
-                console.error(e); // eslint-disable-line
+                console.error(e);
             }
             // if no steps are found then do nothing
             return steps ? Rx.Observable.from(

--- a/web/client/jsapi/MapStore2.js
+++ b/web/client/jsapi/MapStore2.js
@@ -58,7 +58,7 @@ function loadConfigFromStorage(name = 'mapstore.embedded') {
                 return JSON.parse(loaded);
             }
         } catch (e) {
-            console.error(e); // eslint-disable-line
+            console.error(e);
             return null;
         }
     }


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#7014

Instead of disable single lines, allow `console.error` is more useful