### PR TITLE
Issue #7486 background selector missing translation

### DIFF
--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -140,7 +140,7 @@ export default class BackgroundDialog extends React.Component {
         if (this.props.layer.type === "wms") {
             return (<React.Fragment>
                 <FormGroup controlId="formControlsSelect">
-                    <ControlLabel><Message msgId="layerProperties.format" /></ControlLabel>
+                    <ControlLabel><Message msgId="layerProperties.format.title" /></ControlLabel>
                     <Select
                         onChange={event => this.setState({ format: event && event.value })}
                         value={this.state.format || this.props.defaultFormat}


### PR DESCRIPTION
## Description
Links the translation string "Format", used in the background selector plugin, when loading a new users' defined background layer. to the correct string.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) N/A
- [ ] Docs have been added / updated (for bug fixes / features) N/A


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
When a user adds a new background layer, selecting one service from the available list a dialog opens. The dropdown description label to define the format of the new layer contains the string `layerProperties.format`, which is not correct since it is the key in the object contained in the file `data.<language>.json`.
#7486

**What is the new behavior?**
When a user adds a new background layer, selecting one service from the available list a dialog opens. The dropdown description label to define the format of the new layer contains the string `Format`.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
