### PR TITLE
Create new dashboard, the warning tooltip is shown for a very short time

### DIFF
--- a/web/client/plugins/widgetbuilder/LayerSelector.jsx
+++ b/web/client/plugins/widgetbuilder/LayerSelector.jsx
@@ -35,7 +35,7 @@ export default ({ onClose = () => { }, setSelected = () => { }, onLayerChoice = 
     (<BorderLayout
         className="bg-body layer-selector"
         header={<BuilderHeader onClose={onClose}>
-            <Toolbar stepButtons={stepButtons} canProceed={canProceed} onProceed={() => onLayerChoice(layer)} />
+            <Toolbar stepButtons={stepButtons} canProceed={canProceed && selected} onProceed={() => onLayerChoice(layer)} />
             {selected && !canProceed && error ? <InfoPopover
                 trigger={false}
                 glyph="warning-sign"

--- a/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
+++ b/web/client/plugins/widgetbuilder/enhancers/layerSelector.js
@@ -42,7 +42,7 @@ export default compose(
                         .do(l => setLayer({...l, visibility: !isUndefined(l.visibility) ? l.visibility : true}))
                         .mapTo({ canProceed: true })
                         .catch((error) => Rx.Observable.of({ error, canProceed: false }))
-            ).startWith({})
+            ).startWith({ canProceed: true })
             .combineLatest(props$, ({ canProceed, error } = {}, props) => ({
                 error,
                 canProceed,


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The warning tooltip is shown, only if layer validation return a warning / error

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7335 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
the tooltip has shown only if the validation process return an error

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
