### PR TITLE
#7294 loading too many extension crashes

### DIFF
--- a/build/createExtensionWebpackConfig.js
+++ b/build/createExtensionWebpackConfig.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 const shared = require('./moduleFederation').shared;
 const ModuleFederationPlugin = require('webpack/lib/container/ModuleFederationPlugin');
-
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 /**
  * Produces a webpack configuration that allow to create a MapStore extension.
@@ -22,7 +22,14 @@ module.exports = ({ prod = true, name, exposes, alias = {}, publicPath, destinat
     mode: prod ? "production" : "development",
     entry: {},
     optimization: {
-        minimize: !!prod
+        minimize: !!prod,
+        ...(prod && {
+            minimizer: [
+                // For webpack@5 you can use the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`)
+                `...`,
+                new CssMinimizerPlugin() // minify css bundle
+            ]
+        })
     },
     resolve: {
         fallback: {
@@ -50,10 +57,7 @@ module.exports = ({ prod = true, name, exposes, alias = {}, publicPath, destinat
                 use: [
                     prod ? MiniCssExtractPlugin.loader : "style-loader", // because HMR do not work with mini-css plugin
                     {
-                        loader: 'css-loader',
-                        options: {
-                            minimize: true
-                        }
+                        loader: 'css-loader'
                     }
                 ]
             },
@@ -75,14 +79,14 @@ module.exports = ({ prod = true, name, exposes, alias = {}, publicPath, destinat
                         limit: 8192
                     }
                 }] // inline base64 URLs for <=8k images, direct URLs for the rest
-            },
+            }
         ]
     },
     output: {
         publicPath,
         chunkFilename: 'assets/js/[name].[chunkhash:8].js',
-        path: destination
-
+        path: destination,
+        uniqueName: name
     },
     ...overrides
 });


### PR DESCRIPTION
This PR adds an improvement to the extension build configuration to ensure uniqueName based on the extension name so it's unique without changing the name of the package.json. This PR update also the configuration for css minimizer

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Minor improvement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7294

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
With this configuration the bundle has always a unique context based on the name of the extension

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
