### PR TITLE
7038-Wrong-text-in-app-context

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -79,6 +79,7 @@ export default class ContextCreator extends React.Component {
         user: PropTypes.object,
         loading: PropTypes.bool,
         loadFlags: PropTypes.object,
+        contextId: PropTypes.object,
         isValidContextName: PropTypes.bool,
         contextNameChecked: PropTypes.bool,
         curStepId: PropTypes.string,
@@ -267,6 +268,7 @@ export default class ContextCreator extends React.Component {
                         this.props.loading || !this.props.isValidContextName || !this.props.contextNameChecked,
                     component:
                         <GeneralSettings
+                            contextId={this.props.contextId}
                             contextName={this.props.resource.name}
                             windowTitle={this.props.newContext.windowTitle}
                             isValidContextName={this.props.isValidContextName}

--- a/web/client/components/contextcreator/GeneralSettingsStep.jsx
+++ b/web/client/components/contextcreator/GeneralSettingsStep.jsx
@@ -18,7 +18,9 @@ export default ({contextName = "", windowTitle = "", isValidContextName = true, 
             <div className="text-center">
                 <Glyphicon glyph="wrench" style={{ fontSize: 128 }}/>
             </div>
-            <h1 className="text-center"><Message msgId="contextCreator.generalSettings.title"/></h1>
+            <h1 className="text-center">
+                {window.location.href.indexOf('new') === -1   ? <Message msgId="contextCreator.generalSettings.edit"/> : <Message msgId="contextCreator.generalSettings.title"/>}
+            </h1>
             <FormGroup validationState={contextName.length > 0 && contextNameChecked ? (isValidContextName ? 'success' : 'error') : null}>
                 <ControlLabel>
                     <Message msgId="contextCreator.generalSettings.name"/>

--- a/web/client/components/contextcreator/GeneralSettingsStep.jsx
+++ b/web/client/components/contextcreator/GeneralSettingsStep.jsx
@@ -12,14 +12,14 @@ import Message from '../I18N/Message';
 import {FormGroup, ControlLabel, FormControl, Glyphicon} from 'react-bootstrap';
 import {getMessageById} from '../../utils/LocaleUtils';
 
-export default ({contextName = "", windowTitle = "", isValidContextName = true, contextNameChecked = true, loading = false, onChange = () => {}, context = {}}) => (
+export default ({contextId, contextName = "", windowTitle = "", isValidContextName = true, contextNameChecked = true, loading = false, onChange = () => {}, context = {}}) => (
     <div className="general-settings-step">
         <div style={{ margin: 'auto' }}>
             <div className="text-center">
                 <Glyphicon glyph="wrench" style={{ fontSize: 128 }}/>
             </div>
             <h1 className="text-center">
-                {window.location.href.indexOf('new') === -1   ? <Message msgId="contextCreator.generalSettings.edit"/> : <Message msgId="contextCreator.generalSettings.title"/>}
+                {contextId === "new" ? <Message msgId="contextCreator.generalSettings.title"/> : <Message msgId="contextCreator.generalSettings.edit"/> }
             </h1>
             <FormGroup validationState={contextName.length > 0 && contextNameChecked ? (isValidContextName ? 'success' : 'error') : null}>
                 <ControlLabel>

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -2887,6 +2887,7 @@
             "generalSettings": {
                 "label": "Allgemeine Einstellungen",
                 "title": "Erstellen Sie einen neuen App-Kontext",
+                "edit": "App-Kontext bearbeiten",
                 "name": "Name",
                 "namePlaceholder": "Geben Sie den Namen des App-Kontexts ein...",
                 "windowTitle": "Fenstertitel",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -2900,6 +2900,7 @@
             "generalSettings": {
                 "label": "General Settings",
                 "title": "Create new app context",
+                "edit": "Edit app context",
                 "name": "Name",
                 "namePlaceholder": "Enter app context name...",
                 "windowTitle": "Window title",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -2887,6 +2887,7 @@
             "generalSettings": {
                 "label": "Configuración general",
                 "title": "Crear nuevo contexto de aplicación",
+                "edit": "Editar el contexto de la aplicación",
                 "name": "Nombre",
                 "namePlaceholder": "Ingrese el nombre del contexto de la aplicación...",
                 "windowTitle": "Título de la ventana",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -2889,6 +2889,7 @@
             "generalSettings": {
                 "label": "Paramètres Généraux",
                 "title": "Créer un nouveau contexte applicatif",
+                "edit": "Modifier le contexte de l'application",
                 "name": "Nom",
                 "namePlaceholder": "Entrez le nom du contexte applicatif...",
                 "windowTitle": "Titre de la fenêtre",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2887,10 +2887,10 @@
         "contextCreator": {
             "generalSettings": {
                 "label": "Impostazioni Generali",
-                "title": "Crea un nuovo contesto per l'app",
-                "edit": "Modifica il contesto dell'app",
+                "title": "Crea un nuovo contesto applicativo",
+                "edit": "Modifica il contesto applicativo",
                 "name": "Nome",
-                "namePlaceholder": "Inserisci il nome del contesto dell'app...",
+                "namePlaceholder": "Inserisci il nome del contesto applicativo...",
                 "windowTitle": "Titolo della finestra",
                 "windowTitlePlaceholder": "Inserisci il titolo della finestra..."
             },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -2888,6 +2888,7 @@
             "generalSettings": {
                 "label": "Impostazioni Generali",
                 "title": "Crea un nuovo contesto per l'app",
+                "edit": "Modifica il contesto dell'app",
                 "name": "Nome",
                 "namePlaceholder": "Inserisci il nome del contesto dell'app...",
                 "windowTitle": "Titolo della finestra",


### PR DESCRIPTION
## Description
Fix Wrong text in app context wizard step 1 when editing an existing context 
related to this issue https://github.com/geosolutions-it/mapstore2/issues/7038

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No