### PR TITLE
#7171 Allow jumping from one wizard steps to another in editing

### DIFF
--- a/web/client/components/contextcreator/ContextCreator.jsx
+++ b/web/client/components/contextcreator/ContextCreator.jsx
@@ -154,7 +154,8 @@ export default class ContextCreator extends React.Component {
         selectedTheme: PropTypes.string,
         basicVariables: PropTypes.object,
         customVariablesEnabled: PropTypes.bool,
-        onToggleCustomVariables: PropTypes.func
+        onToggleCustomVariables: PropTypes.func,
+        enableClickOnStep: PropTypes.bool
     };
 
     static contextTypes = {
@@ -264,6 +265,7 @@ export default class ContextCreator extends React.Component {
 
         return (
             <Stepper
+                enableClickOnStep={this.props.enableClickOnStep}
                 loading={this.props.loading && this.props.loadFlags.contextSaving}
                 currentStepId={this.props.curStepId}
                 onSetStep={this.props.onSetStep}

--- a/web/client/components/misc/Stepper.jsx
+++ b/web/client/components/misc/Stepper.jsx
@@ -81,7 +81,7 @@ export default ({
                                     }}/>
                             </div>}
                             <div key={'label' + step.id}
-                                style={{ padding: 8, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+                                style={{ padding: 8, display: 'flex', alignItems: 'center', cursor: enableClickOnStep  ? 'pointer' : 'default' }}
                                 onClick={() => enableClickOnStep && onSetStep(step.id)}
                                 role="button" tabIndex="0"
                                 onKeyDown={(event) => (event.key === ' ' || event.key === 'Enter' || event.key === 'Spacebar') && enableClickOnStep && onSetStep(step.id)}>

--- a/web/client/components/misc/Stepper.jsx
+++ b/web/client/components/misc/Stepper.jsx
@@ -24,7 +24,8 @@ export default ({
     onShowBackToPageConfirmation = () => { },
     showBackToPageConfirmation = false,
     backToPageConfirmationMessage = 'contextCreator.undo',
-    onConfirmBackToPage = () => { }
+    onConfirmBackToPage = () => { },
+    enableClickOnStep = false
 }) => {
     const curStepIndex = steps.findIndex(step => step.id === currentStepId);
 
@@ -79,7 +80,11 @@ export default ({
                                         width: '100%'
                                     }}/>
                             </div>}
-                            <div key={'label' + step.id} style={{ padding: 8, display: 'flex', alignItems: 'center' }}>
+                            <div key={'label' + step.id}
+                                style={{ padding: 8, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+                                onClick={() => enableClickOnStep && onSetStep(step.id)}
+                                role="button" tabIndex="0"
+                                onKeyDown={(event) => (event.key === ' ' || event.key === 'Enter' || event.key === 'Spacebar') && enableClickOnStep && onSetStep(step.id)}>
                                 <Label
                                     bsStyle={idx === curStepIndex ? 'success' : 'primary'}
                                     style={idx <= curStepIndex ? {} : { backgroundColor: '#aaa'}}>

--- a/web/client/components/misc/__tests__/Stepper-test.jsx
+++ b/web/client/components/misc/__tests__/Stepper-test.jsx
@@ -38,7 +38,7 @@ describe('Stepper component', () => {
         expect(footerStepBar.childElementCount).toBe(1);
     });
 
-    it('Stepper clickable on edit', () => {
+    it('Stepper clickable on edit', (done) => {
         const container = document.getElementById("container");
         const enableClickOnStep = true;
         const steps = [{
@@ -59,6 +59,8 @@ describe('Stepper component', () => {
                     currentStep = steps[i];
                 }
             }
+            expect(currentStep.id).toBe('test2');
+            done();
         };
         ReactDOM.render(<Stepper steps={steps} currentStepId={currentStep.id} enableClickOnStep={enableClickOnStep} onSetStep={onSetStep} />, container);
         const footerStepBar = container.getElementsByClassName('footer-step-bar')[0];
@@ -66,8 +68,6 @@ describe('Stepper component', () => {
         const stepButton = footerStepBar.children[2];
 
         TestUtils.Simulate.click(stepButton);
-
-        expect(currentStep.id).toBe('test2');
     });
 });
 

--- a/web/client/components/misc/__tests__/Stepper-test.jsx
+++ b/web/client/components/misc/__tests__/Stepper-test.jsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import expect from 'expect';
+import * as TestUtils from 'react-dom/test-utils';
 import Stepper from '../Stepper';
 
 describe('Stepper component', () => {
@@ -35,6 +36,38 @@ describe('Stepper component', () => {
         const footerStepBar = container.getElementsByClassName('footer-step-bar')[0];
         expect(footerStepBar).toExist();
         expect(footerStepBar.childElementCount).toBe(1);
+    });
+
+    it('Stepper clickable on edit', () => {
+        const container = document.getElementById("container");
+        const enableClickOnStep = true;
+        const steps = [{
+            id: 'test',
+            label: 'test',
+            component: <div className="test-component"></div>
+        },
+        {
+            id: 'test2',
+            label: 'test2',
+            component: <div className="test-component"></div>
+        }
+        ];
+        let currentStep = steps[0];
+        const onSetStep = (stepId) => {
+            for (let i = 0; i < steps.length; i++) {
+                if (steps[i].id === stepId) {
+                    currentStep = steps[i];
+                }
+            }
+        };
+        ReactDOM.render(<Stepper steps={steps} currentStepId={currentStep.id} enableClickOnStep={enableClickOnStep} onSetStep={onSetStep} />, container);
+        const footerStepBar = container.getElementsByClassName('footer-step-bar')[0];
+
+        const stepButton = footerStepBar.children[2];
+
+        TestUtils.Simulate.click(stepButton);
+
+        expect(currentStep.id).toBe('test2');
     });
 });
 

--- a/web/client/plugins/ContextCreator.jsx
+++ b/web/client/plugins/ContextCreator.jsx
@@ -16,7 +16,7 @@ import {newContextSelector, resourceSelector, creationStepSelector, reloadConfir
     validationStatusSelector, cfgErrorSelector, templatesSelector, parsedTemplateSelector, fileDropStatusSelector, editedTemplateSelector,
     availablePluginsFilterTextSelector, availableTemplatesFilterTextSelector, enabledPluginsFilterTextSelector,
     enabledTemplatesFilterTextSelector, showBackToPageConfirmationSelector, tutorialStepSelector, selectedThemeSelector,
-    customVariablesEnabledSelector} from '../selectors/contextcreator';
+    customVariablesEnabledSelector, isNewContext} from '../selectors/contextcreator';
 import {mapTypeSelector} from '../selectors/maptype';
 import {tutorialSelector} from '../selectors/tutorial';
 import {init, setCreationStep, changeAttribute, saveNewContext, saveTemplate, mapViewerReload, showMapViewerReloadConfirm, showDialog, setFilterText,
@@ -63,7 +63,8 @@ export const contextCreatorSelector = createStructuredSelector({
     pluginsConfig: () => ConfigUtils.getConfigProp('plugins'),
     showBackToPageConfirmation: showBackToPageConfirmationSelector,
     selectedTheme: selectedThemeSelector,
-    customVariablesEnabled: customVariablesEnabledSelector
+    customVariablesEnabled: customVariablesEnabledSelector,
+    enableClickOnStep: state => !isNewContext(state)
 });
 
 /**

--- a/web/client/reducers/__tests__/contextcreator-test.js
+++ b/web/client/reducers/__tests__/contextcreator-test.js
@@ -51,7 +51,8 @@ import {
     setTemplates,
     changeTemplatesKey,
     setSelectedTheme,
-    onToggleCustomVariables
+    onToggleCustomVariables,
+    loadContext
 } from '../../actions/contextcreator';
 const themeDark = {
     id: 'dark',
@@ -580,5 +581,10 @@ describe('contextcreator reducer', () => {
         const state = contextcreator(undefined, onToggleCustomVariables(themeDark));
         expect(state).toExist();
         expect(customVariablesEnabledSelector({contextcreator: state})).toEqual(true);
+    });
+    it('loadContext', () => {
+        const state = contextcreator(undefined, loadContext('testId'));
+        expect(state).toExist();
+        expect(state.contextId).toBe('testId');
     });
 });

--- a/web/client/reducers/contextcreator.js
+++ b/web/client/reducers/contextcreator.js
@@ -15,7 +15,7 @@ import {INIT, SET_CREATION_STEP, SET_WAS_TUTORIAL_SHOWN, SET_TUTORIAL_STEP, MAP_
     CHANGE_PLUGINS_KEY, CHANGE_TEMPLATES_KEY, CHANGE_ATTRIBUTE, LOADING, SHOW_DIALOG, SET_EDITED_CFG, UPDATE_EDITED_CFG,
     SET_VALIDATION_STATUS, SET_PARSED_CFG, SET_CFG_ERROR, ENABLE_UPLOAD_PLUGIN, UPLOADING_PLUGIN, UPLOAD_PLUGIN_ERROR, ADD_PLUGIN_TO_UPLOAD,
     REMOVE_PLUGIN_TO_UPLOAD, PLUGIN_UPLOADED, UNINSTALLING_PLUGIN, UNINSTALL_PLUGIN_ERROR, PLUGIN_UNINSTALLED,
-    BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES} from "../actions/contextcreator";
+    BACK_TO_PAGE_SHOW_CONFIRMATION, SET_SELECTED_THEME, ON_TOGGLE_CUSTOM_VARIABLES, LOAD_CONTEXT} from "../actions/contextcreator";
 import {set} from '../utils/ImmutableUtils';
 
 
@@ -272,6 +272,12 @@ export default (state = {}, action) => {
     }
     case CLEAR_CONTEXT_CREATOR: {
         return {};
+    }
+    case LOAD_CONTEXT: {
+        return {
+            ...state,
+            contextId: action.id
+        };
     }
     case SET_FILTER_TEXT: {
         return set(`filterText.${action.propName}`, action.text, state);

--- a/web/client/selectors/__tests__/contextcreator-test.js
+++ b/web/client/selectors/__tests__/contextcreator-test.js
@@ -11,7 +11,8 @@ import {
     newContextSelector,
     creationStepSelector,
     selectedThemeSelector,
-    customVariablesEnabledSelector
+    customVariablesEnabledSelector,
+    isNewContext
 } from '../contextcreator';
 
 const testState = {
@@ -20,7 +21,8 @@ const testState = {
             name: 'name'
         },
         stepId: 'step',
-        customVariablesEnabled: true
+        customVariablesEnabled: true,
+        contextId: 'new'
     }
 };
 
@@ -51,5 +53,8 @@ describe('contextcreator selectors', () => {
                 selectedTheme: themeDark
             }
         })).toEqual(themeDark);
+    });
+    it('isNewContext', () => {
+        expect(isNewContext(testState)).toBe(true);
     });
 });

--- a/web/client/selectors/contextcreator.js
+++ b/web/client/selectors/contextcreator.js
@@ -42,3 +42,4 @@ export const wasTutorialShownSelector = stepId => state => state.contextcreator?
 export const tutorialStepSelector = state => state.contextcreator?.tutorialStep;
 export const selectedThemeSelector = state => get(state, 'contextcreator.selectedTheme');
 export const customVariablesEnabledSelector = state => get(state, 'contextcreator.customVariablesEnabled', false);
+export const isNewContext = state => state.contextcreator?.contextId === 'new';


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
A new feature to allow jumping through wizard steps when editing a context

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7171

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When editing a context wizard steps are now clickable, to allow jumping directly to the desired step

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
