### PR TITLE
#7459: Async state update on unmounted plugins triggers react warning (#7460)

### DIFF
--- a/web/client/map/hooks/useMapTool.js
+++ b/web/client/map/hooks/useMapTool.js
@@ -17,17 +17,28 @@ const useMapTool = (mapType, tool) => {
     const [loaded, setLoaded] = useState(false);
     const [error, setError] = useState(null);
     const impl = useRef();
+    const isMounted = useRef();
+    useEffect(() => {
+        isMounted.current = true;
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
     useEffect(() => {
         if (mapType && !impl.current) {
             setLoaded(false);
             setError(null);
             import("../" + mapType + "/" + tool)
                 .then(toolImpl => {
-                    impl.current = toolImpl.default;
-                    setLoaded(true);
+                    if (isMounted.current) {
+                        impl.current = toolImpl.default;
+                        setLoaded(true);
+                    }
                 })
                 .catch((e) => {
-                    setError(e);
+                    if (isMounted.current) {
+                        setError(e);
+                    }
                 });
         }
         return () => {};

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -280,12 +280,17 @@ class MapPlugin extends React.Component {
 
         }
         this.updatePlugins(this.props);
+        this._isMounted = true;
     }
 
     UNSAFE_componentWillReceiveProps(newProps) {
         if (newProps.mapType !== this.props.mapType || newProps.actions !== this.props.actions) {
             this.updatePlugins(newProps);
         }
+    }
+
+    componentWillUnmount() {
+        this._isMounted = false;
     }
 
     getHighlightLayer = (projection, index, env) => {
@@ -434,7 +439,7 @@ class MapPlugin extends React.Component {
         pluginsCreator(props.mapType, props.actions).then((plugins) => {
             // #6652 fix mismatch on multiple concurrent plugins loading
             // to make the last mapType match the list of plugins
-            if (plugins.mapType === this.currentMapType) {
+            if (this._isMounted && plugins.mapType === this.currentMapType) {
                 this.setState({plugins});
                 props.onLoadingMapPlugins(false, props.mapType);
                 props.onMapTypeLoaded(true, props.mapType);


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds additional checks to plugins that are loading async components: Map and Locate

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Other... Please describe: Enhancement

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7459

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

The warning `can't perform react state update on an unmounted component` is not showing up anymore

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
