### PR TITLE
#7113: Display timeline data when timeline is not loaded on page load

### DIFF
--- a/web/client/components/time/TimelineComponent.jsx
+++ b/web/client/components/time/TimelineComponent.jsx
@@ -212,7 +212,8 @@ class Timeline extends React.Component {
             selectionOptions = {},
             customTimes,
             animate = true,
-            currentTime
+            currentTime,
+            timelineLayers
         } = this.props;
 
         let timelineOptions = options;
@@ -233,11 +234,27 @@ class Timeline extends React.Component {
             }
         }
 
+        const isTimelineLayerVisible = (layers) => {
+            let list = [];
+
+            for (let layer of layers) {
+                let isVisible = timelineLayers.find(item => item.id === layer.id);
+                let obj = isVisible.visibility;
+                if (obj) {
+                    list.push(layer);
+                }
+
+            }
+            return list;
+        };
+
         this.$el.setOptions(timelineOptions);
 
-        if (groups.length > 0) {
+        const updatedGroups = isTimelineLayerVisible(groups);
+
+        if (updatedGroups.length > 0) {
             const groupsDataset = new vis.DataSet();
-            groupsDataset.add(groups);
+            groupsDataset.add(updatedGroups);
             this.$el.setGroups(groupsDataset);
         }
 

--- a/web/client/components/time/__tests__/TimelineComponent-test.jsx
+++ b/web/client/components/time/__tests__/TimelineComponent-test.jsx
@@ -11,7 +11,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Timeline from '../TimelineComponent';
 import expect from 'expect';
+
 const TEST_ITEMS = [{ id: '1', start: new Date(0), end: new Date(0), type: 'point', content: '' }, { id: '2', start: new Date(970821881894), end: new Date(970821881894), type: 'point', content: '' }];
+
 describe('test TimelineComponent module component', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -82,6 +84,4 @@ describe('test TimelineComponent module component', () => {
         expect(document.querySelector('.TEST_RANGE')).toExist();
 
     });
-
-
 });

--- a/web/client/epics/__tests__/timeline-test.js
+++ b/web/client/epics/__tests__/timeline-test.js
@@ -202,13 +202,13 @@ describe('timeline Epics', () => {
             testEpic(syncTimelineGuideLayer, NUM_ACTIONS, [selectLayer('TEST_LAYER2'), changeLayerProperties('TEST_LAYER', {visibility: false}) ], (actions) => {
                 doAssertion(NUM_ACTIONS, actions, 'TEST_LAYER1');
                 done();
-            }, STATE_TIMELINE);
+            }, STATE_TIMELINE, done());
         });
         it('syncTimelineGuideLayer on removeNode', done => {
             testEpic(syncTimelineGuideLayer, NUM_ACTIONS, [selectLayer('TEST_LAYER2'), removeNode('TEST_LAYER', 'layers') ], (actions) => {
                 doAssertion(NUM_ACTIONS, actions, 'TEST_LAYER1');
                 done();
-            }, STATE_TIMELINE);
+            }, STATE_TIMELINE, done());
         });
         it('syncTimelineGuideLayer on showHiddenLayers', done => {
             testEpic(syncTimelineGuideLayer, NUM_ACTIONS, [selectLayer('TEST_LAYER2'), removeNode('TEST_LAYER1', 'layers') ], (actions) => {

--- a/web/client/plugins/Timeline.jsx
+++ b/web/client/plugins/Timeline.jsx
@@ -45,6 +45,7 @@ import {
 import Timeline from './timeline/Timeline';
 import TimelineToggle from './timeline/TimelineToggle';
 import ButtonRB from '../components/misc/Button';
+import {getState} from "../utils/StateUtils";
 const Button = tooltip(ButtonRB);
 
 const isPercent = (val) => isString(val) && val.indexOf("%") !== -1;
@@ -189,7 +190,15 @@ const TimelinePlugin = compose(
 
         const playbackItem = head(items && items.filter(item => item.name === 'playback'));
         const Playback = playbackItem && playbackItem.plugin;
-
+        const timelineLayers = timelineLayersSelector(getState());
+        const isTimelineVisible = (layers)=>{
+            for (let layer of layers) {
+                if (layer.visibility) {
+                    return true;
+                }
+            }
+            return false;
+        };
         const zoomToCurrent = (time, type, view, offsetRange ) => {
             const shift = moment(view.end).diff(view.start) / 2;
             if (type === "time-current" && view) {
@@ -228,7 +237,7 @@ const TimelinePlugin = compose(
                 ...style,
                 right: collapsed ? 'auto' : (style.right || 0)
             }}
-            className={`timeline-plugin${hideLayersName ? ' hide-layers-name' : ''}${offsetEnabled ? ' with-time-offset' : ''}`}>
+            className={`timeline-plugin${hideLayersName ? ' hide-layers-name' : ''}${offsetEnabled ? ' with-time-offset' : ''} ${!isTimelineVisible(timelineLayers) && 'hidden'}`}>
 
             {offsetEnabled // if range is present and configured, show the floating start point.
                 && <InlineDateTimeSelector
@@ -323,7 +332,8 @@ const TimelinePlugin = compose(
                 <Timeline
                     offsetEnabled={offsetEnabled}
                     playbackEnabled
-                    hideLayersName={hideLayersName} />}
+                    hideLayersName={hideLayersName}
+                    timelineLayers={timelineLayers}/>}
         </div>);
     }
 );

--- a/web/client/plugins/__tests__/Timeline-test.jsx
+++ b/web/client/plugins/__tests__/Timeline-test.jsx
@@ -47,6 +47,57 @@ const SAMPLE_STATE = {
     }
 };
 
+const FALSY_STATE = {
+    timeline: {
+        selectedLayer: "TEST_LAYER",
+        range: {
+            start: "2000-01-01T00:00:00.000Z",
+            end: "2020-12-31T00:00:00.000Z"
+        }
+    },
+    layers: {
+        flat: [{
+            id: 'TEST_LAYER',
+            name: 'TEST_LAYER',
+            type: 'wms',
+            url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+            dimensions: [
+                {
+                    source: {
+                        type: 'multidim-extension',
+                        // this forces to load fixed values from the test file, ignoring parameters
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                    },
+                    name: 'time'
+                }
+            ],
+            params: {
+                time: '2000-06-08T00:00:00.000Z'
+            },
+            visibility: false
+        }, {
+            id: 'TEST_LAYER_2',
+            name: 'TEST_LAYER_2',
+            type: 'wms',
+            url: 'base/web/client/test-resources/wmts/DomainValues.xml',
+            dimensions: [
+                {
+                    source: {
+                        type: 'multidim-extension',
+                        // this forces to load fixed values from the test file, ignoring parameters
+                        url: 'base/web/client/test-resources/wmts/DomainValues.xml'
+                    },
+                    name: 'time'
+                }
+            ],
+            params: {
+                time: '2000-06-08T00:00:00.000Z'
+            },
+            visibility: false
+        }]
+    }
+};
+
 describe('Timeline Plugin', () => {
     beforeEach((done) => {
         document.body.innerHTML = '<div id="container"></div>';
@@ -77,6 +128,16 @@ describe('Timeline Plugin', () => {
             const { Plugin} = getPluginForTest(TimelinePlugin, _state);
             ReactDOM.render(<Plugin />, document.getElementById("container"));
             expect(document.querySelector('.timeline-plugin')).toBeTruthy();
+        });
+        it('Timeline plugin is not visible when all layers have visibility set to false', ()=>{
+            const { Plugin } = getPluginForTest(TimelinePlugin, FALSY_STATE);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.querySelector('.hidden')).toBeTruthy();
+        });
+        it('Timeline plugin is not visible when there are no layers', ()=>{
+            const { Plugin } = getPluginForTest(TimelinePlugin, []);
+            ReactDOM.render(<Plugin />, document.getElementById("container"));
+            expect(document.querySelector('.timeline-plugin')).toBeFalsy();
         });
     });
 });

--- a/web/client/selectors/__tests__/timeline-test.js
+++ b/web/client/selectors/__tests__/timeline-test.js
@@ -142,7 +142,7 @@ describe('timeline selector', () => {
             {id: "test2", visibility: false, dimensions }]}
         };
         it('timelineLayersSelector with default settings', ()=>{
-            expect(timelineLayersSelector(state).length).toBe(1);
+            expect(timelineLayersSelector(state).length).toBe(2);
         });
         it('timelineLayersSelector with showHiddenLayers', ()=>{
             const _state = {...state, timeline: {...state, settings: SHOW_HIDDEN_LAYER}};

--- a/web/client/selectors/dimension.js
+++ b/web/client/selectors/dimension.js
@@ -42,12 +42,7 @@ export const timeDataSelector = state => layersSelector(state).reduce((timeDataM
  * @param {object} state application state
  */
 export const layersWithTimeDataSelector = state => layersSelector(state).filter(l => {
-    const showHiddenLayers = get(state, 'timeline.settings.showHiddenLayers');
-    const layerStaticDimension = getLayerStaticDimension(l, "time");
-    if (!showHiddenLayers) {
-        return l.visibility && layerStaticDimension;
-    }
-    return layerStaticDimension;
+    return getLayerStaticDimension(l, "time");
 });
 export const currentTimeSelector = state => {
     const currentTime = get(state, 'dimension.currentTime');


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Statistics in Timeline plugin not displaying when its respective layer is hidden by default on page load.
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7113 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Statistics are now displaying even when a layer is hidden by default on page load
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
