### PR TITLE
[Backport 2021.02.xx] #7454: Style editor shows not found error if the put request fails (#7471)

### DIFF
--- a/web/client/reducers/__tests__/styleeditor-test.js
+++ b/web/client/reducers/__tests__/styleeditor-test.js
@@ -128,7 +128,7 @@ describe('Test styleeditor reducer', () => {
             canEdit: false,
             error: {
                 parsingCapabilities: {
-                    status: 404,
+                    status: 400,
                     message: 'could not be unmarshalled'
                 }
             }

--- a/web/client/reducers/styleeditor.js
+++ b/web/client/reducers/styleeditor.js
@@ -113,7 +113,8 @@ function styleeditor(state = {}, action) {
             error: {
                 ...state.error,
                 [action.status || 'global']: {
-                    status: action.error && action.error.status || 404,
+                    // use 400 as default eg: CORS error
+                    status: action.error && action.error.status || 400,
                     ...errorInfo
                 }
             }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

Replace the default error status of style editor with 400.
The status error is missing when there are CORS error so we could use the 400 status identifying something not working in the client request.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7454

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The style editor will allows to continue editing in the style editor even if it get's a CORS error in the PUT request while updating the style

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
