### PR TITLE
#7052: Contrast in the box issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,6 @@
     "react-router-dom": "4.2.2",
     "react-scroll-up": "1.3.7",
     "react-select": "1.3.0",
-    "react-selectize": "3.0.1",
     "react-share": "1.15.1",
     "react-sidebar": "2.3.2",
     "react-spinkit": "2.1.2",

--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -6,18 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'react-selectize/themes/index.css';
-
-import { find, isObject, isString } from 'lodash';
+import { find, isObject, isString, uniqBy } from 'lodash';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, ControlLabel, FormControl, FormGroup, Grid, InputGroup } from 'react-bootstrap';
-import { SimpleSelect } from 'react-selectize';
+import Select from 'react-select';
 import Spinner from 'react-spinkit';
 
 import { getMessageById, getSupportedLocales } from '../../../../utils/LocaleUtils';
-import { createFromSearch, flattenGroups, getLabelName } from '../../../../utils/TOCUtils';
+import { isValidNewGroupOption, flattenGroups, getLabelName } from '../../../../utils/TOCUtils';
 import Message from '../../../I18N/Message';
 import LayerNameEditField from './LayerNameEditField';
 
@@ -67,6 +65,9 @@ class General extends React.Component {
             { value: "bottom", label: getMessageById(this.context.messages, "layerProperties.tooltip.bottom") }
         ];
         const groups = this.props.groups && flattenGroups(this.props.groups);
+
+        const SelectCreatable = this.props.allowNew ? Select.Creatable : Select;
+
         return (
             <Grid fluid style={{ paddingTop: 15, paddingBottom: 15 }}>
                 <form ref="settings">
@@ -118,34 +119,36 @@ class General extends React.Component {
                     {this.props.nodeType === 'layers' ?
                         <div>
                             <label key="group-label" className="control-label"><Message msgId="layerProperties.group" /></label>
-                            <SimpleSelect
+                            <SelectCreatable
+                                clearable={false}
                                 key="group-dropdown"
                                 options={
-                                    (groups || (this.props.element && this.props.element.group) || []).map(item => {
-                                        if (isObject(item)) {
-                                            return {...item, label: getLabelName(item.label, groups)};
-                                        }
-                                        return { label: getLabelName(item, groups), value: item };
-                                    })
+                                    uniqBy([
+                                        { value: 'Default', label: 'Default' },
+                                        ...(groups || (this.props.element && this.props.element.group) || []).map(item => {
+                                            if (isObject(item)) {
+                                                return {...item, label: getLabelName(item.label, groups)};
+                                            }
+                                            return { label: getLabelName(item, groups), value: item };
+                                        })
+                                    ], 'value')
                                 }
-                                defaultValue={{ label: getLabelName(this.props.element && this.props.element.group || "Default", groups), value: this.props.element && this.props.element.group || "Default" }}
-                                placeholder={getLabelName(this.props.element && this.props.element.group || "Default", groups)}
-                                onChange={(value) => {
-                                    this.updateEntry("group", { target: { value: value || "Default" } });
+                                isValidNewOption={isValidNewGroupOption}
+                                newOptionCreator={function(option) {
+                                    const { valueKey, label, labelKey } = option;
+                                    const value = label.replace(/\./g, '${dot}').replace(/\//g, '.');
+                                    return {
+                                        [valueKey]: value,
+                                        [labelKey]: label,
+                                        className: 'Select-create-option-placeholder'
+                                    };
                                 }}
-                                theme="bootstrap3"
-                                createFromSearch={this.props.allowNew ? createFromSearch : undefined}
-                                hideResetButton={!this.props.allowNew}
-                                editable={this.props.allowNew}
-                                onValueChange={function(item) {
-                                    // here, we add the selected item to the options array, the "new-option"
-                                    // property, added to items created by the "create-from-search" function above,
-                                    // helps us ensure that the item doesn't already exist in the options array
-                                    if (!!item && !!item.newOption) {
-                                        this.options.unshift({ label: item.label, value: item.value });
-                                    }
-                                    this.onChange(item ? item.value : null);
-                                }} />
+                                value={{ label: getLabelName(this.props.element && this.props.element.group || "Default", groups), value: this.props.element && this.props.element.group || "Default" }}
+                                placeholder={getLabelName(this.props.element && this.props.element.group || "Default", groups)}
+                                onChange={(item) => {
+                                    this.updateEntry("group", { target: { value: item.value || "Default" } });
+                                }}
+                            />
                         </div> : null}
                     {   /* Tooltip section */
                         this.props.showTooltipOptions &&
@@ -153,26 +156,23 @@ class General extends React.Component {
                             <Col xs={12} sm={8} className="first-selectize">
                                 <br />
                                 <label key="tooltip-label" className="control-label"><Message msgId="layerProperties.tooltip.label" /></label>
-                                <SimpleSelect
-                                    hideResetButton
-                                    dropdownDirection={-1}
+                                <Select
+                                    clearable={false}
                                     key="tooltips-dropdown"
                                     options={tooltipItems}
-                                    theme="bootstrap3"
                                     value={find(tooltipItems, o => o.value === (this.props.element.tooltipOptions || "title"))}
-                                    onValueChange={(item) => { this.updateEntry("tooltipOptions", { target: { value: item.value || "title" } }); }} />
+                                    onChange={(item) => { this.updateEntry("tooltipOptions", { target: { value: item.value || "title" } }); }} />
                             </Col>
                             <Col xs={12} sm={4} className="second-selectize">
                                 <br />
                                 <label key="tooltip-placement-label" className="control-label"><Message msgId="layerProperties.tooltip.labelPlacement" /></label>
-                                <SimpleSelect
-                                    hideResetButton
-                                    dropdownDirection={-1}
+                                <Select
+                                    clearable={false}
                                     key="tooltips-placement-dropdown"
                                     options={tooltipPlacementItems}
-                                    theme="bootstrap3"
                                     value={find(tooltipPlacementItems, o => o.value === (this.props.element.tooltipPlacement || "top"))}
-                                    onValueChange={(item) => { this.updateEntry("tooltipPlacement", { target: { value: item.value || "top" } }); }} />
+                                    onChange={(item) => { this.updateEntry("tooltipPlacement", { target: { value: item.value || "top" } }); }}
+                                />
                             </Col>
                         </div>
                     }

--- a/web/client/themes/default/less/dropdown-menu.less
+++ b/web/client/themes/default/less/dropdown-menu.less
@@ -15,15 +15,6 @@
 // **************
 // Layout
 // **************
-/* when flipped we need to let the dropdown to display on top */
-.react-selectize.bootstrap3.dropdown-menu.flipped {
-    top: auto;
-}
-
-//
-.react-selectize.bootstrap3.root-node.simple-select {
-    width: 100%
-}
 
 .first-selectize {
     padding-right: 10px;

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -11,20 +11,12 @@ import { isObject, get } from 'lodash';
 import {getGroupByName} from './LayersUtils';
 import {getLocale} from './LocaleUtils';
 
-export const createFromSearch = function(options, search) {
-    /* only create an option from search if the length of the search string is > 0 and
-    it does no match the label property of an existing option
-    MV: it should also avoid the creation of group with an empty name therefore a new regex has been introduced
-    */
+export const isValidNewGroupOption = function({ label }) {
     const filterWrongGroupRegex = RegExp('^\/|\/$|\/{2,}');
-    if (search.length === 0 || (options.map(function(option) {
-        return option.label;
-    })).indexOf(search) > -1 || filterWrongGroupRegex.test(search)) {
-        return null;
+    if (!label || filterWrongGroupRegex.test(label)) {
+        return false;
     }
-
-    const val = search.replace(/\./g, '${dot}').replace(/\//g, '.');
-    return {label: search, value: val};
+    return true;
 };
 
 /**

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -8,7 +8,7 @@
 import expect from 'expect';
 
 import {
-    createFromSearch,
+    isValidNewGroupOption,
     getTooltip,
     getTooltipFragment,
     flattenGroups,
@@ -16,7 +16,6 @@ import {
     getLabelName
 } from '../TOCUtils';
 
-let options = [{label: "lab1", value: "val1"}];
 const groups = [{
     "id": "first",
     "title": "first",
@@ -85,16 +84,16 @@ const groups = [{
 }];
 
 describe('TOCUtils', () => {
-    it('test createFromSearch for General Fragment with value not allowed', () => {
-        let val = createFromSearch(options, "/as");
-        expect(val).toBe(null);
-        val = createFromSearch(options, "a//s");
-        expect(val).toBe(null);
-        val = createFromSearch(options, "s/d&/");
-        expect(val).toBe(null);
+    it('test isValidNewGroupOption for General Fragment with value not allowed', () => {
+        let val = isValidNewGroupOption({ label: "/as" });
+        expect(val).toBe(false);
+        val = isValidNewGroupOption({ label: "a//s" });
+        expect(val).toBe(false);
+        val = isValidNewGroupOption({ label: "s/d&/" });
+        expect(val).toBe(false);
     });
 
-    it('test createFromSearch for General Fragment with new valid value', () => {
+    it('test getTooltip for General Fragment with new valid value', () => {
         const node = {
             name: 'layer00',
             title: {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:
- refactor of select input of General settings to use react-select
- remove react-selectize because was used only for this component and its own styles were not aligned with the theme

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7052

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Style of select inputs in the general settings are aligned with the theme

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

The dropdown generated from the attribute autocomplete of a text input is a native behaviour of the browser and cannot be styled

see https://github.com/geosolutions-it/MapStore2/issues/7052#issuecomment-875430469
