### PR TITLE
7395 Annotations Issue fixed

### DIFF
--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -63,6 +63,7 @@ export const HIDE_MEASURE_WARNING = 'ANNOTATIONS:HIDE_MEASURE_WARNING';
 export const TOGGLE_SHOW_AGAIN = 'ANNOTATIONS:TOGGLE_SHOW_AGAIN';
 export const GEOMETRY_HIGHLIGHT = 'ANNOTATIONS:GEOMETRY_HIGHLIGHT';
 export const UNSELECT_FEATURE = 'ANNOTATIONS:UNSELECT_FEATURE';
+export const SET_IS_VALID_FEATURE = 'ANNOTATIONS:SET_IS_VALID_FEATURE';
 
 export const initPlugin = () => ({
     type: INIT_PLUGIN
@@ -421,3 +422,8 @@ export const hideMeasureWarning = () => ({
 export const toggleShowAgain = () => ({
     type: TOGGLE_SHOW_AGAIN
 });
+
+export const setIsValidFeature = () => ({
+    type: SET_IS_VALID_FEATURE
+});
+

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -243,7 +243,8 @@ class AnnotationsEditor extends React.Component {
         onToggleShowAgain: PropTypes.func,
         onInitPlugin: PropTypes.func,
         onGeometryHighlight: PropTypes.func,
-        onUnSelectFeature: PropTypes.func
+        onUnSelectFeature: PropTypes.func,
+        setIsValidFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -350,6 +351,15 @@ class AnnotationsEditor extends React.Component {
     };
 
     renderEditingCoordButtons = () => {
+
+        let allValidGemotry = true
+        
+        if(this.props?.editing?.features && this.props.editing?.features?.length > 0){            
+            this.props.editing.features.map((p) => {        
+                if(!p?.properties?.isValidFeature) { allValidGemotry = false }
+            })
+        }        
+        
         return (<Grid className="mapstore-annotations-info-viewer-buttons" fluid>
             <Row className="text-center noTopMargin">
                 <Col xs={12}>
@@ -391,8 +401,8 @@ class AnnotationsEditor extends React.Component {
                                 }
                             }, {
                                 glyph: 'floppy-disk',
-                                tooltipId: !isEmpty(this.props.selected) ? "annotations.saveGeometry" : "annotations.save",
-                                disabled: this.props.selected && this.props.selected.properties && !this.props.selected.properties.isValidFeature,
+                                tooltipId: !allValidGemotry ? "annotations.geometryError" : !isEmpty(this.props.selected) ? "annotations.saveGeometry" : "annotations.save",
+                                disabled: (this.props.selected && this.props.selected.properties && !this.props.selected.properties.isValidFeature) || !allValidGemotry,
                                 onClick: () => this.save()
                             },
                             {
@@ -498,6 +508,7 @@ class AnnotationsEditor extends React.Component {
                     geodesic={this.props.geodesic}
                     defaultPointType={this.getConfig().defaultPointType}
                     defaultStyles={this.props.defaultStyles}
+                    setIsValidFeature={this.props.setIsValidFeature}                    
                 />
                 }
             </div>
@@ -730,6 +741,7 @@ class AnnotationsEditor extends React.Component {
                                 onSetInvalidSelected={this.props.onSetInvalidSelected}
                                 onChangeText={this.props.onChangeText}
                                 renderer={"annotations"}
+                                setIsValidFeature={this.props.setIsValidFeature}
                             />
                             }
                             {this.state.tabValue === 'style' &&

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -352,14 +352,13 @@ class AnnotationsEditor extends React.Component {
 
     renderEditingCoordButtons = () => {
 
-        let allValidGemotry = true
-        
-        if(this.props?.editing?.features && this.props.editing?.features?.length > 0){            
-            this.props.editing.features.map((p) => {        
-                if(!p?.properties?.isValidFeature) { allValidGemotry = false }
-            })
-        }        
-        
+        let allValidGemotry = true;
+        if (this.props?.editing?.features && this.props.editing?.features?.length > 0) {
+            this.props.editing.features.map((p) => {
+                if (!p?.properties?.isValidFeature) { allValidGemotry = false; }
+            });
+        }
+
         return (<Grid className="mapstore-annotations-info-viewer-buttons" fluid>
             <Row className="text-center noTopMargin">
                 <Col xs={12}>
@@ -508,7 +507,7 @@ class AnnotationsEditor extends React.Component {
                     geodesic={this.props.geodesic}
                     defaultPointType={this.getConfig().defaultPointType}
                     defaultStyles={this.props.defaultStyles}
-                    setIsValidFeature={this.props.setIsValidFeature}                    
+                    setIsValidFeature={this.props.setIsValidFeature}
                 />
                 }
             </div>
@@ -643,6 +642,7 @@ class AnnotationsEditor extends React.Component {
     }
 
     render() {
+
         const editing = this.props.editing && (this.props.editing.properties.id === this.props.id);
         let mouseHoverEvents = this.props.mouseHoverEvents ? {
             onMouseEnter: () => {

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -80,7 +80,8 @@ class CoordinatesEditor extends React.Component {
         isMouseEnterEnabled: PropTypes.bool,
         isMouseLeaveEnabled: PropTypes.bool,
         showLengthAndBearingLabel: PropTypes.bool,
-        renderer: PropTypes.string
+        renderer: PropTypes.string,
+        setIsValidFeature: PropTypes.func
     };
 
     static contextTypes = {
@@ -138,8 +139,8 @@ class CoordinatesEditor extends React.Component {
                         value={this.props.properties.radius}
                         projection={this.props.mapProjection}
                         name="radius"
-                        onChange={(radius, uom) => {          
-                            this.props.setIsValidFeature()
+                        onChange={(radius, uom) => {
+                            this.props.setIsValidFeature();
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
@@ -268,7 +269,7 @@ class CoordinatesEditor extends React.Component {
                                 {this.renderLabelTexts(idx, {textLabels, featurePropValue})}
                             </span>
                         </div>
-                        }                        
+                        }
                         <CoordinatesRow
                             format={this.props.format}
                             aeronauticalOptions={this.props.aeronauticalOptions}
@@ -378,7 +379,7 @@ class CoordinatesEditor extends React.Component {
         }
         return components;
     }
-    change = (id, value) => {        
+    change = (id, value) => {
         let tempComps = this.props.components;
         const lat = isNaN(parseFloat(value.lat)) ? "" : parseFloat(value.lat);
         const lon = isNaN(parseFloat(value.lon)) ? "" : parseFloat(value.lon);
@@ -394,7 +395,7 @@ class CoordinatesEditor extends React.Component {
             if (this.props.isMouseEnterEnabled || this.props.type === "LineString" || this.props.type === "Polygon") {
                 this.props.onHighlightPoint(tempComps[id]);
             }
-        }            
+        }
     }
 }
 

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -138,7 +138,8 @@ class CoordinatesEditor extends React.Component {
                         value={this.props.properties.radius}
                         projection={this.props.mapProjection}
                         name="radius"
-                        onChange={(radius, uom) => {
+                        onChange={(radius, uom) => {          
+                            this.props.setIsValidFeature()
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
@@ -267,7 +268,7 @@ class CoordinatesEditor extends React.Component {
                                 {this.renderLabelTexts(idx, {textLabels, featurePropValue})}
                             </span>
                         </div>
-                        }
+                        }                        
                         <CoordinatesRow
                             format={this.props.format}
                             aeronauticalOptions={this.props.aeronauticalOptions}
@@ -326,7 +327,8 @@ class CoordinatesEditor extends React.Component {
                                 } else if (this.props.properties.isValidFeature) {
                                     this.props.onSetInvalidSelected("coords", this.props.components.map(coordToArray));
                                 }
-                            }}/>
+                            }}
+                            setIsValidFeature={this.props.setIsValidFeature}/>
                     </>
                     )}
                 </div>
@@ -376,7 +378,7 @@ class CoordinatesEditor extends React.Component {
         }
         return components;
     }
-    change = (id, value) => {
+    change = (id, value) => {        
         let tempComps = this.props.components;
         const lat = isNaN(parseFloat(value.lat)) ? "" : parseFloat(value.lat);
         const lon = isNaN(parseFloat(value.lon)) ? "" : parseFloat(value.lon);
@@ -392,7 +394,7 @@ class CoordinatesEditor extends React.Component {
             if (this.props.isMouseEnterEnabled || this.props.type === "LineString" || this.props.type === "Polygon") {
                 this.props.onHighlightPoint(tempComps[id]);
             }
-        }
+        }            
     }
 }
 

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -49,18 +49,17 @@ const FeaturesList = (props) => {
         type === "Text" && onAddText();
         onSetStyle(style);
         onStartDrawing({geodesic});
-        setTabValue('coordinates');      
-        setIsValidFeature()  
+        setTabValue('coordinates');
+        setIsValidFeature();
     };
     const circleCenterStyles = defaultPointType === "symbol" ? defaultStyles.POINT?.[defaultPointType] : DEFAULT_ANNOTATIONS_STYLES.Point;
 
     const linePointStyles = defaultPointType === "symbol" ?  [{...defaultStyles.POINT?.[defaultPointType], highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "StartPoint Style", geometry: "startPoint", filtering: false, id: uuidv1()},
         {...defaultStyles.POINT?.[defaultPointType], highlight: true, iconAnchor: [0.5, 0.5], type: "Point", title: "EndPoint Style", geometry: "endPoint", filtering: false, id: uuidv1()}] : getStartEndPointsForLinestring();
 
-    
 
     return (
-        <>        
+        <>
             <div className={'geometries-toolbar'}>
                 <ControlLabel><Message msgId={"annotations.geometries"}/></ControlLabel>
                 <Toolbar
@@ -156,21 +155,17 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
     const {properties} = feature;
     const {glyph, label} = getGeometryGlyphInfo(type);
     const unselect = selected?.properties?.id === properties?.id;
-    
+
     const selectedIsValidFeature = get(feature, "properties.isValidFeature", true);
     const isValidFeature = selectedIsValidFeature || properties?.isValidFeature;
     const allowCardMouseEvent = !unselect && selectedIsValidFeature;
-    let inValidError = null;
-    if(!isValidFeature){           
-      
-    }        
     return (
         <div
             className={cs('geometry-card', {'ms-selected': unselect})}
             onMouseEnter={() => allowCardMouseEvent && onGeometryHighlight(properties.id)}
             onMouseLeave={() => allowCardMouseEvent && onGeometryHighlight(properties.id, false)}
-            onClick={() =>{                
-                
+            onClick={() =>{
+
                 if (unselect) {
                     onUnselectFeature();
                     onGeometryHighlight(properties.id);
@@ -178,8 +173,8 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
                     onSelectFeature([feature]);
                     setTabValue(isMeasureEditDisabled ? 'coordinates' : 'style');
                     onStyleGeometry(!isMeasureEditDisabled);
-                }                
-                setIsValidFeature()
+                }
+                setIsValidFeature();
             } }
         >
             <div className="geometry-card-preview">
@@ -193,35 +188,36 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
                     className: 'square-button-md no-border'
                 }}
                 buttons={[
-                    {                        
+                    {
                         Element: () => {
-                            if(!isValidFeature){
-                                if(feature?.properties?.isCircle){
-                                    return <OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidCircle"/></Tooltip>}>
-                                                <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />                            
-                                            </OverlayTrigger>                                    
-                                } else if(feature?.properties?.isText){
-                                    return <OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidText"/></Tooltip>}>
-                                                <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />                            
-                                            </OverlayTrigger>                                    
-                                } else if (feature?.geometry?.type === 'Polygon'){
-                                    return <OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidPolyline"/></Tooltip>}>
-                                                <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />                            
-                                            </OverlayTrigger>                                                                        
-                                } else if (feature?.geometry?.type === 'Point'){
-                                    return <OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidMarker"/></Tooltip>}>
-                                                <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />                            
-                                            </OverlayTrigger>                                                                                                            
-                                } else if (feature?.geometry?.type === 'LineString'){                                    
-                                    return <OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidPolyline"/></Tooltip>}>
-                                                <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />                            
-                                            </OverlayTrigger>                                                                                                            
+                            if (!isValidFeature) {
+                                if (feature?.properties?.isCircle) {
+                                    return (<OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidCircle"/></Tooltip>}>
+                                        <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />
+                                    </OverlayTrigger>);
+                                } else if (feature?.properties?.isText) {
+                                    return (<OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidText"/></Tooltip>}>
+                                        <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />
+                                    </OverlayTrigger>);
+                                } else if (feature?.geometry?.type === 'Polygon') {
+                                    return (<OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidPolyline"/></Tooltip>}>
+                                        <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />
+                                    </OverlayTrigger>);
+                                } else if (feature?.geometry?.type === 'Point') {
+                                    return (<OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidMarker"/></Tooltip>}>
+                                        <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />
+                                    </OverlayTrigger>);
+                                } else if (feature?.geometry?.type === 'LineString') {
+                                    return (<OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.editor.notValidPolyline"/></Tooltip>}>
+                                        <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />
+                                    </OverlayTrigger>);
                                 }
-                                
-                            }else{
-                                return <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />                                                         
-                            }                             
-                        }                                                                       
+
+                            } else {
+                                return <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")} />;
+                            }
+                            return null;
+                        }
                     },
                     {
                         glyph: 'zoom-to',
@@ -234,7 +230,7 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
                         }
                     },
                     {
-                        glyph: 'trash',                        
+                        glyph: 'trash',
                         tooltip: <Message msgId="annotations.removeGeometry"/>,
                         onClick: (event) => {
                             event.stopPropagation();

--- a/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
@@ -70,9 +70,11 @@ class GeometryEditor extends React.Component {
             onSetInvalidSelected={this.props.onSetInvalidSelected}
             onChangeText={this.props.onChangeText}
             renderer={this.props.renderer}
+            setIsValidFeature={this.props.setIsValidFeature}
             onChange={(components, radius, text, crs) => {
                 let coords = components.map(c => [c.lon, c.lat]);
                 this.props.onChange(coords, radius, text, crs);
+                this.props.setIsValidFeature()
             }}/>);
 
     }

--- a/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
@@ -30,7 +30,8 @@ class GeometryEditor extends React.Component {
         onSetInvalidSelected: PropTypes.func,
         aeronauticalOptions: PropTypes.object,
         onChangeText: PropTypes.func,
-        renderer: PropTypes.string
+        renderer: PropTypes.string,
+        setIsValidFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -49,7 +50,8 @@ class GeometryEditor extends React.Component {
             transitionName: "switch-panel-transition",
             transitionEnterTimeout: 300,
             transitionLeaveTimeout: 300
-        }
+        },
+        setIsValidFeature: () => {}
     };
 
     render() {
@@ -74,7 +76,7 @@ class GeometryEditor extends React.Component {
             onChange={(components, radius, text, crs) => {
                 let coords = components.map(c => [c.lon, c.lat]);
                 this.props.onChange(coords, radius, text, crs);
-                this.props.setIsValidFeature()
+                this.props.setIsValidFeature();
             }}/>);
 
     }

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -41,7 +41,8 @@ class CoordinatesRow extends React.Component {
         formatVisible: PropTypes.bool,
         removeEnabled: PropTypes.bool,
         renderer: PropTypes.string,
-        disabled: PropTypes.bool
+        disabled: PropTypes.bool,
+        setIsValidFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -70,20 +71,19 @@ class CoordinatesRow extends React.Component {
         }
     }
 
-    onChangeLatLon = (coord, val) => {        
-        
+    onChangeLatLon = (coord, val) => {
         this.setState({...this.state, [coord]: parseFloat(val)}, ()=>{
             const changeLat = parseFloat(this.state.lat) !== parseFloat(this.props.component.lat);
-            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);            
+            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);
             this.setState({...this.state, disabledApplyChange: !(changeLat || changeLon)}, ()=> {
-                this.props.setIsValidFeature()
+                this.props.setIsValidFeature();
                 // Auto save on coordinate change for annotations
                 this.props.renderer === "annotations" &&  this.props.onSubmit(this.props.idx, this.state);
             });
         });
     };
 
-    onSubmit = () => {        
+    onSubmit = () => {
         this.props.onSubmit(this.props.idx, this.state);
     };
 

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -70,18 +70,20 @@ class CoordinatesRow extends React.Component {
         }
     }
 
-    onChangeLatLon = (coord, val) => {
+    onChangeLatLon = (coord, val) => {        
+        
         this.setState({...this.state, [coord]: parseFloat(val)}, ()=>{
             const changeLat = parseFloat(this.state.lat) !== parseFloat(this.props.component.lat);
-            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);
+            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);            
             this.setState({...this.state, disabledApplyChange: !(changeLat || changeLon)}, ()=> {
+                this.props.setIsValidFeature()
                 // Auto save on coordinate change for annotations
                 this.props.renderer === "annotations" &&  this.props.onSubmit(this.props.idx, this.state);
             });
         });
     };
 
-    onSubmit = () => {
+    onSubmit = () => {        
         this.props.onSubmit(this.props.idx, this.state);
     };
 

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -74,7 +74,8 @@ import {
     hideMeasureWarning,
     initPlugin,
     geometryHighlight,
-    unSelectFeature
+    unSelectFeature,
+    setIsValidFeature
 } from '../actions/annotations';
 
 import annotationsEpics from '../epics/annotations';
@@ -131,7 +132,8 @@ const commonEditorActions = {
     onHideMeasureWarning: hideMeasureWarning,
     onToggleShowAgain: toggleShowAgain,
     onInitPlugin: initPlugin,
-    onUnSelectFeature: unSelectFeature
+    onUnSelectFeature: unSelectFeature,
+    setIsValidFeature: setIsValidFeature
 };
 const AnnotationsEditor = connect(annotationsInfoSelector,
     {

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -61,7 +61,8 @@ import {
     TOGGLE_SHOW_AGAIN,
     INIT_PLUGIN,
     UNSELECT_FEATURE,
-    START_DRAWING
+    START_DRAWING,
+    SET_IS_VALID_FEATURE
 } from '../actions/annotations';
 
 import {
@@ -72,7 +73,8 @@ import {
     validateFeature,
     getComponents,
     updateAllStyles,
-    getBaseCoord
+    getBaseCoord,
+    getGeometryError
 } from '../utils/AnnotationsUtils';
 
 import { set } from '../utils/ImmutableUtils';
@@ -196,7 +198,9 @@ function annotations(state = {validationErrors: {}}, action) {
         });
     }
     case FEATURES_SELECTED: {
-        let newState = state;
+        let newState = state;  
+        
+      
         let selected = head(action.features) || null;
         if (!selected) {
             return state;
@@ -211,12 +215,18 @@ function annotations(state = {validationErrors: {}}, action) {
         }
 
         let ftChangedIndex = findIndex(state.editing.features, (f) => f.properties.id === selected.properties.id);
-        let selectedGeoJSON = selected;
-        if (selected && selected.properties && selected.properties.isCircle) {
-            selectedGeoJSON = set("geometry", selected.properties.polygonGeom, selectedGeoJSON);
+        let selectedGeoJSON = selected;        
+        if (selected && selected.properties && selected.properties.isCircle) {            
+            if(selected.properties.polygonGeom){
+                selectedGeoJSON = set("geometry", selected.properties.polygonGeom, selectedGeoJSON);
+            } else {
+                selectedGeoJSON = set("geometry.coordinates",[], selectedGeoJSON);
+                selectedGeoJSON = set("geometry.type",'Polygon', selectedGeoJSON);
+            }
+                        
         } else if (selected && selected.properties && selected.properties.isText) {
             selectedGeoJSON = set("geometry.type", "Point", selectedGeoJSON);
-        }
+        }        
         newState = set(`editing.features`, state.editing.features.map(f => {
             return set("properties.canEdit", false, f);
         }), state);
@@ -230,6 +240,8 @@ function annotations(state = {validationErrors: {}}, action) {
             newState = set(`editing.features[${ftChangedIndex}]`, selectedGeoJSON, newState);
             selected = set("style", newState.editing.features[ftChangedIndex].style, selected);
         }
+
+        
         return assign({}, newState, {
             selected,
             coordinateEditorEnabled: !!selected,
@@ -323,7 +335,8 @@ function annotations(state = {validationErrors: {}}, action) {
         }
         return assign({}, newState, {
             selected,
-            unsavedChanges: true
+            unsavedChanges: true,
+            circleCoordinates: action.components[0]
         });
     }
     case CHANGE_TEXT: {
@@ -621,12 +634,12 @@ function annotations(state = {validationErrors: {}}, action) {
             canEdit: true
         };
         if (type === "Text") {
-            properties = set("isText", true, properties);
+            properties = set("isText", true, properties);            
         }
         if (type === "Circle") {
             properties = set("isCircle", true, properties);
-            properties = set("isDrawing", true, properties);
-        }
+            properties = set("isDrawing", true, properties);            
+        }        
         let selected = {type: "Feature", geometry: {type, coordinates: getBaseCoord(type)}, properties,
             style: {...(state.config?.defaultPointType === 'symbol' ? state.defaultStyles?.POINT?.symbol : state.defaultStyles?.POINT.marker), id: uuid.v1()}};
 
@@ -636,7 +649,7 @@ function annotations(state = {validationErrors: {}}, action) {
         // Reset highlight properties of other features except the selected feature
         const editingFeatures = state.editing.features.filter(({properties: prop})=> prop?.id !== selected?.properties?.id)?.map((ft = {})=>{ ft.style = ft?.style?.map(s=> {s.highlight = false; return s;}) || []; return ft;});
         let newState = set(`editing.tempFeatures`, editingFeatures, state);
-
+       
         return assign({}, state, {
             drawing: !newState.drawing,
             featureType: type,
@@ -743,6 +756,23 @@ function annotations(state = {validationErrors: {}}, action) {
     }
     case START_DRAWING:
         return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
+    case SET_IS_VALID_FEATURE:
+                       
+        let updatedFeatures = state.editing.features        
+        updatedFeatures.map((f) => { 
+            
+            const isFeatureValid = validateFeature({
+                properties: f.properties,
+                components: getComponents(f.geometry),
+                type: f.geometry.type
+            })                           
+            f.properties.isValidFeature = isFeatureValid                    
+                         
+        })
+     
+        return assign({}, state, {
+            editing: {...state.editing, features:updatedFeatures },          
+        });
     default:
         return state;
 

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -73,8 +73,7 @@ import {
     validateFeature,
     getComponents,
     updateAllStyles,
-    getBaseCoord,
-    getGeometryError
+    getBaseCoord
 } from '../utils/AnnotationsUtils';
 
 import { set } from '../utils/ImmutableUtils';
@@ -198,9 +197,9 @@ function annotations(state = {validationErrors: {}}, action) {
         });
     }
     case FEATURES_SELECTED: {
-        let newState = state;  
-        
-      
+        let newState = state;
+
+
         let selected = head(action.features) || null;
         if (!selected) {
             return state;
@@ -215,18 +214,18 @@ function annotations(state = {validationErrors: {}}, action) {
         }
 
         let ftChangedIndex = findIndex(state.editing.features, (f) => f.properties.id === selected.properties.id);
-        let selectedGeoJSON = selected;        
-        if (selected && selected.properties && selected.properties.isCircle) {            
-            if(selected.properties.polygonGeom){
+        let selectedGeoJSON = selected;
+        if (selected && selected.properties && selected.properties.isCircle) {
+            if (selected.properties.polygonGeom ) {
                 selectedGeoJSON = set("geometry", selected.properties.polygonGeom, selectedGeoJSON);
             } else {
-                selectedGeoJSON = set("geometry.coordinates",[], selectedGeoJSON);
-                selectedGeoJSON = set("geometry.type",'Polygon', selectedGeoJSON);
+                selectedGeoJSON = set("geometry.coordinates", [], selectedGeoJSON);
+                selectedGeoJSON = set("geometry.type", 'Polygon', selectedGeoJSON);
             }
-                        
+
         } else if (selected && selected.properties && selected.properties.isText) {
             selectedGeoJSON = set("geometry.type", "Point", selectedGeoJSON);
-        }        
+        }
         newState = set(`editing.features`, state.editing.features.map(f => {
             return set("properties.canEdit", false, f);
         }), state);
@@ -241,7 +240,7 @@ function annotations(state = {validationErrors: {}}, action) {
             selected = set("style", newState.editing.features[ftChangedIndex].style, selected);
         }
 
-        
+
         return assign({}, newState, {
             selected,
             coordinateEditorEnabled: !!selected,
@@ -634,12 +633,12 @@ function annotations(state = {validationErrors: {}}, action) {
             canEdit: true
         };
         if (type === "Text") {
-            properties = set("isText", true, properties);            
+            properties = set("isText", true, properties);
         }
         if (type === "Circle") {
             properties = set("isCircle", true, properties);
-            properties = set("isDrawing", true, properties);            
-        }        
+            properties = set("isDrawing", true, properties);
+        }
         let selected = {type: "Feature", geometry: {type, coordinates: getBaseCoord(type)}, properties,
             style: {...(state.config?.defaultPointType === 'symbol' ? state.defaultStyles?.POINT?.symbol : state.defaultStyles?.POINT.marker), id: uuid.v1()}};
 
@@ -649,7 +648,7 @@ function annotations(state = {validationErrors: {}}, action) {
         // Reset highlight properties of other features except the selected feature
         const editingFeatures = state.editing.features.filter(({properties: prop})=> prop?.id !== selected?.properties?.id)?.map((ft = {})=>{ ft.style = ft?.style?.map(s=> {s.highlight = false; return s;}) || []; return ft;});
         let newState = set(`editing.tempFeatures`, editingFeatures, state);
-       
+
         return assign({}, state, {
             drawing: !newState.drawing,
             featureType: type,
@@ -757,21 +756,21 @@ function annotations(state = {validationErrors: {}}, action) {
     case START_DRAWING:
         return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
     case SET_IS_VALID_FEATURE:
-                       
-        let updatedFeatures = state.editing.features        
-        updatedFeatures.map((f) => { 
-            
+
+        let updatedFeatures = state.editing.features;
+        updatedFeatures.map((f) => {
+
             const isFeatureValid = validateFeature({
                 properties: f.properties,
                 components: getComponents(f.geometry),
                 type: f.geometry.type
-            })                           
-            f.properties.isValidFeature = isFeatureValid                    
-                         
-        })
-     
+            });
+            f.properties.isValidFeature = isFeatureValid;
+
+        });
+
         return assign({}, state, {
-            editing: {...state.editing, features:updatedFeatures },          
+            editing: {...state.editing, features: updatedFeatures }
         });
     default:
         return state;

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1191,8 +1191,9 @@
                 "notValidPolyline": "Alle Koordinaten müssen gültig sein (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Fügen Sie einen Textwert und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Geben Sie einen Radius und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Neu"
-            }
+                "newFeature": "Neu"                
+            },
+            "geometryError": "La configración de geometría no es válida."
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "All coordinate must be valid (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insert a text value and a valid coordinate (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Insert a radius value and a valid coordinate (+|- 90° lat, +|-180° lon)",
-                "newFeature": "New"
-            }
+                "newFeature": "New"                
+            },
+            "geometryError": "Geometry Configration is Inavlid."
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "Todas las coordenadas deben ser válidas (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insertar un valor de texto y una coordenada válida (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Ingrese un radio y una coordenada válida (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nuevo"
-            }
+                "newFeature": "Nuevo"                
+            },
+            "geometryError": "La configuración de geometría no es válida."
         },
         "user":{
             "login": "Iniciar sesión",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "Toutes les coordonnées doivent être valides (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insérer une valeur de texte et une coordonnée valide (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Entrez un rayon et une coordonnée valide (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nouveau"
-            }
+                "newFeature": "Nouveau"        
+            },
+            "geometryError": "La configuration de la géométrie n'est pas valide."
         },
         "user": {
             "login": "Connexion",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "Tutte le coordinate devono essere valide (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Inserisci un testo ed una coordinata valida (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Inserisci un raggio ed una coordinata valida (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nuovo"
-            }
+                "newFeature": "Nuovo"                
+            },
+            "geometryError": "La configurazione della geometria non è valida."
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1172,7 +1172,7 @@
                 "notValidPolyline": "Alle coördinaten moeten geldig zijn (+ | - 90 ° lat, + | -180 ° lon)",
                 "notValidText": "Voeg een tekstwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
                 "notValidCircle": "Voeg een straalwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
-                "newFeature": "Nieuw"
+                "newFeature": "Nieuw"                
             }
         },
         "user":{

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1153,7 +1153,7 @@
                 "notValidPolyline": "All koordinat måste vara giltig ( +|- 90 ° lat, +| -180 ° lon)",
                 "notValidText": "Infoga ett textvärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
                 "notValidCircle": "Infoga ett radievärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
-                "newFeature": "Ny"
+                "newFeature": "Ny"                
             }
         },
         "user":{

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright 2018, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -562,8 +562,8 @@ export const validateCoord = (c) => !isNaN(parseFloat(c));
 export const coordToArray = (c = {}) => [c.lon, c.lat];
 export const validateCoordinates = ({components = [], remove = false, type } = {}) => {
     if (components && components.length) {
-        const validComponents = components.filter(AnnotationsUtils.validateCoords);
-
+        const validComponents = components.filter(AnnotationsUtils.validateCoords);        
+        
         if (remove) {
             return validComponents.length > AnnotationsUtils.COMPONENTS_VALIDATION[type].min && validComponents.length === components.length;
         }
@@ -622,8 +622,11 @@ export const isAMissingSymbol = (style) => {
  * @return {boolean} true if it is a valid polygon, false otherwise
 */
 export const isCompletePolygon = (coords = [[[]]]) => {
-    const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
-    return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
+    if(coords && coords[0]){
+        const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
+        return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
+    }    
+    return false
 };
 /**
  * utility to check if the GeoJSON has the annotation model structure i.e. {"type": "ms2-annotations", "features": [list of FeatureCollection]}
@@ -632,6 +635,14 @@ export const isCompletePolygon = (coords = [[[]]]) => {
  * @returns {boolean} if the GeoJSON passes is a ms2-annotation or if the name property of the object passed is Annotations
  */
 export const isAnnotation = (json) => json?.type === ANNOTATION_TYPE || json?.name === "Annotations";
+/**
+ * utitily to get the error based on the type of the geomatery
+ */
+export const getGeometryError = (type = null) => {
+    if(type){
+        return AnnotationsUtils.COMPONENTS_VALIDATION[type].notValid        
+    }
+}
 
 AnnotationsUtils = {
     ANNOTATION_TYPE,

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -1,4 +1,4 @@
-    /*
+/*
  * Copyright 2018, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -562,8 +562,7 @@ export const validateCoord = (c) => !isNaN(parseFloat(c));
 export const coordToArray = (c = {}) => [c.lon, c.lat];
 export const validateCoordinates = ({components = [], remove = false, type } = {}) => {
     if (components && components.length) {
-        const validComponents = components.filter(AnnotationsUtils.validateCoords);        
-        
+        const validComponents = components.filter(AnnotationsUtils.validateCoords);
         if (remove) {
             return validComponents.length > AnnotationsUtils.COMPONENTS_VALIDATION[type].min && validComponents.length === components.length;
         }
@@ -622,11 +621,11 @@ export const isAMissingSymbol = (style) => {
  * @return {boolean} true if it is a valid polygon, false otherwise
 */
 export const isCompletePolygon = (coords = [[[]]]) => {
-    if(coords && coords[0]){
+    if (coords && coords[0]) {
         const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
         return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
-    }    
-    return false
+    }
+    return false;
 };
 /**
  * utility to check if the GeoJSON has the annotation model structure i.e. {"type": "ms2-annotations", "features": [list of FeatureCollection]}
@@ -635,14 +634,6 @@ export const isCompletePolygon = (coords = [[[]]]) => {
  * @returns {boolean} if the GeoJSON passes is a ms2-annotation or if the name property of the object passed is Annotations
  */
 export const isAnnotation = (json) => json?.type === ANNOTATION_TYPE || json?.name === "Annotations";
-/**
- * utitily to get the error based on the type of the geomatery
- */
-export const getGeometryError = (type = null) => {
-    if(type){
-        return AnnotationsUtils.COMPONENTS_VALIDATION[type].notValid        
-    }
-}
 
 AnnotationsUtils = {
     ANNOTATION_TYPE,

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -583,7 +583,7 @@ export function isSimpleGeomType(geomType) {
 }
 export function getSimpleGeomType(geomType = "Point") {
     switch (geomType) {
-    case "Point": case "LineString": case "Polygon": case "Circle": return geomType;
+    case "Point": case "LineString": case "Polygon": case "Circle": return "Circle";
     case "MultiPoint": case "Marker": return "Point";
     case "MultiLineString": return "LineString";
     case "MultiPolygon": return "Polygon";


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR applies following changes:

- For any geometry selection from annotation plugin, if we keep empty value then it will not crash.
- Annotation plugin will not crash when circle geometry has empty value
- Error toot tip added for the errors/validation cases.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7395
crash on saving the annotations
on re-opening the circle geometry applications gets crashed

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
will not crash on saving the annotations
application will not crash on re-opening the circle geometry

error message added
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
