### PR TITLE
#7074: Visual Style Editor crashes the app with raster layers 

### DIFF
--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -9,6 +9,7 @@
 import React, { useRef, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';
+import isArray from 'lodash/isArray';
 import { Glyphicon, FormControl as FormControlRB, FormGroup } from 'react-bootstrap';
 import Fields from './Fields';
 import uuidv1 from 'uuid/v1';
@@ -254,8 +255,12 @@ const RulesEditor = forwardRef(({
                         classificationType
                     } = ruleBlock[ruleKind] || {};
 
-                    // attributes could be false so it is not possible to use ?. operator
-                    const isCustomNumber =  attributes && attributes.filter(({label}) => label === rule?.attribute)?.[0]?.type === 'number';
+                    // ensure that attributes is an array
+                    // before to look if the current selected attribute is of type number
+                    // the attribute select of the classification rule changes the disabled attribute based on type
+                    const isCustomNumber =  isArray(attributes)
+                        ? (attributes.find(({ label }) => label === rule?.attribute) || {})?.type === 'number'
+                        : false;
                     return (
                         <Rule
                             // force render if draggable is enabled

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -253,7 +253,9 @@ const RulesEditor = forwardRef(({
                         hideScaleDenominator,
                         classificationType
                     } = ruleBlock[ruleKind] || {};
-                    const isCustomNumber =  attributes?.filter(({label}) => label === rule?.attribute)?.[0]?.type === 'number';
+
+                    // attributes could be false so it is not possible to use ?. operator
+                    const isCustomNumber =  attributes && attributes.filter(({label}) => label === rule?.attribute)?.[0]?.type === 'number';
                     return (
                         <Rule
                             // force render if draggable is enabled

--- a/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
+++ b/web/client/components/styleeditor/__tests__/RulesEditor-test.jsx
@@ -475,6 +475,43 @@ describe('RulesEditor', () => {
 
     });
 
+    it('should not crash the app if attributes is false', () => {
+        ReactDOM.render(
+            <RulesEditor
+                config={{
+                    attributes: false
+                }}
+                rules={[
+                    {
+                        name: 'Fill rule',
+                        ruleId: 1,
+                        symbolizers: [{
+                            symbolizerId: 1,
+                            kind: 'Fill',
+                            color: '#dddddd',
+                            fillOpacity: 1,
+                            outlineColor: '#777777',
+                            outlineWidth: 1
+                        }]
+                    }
+                ]}
+            />, document.getElementById('container'));
+        const ruleEditorNode = document.querySelector('.ms-style-rules-editor');
+        expect(ruleEditorNode).toBeTruthy();
+
+        const rulesNode = document.querySelectorAll('.ms-style-rule');
+        expect(rulesNode.length).toBe(1);
+
+        const ruleHeadNode = rulesNode[0].querySelector('.ms-style-rule-head');
+
+        const ruleHeadButtonNodes = ruleHeadNode.querySelectorAll('button');
+        expect([...ruleHeadButtonNodes].map(btn => btn.children[0].getAttribute('class'))).toEqual([
+            'glyphicon glyphicon-1-ruler',
+            'glyphicon glyphicon-trash'
+        ]);
+
+    });
+
 
     it('should render symbolizer with mark pattern', () => {
         ReactDOM.render(

--- a/web/client/plugins/styleeditor/StyleCodeEditor.jsx
+++ b/web/client/plugins/styleeditor/StyleCodeEditor.jsx
@@ -71,7 +71,7 @@ function getAttributes(hintProperties, geometryType) {
                     ? 'number'
                     : 'string'
             };
-        });
+        }) || [];
 }
 
 const ConnectedVisualStyleEditor = connect(


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Sometimes attributes inside the visual style editor could return `false` so valid for the `?.` operator but not valid for the .filter function

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7074

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
App does not crash after switching to visual style editor with raster layers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
