### PR TITLE
Update mapstore-migration-guide.md with auth for upload plugins

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -540,6 +540,30 @@ const appStore = (
 
 ## Migration from 2020.01.00 to 2020.02.00
 
+### New authentication rule for internal services
+
+With this new version the support for uploading extensions has been introduced. A new entry point needs administration authorization to allow the upload of new plugins by the administrator. So:
+
+- In `localConfig.json` add the following entry in the `authenticationRules` array:
+```json
+{
+    "urlPattern": ".*rest/config.*",
+    "method": "bearer"
+  }
+
+```
+the final entry should look like this 
+
+```json
+ "authenticationRules": [{
+        "urlPattern": ".*geostore.*",
+        "method": "bearer"
+      }, {
+        "urlPattern": ".*rest/config.*",
+        "method": "bearer"
+      }, ...],
+```
+
 ### Translation files
 
 - The translations file extension has been changed into JSON. Now translation files has been renamed from `data.<locale>` to `data.<locale>.json`. This change makes the `.json` extension mandatory for all translation files. This means that depending projects with custom translation files should be renabled in the same name. E.g. `data.it-IT` have to be renamed as `data.it-IT.json`


### PR DESCRIPTION
## Description
Add this missing migration guideline to add the support and the authorization to upload extensions.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information


[//]: # (rtdbot-start)

URL of RTD document: https://mapstore.readthedocs.io/en/offtherailz-upload_doc/ ![Documentation Status](https://readthedocs.org/projects/mapstore/badge/?version=offtherailz-upload_doc)

[//]: # (rtdbot-end)
