### PR TITLE
#7345: Fix Annotation plugin crash issue

### DIFF
--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -326,6 +326,69 @@ describe('Test the annotations reducer', () => {
         expect(state.featureType).toBe("Text");
         expect(state.drawing).toBe(true);
     });
+    it('toggle add point, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Point"
+        });
+        testAllProperty(state.editing.features[0].geometry, {
+            type: "Point",
+            coordinates: []
+        });
+    });
+    it('toggle add text, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Text"
+        });
+        testAllProperty(state.editing.features[0].geometry, {
+            type: "Point",
+            coordinates: []
+        });
+    });
+    it('toggle add line, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "LineString"
+        });
+        testAllProperty(state.editing.features[0].geometry, {
+            type: "LineString",
+            coordinates: []
+        });
+    });
+    it('toggle add polygon, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Polygon"
+        });
+        testAllProperty(state.editing.features[0].geometry, {
+            type: "Polygon",
+            coordinates: []
+        });
+    });
+    it('toggle add circle, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Circle"
+        });
+        expect(state.editing.features[0].geometry.type).toBe("Polygon");
+        expect(state.editing.features[0].geometry.coordinates).toEqual([[]]);
+    });
     it('validate error', () => {
         const state = annotations({validationErrors: {}}, {
             type: VALIDATION_ERROR,

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -632,7 +632,6 @@ function annotations(state = {validationErrors: {}}, action) {
 
         let geojsonFt = set("geometry.type", type === "Text" ? "Point" : type === "Circle" ? "Polygon" : type, selected);
         geojsonFt = set("geometry.coordinates", type === "Circle" ? [[]] : [], geojsonFt);
-        geojsonFt = set("geometry", type === "Point" || type === "Text" ? null : geojsonFt.geometry, geojsonFt);
 
         // Reset highlight properties of other features except the selected feature
         const editingFeatures = state.editing.features.filter(({properties: prop})=> prop?.id !== selected?.properties?.id)?.map((ft = {})=>{ ft.style = ft?.style?.map(s=> {s.highlight = false; return s;}) || []; return ft;});


### PR DESCRIPTION
## Description
- Annotation plugin get crash when geometry step skipped for Point/Text geometry.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
**What is the current behavior?**
#7345 

**What is the new behavior?**
- Annotation plugin works fine even if we skip geometry step for Point/Text geometry.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
