### PR TITLE
#7276 Improve feedback about feature info

### DIFF
--- a/web/client/components/data/identify/DefaultViewer.jsx
+++ b/web/client/components/data/identify/DefaultViewer.jsx
@@ -95,6 +95,22 @@ class DefaultViewer extends React.Component {
         return validator.getValidResponses([response]);
     }
 
+    getInvalidTitles = () => {
+        const {invalidResponses} = this.getResponseProperties();
+        const titlesWithResponse = invalidResponses
+            .filter(({response}) => response !== "")
+            .map((res) => {
+                const {layerMetadata} = res;
+                return layerMetadata.title;
+            });
+        const titlesEmptyResponse = invalidResponses
+            .filter(({response}) => response === "")
+            .map((res) => {
+                const {layerMetadata} = res;
+                return layerMetadata.title;
+            });
+        return {titlesWithResponse, titlesEmptyResponse};
+    };
     renderEmptyLayers = () => {
         const {invalidResponses, emptyResponses} = this.getResponseProperties();
         if (this.props.missingResponses === 0 && emptyResponses) {
@@ -105,15 +121,17 @@ class DefaultViewer extends React.Component {
             allowRender =  allowRender && this.props.missingResponses === 0;
         }
         if (allowRender) {
-            const titles = invalidResponses.map((res) => {
-                const {layerMetadata} = res;
-                return layerMetadata.title;
-            });
+            const {titlesWithResponse, titlesEmptyResponse} = this.getInvalidTitles();
             return this.props.showEmptyMessageGFI ? (
-                <Alert bsStyle={"info"}>
-                    <Message msgId={"noInfoForLayers"} />
-                    <b>{titles.join(', ')}</b>
-                </Alert>
+                <>
+                    {titlesWithResponse.length ? <Alert bsStyle={"info"}>
+                        <Message msgId={"noInfoForLayers"} />
+                        <b>{titlesWithResponse.join(', ')}</b>
+                    </Alert> : null}
+                    {titlesEmptyResponse.length ? <Alert bsStyle={"danger"}>
+                        <h5><HTML msgId="emptyResponse" msgParams={{layers: titlesEmptyResponse.join(', ')}}/></h5>
+                    </Alert> : null
+                    }</>
             ) : null;
         }
         return null;
@@ -130,10 +148,18 @@ class DefaultViewer extends React.Component {
     renderEmptyPages = () => {
         const {emptyResponses} = this.getResponseProperties();
         if (this.props.missingResponses === 0 && emptyResponses) {
+            const {titlesWithResponse, titlesEmptyResponse} = this.getInvalidTitles();
+
             return (
-                <Alert bsStyle={"danger"}>
-                    <h4><HTML msgId="noFeatureInfo"/></h4>
-                </Alert>
+                <>{
+                    titlesWithResponse.length ? <Alert bsStyle={"info"}>
+                        <Message msgId={"noInfoForLayers"} />
+                        <b>{titlesWithResponse.join(', ')}</b>
+                    </Alert> : null}
+                {titlesEmptyResponse.length ? <Alert bsStyle={"danger"}>
+                    <h5><HTML msgId="emptyResponse" msgParams={{layers: titlesEmptyResponse.join(', ')}}/></h5>
+                </Alert> : null
+                }</>
             );
         }
         return null;
@@ -192,7 +218,7 @@ class DefaultViewer extends React.Component {
         componentOrder = this.props.isMobile ? componentOrder : reverse(componentOrder);
         return (
             <div className="mapstore-identify-viewer">
-                {!emptyResponses ? componentOrder.map((c)=> c) : this.renderEmptyPages()}
+                {!emptyResponses ? componentOrder.map((c)=> c) : this.renderEmptyPages(this.props)}
             </div>
         );
     }

--- a/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
+++ b/web/client/components/data/identify/__tests__/DefaultViewer-test.jsx
@@ -96,15 +96,15 @@ describe('DefaultViewer', () => {
         expect(dom.getElementsByClassName("alert").length).toBe(1);
     });
 
-    it('creates the DefaultViewer component with no results', () => {
+    it('creates the DefaultViewer component with no results and no response', () => {
         const viewer = ReactDOM.render(
             <DefaultViewer emptyResponses/>,
             document.getElementById("container")
         );
 
         expect(viewer).toExist();
-        const dom = ReactDOM.findDOMNode(viewer);
-        expect(dom.getElementsByClassName("alert").length).toBe(1);
+        const defaultViewer = document.querySelector('.mapstore-identify-viewer');
+        expect(defaultViewer.childNodes.length).toBe(0);
     });
 
     it('creates the DefaultViewer component with an empty and an non empty layer results', () => {
@@ -137,6 +137,37 @@ describe('DefaultViewer', () => {
         expect(gfiViewer.childNodes.length).toBe(2);
         expect(gfiViewer.childNodes[0]).toEqual(swipeableView);
         expect(gfiViewer.childNodes[1]).toEqual(alertInfo);
+    });
+    it('creates the DefaultViewer component with an empty body response and an non empty layer results', () => {
+        const responses = [{
+            response: "",
+            layerMetadata: {
+                title: 'a'
+            }
+        }, {
+            response: "A",
+            layerMetadata: {
+                title: 'b'
+            }
+        }];
+        const viewer = ReactDOM.render(
+            <DefaultViewer responses={responses}/>,
+            document.getElementById("container")
+        );
+
+        expect(viewer).toExist();
+        const dom = ReactDOM.findDOMNode(viewer);
+        expect(dom.getElementsByClassName("alert").length).toBe(1);
+        expect(dom.getElementsByClassName("panel").length).toBe(2);
+
+        // Desktop view
+        const gfiViewer = document.querySelector('.mapstore-identify-viewer');
+        const emptyReponseAlert = document.querySelector('.alert-danger');
+        const swipeableView = document.querySelector('.swipeable-view');
+        expect(gfiViewer).toBeTruthy();
+        expect(gfiViewer.childNodes.length).toBe(2);
+        expect(gfiViewer.childNodes[0]).toEqual(swipeableView);
+        expect(gfiViewer.childNodes[1]).toEqual(emptyReponseAlert);
     });
 
     it('creates the DefaultViewer component with Identify floating', () => {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -714,6 +714,7 @@
             "title": "Ooops! Etwas ist schiefgelaufen.",
             "text": "Ein Fehler ist während dieser <b>GetFeatureInfo</b> Anfrage aufgetreten"
         },
+        "emptyResponse": "Diese Ebenen <b>{layers}</b> haben eine leere Antwort zurückgegeben.<br/>Mögliche Ursachen sind: <li>die Proxy-Konfiguration</li>",
         "noFeatureInfo": "Zu diesem Punkt sind keine Informationen verfügbar",
         "noInfoForLayers": "Für die folgenden Ebenen gibt es keine Objekte: ",
         "history":{

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -675,6 +675,7 @@
             "title": "Ooops! Something's wrong",
             "text": "An error has occurred during this <b>GetFeatureInfo</b> request"
         },
+        "emptyResponse": "These layers <b>{layers}</b> have returned an empty response.<br/>Possible causes are: <li>the proxy configuration</li>",
         "noFeatureInfo": "There is no information available for this point",
         "noInfoForLayers": "There are no features for the following layers: ",
         "history":{

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -675,6 +675,7 @@
             "title": "Ooops! Algo va mal",
             "text": "Un error se ha producido durante esta <b>GetFeatureInfo</b> petición"
         },
+        "emptyResponse": "Estas capas <b>{layers}</b> han devuelto una respuesta vacía. <br/> Las posibles causas son: <li>la configuración del proxy</li>",
         "noFeatureInfo": "No hay información disponible para este punto",
         "noInfoForLayers": "No hay características para las siguientes capas: ",
         "history":{

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -675,6 +675,7 @@
             "title": "Ooops! Quelque chose ne fonctionne pas",
             "text": "Une erreur s'est produite au cours de cette requête <b>GetFeatureInfo</b>"
         },
+        "emptyResponse": "Ces couches <b>{layers}</b> ont renvoyé une réponse vide.<br/>Les causes possibles sont : <li>la configuration du proxy</li>",
         "noFeatureInfo": "Aucune information n'est disponible pour ce point",
         "noInfoForLayers": "Il n'y a aucun objet pour les couches suivantes : ",
         "history": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -675,6 +675,7 @@
             "title": "Ooops! Qualcosa non va",
             "text": "Si è verificato un errore nel fare questa richiesta <b>GetFeatureInfo</b>"
         },
+        "emptyResponse": "Questi livelli <b>{layers}</b> hanno ritornato una risposta vuota<br/>Possibili cause sono: <li>la configurazione del proxy</li>",
         "noFeatureInfo": "Non ci sono informazioni disponibili per questo punto",
         "noInfoForLayers": "Non ci sono features per i seguenti layers: ",
         "history":{

--- a/web/client/utils/FeatureInfoUtils.js
+++ b/web/client/utils/FeatureInfoUtils.js
@@ -84,13 +84,13 @@ export const Validator = {
          *Parse the JSON to get only the valid json responses
          */
         getValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
+            return responses.filter((res) => res?.response?.features?.length);
         },
         /**
          * Parse the JSON to get only the NOT valid json responses
          */
         getNoValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
+            return responses.filter((res) => res.response === "" || res?.response?.features?.length === 0);
         }
     },
     PROPERTIES: {
@@ -98,13 +98,13 @@ export const Validator = {
          *Parse the JSON to get only the valid json responses
          */
         getValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
+            return responses.filter((res) => res?.response?.features?.length);
         },
         /**
          * Parse the JSON to get only the NOT valid json responses
          */
         getNoValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
+            return responses.filter((res) => res.response === "" || res?.response?.features?.length === 0);
         }
     },
     GML3: {
@@ -126,13 +126,13 @@ export const Validator = {
          *Parse the JSON to get only the valid json responses
          */
         getValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length);
+            return responses.filter((res) => res?.response?.features?.length);
         },
         /**
          * Parse the JSON to get only the NOT valid json responses
          */
         getNoValidResponses(responses) {
-            return responses.filter((res) => res.response && res.response.features && res.response.features.length === 0);
+            return responses.filter((res) => res.response === "" || res?.response?.features?.length === 0);
         }
     }
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR provides changes to how messages and feedback are presented i will list before and after for the different use cases that we can have.

[in this map](https://dev-mapstore.geosolutionsgroup.com/mapstore/#/viewer/openlayers/35736) i have configured 4 layers:
- segnalazione muri (it will return empty response always)
- sopralluoghi (it will return empty response always)
- linea costa (a valid layer with correct responses)
- regioni italiane (a valid layer with correct responses)

by clicking on different points and turning on and off the layers you can test different combinations

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7276

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
this has been removed
![image](https://user-images.githubusercontent.com/11991428/132828221-9e814673-320d-4d00-8cd9-71bff129fcb4.png)
and a different way to identify invalid responses have been included

- when an invalid response with an empty body is returned we show this error message
![image](https://user-images.githubusercontent.com/11991428/132828377-476d5e85-18e8-4574-aef4-b86dd499285d.png)

- when an invalid response with a valid body is returned we show this info message
![image](https://user-images.githubusercontent.com/11991428/132828482-6b12a0ef-d2d9-44cd-8729-0d12c0e1a252.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

Here is a list of all combination tested

![image](https://user-images.githubusercontent.com/11991428/132829291-88a65fab-085c-45a0-80d1-0586e1dac05e.png)

![image](https://user-images.githubusercontent.com/11991428/132829321-112fbcf9-e4ea-42b6-b9dd-17230a527b2c.png)

![image](https://user-images.githubusercontent.com/11991428/132829381-731bc839-acae-4335-bdbe-86813c813922.png)

![image](https://user-images.githubusercontent.com/11991428/132829478-c28e9e59-4902-4650-94bc-a7cc55e6d9d6.png)

![image](https://user-images.githubusercontent.com/11991428/132829522-9828dbe6-3274-426c-a395-1a3d9d7bf367.png)

![image](https://user-images.githubusercontent.com/11991428/132829554-7910eff3-f71c-4b82-83d2-0636c2aa7110.png)
