### PR TITLE
#7374: Geostory section update current page race condition fix

### DIFF
--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -34,7 +34,8 @@ import {
     handlePendingGeoStoryChanges,
     loadStoryOnHistoryPop,
     scrollOnLoad,
-    hideCarouselItemsOnUpdateCurrentPage
+    hideCarouselItemsOnUpdateCurrentPage,
+    urlUpdateOnScroll
 } from '../geostory';
 import {
     ADD,
@@ -63,7 +64,9 @@ import {
     SET_PENDING_CHANGES,
     LOAD_GEOSTORY,
     update,
-    HIDE_CAROUSEL_ITEMS
+    HIDE_CAROUSEL_ITEMS,
+    updateCurrentPage,
+    geostoryScrolling
 } from '../../actions/geostory';
 import { SET_CONTROL_PROPERTY } from '../../actions/controls';
 import {
@@ -1763,6 +1766,36 @@ describe('Geostory Epics', () => {
                 done();
             });
         });
+    });
+    it('urlUpdateOnScroll', (done)=> {
+        const NUM_ACTIONS = 1;
+        testEpic(addTimeoutEpic(urlUpdateOnScroll), NUM_ACTIONS, [ updateCurrentPage({}), geostoryScrolling(true)],
+            (actions) => {
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                done();
+            }
+        );
+    });
+    it('urlUpdateOnScrol, push state to history', (done)=> {
+        const NUM_ACTIONS = 1;
+        const oldHash = window.location.hash;
+        window.location.hash = "#/shared/5";
+        testEpic(addTimeoutEpic(urlUpdateOnScroll), NUM_ACTIONS, [ updateCurrentPage({sectionId: 1}), geostoryScrolling(true)],
+            (actions) => {
+                expect(window.location.href).toContain('shared/5/section/1');
+                expect(actions[0].type).toBe(TEST_TIMEOUT);
+                window.location.hash = oldHash;
+                done();
+            }, {
+                geostory: {
+                    updateUrlOnScroll: true,
+                    mode: "show",
+                    resource: {
+                        id: 5
+                    }
+                }
+            }
+        );
     });
     it('scrollOnLoad', (done) => {
         const NUM_ACTIONS = 2;

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -572,7 +572,7 @@ export const urlUpdateOnScroll = (action$, {getState}) =>
                 .map(a => !a.status)
                 .startWith(true)
         ))
-        .debounceTime(50) // little delay if too many UPDATE_CURRENT_PAGE actions come
+        .debounceTime(100) // little delay if too many UPDATE_CURRENT_PAGE actions come
         .switchMap(({sectionId, columnId}) => {
             if (
                 modeSelector(getState()) !== 'edit' && (!!columnId || !!sectionId)


### PR DESCRIPTION
## Description
This PR attempts to fix occasional race condition occurrence causing navigational issue to a Geostory section, by increasing the delay time in the semaphore.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#7374

**What is the new behavior?**
Navigating to geostory section via url should always land the user in the intended section

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
