### PR TITLE
[Backport ] #7527: Cannot scroll a geostory on mobile when the map takes all the viewport (#7528)

### DIFF
--- a/web/client/components/geostory/media/Map.jsx
+++ b/web/client/components/geostory/media/Map.jsx
@@ -106,7 +106,14 @@ export default compose(
                     style: {
                         // removed width and height from style and added to .less
                         // to use different sizes in story sections
-                        cursor: isMapInfoControlActive ? 'pointer' : 'default'
+                        cursor: isMapInfoControlActive ? 'pointer' : 'default',
+
+                        // openlayers map does not propagate the events even if if the interactions are set to false
+                        // we need to disable all the pointer and touch events to make the geostory scrollable also on mobile devices
+                        ...((expandable && !active) && {
+                            pointerEvents: 'none',
+                            touchAction: 'none'
+                        })
                     }
                 }} // if map id is passed as number, the resource id, ol throws an error
                 layers={geoStoryLayers ? [ ...layers, ...geoStoryLayers ] : layers}

--- a/web/client/components/geostory/media/__tests__/Map-test.jsx
+++ b/web/client/components/geostory/media/__tests__/Map-test.jsx
@@ -75,4 +75,28 @@ describe('Map component', () => {
             />,
             document.getElementById("container"));
     });
+    it('should remove the pointer events and touch actions if not active and expandable', (done) => {
+        const MAP = {
+            layers: [],
+            mapInfoControl: true
+        };
+        ReactDOM.render(
+            <Map
+                id="map"
+                mapType="openlayers"
+                map={MAP}
+                expandable
+                onMapTypeLoaded={() => {
+                    const container = document.getElementById('container');
+                    const mediaMapNode = container.querySelector('.ms-media-map');
+                    expect(mediaMapNode).toBeTruthy();
+                    const mapContainer = container.querySelector('#media-map');
+                    expect(mapContainer).toBeTruthy();
+                    expect(mapContainer.style.pointerEvents).toBe('none');
+                    expect(mapContainer.style.touchAction).toBe('none');
+                    done();
+                }}
+            />,
+            document.getElementById("container"));
+    });
 });

--- a/web/client/themes/default/less/geostory.less
+++ b/web/client/themes/default/less/geostory.less
@@ -455,7 +455,7 @@
             }
         }
     }
-    .ms-section-paragraph {
+    .ms-section-paragraph .ms-content-column .ms-column-contents .ms-content {
         padding-left: @ms-story-padding-small-screen;
         padding-right: @ms-story-padding-small-screen;
     }
@@ -512,7 +512,7 @@
         &.ms-align-left .ms-content-body { margin-left: 0; margin-right: auto; }
         &.ms-align-right .ms-content-body { margin-left: auto; margin-right: 0; }
     }
-    .ms-section-paragraph {
+    .ms-section-paragraph .ms-content-column .ms-column-contents .ms-content {
         padding-left: @ms-story-padding-medium-screen;
         padding-right: @ms-story-padding-medium-screen;
     }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR adds new css rules to a geostory map when it's not active on mobile. The new rules will disable the pointers and touch events to allows the propagation of the scroll event.
This PR fixes also a minor bug on the mobile layout of geostory, the padding introduced for the webpage were not update correctly on small screens

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7527

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

It's possible to scroll the geostory even if the map in fullscreen uses openlayers

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
