### PR TITLE
#7104: Fix GFI popup viewer in embedded mode

### DIFF
--- a/web/client/components/common/enhancers/withIdentifyPopup.jsx
+++ b/web/client/components/common/enhancers/withIdentifyPopup.jsx
@@ -139,7 +139,7 @@ export const  withPopupSupport =  branch(({map: {mapInfoControl = false} = {}}) 
         withPropsOnChange(["mapInfo", "popups"], ({mapInfo, popups, options: {mapOptions: {mapInfoFormat = getDefaultInfoFormat()} = {}} = {}}) => {
             const {responses, requests, validResponses} = mapInfo;
             const component = () => (<MapInfoViewer
-                renderEmpty
+                renderValidOnly
                 responses={responses} requests={requests}
                 validResponses={validResponses}
                 format={mapInfoFormat} showEmptyMessageGFI missingResponses={(requests || []).length - (responses || []).length} />);

--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -37,7 +37,7 @@ class DefaultViewer extends React.Component {
         onUpdateIndex: PropTypes.func,
         setIndex: PropTypes.func,
         showEmptyMessageGFI: PropTypes.bool,
-        renderEmpty: PropTypes.bool,
+        renderValidOnly: PropTypes.bool,
         loaded: PropTypes.bool,
         isMobile: PropTypes.bool
     };
@@ -58,7 +58,7 @@ class DefaultViewer extends React.Component {
         },
         containerProps: {},
         showEmptyMessageGFI: true,
-        renderEmpty: false,
+        renderValidOnly: false,
         onNext: () => {},
         onPrevious: () => {},
         setIndex: () => {},
@@ -75,7 +75,7 @@ class DefaultViewer extends React.Component {
     getResponseProperties = () => {
         const validator = this.props.validator(this.props.format);
         const responses = this.props.responses.map(res => res === undefined ? {} : res); // Replace any undefined responses
-        const validResponses = this.props.renderEmpty ? validator.getValidResponses(responses) : responses;
+        const validResponses = this.props.renderValidOnly ? validator.getValidResponses(responses) : responses;
         const invalidResponses = validator.getNoValidResponses(this.props.responses);
         const emptyResponses = this.props.requests.length === invalidResponses.length;
         const currResponse = this.getCurrentResponse(validResponses[this.props.index]);
@@ -101,7 +101,7 @@ class DefaultViewer extends React.Component {
             return null;
         }
         let allowRender = invalidResponses.length !== 0;
-        if (!this.props.renderEmpty) {
+        if (!this.props.renderValidOnly) {
             allowRender =  allowRender && this.props.missingResponses === 0;
         }
         if (allowRender) {

--- a/web/client/components/data/identify/PopupViewer.jsx
+++ b/web/client/components/data/identify/PopupViewer.jsx
@@ -47,14 +47,14 @@ const selector = createSelector([
     showEmptyMessageGFISelector,
     identifyFloatingToolSelector,
     isLoadedResponseSelector],
-(responses, validResponses, requests, format, showEmptyMessageGFI, renderEmpty, loaded) => ({
+(responses, validResponses, requests, format, showEmptyMessageGFI, renderValidOnly, loaded) => ({
     responses,
     validResponses,
     requests,
     format,
     showEmptyMessageGFI,
     missingResponses: (requests || []).length - (responses || []).length,
-    renderEmpty,
+    renderValidOnly,
     loaded
 }));
 

--- a/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
@@ -86,7 +86,7 @@ describe('DefaultViewer', () => {
             }]
         });
         const viewer = ReactDOM.render(
-            <DefaultViewer validator={validator} renderEmpty/>,
+            <DefaultViewer validator={validator} renderValidOnly/>,
             document.getElementById("container")
         );
 
@@ -152,7 +152,7 @@ describe('DefaultViewer', () => {
             }
         }];
         const viewer = ReactDOM.render(
-            <DefaultViewer responses={responses} renderEmpty/>,
+            <DefaultViewer responses={responses} renderValidOnly/>,
             document.getElementById("container")
         );
 
@@ -230,7 +230,7 @@ describe('DefaultViewer', () => {
             }
         }];
         ReactDOM.render(
-            <DefaultViewer responses={responses} header={SwipeHeader} renderEmpty/>,
+            <DefaultViewer responses={responses} header={SwipeHeader} renderValidOnly/>,
             document.getElementById("container")
         );
         const header = document.querySelector('.ms-identify-swipe-header');

--- a/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
+++ b/web/client/components/geostory/common/enhancers/withPopupSupport.jsx
@@ -235,7 +235,7 @@ export default branch(
                     return onClickMarker(validResponses, layerInfo, popups);
                 }
                 return {popups: popups.map((popup) => ({...popup, component: ()=> (<MapInfoViewer
-                    renderEmpty
+                    renderValidOnly
                     responses={responses} requests={requests}
                     validResponses={validResponses}
                     format={mapInfoFormat} showEmptyMessageGFI

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -27,7 +27,7 @@ import assign from 'object-assign';
 import 'babel-polyfill';
 
 describe('Test the mapInfo reducer', () => {
-    let appState = {configuration: {infoFormat: 'text/plain'}, responses: [], requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
+    const appState = {configuration: {infoFormat: 'text/plain'}, responses: [], requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
 
     it('returns original state on unrecognized action', () => {
         let state = mapInfo(1, {type: 'UNKNOWN'});
@@ -115,6 +115,34 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].queryParams).toBe("params");
         expect(state.responses[1].layerMetadata).toBe("meta");
         expect(state.index).toBe(1);
+    });
+    it('creates a feature info data from successful request on showInMapPopup', () => {
+        let testAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: "data",
+            requestParams: "params",
+            layerMetadata: "meta",
+            reqId: 10
+        };
+
+        let state = mapInfo({...appState, showInMapPopup: true}, testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.responses[0].response).toBe("data");
+        expect(state.responses[0].queryParams).toBe("params");
+        expect(state.responses[0].layerMetadata).toBe("meta");
+        expect(state.index).toBe(0);
+
+        state = mapInfo(assign({}, appState, {responses: [], showInMapPopup: true}), testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(1);
+        expect(state.index).toBe(0);
+
+        state = mapInfo(assign({}, appState, {responses: ["test"], showInMapPopup: true}), {...testAction, reqId: 11});
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.responses[0]).toBeTruthy();
+        expect(state.index).toBe(0);
     });
 
     it('creates a feature info data from vector info request', () => {

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -84,7 +84,7 @@ function receiveResponse(state, action, type) {
         // Handle data and vector responses
         const {configuration: config, requests} = state;
         let responses = state.responses || [];
-        const isHover = (config?.trigger === "hover"); // Display info trigger
+        const isHover = (config?.trigger === "hover") || state?.showInMapPopup; // Display feature info in popup
 
         if (!isVector) {
             const updateResponse = {
@@ -381,7 +381,8 @@ function mapInfo(state = initState, action) {
 
         );
         let responses = state.responses || [];
-        const isHover = state?.configuration?.trigger === 'hover' || false;
+        // Display feature info in popup
+        const isHover = state?.configuration?.trigger === 'hover' || state?.showInMapPopup;
         const vectorResponse = {
             response: {
                 crs: null,

--- a/web/client/selectors/__tests__/map-test.js
+++ b/web/client/selectors/__tests__/map-test.js
@@ -170,7 +170,7 @@ describe('Test map selectors', () => {
         expect(isMouseMoveIdentifyActive).toBe(true);
     });
     it('test identifyFloatingToolSelector', () => {
-        const renderEmpty = identifyFloatingToolSelector({mode: "embedded"});
-        expect(renderEmpty).toBe(true);
+        const renderValidOnly = identifyFloatingToolSelector({mode: "embedded"});
+        expect(renderValidOnly).toBe(true);
     });
 });


### PR DESCRIPTION
## Description
This PR fixes the popup viewer of GFI in embedded mode

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#7104 

**What is the new behavior?**
The GFI popup viewer will display only one response in viewer panel and allows to paginate to other responses via the header arrow keys

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
