### PR TITLE
#7142: Carousel viewer slider

### DIFF
--- a/web/client/components/geostory/contents/carousel/ViewerSlider.jsx
+++ b/web/client/components/geostory/contents/carousel/ViewerSlider.jsx
@@ -1,0 +1,22 @@
+import Button from "../../../misc/Button";
+import {Glyphicon} from "react-bootstrap";
+import React from "react";
+
+export default ({currentIndex, contents = [], onTraverseCard = () => {}}) => {
+    return (
+        <>
+            <Button
+                className="ms-carousel-slider left-arrow"
+                disabled={currentIndex === 0}
+                onClick={() => onTraverseCard()}>
+                < Glyphicon style={{fontSize: 22}} glyph={'chevron-left'}/>
+            </Button>
+            <Button
+                className="ms-carousel-slider right-arrow"
+                onClick={() => onTraverseCard('right')}
+                disabled={currentIndex === contents.length - 1}>
+                < Glyphicon style={{fontSize: 22}} glyph={'chevron-right'}/>
+            </Button>
+        </>
+    );
+};

--- a/web/client/components/geostory/contents/carousel/__tests__/ViewerSlider-test.jsx
+++ b/web/client/components/geostory/contents/carousel/__tests__/ViewerSlider-test.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from "react";
+import ReactDOM from "react-dom";
+import ViewerSlider from "../ViewerSlider";
+import expect from "expect";
+import TestUtils from 'react-dom/test-utils';
+
+describe('ViewerSlider component', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('ViewerSlider rendering with defaults', () => {
+        ReactDOM.render(<ViewerSlider/>, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const el = container.querySelectorAll('.ms-carousel-slider');
+        expect(el.length).toBe(2);
+        expect(el[0].querySelector('.glyphicon-chevron-left')).toBeTruthy();
+        expect(el[1].querySelector('.glyphicon-chevron-right')).toBeTruthy();
+    });
+    it('ViewerSlider rendering with left arrow disabled', () => {
+        ReactDOM.render(<ViewerSlider currentIndex={0}/>, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const leftNav = container.querySelector('.ms-carousel-slider.left-arrow');
+        expect(leftNav).toBeTruthy();
+        expect(leftNav.classList.contains('disabled')).toBeTruthy();
+    });
+    it('ViewerSlider rendering with right arrow disabled', () => {
+        ReactDOM.render(<ViewerSlider currentIndex={1} contents={[1, 2]}/>, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const rightNav = container.querySelector('.ms-carousel-slider.right-arrow');
+        expect(rightNav).toBeTruthy();
+        expect(rightNav.classList.contains('disabled')).toBeTruthy();
+    });
+    it('ViewerSlider test onTraverseCard left', () => {
+        const action = {onTraverseCard: () => {}};
+        const spyOnTraverse = expect.spyOn(action, 'onTraverseCard');
+        ReactDOM.render(<ViewerSlider currentIndex={1} contents={[1, 2]} onTraverseCard={action.onTraverseCard}/>, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const leftNav = container.querySelector('.ms-carousel-slider.left-arrow');
+        expect(leftNav).toBeTruthy();
+        TestUtils.Simulate.click(leftNav);
+        expect(spyOnTraverse).toHaveBeenCalled();
+    });
+    it('ViewerSlider test onTraverseCard right', () => {
+        const action = {onTraverseCard: () => {}};
+        const spyOnTraverse = expect.spyOn(action, 'onTraverseCard');
+        ReactDOM.render(<ViewerSlider currentIndex={0} contents={[1, 2]} onTraverseCard={action.onTraverseCard}/>, document.getElementById("container"));
+        const container = document.getElementById("container");
+        const rightNav = container.querySelector('.ms-carousel-slider.right-arrow');
+        expect(rightNav).toBeTruthy();
+        TestUtils.Simulate.click(rightNav);
+        expect(spyOnTraverse).toHaveBeenCalled();
+        expect(spyOnTraverse.calls[0].arguments[0]).toBe('right');
+    });
+});

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -27,10 +27,12 @@ import {
 import pattern from './patterns/world.svg';
 import get from 'lodash/get';
 import find from 'lodash/find';
+import findIndex from 'lodash/findIndex';
 import Carousel from "../../contents/carousel/Carousel";
 import InfoCarousel from "../../contents/carousel/InfoCarousel";
 import LocalDrawSupport from '../../common/map/LocalDrawSupport';
 import FitBounds from '../../common/map/FitBounds';
+import ViewerSlider from "../../contents/carousel/ViewerSlider";
 
 /**
  * GeoCarousel Section Type
@@ -152,6 +154,17 @@ const GeoCarousel = ({
     const isMapBackground = background?.type === MediaTypes.MAP;
 
     const { features = [] } = contents.find(content => content.id === contentId) || {};
+
+    const currentContentIndex = findIndex(contents, ({id: _id}) => contentId === _id);
+    const onTraverseCard = (traverse = 'left') => {
+        let _contentId;
+        if (traverse === 'left') {
+            _contentId = contents?.[currentContentIndex === 0 ? 0 : currentContentIndex - 1]?.id;
+        } else {
+            _contentId = contents?.[currentContentIndex === contents.length - 1 ? currentContentIndex : currentContentIndex + 1]?.id;
+        }
+        update(`sections[{"id":"${id}"}].contents[{"id":"${_contentId}"}].carouselToggle`, true);
+    };
 
     const contentsLayer = getVectorLayerFromContents({
         id,
@@ -284,6 +297,9 @@ const GeoCarousel = ({
                 onEnableDraw({ contentId: content.id, sectionId: id });
             }}
         />
+        {mode === Modes.VIEW && !expandableMedia && <ViewerSlider
+            currentIndex={currentContentIndex} contents={contents} onTraverseCard={onTraverseCard}/>
+        }
         {mode === Modes.EDIT && !hideContent && <AddBar
             containerWidth={viewWidth}
             containerHeight={viewHeight}

--- a/web/client/components/geostory/layouts/sections/__tests__/GoeCarousel-test.jsx
+++ b/web/client/components/geostory/layouts/sections/__tests__/GoeCarousel-test.jsx
@@ -176,4 +176,47 @@ describe('GeoCarousel component', () => {
         expect(el).toBeTruthy();
         expect(el.textContent).toBe('geostory.carouselAddMapInfo');
     });
+    it('render Geocarousel with viewer slider', () => {
+        ReactDOM.render(
+            <Provider store={{
+                getState: () => {},
+                subscribe: () => {},
+                dispatch: () => {}
+            }}>
+                <Comp mode={Modes.VIEW} background={{}} contents={CONTENTS} />
+            </Provider>
+            , document.getElementById("container"));
+        const container = document.getElementById('container');
+        const el = container.querySelectorAll('.ms-carousel-slider');
+        expect(el.length).toBe(2);
+    });
+    it('render Geocarousel viewer slider only in desktop & in view only mode', () => {
+        // Edit mode
+        ReactDOM.render(
+            <Provider store={{
+                getState: () => {},
+                subscribe: () => {},
+                dispatch: () => {}
+            }}>
+                <Comp mode={Modes.EDIT} background={{}} contents={CONTENTS} />
+            </Provider>
+            , document.getElementById("container"));
+        let container = document.getElementById('container');
+        let el = container.querySelectorAll('.ms-carousel-slider');
+        expect(el.length).toBe(0);
+
+        // Mobile view
+        ReactDOM.render(
+            <Provider store={{
+                getState: () => {},
+                subscribe: () => {},
+                dispatch: () => {}
+            }}>
+                <Comp mode={Modes.VIEW} expandableMedia background={{}} contents={CONTENTS} />
+            </Provider>
+            , document.getElementById("container"));
+        container = document.getElementById('container');
+        el = container.querySelectorAll('.ms-carousel-slider');
+        expect(el.length).toBe(0);
+    });
 });

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -88,6 +88,9 @@
                 .ms-geo-carousel-item-selected {
                     .border-color-var(@theme-vars[primary]);
                 }
+                .ms-carousel-slider {
+                    .background-color-var(@theme-vars[main-bg]);
+                }
             }
 
             .ms-carousel-map-info,
@@ -800,6 +803,23 @@
                 height: 100%;
             }
         }
+        .ms-carousel-slider {
+            position: absolute;
+            top: calc(50% - 10px);
+            bottom: 2px;
+            height: 50px;
+            width: 50px;
+            border-radius: 50%;
+            text-align: center;
+            font-weight: bold;
+            border-color: transparent;
+            &.left-arrow {
+                left: 4px;
+            }
+            &.right-arrow {
+                right: 4px;
+            }
+        }
 
         .add-bar {
             position: relative;
@@ -1012,7 +1032,7 @@
                 min-width: 500px;
                     display: flex; // align vertically the content
                     pointer-events: none; // pass pointer events to background (this div takes full width and height)
-                    padding: 64px (@square-btn-medium-size + 6px);
+                    padding: 64px (@square-btn-size + 8px);
                     padding-top: 164px;
                 &>.ms-content-body {
                     // override background of paragraph (or title) content.


### PR DESCRIPTION
## Description
This PR adds a slider feature to Geocarousel section in view mode

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#7142 

**What is the new behavior?**
Geocarousel section cards can be traversed with arrow keys in desktop and in view mode
![2021-08-13 18_55_18-](https://user-images.githubusercontent.com/26929983/129363836-925101d3-8677-46b7-a981-1b26180bd436.jpg)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
