### PR TITLE
#7147: Annotations marker picker should target the correct container node in custom project

### DIFF
--- a/web/client/components/style/MarkerPropertyPicker.jsx
+++ b/web/client/components/style/MarkerPropertyPicker.jsx
@@ -13,7 +13,7 @@ import { getConfigProp } from '../../utils/ConfigUtils';
 
 function MarkerPropertyPicker({
     disabled,
-    containerNode,
+    containerNode = document.querySelector('.' + (getConfigProp('themePrefix') || 'ms2') + " > div") || document.body,
     onOpen,
     placement,
     children,
@@ -288,8 +288,7 @@ MarkerPropertyPicker.defaultProps = {
     line: false,
     onChangeColor: () => {},
     pickerProps: {},
-    onOpen: () => {},
-    containerNode: document.querySelector('.' + (getConfigProp('themePrefix') || 'ms2') + " > div") || document.body
+    onOpen: () => {}
 };
 
 export default MarkerPropertyPicker;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR moves the definition of containerNode to props level instead to defaultProps to ensure the latest valid container is in use when containerNode is undefined

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7147

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Markers popup of annotation are visible in custom application

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
