### PR TITLE
[Backport 2021.02.xx] #7208 Fullscreen button custom query selector doesn't work 

### DIFF
--- a/web/client/actions/__tests__/fullscreen-test.js
+++ b/web/client/actions/__tests__/fullscreen-test.js
@@ -18,6 +18,6 @@ describe('Test correctness of the fullscreen actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(TOGGLE_FULLSCREEN);
         expect(retval.enable).toBe(true);
-        expect(retval.elementSelector).toBe(testControl);
+        expect(retval.querySelector).toBe(testControl);
     });
 });

--- a/web/client/actions/fullscreen.js
+++ b/web/client/actions/fullscreen.js
@@ -17,13 +17,13 @@ export const TOGGLE_FULLSCREEN = "TOGGLE_FULLSCREEN";
  * when fullscreen have to be toggled
  * @memberof actions.fullscreen
  * @param  {boolean} enable          true for enable, false for disable
- * @param  {string} elementSelector querySelector string to use to get the element to fullscreen.
+ * @param  {string} querySelector querySelector string to use to get the element to fullscreen.
  * @return {action}                   the action of type `TOGGLE_FULLSCREEN` with enable flag and element selector.
  */
-export function toggleFullscreen(enable, elementSelector) {
+export function toggleFullscreen(enable, querySelector) {
     return {
         type: TOGGLE_FULLSCREEN,
         enable,
-        elementSelector
+        querySelector
     };
 }


### PR DESCRIPTION
* rename elementselector in querySelector

* rename fullscreen test method

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7208 

**What is the new behavior?**
custom query selector works, to pass the element to feature full screen

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
