### PR TITLE
#7185: Geolocation orientation in mobile for OL and Leaflet map

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "leaflet-extra-markers": "1.0.6",
     "leaflet-minimap": "3.6.0",
     "leaflet-plugins": "3.0.2",
+    "leaflet-rotatedmarker": "0.2.0",
     "leaflet-simple-graticule": "1.0.2",
     "leaflet.gridlayer.googlemutant": "0.6.4",
     "leaflet.locatecontrol": "0.62.0",

--- a/web/client/map/leaflet/locate.js
+++ b/web/client/map/leaflet/locate.js
@@ -14,7 +14,7 @@ const defaultOpt = { // For all configuration options refer to https://github.co
     stopFollowingOnDrag: true,
     locateOptions: {
         maximumAge: 2000,
-        enableHighAccuracy: false,
+        enableHighAccuracy: true, // heading is only defined if the enableHighAccuracy is set to true
         timeout: 10000,
         maxZoom: 18,
         watch: true  // if you overwrite this, visualization cannot be updated

--- a/web/client/map/openlayers/locate.js
+++ b/web/client/map/openlayers/locate.js
@@ -16,7 +16,7 @@ const defaultOpt = {
     keepCurrentZoomLevel: false,
     locateOptions: {
         maximumAge: 2000,
-        enableHighAccuracy: false,
+        enableHighAccuracy: true, // heading is only defined if the enableHighAccuracy is set to true
         timeout: 10000,
         maxZoom: 18
     }

--- a/web/client/product/assets/symbols/navigation_arrow.svg
+++ b/web/client/product/assets/symbols/navigation_arrow.svg
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="iso-8859-1"?>
+<svg
+    version="1.1"
+    id="navigation_arrow"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100px"
+    height="100px"
+    viewBox="-100 0 100 100"
+    xml:space="preserve">
+		<path transform="rotate(90)" d="M 0,50 L 100,0 L 70,50 L 100,100" />
+</svg>

--- a/web/client/product/assets/symbols/symbols.json
+++ b/web/client/product/assets/symbols/symbols.json
@@ -14,5 +14,6 @@
   {"name": "arrow-south-west", "label": "Arrow South West"},
   {"name": "arrow-west", "label": "Arrow West"},
   {"name": "arrow-north-west", "label": "Arrow North West"},
-  {"name": "traffic-cone", "label": "Traffic Cone"}
+  {"name": "traffic-cone", "label": "Traffic Cone"},
+  {"name": "navigation_arrow", "label": "Navigation"}
 ]

--- a/web/client/utils/leaflet/LLocate.js
+++ b/web/client/utils/leaflet/LLocate.js
@@ -1,7 +1,9 @@
 import L from 'leaflet';
 import 'leaflet.locatecontrol';
 import 'leaflet.locatecontrol/dist/L.Control.Locate.css';
+import 'leaflet-rotatedmarker';
 import throttle from 'lodash/throttle';
+import isNil from 'lodash/isNil';
 
 L.Control.MSLocate = L.Control.Locate.extend({
     setMap: function(map) {
@@ -12,9 +14,7 @@ L.Control.MSLocate = L.Control.Locate.extend({
         this._prevBounds = null;
         // extend the follow marker style and circle from the normal style
         let tmp = {};
-        L.extend(tmp, this.options.markerStyle, this.options.followMarkerStyle);
-        this.options.followMarkerStyle = tmp;
-        tmp = {};
+        this.options.followMarkerStyle = this.defaultFollowMarkerStyle();
         L.extend(tmp, this.options.circleStyle, this.options.followCircleStyle);
         this.options.followCircleStyle = tmp;
         this._resetVariables();
@@ -40,6 +40,50 @@ L.Control.MSLocate = L.Control.Locate.extend({
             throttle(this._onLocationFound, this.options.locateOptions.rateControl)
             : this._onLocationFound;
     },
+    _drawMarker: function() {
+        let { accuracy: radius, latlng, heading } = this._event || {};
+        if (radius === undefined) {
+            radius = 0;
+        }
+        const isFollowing = this._isFollowing();
+        // circle with the radius of the location's accuracy
+        if (this.options.drawCircle) {
+            const style = isFollowing ? this.options.followCircleStyle : this.options.circleStyle;
+            if (!this._circle) {
+                this._circle = L.circle(latlng, radius, style).addTo(this._layer);
+            } else {
+                this._circle.setLatLng(latlng).setRadius(radius).setStyle(style);
+            }
+        }
+
+        let distance; let unit;
+        if (this.options.metric) {
+            distance = radius.toFixed(0);
+            unit =  this.options.strings.metersUnit;
+        } else {
+            distance = (radius * 3.2808399).toFixed(0);
+            unit = this.options.strings.feetUnit;
+        }
+
+        // Inner marker
+        if (this.options.drawMarker) {
+            this._marker && this._map.removeLayer(this._marker);
+            if (isFollowing && !isNil(heading)) {
+                this._marker = L.marker(latlng, {
+                    ...this.options.followMarkerStyle,
+                    rotationAngle: heading
+                }).addTo(this._layer);
+            } else {
+                this._marker = L.circleMarker(latlng, this.options.markerStyle).addTo(this._layer);
+            }
+        }
+        const t = this.options?.strings?.popup;
+        if (this.options.showPopup && t && this._marker) {
+            this._marker
+                .bindPopup(L.Util.template(t, {distance: distance, unit: unit}))
+                ._popup.setLatLng(latlng);
+        }
+    },
     _setClasses: function(state) {
         this._map.fire('locatestatus', {state: state});
         return state;
@@ -56,6 +100,19 @@ L.Control.MSLocate = L.Control.Locate.extend({
     },
     setStrings: function(newStrings) {
         this.options.strings = { ...this.options.strings, ...newStrings };
+    },
+    defaultFollowMarkerStyle: function() {
+        return {
+            icon: L.divIcon({
+                className: 'div-heading-icon',
+                opacity: 1,
+                iconSize: 40,
+                fillOpacity: 1,
+                // inline svg as leaflet doesn't allow to set icon color
+                html: `<svg viewBox="-100 0 100 100" xml:space="preserve"><path fill="#2A93EE" transform="rotate(90)" d="M 0,50 L 100,0 L 70,50 L 100,100"/></svg>`
+            }),
+            rotationOrigin: 'center center'
+        };
     }
 });
 

--- a/web/client/utils/leaflet/__tests__/LLocate-test.js
+++ b/web/client/utils/leaflet/__tests__/LLocate-test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import LLocate from '../LLocate';
+import L from 'leaflet';
+
+const defaultOpt = {
+    follow: true,
+    remainActive: true,
+    stopFollowingOnDrag: true,
+    locateOptions: {
+        maximumAge: 2000,
+        enableHighAccuracy: false,
+        timeout: 10000,
+        maxZoom: 18,
+        watch: false
+    }
+};
+describe('Test the leaflet LLocate utils', () => {
+    let map;
+    beforeEach((done)=>{
+        document.body.innerHTML = '<div id="map"></div><div id="container"></div>';
+        map = L.map('map');
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('test LLocate default options', () => {
+        let llocate = new LLocate(defaultOpt);
+        expect(llocate).toBeTruthy();
+        expect(llocate.options.followCircleStyle).toBeTruthy();
+        expect(llocate.options.followMarkerStyle).toBeTruthy();
+        expect(llocate.options.remainActive).toBeTruthy();
+        expect(llocate.options.follow).toBeTruthy();
+    });
+    it('test LLocate setLocateOptions', () => {
+        let llocate = new LLocate(defaultOpt);
+        expect(llocate).toBeTruthy();
+        const updateOptions = {...defaultOpt, locateOptions: {...defaultOpt.locateOptions, enableHighAccuracy: true, watch: true}};
+        llocate.setLocateOptions(updateOptions);
+        expect(llocate.options.locateOptions).toEqual(updateOptions);
+    });
+    it('test LLocate on setMap', () => {
+        let llocate = new LLocate(defaultOpt);
+        expect(llocate).toBeTruthy();
+        llocate.setMap(map);
+        expect(llocate._map).toBeTruthy();
+        expect(llocate.options.followMarkerStyle).toBeTruthy();
+        const {icon: {options: {className}}, rotationOrigin} = llocate.options.followMarkerStyle;
+        expect(className).toBe('div-heading-icon');
+        expect(rotationOrigin).toBe('center center');
+    });
+    it('test LLocate on location found', () => {
+        let llocate = new LLocate(defaultOpt);
+        const latlng = {lat: 71, lng: 13};
+        expect(llocate).toBeTruthy();
+        llocate.setMap(map);
+        expect(llocate._map).toBeTruthy();
+        llocate._activate();
+        try {
+            llocate._map.fireEvent('locationfound', {accuracy: 150, latlng});
+            // eslint-disable-next-line no-empty
+        } catch (e) { } // Ignore invalid map bounds
+        const circleMarker = llocate._circle;
+        const innerMarker = llocate._marker;
+        expect(circleMarker.getLatLng().lat).toBe(latlng.lat);
+        expect(circleMarker.getLatLng().lng).toBe(latlng.lng);
+        expect(circleMarker.getRadius()).toBe(150);
+
+        expect(innerMarker.getLatLng().lat).toBe(latlng.lat);
+        expect(innerMarker.getLatLng().lng).toBe(latlng.lng);
+        expect(innerMarker.options).toBeTruthy();
+    });
+    it('test LLocate on heading change', () => {
+        let llocate = new LLocate(defaultOpt);
+        const latlng = {lat: 71, lng: 13};
+        expect(llocate).toBeTruthy();
+        llocate.setMap(map);
+        expect(llocate._map).toBeTruthy();
+        llocate._activate();
+        try {
+            llocate._map.fireEvent('locationfound', {accuracy: 150, latlng, heading: 90});
+            // eslint-disable-next-line no-empty
+        } catch (e) { } // Ignore invalid map bounds
+        const circleMarker = llocate._circle;
+        const innerMarker = llocate._marker;
+        expect(circleMarker.getLatLng().lat).toBe(latlng.lat);
+        expect(circleMarker.getLatLng().lng).toBe(latlng.lng);
+        expect(circleMarker.getRadius()).toBe(150);
+
+        expect(llocate._event.heading).toBe(90);
+
+        expect(innerMarker.getLatLng().lat).toBe(latlng.lat);
+        expect(innerMarker.getLatLng().lng).toBe(latlng.lng);
+        expect(innerMarker.options).toBeTruthy();
+        const {icon} = innerMarker.options;
+        expect(icon).toBeTruthy();
+        // Marker is navigation icon
+        expect(icon.options.className).toBe('div-heading-icon');
+        expect(innerMarker.options.rotationAngle).toBe(90);
+        expect(innerMarker.options.rotationOrigin).toBeTruthy();
+    });
+});

--- a/web/client/utils/openlayers/__tests__/OlLocate-test.js
+++ b/web/client/utils/openlayers/__tests__/OlLocate-test.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import OlLocate from '../OlLocate';
+
+const defaultOpt = {
+    follow: true,
+    remainActive: true,
+    stopFollowingOnDrag: true,
+    locateOptions: {
+        maximumAge: 2000,
+        enableHighAccuracy: false,
+        timeout: 10000,
+        maxZoom: 18,
+        watch: false
+    }
+};
+describe('Test the OlLocate utils', () => {
+    let map;
+    beforeEach((done)=>{
+        document.body.innerHTML = '<div id="map"></div><div id="container"></div>';
+        map = new Map({target: 'map', view: new View({center: [0, 0], zoom: 1})});
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('test olLocate default options', () => {
+        let olLocate = new OlLocate(map, defaultOpt);
+        expect(olLocate).toBeTruthy();
+        expect(olLocate.geolocate).toBeTruthy();
+        expect(olLocate.map).toBeTruthy();
+        expect(olLocate.layer).toBeTruthy();
+        expect(olLocate.posFt).toBeTruthy();
+
+        // Default options
+        expect(olLocate.options.remainActive).toBeTruthy();
+        expect(olLocate.options.follow).toBeTruthy();
+        expect(olLocate.options.style).toBeTruthy();
+        expect(olLocate.options.style.locate).toBeTruthy();
+        expect(olLocate.options.style.heading).toBeTruthy();
+        expect(olLocate.options.style.circleAccuracy).toBeTruthy();
+        expect(olLocate.options.strings).toBeTruthy();
+        expect(olLocate.options.locateOptions).toBeTruthy();
+        expect(olLocate.options.locateOptions).toEqual(defaultOpt.locateOptions);
+    });
+    it('test olLocate setTrackingOptions', () => {
+        let olLocate = new OlLocate(map, defaultOpt);
+        expect(olLocate).toBeTruthy();
+        const updateOptions = {...defaultOpt, locateOptions: {...defaultOpt.locateOptions, enableHighAccuracy: true, watch: true}};
+        olLocate.setTrackingOptions(updateOptions);
+        expect(olLocate.options.locateOptions).toEqual(updateOptions);
+    });
+    it('test olLocate on follow', () => {
+        let olLocate = new OlLocate(map, defaultOpt);
+        expect(olLocate).toBeTruthy();
+        olLocate.startFollow();
+        olLocate.geolocate.setProperties({position: [10, 20], accuracy: 10});
+        expect(olLocate.map.getView().getCenter()).toEqual([10, 20]);
+    });
+    it('test olLocate on position change', () => {
+        let olLocate = new OlLocate(map, defaultOpt);
+        expect(olLocate).toBeTruthy();
+        olLocate.startFollow();
+        olLocate.geolocate.setProperties({position: [10, 20], accuracy: 10});
+        olLocate.geolocate.dispatchEvent('change:position');
+        expect(olLocate.p).toBeTruthy();
+        expect(olLocate.p).toEqual([10, 20]);
+        expect(olLocate.posFt).toBeTruthy();
+        expect(olLocate.posFt.getGeometry()).toBeTruthy();
+        expect(olLocate.posFt.getStyle().getImage().getRadius()).toBe(6);
+        expect(olLocate.map.getView().getCenter()).toEqual([10, 20]);
+        expect(olLocate.geolocate.getTracking()).toBeFalsy();
+    });
+    it('test olLocate on heading change', (done) => {
+        let olLocate = new OlLocate(map, defaultOpt);
+        expect(olLocate).toBeTruthy();
+        olLocate.geolocate.setProperties({position: [10, 20], accuracy: 10, heading: 90});
+        olLocate.geolocate.dispatchEvent('change:position');
+        expect(olLocate.geolocate.getHeading()).toBe(90);
+        expect(olLocate.p).toBeTruthy();
+        expect(olLocate.p).toEqual([10, 20]);
+        expect(olLocate.posFt).toBeTruthy();
+        expect(olLocate.posFt.getGeometry()).toBeTruthy();
+        setTimeout(() => {
+            expect(olLocate.posFt.getStyle().length).toBe(2);
+            done();
+        }, 1000);
+
+    });
+});


### PR DESCRIPTION
## Description
This PR adds commits to add new feature to OL and Leaflet maps to show Geolocation orientation in devices that supports heading prop of Geolocation API

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#7185 

**What is the new behavior?**
When geolocation is activated and in supported devices (Mobile, tablet, etc.) with `enableHighAccuracy: true` , the heading props is used to display navigation arrow marker with rotation angle determined by the heading radian or degree value based on OL and leaflet map respectively
![2021-08-09 20_10_16-MapStore HomePage](https://user-images.githubusercontent.com/26929983/128725238-49f8e2e7-cbc8-43e4-a05d-083c1c711a2d.jpg)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
