### PR TITLE
6882: Fix Time filter panel for many dates is not completely visible 

### DIFF
--- a/web/client/components/data/query/DateField.jsx
+++ b/web/client/components/data/query/DateField.jsx
@@ -71,7 +71,7 @@ class DateField extends React.Component {
 
         let dateRow = this.props.operator === "><" ?
             (<div className="query-field">
-                <div className="query-field-value">
+                <div className="query-field-value date-filter-left">
                     {this.props.showLabels && <Message msgId="queryform.from"/>}
                     <UTCDateTimePicker
                         type={this.props.attType}
@@ -82,7 +82,7 @@ class DateField extends React.Component {
                         format={getDateTimeFormat(this.context.locale, this.props.attType)}
                         onChange={(date) => this.updateValueState({startDate: date, endDate: enddate})}/>
                 </div>
-                <div className="query-field-value">
+                <div className="query-field-value date-filter-right">
                     {this.props.showLabels && <Message msgId="queryform.to"/>}
                     <UTCDateTimePicker
                         type={this.props.attType}

--- a/web/client/themes/default/less/query-panel.less
+++ b/web/client/themes/default/less/query-panel.less
@@ -56,6 +56,11 @@
     }
 }
 
+/* Avoid overflow of the right date-picker visibility when date filter "between" is used */
+.query-field-value.date-filter-right .rw-calendar-popup.rw-popup-container {
+    transform: translateX(-40%);
+}
+
 .mapstore-string-select {
     position: relative;
     display: inline-block;

--- a/web/client/themes/default/less/react-widgets.less
+++ b/web/client/themes/default/less/react-widgets.less
@@ -25,6 +25,3 @@
         line-height: (@input-height / 2);
     }
 }
-.rw-calendar-popup.rw-popup-container {
-    transform: translate(-40%);
-}

--- a/web/client/themes/default/less/react-widgets.less
+++ b/web/client/themes/default/less/react-widgets.less
@@ -25,3 +25,6 @@
         line-height: (@input-height / 2);
     }
 }
+.rw-calendar-popup.rw-popup-container {
+    transform: translate(-40%);
+}


### PR DESCRIPTION
## Description
I try to use >< date filter with 1920 x 1080 screen size, but i cant select the second filter correctly.
As well, we cant really read selected dates values.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Nex next date/month/year for the second filter's values are not selectable 

#6882 

**What is the new behavior?**
I'm able to select next month (or year) and to select all dates.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
