### PR TITLE
#7053: Background problem on setting panel 

### DIFF
--- a/web/client/themes/default/less/panels.less
+++ b/web/client/themes/default/less/panels.less
@@ -11,6 +11,11 @@
 // **************
 #ms-components-theme(@theme-vars) {
     .ms-side-panel {
+
+        > div > div {
+            // override the inline style
+            .background-color-var(@theme-vars[main-bg], true);
+        }
         .ms-header {
             .background-color-var(@theme-vars[main-bg]);
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The inline style was set to white by default, adding the correct style variable fixes the issue

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7053

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Side panel color is equal to main-bg color

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
