### PR TITLE
#7079 Removing publicPath from build to allow auto script resolution

### DIFF
--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -277,7 +277,7 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         }] : [])
     },
     devServer: devServer || {
-        publicPath: "/" + publicPath,
+        publicPath: "/dist/",
         proxy: proxy || {
             '/rest': {
                 target: "https://dev-mapstore.geosolutionsgroup.com/mapstore",

--- a/build/prod-webpack.config.js
+++ b/build/prod-webpack.config.js
@@ -28,12 +28,14 @@ module.exports = require('./buildConfig')(
     [
         new HtmlWebpackPlugin({
             template: path.join(paths.framework, 'indexTemplate.html'),
+            publicPath: 'dist/',
             chunks: ['mapstore2'],
             inject: "body",
             hash: true
         }),
         new HtmlWebpackPlugin({
             template: path.join(paths.framework, 'embeddedTemplate.html'),
+            publicPath: 'dist/',
             chunks: ['embedded'],
             inject: "body",
             hash: true,
@@ -41,6 +43,7 @@ module.exports = require('./buildConfig')(
         }),
         new HtmlWebpackPlugin({
             template: path.join(paths.framework, 'apiTemplate.html'),
+            publicPath: 'dist/',
             chunks: ['ms2-api'],
             inject: 'head',
             hash: true,
@@ -48,6 +51,7 @@ module.exports = require('./buildConfig')(
         }),
         new HtmlWebpackPlugin({
             template: path.join(paths.framework, 'geostory-embedded-template.html'),
+            publicPath: 'dist/',
             chunks: ['geostory-embedded'],
             inject: "body",
             hash: true,
@@ -55,6 +59,7 @@ module.exports = require('./buildConfig')(
         }),
         new HtmlWebpackPlugin({
             template: path.join(paths.framework, 'dashboard-embedded-template.html'),
+            publicPath: 'dist/',
             chunks: ['dashboard-embedded'],
             inject: 'body',
             hash: true,

--- a/build/prod-webpack.config.js
+++ b/build/prod-webpack.config.js
@@ -45,7 +45,7 @@ module.exports = require('./buildConfig')(
             template: path.join(paths.framework, 'apiTemplate.html'),
             publicPath: 'dist/',
             chunks: ['ms2-api'],
-            inject: 'head',
+            inject: 'body',
             hash: true,
             filename: 'api.html'
         }),

--- a/build/prod-webpack.config.js
+++ b/build/prod-webpack.config.js
@@ -15,7 +15,7 @@ module.exports = require('./buildConfig')(
     {
         "mapstore2": path.join(paths.code, "product", "app"),
         "embedded": path.join(paths.code, "product", "embedded"),
-        "api": path.join(paths.code, "product", "api"),
+        "ms2-api": path.join(paths.code, "product", "api"),
         "dashboard-embedded": path.join(paths.code, "product", "dashboardEmbedded"),
         "geostory-embedded": path.join(paths.code, "product", "geostoryEmbedded")
     },

--- a/build/prod-webpack.config.js
+++ b/build/prod-webpack.config.js
@@ -15,7 +15,7 @@ module.exports = require('./buildConfig')(
     {
         "mapstore2": path.join(paths.code, "product", "app"),
         "embedded": path.join(paths.code, "product", "embedded"),
-        "ms2-api": path.join(paths.code, "product", "api"),
+        "api": path.join(paths.code, "product", "api"),
         "dashboard-embedded": path.join(paths.code, "product", "dashboardEmbedded"),
         "geostory-embedded": path.join(paths.code, "product", "geostoryEmbedded")
     },
@@ -23,7 +23,7 @@ module.exports = require('./buildConfig')(
     paths,
     [extractThemesPlugin, ModuleFederationPlugin],
     true,
-    "dist/",
+    undefined,
     undefined,
     [
         new HtmlWebpackPlugin({

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -3,11 +3,11 @@ const path = require("path");
 const themeEntries = require('./themes.js').themeEntries;
 const extractThemesPlugin = require('./themes.js').extractThemesPlugin;
 const moduleFederationPlugin = require('./moduleFederation.js').plugin;
-
-module.exports = require('./buildConfig')(
+const config = require('./buildConfig')(
     {
         [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app"),
         "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded"),
+        "ms2-api": path.join(__dirname, "..", "web", "client", "product", "api"),
         "dashboard-embedded": path.join(__dirname, "..", "web", "client", "product", "dashboardEmbedded"),
         "geostory-embedded": path.join(__dirname, "..", "web", "client", "product", "geostoryEmbedded")
     },
@@ -20,5 +20,6 @@ module.exports = require('./buildConfig')(
     },
     [extractThemesPlugin, moduleFederationPlugin],
     false,
-    "dist/"
+    undefined
 );
+module.exports = config;

--- a/project/standard/templates/prod-webpack.config.js
+++ b/project/standard/templates/prod-webpack.config.js
@@ -24,7 +24,7 @@ module.exports = require('./MapStore2/build/buildConfig')(
     paths,
     [extractThemesPlugin, ModuleFederationPlugin],
     true,
-    "dist/",
+    undefined,
     '.__PROJECTNAME__',
     [
         new HtmlWebpackPlugin({

--- a/project/standard/templates/webpack.config.js
+++ b/project/standard/templates/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = require('./MapStore2/build/buildConfig')(
     },
     [extractThemesPlugin, ModuleFederationPlugin],
     false,
-    "dist/",
+    undefined,
     '.__PROJECTNAME__',
     [],
     {


### PR DESCRIPTION
## Description
This PR removes the `publicPath` set to "dist" to use default ('auto'). This allows to use api even outside root of the application.
devServer publicPath is set to "/dist/" to allow to retrieve data. Moreover, because HTML are copied in the root, I set their public path to "dist/". 
In order to fix the `api.html`, I had also to move the script from `head` to `body` (script is anyway executed on body load, so it works for me. If injected in head, I had errors triggered by ms2-api).

note: 
If you want to provide a `publicPath` different from default, you will have to pass also devServer configuration to `buildConfig`.

- TODO: Need to test deployed version.

RFC

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7079

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
