### PR TITLE
Revert "Disable Coveralls stable branch" (#7347)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,6 @@ jobs:
         run: npm test -- --reporters mocha,coverage,coveralls
         
       - name: Coveralls
-        if: ${{ false }}
         uses: coverallsapp/github-action@master
         with:
            github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#7337

Same as #7347 for stable branch. https://status.coveralls.io/