### PR TITLE
Issue #7376; fixed connected crashing maps in dashboard

### DIFF
--- a/web/client/components/widgets/enhancers/dependenciesToWidget.js
+++ b/web/client/components/widgets/enhancers/dependenciesToWidget.js
@@ -69,6 +69,7 @@ const buildDependencies = (map, deps, originalWidgetId) => {
         const dependenciesGenerated = Object.keys(map).reduce((ret, k) => {
             if (k === "dependenciesMap" && deps[map[k]] && deps[map.mapSync] &&
                 deps[map[k]][k] && deps[map[k]][k].indexOf(originalWidgetId) === -1 // avoiding loop
+                && !ret.mapSync
             ) {
                 // go recursively until we get the dependencies from table ancestors
                 return {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7376 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The preview of the chart  is visualized and the user is able to save without crushing
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
