### PR TITLE
Map infobox styling issue fixes. Resolves #7083

### DIFF
--- a/web/client/components/details/DetailsPanel.jsx
+++ b/web/client/components/details/DetailsPanel.jsx
@@ -9,24 +9,19 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import Message from '../I18N/Message';
-import { Glyphicon, Panel } from 'react-bootstrap';
-import Dock from 'react-dock';
+import { Panel } from 'react-bootstrap';
 import BorderLayout from '../layout/BorderLayout';
-import ResizeDetector from 'react-resize-detector';
+import DockPanel from "../misc/panels/DockPanel";
 
 class DetailsPanel extends React.Component {
     static propTypes = {
         id: PropTypes.string,
         active: PropTypes.bool,
-        closeGlyph: PropTypes.string,
         panelStyle: PropTypes.object,
         panelClassName: PropTypes.string,
         style: PropTypes.object,
-        onClose: PropTypes.func,
-        dockProps: PropTypes.object,
-        width: PropTypes.number,
-        dockStyle: PropTypes.object
-    }
+        onClose: PropTypes.func
+    };
 
     static contextTypes = {
         messages: PropTypes.object
@@ -36,53 +31,34 @@ class DetailsPanel extends React.Component {
         id: "mapstore-details",
         panelStyle: {
             zIndex: 100,
-            overflow: "hidden",
-            height: "100%",
-            marginBottom: 0
+            marginBottom: 0,
+            minHeight: '100%'
         },
-        onClose: () => {},
+        style: {},
+        onClose: () => {
+        },
         active: false,
-        panelClassName: "details-panel",
-        width: 658,
-        closeGlyph: "1-close",
-        dockProps: {
-            dimMode: "none",
-            size: 0.30,
-            fluid: true,
-            position: "right",
-            zIndex: 1030,
-            bottom: 0
-        },
-        dockStyle: {}
-    }
+        panelClassName: "details-panel"
+    };
 
     render() {
-        const panelHeader = (
-            <span>
-                <Glyphicon glyph="sheet"/>
-                <span className="details-panel-title">
-                    <Message msgId="details.title"/>
-                </span>
-                <button onClick={() => this.props.onClose()} className="details-close close">
-                    {this.props.closeGlyph ?
-                        <Glyphicon glyph={this.props.closeGlyph} /> :
-                        <span>×</span>}</button>
-            </span>);
-
         return (
-            <ResizeDetector handleWidth>
-                { ({ width }) =>
-                    <div className="react-dock-no-resize">
-                        <Dock dockStyle={this.props.dockStyle} {...this.props.dockProps} isVisible={this.props.active} fluid size={this.props.width / width > 1 ? 1 : this.props.width / width}>
-                            <Panel id={this.props.id} header={panelHeader} style={this.props.panelStyle} className={this.props.panelClassName}>
-                                <BorderLayout>
-                                    {this.props.children}
-                                </BorderLayout>
-                            </Panel>
-                        </Dock>
-                    </div>
-                }
-            </ResizeDetector>
+            <DockPanel
+                open={this.props.active}
+                size={660}
+                position="right"
+                bsStyle="primary"
+                title={<Message msgId="details.title"/>}
+                onClose={() => this.props.onClose()}
+                glyph="sheet"
+                style={{height: 'calc(100% - 30px)'}}
+            >
+                <Panel id={this.props.id} style={this.props.panelStyle} className={this.props.panelClassName}>
+                    <BorderLayout>
+                        {this.props.children}
+                    </BorderLayout>
+                </Panel>
+            </DockPanel>
         );
     }
 }

--- a/web/client/components/details/DetailsPanel.jsx
+++ b/web/client/components/details/DetailsPanel.jsx
@@ -18,6 +18,7 @@ class DetailsPanel extends React.Component {
         id: PropTypes.string,
         active: PropTypes.bool,
         panelStyle: PropTypes.object,
+        dockStyle: PropTypes.object,
         panelClassName: PropTypes.string,
         style: PropTypes.object,
         onClose: PropTypes.func
@@ -51,7 +52,7 @@ class DetailsPanel extends React.Component {
                 title={<Message msgId="details.title"/>}
                 onClose={() => this.props.onClose()}
                 glyph="sheet"
-                style={{height: 'calc(100% - 30px)'}}
+                style={this.props.dockStyle}
             >
                 <Panel id={this.props.id} style={this.props.panelStyle} className={this.props.panelClassName}>
                     <BorderLayout>

--- a/web/client/themes/default/less/details.less
+++ b/web/client/themes/default/less/details.less
@@ -45,7 +45,11 @@
 // see https://github.com/geosolutions-it/MapStore2/issues/6728
 .ms-details-preview {
     p{
-        margin: 1em;
+        margin: 1rem;
+    }
+    img, h1, h2, h3, h4, h5, h6, blockquote {
+        margin-left: 1rem;
+        margin-right: 1rem;
     }
     p, h1, h2, h3, h4, h5, h6, blockquote{
         &:empty::after {

--- a/web/client/themes/default/less/details.less
+++ b/web/client/themes/default/less/details.less
@@ -59,6 +59,24 @@
     }
 }
 
+// Make wysiwyg editor of map details use same margin rule for floating images
+// so that user actually see that margin between floating image and text.
+.ms-details-draftjs-editor {
+    .ms-text-editor-main {
+        padding-left: 1rem;
+        padding-right: 1rem;
+
+        .rdw-image-alignment {
+            &.rdw-image-left {
+                margin-right: 1rem;
+            }
+            &.rdw-image-right {
+                margin-left: 1rem;
+            }
+        }
+    }
+}
+
 /////////////////////
 // LIBRARIES FIX
 /////////////////////

--- a/web/client/themes/default/less/maps-properties.less
+++ b/web/client/themes/default/less/maps-properties.less
@@ -131,7 +131,7 @@
             .col-xs-6;
             padding: 0;
             float: left;
-            
+
             font-weight: normal;
         }
         .dropzone {
@@ -163,11 +163,8 @@
         .ms-details-preview-container {
             overflow-y: auto;
             flex: 1;
-            overflow-y: auto;
             .ms-details-preview {
-                width: ~"calc(100% - 30px)";
                 margin: 5px 15px;
-                padding: 10px;
                 height: auto;
                 min-height: 500px;
                 .shadow;
@@ -179,7 +176,6 @@
                 }
                 p {
                     word-wrap: break-word;
-                    width: 100%;
                 }
             }
         }


### PR DESCRIPTION
## Description
Improve styling of the map information modal/sidebar panel.
Adds proper margins to the images so that text wont stick to them from the right side.
Changes left/right margins of the elements to use rem units instead of em to make margins equal for headers and regular text.
Replaces map details sidebar dock with the component that is already in use for catalog and few other plugins.
Updates editor styles to make sure that WYSIWYG editor correctly display margin between floating image and text.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [x] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
#7083 

**What is the new behavior?**
Proper margins for text heading, images and other elements in the content.
Shared code-base for the map details information container (DockPanel component)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No


## Other useful information
![image](https://user-images.githubusercontent.com/4226620/140314967-12bd4c2e-69e4-4de2-8eb1-3b202a2a9e18.png)
![image](https://user-images.githubusercontent.com/4226620/140315038-69a81cb5-9fa3-4d50-aeb2-bd67c8738d42.png)
![image](https://user-images.githubusercontent.com/4226620/140315169-f793defd-123e-462f-9a8c-5b386677528b.png)
