### PR TITLE
#7040: Wrong CSS applied to CRS Selector button

### DIFF
--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -60,6 +60,10 @@ class Selector extends React.Component {
         allowedRoles: ['ALL']
     };
 
+    state = {
+        toggled: false
+    };
+
     render() {
 
         let list = [];
@@ -93,11 +97,13 @@ class Selector extends React.Component {
         const isAllowed = includes(this.props.allowedRoles, "ALL") || includes(this.props.allowedRoles, this.props.currentRole);
         return (this.props.enabled && isAllowed ? <Dropdown
             dropup
-            className="ms-prj-selector">
+            className="ms-prj-selector"
+            onToggle={(toggled) => this.setState({ toggled })}
+        >
             <Button
                 bsRole="toggle"
                 bsStyle="primary"
-                className="map-footer-btn"
+                className={`map-footer-btn btn-${this.state.toggled ? 'success' : 'primary'}`}
                 tooltip={<Message msgId="showCrsSelector"/>}
                 tooltipPosition="top">
                 <Glyphicon glyph="crs" />

--- a/web/client/plugins/__tests__/CRSSelector-test.jsx
+++ b/web/client/plugins/__tests__/CRSSelector-test.jsx
@@ -38,6 +38,8 @@ describe('CRSSelector Plugin', () => {
 
         ReactDOM.render(<Plugin filterAllowedCRS={["EPSG:4326", "EPSG:3857"]} additionalCRS={{}}/>, document.getElementById("container"));
         expect(document.getElementsByClassName('ms-prj-selector').length).toBe(1);
+        const button = document.querySelector('.ms-prj-selector > button');
+        expect(button.getAttribute('class').indexOf('btn-primary') !== -1).toBe(true);
     });
     it('render the plugin for role ADMIN with allowedRoles ADMIN, USER', () => {
         const { Plugin } = getPluginForTest(CRSPluginCustomized, {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Fix class names of crs selector button to match the correct state

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7040

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The crs color button is primary when idle and success when toggled

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
