### PR TITLE
[Backport 2021.02.xx] Issue #7367; fix error when editing map widget

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -153,17 +153,19 @@ export const getNestedGroupTitle = (id, groups = []) => {
 
 /**
  * Flatten nested array to a one-level array
- * @param {array} array of objects
- * @returns {array} flattened array
+ * @param {Object[]} array of objects
+ * @returns {Object[]} flattened array
  */
-export const flattenArrayOfObjects = (array) => {
+export const flattenArrayOfObjects = (arrayOfObj) => {
     let result = [];
-    array?.forEach((a) => {
-        result.push(a);
-        if (Array.isArray(a.nodes)) {
-            result = result.concat(flattenArrayOfObjects(a.nodes));
-        }
-    });
+    if (arrayOfObj && Array.isArray(arrayOfObj)) {
+        arrayOfObj?.forEach((array) => {
+            result.push(array);
+            if (Array.isArray(array.nodes)) {
+                result = result.concat(flattenArrayOfObjects(array.nodes));
+            }
+        });
+    }
     return result;
 };
 
@@ -175,9 +177,11 @@ export const flattenArrayOfObjects = (array) => {
  */
 
 export const displayTitle = (id, groups) => {
-    for (let group of groups) {
-        if (group?.id === id) {
-            return group.title;
+    if (groups && Array.isArray(groups)) {
+        for (let group of groups) {
+            if (group?.id === id) {
+                return group.title;
+            }
         }
     }
     return 'Default';

--- a/web/client/utils/__tests__/LayersUtils-test.js
+++ b/web/client/utils/__tests__/LayersUtils-test.js
@@ -1254,5 +1254,15 @@ describe('LayersUtils', () => {
             expect(groupTitle).toExist();
             expect(groupTitle).toEqual('titleLayer001');
         });
+        it('Return an empty array if there is no array of objects', ()=>{
+            const groups = { id: 'default', title: 'Default', nodes: [{id: 'layer001', title: 'titleLayer001'}, {id: 'layer002', title: 'titleLayer002'}]};
+            const flattenedGroups = LayersUtils.flattenArrayOfObjects(groups);
+            expect(flattenedGroups.length).toBe(0);
+        });
+        it('Return title as default if group contains no totle', ()=>{
+            const groups = [];
+            const flattenedGroups = LayersUtils.displayTitle(groups);
+            expect(flattenedGroups).toBe('Default');
+        });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7367 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The edit map widget works without breaking
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
