### PR TITLE
#7368: Horizontal and vertical size for Webpage section in Geostory

### DIFF
--- a/web/client/components/geostory/common/ToolbarDropdownButton.jsx
+++ b/web/client/components/geostory/common/ToolbarDropdownButton.jsx
@@ -31,7 +31,8 @@ export default function ToolbarDropdownButton({
     disabled,
     noTooltipWhenDisabled = false,
     hideMenuItem = () => false,
-    shouldClose
+    shouldClose,
+    showSelectionInTitle = true
 }) {
     const [open, setOpen] = useState(false);
     const [active, setActive] = useState(false);
@@ -56,7 +57,7 @@ export default function ToolbarDropdownButton({
             pullRight={pullRight}
             className={className}
             disabled={disabled}
-            title={<Glyphicon glyph={glyphOption || glyph}/>}
+            title={<Glyphicon glyph={showSelectionInTitle && glyphOption || glyph}/>}
             onToggle={(isOpen, event, eventDetails) => {
                 if (active
                 || eventDetails?.source === 'select'

--- a/web/client/components/geostory/common/__tests__/ToolbarDropdownButton-test.jsx
+++ b/web/client/components/geostory/common/__tests__/ToolbarDropdownButton-test.jsx
@@ -64,4 +64,40 @@ describe('ToolbarDropdownButton component', () => {
         dropdownMenuNode = container.querySelector('.dropdown.open');
         expect(dropdownMenuNode).toBeFalsy();
     });
+    it('show selected glyph in title of dropdown', () => {
+        ReactDOM.render(<ToolbarDropdownButton
+            glyph="small"
+            value={'value'}
+            showSelectionInTitle
+            options={[{
+                glyph: 'large',
+                value: 'value',
+                label: 'Label'
+            }]}
+        />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const buttonNode = container.querySelector('.square-button-md.no-border');
+        expect(buttonNode).toBeTruthy();
+        const glyph = buttonNode.querySelector('.glyphicon-large');
+        expect(glyph).toBeTruthy();
+    });
+    it('show default glyph instead of selected glyph in title of dropdown', () => {
+        ReactDOM.render(<ToolbarDropdownButton
+            glyph="small"
+            value={'value'}
+            showSelectionInTitle={false}
+            options={[{
+                glyph: 'large',
+                value: 'value',
+                label: 'Label'
+            }]}
+        />, document.getElementById("container"));
+        const container = document.getElementById('container');
+        const buttonNode = container.querySelector('.square-button-md.no-border');
+        expect(buttonNode).toBeTruthy();
+        const glyphLarge = buttonNode.querySelector('.glyphicon-large');
+        const glyphDef = buttonNode.querySelector('.glyphicon-small');
+        expect(glyphLarge).toBeFalsy();
+        expect(glyphDef).toBeTruthy();
+    });
 });

--- a/web/client/components/geostory/contents/Column.jsx
+++ b/web/client/components/geostory/contents/Column.jsx
@@ -23,10 +23,11 @@ const ColumnContent = compose(
  * has (sub) contents to render like a page.
  */
 
-const size = (pullRight) => ({
+const size = (pullRight, props = {}) => ({
     id: 'size',
     filterOptions: ({ value }) => value !== 'full',
-    pullRight
+    pullRight,
+    ...props
 });
 
 export default ({
@@ -73,7 +74,12 @@ export default ({
             [ContentTypes.TEXT]: ['remove'],
             [MediaTypes.IMAGE]: ['editMedia', size(), 'showCaption', 'remove'],
             [MediaTypes.MAP]: ['editMedia', 'editMap', size(true), 'showCaption', 'remove'],
-            [ContentTypes.WEBPAGE]: ['editURL', size(true), 'remove'],
+            [ContentTypes.WEBPAGE]: [
+                size(true, {sizeType: 'horizontal'}), // Horizontal size button
+                'editURL',
+                size(true, {sizeType: 'vertical', filterOptions: ({ value }) => value !== 'v-full'}), // Vertical size button
+                'remove'
+            ],
             [MediaTypes.VIDEO]: ['editMedia', 'muted', 'autoplay', 'loop', 'showCaption', 'remove']
         })}
         addButtons={[{

--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -19,6 +19,31 @@ const DeleteButton = withConfirm(ToolbarButton);
 const BUTTON_CLASSES = 'square-button-md no-border';
 const BUTTON_BSSTYLE = { primary: 'btn-primary', "default": 'btn-default'};
 
+const getToolbarSizeProps = (size, sizeType) => {
+    const HORIZONTAL = 'horizontal';
+    const VERTICAL = 'vertical';
+    let pre = '';
+    let [hSize, vSize] = size && size.split(',') || [];
+    let _size = size;
+    let glyph = 'resize-horizontal';
+    if (sizeType === HORIZONTAL) {
+        pre = 'h-';
+        _size = hSize;
+    } else if (sizeType === 'vertical') {
+        pre = 'v-';
+        _size = vSize;
+        glyph = 'resize-vertical';
+    }
+    return {
+        sizeProp: (selected) => (
+            sizeType
+                ? `${sizeType === HORIZONTAL ? selected : hSize},${sizeType === VERTICAL ? selected : vSize}`
+                : selected
+        ),
+        pre, _size, glyph
+    };
+};
+
 /**
  * these components have been created because it was causing an excessive re-rendering
  */
@@ -30,33 +55,36 @@ const BUTTON_BSSTYLE = { primary: 'btn-primary', "default": 'btn-default'};
  * @prop {function} filterOptions filter dropdown options by value (eg `({ value }) => value !== 'full'` to exclude `full` option)
  * @prop {function} pullRight pull dropdown right
  */
-export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {}, filterOptions, pullRight }) =>
-    (<ToolbarDropdownButton
-        value={size}
+export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {}, filterOptions, pullRight, id = 'size', sizeType}) => {
+    const {pre, _size, glyph, sizeProp} = getToolbarSizeProps(size, sizeType);
+    return (<ToolbarDropdownButton
+        value={_size}
         noTooltipWhenDisabled
         disabled={disabled}
-        glyph="resize-horizontal"
-        pullRight={pullRight || (align === "right" || size === "full" || size === "large") && !sectionType}
+        glyph={glyph}
+        pullRight={pullRight || (align === "right" || _size === `${pre}full` || _size === `${pre}large`) && !sectionType}
         tooltipId="geostory.contentToolbar.contentSize"
         options={[{
-            value: 'small',
+            value: `${pre}small`,
             glyph: 'size-small',
             label: <Message msgId="geostory.contentToolbar.smallSizeLabel"/>
         }, {
-            value: 'medium',
+            value: `${pre}medium`,
             glyph: 'size-medium',
             label: <Message msgId="geostory.contentToolbar.mediumSizeLabel"/>
         }, {
-            value: 'large',
+            value: `${pre}large`,
             glyph: 'size-large',
             label: <Message msgId="geostory.contentToolbar.largeSizeLabel"/>
         }, {
-            value: 'full',
+            value: `${pre}full`,
             glyph: 'size-extra-large',
             label: <Message msgId="geostory.contentToolbar.fullSizeLabel"/>
         }].filter((option) => !filterOptions || filterOptions(option))}
-        onSelect={(selected) => update('size', selected)}/>
-    );
+        onSelect={(selected) => update(id, sizeProp(selected))}
+        {...sizeType && {showSelectionInTitle: false}}
+    />);
+};
 
 export const AlignButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {} }) =>
     (<ToolbarDropdownButton

--- a/web/client/components/geostory/contents/__tests__/Column-test.jsx
+++ b/web/client/components/geostory/contents/__tests__/Column-test.jsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
 
 import expect from 'expect';
 import Column from '../Column';
@@ -158,6 +159,22 @@ describe('Column component', () => {
                     'glyphicon glyphicon-map-edit', // map edit tool
                     'glyphicon glyphicon-resize-horizontal', // resize tool
                     'glyphicon glyphicon-caption', // show caption tool
+                    'glyphicon glyphicon-trash' // delete tool
+                ]);
+        });
+        it('Webpage', () => {
+            const store = { dispatch: () => {}, subscribe: () => {}, getState: () => ({}) };
+            ReactDOM.render(<Provider store={store}>
+                <Column mode={Modes.EDIT} contents={[{ type: ContentTypes.WEBPAGE, size: 'h-medium,v-small', url: 'https://domain.com' }]} /></Provider>, document.getElementById("container"));
+            let webpageToolbar = document.querySelector('.ms-content-toolbar .btn-group');
+            expect(webpageToolbar).toExist();
+            const buttons = webpageToolbar.querySelectorAll('.ms-content-toolbar .btn-group button');
+            expect(buttons.length).toBe(4);
+            expect([...webpageToolbar.querySelectorAll('button .glyphicon')].map(glyphicon => glyphicon.getAttribute('class')))
+                .toEqual([
+                    'glyphicon glyphicon-resize-horizontal', // horizontal size tool
+                    'glyphicon glyphicon-pencil', // edit iframe url
+                    'glyphicon glyphicon-resize-vertical', // vertical size tool
                     'glyphicon glyphicon-trash' // delete tool
                 ]);
         });

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -943,7 +943,6 @@
         }
 
         &.ms-section-paragraph {
-            padding: 0 15%;
             background-color: inherit;
             /*
             overrides for themes of text content
@@ -991,12 +990,22 @@
                         }
                     }
                 }
-                .ms-content.ms-content-webPage {
-                    width: 100%;
-                    height: @ms-web-page-size-height-small;
-                    &.ms-size-large { height: @ms-web-page-size-height-large; }
-                    &.ms-size-medium { height: @ms-web-page-size-height-medium; }
-                    &.ms-size-small { height: @ms-web-page-size-height-small; }
+                .ms-column-contents {
+                    .ms-content {
+                        padding: 0 15%;
+                        &.ms-content-webPage {
+                            padding: 0;
+                            width: 100%;
+                            height: @ms-web-page-size-height-small;
+                            &.ms-size-h-large { width: @ms-story-size-large; }
+                            &.ms-size-h-medium { width: @ms-story-size-medium; }
+                            &.ms-size-h-small {width: @ms-story-size-small;}
+                            &.ms-size-h-full {width: @ms-story-size-full;}
+                            &.ms-size-v-large {height: @ms-web-page-size-height-large;}
+                            &.ms-size-v-medium {height: @ms-web-page-size-height-medium;}
+                            &.ms-size-v-small {height: @ms-web-page-size-height-small;}
+                        }
+                    }
                 }
                 .ms-content.ms-content-video {
                     width: 100%;
@@ -1133,9 +1142,13 @@
                 .ms-content.ms-content-webPage {
                     width: 100%;
                     height: @ms-web-page-size-height-small;
-                    &.ms-size-large { height: @ms-web-page-size-height-large; }
-                    &.ms-size-medium { height: @ms-web-page-size-height-medium; }
-                    &.ms-size-small { height: @ms-web-page-size-height-small; }
+                    &.ms-size-h-large { width: @ms-story-size-large; }
+                    &.ms-size-h-medium { width: @ms-story-size-medium; }
+                    &.ms-size-h-small { width: @ms-story-size-small; }
+                    &.ms-size-h-full { width: @ms-story-size-full; }
+                    &.ms-size-v-large { height: @ms-web-page-size-height-large; }
+                    &.ms-size-v-medium { height: @ms-web-page-size-height-medium; }
+                    &.ms-size-v-small { height: @ms-web-page-size-height-small; }
                 }
                 .ms-content.ms-content-video {
                     width: 100%;

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -80,13 +80,13 @@ export const lists = {
  * @prop {object} theme theme object
  * @prop {string} theme.value one of 'bright', 'dark', 'dark-transparent' or 'bright-transparent'
  * @prop {string} align one of 'center', 'left' or 'right'
- * @prop {string} size one of 'full', 'large', 'medium' or 'small'
+ * @prop {string} size one of 'full', 'large', 'medium', 'small' or 'h-{size},v-{size}'
  */
 export const getClassNameFromProps = ({ theme = {}, align = 'center', size = 'full' }) => {
     const themeValue = theme?.value || isString(theme) && theme;
     const themeClassName = themeValue && themeValue !== 'custom' && isString(themeValue) && ` ms-${themeValue}` || '';
     const alignClassName = ` ms-align-${align}`;
-    const sizeClassName = ` ms-size-${size}`;
+    const sizeClassName = size.split(',').map(sClass=> ` ms-size-${sClass}`).join(''); // when size has both horizontal and vertical classes
     return `${themeClassName}${alignClassName}${sizeClassName}`;
 };
 
@@ -310,7 +310,7 @@ export const getDefaultSectionTemplate = (type, localize = v => v) => {
                     contents: [{
                         id: uuid(),
                         type: ContentTypes.WEBPAGE,
-                        size: 'medium',
+                        size: 'h-medium,v-medium', // Webpage has both horizontal and vertical size button
                         align: 'center'
                     }]
                 }
@@ -359,7 +359,7 @@ export const getDefaultSectionTemplate = (type, localize = v => v) => {
             id: uuid(),
             type,
             title: localize("geostory.builder.defaults.titleWebPage"),
-            size: 'medium',
+            size: 'h-full,v-medium',
             align: 'center'
         };
     }

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -109,6 +109,13 @@ describe("GeoStory Utils", () => {
             size: "medium"
         }); // with custom params
         expect(classes).toBe(" ms-dark ms-align-left ms-size-medium");
+
+        classes = getClassNameFromProps({
+            theme: "dark",
+            align: "left",
+            size: "h-medium,v-small"
+        }); // with custom params
+        expect(classes).toBe(" ms-dark ms-align-left ms-size-h-medium ms-size-v-small");
     });
 
     it('should not apply theme value if object', () => {


### PR DESCRIPTION
## Description
This PR adds support for horizontal sizing of the webpage section in geostory alongside vertical sizing tool

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature

## Issue

**What is the current behavior?**
#7368 

**What is the new behavior?**

- Webpage section now allows for horizontal sizing along with vertical sizing.
- With horizontal sizing allowing `full` size option to fill the section 
- The icons on horizontal and vertical will remain static however the selection is highlighted when dropdown menu is opened
![2021-10-06 15_57_56-MapStore HomePage](https://user-images.githubusercontent.com/26929983/136186245-1287f5cf-c0ec-40b6-8e68-6631a1518efe.jpg)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
https://github.com/geosolutions-it/MapStore2-C040/issues/453