### PR TITLE
#7309 Use only the state of feature grid to define the layer to use in grid

### DIFF
--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -72,11 +72,6 @@ describe('wfsquery Epics', () => {
                 }
             });
             done();
-        }, {
-            layers: {
-                selected: ['layerId'],
-                flat: [{id: 'layerId'}]
-            }
         });
     });
     it('wfsQueryEpic passing query options and default sort', (done) => {
@@ -102,11 +97,7 @@ describe('wfsquery Epics', () => {
             });
             done();
         }, {
-            query: { typeName: 'layer1', featureTypes: {layer1: {attributes: [{attribute: 'NAME'}]}}},
-            layers: {
-                selected: ['layerId'],
-                flat: [{id: 'layerId'}]
-            }
+            query: { typeName: 'layer1', featureTypes: {layer1: {attributes: [{attribute: 'NAME'}]}}}
         });
     });
     it('wfsQueryEpic passing filter object with valid sort options', (done) => {
@@ -132,11 +123,6 @@ describe('wfsquery Epics', () => {
                 }
             });
             done();
-        }, {
-            layers: {
-                selected: ['layerId'],
-                flat: [{id: 'layerId'}]
-            }
         });
     });
     // required to load a featuretype when the layer to use is not the layer selected in TOC
@@ -163,9 +149,43 @@ describe('wfsquery Epics', () => {
                 }
             });
             done();
+        });
+    });
+    it('wfsQueryEpic passing filter merged', (done) => {
+        const expectedResult = require('../../test-resources/wfs/museam.json');
+        mockAxios.onPost().reply(config => {
+            expect(config.data).toContain('<ogc:PropertyName>NAME</ogc:PropertyName>');
+            expect(config.data).toContain('<wfs:SortOrder>DESC</wfs:SortOrder>');
+            return [200, expectedResult];
+        });
+        testEpic(wfsQueryEpic, 2, query("base/web/client/test-resources/wfs/museam.json", { pagination: {maxFeatures: 20, startIndex: 0}, sortOptions: {sortBy: "NAME", sortOrder: "DESC"}, featureTypeName: "layerId"}, {}), actions => {
+            expect(actions.length).toBe(2);
+            actions.map((action) => {
+                switch (action.type) {
+                case QUERY_RESULT:
+                    expect(action.result).toEqual(expectedResult);
+                    expect(action.filterObj.pagination).toEqual({maxFeatures: 20, startIndex: 0});
+                    expect(action.filterObj.sortOptions).toEqual({sortBy: "NAME", sortOrder: "DESC"});
+                    break;
+                case FEATURE_LOADING:
+                    break;
+                default:
+                    expect(false).toBe(true);
+                }
+            });
+            done();
         }, {
             layers: {
-                flat: [{id: 'layerId'}]
+                flat: [{id: 'TEST_LAYER', filter: {}}]
+            },
+            featuregrid: {
+                timeSync: true,
+                pagination: {
+                    size: 10
+                },
+                open: true,
+                selectedLayer: "TEST_LAYER",
+                changes: []
             }
         });
     });
@@ -174,7 +194,6 @@ describe('wfsquery Epics', () => {
         const DATE = "20180101T00:00:00";
         const BASE_TIME_TEST_STATE = {
             layers: {
-                selected: ['TEST_LAYER'],
                 flat: [{
                     id: "TEST_LAYER",
                     title: "Test Layer",
@@ -290,11 +309,6 @@ describe('wfsquery Epics', () => {
                 }
             });
             done();
-        }, {
-            layers: {
-                selected: ['layerId'],
-                flat: [{id: 'layerId'}]
-            }
         });
     });
 
@@ -356,7 +370,6 @@ describe('wfsquery Epics', () => {
                         expanded: false,
                         maskLoading: false
                     },
-                    selected: ['layer1'],
                     settings: {
                         expanded: false,
                         node: null,


### PR DESCRIPTION
## Description
This PR makes the feature grid more independent from the TOC, using it's own state to see what layer to select from the state. (`layers` state is still needed).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7309

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
