### PR TITLE
#7470 use max length url from localConfig setting

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -63,6 +63,11 @@ This is the main structure:
   "unsavedMapChangesDialog": false,
   // optional flag to set default coordinate format (decimal, aeronautical)
   "defaultCoordinateFormat": "aeronautical",
+  // optionals misc settings
+  "miscSettings": {
+      // Use POST requests for each WMS length URL highter than this value.
+      "maxURLLength": 5000
+  },
   // optional state initializer (it will override the one defined in appConfig.js)
   "initialState": {
       // default initial state for every mode (will override initialState imposed by plugins reducers)

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -16,6 +16,7 @@ import assign from 'object-assign';
 import axios from '../../../../libs/ajax';
 import CoordinatesUtils from '../../../../utils/CoordinatesUtils';
 import {needProxy, getProxyUrl} from '../../../../utils/ProxyUtils';
+import { getConfigProp } from '../../../../utils/ConfigUtils';
 
 import {optionsToVendorParams} from '../../../../utils/VendorParamsUtils';
 import {addAuthenticationToSLD, addAuthenticationParameter} from '../../../../utils/SecurityUtils';
@@ -43,7 +44,7 @@ const loadFunction = (options) => function(image, src) {
     // fixes #3916, see https://gis.stackexchange.com/questions/175057/openlayers-3-wms-styling-using-sld-body-and-post-request
     var img = image.getImage();
 
-    if (typeof window.btoa === 'function' && src.length >= (options.maxLengthUrl || Infinity)) {
+    if (typeof window.btoa === 'function' && src.length >= (options.maxLengthUrl || getConfigProp('layerSettings')?.maxURLLength || Infinity)) {
         // GET ALL THE PARAMETERS OUT OF THE SOURCE URL**
         const [url, ...dataEntries] = src.split("&");
 

--- a/web/client/components/map/openlayers/plugins/WMSLayer.js
+++ b/web/client/components/map/openlayers/plugins/WMSLayer.js
@@ -44,7 +44,7 @@ const loadFunction = (options) => function(image, src) {
     // fixes #3916, see https://gis.stackexchange.com/questions/175057/openlayers-3-wms-styling-using-sld-body-and-post-request
     var img = image.getImage();
 
-    if (typeof window.btoa === 'function' && src.length >= (options.maxLengthUrl || getConfigProp('layerSettings')?.maxURLLength || Infinity)) {
+    if (typeof window.btoa === 'function' && src.length >= (options.maxLengthUrl || getConfigProp('miscSettings')?.maxURLLength || Infinity)) {
         // GET ALL THE PARAMETERS OUT OF THE SOURCE URL**
         const [url, ...dataEntries] = src.split("&");
 


### PR DESCRIPTION
Link https://github.com/georchestra/mapstore2-georchestra/issues/412

## Description

This PR insert a `maxURLLength` localConfig param to use POST GetMap request instead of Get request when a layer length URL is Too Large (e.g a filter with a complexe polygon geom).

Example of part of `localConfig.json` file : 
```
  "geoStoreUrl": "rest/geostore/",
  "layerSettings": {
    "maxURLLength": 5000
  },
```

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [X] Docs have been added / updated (for bug fixes / features) ==> **No doc part to change to specify this param...**


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
issue #7470 

**What is the new behavior?**
Use WMS (GetMap) POST request instead of GET request if the URL length limit defined in the localConfig file has been reached.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No
