### PR TITLE
#7046: Catalog loading spinner is fixed

### DIFF
--- a/web/client/themes/default/less/loaders.less
+++ b/web/client/themes/default/less/loaders.less
@@ -16,8 +16,7 @@
     @color-fade: @ms-theme-vars[loader-primary-contrast-fade-color];
 ) {
     text-indent: -9999em;
-    border-width: @border;
-    border-style: solid;
+    border: @border solid transparent;
     .border-top-color-var(@color-fade);
     .border-right-color-var(@color-fade);
     .border-bottom-color-var(@color-fade);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The minifying process of css was changing the order of border-color in the loader spinner and this was causing the effect of a fixed loader

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7046

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

loader is showing the correct border color

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
