### PR TITLE
[Backport 2021.02.xx] #7332: Identify for annotations is showing all internal properties rather than title/description

### DIFF
--- a/web/client/components/data/identify/viewers/PropertiesViewer.js
+++ b/web/client/components/data/identify/viewers/PropertiesViewer.js
@@ -8,14 +8,13 @@
 
 import React from 'react';
 
-import PropertiesViewer from './row/PropertiesViewer';
+import RowViewer from './row/RowViewer';
 
 export default ({response, layer, rowViewer}) => {
-    const RowViewer = (layer && layer.rowViewer) || rowViewer || PropertiesViewer;
     return (
         <div className="mapstore-json-viewer">
             {(response?.features || []).map((feature, i) => {
-                return <RowViewer key={i} feature={feature} title={feature.id + ''} exclude={["bbox"]} {...feature.properties}/>;
+                return <RowViewer key={i} feature={feature} layer={layer} component={rowViewer}/>;
             })}
         </div>
     );

--- a/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/PropertiesViewer.jsx
@@ -6,73 +6,72 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {isString} from 'lodash';
+import { isString } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import {containsHTML} from '../../../../../utils/StringUtils';
-
-const alwaysExcluded = ["exclude", "titleStyle", "listStyle", "componentStyle", "title", "feature"];
-
+import { containsHTML } from '../../../../../utils/StringUtils';
+import Message from '../../../../I18N/Message';
 class PropertiesViewer extends React.Component {
     static displayName = 'PropertiesViewer';
 
     static propTypes = {
-        title: PropTypes.string,
         exclude: PropTypes.array,
+        include: PropTypes.array,
         titleStyle: PropTypes.object,
         listStyle: PropTypes.object,
-        componentStyle: PropTypes.object
+        componentStyle: PropTypes.object,
+        feature: PropTypes.object,
+        labelIds: PropTypes.object
     };
 
     static defaultProps = {
         exclude: [],
         titleStyle: {},
         listStyle: {},
-        componentStyle: {}
+        componentStyle: {},
+        labelIds: {}
     };
 
     getBodyItems = () => {
-        return Object.keys(this.props)
-            .filter(this.toExclude)
+        return Object.keys(this.props?.feature?.properties || {})
+            .filter(this.props?.include?.length > 0 ? this.toInclude : this.toExclude)
             .map((key) => {
-                const val = this.renderProperty(this.props[key]);
+                const val = this.renderProperty(this.props.feature.properties[key]);
                 return (
-                    <tr
+                    <li
                         key={key}
                         style={this.props.listStyle}>
-                        <td>{key}</td>
-                        <td>{containsHTML(val) ? <span dangerouslySetInnerHTML={{__html: val}}/> : val}</td>
-                    </tr>);
+                        <div className="ms-properties-viewer-key">{this.props.labelIds[key] ? <Message msgId={this.props.labelIds[key]}/> : key}</div>
+                        {containsHTML(val) ? <div className="ms-properties-viewer-value" dangerouslySetInnerHTML={{__html: val}}/> : <div className="ms-properties-viewer-value">{val}</div>}
+                    </li>);
             });
     };
 
     renderHeader = () => {
-        if (!this.props.title) {
+        if (this.props.feature?.id === undefined) {
             return null;
         }
+        const title = this.props.feature.id + '';
         return (
-            <thead
-                key={this.props.title}
+            <div
+                key={title}
                 style={this.props.titleStyle}
                 className="ms-properties-viewer-title">
-                <tr>
-                    <th colSpan="2" >{this.props.title}</th>
-                </tr>
-            </thead>
+                {title}
+            </div>
         );
     };
 
     renderBody = () => {
-        var items = this.getBodyItems();
+        const items = this.getBodyItems();
         if (items.length === 0) {
             return null;
         }
         return (
-            <tbody
+            <ul
                 className="ms-properties-viewer-body">
                 {items}
-            </tbody>
+            </ul>
         );
     };
 
@@ -85,19 +84,23 @@ class PropertiesViewer extends React.Component {
 
     render() {
         return (
-            <table
+            <div
                 className="ms-properties-viewer"
                 style={this.props.componentStyle}>
                 {this.renderHeader()}
                 {this.renderBody()}
-            </table>
+            </div>
         );
     }
 
     toExclude = (propName) => {
-        return alwaysExcluded
-            .concat(this.props.exclude)
+        return this.props.exclude
             .indexOf(propName) === -1;
+    };
+
+    toInclude = (propName) => {
+        return this.props.include
+            .indexOf(propName) !== -1;
     };
 }
 

--- a/web/client/components/data/identify/viewers/row/RowViewer.jsx
+++ b/web/client/components/data/identify/viewers/row/RowViewer.jsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { isString } from 'lodash';
+import PropertiesViewer from './PropertiesViewer';
+import { getRowViewer } from '../../../../../utils/MapInfoUtils';
+import { ANNOTATIONS } from '../../../../../utils/AnnotationsUtils';
+import PropTypes from 'prop-types';
+
+const defaultRowViewerOptions = {
+    // we need some default options for annotations
+    // to ensure that only title and description are displayed
+    // when the custom row viewer is not mounted
+    [ANNOTATIONS]: {
+        include: ['title', 'description'],
+        labelIds: {
+            title: 'annotations.field.title',
+            description: 'annotations.field.description'
+        }
+    }
+};
+
+function RowViewer({
+    layer,
+    component,
+    feature
+}) {
+    // the name of the registered viewer could be associate by a string in the rowViewer or id
+    const layerRowViewerProperty = layer?.rowViewer || layer?.layerId;
+    const defaultOptions = isString(layerRowViewerProperty) ? defaultRowViewerOptions[layerRowViewerProperty] : {};
+    const excludeProperties = defaultOptions?.exclude ? defaultOptions.exclude : ['bbox'];
+    const includeProperties = defaultOptions?.include;
+    const labelIds = defaultOptions?.labelIds;
+    const layerRowViewer = isString(layerRowViewerProperty) ? getRowViewer(layerRowViewerProperty) : layerRowViewerProperty;
+    const Row = layerRowViewer || component || PropertiesViewer;
+    return (
+        <Row
+            {...feature.properties}
+            feature={feature}
+            labelIds={labelIds}
+            exclude={excludeProperties}
+            include={includeProperties}
+        />
+    );
+}
+
+RowViewer.propTypes = {
+    layer: PropTypes.string,
+    component: PropTypes.array,
+    feature: PropTypes.array
+};
+
+RowViewer.defaultProps = {
+    layer: {},
+    feature: {}
+};
+
+export default RowViewer;

--- a/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/PropertiesViewer-test.jsx
@@ -24,19 +24,15 @@ describe('PropertiesViewer', () => {
         setTimeout(done);
     });
     it('test defaults', () => {
-        const cmp = ReactDOM.render(<PropertiesViewer/>, document.getElementById("container"));
-        expect(cmp).toExist();
-
-        const cmpDom = ReactDOM.findDOMNode(cmp);
-        expect(cmpDom).toExist();
-
-        expect(cmpDom.childNodes.length).toBe(0);
+        ReactDOM.render(<PropertiesViewer/>, document.getElementById("container"));
+        const viewerNode = document.querySelector('.ms-properties-viewer');
+        expect(viewerNode).toBeTruthy();
     });
     it('test title rendering', () => {
-        ReactDOM.render(<PropertiesViewer title="testTitle"/>, document.getElementById("container"));
+        ReactDOM.render(<PropertiesViewer feature={{ id: "testTitle" }}/>, document.getElementById("container"));
         const titleNode = document.querySelector('.ms-properties-viewer-title');
         expect(titleNode).toBeTruthy();
-        expect(titleNode.querySelector('th').innerHTML).toBe("testTitle");
+        expect(titleNode.innerHTML).toBe("testTitle");
     });
     it('test body rendering', () => {
         const testProps = {
@@ -44,7 +40,7 @@ describe('PropertiesViewer', () => {
             k1: "v1",
             k2: "v2"
         };
-        const cmp = ReactDOM.render(<PropertiesViewer {...testProps}/>, document.getElementById("container"));
+        const cmp = ReactDOM.render(<PropertiesViewer feature={{ properties: testProps }}/>, document.getElementById("container"));
         expect(cmp).toBeTruthy();
 
         const cmpDom = ReactDOM.findDOMNode(cmp);
@@ -59,7 +55,7 @@ describe('PropertiesViewer', () => {
         expect(Array.prototype.reduce.call(body.childNodes, (prev, child, i) => {
             let testKey = testKeys[i];
             let testVal = testProps[testKey];
-            const rowData = child.querySelectorAll('td');
+            const rowData = child.querySelectorAll('div');
             const key = rowData[0].innerHTML;
             const value = rowData[1].innerHTML;
             return prev
@@ -67,33 +63,14 @@ describe('PropertiesViewer', () => {
         }, true)).toBe(true);
     });
 
-    it('test feature isexcluded', () => {
-        const cmp = ReactDOM.render(<PropertiesViewer feature={"myfeature"} title="testTitle" />, document.getElementById("container"));
-        expect(cmp).toExist();
-
-        const cmpDom = ReactDOM.findDOMNode(cmp);
-        expect(cmpDom).toExist();
-
-        expect(cmpDom.innerText.indexOf('myfeature')).toBe(-1);
-    });
-
-
     it('test rendering an html property', () => {
         const testProps = {
-            withHtml: "<div> some text </div>"
+            withHtml: "<p id=\"rendered-html\">some text</p>"
         };
-        const cmp = ReactDOM.render(<PropertiesViewer {...testProps}/>, document.getElementById("container"));
-        expect(cmp).toBeTruthy();
-
-        const cmpDom = ReactDOM.findDOMNode(cmp);
-        expect(cmpDom).toBeTruthy();
-        expect(cmpDom.children.length).toBe(1);
-
-        const body = cmpDom.children[0];
-
-        const tdChildren = body.querySelectorAll('td');
-        const spanChild = tdChildren[1].querySelector('span');
-        expect(spanChild).toBeTruthy();
-        expect(spanChild.innerHTML).toBe(testProps.withHtml);
+        ReactDOM.render(<PropertiesViewer feature={{ properties: testProps }}/>, document.getElementById("container"));
+        const viewerBodyNode = document.querySelector('.ms-properties-viewer-body');
+        const renderedPNode = viewerBodyNode.querySelector('#rendered-html');
+        expect(renderedPNode).toBeTruthy();
+        expect(renderedPNode.innerHTML).toBe('some text');
     });
 });

--- a/web/client/components/data/identify/viewers/row/__tests__/RowViewer-test.jsx
+++ b/web/client/components/data/identify/viewers/row/__tests__/RowViewer-test.jsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import RowViewer from '../RowViewer';
+import { ANNOTATIONS } from '../../../../../../utils/AnnotationsUtils';
+import { registerRowViewer } from '../../../../../../utils/MapInfoUtils';
+
+describe('RowViewer', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('should render with default', () => {
+        ReactDOM.render(<RowViewer />, document.getElementById("container"));
+        const viewerNode = document.querySelector('.ms-properties-viewer');
+        expect(viewerNode).toBeTruthy();
+    });
+    it('should apply default option for annotation layer', () => {
+
+        const TestComponent = ({
+            include
+        }) => {
+            return <div id="annotation-include-option">{include.join()}</div>;
+        };
+
+        ReactDOM.render(
+            <RowViewer
+                layer={{ layerId: ANNOTATIONS }}
+                component={TestComponent}
+                feature={{ properties: {}, id: 'feature' }}
+            />,
+            document.getElementById("container"));
+
+        const includeOptionNode = document.querySelector('#annotation-include-option');
+        expect(includeOptionNode.innerHTML).toBe('title,description');
+    });
+
+    it('should render the registered row viewer', () => {
+
+        const RegisteredComponent = () => {
+            return <div id="registered-viewer"></div>;
+        };
+
+        registerRowViewer(ANNOTATIONS, RegisteredComponent);
+
+        ReactDOM.render(
+            <RowViewer
+                layer={{ layerId: ANNOTATIONS }}
+                feature={{ properties: {}, id: 'feature' }}
+            />,
+            document.getElementById("container"));
+
+        const registeredViewerNode = document.querySelector('#registered-viewer');
+        expect(registeredViewerNode).toBeTruthy();
+
+        registerRowViewer(ANNOTATIONS, undefined);
+    });
+});

--- a/web/client/epics/__tests__/annotations-test.js
+++ b/web/client/epics/__tests__/annotations-test.js
@@ -58,7 +58,7 @@ const {
     setAnnotationStyleEpic, restoreStyleEpic, highlightAnnotationEpic, cleanHighlightAnnotationEpic, closeAnnotationsEpic, confirmCloseAnnotationsEpic,
     downloadAnnotations, onLoadAnnotations, onChangedSelectedFeatureEpic, onBackToEditingFeatureEpic, redrawOnChangeRadiusEpic, redrawOnChangeTextEpic,
     editSelectedFeatureEpic, editCircleFeatureEpic, purgeMapInfoEpic, closeMeasureToolEpic, openEditorEpic, loadDefaultAnnotationsStylesEpic, showHideAnnotationEpic, hideAnnotationGroupEpic, highlightGeometryEpic
-} = annotationsEpics({});
+} = annotationsEpics;
 
 const rootEpic = combineEpics(addAnnotationsLayerEpic, editAnnotationEpic, removeAnnotationEpic, setEditingFeatureEpic, saveAnnotationEpic, newAnnotationEpic, addAnnotationEpic,
     disableInteractionsEpic, cancelEditAnnotationEpic, startDrawingMultiGeomEpic, endDrawGeomEpic,

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -212,7 +212,7 @@ const createNewFeature = (action) => {
 };
 
 
-export default (viewer) => ({
+export default {
     addAnnotationsLayerEpic: (action$, store) => action$.ofType(MAP_CONFIG_LOADED)
         .switchMap(() => {
             const annotationsLayer = annotationsLayerSelector(store.getState());
@@ -241,7 +241,6 @@ export default (viewer) => ({
                 });
 
                 return Rx.Observable.of(updateNode(ANNOTATIONS, 'layer', {
-                    rowViewer: viewer,
                     features,
                     style: {},
                     visibility
@@ -370,7 +369,6 @@ export default (viewer) => ({
                     visibility: true,
                     id: ANNOTATIONS,
                     name: "Annotations",
-                    rowViewer: viewer,
                     hideLoading: true,
                     style: action.style,
                     features: [createNewFeature(action)],
@@ -587,7 +585,6 @@ export default (viewer) => ({
                 visibility: true,
                 id: ANNOTATIONS,
                 name: "Annotations",
-                rowViewer: viewer,
                 hideLoading: true,
                 features: newFeatures,
                 handleClickOnLayer: true
@@ -850,4 +847,4 @@ export default (viewer) => ({
                 .concat(Rx.Observable.of(loading(false)));
         })
 
-});
+};

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -83,6 +83,9 @@ import { setAnnotationMeasurement } from '../actions/measurement';
 import { zoomToExtent } from '../actions/map';
 import { annotationsInfoSelector, annotationsListSelector } from '../selectors/annotations';
 import { mapLayoutValuesSelector } from '../selectors/maplayout';
+import { ANNOTATIONS } from '../utils/AnnotationsUtils';
+import { registerRowViewer } from '../utils/MapInfoUtils';
+
 const commonEditorActions = {
     onUpdateSymbols: updateSymbols,
     onSetErrorSymbol: setErrorSymbol,
@@ -219,6 +222,15 @@ class AnnotationsPanel extends React.Component {
         dockStyle: {}
     };
 
+    componentDidMount() {
+        // register the viewer using the constant layer id of annotation
+        registerRowViewer(ANNOTATIONS, AnnotationsInfoViewer);
+    }
+
+    componentWillUnmount() {
+        registerRowViewer(ANNOTATIONS, undefined);
+    }
+
     render() {
         return this.props.active ? (
             <ContainerDimensions>
@@ -319,5 +331,5 @@ export default createPlugin('Annotations', {
     reducers: {
         annotations: annotationsReducer
     },
-    epics: annotationsEpics(AnnotationsInfoViewer)
+    epics: annotationsEpics
 });

--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -37,6 +37,10 @@
         .color-var(@theme-vars[main-color], true);
         .background-color-var(@theme-vars[main-bg], true);
     }
+
+    .ms-properties-viewer {
+        .border-top-color-var(@theme-vars[main-border-color]);
+    }
 }
 
 // **************
@@ -271,36 +275,37 @@
 .ms-properties-viewer {
     width: 100%;
     min-width: 256px;
+    padding: 8px;
     + .ms-properties-viewer {
         margin-top: 8px;
+        border-top-width: 1px;
+        border-top-style: solid;
     }
     &:last-child {
         padding-bottom: 8px;
     }
-    thead {
-        font-size: 1.1em;
-        margin-bottom: 4px;
-        th {
-            padding: 0 4px 4px;
-            font-weight: normal;
-            word-break: break-word;
+    .ms-properties-viewer-title {
+        padding: 8px 4px;
+        font-size: @font-size-small;
+        font-style: italic;
+    }
+    .ms-properties-viewer-body {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        li {
+            margin-top: 4px;
+        }
+        li > div > p {
+            margin: 0;
         }
     }
-    tbody {
-        font-size: 1em;
+    .ms-properties-viewer-key {
+        font-weight: bold;
     }
-    td {
-        padding: 2px 4px 0;
-        &:first-child {
-            font-weight: bold;
-        }
-        &:last-child {
-            text-align: right;
-        }
-    }
-    tr + tr {
-        border-top-width: 1px;
-        border-top-style: solid;
+    .ms-properties-viewer-key,
+    .ms-properties-viewer-value {
+        padding: 0 4px;
     }
 }
 

--- a/web/client/themes/default/less/map-popup.less
+++ b/web/client/themes/default/less/map-popup.less
@@ -243,4 +243,12 @@
         min-width: 50px;
         min-height: 50px;
     }
+    .mapstore-annotations-info-viewer .mapstore-annotations-info-viewer-items {
+        height: auto;
+        .mapstore-annotations-info-viewer-item {
+            & > span > p, & > p {
+                margin: 0;
+            }
+        }
+    }
 }

--- a/web/client/utils/MapInfoUtils.js
+++ b/web/client/utils/MapInfoUtils.js
@@ -270,6 +270,15 @@ export const filterRequestParams = (layer, includeOptions, excludeParams) => {
     return options;
 };
 
+let rowViewers = {};
+
+export const registerRowViewer = (name, options) => {
+    rowViewers[name] = options;
+};
+
+export const getRowViewer = (name) => {
+    return rowViewers[name];
+};
 
 MapInfoUtils = {
     AVAILABLE_FORMAT,
@@ -281,6 +290,8 @@ MapInfoUtils = {
     getDefaultInfoFormatValueFromLayer,
     getLayerFeatureInfoViewer,
     getLayerFeatureInfo,
-    VIEWERS: {}
+    VIEWERS: {},
+    registerRowViewer,
+    getRowViewer
 };
 

--- a/web/client/utils/mapinfo/vector.js
+++ b/web/client/utils/mapinfo/vector.js
@@ -25,7 +25,8 @@ module.exports = {
                 buffer: props.buffer || 2,
                 units: props.map && props.map.units,
                 rowViewer: layer.rowViewer,
-                viewer: layer.viewer
+                viewer: layer.viewer,
+                layerId: layer.id
             },
             url: ""
         };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR refactors the default properties viewer of identify plugin and it includes following changes:
- registration of row viewer via global function
- assign a specific registered viewer via layer id
- include properties to filter only a specific set of fields
- aligned the style of annotation and properties viewers

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7332

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The identify viewer for annotation shows only title and description and the style of the properties viewer is aligned with the style of the annotation viewer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
