### PR TITLE
6878: Add documentation for activateRemoveGroup in TOC

### DIFF
--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -685,7 +685,7 @@ const checkPluginsEnhancer = branch(
  * @prop {boolean} cfg.activateAddGroupButton: activate a button to add a new group, default `true`
  * @prop {boolean} cfg.showFullTitleOnExpand shows full length title in the legend. default `false`.
  * @prop {boolean} cfg.hideOpacityTooltip hide toolip on opacity sliders
- * @prop {boolean} cfg.activateRemoveGroup activates readonly TOC with no option to add/remove layers and groups, default `true`
+ * @prop {boolean} cfg.activateRemoveGroup if set to false, do not show the remove button for layer groups. default `true`
  * @prop {string[]|string|object|function} cfg.metadataTemplate custom template for displaying metadata
  * example :
  * ```

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -685,6 +685,7 @@ const checkPluginsEnhancer = branch(
  * @prop {boolean} cfg.activateAddGroupButton: activate a button to add a new group, default `true`
  * @prop {boolean} cfg.showFullTitleOnExpand shows full length title in the legend. default `false`.
  * @prop {boolean} cfg.hideOpacityTooltip hide toolip on opacity sliders
+ * @prop {boolean} cfg.activateRemoveGroup activates readonly TOC with no option to add/remove layers and groups, default `true`
  * @prop {string[]|string|object|function} cfg.metadataTemplate custom template for displaying metadata
  * example :
  * ```

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -686,6 +686,12 @@ const checkPluginsEnhancer = branch(
  * @prop {boolean} cfg.showFullTitleOnExpand shows full length title in the legend. default `false`.
  * @prop {boolean} cfg.hideOpacityTooltip hide toolip on opacity sliders
  * @prop {boolean} cfg.activateRemoveGroup if set to false, do not show the remove button for layer groups. default `true`
+  * @prop {boolean} [addLayersPermissions=true] if false, only users of role ADMIN can see has the permission to see add layers button. Default true.
+   @prop {boolean} [removeLayersPermissions=true] if false, only users of role ADMIN can see has the permission to remove layers. Default true.
+   @prop {boolean} [sortingPermissions=true] if false, only users of role ADMIN can see has the permission to move layers in the TOC. Default true.
+   @prop {boolean} [addGroupsPermissions=true] if false, only users of role ADMIN can see has the permission add groups to the TOC. Default true.
+   @prop {boolean} [removeGroupsPermissions=true] if false, only users of role ADMIN can see has the permission remove groups from the TOC. Default true.
+   @prop {boolean} [layerInfoToolPermissions=false] if false, only users of role ADMIN can see has the permission see the layer info tool.. Default false.
  * @prop {string[]|string|object|function} cfg.metadataTemplate custom template for displaying metadata
  * example :
  * ```


### PR DESCRIPTION
## Description
adds documentation for activateRemoveGroup 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Docs

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
The activateRemoveGroup config isn't documented on https://mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.TOC
#6878

**What is the new behavior?**
Adds documentation for activateRemoveGroup
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
