### PR TITLE
[Backport 2021.02.xx] #7082: Map template background duplicate fix (#7212)

### DIFF
--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -22,7 +22,8 @@ import {
     isEmpty,
     findIndex,
     cloneDeep,
-    minBy
+    minBy,
+    omit
 } from 'lodash';
 
 import uuidv1 from 'uuid/v1';
@@ -482,7 +483,10 @@ export const mergeMapConfigs = (cfg1 = {}, cfg2 = {}) => {
             ]
         }] : [])
     ];
-    const backgroundLayers = layers.filter(layer => layer.group === 'background');
+    const toleratedFields = ['id', 'visibility'];
+    const backgroundLayers = layers.filter(layer => layer.group === 'background')
+        // remove duplication by comparing all fields with some level of tolerance
+        .filter((l1, i, a) => findIndex(a, (l2) => isEqual(omit(l1, toleratedFields), omit(l2, toleratedFields))) === i);
     const firstVisible = findIndex(backgroundLayers, layer => layer.visibility);
 
     const sources1 = get(cfg1, 'map.sources', {});

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -2741,6 +2741,13 @@ describe('Test the MapUtils', () => {
     });
 
     it('mergeMapConfigs', () => {
+        const testBackground = {
+            id: "layer4",
+            title: "layer4",
+            source: "osm",
+            name: "layer4",
+            group: "background"
+        };
         const cfg1 = {
             catalogServices: {
                 services: {
@@ -2778,7 +2785,7 @@ describe('Test the MapUtils', () => {
                     group: "group"
                 }, {
                     id: "annotations"
-                }],
+                }, testBackground],
                 projection: "EPSG:4326",
                 units: "m"
             },
@@ -2828,7 +2835,7 @@ describe('Test the MapUtils', () => {
                 }, {
                     id: "layer3",
                     group: undefined
-                }],
+                }, testBackground],
                 projection: "EPSG:900913",
                 units: "m"
             },
@@ -2919,21 +2926,24 @@ describe('Test the MapUtils', () => {
         expect(cfg.map.groups[0].id).toBe("Default");
         expect(cfg.map.groups[1].id).toBe("group");
         expect(cfg.map.groups[2].id).toBe("group2");
-        expect(cfg.map.layers.length).toBe(7);
+        expect(cfg.map.layers.length).toBe(8);
         expect(cfg.map.layers[0].id).toBe(cfg.map.backgrounds[0].id);
         expect(cfg.map.layers[0].group).toBe("background");
-        expect(cfg.map.layers[1].id).toNotBe("layer3");
-        expect(cfg.map.layers[1].id.length).toBe(36);
-        expect(cfg.map.layers[1].group).toBe("group2");
-        expect(cfg.map.layers[2].id).toNotBe("layer2");
+        expect(cfg.map.layers[1].id).toNotBe("layer4");
+        expect(cfg.map.layers[1].title).toBe("layer4");
+        expect(cfg.map.layers[1].group).toBe("background");
+        expect(cfg.map.layers[2].id).toNotBe("layer3");
         expect(cfg.map.layers[2].id.length).toBe(36);
-        expect(cfg.map.layers[3].id).toBe("layer1");
-        expect(cfg.map.layers[3].group).toNotExist();
-        expect(cfg.map.layers[4].id).toBe("layer2");
+        expect(cfg.map.layers[2].group).toBe("group2");
+        expect(cfg.map.layers[3].id).toNotBe("layer2");
+        expect(cfg.map.layers[3].id.length).toBe(36);
+        expect(cfg.map.layers[4].id).toBe("layer1");
         expect(cfg.map.layers[4].group).toNotExist();
-        expect(cfg.map.layers[5].id).toBe("layer3");
-        expect(cfg.map.layers[5].group).toBe("group");
-        expect(cfg.map.layers[6].id).toBe("annotations");
+        expect(cfg.map.layers[5].id).toBe("layer2");
+        expect(cfg.map.layers[5].group).toNotExist();
+        expect(cfg.map.layers[6].id).toBe("layer3");
+        expect(cfg.map.layers[6].group).toBe("group");
+        expect(cfg.map.layers[7].id).toBe("annotations");
         expect(cfg.map.projection).toBe(cfg1.map.projection);
         expect(cfg.map.units).toBe("m");
         expect(cfg.widgetsConfig).toExist();
@@ -2941,7 +2951,7 @@ describe('Test the MapUtils', () => {
         expect(cfg.widgetsConfig.widgets[0].id).toNotBe("widget1");
         expect(cfg.widgetsConfig.widgets[0].id.length).toBe(36);
         expect(cfg.widgetsConfig.widgets[0].layer).toExist();
-        expect(cfg.widgetsConfig.widgets[0].layer.id).toBe(cfg.map.layers[1].id);
+        expect(cfg.widgetsConfig.widgets[0].layer.id).toBe(cfg.map.layers[2].id);
         expect(cfg.widgetsConfig.widgets[0].layer.group).toBe("group2");
         expect(cfg.widgetsConfig.collapsed).toExist();
 


### PR DESCRIPTION
[Backport 2021.02.xx] #7082: Map template background duplicate fix (#7212)