### PR TITLE
#7134: Improve configurability of map catalog in dashboard editor

### DIFF
--- a/web/client/components/maps/enhancers/enhancers.js
+++ b/web/client/components/maps/enhancers/enhancers.js
@@ -60,7 +60,7 @@ const scrollSpyOptions = { querySelector: ".ms2-border-layout-body .ms2-border-l
  * @param {function} fn the original loadPage function
  */
 const emptyMap = fn => (opts, page) => {
-    if (page === 0 && opts && !opts.text) {
+    if (!opts.disableEmptyMap && page === 0 && opts && !opts.text) {
         return fn(opts, page).map(({ items, total, ...props}) => ({
             ...props,
             total,
@@ -91,7 +91,7 @@ export const withEmptyMapVirtualScrollProperties = ({ loadPage: lp, scrollSpyOpt
     loadPage: emptyMap(lp),
     hasMore: ({total, items}) => {
         if (items && items.length >= 1 && items[0].id === "EMPTY_MAP") {
-            return total > (items.length + 1);
+            return total > (items.length - 1);
         }
         return total > items.length;
     }
@@ -114,12 +114,12 @@ export const withVirtualScroll = withVirtualScrollEnhancer(({ loadPage: loadPage
 
 // trigger loadFirst on text change
 export const searchOnTextChange = mapPropsStream(props$ =>
-    props$.merge(props$.take(1).switchMap(({ loadFirst = () => { } }) =>
+    props$.merge(props$.take(1).switchMap(({ loadFirst = () => { }, disableEmptyMap }) =>
         props$
             .debounceTime(500)
             .startWith({ searchText: "" })
             .distinctUntilKeyChanged('searchText', (a, b) => a === b)
-            .do(({ searchText, options } = {}) => loadFirst({ text: searchText, options }))
+            .do(({ searchText, options } = {}) => loadFirst({ text: searchText, options, disableEmptyMap }))
             .ignoreElements() // don't want to emit props
     )));
 

--- a/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
+++ b/web/client/components/widgets/builder/wizard/map/MapSelector.jsx
@@ -22,7 +22,7 @@ const MapCatalog = mcEnhancer(MapCatalogComp);
 /**
  * Builder page that allows layer's selection
  */
-export default handleMapSelect(({ onClose = () => { }, setSelected = () => { }, onMapChoice = () => { }, stepButtons = [], selected } = {}) =>
+export default handleMapSelect(({ onClose = () => { }, setSelected = () => { }, onMapChoice = () => { }, stepButtons = [], selected, disableEmptyMap } = {}) =>
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
@@ -40,5 +40,5 @@ export default handleMapSelect(({ onClose = () => { }, setSelected = () => { }, 
                 }]} />
         </BuilderHeader>}
     >
-        <MapCatalog title={<Message msgId="widgets.builder.wizard.selectAMap" />} selected={selected} onSelected={r => setSelected(r)} />
+        <MapCatalog title={<Message msgId="widgets.builder.wizard.selectAMap" />} selected={selected} onSelected={r => setSelected(r)} disableEmptyMap={disableEmptyMap}/>
     </BorderLayout>));

--- a/web/client/components/widgets/builder/wizard/map/enhancers/handleMapSelect.js
+++ b/web/client/components/widgets/builder/wizard/map/enhancers/handleMapSelect.js
@@ -8,10 +8,10 @@
 
 import { compose, withState, mapPropsStream, withHandlers } from 'recompose';
 
-import GeoStoreDAO from '../../../../../../api/GeoStoreDAO';
 import axios from '../../../../../../libs/ajax';
 import ConfigUtils from '../../../../../../utils/ConfigUtils';
 import { excludeGoogleBackground, extractTileMatrixFromSources } from '../../../../../../utils/LayersUtils';
+import { getResource } from '../../../../../../api/persistence';
 import '../../../../../../libs/bindings/rxjsRecompose';
 
 const handleMapSelect = compose(
@@ -20,7 +20,9 @@ const handleMapSelect = compose(
         onMapChoice: ({ onMapSelected = () => { }, onSetIdentifyTrue = () => {}, selectedSource = {}, includeMapId = false } = {}) => map =>
             (typeof map.id === 'string'
                 ? axios.get(map.id).then(response => response.data)
-                : GeoStoreDAO.getData(map.id, {baseURL: selectedSource.baseURL})
+                : getResource(map.id, { baseURL: selectedSource.baseURL, includeAttributes: false })
+                    .toPromise()
+                    .then(({ data }) => data)
             ).then(config => {
                 let mapState = (!config.version && typeof map.id !== 'string') ? ConfigUtils.convertFromLegacy(config) : ConfigUtils.normalizeConfig(config.map);
                 return {

--- a/web/client/observables/__tests__/geostore-test.js
+++ b/web/client/observables/__tests__/geostore-test.js
@@ -8,7 +8,7 @@
 import expect from 'expect';
 
 import geoStoreMock from './geoStoreMock';
-import { createResource, deleteResource, getResourceIdByName, updateResource } from '../geostore';
+import { createResource, deleteResource, getResourceIdByName, updateResource, getResource } from '../geostore';
 const testAndResolve = (test = () => {}, value) => (...args) => {
     test(...args);
     return Promise.resolve(value);
@@ -239,5 +239,91 @@ describe('geostore observables for resources management', () => {
                 e => done(e)
             );
         });
+    });
+    it('getResource with default arguments', done => {
+
+        const ID = 7;
+
+        const DummyAPI = {
+            getShortResource: testAndResolve(
+                id => expect(id).toBe(ID),
+                {}
+            ),
+            getResourceAttributes: testAndResolve(
+                id => expect(id).toBe(ID),
+                [{
+                    "name": "thumbnail",
+                    "type": "STRING",
+                    "value": "rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri"
+                }]
+            ),
+            getData: testAndResolve(
+                (id) => {
+                    expect(id).toBe(ID);
+                },
+                {}
+            )
+        };
+        getResource(ID, {}, DummyAPI)
+            .subscribe(
+                (res) => {
+                    try {
+                        expect(res).toEqual(
+                            {
+                                attributes: { thumbnail: 'rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri' },
+                                data: {},
+                                permissions: undefined
+                            }
+                        );
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                },
+                e => expect(true).toBe(false, e)
+            );
+    });
+    it('getResource with includeAttributes set to false ', done => {
+
+        const ID = 7;
+
+        const DummyAPI = {
+            getShortResource: testAndResolve(
+                id => expect(id).toBe(ID),
+                {}
+            ),
+            getResourceAttributes: testAndResolve(
+                id => expect(id).toBe(ID),
+                [{
+                    "name": "thumbnail",
+                    "type": "STRING",
+                    "value": "rest%2Fgeostore%2Fdata%2F2%2Fraw%3Fdecode%3Ddatauri"
+                }]
+            ),
+            getData: testAndResolve(
+                (id) => {
+                    expect(id).toBe(ID);
+                },
+                {}
+            )
+        };
+        getResource(ID, { includeAttributes: false }, DummyAPI)
+            .subscribe(
+                (res) => {
+                    try {
+                        expect(res).toEqual(
+                            {
+                                attributes: {},
+                                data: {},
+                                permissions: undefined
+                            }
+                        );
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                },
+                e => expect(true).toBe(false, e)
+            );
     });
 });

--- a/web/client/observables/geostore.js
+++ b/web/client/observables/geostore.js
@@ -159,11 +159,15 @@ const updateOtherLinkedResourcesPermissions = (id, linkedResources, permission, 
  * @param {object} API the API to use, default GeoStoreDAO
  * @return an observable that emits the resource
  */
-export const getResource = (id, { includeAttributes = true, withData = true, withPermissions = false } = {}, API = GeoStoreDAO) =>
+export const getResource = (id, { includeAttributes = true, withData = true, withPermissions = false, baseURL } = {}, API = GeoStoreDAO) =>
     Observable.forkJoin([
         Observable.defer(() => API.getShortResource(id)).pluck("ShortResource"),
-        ...(includeAttributes ? [ Observable.defer(() => API.getResourceAttributes(id))] : []),
-        ...(withData ? [Observable.defer(() =>API.getData(id))] : []),
+        Observable.defer(() => includeAttributes
+            ? API.getResourceAttributes(id)
+            // when includeAttributes is false we should return an empty array
+            // to keep the order of response in the .map argument
+            : new Promise(resolve => resolve([]))),
+        ...(withData ? [Observable.defer(() =>API.getData(id, { baseURL }))] : []),
         ...(withPermissions ? [Observable.defer( () => API.getResourcePermissions(id, {}, true))] : [])
     ]).map(([resource, attributes, data, permissions]) => ({
         ...resource,

--- a/web/client/plugins/DashboardEditor.jsx
+++ b/web/client/plugins/DashboardEditor.jsx
@@ -89,9 +89,10 @@ const EditorToolbar = compose(
  * @name DashboardEditor
  * @class
  * @memberof plugins
-* @prop {object} cfg.catalog **Deprecated** in favor of `cfg.services`. Can contain a catalog configuration
-* @prop {object} cfg.services Object with the catalogs available to select layers for maps, charts and tables. The format is the same of the `Catalog` plugin.
+ * @prop {object} cfg.catalog **Deprecated** in favor of `cfg.services`. Can contain a catalog configuration
+ * @prop {object} cfg.services Object with the catalogs available to select layers for maps, charts and tables. The format is the same of the `Catalog` plugin.
  * @prop {string} cfg.selectedService the key of service selected by default from the list of `cfg.services`
+ * @prop {boolean} cfg.disableEmptyMap disable empty map entry from the available maps of map widget
  */
 class DashboardEditorComponent extends React.Component {
     static propTypes = {
@@ -110,7 +111,8 @@ class DashboardEditorComponent extends React.Component {
         src: PropTypes.string,
         style: PropTypes.object,
         pluginCfg: PropTypes.object,
-        catalog: PropTypes.object
+        catalog: PropTypes.object,
+        disableEmptyMap: PropTypes.bool
     };
     static defaultProps = {
         id: "dashboard-editor",
@@ -138,7 +140,7 @@ class DashboardEditorComponent extends React.Component {
         const defaultServices = this.props.pluginCfg.services || {};
 
         return this.props.editing
-            ? <div className="dashboard-editor de-builder"><Builder defaultSelectedService={defaultSelectedService} defaultServices={defaultServices} enabled={this.props.editing} onClose={() => this.props.setEditing(false)} catalog={this.props.catalog} /></div>
+            ? <div className="dashboard-editor de-builder"><Builder disableEmptyMap={this.props.disableEmptyMap} defaultSelectedService={defaultSelectedService} defaultServices={defaultServices} enabled={this.props.editing} onClose={() => this.props.setEditing(false)} catalog={this.props.catalog} /></div>
             : (<div className="ms-vertical-toolbar dashboard-editor de-toolbar" id={this.props.id}>
                 <EditorToolbar transitionProps={false} btnGroupProps={{ vertical: true }} btnDefaultProps={{ tooltipPosition: 'right', className: 'square-button-md', bsStyle: 'primary' }} />
                 {this.props.loading ? <LoadingSpinner style={{ position: 'fixed', bottom: 0}} /> : null}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds:

- a new property disableEmptyMap to remove the empty map entry from map catalog
- use persistence api after selecting a map in the map catalog in this way we can override the request in custom project

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7134

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
