### PR TITLE
#7371: sessionToken is not correctly read on refresh session (aligned to work with new geostore responses)

### DIFF
--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -452,7 +452,7 @@ const Api = {
         // accessToken is actually the sessionID
         const url = "session/refresh/" + accessToken + "/" + refreshToken;
         return axios.post(url, null, this.addBaseUrl(parseOptions(options))).then(function(response) {
-            return response.data;
+            return response.data?.sessionToken ?? response.data;
         });
     },
     /**

--- a/web/client/api/__tests__/GeoStoreDAO-test.jsx
+++ b/web/client/api/__tests__/GeoStoreDAO-test.jsx
@@ -152,6 +152,13 @@ describe('Test correctness of the GeoStore APIs', () => {
             done();
         });
     });
+    it("test refresh session", (done) => {
+        mockAxios.onPost().reply(200, { sessionToken: {access_token: "token"} });
+        API.refreshToken("access", "refresh", {}).then(response => {
+            expect(response.access_token).toBe("token");
+            done();
+        });
+    });
     it("test generateMetadata default", () => {
         const metadata = API.generateMetadata();
         const name = "";


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The refresh session response is not correctly read and stored, so the authentication session is invalidated after a refresh.
This PR correctly reads the geostore refresh session service response, that has been refactored with the Spring libraries upgrade.
Both the new and old response type are accepted.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7371 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7371 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The authentication session remains valid after one or more refresh session requests

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
