### PR TITLE
[Backport 2021.02.xx] #7201: Nested services does not show the correct label (#7203)

### DIFF
--- a/web/client/themes/default/less/map-search-bar.less
+++ b/web/client/themes/default/less/map-search-bar.less
@@ -345,4 +345,16 @@ div.MapSearchBar .form-control:focus {
     .aeronautical .react-numeric-input {
         width: 100%;
     }
+    .form-group{
+        .input-group{
+            .input-group-addon{
+               width: auto;
+               border: 0px solid transparent;
+               .selectedItem-text{
+                    max-width: 200px;
+               }
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7201 

**What is the new behavior?**
when the user chooses an address and passes the second step,
the address label has to show in the search box

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
