### PR TITLE
#7231 make synch to map always active if configured so

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -285,6 +285,9 @@ const EditorPlugin = compose(
             if (!isEqual(newOptions, oldOptions) ) {
                 this.props.onMount(newOptions);
             }
+            if (this.props.enableMapFilterSync) {
+                this.props.setSyncTool(true);
+            }
         }
     }),
     connect(selector,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

@offtherailz the did mount of feature editor is run only once, even if i render null in case props.open is false
so in this way we always activate it when feature grid opens

let me know if this solution is acceptable

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7231

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
when feature grid opens if enableMapFilterSync is true it ill set to true also the sync map flag

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
