### PR TITLE
#7452 clean up the main product references to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Use the default credentials (admin / admin) to login and start creating your map
     docker-compose down --remove-orphans --rmi all -v
     ```
 
+### Using the local Backend
+
+One option for the backend is to start it locally without using a java web container and a war file.
+The only thing to do is to run this command in one terminal:
+```shell
+    npm run backend
+```
+
+The project will point to this backend by default (check `build/webpack.config.js`)
+
 ### Using the Web Archive (WAR file)
 
 After downloading the MapStore war file, install it in your java web container (e.g. Tomcat), with usual procedures for the container (normally you only need to copy the war file in the webapps subfolder).

--- a/build/buildConfig.js
+++ b/build/buildConfig.js
@@ -280,36 +280,25 @@ module.exports = (...args) => mapArgumentsToObject(args, ({
         publicPath: "/dist/",
         proxy: proxy || {
             '/rest': {
-                target: "https://dev-mapstore.geosolutionsgroup.com/mapstore",
-                secure: false,
-                headers: {
-                    host: "dev-mapstore.geosolutionsgroup.com"
-                }
-            },
-            '/pdf': {
-                target: "https://dev-mapstore.geosolutionsgroup.com/mapstore",
-                secure: false,
-                headers: {
-                    host: "dev-mapstore.geosolutionsgroup.com"
-                }
-            },
-            '/mapstore/pdf': {
-                target: "https://dev-mapstore.geosolutionsgroup.com",
-                secure: false,
-                headers: {
-                    host: "dev-mapstore.geosolutionsgroup.com"
-                }
+                target: "http://localhost:8080/mapstore"
             },
             '/proxy': {
-                target: "https://dev-mapstore.geosolutionsgroup.com/mapstore",
-                secure: false,
-                headers: {
-                    host: "dev-mapstore.geosolutionsgroup.com"
-                }
+                target: "http://localhost:8080/mapstore"
             },
-            '/docs': {
-                target: "http://localhost:8081",
-                pathRewrite: {'/docs': '/mapstore/docs'}
+            '/extensions.json': {
+                target: "http://localhost:8080/mapstore"
+            },
+            '/dist/extensions': {
+                target: "http://localhost:8080/mapstore"
+            },
+            '/pdf': {
+                target: "http://localhost:8080/mapstore"
+            },
+            '/mapstore/pdf': {
+                target: "http://localhost:8080"
+            },
+            '/geofence': {
+                target: "http://localhost:8080"
             }
         }
     },

--- a/build/prod-webpack.config.js
+++ b/build/prod-webpack.config.js
@@ -11,8 +11,8 @@ const paths = {
     code: path.join(__dirname, "..", "web", "client")
 };
 
-module.exports = require('./buildConfig')(
-    {
+module.exports = require('./buildConfig')({
+    bundles: {
         "mapstore2": path.join(paths.code, "product", "app"),
         "embedded": path.join(paths.code, "product", "embedded"),
         "ms2-api": path.join(paths.code, "product", "api"),
@@ -21,11 +21,11 @@ module.exports = require('./buildConfig')(
     },
     themeEntries,
     paths,
-    [extractThemesPlugin, ModuleFederationPlugin],
-    true,
-    undefined,
-    undefined,
-    [
+    plugins: [extractThemesPlugin, ModuleFederationPlugin],
+    prod: true,
+    cssPrefix: undefined,
+    publicPath: undefined,
+    prodPlugins: [
         new HtmlWebpackPlugin({
             template: path.join(paths.framework, 'indexTemplate.html'),
             publicPath: 'dist/',
@@ -65,5 +65,5 @@ module.exports = require('./buildConfig')(
             hash: true,
             filename: 'dashboard-embedded.html'
         })
-    ]
+    ]}
 );

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -3,8 +3,8 @@ const path = require("path");
 const themeEntries = require('./themes.js').themeEntries;
 const extractThemesPlugin = require('./themes.js').extractThemesPlugin;
 const moduleFederationPlugin = require('./moduleFederation.js').plugin;
-const config = require('./buildConfig')(
-    {
+const config = require('./buildConfig')({
+    bundles: {
         [process.env.bundle || "mapstore2"]: path.join(__dirname, "..", "web", "client", "product", process.env.entrypoint || process.env.bundle || "app"),
         "embedded": path.join(__dirname, "..", "web", "client", "product", "embedded"),
         "ms2-api": path.join(__dirname, "..", "web", "client", "product", "api"),
@@ -12,14 +12,38 @@ const config = require('./buildConfig')(
         "geostory-embedded": path.join(__dirname, "..", "web", "client", "product", "geostoryEmbedded")
     },
     themeEntries,
-    {
+    paths: {
         base: path.join(__dirname, ".."),
         dist: path.join(__dirname, "..", "web", "client", "dist"),
         framework: path.join(__dirname, "..", "web", "client"),
         code: path.join(__dirname, "..", "web", "client")
     },
-    [extractThemesPlugin, moduleFederationPlugin],
-    false,
-    undefined
-);
+    plugins: [extractThemesPlugin, moduleFederationPlugin],
+    prod: false,
+    publicPath: undefined,
+    cssPrefix: undefined,
+    proxy: {
+        '/rest': {
+            target: "http://localhost:8080/mapstore"
+        },
+        '/proxy': {
+            target: "http://localhost:8080/mapstore"
+        },
+        '/extensions.json': {
+            target: "http://localhost:8080/mapstore"
+        },
+        '/dist/extensions': {
+            target: "http://localhost:8080/mapstore"
+        },
+        '/pdf': {
+            target: "http://localhost:8080/mapstore"
+        },
+        '/mapstore/pdf': {
+            target: "http://localhost:8080"
+        },
+        '/geofence': {
+            target: "http://localhost:8080"
+        }
+    }
+});
 module.exports = config;

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -21,29 +21,6 @@ const config = require('./buildConfig')({
     plugins: [extractThemesPlugin, moduleFederationPlugin],
     prod: false,
     publicPath: undefined,
-    cssPrefix: undefined,
-    proxy: {
-        '/rest': {
-            target: "http://localhost:8080/mapstore"
-        },
-        '/proxy': {
-            target: "http://localhost:8080/mapstore"
-        },
-        '/extensions.json': {
-            target: "http://localhost:8080/mapstore"
-        },
-        '/dist/extensions': {
-            target: "http://localhost:8080/mapstore"
-        },
-        '/pdf': {
-            target: "http://localhost:8080/mapstore"
-        },
-        '/mapstore/pdf': {
-            target: "http://localhost:8080"
-        },
-        '/geofence': {
-            target: "http://localhost:8080"
-        }
-    }
+    cssPrefix: undefined
 });
 module.exports = config;

--- a/docs/developer-guide/developing.md
+++ b/docs/developer-guide/developing.md
@@ -21,17 +21,15 @@ After a while (depending on the network bandwidth) the full set of dependencies 
 
 `npm start`
 
-Then point your preferred browser to [http://localhost:8081](http://localhost:8081). By default the front-end works using the online dev server as back-end. This configuration is useful for a quick startup, but is not the suggested configuration if you want to develop.
-To learn how to connect the front-end dev server to a local back-end read the following instructions.
+Then point your preferred browser to [http://localhost:8081](http://localhost:8081). By default the frontend works using the local dev server as backend. This configuration is suggested if you want to develop.
 
-### Connect Front-end to local back-end
+See the next paragraph to understand what have changed in order to use a local backend
 
-By default `npm start` uses the online dev server as a backend.
-This configuration needs to be changed to develop locally in order to access all the functionalities.
+### Migration to connect frontend to local backend
 
-To use a local back-end you have to:
+Now, by default `npm start` uses the local dev server as a backend.
 
-* **Remove auth configuration dedicated to GeoServer** from `localConfig.json --> authenticationRules` (it provides the MapStore/GeoServer integration for dev-server, that is not present in your local back-end)
+* **Removed auth configuration dedicated to GeoServer** from `localConfig.json --> authenticationRules` (it provides the MapStore/GeoServer integration for dev-server, that is not present in the local backend)
 
 ```diff
 "authenticationRules": [{
@@ -48,9 +46,9 @@ To use a local back-end you have to:
     }],
 ```
 
-* **Run the back-end locally**. See the [dedicated section in this page](#back-end)
+* **Run the backend locally**. See the [dedicated section in this page](#backend)
 
-* **Setup dev-server to use the local back-end**, applying this changes to `buildConfig.js` --> devServer configuration. (the configuration of the port and path depends on how you configured the local back-end.
+* **Setup dev-server to use the local backend**, applying this changes to `buildConfig.js` --> devServer configuration. (the configuration of the port and path depends on how you configured the local backend.
 
 ```javascript
 devServer: {
@@ -129,13 +127,13 @@ To run the same tests Travis will check (before a pull request):
 
 More information on frontend building tools and configuration is available [here](frontend-building-tools-and-configuration)
 
-## Back-end
+## Backend
 
-In order to have a full running MapStore in development environment, you need to run also the back-end java part locally. In this section you will find how to start the back-end and how to develop with it.
+In order to have a full running MapStore in development environment, you need to run also the backend java part locally. In this section you will find how to start the backend and how to develop with it.
 
 ### Defaults Users and Database
 
-Running MapStore back-end locally, on start-up you will find the following users:
+Running MapStore backend locally, on start-up you will find the following users:
 
 * `admin`, with ADMIN role and password `admin`
 * `user` with USER role with password `user`
@@ -144,24 +142,25 @@ You can login as `admin` to set-up new users and access to all the features rese
 
 The database used by default in this mode is H2 on disk. You can find the files of the database in the directory `webapps/mapstore/` starting from your execution context. Check how to set-up database in the dedicated section of the documentation.
 
-### Running Back-end
+### Running Backend
 
-When we say "running the back-end", in fact we say that we are running some sort of a whole instance of MapStore locally, that can be used as back-end for your front-end dev server, or for debugging of the back-end itself.
+When we say "running the backend", in fact we say that we are running some sort of a whole instance of MapStore locally, that can be used as backend for your frontend dev server, or for debugging of the backend itself.
 
 #### Embedded tomcat
 
 MapStore is configured to use a tomcat maven plugin-in to build and run mapstore locally. To use it you have to:
 
-* make sure to run at least once `mvn install` in the root directory, to make `mapstore-product` artifact available.
-* `cd product` directory
-* run `mvn cargo:run`
+* make sure to run at least once `mvn install` **in the root** directory, to make `mapstore-product` artifact available.
+* npm run backend
 
-Your local back-end will now start at [http://localhost:8080/mapstore/](http://localhost:8080/mapstore/).
-If you want to change the port you can edit the dedicated entry in `product/pom.xml`, just remember to change also the dev-server proxy configuration on the front-end in the same way.
+Now you are good to go, and you can start the frontend
+
+Your local backend will now start at [http://localhost:8080/mapstore/](http://localhost:8080/mapstore/).
+If you want to change the port you can edit the dedicated entry in `product/pom.xml`, just remember to change also the dev-server proxy configuration on the frontend in the same way.
 
 #### Local tomcat instance
 
-If you prefer, or if you have some problems with `mvn cargo:run`, you can run MapStore back-end in a tomcat instance instead of using the embedded one.
+If you prefer, or if you have some problems with `mvn cargo:run`, you can run MapStore backend in a tomcat instance instead of using the embedded one.
 To do so, you can :
 
 * download a tomcat standalone [here](https://mapstore.readthedocs.io/en/latest/developer-guide/requirements/) and extract to a folder of your choice
@@ -169,11 +168,11 @@ To do so, you can :
 * Copy the `mapstore.war` and then head back to your tomcat folder. Look for a `webapps` folder and paste the `mapstore.war` file there.
 * To start tomcat server, go to the terminal, `cd` into the root of your tomcat extracted folder and run `./bin/startup.sh` ( unix systems) or `./bin/startup.bat` (Windows). The server will start on port `8080` and Mapstore will be running at `http://localhost:8080/mapstore`. For development purposes we're only interested in the backend that was started on the tomcat server along with Mapstore.
 
-Even in this case you can connect your front-end to point to this instance of MapStore.
+Even in this case you can connect your frontend to point to this instance of MapStore.
 
 ### Debug
 
-To run or debug the server side part of MapStore we suggest to run the back-end in tomcat (embedded or installed) and connect in remote debugging to it. This guide explains how to do it with Eclipse. This procedure has been tested with Eclipse Luna.
+To run or debug the server side part of MapStore we suggest to run the backend in tomcat (embedded or installed) and connect in remote debugging to it. This guide explains how to do it with Eclipse. This procedure has been tested with Eclipse Luna.
 
 ### Enable Remote Debugging
 

--- a/project/standard/templates/prod-webpack.config.js
+++ b/project/standard/templates/prod-webpack.config.js
@@ -12,8 +12,8 @@ const paths = {
     code: [path.join(__dirname, "js"), path.join(__dirname, "MapStore2", "web", "client")]
 };
 
-module.exports = require('./MapStore2/build/buildConfig')(
-    {
+module.exports = require('./MapStore2/build/buildConfig')({
+    bundles: {
         '__PROJECTNAME__': path.join(__dirname, "js", "app"),
         '__PROJECTNAME__-embedded': path.join(__dirname, "js", "embedded"),
         '__PROJECTNAME__-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
@@ -22,11 +22,11 @@ module.exports = require('./MapStore2/build/buildConfig')(
     },
     themeEntries,
     paths,
-    [extractThemesPlugin, ModuleFederationPlugin],
-    true,
-    undefined,
-    '.__PROJECTNAME__',
-    [
+    plugins: [extractThemesPlugin, ModuleFederationPlugin],
+    prod: true,
+    publicPath: undefined,
+    cssPrefix: '.__PROJECTNAME__',
+    prodPlugins: [
         new HtmlWebpackPlugin({
             template: path.join(__dirname, 'indexTemplate.html'),
             chunks: ['__PROJECTNAME__'],
@@ -67,9 +67,9 @@ module.exports = require('./MapStore2/build/buildConfig')(
             filename: 'dashboard-embedded.html'
         })
     ],
-    {
+    alias: {
         "@mapstore/patcher": path.resolve(__dirname, "node_modules", "@mapstore", "patcher"),
         "@mapstore": path.resolve(__dirname, "MapStore2", "web", "client"),
         "@js": path.resolve(__dirname, "js")
-    }
+    }}
 );

--- a/project/standard/templates/webpack.config.js
+++ b/project/standard/templates/webpack.config.js
@@ -4,8 +4,8 @@ const themeEntries = require('./MapStore2/build/themes.js').themeEntries;
 const extractThemesPlugin = require('./MapStore2/build/themes.js').extractThemesPlugin;
 const ModuleFederationPlugin = require('./MapStore2/build/moduleFederation').plugin;
 
-module.exports = require('./MapStore2/build/buildConfig')(
-    {
+module.exports = require('./MapStore2/build/buildConfig')({
+    bundles: {
         '__PROJECTNAME__': path.join(__dirname, "js", "app"),
         '__PROJECTNAME__-embedded': path.join(__dirname, "js", "embedded"),
         '__PROJECTNAME__-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
@@ -13,20 +13,20 @@ module.exports = require('./MapStore2/build/buildConfig')(
         "dashboard-embedded": path.join(__dirname, "js", "dashboardEmbedded")
     },
     themeEntries,
-    {
+    paths: {
         base: __dirname,
         dist: path.join(__dirname, "dist"),
         framework: path.join(__dirname, "MapStore2", "web", "client"),
         code: [path.join(__dirname, "js"), path.join(__dirname, "MapStore2", "web", "client")]
     },
-    [extractThemesPlugin, ModuleFederationPlugin],
-    false,
-    undefined,
-    '.__PROJECTNAME__',
-    [],
-    {
+    plugins: [extractThemesPlugin, ModuleFederationPlugin],
+    prod: false,
+    publicPath: undefined,
+    cssPrefix: '.__PROJECTNAME__',
+    prodPlugins: [],
+    alias: {
         "@mapstore/patcher": path.resolve(__dirname, "node_modules", "@mapstore", "patcher"),
         "@mapstore": path.resolve(__dirname, "MapStore2", "web", "client"),
         "@js": path.resolve(__dirname, "js")
-    }
+    }}
 );


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

WIP: this requires also changes for using data-dir, otherwise geoserver integration will not work

this pr cleans up the backend references in the doc and 
set up the default proxy to be the local backend

I have also changed the webpack.config for dev and prod to use object param notation

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7452 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
- it uses by default the local backend
- and it uses object notation
- doc has been aligned

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
