### PR TITLE
Issue #7379; handled edge cases that caused display settings crash

### DIFF
--- a/web/client/components/TOC/DefaultLayer.jsx
+++ b/web/client/components/TOC/DefaultLayer.jsx
@@ -217,7 +217,7 @@ class DefaultLayer extends React.Component {
     filterLayers = (layer) => {
         const translation = isObject(layer.title) ? layer.title[this.props.currentLocale] || layer.title.default : layer.title;
         const title = translation || layer.name;
-        return title.toLowerCase().indexOf(this.props.filterText.toLowerCase()) !== -1;
+        return !isObject(title) ? title.toLowerCase().indexOf(this.props.filterText.toLowerCase()) !== -1 : '';
     };
 
 }

--- a/web/client/components/TOC/fragments/Title.jsx
+++ b/web/client/components/TOC/fragments/Title.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { Tooltip } from 'react-bootstrap';
 import OverlayTrigger from '../../misc/OverlayTrigger';
 import { getTitleAndTooltip } from '../../../utils/TOCUtils';
+import { isObject } from 'lodash';
 import './css/toctitle.css';
 
 class Title extends React.Component {
@@ -38,8 +39,10 @@ class Title extends React.Component {
     };
 
     getFilteredTitle = (title) => {
-        const splitTitle = title.toLowerCase().split(this.props.filterText.toLowerCase());
-
+        if (isObject(title)) {
+            return title?.target?.value ?  title.target.value : '';
+        }
+        const splitTitle =  !isObject(title) ? title.toLowerCase().split(this.props.filterText.toLowerCase()) : title.target.value;
         return this.props.filterText ? splitTitle.reduce((a, b, idx) => {
             if (idx === splitTitle.length - 1) {
                 return [...a, b];

--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -109,7 +109,7 @@ class General extends React.Component {
                         <ControlLabel><Message msgId="layerProperties.description" /></ControlLabel>
                         {this.props.element.capabilitiesLoading ? <Spinner spinnerName="circle" /> :
                             <FormControl
-                                defaultValue={this.props.element.description || ''}
+                                defaultValue={isObject(this.props.element.description) ? '' : this.props.element.description || ''}
                                 key="description"
                                 rows="2"
                                 componentClass="textarea"

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -88,7 +88,10 @@ const addFilteredAttributesGroups = (nodes, filters) => {
 const filterLayersByTitle = (layer, filterText, currentLocale) => {
     const translation = isObject(layer.title) ? layer.title[currentLocale] || layer.title.default : layer.title;
     const title = translation || layer.name;
-    return title.toLowerCase().indexOf(filterText.toLowerCase()) !== -1;
+    if (isObject(title)) {
+        return title?.target?.value ? title.target.value : '';
+    }
+    return title ? title.toLowerCase().indexOf(filterText.toLowerCase()) !== -1 : '';
 };
 
 const tocSelector = createSelector(


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7379 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Layer display settings does not crush on focus and blur of the various inputs and select
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
