### PR TITLE
#7266: Feature editor virtual scroll fix

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -144,6 +144,7 @@ const FeatureDock = (props = {
     dialogs: EMPTY_OBJ,
     select: EMPTY_ARR
 }) => {
+    const virtualScroll  = props.virtualScroll ?? true;
     const maxZoom  = props?.pluginCfg?.maxZoom;
     const dockProps = {
         dimMode: "none",
@@ -162,7 +163,7 @@ const FeatureDock = (props = {
     // const editors = items.filter(({target}) => target === 'editors');
 
     useEffect(() => {
-        props.initPlugin({virtualScroll: props.virtualScroll, editingAllowedRoles: props.editingAllowedRoles, maxStoredPages: props.maxStoredPages});
+        props.initPlugin({virtualScroll, editingAllowedRoles: props.editingAllowedRoles, maxStoredPages: props.maxStoredPages});
     }, []);
 
     return (
@@ -204,7 +205,7 @@ const FeatureDock = (props = {
                         tools={props.gridTools}
                         pagination={props.pagination}
                         pages={props.pages}
-                        virtualScroll={props.virtualScroll}
+                        virtualScroll={virtualScroll}
                         maxStoredPages={props.maxStoredPages}
                         vsOverScan={props.vsOverScan}
                         scrollDebounce={props.scrollDebounce}

--- a/web/client/plugins/__tests__/FeatureEditor-test.jsx
+++ b/web/client/plugins/__tests__/FeatureEditor-test.jsx
@@ -25,10 +25,12 @@ describe('FeatureEditor Plugin', () => {
         setTimeout(done);
     });
     it('render FeatureEditor plugin', () => {
-        const {Plugin} = getPluginForTest(FeatureEditor, {featuregrid: {...featuregrid, open: true}});
+        const {Plugin, store} = getPluginForTest(FeatureEditor, {featuregrid: {...featuregrid, open: true}});
         ReactDOM.render(<Plugin/>, document.getElementById("container"));
         const container = document.querySelector('.feature-grid-container');
         expect(container).toBeTruthy();
+        const state = store.getState().featuregrid;
+        expect(state.virtualScroll).toBe(true);
     });
     it('onInit FeatureEditor plugin', () => {
         const props = {


### PR DESCRIPTION
## Description
This PR fixes default props value (`virtualScroll`) not being set upon FeatureEditor plugin initialization

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#7266 

**What is the new behavior?**
The default value is properly set and the virtual scroll is enabled while hiding the navigational buttons in feature grid

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
