### PR TITLE
[Backport 2021.02.xx] #7432: Empty feature grid when switching between layers (#7495)

### DIFF
--- a/web/client/epics/__tests__/wfsquery-test.js
+++ b/web/client/epics/__tests__/wfsquery-test.js
@@ -12,11 +12,11 @@ import axios from '../../libs/ajax';
 import MockAdapter from 'axios-mock-adapter';
 import { parse } from 'url';
 import { head } from 'lodash';
-import { UPDATE_GEOMETRY } from '../../actions/queryform';
+import { UPDATE_GEOMETRY, CHANGE_SPATIAL_ATTRIBUTE } from '../../actions/queryform';
 import { changeMapView } from '../../actions/map';
 import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from './epicTestUtils';
-import { QUERY_RESULT, FEATURE_LOADING, query, updateQuery, featureTypeSelected } from '../../actions/wfsquery';
-import { viewportSelectedEpic, wfsQueryEpic } from '../wfsquery';
+import { QUERY_RESULT, FEATURE_LOADING, query, updateQuery, featureTypeSelected, FEATURE_TYPE_LOADED } from '../../actions/wfsquery';
+import { viewportSelectedEpic, wfsQueryEpic, featureTypeSelectedEpic } from '../wfsquery';
 import { LAYER_LOAD } from '../../actions/layers';
 
 
@@ -298,7 +298,7 @@ describe('wfsquery Epics', () => {
         });
     });
 
-    describe('featureTypeSelectedEpic', ()=>  {
+    describe('featureTypeSelectedEpic', () => {
         const expectedResult = require('../../test-resources/vector/feature-collection-vector.json');
         const flatLayers = [{
             id: 'layer1',
@@ -308,7 +308,44 @@ describe('wfsquery Epics', () => {
             type: 'vector',
             features: expectedResult
         }];
+        const wmsLayer = [{
+            id: 'layer2',
+            name: 'poi',
+            title: 'layer2 title',
+            description: 'layer2 description',
+            type: 'wms'
+        }];
         it('vector layer', (done) => {
+            const mockState = {
+                query: {
+                    data: {},
+                    featureTypes: [],
+                    typeName: 'layer1',
+                    url: '/dummy'},
+                featuregrid: {
+                    timeSync: true,
+                    pagination: {
+                        size: 10
+                    },
+                    open: true,
+                    selectedLayer: "layer1",
+                    changes: [],
+                    mode: 'VIEW'
+                },
+                layers: {
+                    flat: flatLayers,
+                    layerMetadata: {
+                        expanded: false,
+                        maskLoading: false
+                    },
+                    settings: {
+                        expanded: false,
+                        node: null,
+                        nodeType: null,
+                        options: {}
+                    }
+                }
+            };
             mockAxios.onPost().reply(() => {return [200, expectedResult];});
             testEpic(addTimeoutEpic(wfsQueryEpic, 500), 4, [
                 query("base/web/client/test-resources/vector/feature-collection-vector.json", {pagination: {} }),
@@ -333,13 +370,17 @@ describe('wfsquery Epics', () => {
                 });
                 done();
             },
-            {
+            mockState
+            );
+        });
+
+        it('featureTypeSelectedEpic', (done) => {
+            const mockState = {
                 query: {
                     data: {},
                     featureTypes: [],
                     typeName: 'layer1',
-                    url: '/dummy'
-                },
+                    url: '/dummy'},
                 featuregrid: {
                     timeSync: true,
                     pagination: {
@@ -351,7 +392,7 @@ describe('wfsquery Epics', () => {
                     mode: 'VIEW'
                 },
                 layers: {
-                    flat: flatLayers,
+                    flat: wmsLayer,
                     layerMetadata: {
                         expanded: false,
                         maskLoading: false
@@ -364,7 +405,39 @@ describe('wfsquery Epics', () => {
                         options: {}
                     }
                 }
-            });
+            };
+            const wfsResults = require('../../test-resources/wfs/describe-pois.json');
+            mockAxios.onGet().reply(() => [200, wfsResults]);
+            testEpic(featureTypeSelectedEpic, 2,
+                featureTypeSelected('/dummy', 'poi'), ([changeSpatialAttribute, featureTypeLoaded]) => {
+                    try {
+                        expect(featureTypeLoaded.type).toBe(FEATURE_TYPE_LOADED);
+                        expect(changeSpatialAttribute.type).toBe(CHANGE_SPATIAL_ATTRIBUTE);
+                        expect(featureTypeLoaded.featureType.attributes).toEqual([{
+                            label: "NAME",
+                            attribute: "NAME",
+                            type: "string",
+                            valueId: "id",
+                            valueLabel: "name",
+                            values: []
+                        },
+                        {
+                            label: "THUMBNAIL",
+                            attribute: "THUMBNAIL",
+                            type: "string",
+                            valueId: "id",
+                            valueLabel: "name",
+                            values: []
+                        },
+                        {
+                            label: "MAINPAGE", attribute: "MAINPAGE", type: "string", valueId: "id", valueLabel: "name", values: []
+                        }]);
+
+                    } catch (error) {
+                        done(error);
+                    }
+                    done();
+                }, mockState);
         });
     });
 });

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -140,7 +140,6 @@ import { error, warning } from '../actions/notifications';
 
 import {
     describeSelector,
-    isDescribeLoaded,
     getFeatureById,
     wfsURL,
     wfsFilter,
@@ -263,9 +262,6 @@ const createInitialQueryFlow = (action$, store, {url, name, id} = {}) => {
         ogcVersion: '1.1.0'
     });
 
-    if (isDescribeLoaded(store.getState(), name)) {
-        return Rx.Observable.of(createInitialQuery(), featureTypeSelected(url, name));
-    }
     return Rx.Observable.of(featureTypeSelected(url, name)).merge(
         action$.ofType(FEATURE_TYPE_LOADED).filter(({typeName} = {}) => typeName === name)
             .map(createInitialQuery)

--- a/web/client/epics/wfsquery.js
+++ b/web/client/epics/wfsquery.js
@@ -101,7 +101,7 @@ export const featureTypeSelectedEpic = (action$, store) =>
             if (isDescribeLoaded(state, action.typeName)) {
                 const info = extractInfo(layerDescribeSelector(state, action.typeName));
                 const geometry = info.geometry[0] && info.geometry[0].attribute ? info.geometry[0].attribute : 'the_geom';
-                return Rx.Observable.of(changeSpatialAttribute(geometry));
+                return Rx.Observable.of(featureTypeLoaded(action.typeName, info), changeSpatialAttribute(geometry), Rx.Scheduler.async); // async scheduler is needed to allow invokers of `FEATURE_TYPE_SELECTED` to intercept `FEATURE_TYPE_LOADED` action as response.
             }
 
             const selectedLayer = selectedLayerSelector(state);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
The feature grid queries each new layer selected correctly and displays results.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7432 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The feature grid lists records of the layer selected when querying layer after layer after layer

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
