### PR TITLE
backport 2021.01.xx - #6960: Map error when default_map_backgrounds is missing. (#6968)

### DIFF
--- a/web/client/selectors/__tests__/catalog-test.js
+++ b/web/client/selectors/__tests__/catalog-test.js
@@ -136,6 +136,10 @@ describe('Test catalog selectors', () => {
         const bgService = retVal.default_map_backgrounds;
         expect(bgService.readOnly).toBe(true);
     });
+    it('test servicesSelectorWithBackgrounds with empty state', () => {
+        const retVal = servicesSelectorWithBackgrounds({});
+        expect(retVal).toBeFalsy();
+    });
     it('test newServiceTypeSelector', () => {
         const retVal = newServiceTypeSelector(state);
         expect(retVal).toExist();

--- a/web/client/selectors/catalog.js
+++ b/web/client/selectors/catalog.js
@@ -14,7 +14,7 @@ import { projectionSelector } from './map';
 export const staticServicesSelector = (state) => get(state, "catalog.default.staticServices");
 export const servicesSelector = (state) => get(state, "catalog.services");
 export const servicesSelectorWithBackgrounds = createSelector(staticServicesSelector, servicesSelector, (staticServices, services) => {
-    const backgroundService = staticServices.default_map_backgrounds;
+    const backgroundService = staticServices?.default_map_backgrounds;
     if (backgroundService) {
         // static services are readOnly by default
         backgroundService.readOnly = true;


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

backport 2021.01.xx - #6960: Map error when default_map_backgrounds is missing. (#6968)