### PR TITLE
Backport 2021.01.xx - #7229 fix problem when only empty data are returned (#7230)

### DIFF
--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -121,34 +121,6 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].layerMetadata).toBe("meta");
         expect(state.index).toBe(1);
     });
-    it('creates a feature info data from successful request on showInMapPopup', () => {
-        let testAction = {
-            type: 'LOAD_FEATURE_INFO',
-            data: "data",
-            requestParams: "params",
-            layerMetadata: "meta",
-            reqId: 10
-        };
-
-        let state = mapInfo({...appState, showInMapPopup: true}, testAction);
-        expect(state.responses).toExist();
-        expect(state.responses.length).toBe(2);
-        expect(state.responses[0].response).toBe("data");
-        expect(state.responses[0].queryParams).toBe("params");
-        expect(state.responses[0].layerMetadata).toBe("meta");
-        expect(state.index).toBe(0);
-
-        state = mapInfo(assign({}, appState, {responses: [], showInMapPopup: true}), testAction);
-        expect(state.responses).toExist();
-        expect(state.responses.length).toBe(1);
-        expect(state.index).toBe(0);
-
-        state = mapInfo(assign({}, appState, {responses: ["test"], showInMapPopup: true}), {...testAction, reqId: 11});
-        expect(state.responses).toExist();
-        expect(state.responses.length).toBe(2);
-        expect(state.responses[0]).toBeTruthy();
-        expect(state.index).toBe(0);
-    });
     it('creates a feature info with empty data from successful request', () => {
         let testAction = {
             type: 'LOAD_FEATURE_INFO',

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -27,7 +27,12 @@ import assign from 'object-assign';
 import 'babel-polyfill';
 
 describe('Test the mapInfo reducer', () => {
-    let appState = {configuration: {infoFormat: 'text/plain'}, responses: [], requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
+    const appState = {
+        configuration: {
+            infoFormat: 'text/plain'
+        },
+        responses: [],
+        requests: [{reqId: 10, request: "test"}, {reqId: 11, request: "test1"}]};
 
     it('returns original state on unrecognized action', () => {
         let state = mapInfo(1, {type: 'UNKNOWN'});
@@ -116,7 +121,62 @@ describe('Test the mapInfo reducer', () => {
         expect(state.responses[1].layerMetadata).toBe("meta");
         expect(state.index).toBe(1);
     });
+    it('creates a feature info data from successful request on showInMapPopup', () => {
+        let testAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: "data",
+            requestParams: "params",
+            layerMetadata: "meta",
+            reqId: 10
+        };
 
+        let state = mapInfo({...appState, showInMapPopup: true}, testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.responses[0].response).toBe("data");
+        expect(state.responses[0].queryParams).toBe("params");
+        expect(state.responses[0].layerMetadata).toBe("meta");
+        expect(state.index).toBe(0);
+
+        state = mapInfo(assign({}, appState, {responses: [], showInMapPopup: true}), testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(1);
+        expect(state.index).toBe(0);
+
+        state = mapInfo(assign({}, appState, {responses: ["test"], showInMapPopup: true}), {...testAction, reqId: 11});
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.responses[0]).toBeTruthy();
+        expect(state.index).toBe(0);
+    });
+    it('creates a feature info with empty data from successful request', () => {
+        let testAction = {
+            type: 'LOAD_FEATURE_INFO',
+            data: "",
+            requestParams: "params",
+            layerMetadata: "meta",
+            reqId: 10
+        };
+
+        let state = mapInfo(appState, testAction);
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(1);
+        expect(state.responses[0].response).toBe("");
+        expect(state.responses[0].queryParams).toBe("params");
+        expect(state.responses[0].layerMetadata).toBe("meta");
+        expect(state.index).toBe(undefined);
+        expect(state.loaded).toBe(undefined);
+
+        state = mapInfo(assign({}, appState, {responses: ["test"]}), {...testAction, reqId: 11});
+        expect(state.responses).toExist();
+        expect(state.responses.length).toBe(2);
+        expect(state.responses[0]).toBeTruthy();
+        expect(state.responses[1].response).toBe("");
+        expect(state.responses[1].queryParams).toBe("params");
+        expect(state.responses[1].layerMetadata).toBe("meta");
+        expect(state.index).toBe(undefined);
+        expect(state.loaded).toBe(true);
+    });
     it('creates a feature info data from vector info request', () => {
         let testAction = {
             type: 'GET_VECTOR_INFO',

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -56,10 +56,11 @@ const isIndexValid = (state, responses, requestIndex, isVector) => {
     // Index when first response received is valid
     const validResponse = getValidator(infoFormat)?.getValidResponses([responses[requestIndex]]);
     const inValidResponse = getValidator(infoFormat)?.getNoValidResponses(responses);
-    return ((isUndefined(index) && !!validResponse.length)
-        || (!isVector && requests.length === inValidResponse.filter(res=>res).length)
-        || (isUndefined(index) && isVector && requests.filter(r=>isEmpty(r)).length === queryableLayers.length) // Check if all requested layers are vector
-    );
+    const cond1 = isUndefined(index) && !!validResponse.length;
+    const cond2 = !isVector && requests.length === inValidResponse.filter(res => res).length;
+    const cond3 = isUndefined(index) && isVector && requests.filter(r => isEmpty(r)).length === queryableLayers.length;
+    return (cond1 || cond2 || cond3);
+    // Check if all requested layers are vector
 };
 /**
  * Handles responses based on the type ["data"|"exceptions","error","vector"] of the responses received
@@ -107,6 +108,10 @@ function receiveResponse(state, action, type) {
             indexObj = {loaded: true, index: 0};
         } else if (!isHover && isIndexValid(state, responses, requestIndex, isVector)) {
             indexObj = {loaded: true, index: requestIndex};
+        } else if (responses.length === requests.length && !indexObj?.loaded) {
+            // if all responses are empty hence valid but with no valid index
+            // then set loaded to true
+            indexObj = {loaded: true};
         }
         // Set responses and index as first response is received
         return assign({}, state, {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Backport 2021.01.xx - #7229 fix problem when only empty data are returned (#7230)