### PR TITLE
#7081: Text widget placeholder is not visible

### DIFF
--- a/web/client/components/catalog/CatalogServiceEditor.jsx
+++ b/web/client/components/catalog/CatalogServiceEditor.jsx
@@ -17,8 +17,6 @@ import Message from "../I18N/Message";
 import AdvancedSettings from './editor/AdvancedSettings';
 import MainForm from './editor/MainForm';
 
-import 'react-quill/dist/quill.snow.css';
-
 export default ({
     service = {
         title: "",

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import 'react-quill/dist/quill.snow.css';
-
 import { head, isEmpty, isFunction, isUndefined } from 'lodash';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';

--- a/web/client/components/resources/modals/fragments/editors/QuillEditor.jsx
+++ b/web/client/components/resources/modals/fragments/editors/QuillEditor.jsx
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'react-quill/dist/quill.snow.css';
-
 import {identity} from 'lodash';
 import React from 'react';
 import ReactQuill from 'react-quill';

--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -6,6 +6,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@import '~react-quill/dist/quill.snow.css';
+
 // **************
 // Theme
 // **************
@@ -25,6 +27,9 @@
     }
     .ql-snow .ql-picker {
         .color-var(@theme-vars[main-color]);
+    }
+    .ql-editor.ql-blank::before {
+        .color-var(@theme-vars[placeholder-color]);
     }
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR change the way we include the style for the quill library and fix the color of the placeholder text

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7081

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Now the style of quill text editor is correctly applied

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
