### PR TITLE
#7508 Annotation plugin crash because of invalid geometry

### DIFF
--- a/web/client/actions/__tests__/annotations-test.js
+++ b/web/client/actions/__tests__/annotations-test.js
@@ -94,7 +94,8 @@ import {
     INIT_PLUGIN, initPlugin,
     TOGGLE_SHOW_AGAIN, toggleShowAgain,
     HIDE_MEASURE_WARNING, hideMeasureWarning,
-    UNSELECT_FEATURE, unSelectFeature
+    UNSELECT_FEATURE, unSelectFeature,
+    VALIDATE_FEATURE, validateFeature
 } from '../annotations';
 
 describe('Test correctness of the annotations actions', () => {
@@ -436,5 +437,9 @@ describe('Test correctness of the annotations actions', () => {
     it('unSelectFeature ', () => {
         const result = unSelectFeature();
         expect(result.type).toBe(UNSELECT_FEATURE);
+    });
+    it('validateFeature ', () => {
+        const result = validateFeature();
+        expect(result.type).toBe(VALIDATE_FEATURE);
     });
 });

--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -63,7 +63,7 @@ export const HIDE_MEASURE_WARNING = 'ANNOTATIONS:HIDE_MEASURE_WARNING';
 export const TOGGLE_SHOW_AGAIN = 'ANNOTATIONS:TOGGLE_SHOW_AGAIN';
 export const GEOMETRY_HIGHLIGHT = 'ANNOTATIONS:GEOMETRY_HIGHLIGHT';
 export const UNSELECT_FEATURE = 'ANNOTATIONS:UNSELECT_FEATURE';
-export const SET_IS_VALID_FEATURE = 'ANNOTATIONS:SET_IS_VALID_FEATURE';
+export const VALIDATE_FEATURE = 'ANNOTATIONS:VALIDATE_FEATURE';
 
 export const initPlugin = () => ({
     type: INIT_PLUGIN
@@ -423,7 +423,7 @@ export const toggleShowAgain = () => ({
     type: TOGGLE_SHOW_AGAIN
 });
 
-export const setIsValidFeature = () => ({
-    type: SET_IS_VALID_FEATURE
+export const featureValidationCheck = () => ({
+    type: VALIDATE_FEATURE
 });
 

--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -423,7 +423,7 @@ export const toggleShowAgain = () => ({
     type: TOGGLE_SHOW_AGAIN
 });
 
-export const featureValidationCheck = () => ({
+export const validateFeature = () => ({
     type: VALIDATE_FEATURE
 });
 

--- a/web/client/actions/annotations.js
+++ b/web/client/actions/annotations.js
@@ -63,6 +63,7 @@ export const HIDE_MEASURE_WARNING = 'ANNOTATIONS:HIDE_MEASURE_WARNING';
 export const TOGGLE_SHOW_AGAIN = 'ANNOTATIONS:TOGGLE_SHOW_AGAIN';
 export const GEOMETRY_HIGHLIGHT = 'ANNOTATIONS:GEOMETRY_HIGHLIGHT';
 export const UNSELECT_FEATURE = 'ANNOTATIONS:UNSELECT_FEATURE';
+export const SET_IS_VALID_FEATURE = 'ANNOTATIONS:SET_IS_VALID_FEATURE';
 
 export const initPlugin = () => ({
     type: INIT_PLUGIN
@@ -421,3 +422,8 @@ export const hideMeasureWarning = () => ({
 export const toggleShowAgain = () => ({
     type: TOGGLE_SHOW_AGAIN
 });
+
+export const setIsValidFeature = () => ({
+    type: SET_IS_VALID_FEATURE
+});
+

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -244,7 +244,7 @@ class AnnotationsEditor extends React.Component {
         onInitPlugin: PropTypes.func,
         onGeometryHighlight: PropTypes.func,
         onUnSelectFeature: PropTypes.func,
-        onFeatureValidationCheck: PropTypes.func
+        onValidateFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -351,7 +351,7 @@ class AnnotationsEditor extends React.Component {
     };
 
     renderEditingCoordButtons = () => {
-        const allGeometryIsValid = this.allGeometryIsValid();
+        const areAllFeaturesValid = this.validateFeatures();
         return (<Grid className="mapstore-annotations-info-viewer-buttons" fluid>
             <Row className="text-center noTopMargin">
                 <Col xs={12}>
@@ -361,6 +361,7 @@ class AnnotationsEditor extends React.Component {
                             {
                                 glyph: 'arrow-left',
                                 tooltipId: "annotations.back",
+                                tooltipPosition: 'bottom',
                                 visible: true,
                                 disabled: this.props?.selected?.properties
                                     && !this.props?.selected?.properties?.isValidFeature || false,
@@ -386,6 +387,7 @@ class AnnotationsEditor extends React.Component {
                             }, {
                                 glyph: 'trash',
                                 tooltipId: "annotations.remove",
+                                tooltipPosition: 'bottom',
                                 disabled: !this.props.annotations.length,
                                 visible: !this.props.selected,
                                 onClick: () => {
@@ -393,13 +395,15 @@ class AnnotationsEditor extends React.Component {
                                 }
                             }, {
                                 glyph: 'floppy-disk',
-                                tooltipId: !allGeometryIsValid ? "annotations.geometryError" : !isEmpty(this.props.selected) ? "annotations.saveGeometry" : "annotations.save",
-                                disabled: (this.props.selected && this.props.selected.properties && !this.props.selected.properties.isValidFeature) || !allGeometryIsValid,
+                                tooltipPosition: 'bottom',
+                                tooltipId: !areAllFeaturesValid ? "annotations.annotationSaveGeometryError" : !isEmpty(this.props.selected) ? "annotations.saveGeometry" : "annotations.save",
+                                disabled: (this.props.selected && this.props.selected.properties && !this.props.selected.properties.isValidFeature) || !areAllFeaturesValid,
                                 onClick: () => this.save()
                             },
                             {
                                 glyph: 'download',
                                 tooltip: <Message msgId="annotations.downloadcurrenttooltip" />,
+                                tooltipPosition: 'bottom',
                                 disabled: Object.keys(this.validate()).length !== 0 || this.props.unsavedChanges,
                                 visible: !this.props.selected,
                                 onClick: () => {
@@ -500,8 +504,8 @@ class AnnotationsEditor extends React.Component {
                     geodesic={this.props.geodesic}
                     defaultPointType={this.getConfig().defaultPointType}
                     defaultStyles={this.props.defaultStyles}
-                    onFeatureValidationCheck={this.props.onFeatureValidationCheck}
-                    allGeometryIsValid={this.allGeometryIsValid}
+                    onValidateFeature={this.props.onValidateFeature}
+                    validateFeatures={this.validateFeatures}
                 />
                 }
             </div>
@@ -734,7 +738,7 @@ class AnnotationsEditor extends React.Component {
                                 onSetInvalidSelected={this.props.onSetInvalidSelected}
                                 onChangeText={this.props.onChangeText}
                                 renderer={"annotations"}
-                                onFeatureValidationCheck={this.props.onFeatureValidationCheck}
+                                onValidateFeature={this.props.onValidateFeature}
                             />
                             }
                             {this.state.tabValue === 'style' &&
@@ -769,14 +773,12 @@ class AnnotationsEditor extends React.Component {
         );
     }
 
-    allGeometryIsValid = () => {
-        let allGeometryIsValid = true;
-        if (this.props?.editing?.features && this.props.editing?.features?.length > 0) {
-            this.props.editing.features.map((p) => {
-                if (!p?.properties?.isValidFeature) { allGeometryIsValid = false; }
-            });
+    validateFeatures = () => {
+        let areAllGeometriesValid = true;
+        if (Array.isArray(this.props?.editing?.features)) {
+            areAllGeometriesValid = this.props.editing.features.every(feature => feature?.properties?.isValidFeature);
         }
-        return allGeometryIsValid;
+        return areAllGeometriesValid;
     };
 
     change = (field, value) => {

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -244,7 +244,7 @@ class AnnotationsEditor extends React.Component {
         onInitPlugin: PropTypes.func,
         onGeometryHighlight: PropTypes.func,
         onUnSelectFeature: PropTypes.func,
-        setIsValidFeature: PropTypes.func
+        onFeatureValidationCheck: PropTypes.func
     };
 
     static defaultProps = {
@@ -500,7 +500,7 @@ class AnnotationsEditor extends React.Component {
                     geodesic={this.props.geodesic}
                     defaultPointType={this.getConfig().defaultPointType}
                     defaultStyles={this.props.defaultStyles}
-                    setIsValidFeature={this.props.setIsValidFeature}
+                    onFeatureValidationCheck={this.props.onFeatureValidationCheck}
                     allGeometryIsValid={this.allGeometryIsValid}
                 />
                 }
@@ -734,7 +734,7 @@ class AnnotationsEditor extends React.Component {
                                 onSetInvalidSelected={this.props.onSetInvalidSelected}
                                 onChangeText={this.props.onChangeText}
                                 renderer={"annotations"}
-                                setIsValidFeature={this.props.setIsValidFeature}
+                                onFeatureValidationCheck={this.props.onFeatureValidationCheck}
                             />
                             }
                             {this.state.tabValue === 'style' &&

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -243,7 +243,8 @@ class AnnotationsEditor extends React.Component {
         onToggleShowAgain: PropTypes.func,
         onInitPlugin: PropTypes.func,
         onGeometryHighlight: PropTypes.func,
-        onUnSelectFeature: PropTypes.func
+        onUnSelectFeature: PropTypes.func,
+        setIsValidFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -350,6 +351,8 @@ class AnnotationsEditor extends React.Component {
     };
 
     renderEditingCoordButtons = () => {
+
+        const allGeometryIsValid = this.allGeometryIsValid();
         return (<Grid className="mapstore-annotations-info-viewer-buttons" fluid>
             <Row className="text-center noTopMargin">
                 <Col xs={12}>
@@ -391,8 +394,8 @@ class AnnotationsEditor extends React.Component {
                                 }
                             }, {
                                 glyph: 'floppy-disk',
-                                tooltipId: !isEmpty(this.props.selected) ? "annotations.saveGeometry" : "annotations.save",
-                                disabled: this.props.selected && this.props.selected.properties && !this.props.selected.properties.isValidFeature,
+                                tooltipId: !allGeometryIsValid ? "annotations.geometryError" : !isEmpty(this.props.selected) ? "annotations.saveGeometry" : "annotations.save",
+                                disabled: (this.props.selected && this.props.selected.properties && !this.props.selected.properties.isValidFeature) || !allGeometryIsValid,
                                 onClick: () => this.save()
                             },
                             {
@@ -498,6 +501,8 @@ class AnnotationsEditor extends React.Component {
                     geodesic={this.props.geodesic}
                     defaultPointType={this.getConfig().defaultPointType}
                     defaultStyles={this.props.defaultStyles}
+                    setIsValidFeature={this.props.setIsValidFeature}
+                    allGeometryIsValid={this.allGeometryIsValid}
                 />
                 }
             </div>
@@ -730,6 +735,7 @@ class AnnotationsEditor extends React.Component {
                                 onSetInvalidSelected={this.props.onSetInvalidSelected}
                                 onChangeText={this.props.onChangeText}
                                 renderer={"annotations"}
+                                setIsValidFeature={this.props.setIsValidFeature}
                             />
                             }
                             {this.state.tabValue === 'style' &&
@@ -763,6 +769,16 @@ class AnnotationsEditor extends React.Component {
             </div>
         );
     }
+
+    allGeometryIsValid = () => {
+        let allGeometryIsValid = true;
+        if (this.props?.editing?.features && this.props.editing?.features?.length > 0) {
+            this.props.editing.features.map((p) => {
+                if (!p?.properties?.isValidFeature) { allGeometryIsValid = false; }
+            });
+        }
+        return allGeometryIsValid;
+    };
 
     change = (field, value) => {
         this.props.onChangeProperties(field, value);

--- a/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/AnnotationsEditor.jsx
@@ -351,7 +351,6 @@ class AnnotationsEditor extends React.Component {
     };
 
     renderEditingCoordButtons = () => {
-
         const allGeometryIsValid = this.allGeometryIsValid();
         return (<Grid className="mapstore-annotations-info-viewer-buttons" fluid>
             <Row className="text-center noTopMargin">

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -80,7 +80,8 @@ class CoordinatesEditor extends React.Component {
         isMouseEnterEnabled: PropTypes.bool,
         isMouseLeaveEnabled: PropTypes.bool,
         showLengthAndBearingLabel: PropTypes.bool,
-        renderer: PropTypes.string
+        renderer: PropTypes.string,
+        setIsValidFeature: PropTypes.func
     };
 
     static contextTypes = {
@@ -138,8 +139,8 @@ class CoordinatesEditor extends React.Component {
                         value={this.props.properties.radius}
                         projection={this.props.mapProjection}
                         name="radius"
-                        onChange={(radius, uom) => {          
-                            this.props.setIsValidFeature()
+                        onChange={(radius, uom) => {
+                            this.props.setIsValidFeature();
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
@@ -268,7 +269,7 @@ class CoordinatesEditor extends React.Component {
                                 {this.renderLabelTexts(idx, {textLabels, featurePropValue})}
                             </span>
                         </div>
-                        }                        
+                        }
                         <CoordinatesRow
                             format={this.props.format}
                             aeronauticalOptions={this.props.aeronauticalOptions}
@@ -378,7 +379,7 @@ class CoordinatesEditor extends React.Component {
         }
         return components;
     }
-    change = (id, value) => {        
+    change = (id, value) => {
         let tempComps = this.props.components;
         const lat = isNaN(parseFloat(value.lat)) ? "" : parseFloat(value.lat);
         const lon = isNaN(parseFloat(value.lon)) ? "" : parseFloat(value.lon);
@@ -394,7 +395,7 @@ class CoordinatesEditor extends React.Component {
             if (this.props.isMouseEnterEnabled || this.props.type === "LineString" || this.props.type === "Polygon") {
                 this.props.onHighlightPoint(tempComps[id]);
             }
-        }            
+        }
     }
 }
 

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -81,7 +81,7 @@ class CoordinatesEditor extends React.Component {
         isMouseLeaveEnabled: PropTypes.bool,
         showLengthAndBearingLabel: PropTypes.bool,
         renderer: PropTypes.string,
-        onFeatureValidationCheck: PropTypes.func
+        onValidateFeature: PropTypes.func
     };
 
     static contextTypes = {
@@ -98,7 +98,7 @@ class CoordinatesEditor extends React.Component {
         onChangeText: () => {},
         onChangeCurrentFeature: () => {},
         onSetInvalidSelected: () => {},
-        onFeatureValidationCheck: () => {},
+        onValidateFeature: () => {},
         componentsValidation: {
             "Bearing": {min: 2, max: 2, add: true, remove: true, validation: "validateCoordinates", notValid: "annotations.editor.notValidPolyline"},
             "Polygon": {min: 3, add: true, remove: true, validation: "validateCoordinates", notValid: "annotations.editor.notValidPolyline"},
@@ -141,7 +141,7 @@ class CoordinatesEditor extends React.Component {
                         projection={this.props.mapProjection}
                         name="radius"
                         onChange={(radius, uom) => {
-                            this.props.onFeatureValidationCheck();
+                            this.props.onValidateFeature();
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
@@ -330,7 +330,7 @@ class CoordinatesEditor extends React.Component {
                                     this.props.onSetInvalidSelected("coords", this.props.components.map(coordToArray));
                                 }
                             }}
-                            onFeatureValidationCheck={this.props.onFeatureValidationCheck}/>
+                            onValidateFeature={this.props.onValidateFeature}/>
                     </>
                     )}
                 </div>

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -138,7 +138,8 @@ class CoordinatesEditor extends React.Component {
                         value={this.props.properties.radius}
                         projection={this.props.mapProjection}
                         name="radius"
-                        onChange={(radius, uom) => {
+                        onChange={(radius, uom) => {          
+                            this.props.setIsValidFeature()
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
@@ -267,7 +268,7 @@ class CoordinatesEditor extends React.Component {
                                 {this.renderLabelTexts(idx, {textLabels, featurePropValue})}
                             </span>
                         </div>
-                        }
+                        }                        
                         <CoordinatesRow
                             format={this.props.format}
                             aeronauticalOptions={this.props.aeronauticalOptions}
@@ -326,7 +327,8 @@ class CoordinatesEditor extends React.Component {
                                 } else if (this.props.properties.isValidFeature) {
                                     this.props.onSetInvalidSelected("coords", this.props.components.map(coordToArray));
                                 }
-                            }}/>
+                            }}
+                            setIsValidFeature={this.props.setIsValidFeature}/>
                     </>
                     )}
                 </div>
@@ -376,7 +378,7 @@ class CoordinatesEditor extends React.Component {
         }
         return components;
     }
-    change = (id, value) => {
+    change = (id, value) => {        
         let tempComps = this.props.components;
         const lat = isNaN(parseFloat(value.lat)) ? "" : parseFloat(value.lat);
         const lon = isNaN(parseFloat(value.lon)) ? "" : parseFloat(value.lon);
@@ -392,7 +394,7 @@ class CoordinatesEditor extends React.Component {
             if (this.props.isMouseEnterEnabled || this.props.type === "LineString" || this.props.type === "Polygon") {
                 this.props.onHighlightPoint(tempComps[id]);
             }
-        }
+        }            
     }
 }
 

--- a/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/CoordinatesEditor.jsx
@@ -81,7 +81,7 @@ class CoordinatesEditor extends React.Component {
         isMouseLeaveEnabled: PropTypes.bool,
         showLengthAndBearingLabel: PropTypes.bool,
         renderer: PropTypes.string,
-        setIsValidFeature: PropTypes.func
+        onFeatureValidationCheck: PropTypes.func
     };
 
     static contextTypes = {
@@ -98,6 +98,7 @@ class CoordinatesEditor extends React.Component {
         onChangeText: () => {},
         onChangeCurrentFeature: () => {},
         onSetInvalidSelected: () => {},
+        onFeatureValidationCheck: () => {},
         componentsValidation: {
             "Bearing": {min: 2, max: 2, add: true, remove: true, validation: "validateCoordinates", notValid: "annotations.editor.notValidPolyline"},
             "Polygon": {min: 3, add: true, remove: true, validation: "validateCoordinates", notValid: "annotations.editor.notValidPolyline"},
@@ -140,7 +141,7 @@ class CoordinatesEditor extends React.Component {
                         projection={this.props.mapProjection}
                         name="radius"
                         onChange={(radius, uom) => {
-                            this.props.setIsValidFeature();
+                            this.props.onFeatureValidationCheck();
                             if (this.isValid(this.props.components, radius )) {
                                 this.props.onChangeRadius(parseFloat(radius), this.props.components.map(coordToArray), uom);
                             } else if (radius !== "") {
@@ -329,7 +330,7 @@ class CoordinatesEditor extends React.Component {
                                     this.props.onSetInvalidSelected("coords", this.props.components.map(coordToArray));
                                 }
                             }}
-                            setIsValidFeature={this.props.setIsValidFeature}/>
+                            onFeatureValidationCheck={this.props.onFeatureValidationCheck}/>
                     </>
                     )}
                 </div>

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
 */
 import React from 'react';
-import {Glyphicon, ControlLabel} from 'react-bootstrap';
+import {Glyphicon, ControlLabel, Tooltip } from 'react-bootstrap';
 import uuidv1 from 'uuid/v1';
 import bbox from '@turf/bbox';
 import Toolbar from '../../misc/toolbar/Toolbar';
+import OverlayTrigger from '../../misc/OverlayTrigger';
 import cs from 'classnames';
 import Message from '../../I18N/Message';
 import {get} from 'lodash';
@@ -36,10 +37,13 @@ const FeaturesList = (props) => {
         setPopupWarning,
         geodesic,
         defaultStyles,
-        defaultPointType
+        defaultPointType,
+        setIsValidFeature,
+        allGeometryIsValid
     } = props;
     const {features = []} = editing || {};
     const isValidFeature = get(props, "selected.properties.isValidFeature", true);
+    const allFeaturesAreValid = allGeometryIsValid();
 
     const onClickGeometry = (type, style) => {
         onStyleGeometry(false);
@@ -48,6 +52,7 @@ const FeaturesList = (props) => {
         onSetStyle(style);
         onStartDrawing({geodesic});
         setTabValue('coordinates');
+        setIsValidFeature();
     };
     const circleCenterStyles = defaultPointType === "symbol" ? defaultStyles.POINT?.[defaultPointType] : DEFAULT_ANNOTATIONS_STYLES.Point;
 
@@ -134,7 +139,7 @@ const FeaturesList = (props) => {
             {features && features.length === 0 && <div style={{ textAlign: 'center' }}><Message msgId="annotations.addGeometry"/></div>}
             {features?.map((feature, key) => {
                 return (
-                    <FeatureCard feature={feature} key={key} {...props}/>
+                    <FeatureCard disabled={!allFeaturesAreValid} setIsValidFeature={setIsValidFeature} feature={feature} key={key} {...props}/>
                 );
             })}
         </>
@@ -146,29 +151,52 @@ const FeaturesList = (props) => {
  * @function
  *
  */
-const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSelectFeature, onUnselectFeature, setTabValue, isMeasureEditDisabled, onStyleGeometry, onGeometryHighlight}) => {
+const FeatureCard = ({
+    feature,
+    selected,
+    disabled,
+    onDeleteGeometry,
+    onZoom,
+    maxZoom,
+    onSelectFeature,
+    onUnselectFeature,
+    setTabValue,
+    isMeasureEditDisabled,
+    onStyleGeometry,
+    onGeometryHighlight,
+    setIsValidFeature
+}) => {
     const type = getGeometryType(feature);
     const {properties} = feature;
     const {glyph, label} = getGeometryGlyphInfo(type);
-    const unselect = selected?.properties?.id === properties?.id;
-    const selectedIsValidFeature = get(selected, "properties.isValidFeature", true);
-    const isValidFeature = selectedIsValidFeature || properties?.isValidFeature;
-    const allowCardMouseEvent = !unselect && selectedIsValidFeature;
+    const isSelected = selected?.properties?.id === properties?.id;
 
-    return (
+    const selectedIsValidFeature = get(selected, "properties.isValidFeature", true);
+    const isValidFeature = properties?.isValidFeature;
+    const allowCardMouseEvent = !isSelected && selectedIsValidFeature;
+
+    const overlayWrapper = (content) => (
+        <OverlayTrigger placement="left" overlay={<Tooltip><Message msgId="annotations.resolveAllErrors"/></Tooltip>}>
+            {content}
+        </OverlayTrigger>
+    );
+
+    const content = (
         <div
-            className={cs('geometry-card', {'ms-selected': unselect})}
+            className={cs('geometry-card', {'ms-selected': isSelected, 'ms-disabled': disabled && !isSelected})}
             onMouseEnter={() => allowCardMouseEvent && onGeometryHighlight(properties.id)}
             onMouseLeave={() => allowCardMouseEvent && onGeometryHighlight(properties.id, false)}
             onClick={() =>{
-                if (unselect) {
+
+                if (isSelected && isValidFeature) {
                     onUnselectFeature();
                     onGeometryHighlight(properties.id);
-                } else {
+                } else if (!disabled) {
                     onSelectFeature([feature]);
                     setTabValue(isMeasureEditDisabled ? 'coordinates' : 'style');
                     onStyleGeometry(!isMeasureEditDisabled);
                 }
+                setIsValidFeature();
             } }
         >
             <div className="geometry-card-preview">
@@ -183,11 +211,9 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
                 }}
                 buttons={[
                     {
-                        Element: () => <Glyphicon glyph={isValidFeature ? "ok-sign" : "exclamation-mark"} className={"text-" + (isValidFeature ? "success" : "danger")}/>
-                    },
-                    {
                         glyph: 'zoom-to',
                         visible: isValidFeature,
+                        className: cs({'inactive': disabled && !isSelected, 'square-button-md no-border': true}),
                         tooltip: <Message msgId="annotations.zoomToGeometry"/>,
                         onClick: (event) => {
                             event.stopPropagation();
@@ -197,7 +223,7 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
                     },
                     {
                         glyph: 'trash',
-                        visible: isValidFeature,
+                        className: cs({'inactive': disabled && !isSelected, 'square-button-md no-border': true}),
                         tooltip: <Message msgId="annotations.removeGeometry"/>,
                         onClick: (event) => {
                             event.stopPropagation();
@@ -208,6 +234,8 @@ const FeatureCard = ({feature, selected, onDeleteGeometry, onZoom, maxZoom, onSe
             />
         </div>
     );
+
+    return disabled && !isSelected ? overlayWrapper(content) : content;
 };
 
 FeaturesList.defaultProps = {
@@ -221,7 +249,8 @@ FeaturesList.defaultProps = {
     setTabValue: () => {},
     isMeasureEditDisabled: true,
     defaultPointType: 'marker',
-    defaultStyles: {}
+    defaultStyles: {},
+    setIsValidFeature: () => {}
 };
 
 export default FeaturesList;

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -38,12 +38,12 @@ const FeaturesList = (props) => {
         geodesic,
         defaultStyles,
         defaultPointType,
-        onFeatureValidationCheck,
-        allGeometryIsValid
+        onValidateFeature,
+        validateFeatures
     } = props;
     const {features = []} = editing || {};
     const isValidFeature = get(props, "selected.properties.isValidFeature", true);
-    const allFeaturesAreValid = allGeometryIsValid();
+    const areAllFeaturesValid = validateFeatures();
 
     const onClickGeometry = (type, style) => {
         onStyleGeometry(false);
@@ -52,7 +52,7 @@ const FeaturesList = (props) => {
         onSetStyle(style);
         onStartDrawing({geodesic});
         setTabValue('coordinates');
-        onFeatureValidationCheck();
+        onValidateFeature();
     };
     const circleCenterStyles = defaultPointType === "symbol" ? defaultStyles.POINT?.[defaultPointType] : DEFAULT_ANNOTATIONS_STYLES.Point;
 
@@ -139,7 +139,7 @@ const FeaturesList = (props) => {
             {features && features.length === 0 && <div style={{ textAlign: 'center' }}><Message msgId="annotations.addGeometry"/></div>}
             {features?.map((feature, key) => {
                 return (
-                    <FeatureCard disabled={!allFeaturesAreValid} onFeatureValidationCheck={onFeatureValidationCheck} feature={feature} key={key} {...props}/>
+                    <FeatureCard disabled={!areAllFeaturesValid} onValidateFeature={onValidateFeature} feature={feature} key={key} {...props}/>
                 );
             })}
         </>
@@ -164,7 +164,7 @@ const FeatureCard = ({
     isMeasureEditDisabled,
     onStyleGeometry,
     onGeometryHighlight,
-    onFeatureValidationCheck
+    onValidateFeature
 }) => {
     const type = getGeometryType(feature);
     const {properties} = feature;
@@ -196,7 +196,7 @@ const FeatureCard = ({
                     setTabValue(isMeasureEditDisabled ? 'coordinates' : 'style');
                     onStyleGeometry(!isMeasureEditDisabled);
                 }
-                onFeatureValidationCheck();
+                onValidateFeature();
             } }
         >
             <div className="geometry-card-preview">
@@ -250,8 +250,8 @@ FeaturesList.defaultProps = {
     isMeasureEditDisabled: true,
     defaultPointType: 'marker',
     defaultStyles: {},
-    onFeatureValidationCheck: () => {},
-    allGeometryIsValid: () => { return true; }
+    onValidateFeature: () => {},
+    validateFeatures: () => { return true; }
 };
 
 export default FeaturesList;

--- a/web/client/components/mapcontrols/annotations/FeaturesList.jsx
+++ b/web/client/components/mapcontrols/annotations/FeaturesList.jsx
@@ -38,7 +38,7 @@ const FeaturesList = (props) => {
         geodesic,
         defaultStyles,
         defaultPointType,
-        setIsValidFeature,
+        onFeatureValidationCheck,
         allGeometryIsValid
     } = props;
     const {features = []} = editing || {};
@@ -52,7 +52,7 @@ const FeaturesList = (props) => {
         onSetStyle(style);
         onStartDrawing({geodesic});
         setTabValue('coordinates');
-        setIsValidFeature();
+        onFeatureValidationCheck();
     };
     const circleCenterStyles = defaultPointType === "symbol" ? defaultStyles.POINT?.[defaultPointType] : DEFAULT_ANNOTATIONS_STYLES.Point;
 
@@ -139,7 +139,7 @@ const FeaturesList = (props) => {
             {features && features.length === 0 && <div style={{ textAlign: 'center' }}><Message msgId="annotations.addGeometry"/></div>}
             {features?.map((feature, key) => {
                 return (
-                    <FeatureCard disabled={!allFeaturesAreValid} setIsValidFeature={setIsValidFeature} feature={feature} key={key} {...props}/>
+                    <FeatureCard disabled={!allFeaturesAreValid} onFeatureValidationCheck={onFeatureValidationCheck} feature={feature} key={key} {...props}/>
                 );
             })}
         </>
@@ -164,7 +164,7 @@ const FeatureCard = ({
     isMeasureEditDisabled,
     onStyleGeometry,
     onGeometryHighlight,
-    setIsValidFeature
+    onFeatureValidationCheck
 }) => {
     const type = getGeometryType(feature);
     const {properties} = feature;
@@ -196,7 +196,7 @@ const FeatureCard = ({
                     setTabValue(isMeasureEditDisabled ? 'coordinates' : 'style');
                     onStyleGeometry(!isMeasureEditDisabled);
                 }
-                setIsValidFeature();
+                onFeatureValidationCheck();
             } }
         >
             <div className="geometry-card-preview">
@@ -250,7 +250,8 @@ FeaturesList.defaultProps = {
     isMeasureEditDisabled: true,
     defaultPointType: 'marker',
     defaultStyles: {},
-    setIsValidFeature: () => {}
+    onFeatureValidationCheck: () => {},
+    allGeometryIsValid: () => { return true; }
 };
 
 export default FeaturesList;

--- a/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
@@ -31,7 +31,7 @@ class GeometryEditor extends React.Component {
         aeronauticalOptions: PropTypes.object,
         onChangeText: PropTypes.func,
         renderer: PropTypes.string,
-        onFeatureValidationCheck: PropTypes.func
+        onValidateFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -51,7 +51,7 @@ class GeometryEditor extends React.Component {
             transitionEnterTimeout: 300,
             transitionLeaveTimeout: 300
         },
-        onFeatureValidationCheck: () => {}
+        onValidateFeature: () => {}
     };
 
     render() {
@@ -72,11 +72,11 @@ class GeometryEditor extends React.Component {
             onSetInvalidSelected={this.props.onSetInvalidSelected}
             onChangeText={this.props.onChangeText}
             renderer={this.props.renderer}
-            onFeatureValidationCheck={this.props.onFeatureValidationCheck}
+            onValidateFeature={this.props.onValidateFeature}
             onChange={(components, radius, text, crs) => {
                 let coords = components.map(c => [c.lon, c.lat]);
                 this.props.onChange(coords, radius, text, crs);
-                this.props.onFeatureValidationCheck();
+                this.props.onValidateFeature();
             }}/>);
 
     }

--- a/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
@@ -70,9 +70,11 @@ class GeometryEditor extends React.Component {
             onSetInvalidSelected={this.props.onSetInvalidSelected}
             onChangeText={this.props.onChangeText}
             renderer={this.props.renderer}
+            setIsValidFeature={this.props.setIsValidFeature}
             onChange={(components, radius, text, crs) => {
                 let coords = components.map(c => [c.lon, c.lat]);
                 this.props.onChange(coords, radius, text, crs);
+                this.props.setIsValidFeature()
             }}/>);
 
     }

--- a/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
@@ -31,7 +31,7 @@ class GeometryEditor extends React.Component {
         aeronauticalOptions: PropTypes.object,
         onChangeText: PropTypes.func,
         renderer: PropTypes.string,
-        setIsValidFeature: PropTypes.func
+        onFeatureValidationCheck: PropTypes.func
     };
 
     static defaultProps = {
@@ -51,7 +51,7 @@ class GeometryEditor extends React.Component {
             transitionEnterTimeout: 300,
             transitionLeaveTimeout: 300
         },
-        setIsValidFeature: () => {}
+        onFeatureValidationCheck: () => {}
     };
 
     render() {
@@ -72,11 +72,11 @@ class GeometryEditor extends React.Component {
             onSetInvalidSelected={this.props.onSetInvalidSelected}
             onChangeText={this.props.onChangeText}
             renderer={this.props.renderer}
-            setIsValidFeature={this.props.setIsValidFeature}
+            onFeatureValidationCheck={this.props.onFeatureValidationCheck}
             onChange={(components, radius, text, crs) => {
                 let coords = components.map(c => [c.lon, c.lat]);
                 this.props.onChange(coords, radius, text, crs);
-                this.props.setIsValidFeature();
+                this.props.onFeatureValidationCheck();
             }}/>);
 
     }

--- a/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
+++ b/web/client/components/mapcontrols/annotations/GeometryEditor.jsx
@@ -30,7 +30,8 @@ class GeometryEditor extends React.Component {
         onSetInvalidSelected: PropTypes.func,
         aeronauticalOptions: PropTypes.object,
         onChangeText: PropTypes.func,
-        renderer: PropTypes.string
+        renderer: PropTypes.string,
+        setIsValidFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -49,7 +50,8 @@ class GeometryEditor extends React.Component {
             transitionName: "switch-panel-transition",
             transitionEnterTimeout: 300,
             transitionLeaveTimeout: 300
-        }
+        },
+        setIsValidFeature: () => {}
     };
 
     render() {
@@ -74,7 +76,7 @@ class GeometryEditor extends React.Component {
             onChange={(components, radius, text, crs) => {
                 let coords = components.map(c => [c.lon, c.lat]);
                 this.props.onChange(coords, radius, text, crs);
-                this.props.setIsValidFeature()
+                this.props.setIsValidFeature();
             }}/>);
 
     }

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -303,7 +303,9 @@ describe("test the AnnotationsEditor Panel", () => {
 
         const viewer = ReactDOM.render(<AnnotationsEditor {...feature} {...actions} editing={{
             properties: feature,
-            features: [{}]
+            features: [{ properties: {
+                isValidFeature: true
+            } }]
         }} onSave={testHandlers.onSaveHandler}
         onError={testHandlers.onErrorHandler}/>, document.getElementById("container"));
         expect(viewer).toExist();

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -28,7 +28,7 @@ const actions = {
     onHideMeasureWarning: () => {},
     onSelectFeature: () => {},
     onUnSelectFeature: () => {},
-    onFeatureValidationCheck: () => {}
+    onValidateFeature: () => {}
 };
 describe("test the AnnotationsEditor Panel", () => {
     beforeEach((done) => {

--- a/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/AnnotationsEditor-test.js
@@ -26,7 +26,9 @@ const actions = {
     onSetAnnotationMeasurement: () => {},
     onDownload: () => {},
     onHideMeasureWarning: () => {},
-    onSelectFeature: () => {}
+    onSelectFeature: () => {},
+    onUnSelectFeature: () => {},
+    onFeatureValidationCheck: () => {}
 };
 describe("test the AnnotationsEditor Panel", () => {
     beforeEach((done) => {
@@ -162,7 +164,9 @@ describe("test the AnnotationsEditor Panel", () => {
             selected={null}
             editing={{
                 properties: feature,
-                features: [{}],
+                features: [{ properties: {
+                    isValidFeature: true
+                } }],
                 visibility: true
             }}
             onSave={testHandlers.onSaveHandler}
@@ -199,7 +203,9 @@ describe("test the AnnotationsEditor Panel", () => {
             selected={{features: [], properties: {isValidFeature: true}}}
             editing={{
                 properties: feature,
-                features: [{}]
+                features: [{ properties: {
+                    isValidFeature: true
+                } }]
             }}
             defaultStyles={defaultStyles}
             onAddNewFeature={testHandlers.onAddNewFeature}

--- a/web/client/components/mapcontrols/annotations/__tests__/FeatureList-test.js
+++ b/web/client/components/mapcontrols/annotations/__tests__/FeatureList-test.js
@@ -120,10 +120,9 @@ describe("test FeatureList component", () => {
         expect(cardTitle.innerText).toBe('Polygon');
 
         const glyphIcons = document.querySelectorAll('.btn-group .glyphicon');
-        expect(glyphIcons.length).toBe(8);
-        expect(glyphIcons[5].className).toContain('ok-sign');
-        expect(glyphIcons[6].className).toContain('zoom-to');
-        expect(glyphIcons[7].className).toContain('trash');
+        expect(glyphIcons.length).toBe(7);
+        expect(glyphIcons[5].className).toContain('zoom-to');
+        expect(glyphIcons[6].className).toContain('trash');
     });
 
     it('test actions on feature card', () => {

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -42,7 +42,7 @@ class CoordinatesRow extends React.Component {
         removeEnabled: PropTypes.bool,
         renderer: PropTypes.string,
         disabled: PropTypes.bool,
-        setIsValidFeature: PropTypes.func
+        onFeatureValidationCheck: PropTypes.func
     };
 
     static defaultProps = {
@@ -50,6 +50,7 @@ class CoordinatesRow extends React.Component {
         formatVisible: false,
         onMouseEnter: () => {},
         onMouseLeave: () => {},
+        onFeatureValidationCheck: () => {},
         showToolButtons: true,
         disabled: false
     };
@@ -76,7 +77,7 @@ class CoordinatesRow extends React.Component {
             const changeLat = parseFloat(this.state.lat) !== parseFloat(this.props.component.lat);
             const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);
             this.setState({...this.state, disabledApplyChange: !(changeLat || changeLon)}, ()=> {
-                this.props.setIsValidFeature();
+                this.props.onFeatureValidationCheck();
                 // Auto save on coordinate change for annotations
                 this.props.renderer === "annotations" &&  this.props.onSubmit(this.props.idx, this.state);
             });

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -42,7 +42,7 @@ class CoordinatesRow extends React.Component {
         removeEnabled: PropTypes.bool,
         renderer: PropTypes.string,
         disabled: PropTypes.bool,
-        onFeatureValidationCheck: PropTypes.func
+        onValidateFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -50,7 +50,7 @@ class CoordinatesRow extends React.Component {
         formatVisible: false,
         onMouseEnter: () => {},
         onMouseLeave: () => {},
-        onFeatureValidationCheck: () => {},
+        onValidateFeature: () => {},
         showToolButtons: true,
         disabled: false
     };
@@ -77,7 +77,7 @@ class CoordinatesRow extends React.Component {
             const changeLat = parseFloat(this.state.lat) !== parseFloat(this.props.component.lat);
             const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);
             this.setState({...this.state, disabledApplyChange: !(changeLat || changeLon)}, ()=> {
-                this.props.onFeatureValidationCheck();
+                this.props.onValidateFeature();
                 // Auto save on coordinate change for annotations
                 this.props.renderer === "annotations" &&  this.props.onSubmit(this.props.idx, this.state);
             });

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -41,7 +41,8 @@ class CoordinatesRow extends React.Component {
         formatVisible: PropTypes.bool,
         removeEnabled: PropTypes.bool,
         renderer: PropTypes.string,
-        disabled: PropTypes.bool
+        disabled: PropTypes.bool,
+        setIsValidFeature: PropTypes.func
     };
 
     static defaultProps = {
@@ -70,20 +71,19 @@ class CoordinatesRow extends React.Component {
         }
     }
 
-    onChangeLatLon = (coord, val) => {        
-        
+    onChangeLatLon = (coord, val) => {
         this.setState({...this.state, [coord]: parseFloat(val)}, ()=>{
             const changeLat = parseFloat(this.state.lat) !== parseFloat(this.props.component.lat);
-            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);            
+            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);
             this.setState({...this.state, disabledApplyChange: !(changeLat || changeLon)}, ()=> {
-                this.props.setIsValidFeature()
+                this.props.setIsValidFeature();
                 // Auto save on coordinate change for annotations
                 this.props.renderer === "annotations" &&  this.props.onSubmit(this.props.idx, this.state);
             });
         });
     };
 
-    onSubmit = () => {        
+    onSubmit = () => {
         this.props.onSubmit(this.props.idx, this.state);
     };
 

--- a/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
+++ b/web/client/components/misc/coordinateeditors/CoordinatesRow.jsx
@@ -70,18 +70,20 @@ class CoordinatesRow extends React.Component {
         }
     }
 
-    onChangeLatLon = (coord, val) => {
+    onChangeLatLon = (coord, val) => {        
+        
         this.setState({...this.state, [coord]: parseFloat(val)}, ()=>{
             const changeLat = parseFloat(this.state.lat) !== parseFloat(this.props.component.lat);
-            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);
+            const changeLon = parseFloat(this.state.lon) !== parseFloat(this.props.component.lon);            
             this.setState({...this.state, disabledApplyChange: !(changeLat || changeLon)}, ()=> {
+                this.props.setIsValidFeature()
                 // Auto save on coordinate change for annotations
                 this.props.renderer === "annotations" &&  this.props.onSubmit(this.props.idx, this.state);
             });
         });
     };
 
-    onSubmit = () => {
+    onSubmit = () => {        
         this.props.onSubmit(this.props.idx, this.state);
     };
 

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -74,7 +74,8 @@ import {
     hideMeasureWarning,
     initPlugin,
     geometryHighlight,
-    unSelectFeature
+    unSelectFeature,
+    setIsValidFeature
 } from '../actions/annotations';
 
 import annotationsEpics from '../epics/annotations';
@@ -134,7 +135,8 @@ const commonEditorActions = {
     onHideMeasureWarning: hideMeasureWarning,
     onToggleShowAgain: toggleShowAgain,
     onInitPlugin: initPlugin,
-    onUnSelectFeature: unSelectFeature
+    onUnSelectFeature: unSelectFeature,
+    setIsValidFeature: setIsValidFeature
 };
 const AnnotationsEditor = connect(annotationsInfoSelector,
     {

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -75,7 +75,7 @@ import {
     initPlugin,
     geometryHighlight,
     unSelectFeature,
-    featureValidationCheck
+    validateFeature
 } from '../actions/annotations';
 
 import annotationsEpics from '../epics/annotations';
@@ -136,7 +136,7 @@ const commonEditorActions = {
     onToggleShowAgain: toggleShowAgain,
     onInitPlugin: initPlugin,
     onUnSelectFeature: unSelectFeature,
-    onFeatureValidationCheck: featureValidationCheck
+    onValidateFeature: validateFeature
 };
 const AnnotationsEditor = connect(annotationsInfoSelector,
     {

--- a/web/client/plugins/Annotations.jsx
+++ b/web/client/plugins/Annotations.jsx
@@ -75,7 +75,7 @@ import {
     initPlugin,
     geometryHighlight,
     unSelectFeature,
-    setIsValidFeature
+    featureValidationCheck
 } from '../actions/annotations';
 
 import annotationsEpics from '../epics/annotations';
@@ -136,7 +136,7 @@ const commonEditorActions = {
     onToggleShowAgain: toggleShowAgain,
     onInitPlugin: initPlugin,
     onUnSelectFeature: unSelectFeature,
-    setIsValidFeature: setIsValidFeature
+    onFeatureValidationCheck: featureValidationCheck
 };
 const AnnotationsEditor = connect(annotationsInfoSelector,
     {

--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -29,6 +29,509 @@ const testFeatures = {
     }
 };
 
+const testValidFeatures = {
+    polygon: {
+        type: 'Feature',
+        geometry: {
+            coordinates: [
+                [
+                    [1, 1],
+                    [2, 2],
+                    [1, 2],
+                    [1, 1]
+                ]
+            ],
+            type: 'Polygon'
+        },
+        properties: {
+            id: '1',
+            isValidFeature: true
+        },
+        style: DEFAULT_ANNOTATIONS_STYLES.Polygon
+    },
+    line: {
+        type: 'Feature',
+        geometry: {
+            coordinates: [
+                [1, 1],
+                [1, 2]
+            ],
+            type: 'LineString'
+        },
+        properties: {
+            id: '2',
+            isValidFeature: true,
+            canEdit: false
+        },
+        style: DEFAULT_ANNOTATIONS_STYLES.LineString
+    },
+    point: {
+        type: 'Feature',
+        geometry: {
+            coordinates: [1, 1],
+            type: 'Point'
+        },
+        properties: {
+            id: '3',
+            isValidFeature: true,
+            canEdit: false
+        },
+        style: DEFAULT_ANNOTATIONS_STYLES.Point
+    },
+    text: {
+        type: 'Feature',
+        geometry: {
+            coordinates: [1, 1],
+            type: 'Point'
+        },
+        properties: {
+            id: '4',
+            isValidFeature: true,
+            canEdit: false,
+            isText: true,
+            valueText: 'New'
+        },
+        style: DEFAULT_ANNOTATIONS_STYLES.Text
+    },
+    circle: {
+        type: 'Feature',
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [-6, 45]
+                ]
+            ]
+        },
+        properties: {
+            isCircle: true,
+            radius: 50000,
+            center: [
+                -6,
+                45
+            ],
+            id: '5',
+            crs: 'EPSG:3857',
+            isGeodesic: true,
+            polygonGeom: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [
+                            -5,
+                            45.44966018186227
+                        ],
+                        [
+                            -5.040245511619825,
+                            45.44876585012077
+                        ],
+                        [
+                            -5.080328396601316,
+                            45.44608646929481
+                        ],
+                        [
+                            -5.120086731957861,
+                            45.441632866923904
+                        ],
+                        [
+                            -5.1593599981818405,
+                            45.43542303680628
+                        ],
+                        [
+                            -5.197989771457299,
+                            45.427482061146456
+                        ],
+                        [
+                            -5.235820404536013,
+                            45.41784200215722
+                        ],
+                        [
+                            -5.272699692655688,
+                            45.4065417637049
+                        ],
+                        [
+                            -5.308479521010984,
+                            45.39362692374563
+                        ],
+                        [
+                            -5.343016490449034,
+                            45.37914953845281
+                        ],
+                        [
+                            -5.376172518248709,
+                            45.36316791908023
+                        ],
+                        [
+                            -5.40781541105422,
+                            45.34574638274048
+                        ],
+                        [
+                            -5.437819407265617,
+                            45.3269549784032
+                        ],
+                        [
+                            -5.466065686438008,
+                            45.306869189532485
+                        ],
+                        [
+                            -5.492442843504256,
+                            45.28556961488434
+                        ],
+                        [
+                            -5.516847325909057,
+                            45.263141629076216
+                        ],
+                        [
+                            -5.539183832021936,
+                            45.2396750246182
+                        ],
+                        [
+                            -5.559365669479263,
+                            45.21526363716062
+                        ],
+                        [
+                            -5.577315072387576,
+                            45.190004955765446
+                        ],
+                        [
+                            -5.59296347659886,
+                            45.163999720048984
+                        ],
+                        [
+                            -5.606251752540127,
+                            45.1373515060707
+                        ],
+                        [
+                            -5.6171303953418725,
+                            45.11016630285947
+                        ],
+                        [
+                            -5.625559672260242,
+                            45.082552081472535
+                        ],
+                        [
+                            -5.6315097276241515,
+                            45.05461835847661
+                        ],
+                        [
+                            -5.634960645759172,
+                            45.02647575572444
+                        ],
+                        [
+                            -5.6359024725435924,
+                            44.99823555827448
+                        ],
+                        [
+                            -5.6343351964375135,
+                            44.97000927226758
+                        ],
+                        [
+                            -5.630268689992574,
+                            44.94190818453314
+                        ],
+                        [
+                            -5.623722612997641,
+                            44.91404292564889
+                        ],
+                        [
+                            -5.614726278544349,
+                            44.886523038124345
+                        ],
+                        [
+                            -5.603318483406369,
+                            44.85945655131865
+                        ],
+                        [
+                            -5.589547304217897,
+                            44.83294956464031
+                        ],
+                        [
+                            -5.573469861011175,
+                            44.807105840508896
+                        ],
+                        [
+                            -5.555152049730721,
+                            44.782026408489386
+                        ],
+                        [
+                            -5.534668245384498,
+                            44.757809181937965
+                        ],
+                        [
+                            -5.5121009775208725,
+                            44.73454858842438
+                        ],
+                        [
+                            -5.487540579736171,
+                            44.71233521512217
+                        ],
+                        [
+                            -5.4610848149224624,
+                            44.6912554702829
+                        ],
+                        [
+                            -5.4328384779602645,
+                            44.67139126183614
+                        ],
+                        [
+                            -5.402912977547861,
+                            44.652819694082375
+                        ],
+                        [
+                            -5.37142589883906,
+                            44.635612783372125
+                        ],
+                        [
+                            -5.338500548536219,
+                            44.619837193591955
+                        ],
+                        [
+                            -5.304265484056409,
+                            44.60555399220591
+                        ],
+                        [
+                            -5.268854028357189,
+                            44.592818427530354
+                        ],
+                        [
+                            -5.2324037719756475,
+                            44.58167972785065
+                        ],
+                        [
+                            -5.195056063801597,
+                            44.57218092292017
+                        ],
+                        [
+                            -5.156955492073779,
+                            44.56435868831458
+                        ],
+                        [
+                            -5.118249357057942,
+                            44.55824321304914
+                        ],
+                        [
+                            -5.079087136838294,
+                            44.55385809080196
+                        ],
+                        [
+                            -5.03961994762993,
+                            44.55122023502192
+                        ],
+                        [
+                            -5,
+                            44.55033981813773
+                        ],
+                        [
+                            -4.96038005237007,
+                            44.55122023502192
+                        ],
+                        [
+                            -4.920912863161706,
+                            44.55385809080196
+                        ],
+                        [
+                            -4.881750642942057,
+                            44.55824321304914
+                        ],
+                        [
+                            -4.84304450792622,
+                            44.56435868831458
+                        ],
+                        [
+                            -4.804943936198402,
+                            44.57218092292017
+                        ],
+                        [
+                            -4.7675962280243525,
+                            44.58167972785065
+                        ],
+                        [
+                            -4.731145971642811,
+                            44.592818427530354
+                        ],
+                        [
+                            -4.695734515943591,
+                            44.60555399220591
+                        ],
+                        [
+                            -4.661499451463782,
+                            44.619837193591955
+                        ],
+                        [
+                            -4.62857410116094,
+                            44.635612783372125
+                        ],
+                        [
+                            -4.597087022452139,
+                            44.652819694082375
+                        ],
+                        [
+                            -4.5671615220397355,
+                            44.67139126183614
+                        ],
+                        [
+                            -4.5389151850775376,
+                            44.6912554702829
+                        ],
+                        [
+                            -4.512459420263829,
+                            44.71233521512217
+                        ],
+                        [
+                            -4.4878990224791275,
+                            44.73454858842438
+                        ],
+                        [
+                            -4.465331754615501,
+                            44.757809181937965
+                        ],
+                        [
+                            -4.444847950269279,
+                            44.782026408489386
+                        ],
+                        [
+                            -4.426530138988825,
+                            44.807105840508896
+                        ],
+                        [
+                            -4.410452695782103,
+                            44.83294956464031
+                        ],
+                        [
+                            -4.39668151659363,
+                            44.85945655131865
+                        ],
+                        [
+                            -4.385273721455651,
+                            44.886523038124345
+                        ],
+                        [
+                            -4.376277387002359,
+                            44.91404292564889
+                        ],
+                        [
+                            -4.369731310007426,
+                            44.94190818453314
+                        ],
+                        [
+                            -4.3656648035624865,
+                            44.97000927226758
+                        ],
+                        [
+                            -4.364097527456407,
+                            44.99823555827448
+                        ],
+                        [
+                            -4.365039354240828,
+                            45.02647575572444
+                        ],
+                        [
+                            -4.368490272375849,
+                            45.05461835847661
+                        ],
+                        [
+                            -4.374440327739758,
+                            45.082552081472535
+                        ],
+                        [
+                            -4.3828696046581275,
+                            45.11016630285947
+                        ],
+                        [
+                            -4.393748247459873,
+                            45.1373515060707
+                        ],
+                        [
+                            -4.407036523401141,
+                            45.163999720048984
+                        ],
+                        [
+                            -4.422684927612423,
+                            45.190004955765446
+                        ],
+                        [
+                            -4.440634330520736,
+                            45.21526363716062
+                        ],
+                        [
+                            -4.460816167978063,
+                            45.2396750246182
+                        ],
+                        [
+                            -4.483152674090942,
+                            45.263141629076216
+                        ],
+                        [
+                            -4.507557156495745,
+                            45.28556961488434
+                        ],
+                        [
+                            -4.533934313561992,
+                            45.306869189532485
+                        ],
+                        [
+                            -4.562180592734383,
+                            45.3269549784032
+                        ],
+                        [
+                            -4.59218458894578,
+                            45.34574638274048
+                        ],
+                        [
+                            -4.623827481751291,
+                            45.36316791908023
+                        ],
+                        [
+                            -4.656983509550966,
+                            45.37914953845281
+                        ],
+                        [
+                            -4.691520478989017,
+                            45.39362692374563
+                        ],
+                        [
+                            -4.727300307344311,
+                            45.4065417637049
+                        ],
+                        [
+                            -4.764179595463987,
+                            45.41784200215722
+                        ],
+                        [
+                            -4.802010228542701,
+                            45.427482061146456
+                        ],
+                        [
+                            -4.8406400018181595,
+                            45.43542303680628
+                        ],
+                        [
+                            -4.879913268042139,
+                            45.441632866923904
+                        ],
+                        [
+                            -4.919671603398683,
+                            45.44608646929481
+                        ],
+                        [
+                            -4.959754488380175,
+                            45.44876585012077
+                        ],
+                        [
+                            -5,
+                            45.44966018186227
+                        ]
+                    ]
+                ]
+            },
+            isValidFeature: true,
+            canEdit: true
+        },
+        style: DEFAULT_ANNOTATIONS_STYLES.Circle
+    }
+};
+
+
 import {
     REMOVE_ANNOTATION,
     CONFIRM_REMOVE_ANNOTATION,
@@ -75,7 +578,8 @@ import {
     hideMeasureWarning,
     toggleShowAgain,
     unSelectFeature,
-    startDrawing
+    startDrawing,
+    validateFeature
 } from '../../actions/annotations';
 
 import { PURGE_MAPINFO_RESULTS } from '../../actions/mapInfo';
@@ -1838,4 +2342,101 @@ describe('Test the annotations reducer', () => {
         expect(annotationsState.config).toBeTruthy();
         expect(annotationsState.config.geodesic).toBe(true);
     });
+    it('validate features - valid geometries', () => {
+        const features = Object.values(testValidFeatures);
+        let state = annotations({
+            editing: {
+                features
+            },
+            selected: null
+        }, validateFeature());
+        expect(state.editing.features[0].properties.isValidFeature).toBe(true);
+        expect(state.editing.features[1].properties.isValidFeature).toBe(true);
+        expect(state.editing.features[2].properties.isValidFeature).toBe(true);
+        expect(state.editing.features[3].properties.isValidFeature).toBe(true);
+        expect(state.editing.features[4].properties.isValidFeature).toBe(true);
+    });
+    it('validate features - invalid geometries', () => {
+        const features = Object.values(testValidFeatures);
+        features[0].geometry.coordinates = [
+            [
+                [1, null]
+            ]
+        ];
+        features[1].geometry.coordinates = [
+            [
+                [1, null]
+            ]
+        ];
+        features[2].geometry.coordinates = [1, null];
+        features[3].geometry.coordinates = [1, null];
+        features[4].geometry.coordinates = [
+            [
+                [1, null]
+            ]
+        ];
+        features[4].properties.center = [null, 45];
+        features[4].properties.radius = null;
+        let state = annotations({
+            editing: {
+                features
+            },
+            selected: null
+        }, validateFeature());
+        expect(state.editing.features[0].properties.isValidFeature).toBe(false);
+        expect(state.editing.features[1].properties.isValidFeature).toBe(false);
+        expect(state.editing.features[2].properties.isValidFeature).toBe(false);
+        expect(state.editing.features[3].properties.isValidFeature).toBe(false);
+        expect(state.editing.features[4].properties.isValidFeature).toBe(false);
+    });
+    it('validate features - invalid text, missing coordinates', () => {
+        const features = [testValidFeatures.text];
+        features[0].geometry.coordinates = [1, null];
+        let state = annotations({
+            editing: {
+                features
+            },
+            selected: null
+        }, validateFeature());
+        expect(state.editing.features[0].properties.isValidFeature).toBe(false);
+    });
+    it('validate features - invalid text, missing text value', () => {
+        const features = [testValidFeatures.text];
+        features[0].properties.valueText = null;
+        let state = annotations({
+            editing: {
+                features
+            },
+            selected: null
+        }, validateFeature());
+        expect(state.editing.features[0].properties.isValidFeature).toBe(false);
+    });
+    it('validate features - invalid circle, missing radius', () => {
+        const features = [testValidFeatures.circle];
+        features[0].properties.radius = null;
+        let state = annotations({
+            editing: {
+                features
+            },
+            selected: null
+        }, validateFeature());
+        expect(state.editing.features[0].properties.isValidFeature).toBe(false);
+    });
+    it('validate features - invalid circle, missing center', () => {
+        const features = [testValidFeatures.circle];
+        features[0].geometry.coordinates = [
+            [
+                [null, 45]
+            ]
+        ];
+        features[0].properties.center = [null, 45];
+        let state = annotations({
+            editing: {
+                features
+            },
+            selected: null
+        }, validateFeature());
+        expect(state.editing.features[0].properties.isValidFeature).toBe(false);
+    });
+
 });

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -259,7 +259,13 @@ function annotations(state = {validationErrors: {}}, action) {
         let ftChangedIndex = findIndex(state.editing.features, (f) => f.properties.id === selected.properties.id);
         let selectedGeoJSON = selected;
         if (selected && selected.properties && selected.properties.isCircle) {
-            selectedGeoJSON = set("geometry", selected.properties.polygonGeom, selectedGeoJSON);
+            if (selected.properties.polygonGeom ) {
+                selectedGeoJSON = set("geometry", selected.properties.polygonGeom, selectedGeoJSON);
+            } else {
+                selectedGeoJSON = set("geometry.coordinates", [], selectedGeoJSON);
+                selectedGeoJSON = set("geometry.type", 'Polygon', selectedGeoJSON);
+            }
+
         } else if (selected && selected.properties && selected.properties.isText) {
             selectedGeoJSON = set("geometry.type", "Point", selectedGeoJSON);
         }

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -73,8 +73,7 @@ import {
     validateFeature,
     getComponents,
     updateAllStyles,
-    getBaseCoord,
-    getGeometryError
+    getBaseCoord
 } from '../utils/AnnotationsUtils';
 
 import { set } from '../utils/ImmutableUtils';
@@ -198,9 +197,9 @@ function annotations(state = {validationErrors: {}}, action) {
         });
     }
     case FEATURES_SELECTED: {
-        let newState = state;  
-        
-      
+        let newState = state;
+
+
         let selected = head(action.features) || null;
         if (!selected) {
             return state;
@@ -215,18 +214,18 @@ function annotations(state = {validationErrors: {}}, action) {
         }
 
         let ftChangedIndex = findIndex(state.editing.features, (f) => f.properties.id === selected.properties.id);
-        let selectedGeoJSON = selected;        
-        if (selected && selected.properties && selected.properties.isCircle) {            
-            if(selected.properties.polygonGeom){
+        let selectedGeoJSON = selected;
+        if (selected && selected.properties && selected.properties.isCircle) {
+            if (selected.properties.polygonGeom ) {
                 selectedGeoJSON = set("geometry", selected.properties.polygonGeom, selectedGeoJSON);
             } else {
-                selectedGeoJSON = set("geometry.coordinates",[], selectedGeoJSON);
-                selectedGeoJSON = set("geometry.type",'Polygon', selectedGeoJSON);
+                selectedGeoJSON = set("geometry.coordinates", [], selectedGeoJSON);
+                selectedGeoJSON = set("geometry.type", 'Polygon', selectedGeoJSON);
             }
-                        
+
         } else if (selected && selected.properties && selected.properties.isText) {
             selectedGeoJSON = set("geometry.type", "Point", selectedGeoJSON);
-        }        
+        }
         newState = set(`editing.features`, state.editing.features.map(f => {
             return set("properties.canEdit", false, f);
         }), state);
@@ -241,7 +240,7 @@ function annotations(state = {validationErrors: {}}, action) {
             selected = set("style", newState.editing.features[ftChangedIndex].style, selected);
         }
 
-        
+
         return assign({}, newState, {
             selected,
             coordinateEditorEnabled: !!selected,
@@ -640,12 +639,12 @@ function annotations(state = {validationErrors: {}}, action) {
             canEdit: true
         };
         if (type === "Text") {
-            properties = set("isText", true, properties);            
+            properties = set("isText", true, properties);
         }
         if (type === "Circle") {
             properties = set("isCircle", true, properties);
-            properties = set("isDrawing", true, properties);            
-        }        
+            properties = set("isDrawing", true, properties);
+        }
         let selected = {type: "Feature", geometry: {type, coordinates: getBaseCoord(type)}, properties,
             style: {...(state.config?.defaultPointType === 'symbol' ? state.defaultStyles?.POINT?.symbol : state.defaultStyles?.POINT.marker), id: uuid.v1()}};
 
@@ -655,7 +654,7 @@ function annotations(state = {validationErrors: {}}, action) {
         // Reset highlight properties of other features except the selected feature
         const editingFeatures = state.editing.features.filter(({properties: prop})=> prop?.id !== selected?.properties?.id)?.map((ft = {})=>{ ft.style = ft?.style?.map(s=> {s.highlight = false; return s;}) || []; return ft;});
         let newState = set(`editing.tempFeatures`, editingFeatures, state);
-       
+
         return assign({}, state, {
             drawing: !newState.drawing,
             featureType: type,
@@ -763,21 +762,21 @@ function annotations(state = {validationErrors: {}}, action) {
     case START_DRAWING:
         return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
     case SET_IS_VALID_FEATURE:
-                       
-        let updatedFeatures = state.editing.features        
-        updatedFeatures.map((f) => { 
-            
+
+        let updatedFeatures = state.editing.features;
+        updatedFeatures.map((f) => {
+
             const isFeatureValid = validateFeature({
                 properties: f.properties,
                 components: getComponents(f.geometry),
                 type: f.geometry.type
-            })                           
-            f.properties.isValidFeature = isFeatureValid                    
-                         
-        })
-     
+            });
+            f.properties.isValidFeature = isFeatureValid;
+
+        });
+
         return assign({}, state, {
-            editing: {...state.editing, features:updatedFeatures },          
+            editing: {...state.editing, features: updatedFeatures }
         });
     default:
         return state;

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -198,8 +198,6 @@ function annotations(state = {validationErrors: {}}, action) {
     }
     case FEATURES_SELECTED: {
         let newState = state;
-
-
         let selected = head(action.features) || null;
         if (!selected) {
             return state;
@@ -755,15 +753,13 @@ function annotations(state = {validationErrors: {}}, action) {
     case START_DRAWING:
         return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
     case VALIDATE_FEATURE:
-
-        let updatedFeatures = state.editing.features;
-        updatedFeatures.map((f) => {
-            f.properties.isValidFeature = validateFeature({
+        let updatedFeatures = state.editing.features.map((f) => {
+            const isValidFeature = validateFeature({
                 properties: f.properties,
                 components: getComponents(f.geometry),
                 type: getGeometryType(f)
             });
-
+            return set(`properties.isValidFeature`, isValidFeature, f);
         });
 
         return assign({}, state, {

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -47,7 +47,7 @@ import {
     SET_DEFAULT_STYLE,
     SET_EDITING_FEATURE,
     SET_INVALID_SELECTED,
-    SET_IS_VALID_FEATURE,
+    VALIDATE_FEATURE,
     SET_STYLE,
     SHOW_ANNOTATION,
     START_DRAWING,
@@ -754,7 +754,7 @@ function annotations(state = {validationErrors: {}}, action) {
     }
     case START_DRAWING:
         return {...state, config: {...state.config, geodesic: get(action.options, 'geodesic', false)}};
-    case SET_IS_VALID_FEATURE:
+    case VALIDATE_FEATURE:
 
         let updatedFeatures = state.editing.features;
         updatedFeatures.map((f) => {

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -70,7 +70,7 @@ import {
     convertGeoJSONToInternalModel,
     getAvailableStyler,
     getBaseCoord,
-    getComponents,
+    getComponents, getGeometryType,
     updateAllStyles,
     validateCoordsArray,
     validateFeature
@@ -761,7 +761,7 @@ function annotations(state = {validationErrors: {}}, action) {
             f.properties.isValidFeature = validateFeature({
                 properties: f.properties,
                 components: getComponents(f.geometry),
-                type: f.geometry.type
+                type: getGeometryType(f)
             });
 
         });

--- a/web/client/reducers/annotations.js
+++ b/web/client/reducers/annotations.js
@@ -8,78 +8,78 @@
 
 import assign from 'object-assign';
 
-import { transformLineToArcs } from '../utils/CoordinatesUtils';
+import {transformLineToArcs} from '../utils/CoordinatesUtils';
 import circle from '@turf/circle';
-import { PURGE_MAPINFO_RESULTS } from '../actions/mapInfo';
-import { TOGGLE_CONTROL } from '../actions/controls';
-import { FEATURES_SELECTED, DRAWING_FEATURE } from '../actions/draw';
+import {PURGE_MAPINFO_RESULTS} from '../actions/mapInfo';
+import {TOGGLE_CONTROL} from '../actions/controls';
+import {DRAWING_FEATURE, FEATURES_SELECTED} from '../actions/draw';
 
 import {
-    REMOVE_ANNOTATION,
-    CONFIRM_REMOVE_ANNOTATION,
-    CANCEL_REMOVE_ANNOTATION,
-    CLOSE_ANNOTATIONS,
-    CONFIRM_CLOSE_ANNOTATIONS,
-    CANCEL_CLOSE_ANNOTATIONS,
-    EDIT_ANNOTATION,
-    CANCEL_EDIT_ANNOTATION,
-    SAVE_ANNOTATION,
-    TOGGLE_ADD,
-    VALIDATION_ERROR,
-    REMOVE_ANNOTATION_GEOMETRY,
-    TOGGLE_STYLE,
-    SET_STYLE,
-    NEW_ANNOTATION,
-    SHOW_ANNOTATION,
-    CANCEL_SHOW_ANNOTATION,
-    FILTER_ANNOTATIONS,
-    UNSAVED_CHANGES,
-    TOGGLE_GEOMETRY_MODAL,
-    TOGGLE_CHANGES_MODAL,
-    CHANGED_PROPERTIES,
-    TOGGLE_STYLE_MODAL,
-    UNSAVED_STYLE,
+    ADD_NEW_FEATURE,
     ADD_TEXT,
-    CHANGED_SELECTED,
-    RESET_COORD_EDITOR,
+    CANCEL_CLOSE_ANNOTATIONS,
+    CANCEL_EDIT_ANNOTATION,
+    CANCEL_REMOVE_ANNOTATION,
+    CANCEL_SHOW_ANNOTATION,
+    CHANGE_FORMAT,
+    CHANGE_GEOMETRY_TITLE,
     CHANGE_RADIUS,
     CHANGE_TEXT,
-    ADD_NEW_FEATURE,
-    SET_EDITING_FEATURE,
-    SET_INVALID_SELECTED,
-    TOGGLE_DELETE_FT_MODAL,
+    CHANGED_PROPERTIES,
+    CHANGED_SELECTED,
+    CLOSE_ANNOTATIONS,
+    CONFIRM_CLOSE_ANNOTATIONS,
     CONFIRM_DELETE_FEATURE,
-    HIGHLIGHT_POINT,
-    CHANGE_FORMAT,
-    UPDATE_SYMBOLS,
+    CONFIRM_REMOVE_ANNOTATION,
+    EDIT_ANNOTATION,
     ERROR_SYMBOLS,
-    SET_DEFAULT_STYLE,
-    LOADING,
-    CHANGE_GEOMETRY_TITLE,
+    FILTER_ANNOTATIONS,
     FILTER_MARKER,
     HIDE_MEASURE_WARNING,
-    TOGGLE_SHOW_AGAIN,
+    HIGHLIGHT_POINT,
     INIT_PLUGIN,
-    UNSELECT_FEATURE,
+    LOADING,
+    NEW_ANNOTATION,
+    REMOVE_ANNOTATION,
+    REMOVE_ANNOTATION_GEOMETRY,
+    RESET_COORD_EDITOR,
+    SAVE_ANNOTATION,
+    SET_DEFAULT_STYLE,
+    SET_EDITING_FEATURE,
+    SET_INVALID_SELECTED,
+    SET_IS_VALID_FEATURE,
+    SET_STYLE,
+    SHOW_ANNOTATION,
     START_DRAWING,
-    SET_IS_VALID_FEATURE
+    TOGGLE_ADD,
+    TOGGLE_CHANGES_MODAL,
+    TOGGLE_DELETE_FT_MODAL,
+    TOGGLE_GEOMETRY_MODAL,
+    TOGGLE_SHOW_AGAIN,
+    TOGGLE_STYLE,
+    TOGGLE_STYLE_MODAL,
+    UNSAVED_CHANGES,
+    UNSAVED_STYLE,
+    UNSELECT_FEATURE,
+    UPDATE_SYMBOLS,
+    VALIDATION_ERROR
 } from '../actions/annotations';
 
 import {
-    validateCoordsArray,
-    getAvailableStyler,
-    convertGeoJSONToInternalModel,
     addIds,
-    validateFeature,
+    convertGeoJSONToInternalModel,
+    getAvailableStyler,
+    getBaseCoord,
     getComponents,
     updateAllStyles,
-    getBaseCoord
+    validateCoordsArray,
+    validateFeature
 } from '../utils/AnnotationsUtils';
 
-import { set } from '../utils/ImmutableUtils';
-import { head, findIndex, isNil, slice, castArray, get } from 'lodash';
+import {set} from '../utils/ImmutableUtils';
+import {castArray, findIndex, get, head, isNil, slice} from 'lodash';
 import uuid from 'uuid';
-import { getApi } from '../api/userPersistedStorage';
+import {getApi} from '../api/userPersistedStorage';
 
 const fixCoordinates = (coords, type) => {
     switch (type) {
@@ -301,13 +301,6 @@ function annotations(state = {validationErrors: {}}, action) {
     case CHANGE_RADIUS: {
         let newState;
         let selected = set("properties.radius", action.radius, state.selected);
-        if (action.components.length === 0 || action.radius === null) {
-            selected = set("properties.isValidFeature", false, selected);
-            return assign({}, state, {
-                selected,
-                unsavedChanges: true
-            });
-        }
         selected = set("properties.isValidFeature", validateFeature({
             properties: selected.properties,
             components: getComponents({coordinates: action.components[0] || [], type: "Circle"}),
@@ -765,13 +758,11 @@ function annotations(state = {validationErrors: {}}, action) {
 
         let updatedFeatures = state.editing.features;
         updatedFeatures.map((f) => {
-
-            const isFeatureValid = validateFeature({
+            f.properties.isValidFeature = validateFeature({
                 properties: f.properties,
                 components: getComponents(f.geometry),
                 type: f.geometry.type
             });
-            f.properties.isValidFeature = isFeatureValid;
 
         });
 

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -46,14 +46,6 @@
                 &.ms-disabled {
                     cursor: not-allowed;
                     .background-color-var(@theme-vars[disabled-bg]);
-
-                    .btn.inactive {
-                        background: none;
-
-                        &:hover, &:focus {
-                            .background-color-var(@theme-vars[main-bg]);
-                        }
-                    }
                 }
             }
         }

--- a/web/client/themes/default/less/annotations.less
+++ b/web/client/themes/default/less/annotations.less
@@ -14,7 +14,7 @@
     .annotations-edit-error {
         .color-var(@theme-vars[danger]);
     }
-    
+
     .ms-marker-shape-content,
     .ms-marker-icon-content,
     #mapstore-annotations-panel {
@@ -42,6 +42,18 @@
             .geometry-card {
                 &.ms-selected {
                     .border-color-var(@theme-vars[focus-color]);
+                }
+                &.ms-disabled {
+                    cursor: not-allowed;
+                    .background-color-var(@theme-vars[disabled-bg]);
+
+                    .btn.inactive {
+                        background: none;
+
+                        &:hover, &:focus {
+                            .background-color-var(@theme-vars[main-bg]);
+                        }
+                    }
                 }
             }
         }
@@ -371,7 +383,6 @@
 .mapstore-annotations-info-viewer > .annotations-edit-error {
     height: 22px;
     border-bottom-width: 1px;
-    border-bottom-style: 1px;
     margin-bottom: 10px;
 }
 

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1191,8 +1191,9 @@
                 "notValidPolyline": "Alle Koordinaten müssen gültig sein (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Fügen Sie einen Textwert und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Geben Sie einen Radius und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Neu"
-            }
+                "newFeature": "Neu"                
+            },
+            "geometryError": "La configración de geometría no es válida."
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1194,6 +1194,7 @@
                 "newFeature": "Neu"
             },
             "geometryError": "Geometriekonfiguration ist ungültig",
+            "annotationSaveGeometryError": "Das Speichern ist aufgrund einer ungültigen Geometrie deaktiviert. Bitte korrigieren Sie dies, um die Anmerkung zu speichern",
             "resolveAllErrors": "Bitte beheben Sie alle Validierungsfehler, bevor Sie andere Geometrien bearbeiten"
         },
         "user":{

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1191,9 +1191,10 @@
                 "notValidPolyline": "Alle Koordinaten müssen gültig sein (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Fügen Sie einen Textwert und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Geben Sie einen Radius und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Neu"                
+                "newFeature": "Neu"
             },
-            "geometryError": "La configración de geometría no es válida."
+            "geometryError": "Geometriekonfiguration ist ungültig",
+            "resolveAllErrors": "Bitte beheben Sie alle Validierungsfehler, bevor Sie andere Geometrien bearbeiten"
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1154,8 +1154,8 @@
                 "notValidCircle": "Insert a radius value and a valid coordinate (+|- 90° lat, +|-180° lon)",
                 "newFeature": "New"
             },
-          "geometryError": "Geometry Configuration is invalid",
-          "resolveAllErrors": "Please fix any validation errors before editing other geometries"
+            "geometryError": "Geometry configuration is invalid",
+            "resolveAllErrors": "Please fix any validation errors before editing other geometries"
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1155,6 +1155,7 @@
                 "newFeature": "New"
             },
             "geometryError": "Geometry configuration is invalid",
+            "annotationSaveGeometryError": "Saving is disabled due to invalid geometry, please fix it to save the annotation",
             "resolveAllErrors": "Please fix any validation errors before editing other geometries"
         },
         "user":{

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1153,7 +1153,9 @@
                 "notValidText": "Insert a text value and a valid coordinate (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Insert a radius value and a valid coordinate (+|- 90° lat, +|-180° lon)",
                 "newFeature": "New"
-            }
+            },
+          "geometryError": "Geometry Configuration is invalid",
+          "resolveAllErrors": "Please fix any validation errors before editing other geometries"
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1155,6 +1155,7 @@
                 "newFeature": "Nuevo"
             },
             "geometryError": "La configuración de geometría no es válida",
+            "annotationSaveGeometryError": "El guardado está deshabilitado debido a una geometría no válida, corríjalo para guardar la anotación",
             "resolveAllErrors": "Corrija los errores de validación antes de editar otras geometrías"
         },
         "user":{

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1152,9 +1152,10 @@
                 "notValidPolyline": "Todas las coordenadas deben ser válidas (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insertar un valor de texto y una coordenada válida (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Ingrese un radio y una coordenada válida (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nuevo"                
+                "newFeature": "Nuevo"
             },
-            "geometryError": "La configuración de geometría no es válida."
+            "geometryError": "La configuración de geometría no es válida",
+            "resolveAllErrors": "Corrija los errores de validación antes de editar otras geometrías"
         },
         "user":{
             "login": "Iniciar sesión",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "Todas las coordenadas deben ser válidas (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insertar un valor de texto y una coordenada válida (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Ingrese un radio y una coordenada válida (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nuevo"
-            }
+                "newFeature": "Nuevo"                
+            },
+            "geometryError": "La configuración de geometría no es válida."
         },
         "user":{
             "login": "Iniciar sesión",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1152,9 +1152,10 @@
                 "notValidPolyline": "Toutes les coordonnées doivent être valides (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insérer une valeur de texte et une coordonnée valide (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Entrez un rayon et une coordonnée valide (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nouveau"        
+                "newFeature": "Nouveau"
             },
-            "geometryError": "La configuration de la géométrie n'est pas valide."
+            "geometryError": "La configuration de la géométrie n'est pas valide",
+            "resolveAllErrors": "Veuillez corriger les erreurs de validation avant de modifier d'autres géométries"
         },
         "user": {
             "login": "Connexion",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "Toutes les coordonnées doivent être valides (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Insérer une valeur de texte et une coordonnée valide (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Entrez un rayon et une coordonnée valide (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nouveau"
-            }
+                "newFeature": "Nouveau"        
+            },
+            "geometryError": "La configuration de la géométrie n'est pas valide."
         },
         "user": {
             "login": "Connexion",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1155,6 +1155,7 @@
                 "newFeature": "Nouveau"
             },
             "geometryError": "La configuration de la géométrie n'est pas valide",
+            "annotationSaveGeometryError": "L'enregistrement est désactivé en raison d'une géométrie non valide, veuillez le corriger pour enregistrer l'annotation",
             "resolveAllErrors": "Veuillez corriger les erreurs de validation avant de modifier d'autres géométries"
         },
         "user": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1155,7 +1155,8 @@
                 "newFeature": "Nuovo"
             },
             "geometryError": "La configurazione della geometria non è valida",
-            "resolveAllErrors": "Si prega di correggere eventuali errori di convalida prima di modificare altre geometrie"
+            "annotationSaveGeometryError": "Il salvataggio è disabilitato a causa di una geometria non valida, correggilo per salvare l'annotazione",
+            "resolveAllErrors": "Si prega di correggere gli errori prima di modificare altre geometrie"
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1152,9 +1152,10 @@
                 "notValidPolyline": "Tutte le coordinate devono essere valide (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Inserisci un testo ed una coordinata valida (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Inserisci un raggio ed una coordinata valida (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nuovo"                
+                "newFeature": "Nuovo"
             },
-            "geometryError": "La configurazione della geometria non è valida."
+            "geometryError": "La configurazione della geometria non è valida",
+            "resolveAllErrors": "Si prega di correggere eventuali errori di convalida prima di modificare altre geometrie"
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1152,8 +1152,9 @@
                 "notValidPolyline": "Tutte le coordinate devono essere valide (+|- 90° lat, +|-180° lon)",
                 "notValidText": "Inserisci un testo ed una coordinata valida (+|- 90° lat, +|-180° lon)",
                 "notValidCircle": "Inserisci un raggio ed una coordinata valida (+|- 90° lat, +|-180° lon)",
-                "newFeature": "Nuovo"
-            }
+                "newFeature": "Nuovo"                
+            },
+            "geometryError": "La configurazione della geometria non è valida."
         },
         "user":{
             "login": "Login",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1172,7 +1172,7 @@
                 "notValidPolyline": "Alle coördinaten moeten geldig zijn (+ | - 90 ° lat, + | -180 ° lon)",
                 "notValidText": "Voeg een tekstwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
                 "notValidCircle": "Voeg een straalwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
-                "newFeature": "Nieuw"
+                "newFeature": "Nieuw"                
             }
         },
         "user":{

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -554,7 +554,7 @@
             "filterIconEnabled": "Schakel laagfilter uit",
             "filterIconDisabled": "Schakel laagfilter in",
 	    "notVisibleZoomIn": "De laag is niet zichtbaar omdat deze buiten de resolutiegrenzen valt. Zoom in om de laag te tonen",
-            "notVisibleZoomOut": "De laag is niet zichtbaar omdat deze buiten de resolutiegrenzen valt. Zoom uit om de laag weer te geven",	
+            "notVisibleZoomOut": "De laag is niet zichtbaar omdat deze buiten de resolutiegrenzen valt. Zoom uit om de laag weer te geven",
             "refreshOptions": {
                 "bbox": "BBOX bijwerken",
                 "search": "De zoekopties bijwerken",
@@ -1171,8 +1171,7 @@
                 "notValidMarker": "Voer een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
                 "notValidPolyline": "Alle coördinaten moeten geldig zijn (+ | - 90 ° lat, + | -180 ° lon)",
                 "notValidText": "Voeg een tekstwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
-                "notValidCircle": "Voeg een straalwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)",
-                "newFeature": "Nieuw"                
+                "notValidCircle": "Voeg een straalwaarde en een geldige coördinaat in (+ | - 90 ° lat, + | -180 ° lon)"
             }
         },
         "user":{

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1152,8 +1152,7 @@
                 "notValidMarker": "Infoga en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
                 "notValidPolyline": "All koordinat måste vara giltig ( +|- 90 ° lat, +| -180 ° lon)",
                 "notValidText": "Infoga ett textvärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
-                "notValidCircle": "Infoga ett radievärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
-                "newFeature": "Ny"                
+                "notValidCircle": "Infoga ett radievärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)"
             }
         },
         "user":{

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1153,7 +1153,7 @@
                 "notValidPolyline": "All koordinat måste vara giltig ( +|- 90 ° lat, +| -180 ° lon)",
                 "notValidText": "Infoga ett textvärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
                 "notValidCircle": "Infoga ett radievärde och en giltig koordinat ( +|- 90 ° lat, +| -180 ° lon)",
-                "newFeature": "Ny"
+                "newFeature": "Ny"                
             }
         },
         "user":{

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright 2018, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -562,8 +562,8 @@ export const validateCoord = (c) => !isNaN(parseFloat(c));
 export const coordToArray = (c = {}) => [c.lon, c.lat];
 export const validateCoordinates = ({components = [], remove = false, type } = {}) => {
     if (components && components.length) {
-        const validComponents = components.filter(AnnotationsUtils.validateCoords);
-
+        const validComponents = components.filter(AnnotationsUtils.validateCoords);        
+        
         if (remove) {
             return validComponents.length > AnnotationsUtils.COMPONENTS_VALIDATION[type].min && validComponents.length === components.length;
         }
@@ -622,8 +622,11 @@ export const isAMissingSymbol = (style) => {
  * @return {boolean} true if it is a valid polygon, false otherwise
 */
 export const isCompletePolygon = (coords = [[[]]]) => {
-    const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
-    return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
+    if(coords && coords[0]){
+        const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
+        return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
+    }    
+    return false
 };
 /**
  * utility to check if the GeoJSON has the annotation model structure i.e. {"type": "ms2-annotations", "features": [list of FeatureCollection]}
@@ -632,6 +635,14 @@ export const isCompletePolygon = (coords = [[[]]]) => {
  * @returns {boolean} if the GeoJSON passes is a ms2-annotation or if the name property of the object passed is Annotations
  */
 export const isAnnotation = (json) => json?.type === ANNOTATION_TYPE || json?.name === "Annotations";
+/**
+ * utitily to get the error based on the type of the geomatery
+ */
+export const getGeometryError = (type = null) => {
+    if(type){
+        return AnnotationsUtils.COMPONENTS_VALIDATION[type].notValid        
+    }
+}
 
 AnnotationsUtils = {
     ANNOTATION_TYPE,

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -1,4 +1,4 @@
-    /*
+/*
  * Copyright 2018, GeoSolutions Sas.
  * All rights reserved.
  *
@@ -562,8 +562,7 @@ export const validateCoord = (c) => !isNaN(parseFloat(c));
 export const coordToArray = (c = {}) => [c.lon, c.lat];
 export const validateCoordinates = ({components = [], remove = false, type } = {}) => {
     if (components && components.length) {
-        const validComponents = components.filter(AnnotationsUtils.validateCoords);        
-        
+        const validComponents = components.filter(AnnotationsUtils.validateCoords);
         if (remove) {
             return validComponents.length > AnnotationsUtils.COMPONENTS_VALIDATION[type].min && validComponents.length === components.length;
         }
@@ -622,11 +621,11 @@ export const isAMissingSymbol = (style) => {
  * @return {boolean} true if it is a valid polygon, false otherwise
 */
 export const isCompletePolygon = (coords = [[[]]]) => {
-    if(coords && coords[0]){
+    if (coords && coords[0]) {
         const validCoords = coords[0].filter(AnnotationsUtils.validateCoordsArray);
         return validCoords.length > 3 && head(validCoords)[0] === last(validCoords)[0] && head(validCoords)[1] === last(validCoords)[1];
-    }    
-    return false
+    }
+    return false;
 };
 /**
  * utility to check if the GeoJSON has the annotation model structure i.e. {"type": "ms2-annotations", "features": [list of FeatureCollection]}
@@ -635,14 +634,6 @@ export const isCompletePolygon = (coords = [[[]]]) => {
  * @returns {boolean} if the GeoJSON passes is a ms2-annotation or if the name property of the object passed is Annotations
  */
 export const isAnnotation = (json) => json?.type === ANNOTATION_TYPE || json?.name === "Annotations";
-/**
- * utitily to get the error based on the type of the geomatery
- */
-export const getGeometryError = (type = null) => {
-    if(type){
-        return AnnotationsUtils.COMPONENTS_VALIDATION[type].notValid        
-    }
-}
 
 AnnotationsUtils = {
     ANNOTATION_TYPE,

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -583,7 +583,7 @@ export function isSimpleGeomType(geomType) {
 }
 export function getSimpleGeomType(geomType = "Point") {
     switch (geomType) {
-    case "Point": case "LineString": case "Polygon": case "Circle": return geomType;
+    case "Point": case "LineString": case "Polygon": case "Circle": return "Circle";
     case "MultiPoint": case "Marker": return "Point";
     case "MultiLineString": return "LineString";
     case "MultiPolygon": return "Polygon";

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -583,7 +583,7 @@ export function isSimpleGeomType(geomType) {
 }
 export function getSimpleGeomType(geomType = "Point") {
     switch (geomType) {
-    case "Point": case "LineString": case "Polygon": case "Circle": return "Circle";
+    case "Point": case "LineString": case "Polygon": case "Circle": return geomType;
     case "MultiPoint": case "Marker": return "Point";
     case "MultiLineString": return "LineString";
     case "MultiPolygon": return "Polygon";

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -811,15 +811,19 @@ describe('Test the AnnotationsUtils', () => {
     });
 
     it('test isCompletePolygon defaults', () => {
-        const polygonCoords1 = [[[1, 1], [2, 2]]];
-        const polygonCoords2 = [[[1, 1], [2, 2], [1, 1]]];
-        const polygonCoords3 = [[[1, 1], [2, 2], [3, 3], [1, 1]]];
-        const polygonCoords4 = [[[1, 1], [2, undefined], [3, 3], [1, 1]]];
+        const polygonCoords0 = [];
+        const polygonCoords1 = [[[1, 1]]];
+        const polygonCoords2 = [[[1, 1], [2, 2]]];
+        const polygonCoords3 = [[[1, 1], [2, 2], [1, 1]]];
+        const polygonCoords4 = [[[1, 1], [2, 2], [3, 3], [1, 1]]];
+        const polygonCoords5 = [[[1, 1], [2, undefined], [3, 3], [1, 1]]];
         expect(isCompletePolygon()).toBe(false);
+        expect(isCompletePolygon(polygonCoords0)).toBe(false);
         expect(isCompletePolygon(polygonCoords1)).toBe(false);
         expect(isCompletePolygon(polygonCoords2)).toBe(false);
-        expect(isCompletePolygon(polygonCoords3)).toBe(true);
-        expect(isCompletePolygon(polygonCoords4)).toBe(false);
+        expect(isCompletePolygon(polygonCoords3)).toBe(false);
+        expect(isCompletePolygon(polygonCoords4)).toBe(true);
+        expect(isCompletePolygon(polygonCoords5)).toBe(false);
     });
     it('test getDashArrayFromStyle', () => {
         // default


### PR DESCRIPTION
## Description
There is a set of conditions that lead to app crash when geometries attached to the annotation are edited.
All these cases related to invalid geometry because one of its coordinates is null.

This PR provides following changes:
1. User will have to fix all validation errors of the selected geometry before change to another geometry or new geometry creation.
2. Geometries that are not selected will be inactive (like if they were disabled elements) in the list if currently selected geometry has validation errors. 
3. User's click on inactive geometries won't trigger change of selected geometry.
4. User's click on active geometry won't deselect it if there are validation errors.
5. Validation mark is removed from geometries list and kept inside geometry edit form. No sense to keep it in two places, only one geometry at a time might be invalid.
6. It's not possible to save invalid geometry. It's not possible to save annotation with invalid geometries.

This concept will make impossible to save geometries with invalid coordinates.

Other changes:
- Changed behavior when user click on the map while invalid "Text" or "Marker" geometry is inactive.
- Invalidate Circle geometry properly if radius is not set.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:


## Issue

**What is the current behavior?**
#7508 

**What is the new behavior?**
- It's not possible to change selected geometry when there are validation errors.
- Click on the map while "Text" and "Marker" geometry is invalid won't trigger new geometry creation.
- Circle geometry was not invalidated inside of editing.features state branch, this led to the issue when geometry marked as invalid in edit form, but remains valid on the level of geometries list. This behavior is fixed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
