### PR TITLE
#7381 Fix zoom to extent for search info

### DIFF
--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -208,7 +208,7 @@ describe('search Epics', () => {
     });
 
 
-    it.only('produces the selectSearchItem epic and GFI for single layer', (done) => {
+    it('produces the selectSearchItem epic and GFI for single layer', (done) => {
         let action = selectSearchItem({
             "id": "Feature_1",
             "type": "Feature",

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -208,7 +208,7 @@ describe('search Epics', () => {
     });
 
 
-    it('produces the selectSearchItem epic and GFI for single layer', (done) => {
+    it.only('produces the selectSearchItem epic and GFI for single layer', (done) => {
         let action = selectSearchItem({
             "id": "Feature_1",
             "type": "Feature",
@@ -235,13 +235,12 @@ describe('search Epics', () => {
         });
 
         const NUM_ACTIONS = 6;
-        testEpic(addTimeoutEpic(searchItemSelected, 100), NUM_ACTIONS, action, (actions) => {
-            expect(actions.length).toBe(NUM_ACTIONS);
+        testEpic(addTimeoutEpic(searchItemSelected, 0), NUM_ACTIONS, action, (actions) => {
             expect(actions[0].type).toBe(TEXT_SEARCH_RESULTS_PURGE);
             expect(actions[1].type).toBe(FEATURE_INFO_CLICK);
             expect(actions[1].itemId).toEqual("Feature_1");
             expect(actions[1].filterNameList).toEqual(["gs:layername"]);
-            expect(actions[1].overrideParams).toEqual({"gs:layername": {info_format: "text/html", featureid: "Feature_1"}});
+            expect(actions[1].overrideParams).toEqual({"gs:layername": {info_format: "text/html", featureid: "Feature_1", CQL_FILTER: undefined}}); // forces CQL FILTER to undefined (server do not support featureid + CQL_FILTER)
             expect(actions[2].type).toBe(SHOW_MAPINFO_MARKER);
             expect(actions[3].type).toBe(ZOOM_TO_EXTENT);
             expect(actions[4].type).toBe(TEXT_SEARCH_ADD_MARKER);
@@ -621,7 +620,7 @@ describe('search Epics', () => {
                     }
                 }
             });
-        const NUM_ACTIONS = 4;
+        const NUM_ACTIONS = 3;
         testEpic(addTimeoutEpic(textSearchShowGFIEpic, 100), NUM_ACTIONS, action, (actions) => {
             expect(actions).toExist();
             expect(actions.length).toBe(NUM_ACTIONS);
@@ -629,8 +628,7 @@ describe('search Epics', () => {
             expect(actions[0].overrideParams.layerName.info_format).toBe("text/html");
             expect(actions[0].overrideParams.layerName.featureid).toBe("layer_01");
             expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
-            expect(actions[2].type).toBe(ZOOM_TO_EXTENT);
-            expect(actions[3].type).toBe(TEXT_SEARCH_ADD_MARKER);
+            expect(actions[2].type).toBe(TEXT_SEARCH_ADD_MARKER);
             done();
         }, {layers: {flat: [{name: "layerName", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, featureInfo: {format: "HTML"}, queryable: true, type: "wms"}]}});
     });

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -30,7 +30,7 @@ import {
 } from '../../actions/search';
 
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
-import { FEATURE_INFO_CLICK, SHOW_MAPINFO_MARKER } from '../../actions/mapInfo';
+import { FEATURE_INFO_CLICK, SHOW_MAPINFO_MARKER, loadFeatureInfo } from '../../actions/mapInfo';
 import { ZOOM_TO_EXTENT, ZOOM_TO_POINT } from '../../actions/map';
 import { UPDATE_ADDITIONAL_LAYER } from '../../actions/additionallayers';
 import { searchEpic, searchItemSelected, zoomAndAddPointEpic, searchOnStartEpic, textSearchShowGFIEpic } from '../search';
@@ -620,8 +620,8 @@ describe('search Epics', () => {
                     }
                 }
             });
-        const NUM_ACTIONS = 3;
-        testEpic(addTimeoutEpic(textSearchShowGFIEpic, 100), NUM_ACTIONS, action, (actions) => {
+        const NUM_ACTIONS = 4;
+        testEpic(addTimeoutEpic(textSearchShowGFIEpic, 100), NUM_ACTIONS, [action, loadFeatureInfo()], (actions) => {
             expect(actions).toExist();
             expect(actions.length).toBe(NUM_ACTIONS);
             expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
@@ -629,6 +629,7 @@ describe('search Epics', () => {
             expect(actions[0].overrideParams.layerName.featureid).toBe("layer_01");
             expect(actions[1].type).toBe(SHOW_MAPINFO_MARKER);
             expect(actions[2].type).toBe(TEXT_SEARCH_ADD_MARKER);
+            expect(actions[3].type).toBe(ZOOM_TO_EXTENT);
             done();
         }, {layers: {flat: [{name: "layerName", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, featureInfo: {format: "HTML"}, queryable: true, type: "wms"}]}});
     });

--- a/web/client/epics/__tests__/search-test.js
+++ b/web/client/epics/__tests__/search-test.js
@@ -30,7 +30,7 @@ import {
 } from '../../actions/search';
 
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
-import { FEATURE_INFO_CLICK, SHOW_MAPINFO_MARKER, loadFeatureInfo } from '../../actions/mapInfo';
+import { FEATURE_INFO_CLICK, SHOW_MAPINFO_MARKER, loadFeatureInfo, UPDATE_CENTER_TO_MARKER } from '../../actions/mapInfo';
 import { ZOOM_TO_EXTENT, ZOOM_TO_POINT } from '../../actions/map';
 import { UPDATE_ADDITIONAL_LAYER } from '../../actions/additionallayers';
 import { searchEpic, searchItemSelected, zoomAndAddPointEpic, searchOnStartEpic, textSearchShowGFIEpic } from '../search';
@@ -592,7 +592,7 @@ describe('search Epics', () => {
     it('searchOnStartEpic, that sends a Getfeature and a GFI requests', (done) => {
         let action = searchLayerWithFilter({layer: "layerName", cql_filter: "cql"});
         const NUM_ACTIONS = 2;
-        testEpic(addTimeoutEpic(searchOnStartEpic, 100), NUM_ACTIONS, action, (actions) => {
+        testEpic(searchOnStartEpic, NUM_ACTIONS, action, (actions) => {
             expect(actions).toExist();
             expect(actions.length).toBe(NUM_ACTIONS);
             expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
@@ -621,7 +621,7 @@ describe('search Epics', () => {
                 }
             });
         const NUM_ACTIONS = 4;
-        testEpic(addTimeoutEpic(textSearchShowGFIEpic, 100), NUM_ACTIONS, [action, loadFeatureInfo()], (actions) => {
+        testEpic(textSearchShowGFIEpic, NUM_ACTIONS, [action, loadFeatureInfo()], (actions) => {
             expect(actions).toExist();
             expect(actions.length).toBe(NUM_ACTIONS);
             expect(actions[0].type).toBe(FEATURE_INFO_CLICK);
@@ -632,5 +632,42 @@ describe('search Epics', () => {
             expect(actions[3].type).toBe(ZOOM_TO_EXTENT);
             done();
         }, {layers: {flat: [{name: "layerName", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, featureInfo: {format: "HTML"}, queryable: true, type: "wms"}]}});
+    });
+    it('textSearchShowGFIEpic, temporary disable center to marker', (done) => {
+        let action = showGFI(
+            {
+                layer: "layerName",
+                type: "Feature",
+                bbox: [125, 10, 126, 11],
+                geometry: {
+                    type: "Point",
+                    coordinates: [125.6, 10.1]
+                },
+                id: "layer_01",
+                "__SERVICE__": {
+                    launchInfoPanel: "single_layer",
+                    openFeatureInfoButtonEnabled: true,
+                    options: {
+                        typeName: "layerName",
+                        maxZoomLevel: 20
+                    }
+                }
+            });
+        const NUM_ACTIONS = 6;
+        testEpic(textSearchShowGFIEpic, NUM_ACTIONS, [action, loadFeatureInfo()], (actions) => {
+            expect(actions).toExist();
+            expect(actions.length).toBe(NUM_ACTIONS);
+            expect(actions[0].type).toBe(UPDATE_CENTER_TO_MARKER);
+            expect(actions[0].status).toBe(false);
+            expect(actions[1].type).toBe(FEATURE_INFO_CLICK);
+            expect(actions[1].overrideParams.layerName.info_format).toBe("text/html");
+            expect(actions[1].overrideParams.layerName.featureid).toBe("layer_01");
+            expect(actions[2].type).toBe(SHOW_MAPINFO_MARKER);
+            expect(actions[3].type).toBe(TEXT_SEARCH_ADD_MARKER);
+            expect(actions[4].type).toBe(ZOOM_TO_EXTENT);
+            expect(actions[5].type).toBe(UPDATE_CENTER_TO_MARKER);
+            expect(actions[5].status).toBe(true);
+            done();
+        }, { mapInfo: {centerToMarker: true}, layers: {flat: [{name: "layerName", url: "base/web/client/test-resources/wms/GetFeature.json", visibility: true, featureInfo: {format: "HTML"}, queryable: true, type: "wms"}]}});
     });
 });

--- a/web/client/epics/search.js
+++ b/web/client/epics/search.js
@@ -12,10 +12,10 @@ import pointOnSurface from '@turf/point-on-surface';
 import assign from 'object-assign';
 import { sortBy, isNil } from 'lodash';
 
-import { queryableLayersSelector, getLayerFromName } from '../selectors/layers';
+import { queryableLayersSelector, getLayerFromName, centerToMarkerSelector } from '../selectors/layers';
 
 import { updateAdditionalLayer } from '../actions/additionallayers';
-import { showMapinfoMarker, featureInfoClick } from '../actions/mapInfo';
+import { showMapinfoMarker, featureInfoClick, updateCenterToMarker, LOAD_FEATURE_INFO, ERROR_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO  } from '../actions/mapInfo';
 import { zoomToExtent, zoomToPoint } from '../actions/map';
 import { changeLayerProperties } from '../actions/layers';
 import {
@@ -153,7 +153,18 @@ export const searchItemSelected = (action$, store) =>
                                 forceVisibility = item.__SERVICE__.forceSearchLayerVisibility;
                                 filterNameList = [typeName];
                                 itemId = item.id;
-                                overrideParams = { [item.__SERVICE__.options.typeName]: { info_format: getInfoFormat(layerObj, state), featureid: itemId } };
+                                overrideParams = {
+                                    [item.__SERVICE__.options.typeName]: {
+                                        info_format: getInfoFormat(layerObj, state),
+                                        ...(itemId
+                                            ? {
+                                                featureid: itemId,
+                                                CQL_FILTER: undefined
+                                            }
+                                            : {}
+                                        )
+                                    }
+                                };
                             }
                             return [
                                 ...(forceVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
@@ -196,6 +207,7 @@ export const searchItemSelected = (action$, store) =>
  */
 export const textSearchShowGFIEpic = (action$, store) =>
     action$.ofType(TEXT_SEARCH_SHOW_GFI)
+        .filter(({item = {}}) => !item?.__SERVICE__?.customGFI)
         .switchMap(({item}) => {
             const state = store.getState();
             const typeName = item?.__SERVICE__?.options?.typeName;
@@ -208,12 +220,38 @@ export const textSearchShowGFIEpic = (action$, store) =>
                 showGFIForService(item?.__SERVICE__) && layerIsVisibleForGFI(layerObj, item?.__SERVICE__) ?
                 Rx.Observable.of(
                     ...(item?.__SERVICE__?.forceSearchLayerVisibility && layerObj ? [changeLayerProperties(layerObj.id, {visibility: true})] : []),
-                    featureInfoClick({ latlng }, typeName, [typeName], { [typeName]: { info_format: getInfoFormat(layerObj, state), featureid: itemId } }, itemId),
+                    featureInfoClick({ latlng }, typeName, [typeName], {
+                        [typeName]: {
+                            info_format: getInfoFormat(layerObj, state),
+                            ...(itemId
+                                ? {
+                                    featureid: itemId,
+                                    // GeoServer rises an error in case CQL_FILTER and featureId are present in the same time
+                                    // so we need to remove it (anyway featureid filter is enough)
+                                    CQL_FILTER: undefined
+                                }
+                                : {}
+                            )
+                        } }, itemId),
                     showMapinfoMarker(),
-                    zoomToExtent([bbox[0], bbox[1], bbox[2], bbox[3]], "EPSG:4326", item?.__SERVICE__?.options?.maxZoomLevel || 21),
                     addMarker(item)
-                ) :
-                Rx.Observable.empty();
+                ).merge(
+                    // wait for response received (so feature info panel open)
+                    // to zoom to extent, in order to center the geometry in the visible bounding box
+                    bbox ?
+                        action$
+                            .ofType(LOAD_FEATURE_INFO)
+                            .take(1)
+                            .mapTo(zoomToExtent([bbox[0], bbox[1], bbox[2], bbox[3]], "EPSG:4326", item?.__SERVICE__?.options?.maxZoomLevel || 21))
+                            .takeUntil(action$.ofType(EXCEPTIONS_FEATURE_INFO, ERROR_FEATURE_INFO))
+                        : Rx.Observable.empty()
+                )
+                // disable temporary centerToMarker when this operation happens, because we have the zoom
+                    .let(stream$ => bbox && centerToMarkerSelector(store.getState())
+                        ? stream$.startWith(updateCenterToMarker(false)).concat(Rx.Observable.of(updateCenterToMarker(true)))
+                        : stream$
+                    )
+                : Rx.Observable.empty();
         });
 
 /**


### PR DESCRIPTION
## Description
The fix disable temporary centerToMarker and instead applies a zoomToExtent after receiving the feature info response.
Moreover forces to remove "CQL_FILTER" to avoid to do a query with both CQL_FILTER and featureid, that is denied by GeoServer.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7381

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
