### PR TITLE
#7502 - Removed CSS fixed heights properties and allowed text wrap in modal headers

### DIFF
--- a/web/client/themes/default/less/modal.less
+++ b/web/client/themes/default/less/modal.less
@@ -137,7 +137,9 @@
         }
 
         & > .modal-header {
-            height: @square-btn-size;
+            @media (min-width: @screen-xs-max) {
+                height: @square-btn-size;
+            }
             padding: ((@square-btn-size - @font-size-h4) / 2);
             border: none;
             flex-shrink: 0;
@@ -145,10 +147,12 @@
                 display: flex;
                 .ms-title {
                     flex: 1;
-                    height: @font-size-h4;
-                    line-height: @font-size-h4;
                     text-overflow: ellipsis;
-                    white-space: nowrap;
+                    @media (min-width: @screen-xs-max) {
+                        white-space: nowrap;
+                        height: @font-size-h4;
+                        line-height: @font-size-h4;
+                    }
                 }
                 .ms-header-btn {
                     cursor: pointer;


### PR DESCRIPTION
## Description
The `ResizableModal` component headers text are now wrapping and expanding in height when the size of the modal is not big enough to contain the text in one line, for example on mobile phone screens.

See below

![recording_1](https://user-images.githubusercontent.com/14953970/141344139-8e2a9142-ab7e-491f-a7c0-11c852f1d4e6.gif)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) N/A
- [ ] Docs have been added / updated (for bug fixes / features) N/A


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
On a small sized screen, from the home page, accessing maps details, the modal window was not showing the entire title text, the expand and close buttons on the window header. 

[#7502](https://github.com/geosolutions-it/MapStore2/issues/7502)

**What is the new behavior?**
On a small sized screen, from the home page, accessing maps details, on the modal window the entire title text wraps on multiple lines, the header grows vertically to contain the text, the expand and close buttons on the window header are appearing on the right of the text. 
 
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
