### PR TITLE
#7058: Tutorial is white

### DIFF
--- a/web/client/themes/default/less/tutorial.less
+++ b/web/client/themes/default/less/tutorial.less
@@ -12,11 +12,13 @@
 #ms-components-theme(@theme-vars) {
 
     .joyride-tooltip__button--primary {
+        .color-var(@theme-vars[primary-contrast], true);
         .background-color-var(@theme-vars[primary], true);
 
         &:active,
         &:focus,
         &:hover {
+            .color-var(@theme-vars[primary-contrast], true);
             .background-color-var(@theme-vars[primary], true);
         }
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Fix contrast color of primary button of tutorial plugin.

see https://github.com/geosolutions-it/MapStore2/issues/7058#issuecomment-874190059

![image](https://user-images.githubusercontent.com/19175505/124493639-29ccb500-ddb6-11eb-9f70-0381f4740056.png)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7058

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
