### PR TITLE
#7384 Feature grid enhancements

### DIFF
--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -181,7 +181,7 @@ export function toggleSelection(features) {
  * Changes the selection options for the feature grid. It allows to set independently the possibility
  * to do multiple selection and to show/hide the checkboxes.
  * @memberof actions.featuregrid
- * @param {boolean} [options.multiselect=false] if true, allows multiple feature selection
+ * @param {boolean} [options.multiselect] if true, allows multiple feature selection
  * @param {boolean} [showCheckbox] allow to show/hide checkboxes.
  * @returns
  */

--- a/web/client/actions/featuregrid.js
+++ b/web/client/actions/featuregrid.js
@@ -177,10 +177,19 @@ export function toggleSelection(features) {
         features
     };
 }
-export function setSelectionOptions({multiselect = false} = {}) {
+/**
+ * Changes the selection options for the feature grid. It allows to set independently the possibility
+ * to do multiple selection and to show/hide the checkboxes.
+ * @memberof actions.featuregrid
+ * @param {boolean} [options.multiselect=false] if true, allows multiple feature selection
+ * @param {boolean} [showCheckbox] allow to show/hide checkboxes.
+ * @returns
+ */
+export function setSelectionOptions({multiselect, showCheckbox} = {}) {
     return {
         type: SET_SELECTION_OPTIONS,
-        multiselect
+        multiselect,
+        showCheckbox
     };
 
 }

--- a/web/client/actions/wfsquery.js
+++ b/web/client/actions/wfsquery.js
@@ -107,11 +107,19 @@ export function queryError(error) {
         error
     };
 }
-export function updateQuery(updates, reason) {
+/**
+ * Triggers a new query updating some parameters.
+ * @param {object} [param.updates] updates to apply to the filter object (merged with the original filter)
+ * @param {string} [param.reason] "geometry" or undefined. If "geometry", triggers selection of features.
+ * @param {boolean} [param.useLayerFilter] enable/disable the usage of the current layer filter
+ * @returns
+ */
+export function updateQuery({updates, reason, useLayerFilter} = {}) {
     return {
         type: UPDATE_QUERY,
         updates,
-        reason
+        reason,
+        useLayerFilter
     };
 }
 export function loadFeature(baseUrl, typeName) {

--- a/web/client/components/data/featuregrid/FeatureGrid.jsx
+++ b/web/client/components/data/featuregrid/FeatureGrid.jsx
@@ -44,7 +44,6 @@ class FeatureGrid extends React.PureComponent {
         columnSettings: PropTypes.object,
         gridOptions: PropTypes.object,
         actionOpts: PropTypes.object,
-        initPlugin: PropTypes.func,
         tools: PropTypes.array,
         gridEvents: PropTypes.object,
         virtualScroll: PropTypes.bool,
@@ -57,7 +56,6 @@ class FeatureGrid extends React.PureComponent {
     };
     static defaultProps = {
         editingAllowedRoles: ["ADMIN"],
-        initPlugin: () => {},
         autocompleteEnabled: false,
         gridComponent: AdaptiveGrid,
         changes: {},

--- a/web/client/components/data/featuregrid/enhancers/editor.js
+++ b/web/client/components/data/featuregrid/enhancers/editor.js
@@ -174,7 +174,7 @@ const featuresToGrid = compose(
         }
     ),
     withPropsOnChange(
-        ["gridOpts", "describeFeatureType", "actionOpts", "mode", "select", "columns"],
+        ["gridOpts", "describeFeatureType", "actionOpts", "mode", "select", "columns", "showCheckbox"],
         props => {
             // bind proper events and setup the columns array
             // bind and get proper grid events from gridEvents object
@@ -190,7 +190,7 @@ const featuresToGrid = compose(
                 ...gridOpts,
                 enableCellSelect: props.mode === "EDIT",
                 rowSelection: {
-                    showCheckbox: props.mode === "EDIT",
+                    showCheckbox: props.showCheckbox || props.mode === "EDIT",
                     selectBy: {
                         keys: {
                             rowKey: '_!_id_!_',

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -179,7 +179,7 @@ export const wfsQueryEpic = (action$, store) =>
             const layer = selectedLayerSelector(store.getState());
             const useLayerFilter = useLayerFilterSelector(store.getState());
 
-            const {layerFilter, params} = (layer) ?? {};
+            const {layerFilter, params} = layer ?? {};
             const cqlFilter = find(Object.keys(params || {}), (k = "") => k.toLowerCase() === "cql_filter");
 
             // use original filter if the selected layer is vector type

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -52,7 +52,7 @@ import { describeFeatureTypeToAttributes } from '../utils/FeatureTypeUtils';
 import * as notifications from '../actions/notifications';
 import { find } from 'lodash';
 
-import {selectedLayerSelector} from '../selectors/featuregrid';
+import {selectedLayerSelector, useLayerFilterSelector} from '../selectors/featuregrid';
 import {layerLoad} from '../actions/layers';
 
 import { mergeFiltersToOGC } from '../utils/FilterUtils';
@@ -177,14 +177,15 @@ export const wfsQueryEpic = (action$, store) =>
             const searchUrl = ConfigUtils.filterUrlParams(action.searchUrl, authkeyParamNameSelector(store.getState()));
             // getSelected Layer and merge layerFilter and cql_filter in params  with action filter
             const layer = selectedLayerSelector(store.getState());
+            const useLayerFilter = useLayerFilterSelector(store.getState());
 
-            const {layerFilter, params} = layer ?? {};
+            const {layerFilter, params} = (layer) ?? {};
             const cqlFilter = find(Object.keys(params || {}), (k = "") => k.toLowerCase() === "cql_filter");
 
             // use original filter if the selected layer is vector type
             const ogcFilter = layer?.type === "vector" ?
                 action.filterObj
-                : mergeFiltersToOGC({ogcVersion: '1.1.0'}, cqlFilter, layerFilter, action.filterObj);
+                : mergeFiltersToOGC({ogcVersion: '1.1.0'}, cqlFilter, useLayerFilter ? layerFilter : null, action.filterObj);
             const { url, options: queryOptions } = addTimeParameter(searchUrl, action.queryOptions || {}, store.getState());
             const options = {
                 ...action.filterObj.pagination,

--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -181,8 +181,8 @@ const FeatureDock = (props = {
                     footer={getFooter(props)}>
                     {getDialogs(props.tools)}
                     <Grid
+                        showCheckbox={props.showCheckbox}
                         editingAllowedRoles={props.editingAllowedRoles}
-                        initPlugin={props.initPlugin}
                         customEditorsOptions={props.customEditorsOptions}
                         autocompleteEnabled={props.autocompleteEnabled}
                         url={props.url}

--- a/web/client/reducers/__tests__/featuregrid-test.js
+++ b/web/client/reducers/__tests__/featuregrid-test.js
@@ -84,10 +84,10 @@ import {
     setPagination
 } from '../../actions/featuregrid';
 
-import { paginationSelector } from '../../selectors/featuregrid';
+import { paginationSelector, useLayerFilterSelector } from '../../selectors/featuregrid';
 
 
-import { featureTypeLoaded, createQuery } from '../../actions/wfsquery';
+import { featureTypeLoaded, createQuery, updateQuery } from '../../actions/wfsquery';
 import { changeDrawingStatus } from '../../actions/draw';
 import museam from '../../test-resources/wfs/museam.json';
 describe('Test the featuregrid reducer', () => {
@@ -279,7 +279,7 @@ describe('Test the featuregrid reducer', () => {
         expect(state.drawing).toBe(false);
     });
     it('setSelectionOptions({multiselect= false} = {})', () => {
-        let state = featuregrid( {}, setSelectionOptions({}));
+        let state = featuregrid( {}, setSelectionOptions({multiselect: false}));
         expect(state.multiselect).toBe(false);
     });
     it('changePage', () => {
@@ -392,5 +392,53 @@ describe('Test the featuregrid reducer', () => {
     it('setPagination', () => {
         const newState = featuregrid(undefined, setPagination(10000));
         expect(paginationSelector({ featuregrid: newState })).toEqual({page: 0, size: 10000});
+    });
+    describe('updateQuery', () => {
+        it('when useLayerFilter is specified, update it', () => {
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid(undefined, updateQuery({useLayerFilter: true}))
+                })
+            ).toEqual(true); // default is true from selector
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid(undefined, updateQuery({useLayerFilter: false}))
+                })
+            ).toEqual(false); // from the default is set to false
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid({useLayerFilter: false}, updateQuery({useLayerFilter: true}))
+                })
+            ).toEqual(true); // remains true
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid({useLayerFilter: true}, updateQuery({useLayerFilter: false}))
+                })
+            ).toEqual(false); // changes to false
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid({useLayerFilter: false}, updateQuery({useLayerFilter: false}))
+                })
+            ).toEqual(false); // remains false
+
+        });
+        it('when useLayerFilter is not specified, nothing changes', () => {
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid(undefined, updateQuery())
+                })
+            ).toEqual(true); // default is true from selector
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid({useLayerFilter: true}, updateQuery())
+                })
+            ).toEqual(true); // remains true
+            expect(
+                useLayerFilterSelector({
+                    featuregrid: featuregrid({useLayerFilter: false}, updateQuery())
+                })
+            ).toEqual(false); // remains false
+        });
+
     });
 });

--- a/web/client/reducers/featuregrid.js
+++ b/web/client/reducers/featuregrid.js
@@ -50,7 +50,7 @@ import {
     SET_PAGINATION
 } from '../actions/featuregrid';
 
-import { FEATURE_TYPE_LOADED, QUERY_CREATE } from '../actions/wfsquery';
+import { FEATURE_TYPE_LOADED, QUERY_CREATE, UPDATE_QUERY } from '../actions/wfsquery';
 import { CHANGE_DRAWING_STATUS } from '../actions/draw';
 import uuid from 'uuid';
 import { getApi } from '../api/userPersistedStorage';
@@ -75,7 +75,6 @@ const emptyResultsState = {
         size: 20
     },
     select: [],
-    multiselect: false,
     drawing: false,
     newFeatures: [],
     features: [],
@@ -197,7 +196,7 @@ function featuregrid(state = emptyResultsState, action) {
             select: state.select.filter(f1 => !isPresent(f1, action.features))
         });
     case SET_SELECTION_OPTIONS: {
-        return assign({}, state, {multiselect: action.multiselect});
+        return assign({}, state, {multiselect: action.multiselect ?? state.multiselect, showCheckbox: action.showCheckbox ?? state.showCheckbox});
     }
     case UPDATE_EDITORS_OPTIONS:
         return assign({}, state, { customEditorsOptions: action.payload });
@@ -403,6 +402,12 @@ function featuregrid(state = emptyResultsState, action) {
             filters: {
             }
         });
+    }
+    case UPDATE_QUERY: {
+        return {
+            ...state,
+            useLayerFilter: action.useLayerFilter ?? state.useLayerFilter // if not present, keep current
+        };
     }
     case SIZE_CHANGE : {
         const maxDockSize = action.dockProps && action.dockProps.maxDockSize;

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -184,3 +184,4 @@ export const isEditingAllowedSelector = state => {
     return (editingAllowedRoles.indexOf(role) !== -1 || canEdit) && !isCesium(state);
 };
 export const paginationSelector = state => get(state, "featuregrid.pagination");
+export const useLayerFilterSelector = state => get(state, "featuregrid.useLayerFilter") ?? true;

--- a/web/client/selectors/featuregrid.js
+++ b/web/client/selectors/featuregrid.js
@@ -184,4 +184,4 @@ export const isEditingAllowedSelector = state => {
     return (editingAllowedRoles.indexOf(role) !== -1 || canEdit) && !isCesium(state);
 };
 export const paginationSelector = state => get(state, "featuregrid.pagination");
-export const useLayerFilterSelector = state => get(state, "featuregrid.useLayerFilter") ?? true;
+export const useLayerFilterSelector = state => get(state, "featuregrid.useLayerFilter", true);


### PR DESCRIPTION
## Description
This PR adds the following changes to provide functionalities suggested in #7384 

- Change action `setSelectionOptions`  (and reducer `featuregrid` for this action)
    - adding a `showCheckbox` option.
    - uniforming the logic so if `multiselect` or `showCheckbox are not specified, they will remain unchanged
- Change signature of `updateQuery` a(and reducer `featuregrid` for this) dding the optional parameter `useLayerFilter`. This sets a flag in featuregird to enable / disable this filtering. 
- Changed the plugin "FeatureEditor" to handle the `showCheckbox` parameter
- Changed the epic to handle the `useLayerFilter` set to false.
- Aligned method signature changes and other minor fixes to do for the new use cases.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7384

**What is the new behavior?**
Some additional possibiilities given to developers. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

No functional tests can be done on this.
