### PR TITLE
#7428 Some typos in the User Session reset

### DIFF
--- a/web/client/epics/__tests__/usersession-test.js
+++ b/web/client/epics/__tests__/usersession-test.js
@@ -6,9 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { testEpic } from './epicTestUtils';
-import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator } from "../usersession";
+import { saveUserSessionEpicCreator, autoSaveSessionEpicCreator, loadUserSessionEpicCreator, removeUserSessionEpicCreator } from "../usersession";
 import { saveUserSession, loadUserSession,
-    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED, userSessionStartSaving, userSessionStopSaving } from "../../actions/usersession";
+    USER_SESSION_SAVED, USER_SESSION_LOADING, SAVE_USER_SESSION, USER_SESSION_LOADED, USER_SESSION_REMOVED, userSessionStartSaving, userSessionStopSaving, removeUserSession
+} from "../../actions/usersession";
+import { CLOSE_FEATURE_GRID } from '../../actions/featuregrid';
+import { TEXT_SEARCH_RESET } from '../../actions/search';
 import expect from "expect";
 import {Providers} from  "../../api/usersession";
 import {Observable} from "rxjs";
@@ -42,7 +45,7 @@ describe('usersession Epics', () => {
         Providers.test = {
             getSession: () => Observable.of(["1", {}]),
             writeSession: (id) => Observable.of(id),
-            removeSession: () => () => Observable.empty()
+            removeSession: (id) => Observable.of(id)
         };
     });
     afterEach(() =>  {
@@ -114,6 +117,22 @@ describe('usersession Epics', () => {
             expect(actions[1].type).toBe(USER_SESSION_LOADED);
             expect(actions[1].id).toBe("1");
             expect(actions[1].session).toExist();
+        }, initialState, done);
+    });
+
+    it('user session is removed', (done) => {
+        testEpic(removeUserSessionEpicCreator(idSelector), 6, removeUserSession(), (actions) => {
+            expect(actions[0].type).toBe(USER_SESSION_LOADING);
+            expect(actions[1].type).toBe(USER_SESSION_REMOVED);
+            expect(actions[1].id).toBeFalsy();
+            expect(actions[1].session).toBeFalsy();
+        }, initialState, done);
+    });
+
+    it('CLOSE_FEATURE_GRID and TEXT_SEARCH_RESET actions are triggered', (done) => {
+        testEpic(removeUserSessionEpicCreator(idSelector), 6, removeUserSession(), (actions) => {
+            expect(actions[2].type).toBe(CLOSE_FEATURE_GRID);
+            expect(actions[3].type).toBe(TEXT_SEARCH_RESET);
         }, initialState, done);
     });
 

--- a/web/client/epics/usersession.js
+++ b/web/client/epics/usersession.js
@@ -11,7 +11,10 @@ import { error, success } from '../actions/notifications';
 import { SAVE_USER_SESSION, LOAD_USER_SESSION, REMOVE_USER_SESSION, USER_SESSION_REMOVED,
     USER_SESSION_START_SAVING, USER_SESSION_STOP_SAVING,
     userSessionSaved, userSessionLoaded, loading, saveUserSession, userSessionRemoved,
-    userSessionStartSaving, userSessionStopSaving } from "../actions/usersession";
+    userSessionStartSaving, userSessionStopSaving
+} from "../actions/usersession";
+import { closeFeatureGrid } from '../actions/featuregrid';
+import { resetSearch } from '../actions/search';
 import { LOCATION_CHANGE } from "connected-react-router";
 import UserSession from "../api/usersession";
 import {loadMapConfig} from "../actions/config";
@@ -126,12 +129,16 @@ export const loadUserSessionEpicCreator = (nameSelector = userSessionNameSelecto
  *
  * const idSelector = (state) => ({state.usersession.id})
  * const epic = removeUserSessionEpicCreator(idSelector)
+ *
+ * In order to clean up all plugins state as and where expected,
+ * closeFeatureGrid and resetSearch actions are included in the stream
  */
 export const removeUserSessionEpicCreator = (idSelector = userSessionIdSelector) => (action$, store) =>
     action$.ofType(REMOVE_USER_SESSION).switchMap(() => {
         const state = store.getState();
         const sessionId = idSelector(state);
-        return removeSession(sessionId).switchMap(() => Rx.Observable.of(userSessionRemoved(), success({
+
+        return removeSession(sessionId).switchMap(() => Rx.Observable.of(userSessionRemoved(), closeFeatureGrid(), resetSearch(), success({
             title: "success",
             message: "userSession.successRemoved"
         }))).let(wrapStartStop(


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
User session reset triggers a cleanup in plugin states where needed (Attributes table and search tool)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7428 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Attribute table is closed and search tool is cleared when user session is reset

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
