### PR TITLE
7090-Wrong-group-names-in-layer-setting-selector

### DIFF
--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -15,7 +15,7 @@ import Select from 'react-select';
 import Spinner from 'react-spinkit';
 
 import { getMessageById, getSupportedLocales } from '../../../../utils/LocaleUtils';
-import { isValidNewGroupOption, getLabelName, flattenGroupsByTitle} from '../../../../utils/TOCUtils';
+import { isValidNewGroupOption, getLabelName, flattenGroupsByTitle, getGroupTitle} from '../../../../utils/TOCUtils';
 import Message from '../../../I18N/Message';
 import LayerNameEditField from './LayerNameEditField';
 
@@ -143,7 +143,7 @@ class General extends React.Component {
                                         className: 'Select-create-option-placeholder'
                                     };
                                 }}
-                                value={{ label: getLabelName(this.props.element && this.props.element.group || "Default", groups), value: this.props.element && this.props.element.group || "Default" }}
+                                value={{ label: getGroupTitle(this.props.element.group, groups), value: this.props.element && this.props.element.group || "Default" }}
                                 placeholder={getLabelName(this.props.element && this.props.element.group || "Default", groups)}
                                 onChange={(item) => {
                                     this.updateEntry("group", { target: { value: item.value || "Default" } });

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -102,6 +102,15 @@ export const flattenGroupsByTitle = (groups, idx = 0, wholeGroup = false) => {
     }, []);
 };
 
+// eslint-disable-next-line consistent-return
+export const getGroupTitle = (groupLabel, groups ) => {
+    for (let i = 0; i < groups.length; i++) {
+        if (groups[i].value === groupLabel) {
+            return groups[i].label;
+        }
+    }
+};
+
 export const getLabelName = (groupLabel = "", groups = []) => {
     let label = groupLabel.replace(/[^\.\/]+/g, match => {
         const title = get(getGroupByName(match, groups), 'title');

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -103,7 +103,7 @@ export const flattenGroupsByTitle = (groups, idx = 0, wholeGroup = false) => {
 };
 
 // eslint-disable-next-line consistent-return
-export const getGroupTitle = (groupLabel, groups ) => {
+export const getGroupTitle = (groupLabel = "", groups = [] ) => {
     for (let i = 0; i < groups.length; i++) {
         if (groups[i].value === groupLabel) {
             return groups[i].label;

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -91,6 +91,17 @@ export const flattenGroups = (groups, idx = 0, wholeGroup = false) => {
         return acc;
     }, []);
 };
+
+export const flattenGroupsByTitle = (groups, idx = 0, wholeGroup = false) => {
+    return groups.filter((group) => group.nodes).reduce((acc, g) => {
+        acc.push(wholeGroup ? g : {label: g.title.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id});
+        if (g.nodes.length > 0) {
+            return acc.concat(flattenGroupsByTitle(g.nodes, idx + 1, wholeGroup));
+        }
+        return acc;
+    }, []);
+};
+
 export const getLabelName = (groupLabel = "", groups = []) => {
     let label = groupLabel.replace(/[^\.\/]+/g, match => {
         const title = get(getGroupByName(match, groups), 'title');
@@ -104,3 +115,4 @@ export const getLabelName = (groupLabel = "", groups = []) => {
     label = label.replace(/\${dot}/g, '.');
     return label;
 };
+

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -12,6 +12,7 @@ import {
     getTooltip,
     getTooltipFragment,
     flattenGroups,
+    flattenGroupsByTitle,
     getTitleAndTooltip,
     getLabelName
 } from '../TOCUtils';
@@ -147,6 +148,18 @@ describe('TOCUtils', () => {
         expect(allGroups[2].id).toBe("first.second.third");
         expect(allGroups[2].value).toBe(undefined);
     });
+
+    it('test flattenGroupsByTitle, wholeGroup true', () => {
+        const allGroups = flattenGroupsByTitle(groups, 0, true);
+        expect(allGroups.length).toBe(3);
+        expect(allGroups[0].id).toBe("first");
+        expect(allGroups[0].value).toBe(undefined);
+        expect(allGroups[1].id).toBe("first.second");
+        expect(allGroups[1].value).toBe(undefined);
+        expect(allGroups[2].id).toBe("first.second.third");
+        expect(allGroups[2].value).toBe(undefined);
+    });
+
     it('test flattenGroups, wholeGroup false', () => {
         const allGroups = flattenGroups(groups);
         expect(allGroups.length).toBe(3);


### PR DESCRIPTION
 
Solve the problem of the identifier appearing instead of the layer name if it is selected from the group 
related to this issue 
https://github.com/geosolutions-it/mapstore2/issues/7090

**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
