### PR TITLE
Disable Coveralls stable branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
         run: npm test -- --reporters mocha,coverage,coveralls
         
       - name: Coveralls
+        if: ${{ false }}
         uses: coverallsapp/github-action@master
         with:
            github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
disable coveralls check because of outage. Revert this PR as well as the system becomes operative again.