### PR TITLE
#6987 add theme step in context creator 

### DIFF
--- a/web/client/actions/__tests__/contextcreator-test.js
+++ b/web/client/actions/__tests__/contextcreator-test.js
@@ -159,10 +159,15 @@ describe('contextcreator actions', () => {
         expect(retval.type).toBe(LOAD_EXTENSIONS);
     });
     it('setSelectedTheme', () => {
-        const theme = "dark";
+        const theme = {
+            id: 'dark',
+            label: 'Dark',
+            type: 'link',
+            href: 'dist/themes/dark.css'
+        };
         const retval = setSelectedTheme(theme);
         expect(retval).toExist();
         expect(retval.type).toBe(SET_SELECTED_THEME);
-        expect(retval.theme).toBe(theme);
+        expect(retval.theme).toEqual(theme);
     });
 });

--- a/web/client/actions/__tests__/contextcreator-test.js
+++ b/web/client/actions/__tests__/contextcreator-test.js
@@ -44,7 +44,9 @@ import {
     addPluginToUpload,
     ADD_PLUGIN_TO_UPLOAD,
     removePluginToUpload,
-    REMOVE_PLUGIN_TO_UPLOAD
+    REMOVE_PLUGIN_TO_UPLOAD,
+    SET_SELECTED_THEME,
+    setSelectedTheme
 } from '../contextcreator';
 
 describe('contextcreator actions', () => {
@@ -155,5 +157,12 @@ describe('contextcreator actions', () => {
         const retval = loadExtensions([{}]);
         expect(retval).toExist();
         expect(retval.type).toBe(LOAD_EXTENSIONS);
+    });
+    it('setSelectedTheme', () => {
+        const theme = "dark";
+        const retval = setSelectedTheme(theme);
+        expect(retval).toExist();
+        expect(retval.type).toBe(SET_SELECTED_THEME);
+        expect(retval.theme).toBe(theme);
     });
 });

--- a/web/client/actions/contextcreator.js
+++ b/web/client/actions/contextcreator.js
@@ -19,6 +19,7 @@ export const CLEAR_CONTEXT_CREATOR = 'CONTEXTCREATOR:CLEAR_CONTEXT_CREATOR';
 export const CHANGE_ATTRIBUTE = 'CONTEXTCREATOR:CHANGE_ATTRIBUTE';
 export const SHOW_DIALOG = 'CONTEXTCREATOR:SHOW_DIALOG';
 export const CHANGE_TEMPLATES_KEY = 'CONTEXTCREATOR:CHANGE_TEMPLATES_KEY';
+export const SET_SELECTED_THEME = 'CONTEXTCREATOR:SET_SELECTED_THEME';
 export const SET_SELECTED_TEMPLATES = 'CONTEXTCREATOR:SET_SELECTED_TEMPLATES';
 export const SET_PARSED_TEMPLATE = 'CONTEXTCREATOR:SET_PARSED_TEMPLATE';
 export const SET_FILE_DROP_STATUS = 'CONTEXTCREATOR:SET_FILE_DROP_STATUS';
@@ -155,6 +156,15 @@ export const changeTemplatesKey = (ids, key, value) => ({
     ids,
     key,
     value
+});
+
+/**
+ * Sets currently selected theme
+ * @param {string} theme the id of the theme
+ */
+export const setSelectedTheme = (theme) => ({
+    type: SET_SELECTED_THEME,
+    theme
 });
 
 /**

--- a/web/client/components/contextcreator/ConfigureThemes.jsx
+++ b/web/client/components/contextcreator/ConfigureThemes.jsx
@@ -6,26 +6,31 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import React, {useState} from 'react';
-import Select from 'react-select';
+import React from 'react';
+import ReactSelect from 'react-select';
 import {ControlLabel} from 'react-bootstrap';
 import Message from '../I18N/Message';
-
+import localizedProps from '../misc/enhancers/localizedProps';
+const Select = localizedProps("noResultsText")(ReactSelect);
+import { getMessageById } from '../../utils/LocaleUtils';
 
 const ConfigureThemes = ({
-    themes,
+    themes = [],
     setSelectedTheme = () => {},
-    selectedTheme = "default"
+    selectedTheme = "",
+    disabled = false,
+    context = {}
 }) => {
     return (
         <div className="configure-themes-step">
             <div className="choose-theme">
                 <ControlLabel><Message msgId="contextCreator.configureThemes.themes"/></ControlLabel>
                 <Select
-                    onChange={({value})  => setSelectedTheme(value)}
+                    clearable
+                    onChange={(option)  => setSelectedTheme(option?.theme)}
                     value={selectedTheme}
-                    options={themes}
-                    disabled={false}
+                    options={themes.map(theme => ({ value: theme.id, label: getMessageById(context, theme?.label) || theme?.id, theme }))}
+                    disabled={disabled}
                     noResultsText="contextCreator.configureThemes.noThemes"
                 />
             </div>

--- a/web/client/components/contextcreator/ConfigureThemes.jsx
+++ b/web/client/components/contextcreator/ConfigureThemes.jsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import React, {useState} from 'react';
+import Select from 'react-select';
+import {ControlLabel} from 'react-bootstrap';
+import Message from '../I18N/Message';
+
+
+const ConfigureThemes = ({
+    themes,
+    setSelectedTheme = () => {},
+    selectedTheme = "default"
+}) => {
+    return (
+        <div className="configure-themes-step">
+            <div className="choose-theme">
+                <ControlLabel><Message msgId="contextCreator.configureThemes.themes"/></ControlLabel>
+                <Select
+                    onChange={({value})  => setSelectedTheme(value)}
+                    value={selectedTheme}
+                    options={themes}
+                    disabled={false}
+                    noResultsText="contextCreator.configureThemes.noThemes"
+                />
+            </div>
+        </div>);
+};
+export default ConfigureThemes;

--- a/web/client/components/contextcreator/ConfigureThemes.jsx
+++ b/web/client/components/contextcreator/ConfigureThemes.jsx
@@ -29,7 +29,7 @@ const ConfigureThemes = ({
                     clearable
                     onChange={(option)  => setSelectedTheme(option?.theme)}
                     value={selectedTheme}
-                    options={themes.map(theme => ({ value: theme.id, label: getMessageById(context, theme?.label) || theme?.id, theme }))}
+                    options={themes.map(theme => ({ value: theme.id, label: theme?.label && getMessageById(context, theme?.label) || theme?.id, theme }))}
                     disabled={disabled}
                     noResultsText="contextCreator.configureThemes.noThemes"
                 />

--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -14,6 +14,7 @@ import Stepper from '../misc/Stepper';
 import GeneralSettings from './GeneralSettingsStep';
 import ConfigurePlugins from './ConfigurePluginsStep';
 import ConfigureMap from './ConfigureMapStep';
+import ConfigureThemes from './ConfigureThemes';
 import {CONTEXT_TUTORIALS} from '../../actions/contextcreator';
 /**
  * Filters plugins and applies overrides.
@@ -146,7 +147,10 @@ export default class ContextCreator extends React.Component {
         showBackToPageConfirmation: PropTypes.bool,
         backToPageDestRoute: PropTypes.string,
         backToPageConfirmationMessage: PropTypes.string,
-        tutorials: PropTypes.object
+        tutorials: PropTypes.object,
+        themes: PropTypes.array,
+        setSelectedTheme: PropTypes.func,
+        selectedTheme: PropTypes.string
     };
 
     static contextTypes = {
@@ -162,6 +166,7 @@ export default class ContextCreator extends React.Component {
         contextNameChecked: true,
         newContext: {},
         resource: {},
+        themes: [{value: "default", label: "Default"}, {value: "dark", label: "Dark"}],
         viewerPlugins: [
             "Map",
             "BackgroundSelector",
@@ -343,7 +348,19 @@ export default class ContextCreator extends React.Component {
                             onEditTemplate={this.props.onEditTemplate}
                             onFilterAvailableTemplates={this.props.onFilterAvailableTemplates}
                             onFilterEnabledTemplates={this.props.onFilterEnabledTemplates}/>
-                }]} />
+                },
+                {
+                    id: 'configure-themes',
+                    label: 'contextCreator.configureThemes.label',
+                    extraToolbarButtons: extraToolbarButtons('configure-themes'),
+                    disableNext: false,
+                    component: <ConfigureThemes
+                        themes={this.props.themes}
+                        setSelectedTheme={this.props.setSelectedTheme}
+                        selectedTheme={this.props.selectedTheme}
+                    />
+                }
+                ]} />
         );
     }
 }

--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -166,7 +166,12 @@ export default class ContextCreator extends React.Component {
         contextNameChecked: true,
         newContext: {},
         resource: {},
-        themes: [{value: "default", label: "Default"}, {value: "dark", label: "Dark"}],
+        themes: [{
+            id: 'dark',
+            label: 'Dark',
+            type: 'link',
+            href: (__MAPSTORE_PROJECT_CONFIG__.themePath || 'dist/themes') + '/dark.css'
+        }],
         viewerPlugins: [
             "Map",
             "BackgroundSelector",

--- a/web/client/components/contextcreator/__tests__/ContextCreator-test.jsx
+++ b/web/client/components/contextcreator/__tests__/ContextCreator-test.jsx
@@ -59,7 +59,7 @@ describe('ContextCreator component', () => {
                         <ContextCreator
                             isCfgValidated
                             allAvailablePlugins={allAvailablePlugins}
-                            curStepId="configure-plugins"
+                            curStepId="configure-themes"
                             onSave={actions.onSave} />
                     </Provider>
                 </Localized>, document.getElementById("container"));
@@ -92,7 +92,7 @@ describe('ContextCreator component', () => {
                         <ContextCreator
                             isCfgValidated
                             allAvailablePlugins={allAvailablePlugins}
-                            curStepId="configure-plugins"
+                            curStepId="configure-themes"
                             saveDestLocation="MY_DESTINATION"
                             onSave={actions.onSave} />
                     </Provider>

--- a/web/client/epics/contextcreator.js
+++ b/web/client/epics/contextcreator.js
@@ -27,7 +27,7 @@ import {SAVE_CONTEXT, SAVE_TEMPLATE, LOAD_CONTEXT, LOAD_TEMPLATE, DELETE_TEMPLAT
 import {newContextSelector, resourceSelector, creationStepSelector, mapConfigSelector, mapViewerLoadedSelector, contextNameCheckedSelector,
     editedPluginSelector, editedCfgSelector, validationStatusSelector, parsedCfgSelector, cfgErrorSelector,
     pluginsSelector, initialEnabledPluginsSelector, templatesSelector, editedTemplateSelector, tutorialsSelector,
-    wasTutorialShownSelector} from '../selectors/contextcreator';
+    wasTutorialShownSelector, selectedThemeSelector} from '../selectors/contextcreator';
 import {CONTEXTS_LIST_LOADED} from '../actions/contextmanager';
 import {wrapStartStop} from '../observables/epics';
 import {isLoggedIn} from '../selectors/security';
@@ -95,10 +95,12 @@ export const saveContextResource = (action$, store) => action$
         }) : plugin);
         const unselectablePlugins = makePlugins(pluginsArray.filter(plugin => !plugin.isUserPlugin));
         const userPlugins = makePlugins(pluginsArray.filter(plugin => plugin.isUserPlugin));
+        const theme = selectedThemeSelector(state);
 
         const newContext = {
             ...context,
             mapConfig,
+            theme,
             plugins: {desktop: unselectablePlugins},
             userPlugins
         };

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -70,6 +70,16 @@ export const contextCreatorSelector = createStructuredSelector({
  * @name ContextCreator
  * @class
  * @prop {string} cfg.saveDestLocation router path when the application is redirected when a context is saved
+ * @prop {object[]} cfg.themes list of themes with default configuration that will appear in the context creation process
+ *
+ * @example
+ * "cfg": {
+ * "themes": [{
+ *      id: 'dark',
+ *      type: 'link',
+ *      href: 'dist/themes/dark.css'
+ *  }]
+ * }
  */
 export default createPlugin('ContextCreator', {
     component: connect(contextCreatorSelector, {

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -15,13 +15,13 @@ import {newContextSelector, resourceSelector, creationStepSelector, reloadConfir
     loadFlagsSelector, isValidContextNameSelector, contextNameCheckedSelector, pluginsSelector, editedPluginSelector, editedCfgSelector,
     validationStatusSelector, cfgErrorSelector, templatesSelector, parsedTemplateSelector, fileDropStatusSelector, editedTemplateSelector,
     availablePluginsFilterTextSelector, availableTemplatesFilterTextSelector, enabledPluginsFilterTextSelector,
-    enabledTemplatesFilterTextSelector, showBackToPageConfirmationSelector, tutorialStepSelector} from '../selectors/contextcreator';
+    enabledTemplatesFilterTextSelector, showBackToPageConfirmationSelector, tutorialStepSelector, selectedThemeSelector} from '../selectors/contextcreator';
 import {mapTypeSelector} from '../selectors/maptype';
 import {tutorialSelector} from '../selectors/tutorial';
 import {init, setCreationStep, changeAttribute, saveNewContext, saveTemplate, mapViewerReload, showMapViewerReloadConfirm, showDialog, setFilterText,
     setSelectedPlugins, setSelectedTemplates, setParsedTemplate, setFileDropStatus, editPlugin, editTemplate, deleteTemplate, updateEditedCfg,
     changePluginsKey, changeTemplatesKey, enablePlugins, disablePlugins, enableUploadPlugin, uploadPlugin, uninstallPlugin,
-    addPluginToUpload, removePluginToUpload, showBackToPageConfirmation, showTutorial} from '../actions/contextcreator';
+    addPluginToUpload, removePluginToUpload, showBackToPageConfirmation, showTutorial, setSelectedTheme} from '../actions/contextcreator';
 import contextcreator from '../reducers/contextcreator';
 import * as epics from '../epics/contextcreator';
 import { userSelector } from '../selectors/security';
@@ -60,7 +60,8 @@ export const contextCreatorSelector = createStructuredSelector({
     uploadResult: state => state.contextcreator && state.contextcreator.uploadResult,
     pluginsToUpload: state => state.contextcreator?.pluginsToUpload,
     pluginsConfig: () => ConfigUtils.getConfigProp('plugins'),
-    showBackToPageConfirmation: showBackToPageConfirmationSelector
+    showBackToPageConfirmation: showBackToPageConfirmationSelector,
+    selectedTheme: selectedThemeSelector
 });
 
 /**
@@ -78,6 +79,7 @@ export default createPlugin('ContextCreator', {
         onFilterEnabledTemplates: setFilterText.bind(null, 'enabledTemplates'),
         setSelectedPlugins,
         setSelectedTemplates,
+        setSelectedTheme,
         setParsedTemplate,
         setFileDropStatus,
         onEditPlugin: editPlugin,

--- a/web/client/plugins/__tests__/ContextCreator-test.jsx
+++ b/web/client/plugins/__tests__/ContextCreator-test.jsx
@@ -33,7 +33,7 @@ describe('ContextCreator plugin', () => {
         ];
         const { Plugin, actions } = getPluginForTest(ContextCreator, {
             contextcreator: {
-                stepId: 'configure-plugins',
+                stepId: 'configure-themes',
                 newContext: {},
                 plugins
             },
@@ -56,7 +56,7 @@ describe('ContextCreator plugin', () => {
         ];
         const { Plugin, actions } = getPluginForTest(ContextCreator, {
             contextcreator: {
-                stepId: 'configure-plugins',
+                stepId: 'configure-themes',
                 plugins
             },
             map: {}

--- a/web/client/reducers/__tests__/contextcreator-test.js
+++ b/web/client/reducers/__tests__/contextcreator-test.js
@@ -21,7 +21,8 @@ import {
     templatesSelector,
     editedPluginSelector,
     editedCfgSelector,
-    editedTemplateSelector
+    editedTemplateSelector,
+    selectedThemeSelector
 } from '../../selectors/contextcreator';
 import {
     setFilterText,
@@ -47,7 +48,8 @@ import {
     setSelectedTemplates,
     setEditedTemplate,
     setTemplates,
-    changeTemplatesKey
+    changeTemplatesKey,
+    setSelectedTheme
 } from '../../actions/contextcreator';
 
 const testContextResource = {
@@ -55,6 +57,7 @@ const testContextResource = {
         windowTitle: 'title',
         mapConfig: {},
         templates: [{id: 2}],
+        theme: "dark",
         plugins: {
             desktop: [{
                 name: 'Catalog',
@@ -173,6 +176,8 @@ describe('contextcreator reducer', () => {
         const newContext = newContextSelector(state);
         const plugins = pluginsSelector(state);
         const templates = templatesSelector(state);
+        const selectedTheme = selectedThemeSelector(state);
+        expect(selectedTheme).toBe(data.theme);
         expect(newContext).toExist();
         expect(newContext.windowTitle).toBe(data.windowTitle);
         expect(newContext.plugins).toNotExist();
@@ -558,5 +563,10 @@ describe('contextcreator reducer', () => {
         const state = contextcreator(undefined, showBackToPageConfirmation(true));
         expect(state).toExist();
         expect(state.showBackToPageConfirmation).toBe(true);
+    });
+    it('setSelectedTheme', () => {
+        const state = contextcreator(undefined, setSelectedTheme("dark"));
+        expect(state).toExist();
+        expect(selectedThemeSelector({contextcreator: state})).toBe("dark");
     });
 });

--- a/web/client/reducers/__tests__/contextcreator-test.js
+++ b/web/client/reducers/__tests__/contextcreator-test.js
@@ -51,13 +51,18 @@ import {
     changeTemplatesKey,
     setSelectedTheme
 } from '../../actions/contextcreator';
-
+const themeDark = {
+    id: 'dark',
+    label: 'Dark',
+    type: 'link',
+    href: 'dist/themes/dark.css'
+};
 const testContextResource = {
     data: {
         windowTitle: 'title',
         mapConfig: {},
         templates: [{id: 2}],
-        theme: "dark",
+        theme: themeDark,
         plugins: {
             desktop: [{
                 name: 'Catalog',
@@ -177,7 +182,7 @@ describe('contextcreator reducer', () => {
         const plugins = pluginsSelector(state);
         const templates = templatesSelector(state);
         const selectedTheme = selectedThemeSelector(state);
-        expect(selectedTheme).toBe(data.theme);
+        expect(selectedTheme).toEqual(data.theme);
         expect(newContext).toExist();
         expect(newContext.windowTitle).toBe(data.windowTitle);
         expect(newContext.plugins).toNotExist();
@@ -565,8 +570,8 @@ describe('contextcreator reducer', () => {
         expect(state.showBackToPageConfirmation).toBe(true);
     });
     it('setSelectedTheme', () => {
-        const state = contextcreator(undefined, setSelectedTheme("dark"));
+        const state = contextcreator(undefined, setSelectedTheme(themeDark));
         expect(state).toExist();
-        expect(selectedThemeSelector({contextcreator: state})).toBe("dark");
+        expect(selectedThemeSelector({contextcreator: state})).toEqual(themeDark);
     });
 });

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -249,7 +249,7 @@ export default (state = {}, action) => {
                 enabled: (pluginTemplates || templates || []).reduce((result, cur) => result || cur.id === template.id, false),
                 selected: false
             })),
-            set('newContext', otherData, set('plugins', contextCreatorPlugins, set('resource', resource, set('selectedTheme', theme || "", state))))));
+            set('newContext', otherData, set('plugins', contextCreatorPlugins, set('resource', resource, set('selectedTheme', theme, state))))));
     }
     case UPDATE_TEMPLATE: {
         const newResource = action.resource || {};

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -15,7 +15,7 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     CHANGE_PLUGINS_KEY, CHANGE_TEMPLATES_KEY, CHANGE_ATTRIBUTE, LOADING, SHOW_DIALOG, SET_EDITED_CFG, UPDATE_EDITED_CFG,
     SET_VALIDATION_STATUS, SET_PARSED_CFG, SET_CFG_ERROR, ENABLE_UPLOAD_PLUGIN, UPLOADING_PLUGIN, UPLOAD_PLUGIN_ERROR, ADD_PLUGIN_TO_UPLOAD,
     REMOVE_PLUGIN_TO_UPLOAD, PLUGIN_UPLOADED, UNINSTALLING_PLUGIN, UNINSTALL_PLUGIN_ERROR, PLUGIN_UNINSTALLED,
-    BACK_TO_PAGE_SHOW_CONFIRMATION} from "../actions/contextcreator";
+    BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 
 const defaultPlugins = [
@@ -132,6 +132,9 @@ export default (state = {}, action) => {
     case SET_TUTORIAL_STEP: {
         return set('tutorialStep', action.stepId, state);
     }
+    case SET_SELECTED_THEME: {
+        return set('selectedTheme', action.theme, state);
+    }
     case MAP_VIEWER_LOADED: {
         return set('mapViewerLoaded', action.status, state);
     }
@@ -201,7 +204,7 @@ export default (state = {}, action) => {
     }
     case SET_RESOURCE: {
         const {data = {plugins: {desktop: []}}, ...resource} = action.resource || {};
-        const {plugins = {desktop: []}, userPlugins = [], templates = [], ...otherData} = data;
+        const {plugins = {desktop: []}, userPlugins = [], templates = [], theme, ...otherData} = data;
         const contextPlugins = get(plugins, 'desktop', []);
 
         const allPlugins = makePluginTree(get(action.pluginsConfig, 'plugins'), ConfigUtils.getConfigProp('plugins'));
@@ -246,7 +249,7 @@ export default (state = {}, action) => {
                 enabled: (pluginTemplates || templates || []).reduce((result, cur) => result || cur.id === template.id, false),
                 selected: false
             })),
-            set('newContext', otherData, set('plugins', contextCreatorPlugins, set('resource', resource, state)))));
+            set('newContext', otherData, set('plugins', contextCreatorPlugins, set('resource', resource, set('selectedTheme', theme || "default", state))))));
     }
     case UPDATE_TEMPLATE: {
         const newResource = action.resource || {};

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -249,7 +249,7 @@ export default (state = {}, action) => {
                 enabled: (pluginTemplates || templates || []).reduce((result, cur) => result || cur.id === template.id, false),
                 selected: false
             })),
-            set('newContext', otherData, set('plugins', contextCreatorPlugins, set('resource', resource, set('selectedTheme', theme || "default", state))))));
+            set('newContext', otherData, set('plugins', contextCreatorPlugins, set('resource', resource, set('selectedTheme', theme || "", state))))));
     }
     case UPDATE_TEMPLATE: {
         const newResource = action.resource || {};

--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -9,7 +9,8 @@ import expect from 'expect';
 
 import {
     newContextSelector,
-    creationStepSelector
+    creationStepSelector,
+    selectedThemeSelector
 } from '../contextcreator';
 
 const testState = {
@@ -29,5 +30,15 @@ describe('contextcreator selectors', () => {
     });
     it('creationStepSelector', () => {
         expect(creationStepSelector(testState)).toBe('step');
+    });
+    it('selectedThemeSelector', () => {
+        expect(selectedThemeSelector(testState)).toBe('default');
+        expect(selectedThemeSelector({
+            ...testState,
+            contextcreator: {
+                ...testState.contextcreator,
+                selectedTheme: "dark"
+            }
+        })).toBe('dark');
     });
 });

--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -32,13 +32,19 @@ describe('contextcreator selectors', () => {
         expect(creationStepSelector(testState)).toBe('step');
     });
     it('selectedThemeSelector', () => {
-        expect(selectedThemeSelector(testState)).toBe('default');
+        const themeDark = {
+            id: 'dark',
+            label: 'Dark',
+            type: 'link',
+            href: 'dist/themes/dark.css'
+        };
+        expect(selectedThemeSelector(testState)).toBeFalsy();
         expect(selectedThemeSelector({
             ...testState,
             contextcreator: {
                 ...testState.contextcreator,
-                selectedTheme: "dark"
+                selectedTheme: themeDark
             }
-        })).toBe('dark');
+        })).toEqual(themeDark);
     });
 });

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -40,4 +40,4 @@ export const showBackToPageConfirmationSelector = state => get(state, 'contextcr
 export const tutorialsSelector = state => state.contextcreator?.tutorials;
 export const wasTutorialShownSelector = stepId => state => state.contextcreator?.wasTutorialShown?.[stepId] || false;
 export const tutorialStepSelector = state => state.contextcreator?.tutorialStep;
-export const selectedThemeSelector = state => get(state, 'contextcreator.selectedTheme', "default");
+export const selectedThemeSelector = state => get(state, 'contextcreator.selectedTheme');

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -40,3 +40,4 @@ export const showBackToPageConfirmationSelector = state => get(state, 'contextcr
 export const tutorialsSelector = state => state.contextcreator?.tutorials;
 export const wasTutorialShownSelector = stepId => state => state.contextcreator?.wasTutorialShown?.[stepId] || false;
 export const tutorialStepSelector = state => state.contextcreator?.tutorialStep;
+export const selectedThemeSelector = state => get(state, 'contextcreator.selectedTheme', "default");

--- a/web/client/themes/default/less/context-creator.less
+++ b/web/client/themes/default/less/context-creator.less
@@ -152,6 +152,19 @@
 
     height: 100%;
 }
+.configure-themes-step {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding: 10px 0 10px 0;
+    max-width: 1000px;
+    margin: auto;
+    height: 100%;
+    .choose-theme {
+        width: 500px;
+        margin: auto;
+    }
+}
 
 .configure-plugins-step {
     padding: 10px 0 10px 0;

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2874,6 +2874,11 @@
                 "windowTitle": "Fenstertitel",
                 "windowTitlePlaceholder": "Fenstertitel eingeben..."
             },
+            "configureThemes": {
+              "label": "Thema konfigurieren",
+              "themes": "Wähle ein Thema",
+              "noThemes": "Keine gefunden"
+            },
             "configurePlugins": {
                 "label": "Plugins konfigurieren",
                 "pluginsFilterPlaceholder": "Plugins nach Namen filtern...",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2887,6 +2887,11 @@
                 "windowTitle": "Window title",
                 "windowTitlePlaceholder": "Enter window title..."
             },
+            "configureThemes": {
+              "label": "Configure Theme",
+              "themes": "Choose a theme",
+              "noThemes": "No themes found"
+            },
             "configurePlugins": {
                 "label": "Configure Plugins",
                 "pluginsFilterPlaceholder": "Filter plugins by name...",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2874,6 +2874,11 @@
                 "windowTitle": "Título de la ventana",
                 "windowTitlePlaceholder": "Ingrese el título de la ventana..."
             },
+            "configureThemes": {
+              "label": "Configurar tema",
+              "themes": "Elige un tema",
+              "noThemes": "No se encontraron"
+            },
             "configurePlugins": {
                 "label": "Configurar complementos",
                 "pluginsFilterPlaceholder": "Filtrar complementos por nombre...",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2876,6 +2876,11 @@
                 "windowTitle": "Titre de la fenêtre",
                 "windowTitlePlaceholder": "Entrez le titre de la fenêtre..."
             },
+            "configureThemes": {
+              "label": "Configurer le thème",
+              "themes": "Choisissez un thème",
+              "noThemes": "Aucun thème trouvé"
+            },
             "configurePlugins": {
                 "label": "Configurer les plugins",
                 "pluginsFilterPlaceholder": "Filtrer les plugins par nom...",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2875,6 +2875,11 @@
                 "windowTitle": "Titolo della finestra",
                 "windowTitlePlaceholder": "Inserisci il titolo della finestra..."
             },
+            "configureThemes": {
+              "label": "Configura il tema",
+              "themes": "Scegli un tema",
+              "noThemes": "Nessun tema trovato"
+            },
             "configurePlugins": {
                 "label": "Configura plugin",
                 "pluginsFilterPlaceholder": "Filtra plug-in per nome...",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
A new step is added to the context creation for the theme selection
the list of themes is overridable with themes property in ContextCreator plugin

context called 6987 can be used for testing when this pr is merged
https://dev-mapstore.geosolutionsgroup.com/mapstore/#/context/6987

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6987

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

the object theme will be saved here in the context state if selected otherwise is undefined
and directly in contextcreator.selectedTheme during customization


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
![image](https://user-images.githubusercontent.com/11991428/123998336-af74ed00-d9d1-11eb-9e92-c92d9362638d.png)

![image](https://user-images.githubusercontent.com/11991428/123998540-dd5a3180-d9d1-11eb-9523-2a83582d93a4.png)
