### PR TITLE
update tutorials mechanism, get rid of regex on url

### DIFF
--- a/web/client/epics/__tests__/tutorial-test.js
+++ b/web/client/epics/__tests__/tutorial-test.js
@@ -9,12 +9,14 @@
 import expect from 'expect';
 
 import { getActionsFromStepEpic, switchTutorialEpic, switchGeostoryTutorialEpic, openDetailsPanelEpic } from '../tutorial';
-import { SETUP_TUTORIAL, updateTutorial, initTutorial, closeTutorial } from '../../actions/tutorial';
+import { SETUP_TUTORIAL, updateTutorial, closeTutorial } from '../../actions/tutorial';
 import { geostoryLoaded, setEditing } from '../../actions/geostory';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
-import { onLocationChanged } from 'connected-react-router';
 import { setApi, getApi } from '../../api/userPersistedStorage';
 import { OPEN_DETAILS_PANEL } from './../../actions/details';
+import { changeMapType } from './../../actions/maptype';
+import { loadFinished } from './../../actions/contextcreator';
+import { setEditorAvailable } from './../../actions/dashboard';
 
 describe('tutorial Epics', () => {
     const GEOSTORY_EDIT_STEPS = [{
@@ -94,17 +96,12 @@ describe('tutorial Epics', () => {
 
     it('switchTutorialEpic with path', (done) => {
 
-        testEpic(switchTutorialEpic, 1, [
-            onLocationChanged({
-                pathname: '/dashboard'
-            }),
-            initTutorial('id', [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, 1, setEditorAvailable(true), (actions) => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
                 case SETUP_TUTORIAL:
-                    expect(action.id).toBe('/dashboard');
+                    expect(action.id).toBe('dashboard');
                     break;
                 default:
                     expect(true).toBe(false);
@@ -121,17 +118,11 @@ describe('tutorial Epics', () => {
                 }
             }
         });
-
     });
 
     it('switchTutorialEpic with viewer path', (done) => {
 
-        testEpic(switchTutorialEpic, 1, [
-            onLocationChanged({
-                pathname: '/viewer/cesium/001'
-            }),
-            initTutorial('id', [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, 1, changeMapType("cesium"), (actions) => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
@@ -156,46 +147,9 @@ describe('tutorial Epics', () => {
 
     });
 
-    it('switchTutorialEpic with path and id', (done) => {
-
-        testEpic(switchTutorialEpic, 1, [
-            onLocationChanged({
-                pathname: '/dashboard/001'
-            }),
-            initTutorial('id', [], {}, null, {}, {})
-        ], (actions) => {
-            expect(actions.length).toBe(1);
-            actions.map((action) => {
-                switch (action.type) {
-                case SETUP_TUTORIAL:
-                    expect(action.id).toBe('dashboard');
-                    break;
-                default:
-                    expect(true).toBe(false);
-                }
-            });
-            done();
-        }, {
-            tutorial: {
-                presetList: {
-                    'dashboard_mobile_tutorial': [],
-                    'dashboard_tutorial': [],
-                    'default_tutorial': [],
-                    'default_mobile_tutorial': []
-                }
-            }
-        });
-
-    });
-
     it('switchTutorialEpic mobile', (done) => {
 
-        testEpic(switchTutorialEpic, 1, [
-            onLocationChanged({
-                pathname: '/dashboard/001'
-            }),
-            initTutorial('id', [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, 1, setEditorAvailable(true), (actions) => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
@@ -225,12 +179,7 @@ describe('tutorial Epics', () => {
 
     it('switchTutorialEpic missing preset steps', (done) => {
 
-        testEpic(switchTutorialEpic, 1, [
-            onLocationChanged({
-                pathname: '/dashboard/001'
-            }),
-            initTutorial('id', [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, 1, setEditorAvailable(true), (actions) => {
             expect(actions.length).toBe(1);
             actions.map((action) => {
                 switch (action.type) {
@@ -253,12 +202,7 @@ describe('tutorial Epics', () => {
     });
     it('switchTutorialEpic selecting geostory_edit_tutorial preset for newgeostory page', (done) => {
         const NUM_ACTIONS = 1;
-        testEpic(switchTutorialEpic, NUM_ACTIONS, [
-            onLocationChanged({
-                pathname: '/geostory/newgeostory'
-            }),
-            initTutorial("", [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, NUM_ACTIONS, geostoryLoaded('newgeostory'), (actions) => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map((action) => {
                 switch (action.type) {
@@ -289,12 +233,7 @@ describe('tutorial Epics', () => {
     });
     it('switchTutorialEpic selecting geostory_view_tutorial preset for story viewer page', (done) => {
         const NUM_ACTIONS = 1;
-        testEpic(switchTutorialEpic, NUM_ACTIONS, [
-            onLocationChanged({
-                pathname: '/geostory/123'
-            }),
-            initTutorial("", [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, NUM_ACTIONS, geostoryLoaded('123'), (actions) => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map((action) => {
                 switch (action.type) {
@@ -325,12 +264,7 @@ describe('tutorial Epics', () => {
     });
     it('switchTutorialEpic selecting geostory_view_tutorial preset for story viewer page, missing presetList', (done) => {
         const NUM_ACTIONS = 1;
-        testEpic(addTimeoutEpic(switchTutorialEpic, 50), NUM_ACTIONS, [
-            onLocationChanged({
-                pathname: '/geostory/newgeostory'
-            }),
-            initTutorial("", [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(addTimeoutEpic(switchTutorialEpic, 50), NUM_ACTIONS,  geostoryLoaded('newgeostory'), (actions) => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map((action) => {
                 switch (action.type) {
@@ -352,12 +286,7 @@ describe('tutorial Epics', () => {
     });
     it('switchTutorialEpic loads correct tutorial for context', (done) => {
         const NUM_ACTIONS = 1;
-        testEpic(switchTutorialEpic, NUM_ACTIONS, [
-            onLocationChanged({
-                pathname: '/context-creator/new'
-            }),
-            initTutorial("", [], {}, null, {}, {})
-        ], (actions) => {
+        testEpic(switchTutorialEpic, NUM_ACTIONS, loadFinished(), (actions) => {
             expect(actions.length).toBe(NUM_ACTIONS);
             actions.map((action) => {
                 switch (action.type) {


### PR DESCRIPTION
## Description
Change tutorial mechanism for it not to be listening to path changes but to actions.
This initiate from mapstore georchestra integration having a different path mechanism and not displaying openlayers/cesium in the url, thus not retrieving the tutorial for 3D.

I don't really understand the point of [action$.ofType(MAPS_LIST_LOADED, CHANGE_MAP_VIEW, INIT_TUTORIAL)
                .take(1)](https://github.com/geosolutions-it/MapStore2/blob/1c55a80c31ca3dd198cbcce5772cc0e2c7c692d7/web/client/epics/tutorial.js#L62) in switchTutorialEpic and thus got rid of it, but that might be too extreme. 

If accepted please accept backport https://github.com/geosolutions-it/MapStore2/pull/7204 as well

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
