### PR TITLE
Add external layer from url via action

### DIFF
--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -85,6 +85,8 @@ Requirements:
 - The number of layers should match the number of sources
 - The source name can be a string that must match a catalog service name present in the map or an object that defines an external catalog (see example)
 
+Supported layer types are WMS, WMTS and WFS.
+
 Example:
 ```
 {

--- a/docs/developer-guide/map-query-parameters.md
+++ b/docs/developer-guide/map-query-parameters.md
@@ -83,14 +83,14 @@ This action allows to add layers directly to the map by taking them from the Cat
 Requirements:
 
 - The number of layers should match the number of sources
-- The source name must match a catalog service name present in the map
+- The source name can be a string that must match a catalog service name present in the map or an object that defines an external catalog (see example)
 
 Example:
 ```
 {
     "type": "CATALOG:ADD_LAYERS_FROM_CATALOGS",
-    "layers": ["workspace1:layer1", "workspace2:layer2"],
-    "sources": ["catalog1", "catalog2"]
+    "layers": ["workspace1:layer1", "workspace2:layer2", "workspace:externallayername"],
+    "sources": ["catalog1", "catalog2", {"type":"WMS","url":"https://example.com/wms"}]
 }
-?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["layer1", "layer2"],"sources":["catalog1", "catalog2"]}]
+?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["layer1", "layer2", "workspace:externallayername"],"sources":["catalog1", "catalog2", {"type":"WMS","url":"https://example.com/wms"}]}]
 ```

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -65,7 +65,7 @@ export const SET_FORMAT_OPTIONS = 'CATALOG:SET_FORMAT_OPTIONS';
 /**
  * Adds a list of layers from the given catalogs to the map
  * @param {string[]} layers list with workspace to be added in the map
- * @param {string[]} sources catalog names related to each layer
+ * @param {string[] | object[] } sources catalog names related to each layer
  */
 export function addLayersMapViewerUrl(layers = [], sources = []) {
     return {

--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -324,6 +324,39 @@ describe('catalog Epics', () => {
             }
         });
     });
+    it('addLayersFromCatalogsEpic wmts via object definion', (done) => {
+        const NUM_ACTIONS = 2;
+        testEpic(addTimeoutEpic(addLayersFromCatalogsEpic, 0), NUM_ACTIONS, addLayersMapViewerUrl(["topp:tasmania_cities_hidden"], [{"type": "wmts", "url": "base/web/client/test-resources/wmts/GetCapabilities-1.0.0.xml"}]), (actions) => {
+            expect(actions.length).toBe(NUM_ACTIONS);
+            actions.map((action) => {
+                switch (action.type) {
+                case ADD_LAYER:
+                    expect(action.layer.name).toBe("topp:tasmania_cities_hidden");
+                    expect(action.layer.title).toBe("tasmania_cities");
+                    expect(action.layer.type).toBe("wmts");
+                    expect(action.layer.url).toBe("http://sample.server/geoserver/gwc/service/wmts");
+                    break;
+                case TEST_TIMEOUT:
+                    break;
+                default:
+                    expect(true).toBe(false);
+                }
+            });
+            done();
+        }, {
+            catalog: {
+                delayAutoSearch: 50,
+                selectedService: "externalService",
+                services: {
+                    "externalService": {
+                        type: "wmts",
+                        url: "base/web/client/test-resources/wmts/GetCapabilities-1.0.0.xml"
+                    }
+                },
+                pageSize: 2
+            }
+        });
+    });
     it('getSupportedFormatsEpic wms', (done) => {
         const NUM_ACTIONS = 3;
         const url = "base/web/client/test-resources/wms/GetCapabilities-1.1.1.xml";

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -120,9 +120,12 @@ export default (API) => ({
                 const addLayerOptions = options || searchOptionsSelector(state);
                 const services = servicesSelector(state);
                 const actions = layers
-                    .filter((l, i) => !!services[sources[i]] || sources[i].type !== undefined) // check for catalog name or object definition
+                    .filter((l, i) => !!services[sources[i]] || typeof sources[i] === 'object') // check for catalog name or object definition
                     .map((l, i) => {
-                        const { type: format, url, ...service } = services[sources[i]];
+                        const source = sources[i];
+                        const service = typeof source === 'object' ? source : services[source];
+                        const format = service.type.toLowerCase();
+                        const url = service.url;
                         const text = layers[i];
                         return Rx.Observable.defer(() =>
                             API[format].textSearch(url, startPosition, maxRecords, text, {...addLayerOptions, ...service}).catch(() => ({ results: [] }))

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -63,6 +63,7 @@ import {
     extractOGCServicesReferences,
     getCatalogRecords,
     recordToLayer,
+    wfsToLayer,
     getSupportedFormat
 } from '../utils/CatalogUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
@@ -138,8 +139,8 @@ export default (API) => ({
                                 const { format, url, text, ...result } = r;
                                 const locales = currentMessagesSelector(state);
                                 const records = getCatalogRecords(format, result, addLayerOptions, locales) || [];
-                                const record = head(records.filter(rec => rec.identifier === text)); // exact match of text and record identifier
-                                const { wms, wmts } = extractOGCServicesReferences(record);
+                                const record = head(records.filter(rec => rec.identifier || rec.name === text)); // exact match of text and record identifier
+                                const { wms, wmts, wfs } = extractOGCServicesReferences(record);
                                 let layer = {};
                                 const layerBaseConfig = {}; // DO WE NEED TO FETCH IT FROM STATE???
                                 const authkeyParamName = authkeyParamNameSelector(state);
@@ -163,6 +164,8 @@ export default (API) => ({
                                     layer = recordToLayer(record, "wmts", {
                                         removeParams: authkeyParamName
                                     }, layerBaseConfig);
+                                } else if (wfs) {
+                                    layer = wfsToLayer(record);
                                 } else {
                                     const { esri } = extractEsriReferences(record);
                                     if (esri) {

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -120,7 +120,7 @@ export default (API) => ({
                 const addLayerOptions = options || searchOptionsSelector(state);
                 const services = servicesSelector(state);
                 const actions = layers
-                    .filter((l, i) => !!services[sources[i]]) // ignore wrong catalog name
+                    .filter((l, i) => !!services[sources[i]] || sources[i].type !== undefined) // check for catalog name or object definition
                     .map((l, i) => {
                         const { type: format, url, ...service } = services[sources[i]];
                         const text = layers[i];


### PR DESCRIPTION
## Description
This PR intents to solve issue #7262. It allows adding external layers to mapstore via the url, using the `CATALOG:ADD_LAYERS_FROM_CATALOGS` action. Therefore, the layer source needs to be defined as an object:

```
{
   "type":"WMS",
   "url":"https://example.com/wms"
 }
```

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7262 

**What is the new behavior?**
External layers can be added to mapstore via the url. The following examples should work for testing the PR in a local instance:

- WMS layer from local catalog: http://localhost:8081/?debug=true#/viewer/openlayers/13184?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["eco_comm:audiar_commerce_2014"],"sources":["WMS%20RM"]}]
- WMS layer from external catalog: http://localhost:8081/?debug=true#/viewer/openlayers/13184?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["CP.CadastralBuilding"],"sources":[{"type":"wms","url":"https://geobretagne.fr/geoserver/cadastre/wms"}]}]
- WMS layers from local and external catalogs: http://localhost:8081/?debug=true#/viewer/openlayers/13184?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["CP.CadastralBuilding","eco_comm:audiar_commerce_2014"],"sources":[{"type":"WMS","url":"https://geobretagne.fr/geoserver/cadastre/wms"},"WMS%20RM"]}]

- WMTS layer from external catalog: http://localhost:8081/?debug=true#/viewer/openlayers/13184?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["satellite-ancien"],"sources":[{"type":"wmts","url":"https://tile.geobretagne.fr/gwc02/service/wmts"}]}]

- WFS layer from external catalog: http://localhost:8081/?debug=true#/viewer/openlayers/13184?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["dreal_b:ae_annotation_edit"],"sources":[{"type":"wfs","url":"https://geobretagne.fr/geoserver/dreal_b/wfs"}]}]

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
