### PR TITLE
Revert "Disable temporary coveralls because of an outage."

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,6 @@ jobs:
         run: npm test -- --reporters mocha,coverage,coveralls
         
       - name: Coveralls
-        if: ${{ false }}
         uses: coverallsapp/github-action@master
         with:
            github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#7336

Now coveralls.io seems to be operational again:
https://status.coveralls.io/