### PR TITLE
#6302 Prevent google layers in old maps to make mapstore crash

### DIFF
--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -590,7 +590,7 @@ describe('Leaflet layer', () => {
             map.eachLayer(function() {lcount++; });
             expect(lcount).toBe(1);
         });
-    })
+    });
 
 
     it('creates a bing layer for leaflet map', () => {

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -539,43 +539,59 @@ describe('Leaflet layer', () => {
         map.eachLayer((l) => {urls = l._urls;});
         expect(urls.length).toBe(2);
     });
+    describe("GoogleLayer", () => {
+        it('if google lib doesn\'t exist, layer is null',() => {
+            var options = {
+                "type": "google",
+                "name": "ROADMAP"
+            };
 
-    it('creates a google layer for leaflet map', () => {
-        var options = {
-            "type": "google",
-            "name": "ROADMAP"
-        };
-        var google = {
-            maps: {
-                MapTypeId: {
-                    HYBRID: 'hybrid',
-                    SATELLITE: 'satellite',
-                    ROADMAP: 'roadmap',
-                    TERRAIN: 'terrain'
-                },
-                Map: function() {
-                    this.setMapTypeId = function() {};
-                    this.setCenter = function() {};
-                    this.setZoom = function() {};
-                    this.setTilt = function() {};
-                },
-                LatLng: function() {
+            window.google = undefined;
 
+            // create layers
+            let layer = ReactDOM.render(
+                <LeafLetLayer type="google" options={options} map={map}/>, document.getElementById("container"));
+
+            expect(layer.layer).toBeFalsy();
+        });
+        it('creates a google layer for leaflet map', () => {
+            var options = {
+                "type": "google",
+                "name": "ROADMAP"
+            };
+            var google = {
+                maps: {
+                    MapTypeId: {
+                        HYBRID: 'hybrid',
+                        SATELLITE: 'satellite',
+                        ROADMAP: 'roadmap',
+                        TERRAIN: 'terrain'
+                    },
+                    Map: function() {
+                        this.setMapTypeId = function() {};
+                        this.setCenter = function() {};
+                        this.setZoom = function() {};
+                        this.setTilt = function() {};
+                    },
+                    LatLng: function() {
+
+                    }
                 }
-            }
-        };
-        window.google = google;
+            };
+            window.google = google;
 
-        // create layers
-        let layer = ReactDOM.render(
-            <LeafLetLayer type="google" options={options} map={map}/>, document.getElementById("container"));
-        let lcount = 0;
+            // create layers
+            let layer = ReactDOM.render(
+                <LeafLetLayer type="google" options={options} map={map}/>, document.getElementById("container"));
+            let lcount = 0;
 
-        expect(layer).toExist();
-        // count layers
-        map.eachLayer(function() {lcount++; });
-        expect(lcount).toBe(1);
-    });
+            expect(layer).toExist();
+            // count layers
+            map.eachLayer(function() {lcount++; });
+            expect(lcount).toBe(1);
+        });
+    })
+
 
     it('creates a bing layer for leaflet map', () => {
         var options = {

--- a/web/client/components/map/leaflet/__tests__/Layer-test.jsx
+++ b/web/client/components/map/leaflet/__tests__/Layer-test.jsx
@@ -540,7 +540,7 @@ describe('Leaflet layer', () => {
         expect(urls.length).toBe(2);
     });
     describe("GoogleLayer", () => {
-        it('if google lib doesn\'t exist, layer is null',() => {
+        it('if google lib doesn\'t exist, layer is null', () => {
             var options = {
                 "type": "google",
                 "name": "ROADMAP"

--- a/web/client/components/map/leaflet/plugins/GoogleLayer.js
+++ b/web/client/components/map/leaflet/plugins/GoogleLayer.js
@@ -9,8 +9,13 @@
 import Layers from '../../../../utils/leaflet/Layers';
 import L from 'leaflet';
 import 'leaflet.gridlayer.googlemutant';
-
+function getGMapsLib() {
+    return window?.google?.maps;
+}
 Layers.registerType('google', (options) => {
+    if (!getGMapsLib()) {
+        return null;
+    }
     return L.gridLayer.googleMutant({
         type: options.name.toLowerCase(),
         maxNativeZoom: options.maxNativeZoom || 18,

--- a/web/client/components/map/openlayers/__tests__/Layer-test.jsx
+++ b/web/client/components/map/openlayers/__tests__/Layer-test.jsx
@@ -1067,42 +1067,56 @@ describe('Openlayers layer', () => {
         layer.layer.remove();
     });
 
-    it('creates a google layer for openlayers map', () => {
-        var google = {
-            maps: {
-                MapTypeId: {
-                    HYBRID: 'hybrid',
-                    SATELLITE: 'satellite',
-                    ROADMAP: 'roadmap',
-                    TERRAIN: 'terrain'
-                },
-                Map: function() {
-                    this.setMapTypeId = function() {};
-                    this.setCenter = function() {};
-                    this.setZoom = function() {};
-                    this.setTilt = function() {};
-                },
-                LatLng: function() {
+    describe('Google layer', () => {
+        it('layer creator returns null without failing if window.google doesn\'t exist', () => {
+            var options = {
+                "type": "google",
+                "name": "ROADMAP",
+                "visibility": true
+            };
+            window.google = undefined;
+            let layer = ReactDOM.render(
+                <OpenlayersLayer type="google" options={options} map={map} mapId="map"/>, document.getElementById("container"));
+            expect(layer).toBeTruthy(); // no exception on creation
+        });
+        it('creates a google layer for openlayers map', () => {
+            var google = {
+                maps: {
+                    MapTypeId: {
+                        HYBRID: 'hybrid',
+                        SATELLITE: 'satellite',
+                        ROADMAP: 'roadmap',
+                        TERRAIN: 'terrain'
+                    },
+                    Map: function() {
+                        this.setMapTypeId = function() {};
+                        this.setCenter = function() {};
+                        this.setZoom = function() {};
+                        this.setTilt = function() {};
+                    },
+                    LatLng: function() {
 
+                    }
                 }
-            }
-        };
-        var options = {
-            "type": "google",
-            "name": "ROADMAP",
-            "visibility": true
-        };
-        window.google = google;
+            };
+            var options = {
+                "type": "google",
+                "name": "ROADMAP",
+                "visibility": true
+            };
+            window.google = google;
 
-        // create layers
-        let layer = ReactDOM.render(
-            <OpenlayersLayer type="google" options={options} map={map} mapId="map"/>, document.getElementById("container"));
+            // create layers
+            let layer = ReactDOM.render(
+                <OpenlayersLayer type="google" options={options} map={map} mapId="map"/>, document.getElementById("container"));
 
-        expect(layer).toExist();
-        // count layers
-        // google maps does not create a real ol layer, it is just injecting a gmaps api layer into DOM
-        expect(map.getLayers().getLength()).toBe(0);
+            expect(layer).toBeTruthy();
+            // count layers
+            // google maps does not create a real ol layer, it is just injecting a gmaps api layer into DOM
+            expect(map.getLayers().getLength()).toBe(0);
+        });
     });
+
 
     it('creates and overlay layer for openlayers map', () => {
         let container = document.createElement('div');

--- a/web/client/components/map/openlayers/plugins/GoogleLayer.js
+++ b/web/client/components/map/openlayers/plugins/GoogleLayer.js
@@ -202,7 +202,8 @@ Layers.registerType('google', {
         if (!gmaps[mapId]) {
             return;
         }
-        let google = window.google;
+        let gMapsLib = getGMapsLib();
+
         if (!oldOptions.visibility && newOptions.visibility) {
             let view = map.getView();
             const center = transform(view.getCenter(), 'EPSG:3857', 'EPSG:4326');

--- a/web/client/components/map/openlayers/plugins/GoogleLayer.js
+++ b/web/client/components/map/openlayers/plugins/GoogleLayer.js
@@ -18,20 +18,27 @@ let startEvent = isTouchSupported ? 'touchstart' : 'mousedown';
 let moveEvent = isTouchSupported ? 'touchmove' : 'mousemove';
 let endEvent = isTouchSupported ? 'touchend' : 'mouseup';
 
+
+function getGMapsLib() {
+    return window?.google?.maps;
+}
 Layers.registerType('google', {
     create: (options, map, mapId) => {
         if (document.getElementById(mapId + 'gmaps')) {
-            let google = window.google;
+            let gMapsLib = getGMapsLib();
+            if (!gMapsLib) {
+                return null;
+            }
             if (!layersMap) {
                 layersMap = {
-                    'HYBRID': google.maps.MapTypeId.HYBRID,
-                    'SATELLITE': google.maps.MapTypeId.SATELLITE,
-                    'ROADMAP': google.maps.MapTypeId.ROADMAP,
-                    'TERRAIN': google.maps.MapTypeId.TERRAIN
+                    'HYBRID': gMapsLib.MapTypeId.HYBRID,
+                    'SATELLITE': gMapsLib.MapTypeId.SATELLITE,
+                    'ROADMAP': gMapsLib.MapTypeId.ROADMAP,
+                    'TERRAIN': gMapsLib.MapTypeId.TERRAIN
                 };
             }
             if (!gmaps[mapId]) {
-                gmaps[mapId] = new google.maps.Map(document.getElementById(mapId + 'gmaps'), {
+                gmaps[mapId] = new gMapsLib.Map(document.getElementById(mapId + 'gmaps'), {
                     disableDefaultUI: true,
                     keyboardShortcuts: false,
                     draggable: false,
@@ -47,7 +54,7 @@ Layers.registerType('google', {
             let setCenter = function() {
                 if (gmaps[mapId] && mapContainer.style.visibility !== 'hidden') {
                     const center = transform(map.getView().getCenter(), 'EPSG:3857', 'EPSG:4326');
-                    gmaps[mapId].setCenter(new google.maps.LatLng(center[1], center[0]));
+                    gmaps[mapId].setCenter(new gMapsLib.LatLng(center[1], center[0]));
                 }
             };
             let setZoom = function() {
@@ -108,7 +115,7 @@ Layers.registerType('google', {
                     const rotation = map.getView().getRotation() * 180 / Math.PI;
 
                     mapContainer.style.transform = "rotate(" + rotation + "deg)";
-                    google.maps.event.trigger(gmaps[mapId], "resize");
+                    gMapsLib.event.trigger(gmaps[mapId], "resize");
                 }
             };
 
@@ -140,7 +147,7 @@ Layers.registerType('google', {
                     mapContainer.style.height = size.height + 'px';
                     mapContainer.style.left = Math.round((map.getSize()[0] - size.width) / 2.0) + 'px';
                     mapContainer.style.top = Math.round((map.getSize()[1] - size.height) / 2.0) + 'px';
-                    google.maps.event.trigger(gmaps[mapId], "resize");
+                    gMapsLib.event.trigger(gmaps[mapId], "resize");
                     setCenter();
                 }
             };
@@ -199,7 +206,7 @@ Layers.registerType('google', {
         if (!oldOptions.visibility && newOptions.visibility) {
             let view = map.getView();
             const center = transform(view.getCenter(), 'EPSG:3857', 'EPSG:4326');
-            gmaps[mapId].setCenter(new google.maps.LatLng(center[1], center[0]));
+            gmaps[mapId].setCenter(new gMapsLib.LatLng(center[1], center[0]));
             gmaps[mapId].setZoom(view.getZoom());
         }
         if (!oldOptions.minZoom && newOptions.minZoom) {


### PR DESCRIPTION
## Description
If a map contains some google layers, now fails. This PR prevents this problem.

E.g. 
- Import this map below:
[google_layers.zip](https://github.com/geosolutions-it/MapStore2/files/7136821/google_layers.zip)

- On OL crashes at all
- On leaflet, when select the google layer, then unselect, it fails (after 10 seconds of google maps lib polling).



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6302

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
