### PR TITLE
#7317 Made default locale loading action environment independent

### DIFF
--- a/web/client/actions/__tests__/locale-test.js
+++ b/web/client/actions/__tests__/locale-test.js
@@ -8,6 +8,8 @@
 import expect from 'expect';
 
 import { loadLocale } from '../locale';
+import { setSupportedLocales, getSupportedLocales } from '../../utils/LocaleUtils';
+
 
 describe('Test locale related actions', () => {
     it('does not load a missing translation file', (done) => {
@@ -148,7 +150,15 @@ describe('Test locale related actions', () => {
         });
     });
 
-    it('loads an existing translation file', (done) => {
+    it.only('loads an existing translation file by default', (done) => {
+        const locales = {
+            "en": {
+                code: "en-US",
+                description: "English"
+            }
+        };
+        const oldLocales = getSupportedLocales();
+        setSupportedLocales(locales);
         loadLocale('base/web/client/test-resources')((e) => {
             try {
                 expect(e).toExist();
@@ -156,6 +166,8 @@ describe('Test locale related actions', () => {
                 done();
             } catch (ex) {
                 done(ex);
+            } finally {
+                setSupportedLocales(oldLocales);
             }
         });
     });

--- a/web/client/actions/__tests__/locale-test.js
+++ b/web/client/actions/__tests__/locale-test.js
@@ -150,7 +150,7 @@ describe('Test locale related actions', () => {
         });
     });
 
-    it.only('loads an existing translation file by default', (done) => {
+    it('loads an existing translation file by default', (done) => {
         const locales = {
             "en": {
                 code: "en-US",


### PR DESCRIPTION
## Description
This PR fixes a test that may fail in some environments with a default language supported, but when the relative test file is not present in the list. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7317

**What is the new behavior?**
The test now is forced to use en-US, because forced to be the unique supported language, during the test.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
