### PR TITLE
#7229 fix problem when only empty data are returned

### DIFF
--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -27,7 +27,12 @@ import assign from 'object-assign';
 import 'babel-polyfill';
 
 describe('Test the mapInfo reducer', () => {
-    const appState = {configuration: {infoFormat: 'text/plain'}, responses: [], requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
+    const appState = {
+        configuration: {
+            infoFormat: 'text/plain'
+        },
+        responses: [],
+        requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
 
     it('returns original state on unrecognized action', () => {
         let state = mapInfo(1, {type: 'UNKNOWN'});
@@ -144,7 +149,34 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[0]).toBeTruthy();
         expect(state.index).toBe(0);
     });
+    it('creates a feature info with empty data from successful request', () => {
+        let testAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: "",
+            requestParams: "params",
+            layerMetadata: "meta",
+            reqId: 10
+        };
 
+        let state = mapInfo(appState, testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(1);
+        expect(state.responses[0].response).toBe("");
+        expect(state.responses[0].queryParams).toBe("params");
+        expect(state.responses[0].layerMetadata).toBe("meta");
+        expect(state.index).toBe(undefined);
+        expect(state.loaded).toBe(undefined);
+
+        state = mapInfo(assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.responses[0]).toBeTruthy();
+        expect(state.responses[1].response).toBe("");
+        expect(state.responses[1].queryParams).toBe("params");
+        expect(state.responses[1].layerMetadata).toBe("meta");
+        expect(state.index).toBe(undefined);
+        expect(state.loaded).toBe(true);
+    });
     it('creates a feature info data from vector info request', () => {
         let testAction = {
             type: 'GET_VECTOR_INFO',

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -56,10 +56,11 @@ const isIndexValid = (state, responses, requestIndex, isVector) => {
     // Index when first response received is valid
     const validResponse = getValidator(infoFormat)?.getValidResponses([responses[requestIndex]]);
     const inValidResponse = getValidator(infoFormat)?.getNoValidResponses(responses);
-    return ((isUndefined(index) && !!validResponse.length)
-        || (!isVector && requests.length === inValidResponse.filter(res=>res).length)
-        || (isUndefined(index) && isVector && requests.filter(r=>isEmpty(r)).length === queryableLayers.length) // Check if all requested layers are vector
-    );
+    const cond1 = isUndefined(index) && !!validResponse.length;
+    const cond2 = !isVector && requests.length === inValidResponse.filter(res => res).length;
+    const cond3 = isUndefined(index) && isVector && requests.filter(r => isEmpty(r)).length === queryableLayers.length;
+    return (cond1 || cond2 || cond3);
+    // Check if all requested layers are vector
 };
 /**
  * Handles responses based on the type ["data"|"exceptions","error","vector"] of the responses received
@@ -107,6 +108,10 @@ function receiveResponse(state, action, type) {
             indexObj = {loaded: true, index: 0};
         } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
             indexObj = {loaded: true, index: requestIndex};
+        } else if (responses.length === requests.length && !indexObj?.loaded) {
+            // if all responses are empty hence valid but with no valid index
+            // then set loaded to true
+            indexObj = {loaded: true};
         }
         // Set responses and index as first response is received
         return assign({}, state, {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixing infinite spinner caused by loaded flag never set to true

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7229

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
when the last responses arrives and loaded flag is still not set to true yet, it is set to true


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
