### PR TITLE
[Backport 2021.02.xx] #7191: Extend props of LocalDrawSupport component (#7192)

### DIFF
--- a/web/client/components/geostory/common/map/LocalDrawSupport.jsx
+++ b/web/client/components/geostory/common/map/LocalDrawSupport.jsx
@@ -28,7 +28,8 @@ function LocalDrawSupport({
     mapType,
     features,
     options,
-    onChange
+    onChange,
+    ...props
 }) {
 
     const [status, setStatus] = useState([]);
@@ -42,6 +43,7 @@ function LocalDrawSupport({
 
     return (
         <DrawSupport
+            { ...props }
             map={map}
             drawOwner={mapId}
             drawStatus={status}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport of #7192

This PR improve the LocalDrawSupport component introduced in the GeoCarousel Section PR giving access to the props of the original DrawSupport

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: minor improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7191

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Now it's possible to use the original callback of DrawSupport component in the LocalDrawSupport 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
