### PR TITLE
#7526 Attempt fix to issue with properties placeholder configurer order

### DIFF
--- a/java/web/src/main/resources/applicationContext.xml
+++ b/java/web/src/main/resources/applicationContext.xml
@@ -30,7 +30,7 @@
     </bean>
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="order" value="10"/>
+        <property name="order" value="0"/>
         <property name="locations">
             <list>
                 <value>classpath:geostore.properties</value>
@@ -42,7 +42,7 @@
             </list>
         </property>
         <property name="ignoreResourceNotFound" value="true"/>
-	</bean>
+    </bean>
     <!-- Allows getting database configuration also from the data-dir -->
     <bean class="org.springframework.beans.factory.config.PropertyOverrideConfigurer">
         <property name="ignoreResourceNotFound" value="true"/>

--- a/project/standard/templates/web/src/main/resources/applicationContext.xml
+++ b/project/standard/templates/web/src/main/resources/applicationContext.xml
@@ -28,4 +28,30 @@
         <!-- The default password encoder -->
         <property name="passwordEncoder" ref="${passwordEncoderUsed}"></property>
     </bean>
+
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="order" value="0"/>
+        <property name="locations">
+            <list>
+                <value>classpath:geostore.properties</value>
+                <value>classpath*:geostore.properties</value>
+                <value>classpath:mapstore.properties</value>
+                <value>classpath:ldap.properties</value>
+                <value>file:${datadir.location:}/mapstore.properties</value>
+                <value>file:${datadir.location:}/ldap.properties</value>
+            </list>
+        </property>
+        <property name="ignoreResourceNotFound" value="true"/>
+    </bean>
+    <!-- Allows getting database configuration also from the data-dir -->
+    <bean class="org.springframework.beans.factory.config.PropertyOverrideConfigurer">
+        <property name="ignoreResourceNotFound" value="true"/>
+        <property name="order" value="10"/>
+        <property name="locations">
+            <list>
+                <value>file:${datadir.location:}/geostore-datasource-ovr.properties</value>
+                <value>file:${datadir.location:}/mapstore-ovr.properties</value>
+            </list>
+        </property>
+    </bean>
 </beans>


### PR DESCRIPTION
## Description
This PR tries to provide a solution #7526 
- Change the "order" value to 0. 
- Add to project the defaults for property placeholders configuration (that was missing)

In draft because it has been tested only on binary (editing files on the fly)
- not tested for other installations and projects
- need to check if setting it to 0 changes the priority or the override order from other internal tools (e.g. geostore.properties)
- need to check if also `PropertyOverrideConfigurer' needs the same fix

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7526

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
