### PR TITLE
[Backport 2021.02.xx] #5905 Prevent crash when configured background has no source/name

### DIFF
--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -35,6 +35,7 @@ import AddTileProvider from './buttons/AddTileProvider';
 
 import defaultThumb from './img/default.jpg';
 import defaultBackgroundThumbs from '../../plugins/background/DefaultThumbs';
+import unknown from "../../plugins/background/assets/img/dafault.jpg";
 
 class RecordItem extends React.Component {
     static propTypes = {
@@ -290,7 +291,7 @@ class RecordItem extends React.Component {
                 fullText={this.state.fullText}
                 preview={!this.props.hideThumbnail &&
                     this.renderThumb(record && record.thumbnail ||
-                        background && defaultBackgroundThumbs[background.source][background.name], record)}
+                        background && ((background.name || background.source) ? defaultBackgroundThumbs[background.source][background.name] : unknown), record)}
                 title={record && this.getTitle(record.title)}
                 description={<span><div className ref={sideCardDesc => {
                     this.sideCardDesc = sideCardDesc;

--- a/web/client/components/misc/cardgrids/__tests__/SideCard-test.jsx
+++ b/web/client/components/misc/cardgrids/__tests__/SideCard-test.jsx
@@ -12,6 +12,7 @@ import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import SideCard from '../SideCard';
+import unknown from "../../../../plugins/background/assets/img/dafault.jpg";
 
 describe('SideCard component', () => {
     beforeEach((done) => {
@@ -146,5 +147,29 @@ describe('SideCard component', () => {
         expect(titleClassName).toExist();
         expect(descClassName).toExist();
         expect(infoExtraClassName).toExist();
+    });
+
+    it('SideCard with infoExtra', () => {
+        ReactDOM.render(<SideCard caption="caption" description="desc" title="title" infoExtra={<div className="side-card-test-infoextra"/>}/>,
+            document.getElementById("container"));
+        const container = document.getElementById('container');
+        let body = container.querySelector('.ms-body');
+        let titleClassName = container.querySelector('.mapstore-side-card-title');
+        let descClassName = container.querySelector('.mapstore-side-card-desc');
+
+        const sideCardLeftContainer = container.getElementsByClassName('mapstore-side-card-left-container')[0];
+        expect(sideCardLeftContainer).toExist();
+        let infoExtraClassName = sideCardLeftContainer.querySelector('.side-card-test-infoextra');
+        expect(body).toNotExist();
+        expect(titleClassName).toExist();
+        expect(descClassName).toExist();
+        expect(infoExtraClassName).toExist();
+    });
+
+    it('SideCard display when "unknown" is passed as a preview props', () => {
+        ReactDOM.render(<SideCard preview={unknown} selected/>, document.getElementById("container"));
+        const container = document.getElementById('container');
+        let preview = container.querySelector('.mapstore-side-preview');
+        expect(preview).toExist();
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
App crashes whenever creating a new map that has a default background without a source and/or a name

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#5905 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The app does not crash when selecting a default background with no source and/or name

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
