### PR TITLE
#7054: HTML format visibility 

### DIFF
--- a/web/client/components/misc/HtmlRenderer.jsx
+++ b/web/client/components/misc/HtmlRenderer.jsx
@@ -19,8 +19,15 @@ import React from 'react';
 class HtmlRenderer extends React.Component {
     static propTypes = {
         html: PropTypes.string,
-        id: PropTypes.string
+        id: PropTypes.string,
+        style: PropTypes.object
     };
+
+    static defaultProps = {
+        // the content of an html is not dependent of the MapStore theme
+        // we should provide the default color of the browser
+        style: { color: '#000000' }
+    }
 
     getSourceCode = () => {
         return {
@@ -29,7 +36,7 @@ class HtmlRenderer extends React.Component {
     };
 
     render() {
-        return <div id={this.props.id} dangerouslySetInnerHTML={this.getSourceCode()} />;
+        return <div id={this.props.id} style={this.props.style} dangerouslySetInnerHTML={this.getSourceCode()} />;
     }
 }
 

--- a/web/client/components/misc/__tests__/HtmlRenderer-test.jsx
+++ b/web/client/components/misc/__tests__/HtmlRenderer-test.jsx
@@ -26,16 +26,16 @@ describe("This test for HtmlRenderer component", () => {
 
     it('creates componet with defaults', () => {
         const cmp = ReactDOM.render(<HtmlRenderer/>, document.getElementById("container"));
-        expect(cmp).toExist();
+        expect(cmp).toBeTruthy();
 
         const node = ReactDOM.findDOMNode(cmp);
-        expect(node.id).toNotExist();
+        expect(node.id).toBeFalsy();
         expect(node.childNodes.length).toBe(0);
     });
 
     it('creates empty componet with id', () => {
         const cmp = ReactDOM.render(<HtmlRenderer id="testId"/>, document.getElementById("container"));
-        expect(cmp).toExist();
+        expect(cmp).toBeTruthy();
 
         const node = ReactDOM.findDOMNode(cmp);
         expect(node.id).toBe("testId");
@@ -45,7 +45,7 @@ describe("This test for HtmlRenderer component", () => {
     it('creates a filled componet', () => {
         const srcCode = '<p id="innerP"><span id="innerSPAN">text</span></p>';
         const cmp = ReactDOM.render(<HtmlRenderer html={srcCode}/>, document.getElementById("container"));
-        expect(cmp).toExist();
+        expect(cmp).toBeTruthy();
 
         const node = ReactDOM.findDOMNode(cmp);
         expect(node.childNodes.length).toBe(1);
@@ -57,5 +57,13 @@ describe("This test for HtmlRenderer component", () => {
         const innerSPAN = innerP.childNodes[0];
         expect(innerSPAN.id).toBe("innerSPAN");
         expect(innerSPAN.innerHTML).toBe("text");
+    });
+    it('should change the style of the component', () => {
+        const cmp = ReactDOM.render(<HtmlRenderer style={{ color: 'rgb(255, 255, 255)' }}/>, document.getElementById("container"));
+        expect(cmp).toBeTruthy();
+
+        const node = ReactDOM.findDOMNode(cmp);
+        expect(node.id).toBeFalsy();
+        expect(node.style.color).toBe('rgb(255, 255, 255)');
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The html injected in the html renderer component is not part of the mapstore theme and usually has its own style. This PR provided the default black color to the div wrapper

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7054

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now the default color of the html renderer is #000000 but there is the possibility to override it via style prop

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
