### PR TITLE
[Backport 2021.02.xx] #7410 set default imageryProvider to OSM (#7411)

### DIFF
--- a/web/client/components/map/cesium/Map.jsx
+++ b/web/client/components/map/cesium/Map.jsx
@@ -84,6 +84,7 @@ class CesiumMap extends React.Component {
     componentDidMount() {
         const creditContainer = document.querySelector(this.props.mapOptions?.attribution?.container || '#footer-attribution-container');
         let map = new Cesium.Viewer(this.getDocument().getElementById(this.props.id), assign({
+            imageryProvider: Cesium.createOpenStreetMapImageryProvider(), // redefining to avoid to use default bing (that queries the bing API without any reason, because baseLayerPicker is false, anyway)
             baseLayerPicker: false,
             animation: false,
             fullscreenButton: false,


### PR DESCRIPTION
[Backport 2021.02.xx] #7410 set default imageryProvider to OSM (#7411)