### PR TITLE
[Backport 2021.02.xx] #7195: Improve dialog positioning of Layer Download plugin for custom project project

### DIFF
--- a/web/client/components/data/download/DownloadDialog.jsx
+++ b/web/client/components/data/download/DownloadDialog.jsx
@@ -15,6 +15,7 @@ import Spinner from 'react-spinkit';
 
 import Loader from '../../misc/Loader';
 import Dialog from '../../misc/Dialog';
+import Portal from '../../misc/Portal';
 import Message from '../../I18N/Message';
 import EmptyView from '../../misc/EmptyView';
 import DownloadOptions from './DownloadOptions';
@@ -116,7 +117,7 @@ class DownloadDialog extends React.Component {
             validWFSFormats.filter(f => this.props.wfsFormats.find(wfsF => wfsF.name.toLowerCase() === f.name.toLowerCase())) :
             this.props.wfsFormats;
 
-        return this.props.enabled ? (<Dialog id="mapstore-export" draggable={false} modal>
+        return this.props.enabled ? (<Portal><Dialog id="mapstore-export" draggable={false} modal>
             <span role="header">
                 <span className="about-panel-title"><Message msgId="layerdownload.title" /></span>
                 <button onClick={this.onClose} className="settings-panel-close close">{this.props.closeGlyph ? <Glyphicon glyph={this.props.closeGlyph}/> : <span>×</span>}</button>
@@ -149,7 +150,7 @@ class DownloadDialog extends React.Component {
                     {this.renderIcon()} <Message msgId="layerdownload.export" />
                 </Button>
             </div>}
-        </Dialog>) : null;
+        </Dialog></Portal>) : null;
     }
     handleExport = () => {
         const {url, filterObj, downloadOptions, defaultSrs, srsList, onExport, layer} = this.props;

--- a/web/client/components/data/download/ExportDataResultsComponent.jsx
+++ b/web/client/components/data/download/ExportDataResultsComponent.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { Button, Tooltip, Glyphicon } from 'react-bootstrap';
 
 import Dialog from '../../misc/Dialog';
+import Portal from '../../misc/Portal';
 import ExportDataResults from './ExportDataResults';
 import InfoBubble from '../../misc/infobubble/InfoBubble';
 import DefaultInfoBubbleInner from '../../misc/infobubble/DefaultInnerComponent';
@@ -50,23 +51,27 @@ const ExportDataResultsComponent = ({
                     <DefaultInfoBubbleInner {...infoBubbleMessage} />
                 </InfoBubble>
             </div> : null}
-            <Dialog
-                id="mapstore-export-data-results"
-                style={{display: active ? "block" : "none"}}
-                draggable={false}
-                modal>
-                <span role="header">
-                    <span className="about-panel-title"><Message msgId="exportDataResults.title"/></span>
-                    <button onClick={() => onToggle()} className="settings-panel-close close"><Glyphicon glyph="1-close"/></button>
-                </span>
-                <div role="body">
-                    <ExportDataResults
-                        loading={checkingExportDataEntries}
-                        results={results}
-                        currentLocale={currentLocale}
-                        onRemoveResult={onRemoveResult}/>
-                </div>
-            </Dialog>
+            {/* Portal must be contained in a valid node tag not in <></> */}
+            <div>
+                {active && <Portal>
+                    <Dialog
+                        id="mapstore-export-data-results"
+                        draggable={false}
+                        modal>
+                        <span role="header">
+                            <span className="about-panel-title"><Message msgId="exportDataResults.title"/></span>
+                            <button onClick={() => onToggle()} className="settings-panel-close close"><Glyphicon glyph="1-close"/></button>
+                        </span>
+                        <div role="body">
+                            <ExportDataResults
+                                loading={checkingExportDataEntries}
+                                results={results}
+                                currentLocale={currentLocale}
+                                onRemoveResult={onRemoveResult}/>
+                        </div>
+                    </Dialog>
+                </Portal>}
+            </div>
         </>
     );
 };

--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -227,7 +227,7 @@ export const fetchFormatsWFSDownload = (action$) =>
 export const startFeatureExportDownload = (action$, store) =>
     action$.ofType(DOWNLOAD_FEATURES).switchMap(action => {
         const state = store.getState();
-        const {virtualScroll = false} = state.featuregrid;
+        const {virtualScroll = false} = state.featuregrid || {};
         const service = serviceSelector(state);
         const layer = getSelectedLayer(state);
         const mapBbox = mapBboxSelector(state);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Backport of #7196

This PR wraps the dialog of Layer Download inside a portal so it is easier to controll the z-index in custom project

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe:  Minor changes to existing features

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7195

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

Now the container of Layer Download is the root node

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
