### PR TITLE
#7217 Add support arrays in query form

### DIFF
--- a/web/client/components/data/query/FilterField.jsx
+++ b/web/client/components/data/query/FilterField.jsx
@@ -106,7 +106,12 @@ class FilterField extends React.Component {
         let selectedAttribute;
         if (name === "attribute") {
             selectedAttribute = this.props.attributes.filter((attribute) => attribute.attribute === value)[0];
-            this.props.onUpdateField(rowId, name, value, selectedAttribute && selectedAttribute.type || type, fieldOptions);
+            const fieldType = selectedAttribute && selectedAttribute.type || type;
+            this.props.onUpdateField(rowId, name, value, fieldType, fieldOptions);
+
+            if (fieldType === "array") {
+                this.props.onUpdateField(rowId, "operator", "contains", fieldType, fieldOptions);
+            }
         } else {
             this.props.onUpdateField(rowId, name, value, type === 'boolean' ? 'string' : type, fieldOptions);
 

--- a/web/client/components/data/query/GroupField.jsx
+++ b/web/client/components/data/query/GroupField.jsx
@@ -41,6 +41,7 @@ class GroupField extends React.Component {
         logicComboOptions: PropTypes.array,
         attributePanelExpanded: PropTypes.bool,
         actions: PropTypes.object,
+        arrayOperators: PropTypes.array,
         listOperators: PropTypes.array,
         stringOperators: PropTypes.array,
         booleanOperators: PropTypes.array,
@@ -83,6 +84,7 @@ class GroupField extends React.Component {
         },
         listOperators: ["="],
         stringOperators: ["=", "like", "ilike", "isNull"],
+        arrayOperators: ["contains"],
         booleanOperators: ["="],
         defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "><"]
     };
@@ -123,6 +125,9 @@ class GroupField extends React.Component {
         }
         case "boolean": {
             return this.props.booleanOperators;
+        }
+        case "array": {
+            return this.props.arrayOperators;
         }
         default:
             return this.props.defaultOperators;
@@ -171,6 +176,9 @@ class GroupField extends React.Component {
                     attType="date-time"
                     timeEnabled
                     dateEnabled
+                    operator={filterField.operator}/>
+                <TextField
+                    attType="array"
                     operator={filterField.operator}/>
                 <DateField
                     attType="time"

--- a/web/client/components/data/query/__tests__/GroupField-test.jsx
+++ b/web/client/components/data/query/__tests__/GroupField-test.jsx
@@ -54,6 +54,14 @@ describe('GroupField', () => {
             value: "attribute1",
             type: "list",
             exception: null
+        }, {
+            rowId: 300,
+            groupId: 1,
+            attribute: "Attribute_array",
+            operator: "contains",
+            value: "1234",
+            type: "array",
+            exception: null
         }];
 
         const attributes = [{
@@ -83,7 +91,7 @@ describe('GroupField', () => {
 
         expect(groupfield).toExist();
         expect(groupfield.props.filterFields).toExist();
-        expect(groupfield.props.filterFields.length).toBe(2);
+        expect(groupfield.props.filterFields.length).toBe(3);
         expect(groupfield.props.groupFields).toExist();
         expect(groupfield.props.groupFields.length).toBe(1);
         expect(groupfield.props.groupLevels).toExist();
@@ -105,7 +113,7 @@ describe('GroupField', () => {
         expect(childNodes[1].className === 'query-content').toBeTruthy();
 
         const buttons = document.getElementsByClassName('btn btn-default');
-        expect(buttons.length).toBe(4);
+        expect(buttons.length).toBe(5);
 
         const list = groupfield.getOperator({type: "list"});
         expect(list).toEqual(["="]);

--- a/web/client/utils/FeatureTypeUtils.js
+++ b/web/client/utils/FeatureTypeUtils.js
@@ -64,7 +64,8 @@ const types = {
     'xsd:double': 'number',
     // 'xsd:hexBinary': 'string',
     // 'xsd:NOTATION': 'string',
-    'xsd:float': 'number'
+    'xsd:float': 'number',
+    'xsd:array': 'array'
 };
 export const describeFeatureTypeToAttributes = (data) => get(data, "featureTypes[0].properties")
     .filter((attribute) => attribute.type.indexOf('gml:') !== 0 && types[attribute.type])

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -193,6 +193,29 @@ export const  ogcBooleanField = (attribute, operator, value, nsplaceholder) => {
     }
     return fieldFilter;
 };
+/**
+ * it creates a ogc filter for array attributes
+ * it ignores empty values
+ * @param {string} attribute
+ * @param {string} operator
+ * @param {string|number} value can be anything
+ * @return the ogc filter
+*/
+export const ogcArrayField = (attribute, operator, value, nsplaceholder) => {
+    let fieldFilter = "";
+    if (checkOperatorValidity(value, operator)) {
+        if (operator === "contains" && value !== "") {
+            fieldFilter = `<${nsplaceholder}:PropertyIsEqualTo>
+              <${nsplaceholder}:Function name="InArray">
+                 <${nsplaceholder}:Literal>${value}</${nsplaceholder}:Literal>
+                 <${nsplaceholder}:PropertyName>${attribute}</${nsplaceholder}:PropertyName>
+              </${nsplaceholder}:Function>
+              <${nsplaceholder}:Literal>true</${nsplaceholder}:Literal>
+            </${nsplaceholder}:PropertyIsEqualTo>`
+        }
+    }
+    return fieldFilter;
+};
 export const ogcNumberField = (attribute, operator, value, nsplaceholder) => {
     let fieldFilter;
     if (operator === "><") {
@@ -242,6 +265,9 @@ export const processOGCSimpleFilterField = (field, nsplaceholder) => {
     switch (field.type) {
     case "date":
         filter = ogcDateField(field.attribute, field.operator, field.values, nsplaceholder);
+        break;
+    case "array":
+        filter = ogcArrayField(field.attribute, field.operator, field.values, nsplaceholder);
         break;
     case "number":
         filter = ogcNumberField(field.attribute, field.operator, field.values, nsplaceholder);
@@ -457,6 +483,9 @@ export const processOGCFilterFields = function(group, objFilter, nsplaceholder) 
                 break;
             case "list":
                 fieldFilter = ogcListField(field.attribute, field.operator, field.value, nsplaceholder);
+                break;
+            case "array":
+                fieldFilter = ogcArrayField(field.attribute, field.operator, field.value, nsplaceholder);
                 break;
             default:
                 break;
@@ -796,6 +825,14 @@ export const cqlDateField = function(attribute, operator, value) {
     return fieldFilter;
 };
 
+export const cqlArrayField = function(attribute, operator, value) {
+    switch (operator) {
+        case "contains": {
+            return `InArray(${attribute},${value})=true`
+        }
+    }
+    return "";
+}
 export const cqlStringField = function(attribute, operator, value) {
     let fieldFilter;
     const wrappedAttr = wrapAttributeWithDoubleQuotes(attribute);
@@ -890,6 +927,9 @@ export const processCQLFilterFields = function(group, objFilter) {
                 break;
             case "list":
                 fieldFilter = FilterUtils.cqlListField(field.attribute, field.operator, field.value);
+                break;
+            case "array":
+                fieldFilter = FilterUtils.cqlArrayField(field.attribute, field.operator, field.value);
                 break;
             default:
                 break;
@@ -1148,6 +1188,7 @@ FilterUtils = {
     cqlStringField,
     cqlDateField,
     cqlNumberField,
+    cqlArrayField,
     cqlBooleanField,
     cqlListField,
     toOGCFilter,

--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -206,12 +206,12 @@ export const ogcArrayField = (attribute, operator, value, nsplaceholder) => {
     if (checkOperatorValidity(value, operator)) {
         if (operator === "contains" && value !== "") {
             fieldFilter = `<${nsplaceholder}:PropertyIsEqualTo>
-              <${nsplaceholder}:Function name="InArray">
-                 <${nsplaceholder}:Literal>${value}</${nsplaceholder}:Literal>
-                 <${nsplaceholder}:PropertyName>${attribute}</${nsplaceholder}:PropertyName>
-              </${nsplaceholder}:Function>
-              <${nsplaceholder}:Literal>true</${nsplaceholder}:Literal>
-            </${nsplaceholder}:PropertyIsEqualTo>`
+                <${nsplaceholder}:Function name="InArray">
+                    <${nsplaceholder}:Literal>${value}</${nsplaceholder}:Literal>
+                    <${nsplaceholder}:PropertyName>${attribute}</${nsplaceholder}:PropertyName>
+                </${nsplaceholder}:Function>
+                <${nsplaceholder}:Literal>true</${nsplaceholder}:Literal>
+            </${nsplaceholder}:PropertyIsEqualTo>`;
         }
     }
     return fieldFilter;
@@ -827,12 +827,13 @@ export const cqlDateField = function(attribute, operator, value) {
 
 export const cqlArrayField = function(attribute, operator, value) {
     switch (operator) {
-        case "contains": {
-            return `InArray(${attribute},${value})=true`
-        }
+    case "contains": {
+        return `InArray(${attribute},${value})=true`;
     }
-    return "";
-}
+    default: return "";
+    }
+};
+
 export const cqlStringField = function(attribute, operator, value) {
     let fieldFilter;
     const wrappedAttr = wrapAttributeWithDoubleQuotes(attribute);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

this pr add the possibility to create cql and ogc filters with query form when the type array is used in an attribute
at the moment this is not possible to reproduce in mapstore instances because Geoserver doe not support array
and the DescribeFeatureType returns the wrong type "string" instead of "array" 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7217

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
the filter generated by attribute of type array are managed correclty

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
