### PR TITLE
#7172: fixes compatibility issue with java11

### DIFF
--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -72,6 +72,11 @@
         <artifactId>commons-pool</artifactId>
         <version>1.5.4</version>
     </dependency>
+    <dependency>
+        <groupId>javax.xml.ws</groupId>
+        <artifactId>jaxws-api</artifactId>
+        <version>2.3.1</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Recent java versions need and additional dependency to run the updated MapStore backend. We are going to include it with this PR.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7172 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
MapStore does not start on java11 with this error: java.lang.NoClassDefFoundError: javax/xml/ws/WebServiceFeature

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
MapStore starts fine in java11

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
