### PR TITLE
#7438; fix bbox inconsistent results

### DIFF
--- a/web/client/epics/__tests__/queryparam-test.js
+++ b/web/client/epics/__tests__/queryparam-test.js
@@ -13,6 +13,7 @@ import { changeMapView, ZOOM_TO_EXTENT, CHANGE_MAP_VIEW, clickOnMap } from '../.
 import { SHOW_NOTIFICATION } from '../../actions/notifications';
 import { onLocationChanged } from 'connected-react-router';
 import {toggleControl} from "../../actions/controls";
+import {layerLoad} from "../../actions/layers";
 
 describe('queryparam epics', () => {
     it('test readQueryParamsOnMapEpic without params in url search', (done) => {
@@ -59,7 +60,7 @@ describe('queryparam epics', () => {
             addTimeoutEpic(readQueryParamsOnMapEpic, 10),
             NUMBER_OF_ACTIONS, [
                 onLocationChanged({}),
-                changeMapView()
+                layerLoad()
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
@@ -184,7 +185,7 @@ describe('queryparam epics', () => {
             addTimeoutEpic(readQueryParamsOnMapEpic, 10),
             NUMBER_OF_ACTIONS, [
                 onLocationChanged({}),
-                changeMapView()
+                layerLoad()
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
@@ -215,7 +216,7 @@ describe('queryparam epics', () => {
             addTimeoutEpic(readQueryParamsOnMapEpic, 10),
             NUMBER_OF_ACTIONS, [
                 onLocationChanged({}),
-                changeMapView()
+                layerLoad()
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
@@ -252,7 +253,7 @@ describe('queryparam epics', () => {
             addTimeoutEpic(readQueryParamsOnMapEpic, 10),
             NUMBER_OF_ACTIONS, [
                 onLocationChanged({}),
-                changeMapView()
+                layerLoad()
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
@@ -290,7 +291,7 @@ describe('queryparam epics', () => {
             addTimeoutEpic(readQueryParamsOnMapEpic, 10),
             NUMBER_OF_ACTIONS, [
                 onLocationChanged({}),
-                changeMapView()
+                layerLoad()
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {
@@ -321,7 +322,7 @@ describe('queryparam epics', () => {
             addTimeoutEpic(readQueryParamsOnMapEpic, 10),
             NUMBER_OF_ACTIONS, [
                 onLocationChanged({}),
-                changeMapView()
+                layerLoad()
             ], actions => {
                 expect(actions.length).toBe(NUMBER_OF_ACTIONS);
                 try {

--- a/web/client/epics/queryparams.js
+++ b/web/client/epics/queryparams.js
@@ -11,7 +11,7 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 import {get, head, isNaN, isString, includes, size, toNumber, isEmpty, isObject, isUndefined, inRange} from 'lodash';
 import url from 'url';
 
-import { CHANGE_MAP_VIEW, zoomToExtent, ZOOM_TO_EXTENT, CLICK_ON_MAP, changeMapView } from '../actions/map';
+import {zoomToExtent, ZOOM_TO_EXTENT, CLICK_ON_MAP, changeMapView} from '../actions/map';
 import { ADD_LAYERS_FROM_CATALOGS } from '../actions/catalog';
 import { SEARCH_LAYER_WITH_FILTER, addMarker, resetSearch, hideMarker } from '../actions/search';
 import { TOGGLE_CONTROL, setControlProperty } from '../actions/controls';
@@ -24,6 +24,7 @@ import { getBbox } from "../utils/MapUtils";
 import { mapSelector } from '../selectors/map';
 import { clickPointSelector, isMapInfoOpen, mapInfoEnabledSelector } from '../selectors/mapInfo';
 import { shareSelector } from "../selectors/controls";
+import {LAYER_LOAD} from "../actions/layers";
 
 /*
 it maps params key to function.
@@ -112,16 +113,17 @@ const paramActions = {
 
 /**
  * Intercept on `LOCATION_CHANGE` to get query params from router.location.search string.
- * It needs to wait the first `CHANGE_MAP_VIEW` to ensure that width and height of map are in the state.
- * @param {external:Observable} action$ manages `LOCATION_CHANGE` and `CHANGE_MAP_VIEW`
+ * It needs to wait the first `LAYER_LOAD` to ensure that width and height of map are in the state as well as the final bbox bounds data.
+ * @param {external:Observable} action$ manages `LOCATION_CHANGE` and `LAYER_LOAD`
  * @memberof epics.share
  * @return {external:Observable}
  */
 export const readQueryParamsOnMapEpic = (action$, store) =>
     action$.ofType(LOCATION_CHANGE)
         .switchMap(() =>
-            action$.ofType(CHANGE_MAP_VIEW)
-                .take(2)
+            // action$.ofType(CHANGE_MAP_VIEW)
+            action$.ofType(LAYER_LOAD)
+                .take(1)
                 .switchMap(() => {
                     const state = store.getState();
                     const search = get(state, 'router.location.search') || '';


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7438 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Map now zoom to the expected location
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
