### PR TITLE
Issue #7523 -  Geocarousel improve markers viz

### DIFF
--- a/web/client/components/geostory/layouts/Cascade.jsx
+++ b/web/client/components/geostory/layouts/Cascade.jsx
@@ -127,7 +127,8 @@ const Cascade = ({
     onSort = () => {},
     isDrawEnabled = false,
     onEnableDraw = () => {},
-    defaultMarkerStyle
+    defaultMarkerStyle,
+    highlightedMarkerStyle
 }) => (<BorderLayout  className={`ms-cascade-story ms-${mode}`}>
     <ContainerDimensions
         sections={sections}
@@ -194,6 +195,7 @@ const Cascade = ({
                                     onEnableDraw={onEnableDraw}
                                     background={background}
                                     defaultMarkerStyle={defaultMarkerStyle}
+                                    highlightedMarkerStyle={highlightedMarkerStyle}
                                 />
                             );
                         })

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -179,7 +179,7 @@ const GeoCarousel = ({
 
     const highlightedContentsLayer = getVectorLayerFromContents({
         id: `${id}-highlighted`,
-        contents : contents.filter(content => content.id === contentId),
+        contents: contents.filter(content => content.id === contentId),
         featureStyle: ({ content, feature }) => getContentsFeatureStyle(highlightedMarkerStyle, contents, content, contentId, feature)
     });
 

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -70,6 +70,14 @@ const GeoCarousel = ({
     onSort = () => {},
     onEnableDraw = () => {},
     isDrawEnabled,
+    defaultMarkerStyle = {
+        iconColor: 'cyan',
+        iconShape: 'circle'
+    },
+    highlightedMarkerStyle = {
+        iconColor: 'red',
+        iconShape: 'circle'
+    }
 }) => {
 
     const innerBackgroundNode = useRef();
@@ -166,13 +174,13 @@ const GeoCarousel = ({
     const contentsLayer = getVectorLayerFromContents({
         id,
         contents: contents.filter(content => content.id !== contentId),
-        featureStyle: ({ content, feature }) => getContentsFeatureStyle(contents, content, contentId, feature)
+        featureStyle: ({ content, feature }) => getContentsFeatureStyle(defaultMarkerStyle, contents, content, contentId, feature)
     });
 
     const highlightedContentsLayer = getVectorLayerFromContents({
         id: `${id}-highlighted`,
         contents : contents.filter(content => content.id === contentId),
-        featureStyle: ({ content, feature }) => getContentsFeatureStyle(contents, content, contentId, feature, 'red')
+        featureStyle: ({ content, feature }) => getContentsFeatureStyle(highlightedMarkerStyle, contents, content, contentId, feature)
     });
 
     return (<section

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -75,7 +75,7 @@ const GeoCarousel = ({
         iconShape: 'circle'
     },
     highlightedMarkerStyle = {
-        iconColor: 'red',
+        iconColor: 'green',
         iconShape: 'circle'
     }
 }) => {

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -22,6 +22,7 @@ import {
     Modes,
     SectionTemplates,
     getVectorLayerFromContents,
+    getContentsFeatureStyle,
     getDefaultSectionTemplate
 } from '../../../../utils/GeoStoryUtils';
 import pattern from './patterns/world.svg';
@@ -69,10 +70,6 @@ const GeoCarousel = ({
     onSort = () => {},
     onEnableDraw = () => {},
     isDrawEnabled,
-    defaultMarkerStyle = {
-        iconColor: 'cyan',
-        iconShape: 'circle'
-    }
 }) => {
 
     const innerBackgroundNode = useRef();
@@ -169,23 +166,13 @@ const GeoCarousel = ({
     const contentsLayer = getVectorLayerFromContents({
         id,
         contents: contents.filter(content => content.id !== contentId),
-        featureStyle: ({ content, feature }) => ({
-            ...defaultMarkerStyle,
-            iconText: `${contents.indexOf(content) + 1}`,
-            ...feature.style,
-            highlight: contentId === content.id
-        })
+        featureStyle: ({ content, feature }) => getContentsFeatureStyle(contents, content, contentId, feature)
     });
 
     const highlightedContentsLayer = getVectorLayerFromContents({
         id: `${id}-highlighted`,
         contents : contents.filter(content => content.id === contentId),
-        featureStyle: ({ content, feature }) => ({
-            ...{...defaultMarkerStyle, iconColor: 'red'},
-            iconText: `${contents.indexOf(content) + 1}`,
-            ...feature.style,
-            highlight: contentId === content.id
-        })
+        featureStyle: ({ content, feature }) => getContentsFeatureStyle(contents, content, contentId, feature, 'red')
     });
 
     return (<section

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -169,12 +169,15 @@ const GeoCarousel = ({
     const contentsLayer = getVectorLayerFromContents({
         id,
         contents,
-        featureStyle: ({ content, feature }, idx) => ({
-            ...defaultMarkerStyle,
-            iconText: `${idx + 1}`,
-            ...feature.style,
-            highlight: contentId === content.id
-        })
+        featureStyle: ({ content, feature }, idx) => {
+            const isHighlighted = contentId === content.id;
+            return ({
+                ...(isHighlighted ? {...defaultMarkerStyle, iconColor: 'red'} : defaultMarkerStyle),
+                iconText: `${idx + 1}`,
+                ...feature.style,
+                highlight: isHighlighted
+            });
+        }
     });
 
     return (<section

--- a/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
+++ b/web/client/components/geostory/layouts/sections/GeoCarousel.jsx
@@ -168,16 +168,24 @@ const GeoCarousel = ({
 
     const contentsLayer = getVectorLayerFromContents({
         id,
-        contents,
-        featureStyle: ({ content, feature }, idx) => {
-            const isHighlighted = contentId === content.id;
-            return ({
-                ...(isHighlighted ? {...defaultMarkerStyle, iconColor: 'red'} : defaultMarkerStyle),
-                iconText: `${idx + 1}`,
-                ...feature.style,
-                highlight: isHighlighted
-            });
-        }
+        contents: contents.filter(content => content.id !== contentId),
+        featureStyle: ({ content, feature }) => ({
+            ...defaultMarkerStyle,
+            iconText: `${contents.indexOf(content) + 1}`,
+            ...feature.style,
+            highlight: contentId === content.id
+        })
+    });
+
+    const highlightedContentsLayer = getVectorLayerFromContents({
+        id: `${id}-highlighted`,
+        contents : contents.filter(content => content.id === contentId),
+        featureStyle: ({ content, feature }) => ({
+            ...{...defaultMarkerStyle, iconColor: 'red'},
+            iconText: `${contents.indexOf(content) + 1}`,
+            ...feature.style,
+            highlight: contentId === content.id
+        })
     });
 
     return (<section
@@ -218,7 +226,7 @@ const GeoCarousel = ({
             mediaViewer={mediaViewer}
             contentToolbar={contentToolbar}
             inView={inView}
-            layers={[ contentsLayer ]}
+            layers={[ contentsLayer, highlightedContentsLayer ]}
             isDrawEnabled={isDrawEnabled}
             onEnableDraw={onEnableDraw}
             contentToolbarChildren={!isMapBackground && mode === Modes.EDIT && <InfoCarousel type={'addMap'}/>}

--- a/web/client/components/geostory/layouts/sections/Section.jsx
+++ b/web/client/components/geostory/layouts/sections/Section.jsx
@@ -63,7 +63,8 @@ class Section extends React.Component {
         isDrawEnabled: PropTypes.bool,
         onEnableDraw: PropTypes.func,
         background: PropTypes.object,
-        defaultMarkerStyle: PropTypes.object
+        defaultMarkerStyle: PropTypes.object,
+        highlightedMarkerStyle: PropTypes.object
     };
 
     static defaultProps = {
@@ -120,6 +121,7 @@ class Section extends React.Component {
                 background={this.props.background}
                 onEnableDraw={this.props.onEnableDraw}
                 defaultMarkerStyle={this.props.defaultMarkerStyle}
+                highlightedMarkerStyle={this.props.highlightedMarkerStyle}
             />
         );
     }

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -148,8 +148,8 @@ GeoStory.defaultProps = {
  *       "iconShape": "square" // 'circle', 'square', 'star' or 'penta'
  *     },
  *     "highlightedMarkerStyle": {
- *       "iconColor": "red", // 'orange', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'blue', 'cyan', ->
- *           // -> 'purple', 'violet', 'pink', 'green-dark', 'green', 'green-light' or 'black'
+ *       "iconColor": "green", // 'orange', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'blue', 'cyan', ->
+ *           // -> 'purple', 'violet', 'pink', 'green-dark', 'red', 'green-light' or 'black'
  *       "iconShape": "circle" // 'circle', 'square', 'star' or 'penta'
  *     },
  *     "mediaEditorSettings": {

--- a/web/client/plugins/GeoStory.jsx
+++ b/web/client/plugins/GeoStory.jsx
@@ -127,6 +127,7 @@ GeoStory.defaultProps = {
  * @prop {numeric} cfg.interceptionTime default 100, the debounce before calculations of currentPage active section
  * @prop {object[]} cfg.fontFamilies: A list of objects with font family names and sources where to load them from e.g. [{"family": "Comic sans", "src": "link to source"}]
  * @prop {object} cfg.defaultMarkerStyle define the default marker style used by geo carousel section
+ * @prop {object} cfg.highlightedMarkerStyle define the highlighted marker style used by geo carousel section
  * @prop {object} cfg.mediaEditorSettings settings for media editor services divided by media type
  * @prop {string} cfg.mediaEditorSettings.sourceId selected service identifier used when the modal shows up
  * @prop {object} cfg.mediaEditorSettings.mediaTypes configuration of source options for each media type: image, video and map
@@ -145,6 +146,11 @@ GeoStory.defaultProps = {
  *       "iconColor": "orange", // 'red', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'blue', 'cyan', ->
  *           // -> 'purple', 'violet', 'pink', 'green-dark', 'green', 'green-light' or 'black'
  *       "iconShape": "square" // 'circle', 'square', 'star' or 'penta'
+ *     },
+ *     "highlightedMarkerStyle": {
+ *       "iconColor": "red", // 'orange', 'orange-dark', 'orange', 'yellow', 'blue-dark', 'blue', 'cyan', ->
+ *           // -> 'purple', 'violet', 'pink', 'green-dark', 'green', 'green-light' or 'black'
+ *       "iconShape": "circle" // 'circle', 'square', 'star' or 'penta'
  *     },
  *     "mediaEditorSettings": {
  *       "sourceId": "geostory",

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -657,15 +657,9 @@ export function getVectorLayerFromContents({
     };
 }
 
-export const getContentsFeatureStyle = (
-    markerStyle,
-    contents,
-    content,
-    contentId,
-    feature,
-    ) => ({
+export const getContentsFeatureStyle = (markerStyle, contents, content, contentId, feature) => ({
     ...markerStyle,
-    iconText: `${contents.indexOf(content) + 1}`,
+    iconText: `${findIndex(contents, ({id: _id}) => content.id === _id) + 1}`,
     ...feature.style,
     highlight: contentId === content.id
-})
+});

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -657,6 +657,9 @@ export function getVectorLayerFromContents({
     };
 }
 
+/**
+ * Applies to the contents style passed the iconText (1, 2, 3), merges the default marker style with the specific feature style and adds the `highlighted` flag.
+ */
 export const getContentsFeatureStyle = (markerStyle, contents, content, contentId, feature) => ({
     ...markerStyle,
     iconText: `${findIndex(contents, ({id: _id}) => content.id === _id) + 1}`,

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -658,14 +658,13 @@ export function getVectorLayerFromContents({
 }
 
 export const getContentsFeatureStyle = (
+    markerStyle,
     contents,
     content,
     contentId,
     feature,
-    iconColor='cyan'
     ) => ({
-    iconShape: 'circle',
-    iconColor,
+    ...markerStyle,
     iconText: `${contents.indexOf(content) + 1}`,
     ...feature.style,
     highlight: contentId === content.id

--- a/web/client/utils/GeoStoryUtils.js
+++ b/web/client/utils/GeoStoryUtils.js
@@ -656,3 +656,17 @@ export function getVectorLayerFromContents({
         ], []).reverse()
     };
 }
+
+export const getContentsFeatureStyle = (
+    contents,
+    content,
+    contentId,
+    feature,
+    iconColor='cyan'
+    ) => ({
+    iconShape: 'circle',
+    iconColor,
+    iconText: `${contents.indexOf(content) + 1}`,
+    ...feature.style,
+    highlight: contentId === content.id
+})

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -663,7 +663,7 @@ describe("GeoStory Utils", () => {
     });
     it('getContentsFeatureStyle with highlightedMarkerStyle', () => {
         const defaultMarkerStyle = {
-            iconColor: 'red',
+            iconColor: 'green',
             iconShape: 'circle'
         };
         const contents = [
@@ -679,7 +679,7 @@ describe("GeoStory Utils", () => {
         };
         const markerStyle = getContentsFeatureStyle(defaultMarkerStyle, contents, content, contentId, feature);
         expect(markerStyle).toEqual({
-            iconColor: 'red',
+            iconColor: 'green',
             iconShape: 'circle',
             iconText: '1',
             highlight: true

--- a/web/client/utils/__tests__/GeoStoryUtils-test.js
+++ b/web/client/utils/__tests__/GeoStoryUtils-test.js
@@ -34,7 +34,8 @@ import {
     parseHashUrlScrollUpdate,
     createWebFontLoaderConfig,
     extractFontNames,
-    getVectorLayerFromContents
+    getVectorLayerFromContents,
+    getContentsFeatureStyle
 } from "../GeoStoryUtils";
 
 describe("GeoStory Utils", () => {
@@ -634,6 +635,54 @@ describe("GeoStory Utils", () => {
                     contentRefId: 'content-1'
                 }
             ]
+        });
+    });
+    it('getContentsFeatureStyle with defaultMarkerStyle', () => {
+        const defaultMarkerStyle = {
+            iconColor: 'cyan',
+            iconShape: 'circle'
+        };
+        const contents = [
+            {id: 'cd29a263-d36a-4459-8821-8dce4c761bcc'},
+            {id: 'ef332a5b-3405-4f33-b470-5673cc146fea'}
+        ];
+        const content = {id: 'ef332a5b-3405-4f33-b470-5673cc146fea'};
+        const contentId = '3513848d-07e4-41bc-a029-5f68802a663c';
+        const feature = {
+            type: 'Feature',
+            geometry: {},
+            properties: {}
+        };
+        const markerStyle = getContentsFeatureStyle(defaultMarkerStyle, contents, content, contentId, feature);
+        expect(markerStyle).toEqual({
+            iconColor: 'cyan',
+            iconShape: 'circle',
+            iconText: '2',
+            highlight: false
+        });
+    });
+    it('getContentsFeatureStyle with highlightedMarkerStyle', () => {
+        const defaultMarkerStyle = {
+            iconColor: 'red',
+            iconShape: 'circle'
+        };
+        const contents = [
+            {id: 'cd29a263-d36a-4459-8821-8dce4c761bcc'},
+            {id: 'ef332a5b-3405-4f33-b470-5673cc146fea'}
+        ];
+        const content = {id: 'cd29a263-d36a-4459-8821-8dce4c761bcc'};
+        const contentId = 'cd29a263-d36a-4459-8821-8dce4c761bcc';
+        const feature = {
+            type: 'Feature',
+            geometry: {},
+            properties: {}
+        };
+        const markerStyle = getContentsFeatureStyle(defaultMarkerStyle, contents, content, contentId, feature);
+        expect(markerStyle).toEqual({
+            iconColor: 'red',
+            iconShape: 'circle',
+            iconText: '1',
+            highlight: true
         });
     });
 });


### PR DESCRIPTION
## Description
This RP aims at putting into place improvements for the visualisation of marker items for the GeoCarousel layout, within the geostories functionality.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) N/A


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Improvement request from customer

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
**What is the current behavior?**

When items on the map were too close to each other it was rather difficult to distinguish the selected one from those that were not, this was due to two main issues:

1. The colour of the selected marker did not change, the selected one was added a 'chevron' icon above.
2. The selected item z index did not change and it was not drawn on top of the unselected markers, thus it was sometimes hidden by other markers making it difficult to see. 

**What is the new behavior?**
In response to the issues described above fix were applied as follows:

1. The colour of the selected item now is different then the non-selected ones, whenever an item is selected its colour changes to red.
2. The highlighted/selected items layer is now separated from the unselected/non-highlighted one. The highlighted markers layer is added on top the non-highlighted items one and its z index is higher, as a consequence the selected items will always be drawn on top of non-selected ones. See below

![7523_1](https://user-images.githubusercontent.com/14953970/141760989-f91171ed-6bac-4d8d-87da-7c86082d7025.JPG)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
