### PR TITLE
[Backport 2021.02.xx] #7261 [Style Editor] Some attributes are not visible inside the attribute select box (#7365)

### DIFF
--- a/web/client/components/styleeditor/hint/geocss.js
+++ b/web/client/components/styleeditor/hint/geocss.js
@@ -12,12 +12,13 @@ const parseLocalPart = {
     'double': 'number',
     'long': 'number',
     'decimal': 'number',
+    'integer': 'number',
     'int': 'number'
 };
 
-const getType = ({localPart, prefix}) => {
+const getType = ({localType, prefix}) => {
     return prefix === 'gml' && 'geometry'
-    || parseLocalPart[localPart] || localPart || '';
+    || parseLocalPart[localType] || localType || '';
 };
 
 export default function(CodeMirror) {
@@ -103,5 +104,3 @@ export default function(CodeMirror) {
         return null;
     });
 }
-
-

--- a/web/client/plugins/styleeditor/StyleCodeEditor.jsx
+++ b/web/client/plugins/styleeditor/StyleCodeEditor.jsx
@@ -58,16 +58,19 @@ const styleUpdateTypes = {
 };
 
 function getAttributes(hintProperties, geometryType) {
+    const stringTypeToCheck = [ 'string'];
+    const numberTypeToCheck = ['integer', 'long', 'double', 'float', 'bigdecimal', 'decimal', 'number', 'int'];
+
     return hintProperties && geometryType !== 'raster' && Object.keys(hintProperties)
-        .filter((key) => ['integer', 'long', 'double', 'float', 'bigdecimal', 'string', 'decimal']
-            .indexOf(hintProperties[key].localPart.toLowerCase()) !== -1)
+        .filter((key) => [...stringTypeToCheck, ...numberTypeToCheck]
+            .indexOf(hintProperties[key].localType.toLowerCase()) !== -1)
         .map((key) => {
-            const { localPart } = hintProperties[key];
+            const { localType } = hintProperties[key];
             return {
                 attribute: key,
                 label: key,
-                type: ['integer', 'long', 'double', 'float', 'bigdecimal', 'decimal']
-                    .indexOf(localPart.toLowerCase()) !== -1
+                type: numberTypeToCheck
+                    .indexOf(localType.toLowerCase()) !== -1
                     ? 'number'
                     : 'string'
             };

--- a/web/client/selectors/__tests__/styleeditor-test.js
+++ b/web/client/selectors/__tests__/styleeditor-test.js
@@ -185,59 +185,121 @@ describe('Test styleeditor selector', () => {
     it('test geometryTypeSelector', () => {
         const state = {
             layers: {
-                flat: [
+                "flat": [
                     {
-                        id: 'layerId',
-                        name: 'layerName',
-                        style: 'point',
-                        describeLayer: {
-                            owsType: 'WFS'
+                        "type": "wms",
+                        "style": "pophade",
+                        "format": "image/png",
+                        "url": "https://gs-stable.geo-solutions.it/geoserver/wms",
+                        "visibility": true,
+                        "dimensions": [],
+                        "name": "gs:us_states",
+                        "title": "States of US",
+                        "description": "States of US",
+                        "bbox": {
+                            "crs": "EPSG:4326",
+                            "bounds": {
+                                "minx": "-124.73142200000001",
+                                "miny": "24.955967",
+                                "maxx": "-66.969849",
+                                "maxy": "49.371735"
+                            }
                         },
-                        describeFeatureType: {
-                            complexType: [{
-                                complexContent: {
-                                    extension: {
-                                        sequence: {
-                                            element: [{
-                                                TYPE_NAME: "XSD_1_0.LocalElement",
-                                                maxOccurs: "1",
-                                                minOccurs: 0,
-                                                name: "geom",
-                                                nillable: true,
-                                                otherAttributes: {},
-                                                type: {
-                                                    key: "{http://www.opengis.net/gml}PointPropertyType",
-                                                    localPart: "PointPropertyType",
-                                                    namespaceURI: "http://www.opengis.net/gml",
-                                                    prefix: "gml",
-                                                    string: "{http://www.opengis.net/gml}gml:PointPropertyType"
-                                                }
-                                            }]
-                                        }
-                                    }
+                        "links": [],
+                        "params": {},
+                        "allowedSRS": {
+                            "EPSG:3857": true,
+                            "EPSG:900913": true,
+                            "EPSG:4326": true
+                        },
+                        "catalogURL": null,
+                        "version": "1.3.0",
+                        "infoFormats": [
+                            "text/plain",
+                            "text/html",
+                            "application/json"
+                        ],
+                        "id": "gs:us_states__5",
+                        "loading": false,
+                        "search": {
+                            "url": "https://gs-stable.geo-solutions.it/geoserver/wfs",
+                            "type": "wfs"
+                        },
+                        "previousLoadingError": false,
+                        "loadingError": false,
+                        "opacity": 1,
+                        "describeLayer": {
+                            "TYPE_NAME": "WMS_1_1_1.LayerDescription",
+                            "name": "gs:us_states",
+                            "wfs": "https://gs-stable.geo-solutions.it/geoserver/wfs?authkey=609779ca-0790-4ca3-8c75-f1cc957bb822&",
+                            "owsURL": "https://gs-stable.geo-solutions.it/geoserver/wfs?authkey=609779ca-0790-4ca3-8c75-f1cc957bb822&",
+                            "owsType": "WFS",
+                            "query": [
+                                {
+                                    "TYPE_NAME": "WMS_1_1_1.Query",
+                                    "typeName": "gs:us_states"
                                 }
-                            }]
+                            ],
+                            "geometryType": "MultiPolygon"
+                        },
+                        "describeFeatureType": {
+                            "elementFormDefault": "qualified",
+                            "targetNamespace": "https://gs-stable.geo-solutions.it/geoserver/geoserver",
+                            "targetPrefix": "gs",
+                            "featureTypes": [
+                                {
+                                    "typeName": "us_states",
+                                    "properties": [
+                                        {
+                                            "name": "the_geom",
+                                            "maxOccurs": 1,
+                                            "minOccurs": 0,
+                                            "nillable": true,
+                                            "type": "gml:MultiPolygon",
+                                            "localType": "MultiPolygon"
+                                        },
+                                        {
+                                            "name": "STATE_NAME",
+                                            "maxOccurs": 1,
+                                            "minOccurs": 0,
+                                            "nillable": true,
+                                            "type": "xsd:string",
+                                            "localType": "string"
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     }
                 ],
-                selected: [
-                    'layerId'
-                ],
-                settings: {
-                    expanded: true,
-                    node: 'layerId',
-                    nodeType: 'layers',
-                    options: {
-                        opacity: 1,
-                        style: 'generic'
+                "groups": [
+                    {
+                        "id": "Default",
+                        "title": "Default",
+                        "name": "Default",
+                        "nodes": [
+                            "gs:us_states__5"
+                        ],
+                        "expanded": true
                     }
-                }
+                ],
+                "selected": [
+                    "gs:us_states__5"
+                ],
+                "layerMetadata": {
+                    "expanded": false,
+                    "metadataRecord": {},
+                    "maskLoading": false
+                },
+                "editLayerName": false,
+                "layerNameIsBeingChecked": false,
+                "layerNameChangeError": false
             }
         };
         const retval = geometryTypeSelector(state);
 
         expect(retval).toExist();
-        expect(retval).toBe('point');
+        expect(retval).toBe('polygon');
     });
 
     it('test layerPropertiesSelector', () => {
@@ -251,32 +313,35 @@ describe('Test styleeditor selector', () => {
                         describeLayer: {
                             owsType: 'WFS'
                         },
-                        describeFeatureType: {
-                            complexType: [{
-                                complexContent: {
-                                    extension: {
-                                        sequence: {
-                                            element: [{
-                                                TYPE_NAME: "XSD_1_0.LocalElement",
-                                                maxOccurs: "1",
-                                                minOccurs: 0,
-                                                name: "RANK",
-                                                nillable: true,
-                                                otherAttributes: {},
-                                                type: {
-                                                    key: "{http://www.w3.org/2001/XMLSchema}short",
-                                                    localPart: "short",
-                                                    namespaceURI: "http://www.w3.org/2001/XMLSchema",
-                                                    prefix: "xsd",
-                                                    string: "{http://www.w3.org/2001/XMLSchema}xsd:short"
-                                                }
-                                            }]
+                        "describeFeatureType": {
+                            "elementFormDefault": "qualified",
+                            "targetPrefix": "gs",
+                            "featureTypes": [
+                                {
+                                    "typeName": "us_states",
+                                    "properties": [
+                                        {
+                                            "name": "the_geom",
+                                            "maxOccurs": 1,
+                                            "minOccurs": 0,
+                                            "nillable": true,
+                                            "type": "gml:MultiPolygon",
+                                            "localType": "MultiPolygon"
+                                        },
+                                        {
+                                            "name": "STATE_NAME",
+                                            "maxOccurs": 1,
+                                            "minOccurs": 0,
+                                            "nillable": true,
+                                            "type": "xsd:string",
+                                            "localType": "string"
                                         }
-                                    }
+                                    ]
                                 }
-                            }]
+                            ]
                         }
                     }
+
                 ],
                 selected: [
                     'layerId'
@@ -295,7 +360,7 @@ describe('Test styleeditor selector', () => {
         const retval = layerPropertiesSelector(state);
 
         expect(retval).toExist();
-        expect(retval).toEqual({ RANK: { localPart: 'short', prefix: 'xsd' } });
+        expect(retval).toEqual({ the_geom: { localType: 'MultiPolygon', prefix: 'gml' }, STATE_NAME: { localType: 'string', prefix: 'xsd' } });
     });
     it('test enabledStyleEditorSelector', () => {
         const state = {

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -40,13 +40,14 @@ const EDITOR_MODES = {
 };
 
 const getGeometryType = (geomProperty = {}) => {
-    const localPart = geomProperty.type && geomProperty.type.localPart && geomProperty.type.localPart.toLowerCase() || '';
-    if (localPart.indexOf('polygon') !== -1
-        || localPart.indexOf('surface') !== -1) {
+    const localType = geomProperty.localType && geomProperty.localType.toLowerCase() || '';
+    if (localType.indexOf('polygon') !== -1
+        || localType.indexOf('surface') !== -1
+    ) {
         return 'polygon';
-    } else if (localPart.indexOf('linestring') !== -1) {
+    } else if (localType.indexOf('linestring') !== -1) {
         return 'linestring';
-    } else if (localPart.indexOf('point') !== -1) {
+    } else if (localType.indexOf('point') !== -1) {
         return 'point';
     }
     return 'vector';
@@ -75,17 +76,19 @@ export const generateStyleId = ({title = ''}) => `${title.toLowerCase().replace(
  */
 export const extractFeatureProperties = ({describeLayer = {}, describeFeatureType = {}} = {}) => {
 
-    const owsType = describeLayer && describeLayer.owsType || null;
-    const descProperties = get(describeFeatureType, 'complexType[0].complexContent.extension.sequence.element') || null;
-    const geomProperty = descProperties && head(descProperties.filter(({ type }) => type && type.prefix === 'gml'));
+    const owsType = describeLayer?.owsType || null;
+    const descProperties = get(describeFeatureType, 'featureTypes[0].properties') || null;
+    const geomProperty = descProperties && head(descProperties.filter(({ type, localType }) => {
+        return type && type.includes('gml') && localType;
+    }));
     const geometryType = owsType === 'WCS' && 'raster' || geomProperty && owsType === 'WFS' && getGeometryType(geomProperty) || null;
     const properties = geometryType === 'raster'
         ? describeLayer.bands
-        : descProperties && descProperties.reduce((props, { name, type = {} }) => ({
+        : descProperties && descProperties.reduce((props, { name, type = {}, localType }) => ({
             ...props,
             [name]: {
-                localPart: type.localPart,
-                prefix: type.prefix
+                localType: localType,
+                prefix: type.replace(`:${localType}`, '')
             }
         }), {});
     return {

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -52,54 +52,35 @@ describe('StyleEditorUtils test', () => {
             describeLayer: {
                 owsType: 'WFS'
             },
-            describeFeatureType: {
-                complexType: [{
-                    complexContent: {
-                        extension: {
-                            sequence: {
-                                element: [{
-                                    TYPE_NAME: "XSD_1_0.LocalElement",
-                                    maxOccurs: "1",
-                                    minOccurs: 0,
-                                    name: "RANK",
-                                    nillable: true,
-                                    otherAttributes: {},
-                                    type: {
-                                        key: "{http://www.w3.org/2001/XMLSchema}short",
-                                        localPart: "short",
-                                        namespaceURI: "http://www.w3.org/2001/XMLSchema",
-                                        prefix: "xsd",
-                                        string: "{http://www.w3.org/2001/XMLSchema}xsd:short"
-                                    }
-                                }, {
-                                    TYPE_NAME: "XSD_1_0.LocalElement",
-                                    maxOccurs: "1",
-                                    minOccurs: 0,
-                                    name: "geom",
-                                    nillable: true,
-                                    otherAttributes: {},
-                                    type: {
-                                        key: "{http://www.opengis.net/gml}PointPropertyType",
-                                        localPart: "PointPropertyType",
-                                        namespaceURI: "http://www.opengis.net/gml",
-                                        prefix: "gml",
-                                        string: "{http://www.opengis.net/gml}gml:PointPropertyType"
-                                    }
-                                }]
+            "describeFeatureType": {
+                "elementFormDefault": "qualified",
+                "targetPrefix": "gs",
+                "featureTypes": [
+                    {
+                        "typeName": "us_states",
+                        "properties": [
+                            {
+                                "name": "the_geom",
+                                "maxOccurs": 1,
+                                "minOccurs": 0,
+                                "nillable": true,
+                                "type": "gml:MultiPolygon",
+                                "localType": "MultiPolygon"
+                            },
+                            {
+                                "name": "STATE_NAME",
+                                "maxOccurs": 1,
+                                "minOccurs": 0,
+                                "nillable": true,
+                                "type": "xsd:string",
+                                "localType": "string"
                             }
-                        }
+                        ]
                     }
-                }]
+                ]
             }
         };
-        expect(extractFeatureProperties(layer)).toEqual({
-            geometryType: 'point',
-            properties: {
-                RANK: { localPart: 'short', prefix: 'xsd' },
-                geom: { localPart: 'PointPropertyType', prefix: 'gml' }
-            },
-            owsType: 'WFS'
-        });
+        expect(extractFeatureProperties(layer)).toEqual({ geometryType: 'polygon', properties: { the_geom: { localType: 'MultiPolygon', prefix: 'gml' }, STATE_NAME: { localType: 'string', prefix: 'xsd' } }, owsType: 'WFS' });
 
     });
     it('test getEditorMode', () => {


### PR DESCRIPTION
## Description
All attributes, visible in the FeatureGrid, now are visible also inside the attribute select box, of the style editor.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 
<!-- add here the ReadTheDocs link (if needed) -->



**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7261 

**What is the new behavior?**
In the style editor, now all attributes are visible inside the attribute select box.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
