### PR TITLE
#7217 fix cql filter generated for arrays

### DIFF
--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -828,7 +828,7 @@ export const cqlDateField = function(attribute, operator, value) {
 export const cqlArrayField = function(attribute, operator, value) {
     switch (operator) {
     case "contains": {
-        return `InArray(${attribute},${value})=true`;
+        return `InArray(${value},${attribute})=true`;
     }
     default: return "";
     }

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -1916,7 +1916,7 @@ describe('FilterUtils', () => {
             }]
         };
         let filter = processCQLFilterFields(group, objFilter);
-        expect(filter).toEqual(`InArray(${attribute},${value})=true`);
+        expect(filter).toEqual(`InArray(${value},${attribute})=true`);
         objFilter = {
             filterFields: [{
                 groupId: 1

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -1893,7 +1893,7 @@ describe('FilterUtils', () => {
         const operator = "contains";
         const value = "1234";
         let filter = cqlArrayField(attribute, operator, value);
-        expect(filter).toEqual(`InArray(${attribute},${value})=true`);
+        expect(filter).toEqual(`InArray(${value},${attribute})=true`);
 
         filter = cqlArrayField(attribute, "<", value);
         expect(filter).toEqual("");


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fix cql filter that had inverted attribute and value 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7217
the cql was in the form InArray(attribute_name,value)=true

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
the cql filter is in the form InArray(value,attribute_name)=true

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
