### PR TITLE
#7090 Fix dropdown that displays uuid instead of labels

### DIFF
--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -312,7 +312,7 @@ describe('Test correctness of the layers actions', () => {
     });
 
     it('update settings params', () => {
-        const newParams = { style: 'new_style' };
+        const newParams = { group: "xyz", label: "Modena" };
         const update = true;
         const action = updateSettingsParams(newParams, update);
         expect(action.type).toBe(UPDATE_SETTINGS_PARAMS);

--- a/web/client/components/TOC/TOCItemsSettings.jsx
+++ b/web/client/components/TOC/TOCItemsSettings.jsx
@@ -123,7 +123,7 @@ const TOCItemSettings = (props) => {
                         nodeType={settings.nodeType}
                         settings={settings}
                         retrieveLayerData={onRetrieveLayerData}
-                        onChange={(key, value) => isObject(key) ? onUpdateParams(key, realtimeUpdate) : onUpdateParams({[key]: value}, realtimeUpdate)}
+                        onChange={(key, event) => isObject(key) ? onUpdateParams(key, realtimeUpdate) : onUpdateParams({[key]: event.target.value, label: event.target.label}, realtimeUpdate)}
                         isLocalizedLayerStylesEnabled={isLocalizedLayerStylesEnabled}
                         currentLocaleLanguage={currentLocaleLanguage}/>
                 ))}

--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -14,8 +14,8 @@ import { Col, ControlLabel, FormControl, FormGroup, Grid, InputGroup } from 'rea
 import Select from 'react-select';
 import Spinner from 'react-spinkit';
 
-import { getMessageById, getSupportedLocales } from '../../../../utils/LocaleUtils';
-import { isValidNewGroupOption, flattenGroups, getLabelName } from '../../../../utils/TOCUtils';
+import {getMessageById, getSupportedLocales, getUserLocale} from '../../../../utils/LocaleUtils';
+import {isValidNewGroupOption, getLabelName, flattenGroups} from '../../../../utils/TOCUtils';
 import Message from '../../../I18N/Message';
 import LayerNameEditField from './LayerNameEditField';
 
@@ -64,8 +64,8 @@ class General extends React.Component {
             { value: "right", label: getMessageById(this.context.messages, "layerProperties.tooltip.right") },
             { value: "bottom", label: getMessageById(this.context.messages, "layerProperties.tooltip.bottom") }
         ];
-        const groups = this.props.groups && flattenGroups(this.props.groups);
-
+        const locale = getUserLocale();
+        const groups = this.props.groups && flattenGroups(this.props.groups, 0, false, locale);
         const SelectCreatable = this.props.allowNew ? Select.Creatable : Select;
 
         return (
@@ -143,10 +143,10 @@ class General extends React.Component {
                                         className: 'Select-create-option-placeholder'
                                     };
                                 }}
-                                value={{ label: getLabelName(this.props.element && this.props.element.group || "Default", groups), value: this.props.element && this.props.element.group || "Default" }}
+                                value={{ label: getLabelName(this.props.element && this.props.element.label || "Default", groups), value: this.props.element && this.props.element.group || "Default" }}
                                 placeholder={getLabelName(this.props.element && this.props.element.group || "Default", groups)}
                                 onChange={(item) => {
-                                    this.updateEntry("group", { target: { value: item.value || "Default" } });
+                                    this.updateEntry("group", { target: { value: item.value || "Default", label: item.label } });
                                 }}
                             />
                         </div> : null}
@@ -182,7 +182,9 @@ class General extends React.Component {
         );
     }
 
-    updateEntry = (key, event) => isObject(key) ? this.props.onChange(key) : this.props.onChange(key, event.target.value);
+    updateEntry = (key, event) => {
+        isObject(key) ? this.props.onChange(key) : this.props.onChange(key, event);
+    }
 
     updateTranslation = (key, event) => {
         const title = (key === 'default' && isString(this.props.element.title))

--- a/web/client/components/widgets/builder/wizard/map/__tests__/MapOptions-test.jsx
+++ b/web/client/components/widgets/builder/wizard/map/__tests__/MapOptions-test.jsx
@@ -53,7 +53,7 @@ describe('MapOptions component', () => {
     it('MapOptions rendering node editor', () => {
         ReactDOM.render(<MapOptions
             map={{ groups: [{ id: 'GGG' }], layers: [{ id: "LAYER", group: "GGG", name: "LAYER", options: {} }] }}
-            nodes={[{ id: 'GGG', nodes: [{ id: "LAYER", group: "GGG", name: "LAYER", options: {}}]}]}
+            nodes={[{ id: 'GGG', nodes: [{ id: "LAYER", group: "GGG", name: "LAYER", title: { 'default': 'default'}, options: {}}]}]}
             layers={[{ id: "LAYER", group: "GGG", name: "LAYER", options: {} }]}
             editNode={"LAYER"} />, document.getElementById("container"));
         const container = document.getElementById('container');

--- a/web/client/selectors/__tests__/layers-test.js
+++ b/web/client/selectors/__tests__/layers-test.js
@@ -596,7 +596,7 @@ describe('Test layers selectors', () => {
                 nodes: [
                     {
                         id: 'first.second',
-                        title: 'second',
+                        title: {'default': 'second'},
                         name: 'second',
                         nodes: [
                             {
@@ -625,7 +625,7 @@ describe('Test layers selectors', () => {
         };
         let element = {
             "id": "first.second",
-            "title": "second",
+            "title": {"default": "second" },
             "name": "second",
             "nodes": [
                 {

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -84,7 +84,7 @@ export const getTitleAndTooltip = ({node, currentLocale, tooltipOptions = {separ
 */
 export const flattenGroups = (groups, idx = 0, wholeGroup = false, locale = 'default') => {
     return groups.filter((group) => group.nodes).reduce((acc, g) => {
-        acc.push(wholeGroup ? g : {label: g?.title[locale] ? g?.title[locale]?.replace(/\./g, '/').replace(/\${dot}/g, '.') : g?.title?.default?.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id});
+        acc.push(wholeGroup ? g : isObject(g.title) ? {label: g?.title[locale] ? g?.title[locale]?.replace(/\./g, '/').replace(/\${dot}/g, '.') : g?.title?.default?.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id} : {label: g.title.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id});
         if (g.nodes.length > 0) {
             return acc.concat(flattenGroups(g.nodes, idx + 1, wholeGroup));
         }

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -75,6 +75,16 @@ export const getTitleAndTooltip = ({node, currentLocale, tooltipOptions = {separ
         tooltipText
     };
 };
+
+/**
+ * Replace characters
+ * @param {string} title string with characters to be replaced
+ * @returns {string} string with characters replaced
+ */
+export const replaceCharacters = (title) => {
+    return title?.replace(/\./g, '/').replace(/\${dot}/g, '.');
+};
+
 /**
  * flatten groups and subgroups in a single array
  * @param {object[]} groups node to get the groups and subgroups
@@ -84,7 +94,7 @@ export const getTitleAndTooltip = ({node, currentLocale, tooltipOptions = {separ
 */
 export const flattenGroups = (groups, idx = 0, wholeGroup = false, locale = 'default') => {
     return groups.filter((group) => group.nodes).reduce((acc, g) => {
-        acc.push(wholeGroup ? g : isObject(g.title) ? {label: g?.title[locale] ? g?.title[locale]?.replace(/\./g, '/').replace(/\${dot}/g, '.') : g?.title?.default?.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id} : {label: g.title.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id});
+        acc.push(wholeGroup ? g : isObject(g?.title) ? {label: g?.title[locale] ? replaceCharacters(g?.title[locale]) : replaceCharacters(g?.title?.default), value: g.id} : {label: replaceCharacters(g.title), value: g.id});
         if (g.nodes.length > 0) {
             return acc.concat(flattenGroups(g.nodes, idx + 1, wholeGroup));
         }

--- a/web/client/utils/TOCUtils.js
+++ b/web/client/utils/TOCUtils.js
@@ -82,15 +82,16 @@ export const getTitleAndTooltip = ({node, currentLocale, tooltipOptions = {separ
  * @params {boolean} wholeGroup, if true it returns the whole node
  * @return {object[]} array of nodes (groups and subgroups)
 */
-export const flattenGroups = (groups, idx = 0, wholeGroup = false) => {
+export const flattenGroups = (groups, idx = 0, wholeGroup = false, locale = 'default') => {
     return groups.filter((group) => group.nodes).reduce((acc, g) => {
-        acc.push(wholeGroup ? g : {label: g.id.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id});
+        acc.push(wholeGroup ? g : {label: g?.title[locale] ? g?.title[locale]?.replace(/\./g, '/').replace(/\${dot}/g, '.') : g?.title?.default?.replace(/\./g, '/').replace(/\${dot}/g, '.'), value: g.id});
         if (g.nodes.length > 0) {
             return acc.concat(flattenGroups(g.nodes, idx + 1, wholeGroup));
         }
         return acc;
     }, []);
 };
+
 export const getLabelName = (groupLabel = "", groups = []) => {
     let label = groupLabel.replace(/[^\.\/]+/g, match => {
         const title = get(getGroupByName(match, groups), 'title');

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -23,7 +23,7 @@ const groups = [{
     "nodes": [
         {
             "id": "first.second",
-            "title": { "default": "second"},
+            "title": "second",
             "name": "second",
             "nodes": [
                 {
@@ -81,7 +81,12 @@ const groups = [{
     ],
     "expanded": true,
     "visibility": true
+}, {
+    "id": "second",
+    "title": "Non object title",
+    "name": "Non object name"
 }];
+
 
 describe('TOCUtils', () => {
     it('test isValidNewGroupOption for General Fragment with value not allowed', () => {

--- a/web/client/utils/__tests__/TOCUtils-test.js
+++ b/web/client/utils/__tests__/TOCUtils-test.js
@@ -18,17 +18,17 @@ import {
 
 const groups = [{
     "id": "first",
-    "title": "first",
+    "title": { "default": "first"},
     "name": "first",
     "nodes": [
         {
             "id": "first.second",
-            "title": "second",
+            "title": { "default": "second"},
             "name": "second",
             "nodes": [
                 {
                     "id": "first.second.third",
-                    "title": "third",
+                    "title": { "default": "third"},
                     "name": "third",
                     "nodes": [
                         {
@@ -41,7 +41,7 @@ const groups = [{
                             "name": "topp:states",
                             "opacity": 1,
                             "description": "This is some census data on the states.",
-                            "title": "USA Population",
+                            "title": { "default": "USA Population"},
                             "type": "wms",
                             "url": "https://demo.geo-solutions.it:443/geoserver/wms",
                             "bbox": {
@@ -155,10 +155,10 @@ describe('TOCUtils', () => {
         expect(allGroups[0].label).toBe("first");
         expect(allGroups[1].id).toBe(undefined);
         expect(allGroups[1].value).toBe("first.second");
-        expect(allGroups[1].label).toBe("first/second");
+        expect(allGroups[1].label).toBe("second");
         expect(allGroups[2].id).toBe(undefined);
         expect(allGroups[2].value).toBe("first.second.third");
-        expect(allGroups[2].label).toBe("first/second/third");
+        expect(allGroups[2].label).toBe("third");
     });
     it('test getTitleAndTooltip both', () => {
         const node = {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The Layer Settings dropdown displays the groups' uuid instead of displaying the label names.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7090 

**What is the new behavior?**
<!-- Describe here the new behavior based on your changes -->
Dropdown displays label names instead of uuid.
**NB:** This PR does not fix issue #7037 that was marked as a possible connection to this issue.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
