### PR TITLE
#7368: Fix column content style of webpage

### DIFF
--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -993,8 +993,12 @@
                 .ms-column-contents {
                     .ms-content {
                         padding: 0 15%;
+                        &:not(.ms-content-text) {
+                            padding-bottom: 16px;
+                            padding-top: 16px;
+                        }
                         &.ms-content-webPage {
-                            padding: 0;
+                            padding: 16px 0;
                             width: 100%;
                             height: @ms-web-page-size-height-small;
                             &.ms-size-h-large { width: @ms-story-size-large; }


### PR DESCRIPTION
## Description
This PR fixes the style of content column especially with Webpage section

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
https://github.com/geosolutions-it/MapStore2/issues/7417#issuecomment-959406873

**What is the new behavior?**
Spacing is present between the section's column contents

![2021-11-08 16_54_44-WebMapper - Microsoft Visual Studio (Administrator)](https://user-images.githubusercontent.com/26929983/140733749-94a53275-cf6e-40e3-8f3e-7cf651c40815.jpg)
 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
