### PR TITLE
#7432 Empty feature grid when switching between layers

### DIFF
--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -329,37 +329,37 @@ describe('wfsquery Epics', () => {
             description: 'layer2 description',
             type: 'wms'
         }];
-        const mockState = {
-            query: {
-                data: {},
-                featureTypes: [],
-                typeName: 'layer1',
-                url: '/dummy'},
-            featuregrid: {
-                timeSync: true,
-                pagination: {
-                    size: 10
-                },
-                open: true,
-                selectedLayer: "layer1",
-                changes: [],
-                mode: 'VIEW'
-            },
-            layers: {
-                flat: flatLayers,
-                layerMetadata: {
-                    expanded: false,
-                    maskLoading: false
-                },
-                settings: {
-                    expanded: false,
-                    node: null,
-                    nodeType: null,
-                    options: {}
-                }
-            }
-        };
         it('vector layer', (done) => {
+            const mockState = {
+                query: {
+                    data: {},
+                    featureTypes: [],
+                    typeName: 'layer1',
+                    url: '/dummy'},
+                featuregrid: {
+                    timeSync: true,
+                    pagination: {
+                        size: 10
+                    },
+                    open: true,
+                    selectedLayer: "layer1",
+                    changes: [],
+                    mode: 'VIEW'
+                },
+                layers: {
+                    flat: flatLayers,
+                    layerMetadata: {
+                        expanded: false,
+                        maskLoading: false
+                    },
+                    settings: {
+                        expanded: false,
+                        node: null,
+                        nodeType: null,
+                        options: {}
+                    }
+                }
+            };
             mockAxios.onPost().reply(() => {return [200, expectedResult];});
             testEpic(addTimeoutEpic(wfsQueryEpic, 500), 4, [
                 query("base/web/client/test-resources/vector/feature-collection-vector.json", {pagination: {} }),
@@ -389,16 +389,43 @@ describe('wfsquery Epics', () => {
         });
 
         it('featureTypeSelectedEpic', (done) => {
-            mockState.layers.flat = wmsLayer;
+            const mockState = {
+                query: {
+                    data: {},
+                    featureTypes: [],
+                    typeName: 'layer1',
+                    url: '/dummy'},
+                featuregrid: {
+                    timeSync: true,
+                    pagination: {
+                        size: 10
+                    },
+                    open: true,
+                    selectedLayer: "layer1",
+                    changes: [],
+                    mode: 'VIEW'
+                },
+                layers: {
+                    flat: wmsLayer,
+                    layerMetadata: {
+                        expanded: false,
+                        maskLoading: false
+                    },
+                    settings: {
+                        expanded: false,
+                        node: null,
+                        nodeType: null,
+                        options: {}
+                    }
+                }
+            };
             const wfsResults = require('../../test-resources/wfs/describe-pois.json');
             mockAxios.onGet().reply(() => [200, wfsResults]);
             testEpic(featureTypeSelectedEpic, 2,
                 featureTypeSelected('/dummy', 'poi'), ([changeSpatialAttribute, featureTypeLoaded]) => {
                     try {
                         expect(featureTypeLoaded.type).toBe(FEATURE_TYPE_LOADED);
-
                         expect(changeSpatialAttribute.type).toBe(CHANGE_SPATIAL_ATTRIBUTE);
-
                         expect(featureTypeLoaded.featureType.attributes).toEqual([{
                             label: "NAME",
                             attribute: "NAME",

--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -322,7 +322,14 @@ describe('wfsquery Epics', () => {
             type: 'vector',
             features: expectedResult
         }];
-        const mockStore = {
+        const wmsLayer = [{
+            id: 'layer2',
+            name: 'poi',
+            title: 'layer2 title',
+            description: 'layer2 description',
+            type: 'wms'
+        }];
+        const mockState = {
             query: {
                 data: {},
                 featureTypes: [],
@@ -377,51 +384,46 @@ describe('wfsquery Epics', () => {
                 });
                 done();
             },
-            mockStore
+            mockState
             );
         });
 
         it('featureTypeSelectedEpic', (done) => {
+            mockState.layers.flat = wmsLayer;
             const wfsResults = require('../../test-resources/wfs/describe-pois.json');
             mockAxios.onGet().reply(() => [200, wfsResults]);
-            testEpic(featureTypeSelectedEpic, 1, [
-                featureTypeSelected('/dummy', 'poi')
-            ], async(actions) => {
-                try {
-                    actions.map((action) => {
-                        switch (action.type) {
-                        case CHANGE_SPATIAL_ATTRIBUTE:
-                            break;
-                        case FEATURE_TYPE_LOADED:
-                            expect(action.featureType.attributes).toEqual([{
-                                label: "NAME",
-                                attribute: "NAME",
-                                type: "string",
-                                valueId: "id",
-                                valueLabel: "name",
-                                values: []
-                            },
-                            {
-                                label: "THUMBNAIL",
-                                attribute: "THUMBNAIL",
-                                type: "string",
-                                valueId: "id",
-                                valueLabel: "name",
-                                values: []
-                            },
-                            {
-                                label: "MAINPAGE", attribute: "MAINPAGE", type: "string", valueId: "id", valueLabel: "name", values: []
-                            }]);
-                            break;
-                        default:
-                            expect(true).toBe(true);
-                        }
-                    });
-                } catch (error) {
-                    done(error);
-                }
-                done();
-            }, mockStore);
+            testEpic(featureTypeSelectedEpic, 2,
+                featureTypeSelected('/dummy', 'poi'), ([changeSpatialAttribute, featureTypeLoaded]) => {
+                    try {
+                        expect(featureTypeLoaded.type).toBe(FEATURE_TYPE_LOADED);
+
+                        expect(changeSpatialAttribute.type).toBe(CHANGE_SPATIAL_ATTRIBUTE);
+
+                        expect(featureTypeLoaded.featureType.attributes).toEqual([{
+                            label: "NAME",
+                            attribute: "NAME",
+                            type: "string",
+                            valueId: "id",
+                            valueLabel: "name",
+                            values: []
+                        },
+                        {
+                            label: "THUMBNAIL",
+                            attribute: "THUMBNAIL",
+                            type: "string",
+                            valueId: "id",
+                            valueLabel: "name",
+                            values: []
+                        },
+                        {
+                            label: "MAINPAGE", attribute: "MAINPAGE", type: "string", valueId: "id", valueLabel: "name", values: []
+                        }]);
+
+                    } catch (error) {
+                        done(error);
+                    }
+                    done();
+                }, mockState);
         });
     });
 });

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -261,10 +261,7 @@ const createInitialQueryFlow = (action$, store, {url, name, id} = {}) => {
         filterType: 'OGC',
         ogcVersion: '1.1.0'
     });
-    // This optimization causes a bug when the current feature type is different from the previous
-    // if (isDescribeLoaded(store.getState(), name)) {
-    //     return Rx.Observable.of(createInitialQuery(), featureTypeSelected(url, name));
-    // }
+
     return Rx.Observable.of(featureTypeSelected(url, name)).merge(
         action$.ofType(FEATURE_TYPE_LOADED).filter(({typeName} = {}) => typeName === name)
             .map(createInitialQuery)

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -140,7 +140,6 @@ import { error, warning } from '../actions/notifications';
 
 import {
     describeSelector,
-    isDescribeLoaded,
     getFeatureById,
     wfsURL,
     wfsFilter,
@@ -262,10 +261,10 @@ const createInitialQueryFlow = (action$, store, {url, name, id} = {}) => {
         filterType: 'OGC',
         ogcVersion: '1.1.0'
     });
-
-    if (isDescribeLoaded(store.getState(), name)) {
-        return Rx.Observable.of(createInitialQuery(), featureTypeSelected(url, name));
-    }
+    // This optimization causes a bug when the current feature type is different from the previous
+    // if (isDescribeLoaded(store.getState(), name)) {
+    //     return Rx.Observable.of(createInitialQuery(), featureTypeSelected(url, name));
+    // }
     return Rx.Observable.of(featureTypeSelected(url, name)).merge(
         action$.ofType(FEATURE_TYPE_LOADED).filter(({typeName} = {}) => typeName === name)
             .map(createInitialQuery)

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -100,7 +100,7 @@ export const featureTypeSelectedEpic = (action$, store) =>
             if (isDescribeLoaded(state, action.typeName)) {
                 const info = extractInfo(layerDescribeSelector(state, action.typeName));
                 const geometry = info.geometry[0] && info.geometry[0].attribute ? info.geometry[0].attribute : 'the_geom';
-                return Rx.Observable.of(changeSpatialAttribute(geometry));
+                return Rx.Observable.of(featureTypeLoaded(action.typeName, info), changeSpatialAttribute(geometry), Rx.Scheduler.async);
             }
 
             const selectedLayer = selectedLayerSelector(state);

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -100,7 +100,7 @@ export const featureTypeSelectedEpic = (action$, store) =>
             if (isDescribeLoaded(state, action.typeName)) {
                 const info = extractInfo(layerDescribeSelector(state, action.typeName));
                 const geometry = info.geometry[0] && info.geometry[0].attribute ? info.geometry[0].attribute : 'the_geom';
-                return Rx.Observable.of(featureTypeLoaded(action.typeName, info), changeSpatialAttribute(geometry), Rx.Scheduler.async);
+                return Rx.Observable.of(featureTypeLoaded(action.typeName, info), changeSpatialAttribute(geometry), Rx.Scheduler.async); // async scheduler is needed to allow invokers of `FEATURE_TYPE_SELECTED` to intercept `FEATURE_TYPE_LOADED` action as response.
             }
 
             const selectedLayer = selectedLayerSelector(state);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The feature grid queries each new layer selected correctly and displays results.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7432 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The feature grid lists records of the layer selected when querying layer after layer after layer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
The bug was caused by how optimization was executed when `isDescribeLoaded` returns true in 'createInitialQueryFlow' and  'featureTypeSelectedEpic' epics.