### PR TITLE
#7261 [Style Editor] Some attributes are not visible inside the attribute select box

### DIFF
--- a/web/client/actions/layerCapabilities.js
+++ b/web/client/actions/layerCapabilities.js
@@ -14,6 +14,24 @@ import WCS from '../api/WCS';
 import {getCapabilitiesUrl, formatCapabitiliesOptions} from '../utils/LayersUtils';
 import { get, head } from 'lodash';
 
+const mapMergingFeatureTypeXMLToJson = {
+    type: {
+        "gml:MultiPolygon": "gml:MultiSurfacePropertyType",
+        "xsd:int": "xsd:long",
+        "xsd:number": "xsd:double"
+    },
+    localType: {
+        "MultiPolygon": "MultiSurfacePropertyType",
+        "int": "long",
+        "number": "double"
+    },
+    namespace: {
+        "gml": "http://www.opengis.net/gml",
+        "xsd": "http://www.w3.org/2001/XMLSchema"
+    }
+};
+
+
 export function getDescribeLayer(url, layer, options) {
     return (dispatch /* , getState */) => {
         return WMS.describeLayer(url, layer.name, options).then((describeLayer) => {
@@ -32,23 +50,6 @@ export function getDescribeLayer(url, layer, options) {
                         });
 
                         let typesToAdd = featureTypes.filter(x => !alreadyInTypes.includes(x));
-
-                        const mapMergingFeatureTypeXMLToJson = {
-                            type: {
-                                "gml:MultiPolygon": "gml:MultiSurfacePropertyType",
-                                "xsd:int": "xsd:long",
-                                "xsd:number": "xsd:double"
-                            },
-                            localType: {
-                                "MultiPolygon": "MultiSurfacePropertyType",
-                                "int": "long",
-                                "number": "double"
-                            },
-                            namespace: {
-                                "gml": "http://www.opengis.net/gml",
-                                "xsd": "http://www.w3.org/2001/XMLSchema"
-                            }
-                        };
 
                         const featureTypeNeedToMerge = (mappingFeatureType, rlocalType, rtype) => {
                             const prefix = rtype.replace(`:${rlocalType}`, '');

--- a/web/client/actions/layerCapabilities.js
+++ b/web/client/actions/layerCapabilities.js
@@ -38,19 +38,15 @@ export function getDescribeLayer(url, layer, options) {
             if (describeLayer && describeLayer.owsType === "WFS") {
                 return WFS.describeFeatureTypeOGCSchemas(url, describeLayer.name).then((describeFeatureType) => {
                     WFS.describeFeatureType(url, layer.name).then( (response ) => {
-
                         // TODO move the management of this geometryType in the proper components, getting the describeFeatureType entry:
                         let featureTypes = response?.featureTypes[0].properties;
                         let types = get(describeFeatureType, "complexType[0].complexContent.extension.sequence.element");
-
                         let alreadyInTypes = types.map((item) =>{
                             return featureTypes.find(obj => {
                                 return (obj.name === item.name);
                             });
                         });
-
                         let typesToAdd = featureTypes.filter(x => !alreadyInTypes.includes(x));
-
                         const featureTypeNeedToMerge = (mappingFeatureType, rlocalType, rtype) => {
                             const prefix = rtype.replace(`:${rlocalType}`, '');
                             const   localPart = mappingFeatureType.localType[rlocalType] ? mappingFeatureType.localType[rlocalType] : rlocalType;
@@ -66,17 +62,13 @@ export function getDescribeLayer(url, layer, options) {
                                 }
                             };
                         };
-
-
                         let missingTypes = typesToAdd.length > 0 &&  typesToAdd.reduce((acc, currentValue) => {
                             const { type, ...rest } = currentValue;
                             const ogcJsonSchemaTypes = featureTypeNeedToMerge(mapMergingFeatureTypeXMLToJson, currentValue.localType, currentValue.type);
                             rest.otherAttributes = currentValue;
                             return [...acc, {...rest, ...ogcJsonSchemaTypes}];
                         }, []);
-
                         missingTypes && missingTypes.length > 0 && types.push(...missingTypes);
-
                         let geometryType = head(types && types.filter( elem => elem.name === "the_geom" || elem.type.prefix.indexOf("gml") === 0));
                         geometryType = geometryType && geometryType.type.localPart;
                         describeLayer.geometryType = geometryType && geometryType.split("PropertyType")[0];

--- a/web/client/actions/layerCapabilities.js
+++ b/web/client/actions/layerCapabilities.js
@@ -46,14 +46,7 @@ export function getDescribeLayer(url, layer, options) {
                             rest.otherAttributes = currentValue;
                             return [...acc, rest];
                         }, []);
-                        // const allTypes = (typesToAdd) ? [...types, ...missingTypes] : types;
-                        //console.log(missingTypes)
-                        //const allTypes = [];
-                        //allTypes.push(types, missingTypes);
-                        //console.log(allTypes)
-
-                        types.push(...missingTypes)
-
+                        missingTypes && missingTypes.length > 0 && types.push(...missingTypes);
                         let geometryType = head(types && types.filter( elem => elem.name === "the_geom" || elem.type.prefix.indexOf("gml") === 0));
                         geometryType = geometryType && geometryType.type.localPart;
                         describeLayer.geometryType = geometryType && geometryType.split("PropertyType")[0];


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
All attributes, visible in the FeatureGrid, now are visible also inside the attribute select box, of the style editor.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7261 

**What is the new behavior?**
In the style editor, now all attributes are visible inside the attribute select box.


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
