### PR TITLE
#7410 set default imageryProvider to OSM

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -84,6 +84,7 @@ class CesiumMap extends React.Component {
     componentDidMount() {
         const creditContainer = document.querySelector(this.props.mapOptions?.attribution?.container || '#footer-attribution-container');
         let map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), assign({
+            imageryProvider: Cesium.createOpenStreetMapImageryProvider(), // redefining to avoid to use default bing (that queries the bing API without any reason, because baseLayerPicker is false, anyway)
             baseLayerPicker: false,
             animation: false,
             fullscreenButton: false,


### PR DESCRIPTION
## Description
By default, if no `imageryProvider` is passed, cesium uses Bing as default imageryProvider. This causes the call to the service, that is not needed.

here the compressed code of cesium that does this operation:
![image](https://user-images.githubusercontent.com/1279510/135886922-f25aa91d-2d1a-4ac8-aab9-57ea1f8d5ee1.png)

Now, `imageryProvider` of map is not used (is the background of cesium, but mapstore sets `baseLayerPicker` is set to false so imageryProvider is not used at all.
Using OSM instead, avoid the bing layer to be initialized with the call above. 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7410

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
