### PR TITLE
#6886: Configurable CSW filters

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -180,6 +180,21 @@ Set `selectedService` value to one of the ID of the services object ("Demo CSW S
       "format": "image/png8", // image format needs to be configured also inside layerOptions
       "tileSize": 512 // determine the default tile size for the catalog, valid for WMS and CSW catalogs
   },
+  "filter": { // applicable only for CSW service
+      "staticFilter": "filter is always applied, even when search text is NOT PRESENT",
+      "dynamicFilter": "filter is used when search text is PRESENT and is applied in `AND` with staticFilter. The template is used with ${searchText} placeholder to append search string"
+  }
+}
+```
+CSW service
+<br> `filter` - For both static and dynamic filter, input only xml element contained within <ogc:Filter> (i.e. Do not enclose the filter value in <ogc:Filter>)<br>
+<br>Example:<br>
+```javascript
+{
+    "filter": { // Default filter values
+        "staticFilter": "<ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>dc:type</ogc:PropertyName><ogc:Literal>dataset</ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>dc:type</ogc:PropertyName><ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or>",
+        "dynamicFilter": "<ogc:PropertyIsLike wildCard='%' singleChar='_' escapeChar='\\'><ogc:PropertyName>csw:AnyText</ogc:PropertyName><ogc:Literal>%${searchText}%</ogc:Literal></ogc:PropertyIsLike>"
+    }
 }
 ```
 

--- a/web/client/api/CSW.js
+++ b/web/client/api/CSW.js
@@ -8,7 +8,7 @@
 
 import urlUtil from 'url';
 
-import { head, last } from 'lodash';
+import { head, last, template } from 'lodash';
 import assign from 'object-assign';
 
 import axios from '../libs/ajax';
@@ -25,22 +25,8 @@ const parseUrl = (url) => {
     }));
 };
 
-export const constructXMLBody = (startPosition, maxRecords, searchText) => {
-    if (!searchText) {
-        return `<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-        xmlns:ogc="http://www.opengis.net/ogc"
-        xmlns:gml="http://www.opengis.net/gml"
-        xmlns:dc="http://purl.org/dc/elements/1.1/"
-        xmlns:dct="http://purl.org/dc/terms/"
-        xmlns:gmd="http://www.isotc211.org/2005/gmd"
-        xmlns:gco="http://www.isotc211.org/2005/gco"
-        xmlns:gmi="http://www.isotc211.org/2005/gmi"
-        xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="${startPosition}" maxRecords="${maxRecords}">
-        <csw:Query typeNames="csw:Record">
-            <csw:ElementSetName>full</csw:ElementSetName>
-            <csw:Constraint version="1.1.0">
-        <ogc:Filter>
-            <ogc:Or>
+const defaultStaticFilter =
+    `<ogc:Or>
             <ogc:PropertyIsEqualTo>
                 <ogc:PropertyName>dc:type</ogc:PropertyName>
                 <ogc:Literal>dataset</ogc:Literal>
@@ -49,45 +35,50 @@ export const constructXMLBody = (startPosition, maxRecords, searchText) => {
                 <ogc:PropertyName>dc:type</ogc:PropertyName>
                 <ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal>
             </ogc:PropertyIsEqualTo>
-           </ogc:Or>
-        </ogc:Filter>
-            </csw:Constraint>
-        </csw:Query>
-    </csw:GetRecords>`;
-    }
-    return `<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
-    xmlns:ogc="http://www.opengis.net/ogc"
-    xmlns:gml="http://www.opengis.net/gml"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dct="http://purl.org/dc/terms/"
-    xmlns:gmd="http://www.isotc211.org/2005/gmd"
-    xmlns:gco="http://www.isotc211.org/2005/gco"
-    xmlns:gmi="http://www.isotc211.org/2005/gmi"
-    xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="${startPosition}" maxRecords="${maxRecords}">
-    <csw:Query typeNames="csw:Record">
-        <csw:ElementSetName>full</csw:ElementSetName>
-        <csw:Constraint version="1.1.0">
-            <ogc:Filter>
-            <ogc:And>
-                <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\">
-                    <ogc:PropertyName>csw:AnyText</ogc:PropertyName>
-                    <ogc:Literal>%${searchText}%</ogc:Literal>
-                </ogc:PropertyIsLike>
-                <ogc:Or>
-                <ogc:PropertyIsEqualTo>
-                    <ogc:PropertyName>dc:type</ogc:PropertyName>
-                    <ogc:Literal>dataset</ogc:Literal>
-                </ogc:PropertyIsEqualTo>
-                <ogc:PropertyIsEqualTo>
-                    <ogc:PropertyName>dc:type</ogc:PropertyName>
-                    <ogc:Literal>http://purl.org/dc/dcmitype/Dataset</ogc:Literal>
-                </ogc:PropertyIsEqualTo>
-               </ogc:Or>
-            </ogc:And>
-            </ogc:Filter>
-        </csw:Constraint>
-    </csw:Query>
-</csw:GetRecords>`;
+       </ogc:Or>`;
+
+const defaultDynamicFilter = "<ogc:PropertyIsLike wildCard='%' singleChar='_' escapeChar='\\'>" +
+    "<ogc:PropertyName>csw:AnyText</ogc:PropertyName> " +
+    "<ogc:Literal>%${searchText}%</ogc:Literal> " +
+    "</ogc:PropertyIsLike> ";
+
+export const cswGetRecordsXml = '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" ' +
+    'xmlns:ogc="http://www.opengis.net/ogc" ' +
+    'xmlns:gml="http://www.opengis.net/gml" ' +
+    'xmlns:dc="http://purl.org/dc/elements/1.1/" ' +
+    'xmlns:dct="http://purl.org/dc/terms/" ' +
+    'xmlns:gmd="http://www.isotc211.org/2005/gmd" ' +
+    'xmlns:gco="http://www.isotc211.org/2005/gco" ' +
+    'xmlns:gmi="http://www.isotc211.org/2005/gmi" ' +
+    'xmlns:ows="http://www.opengis.net/ows" service="CSW" version="2.0.2" resultType="results" startPosition="${startPosition}" maxRecords="${maxRecords}"> ' +
+    '<csw:Query typeNames="csw:Record"> ' +
+    '<csw:ElementSetName>full</csw:ElementSetName> ' +
+    '<csw:Constraint version="1.1.0"> ' +
+    '<ogc:Filter> ' +
+    '${filterXml} ' +
+    '</ogc:Filter> ' +
+    '</csw:Constraint> ' +
+    '</csw:Query> ' +
+    '</csw:GetRecords>';
+
+/**
+ * Construct XML body to get records from the CSW service
+ * @param {object} [options] the options to pass to withIntersectionObserver enhancer.
+ * @param {number} startPosition
+ * @param {number} maxRecords
+ * @param {string} searchText
+ * @param {object} filter object holds static and dynamic filter configured for the CSW service
+ * @param {object} filter.staticFilter filter to fetch all record applied always i.e even when no search text is present
+ * @param {object} filter.dynamicFilter filter when search text is present and is applied in conjunction with static filter
+ * @return {string} constructed xml string
+ */
+export const constructXMLBody = (startPosition, maxRecords, searchText, {filter} = {}) => {
+    const staticFilter = filter?.staticFilter || defaultStaticFilter;
+    const dynamicFilter = `<ogc:And>
+        ${template(filter?.dynamicFilter || defaultDynamicFilter)({searchText})}
+        ${staticFilter}
+    </ogc:And>`;
+    return template(cswGetRecordsXml)({filterXml: !searchText ? staticFilter : dynamicFilter, startPosition, maxRecords});
 };
 
 /**
@@ -148,7 +139,7 @@ var Api = {
             });
         });
     },
-    getRecords: function(url, startPosition, maxRecords, filter) {
+    getRecords: function(url, startPosition, maxRecords, filter, options) {
         return new Promise((resolve) => {
             require.ensure(['../utils/ogc/CSW', '../utils/ogc/Filter'], () => {
                 const {CSW, marshaller, unmarshaller } = require('../utils/ogc/CSW');
@@ -157,7 +148,7 @@ var Api = {
                     value: CSW.getRecords(startPosition, maxRecords, typeof filter !== "string" && filter)
                 });
                 if (!filter || typeof filter === "string") {
-                    body = constructXMLBody(startPosition, maxRecords, filter);
+                    body = constructXMLBody(startPosition, maxRecords, filter, options);
                 }
                 resolve(axios.post(parseUrl(url), body, { headers: {
                     'Content-Type': 'application/xml'
@@ -270,9 +261,9 @@ var Api = {
             });
         });
     },
-    textSearch: function(url, startPosition, maxRecords, text) {
+    textSearch: function(url, startPosition, maxRecords, text, options) {
         return new Promise((resolve) => {
-            resolve(Api.getRecords(url, startPosition, maxRecords, text));
+            resolve(Api.getRecords(url, startPosition, maxRecords, text, options));
         });
     },
     workspaceSearch: function(url, startPosition, maxRecords, text, workspace) {

--- a/web/client/api/__tests__/CSW-test.js
+++ b/web/client/api/__tests__/CSW-test.js
@@ -156,4 +156,19 @@ describe("constructXMLBody", () => {
         const body2 = constructXMLBody(1, 5, null);
         expect(body2.indexOf("PropertyIsEqualTo")).toNotBe(-1);
     });
+    it("construct body with custom filter", () => {
+        const filter = {
+            staticFilter: "<ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>dc:type</ogc:PropertyName><ogc:Literal>dataset</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or>",
+            dynamicFilter: "<ogc:PropertyIsLike wildCard='*' singleChar='_' escapeChar='\\'><ogc:PropertyName>csw:AnyText</ogc:PropertyName><ogc:Literal>${searchText}*</ogc:Literal></ogc:PropertyIsLike>"
+        };
+        // With search text
+        let body = constructXMLBody(1, 5, "text", {filter});
+
+        expect(body.indexOf("text*")).toNotBe(-1); // Dynamic filter
+
+        // Empty search
+        body = constructXMLBody(1, 5, null);
+        expect(body.indexOf("dc:type")).toNotBe(-1); // Static filter
+        expect(body.indexOf("text*")).toBe(-1); // Dynamic filter
+    });
 });

--- a/web/client/components/catalog/CompactCatalog.jsx
+++ b/web/client/components/catalog/CompactCatalog.jsx
@@ -74,10 +74,20 @@ const PAGE_SIZE = 10;
 /*
  * retrieves data from a catalog service and converts to props
  */
-const loadPage = ({text, catalog = {}}, page = 0) => Rx.Observable
-    .fromPromise(API[catalog.type].textSearch(catalog.url, page * PAGE_SIZE + (catalog.type === "csw" ? 1 : 0), PAGE_SIZE, text, catalog.type === 'tms' ? {options: {service: catalog}} : {}))
-    .map((result) => ({ result, records: getCatalogRecords(catalog.type, result || [], { url: catalog && catalog.url, service: catalog })}))
-    .map(({records, result}) => resToProps({records, result, catalog}));
+const loadPage = ({text, catalog = {}}, page = 0) => {
+    const type = catalog.type;
+    const _tempOption = {options: {service: catalog}};
+    let options = {};
+    if (type === 'csw') {
+        options = {..._tempOption, filter: catalog.filter};
+    } else if (type === 'tms') {
+        options = _tempOption;
+    }
+    return Rx.Observable
+        .fromPromise(API[type].textSearch(catalog.url, page * PAGE_SIZE + (type === "csw" ? 1 : 0), PAGE_SIZE, text, options))
+        .map((result) => ({ result, records: getCatalogRecords(type, result || [], { url: catalog && catalog.url, service: catalog })}))
+        .map(({records, result}) => resToProps({records, result, catalog}));
+};
 const scrollSpyOptions = {querySelector: ".ms2-border-layout-body .ms2-border-layout-content", pageSize: PAGE_SIZE};
 /**
  * Compat catalog : Reusable catalog component, with infinite scroll.

--- a/web/client/components/catalog/editor/AdvancedSettings/CSWFilters.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/CSWFilters.jsx
@@ -60,7 +60,7 @@ const renderHelpText = (
     </HelpBlock>
 );
 
-const FilterCodeMirror = ({ type, code, setCode, error }) => {
+const FilterCode = ({ type, code, setCode, error }) => {
     const filterProp = `${type}Filter`;
     return (
         <FormGroup>
@@ -93,9 +93,6 @@ export default ({
     const [code, setCode] = useState({ staticFilter, dynamicFilter });
 
     const cmProps = { code, setCode, error };
-    const StaticFilter = FilterCodeMirror;
-    const DynamicFilter = FilterCodeMirror;
-
     const isValid = value => {
         const _filter = template(cswGetRecordsXml)({
             filterXml: value,
@@ -125,8 +122,8 @@ export default ({
 
     return (
         <div className={"catalog-csw-filters"}>
-            <StaticFilter type={"static"} {...cmProps} />
-            <DynamicFilter type={"dynamic"} {...cmProps} />
+            <FilterCode type={"static"} {...cmProps} />
+            <FilterCode type={"dynamic"} {...cmProps} />
         </div>
     );
 };

--- a/web/client/components/catalog/editor/AdvancedSettings/CSWFilters.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/CSWFilters.jsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect } from "react";
+import {
+    Col,
+    ControlLabel,
+    FormGroup,
+    Glyphicon,
+    Tooltip,
+    HelpBlock
+} from "react-bootstrap";
+import { Controlled as CodeMirror } from "react-codemirror2";
+import "codemirror/lib/codemirror.css";
+import "codemirror/theme/material.css";
+import "codemirror/mode/xml/xml";
+import "codemirror/addon/lint/lint";
+import "codemirror/addon/display/autorefresh";
+import template from "lodash/template";
+import isEqual from "lodash/isEqual";
+import { cswGetRecordsXml } from "../../../../api/CSW";
+import OverlayTrigger from "../../../misc/OverlayTrigger";
+import Message from "../../../I18N/Message";
+
+const options = {
+    mode: "xml",
+    theme: "material",
+    lineNumbers: true,
+    lineWrapping: true,
+    autoRefresh: true,
+    indentUnit: 2,
+    tabSize: 2
+};
+const FilterInfo = ({ glyph = "info-sign", className = "", tooltip }) => (
+    <OverlayTrigger placement={"bottom"} overlay={tooltip}>
+        <Glyphicon
+            style={{ marginLeft: 4 }}
+            glyph={glyph}
+            className={className}
+        />
+    </OverlayTrigger>
+);
+
+const tooltip = _type => {
+    let msgId = `catalog.filter.${_type}.info`;
+    if (_type === "error") msgId = `catalog.filter.error`;
+    return (
+        <Tooltip id={"filter"}>
+            <Message msgId={msgId} />
+        </Tooltip>
+    );
+};
+const renderError = (
+    <FilterInfo
+        tooltip={tooltip("error")}
+        glyph={"exclamation-mark"}
+        className={"text-danger"}
+    />
+);
+const renderHelpText = (
+    <HelpBlock style={{ fontSize: 12 }}>
+        <Message msgId={`catalog.filter.dynamic.helpText`} />
+    </HelpBlock>
+);
+
+const FilterCodeMirror = ({ type, code, setCode, error }) => {
+    const filterProp = `${type}Filter`;
+    return (
+        <FormGroup>
+            <Col xs={4}>
+                <ControlLabel>
+                    <Message msgId={`catalog.filter.${type}.label`} />
+                </ControlLabel>
+                <FilterInfo tooltip={tooltip(type)} />
+                {error[type] && renderError}
+            </Col>
+            <Col xs={8} style={{ marginBottom: 5 }}>
+                <CodeMirror
+                    value={code[filterProp]}
+                    options={options}
+                    onBeforeChange={(_, __, value) => {
+                        setCode({ ...code, [filterProp]: value });
+                    }}
+                />
+                {type === 'dynamic' && renderHelpText}
+            </Col>
+        </FormGroup>
+    );
+};
+
+export default ({
+    onChangeServiceProperty = () => {},
+    filter: { staticFilter, dynamicFilter } = {}
+} = {}) => {
+    const [error, setError] = useState({});
+    const [code, setCode] = useState({ staticFilter, dynamicFilter });
+
+    const cmProps = { code, setCode, error };
+    const StaticFilter = FilterCodeMirror;
+    const DynamicFilter = FilterCodeMirror;
+
+    const isValid = value => {
+        const _filter = template(cswGetRecordsXml)({
+            filterXml: value,
+            startPosition: 1,
+            maxRecords: 4
+        });
+        return !new DOMParser()
+            .parseFromString(_filter, "application/xml")
+            ?.getElementsByTagName("parsererror")?.length;
+    };
+
+    useEffect(() => {
+        const validFt = isValid(code.staticFilter);
+        validFt &&
+            !isEqual(code.staticFilter, staticFilter) &&
+            onChangeServiceProperty("filter.staticFilter", code.staticFilter);
+        setError({ ...error, "static": !validFt });
+    }, [code.staticFilter]);
+
+    useEffect(() => {
+        const validFt = isValid(code.dynamicFilter);
+        validFt &&
+            !isEqual(code.dynamicFilter, dynamicFilter) &&
+            onChangeServiceProperty("filter.dynamicFilter", code.dynamicFilter);
+        setError({ ...error, dynamic: !validFt });
+    }, [code.dynamicFilter]);
+
+    return (
+        <div className={"catalog-csw-filters"}>
+            <StaticFilter type={"static"} {...cmProps} />
+            <DynamicFilter type={"dynamic"} {...cmProps} />
+        </div>
+    );
+};

--- a/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
@@ -12,6 +12,7 @@ import { FormGroup, Checkbox, Col } from "react-bootstrap";
 
 import Message from "../../../I18N/Message";
 import InfoPopover from '../../../widgets/widget/InfoPopover';
+import CSWFilters from "./CSWFilters";
 
 /**
  * Common Advanced settings form, used by WMS/CSW/WMTS
@@ -96,5 +97,8 @@ export default ({
             </Col>
         </FormGroup>)}
         {children}
+        {!isNil(service.type) && service.type === "csw" &&
+            <CSWFilters filter={service?.filter} onChangeServiceProperty={onChangeServiceProperty}/>
+        }
     </div>
 );

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/CSWFilters-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/CSWFilters-test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import CSWFilters from '../CSWFilters';
+
+describe('Test CSWFilters', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('creates the component with defaults', () => {
+        ReactDOM.render(<CSWFilters/>, document.getElementById("container"));
+        const [catalog] = document.getElementsByClassName("catalog-csw-filters");
+        expect(catalog).toBeTruthy();
+    });
+    it('render component with filter fields', () => {
+        const filterProp = {staticFilter: "<h1>test</h1>", dynamicFilter: "<h2>Test</h2>"};
+        ReactDOM.render(<CSWFilters filter={filterProp}/>, document.getElementById("container"));
+        const [catalog] = document.getElementsByClassName("catalog-csw-filters");
+        expect(catalog).toBeTruthy();
+        const filters = document.getElementsByClassName('react-codemirror2');
+        expect(filters.length).toBe(2);
+
+        const labels = document.getElementsByClassName('control-label');
+        expect(labels.length).toBe(2);
+        expect(labels[0].textContent).toBe('catalog.filter.static.label');
+        expect(labels[1].textContent).toBe('catalog.filter.dynamic.label');
+
+        const codes = document.getElementsByClassName('CodeMirror-line');
+        expect(codes.length).toBe(2);
+        expect(codes[0].textContent).toBe(filterProp.staticFilter);
+        expect(codes[1].textContent).toBe(filterProp.dynamicFilter);
+
+    });
+    it('render component with invalid filter', () => {
+        const filterProp = {dynamicFilter: '<h1>test</h1><s>'};
+        ReactDOM.render(<CSWFilters filter={filterProp}/>, document.getElementById("container"));
+        const [catalog] = document.getElementsByClassName("catalog-csw-filters");
+        expect(catalog).toBeTruthy();
+        const filters = document.getElementsByClassName('react-codemirror2');
+        expect(filters.length).toBe(2);
+        const error = document.querySelector('.glyphicon-exclamation-mark');
+        expect(error).toBeTruthy();
+    });
+    it('test component onChangeServiceProperty', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<CSWFilters onChangeServiceProperty={action.onChangeServiceProperty} filter={{dynamicFilter: '<h1>test</h1>'}}/>, document.getElementById("container"));
+        const [catalog] = document.getElementsByClassName("catalog-csw-filters");
+        expect(catalog).toBeTruthy();
+        const filters = document.getElementsByClassName('react-codemirror2');
+        expect(filters.length).toBe(2);
+        expect(spyOn).toNotHaveBeenCalled();
+    });
+});

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -68,6 +68,7 @@ describe('catalog Epics', () => {
         testEpic(autoSearchEpic, NUM_ACTIONS, changeText(""), (actions) => {
             expect(actions.length).toBe(NUM_ACTIONS);
             expect(actions[0].type).toBe(TEXT_SEARCH);
+            expect(actions[0].options).toEqual({filter: "test"});
             done();
         }, {
             catalog: {
@@ -76,7 +77,8 @@ describe('catalog Epics', () => {
                 services: {
                     "cswCatalog": {
                         type: "csw",
-                        url: "url"
+                        url: "url",
+                        filter: "test"
                     }
                 },
                 pageSize: 2

--- a/web/client/plugins/widgetbuilder/CatalogServiceEditor.jsx
+++ b/web/client/plugins/widgetbuilder/CatalogServiceEditor.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { isEmpty } from 'lodash';
 
 import uuid from 'uuid';
+import {set} from "../../utils/ImmutableUtils";
 import CatalogServiceEditorComponent from '../../components/catalog/CatalogServiceEditor';
 import { DEFAULT_ALLOWED_PROVIDERS } from '../MetadataExplorer';
 
@@ -48,7 +49,7 @@ export default ({service: defaultService, catalogServices,
         if (currentData[property]) {
             currentData[property] = typeof value === 'boolean' ? !(currentData[property]) : value;
         } else {
-            currentData = {...currentData, [property]: value};
+            currentData = set(`${property}`, value, currentData);
         }
         setService(currentData);
     };

--- a/web/client/reducers/__tests__/catalog-test.js
+++ b/web/client/reducers/__tests__/catalog-test.js
@@ -135,8 +135,12 @@ describe('Test the catalog reducer', () => {
     });
     it('CHANGE_SERVICE_PROPERTY', () => {
         let autoload = true;
-        const state = catalog({newService: {}}, {type: CHANGE_SERVICE_PROPERTY, property: "autoload", value: true});
+        let state = catalog({newService: {}}, {type: CHANGE_SERVICE_PROPERTY, property: "autoload", value: true});
         expect(state.newService.autoload).toBe(autoload);
+
+        // Path as property value
+        state = catalog({newService: {}}, {type: CHANGE_SERVICE_PROPERTY, property: "filter.staticFilter", value: "test"});
+        expect(state.newService.filter.staticFilter).toBe("test");
     });
     it('SAVING_SERVICE', () => {
         let saving = true;

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -127,7 +127,7 @@ function catalog(state = {
     case CHANGE_TEXT:
         return set("searchOptions.text", action.text, state);
     case CHANGE_SERVICE_PROPERTY: {
-        return  set(`newService["${action.property}"]`, action.value, state);
+        return  set(`newService.${action.property}`, action.value, state);
     }
     case CHANGE_TITLE:
         return set("newService.title", action.title, state);

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1459,6 +1459,18 @@
             "format": {
                 "noOption": "Keine Option",
                 "loading": "Wird geladen..."
+            },
+            "filter": {
+                "static": {
+                    "label": "Statischer Filter",
+                    "info": "Filter wird immer angewendet, auch bei leerer Suche"
+                },
+                "dynamic": {
+                    "label": "Dynamischer Filter",
+                    "info": "Filter wird verwendet, wenn Suchtext vorhanden ist und wird in 'UND' mit statischem Filter angewendet",
+                    "helpText": "Verwenden Sie eine Vorlage mit dem Platzhalter ${searchText}, um die Suchzeichenfolge zu erfassen"
+                },
+              "error": "Ungültige XML-Syntax"
             }
         },
         "uploader": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1421,6 +1421,18 @@
             "format": {
                 "noOption": "No option",
                 "loading": "Loading..."
+            },
+            "filter": {
+                "static": {
+                    "label": "Static Filter",
+                    "info": "Filter is applied always, even in empty search"
+                },
+                "dynamic": {
+                    "label": "Dynamic Filter",
+                    "info": "Filter is used when search text is present and is applied in 'AND' with static filter",
+                    "helpText": "Use template with ${searchText} placeholder to capture search string"
+                },
+                "error": "Invalid xml syntax"
             }
         },
         "uploader": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1421,6 +1421,18 @@
             "format": {
                 "noOption": "Sin opcion",
                 "loading": "Cargando..."
+            },
+            "filter": {
+                "static": {
+                    "label": "Filtro estático",
+                    "info": "El filtro se aplica siempre, incluso en la búsqueda vacía"
+                },
+                "dynamic": {
+                    "label": "Filtro dinámico",
+                    "info": "El filtro se usa cuando el texto de búsqueda está presente y se aplica en 'AND' con un filtro estático",
+                    "helpText": "Utilice la plantilla con el marcador de posición $ {searchText} para capturar la cadena de búsqueda"
+                },
+                "error": "Sintaxis XML no válida"
             }
         },
         "uploader": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1422,6 +1422,18 @@
             "format": {
                 "noOption": "Pas d'option",
                 "loading": "Chargement..."
+            },
+            "filter": {
+                "static": {
+                    "label": "Filtre statique",
+                    "info": "Le filtre est toujours appliqué, même dans une recherche vide"
+                },
+                "dynamic": {
+                    "label": "Filtre dynamique",
+                    "info": "Le filtre est utilisé lorsque le texte de recherche est présent et est appliqué dans 'AND' avec un filtre statique",
+                    "helpText": "Utilisez un modèle avec un espace réservé ${searchText} pour capturer la chaîne de recherche"
+                },
+                "error": "Syntaxe xml non valide"
             }
         },
         "uploader": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1431,7 +1431,7 @@
                 "dynamic": {
                     "label": "Filtro dinamico",
                     "info": "Il filtro viene utilizzato quando è presente il testo di ricerca e viene applicato in 'AND' con filtro statico",
-                    "helpText": "Usa il modello con il segnaposto ${searchText} per acquisire la stringa di ricerca"
+                    "helpText": "Usa il segnaposto ${searchText} nel modello per inserire la stringa di ricerca"
                 },
                 "error": "Sintassi xml non valida"
             }

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1422,6 +1422,18 @@
             "format": {
                 "noOption": "Nessuna opzione",
                 "loading": "Caricamento in corso..."
+            },
+            "filter": {
+                "static": {
+                    "label": "Filtro statico",
+                    "info": "Il filtro viene applicato sempre, anche nella ricerca vuota"
+                },
+                "dynamic": {
+                    "label": "Filtro dinamico",
+                    "info": "Il filtro viene utilizzato quando è presente il testo di ricerca e viene applicato in 'AND' con filtro statico",
+                    "helpText": "Usa il modello con il segnaposto ${searchText} per acquisire la stringa di ricerca"
+                },
+                "error": "Sintassi xml non valida"
             }
         },
         "uploader": {


### PR DESCRIPTION
## Description
This PR adds possibility to configure CSW filters from localConfig and from advanced settings of Catalog

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#6886  &  #7084 

**What is the new behavior?**
The CSW filter is configurable as below
- `staticFilter `- filter is always applied, even when search text is NOT PRESENT
- `dynamicFilter `- filter is used when search text is PRESENT and is applied in `AND` with `staticFilter`. The template is used with ${searchText} placeholder to append search string

_Example_
```
{ 
  filter: {
    staticFilter: "<ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>dc:type</ogc:PropertyName><ogc:Literal>dataset</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or>",
    dynamicFilter: "<ogc:PropertyIsLike wildCard='*' singleChar='_' escapeChar='\\'><ogc:PropertyName>csw:AnyText</ogc:PropertyName><ogc:Literal>${searchText}*</ogc:Literal></ogc:PropertyIsLike>"
  }
}
```
Note: `filter` - For both static and dynamic filter, input only xml element contained within <ogc:Filter> (i.e. Do not enclose the filter value in <ogc:Filter>)<br>

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
