### PR TITLE
#7258: WPS export error when a layer has an ilike filter attribute (#7353)

### DIFF
--- a/web/client/epics/layerdownload.js
+++ b/web/client/epics/layerdownload.js
@@ -294,7 +294,7 @@ export const startFeatureExportDownload = (action$, store) =>
                 dataFilter: action.downloadOptions.downloadFilteredDataSet ? {
                     type: 'TEXT',
                     data: {
-                        mimeType: 'text/plain; subtype=filter/1.0',
+                        mimeType: 'text/xml; subtype=filter/1.1',
                         data: mergeFiltersToOGC({
                             ogcVersion: '1.0.0',
                             addXmlnsToRoot: true,


### PR DESCRIPTION
## Description
When an attribute ILIKE filter is set on a layer, WPS export  the file.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7258

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
When an attribute ILIKE filter is set on a layer, WPS export  the file.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
