### PR TITLE
[Backport 2021.02.xx] #7124 fix issue with map sync not being active

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -245,6 +245,8 @@ const EditorPlugin = compose(
             this.props.onMount(pick(this.props, ['showFilteredObject', 'showTimeSync', 'timeSync', 'customEditorsOptions']));
             if (this.props.enableMapFilterSync) {
                 this.props.setSyncTool(true);
+            } else {
+                this.props.setSyncTool(false);
             }
         },
         // TODO: fix this in contexts
@@ -258,6 +260,8 @@ const EditorPlugin = compose(
             }
             if (this.props.enableMapFilterSync) {
                 this.props.setSyncTool(true);
+            } else {
+                this.props.setSyncTool(false);
             }
         }
     }),


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7124 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The Map Tool syncs or does not sync by default depending on the respective configuration set during context creation.



## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
