### PR TITLE
#7190: Edit feature icon visibility fix

### DIFF
--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -74,10 +74,7 @@ class FeatureGrid extends React.PureComponent {
     constructor(props) {
         super(props);
     }
-    // TODO: externalize initPlugin
-    componentDidMount() {
-        this.props.initPlugin({virtualScroll: this.props.virtualScroll, editingAllowedRoles: this.props.editingAllowedRoles, maxStoredPages: this.props.maxStoredPages});
-    }
+
     getChildContext() {
         return {
             isModified: (id, key) => {

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, {useEffect} from 'react';
 import {connect} from 'react-redux';
 import {createSelector, createStructuredSelector} from 'reselect';
 import {bindActionCreators} from 'redux';
@@ -167,6 +167,10 @@ const FeatureDock = (props = {
         zIndex: 1030
     };
     // columns={[<aside style={{backgroundColor: "red", flex: "0 0 12em"}}>column-selector</aside>]}
+
+    useEffect(() => {
+        props.initPlugin({virtualScroll: props.virtualScroll, editingAllowedRoles: props.editingAllowedRoles, maxStoredPages: props.maxStoredPages});
+    }, []);
 
     return (
         <Dock {...dockProps} onSizeChange={size => { props.onSizeChange(size, dockProps); }}>

--- a/web/client/plugins/__tests__/FeatureEditor-test.jsx
+++ b/web/client/plugins/__tests__/FeatureEditor-test.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { getPluginForTest } from './pluginsTestUtils';
+import featuregrid from '../../reducers/featuregrid';
+import FeatureEditor from "../FeatureEditor";
+
+describe('FeatureEditor Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('render FeatureEditor plugin', () => {
+        const {Plugin} = getPluginForTest(FeatureEditor, {featuregrid: {...featuregrid, open: true}});
+        ReactDOM.render(<Plugin/>, document.getElementById("container"));
+        const container = document.querySelector('.feature-grid-container');
+        expect(container).toBeTruthy();
+    });
+    it('onInit FeatureEditor plugin', () => {
+        const props = {
+            virtualScroll: false,
+            editingAllowedRoles: ['USER', 'ADMIN'],
+            maxStoredPages: 5
+        };
+        const {Plugin, store} = getPluginForTest(FeatureEditor, {featuregrid});
+        ReactDOM.render(<Plugin {...props}/>, document.getElementById("container"));
+        const state = store.getState().featuregrid;
+        expect(state.virtualScroll).toBeFalsy();
+        expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
+        expect(state.maxStoredPages).toBe(props.maxStoredPages);
+    });
+});


### PR DESCRIPTION
## Description
This PR adds fix to feature grid plugin to update configuration on plugin initialization rather than on feature grid mount, to enable/disable edit button on GFI based on user roles

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue
**What is the current behavior?**
#7190

**What is the new behavior?**
The GFI feature edit icon will be enabled/disabled properly based on the supported roles configured for feature grid
Fix works for USER roles now

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
