### PR TITLE
[Backport 2021.02.xx] #7370: enableInfoForSelectedLayers configuration for Identify plugin

### DIFF
--- a/web/client/actions/__tests__/mapInfo-test.js
+++ b/web/client/actions/__tests__/mapInfo-test.js
@@ -40,7 +40,11 @@ import {
     TOGGLE_HIGHLIGHT_FEATURE,
     toggleHighlightFeature,
     SET_MAP_TRIGGER,
-    setMapTrigger, checkIdentifyIsMounted, IDENTIFY_IS_MOUNTED
+    setMapTrigger,
+    checkIdentifyIsMounted,
+    IDENTIFY_IS_MOUNTED,
+    onInitPlugin,
+    INIT_PLUGIN
 } from '../mapInfo';
 
 describe('Test correctness of the map actions', () => {
@@ -169,5 +173,8 @@ describe('Test correctness of the map actions', () => {
     });
     it('check if Identify is not mounted', () => {
         expect(checkIdentifyIsMounted(false)).toEqual({type: IDENTIFY_IS_MOUNTED, isMounted: false });
+    });
+    it('onInitPlugin', () => {
+        expect(onInitPlugin({cfg1: false})).toEqual({type: INIT_PLUGIN, cfg: {cfg1: false} });
     });
 });

--- a/web/client/actions/mapInfo.js
+++ b/web/client/actions/mapInfo.js
@@ -38,6 +38,7 @@ export const TOGGLE_EMPTY_MESSAGE_GFI = "IDENTIFY:TOGGLE_EMPTY_MESSAGE_GFI";
 
 export const SET_SHOW_IN_MAP_POPUP = "IDENTIFY:SET_SHOW_IN_MAP_POPUP";
 export const IDENTIFY_IS_MOUNTED = "IDENTIFY:IDENTIFY_IS_MOUNTED";
+export const INIT_PLUGIN = 'IDENTIFY:INIT_PLUGIN';
 
 export const toggleEmptyMessageGFI = () => ({type: TOGGLE_EMPTY_MESSAGE_GFI});
 
@@ -296,3 +297,5 @@ export const checkIdentifyIsMounted = (isMounted)=> ({
     type: IDENTIFY_IS_MOUNTED,
     isMounted
 });
+
+export const onInitPlugin = (cfg) => ({type: INIT_PLUGIN, cfg});

--- a/web/client/components/data/identify/enhancers/identify.js
+++ b/web/client/components/data/identify/enhancers/identify.js
@@ -72,10 +72,15 @@ export const identifyLifecycle = compose(
                 showInMapPopup,
                 changeMousePointer = () => {},
                 disableCenterToMarker,
+                enableInfoForSelectedLayers = true,
                 onEnableCenterToMarker = () => {},
                 setShowInMapPopup = () => {},
-                checkIdentifyIsMounted = () => {}
+                checkIdentifyIsMounted = () => {},
+                onInitPlugin = () => {}
             } = this.props;
+
+            // Initialize plugin configuration
+            onInitPlugin({enableInfoForSelectedLayers});
 
             if (enabled || showInMapPopup) {
                 changeMousePointer('pointer');

--- a/web/client/epics/__tests__/identify-test.js
+++ b/web/client/epics/__tests__/identify-test.js
@@ -531,6 +531,110 @@ describe('identify Epics', () => {
             }
         }, state);
     });
+    it('getFeatureInfoOnFeatureInfoClick with enableInfoForSelectedLayers set to true', (done) => {
+        const state = {
+            map: TEST_MAP_STATE,
+            mapInfo: {
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } },
+                highlight: true,
+                enableInfoForSelectedLayers: true
+            },
+            layers: {
+                flat: [{
+                    id: "TEST",
+                    "title": "TITLE",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }, {
+                    id: "TEST2",
+                    name: "TEST2",
+                    "title": "TITLE2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }],
+                selected: ["TEST"]
+            }
+        };
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
+        testEpic(getFeatureInfoOnFeatureInfoClick, 3, sentActions, (actions) => {
+            try {
+                const [a0, a1, a2] = actions;
+                expect(a0).toExist();
+                expect(a0.type).toBe(PURGE_MAPINFO_RESULTS);
+                expect(a1).toExist();
+                expect(a1.type).toBe(NEW_MAPINFO_REQUEST);
+                expect(a1.reqId).toExist();
+                expect(a1.request).toExist();
+                expect(a2).toExist();
+                expect(a2.type).toBe(LOAD_FEATURE_INFO);
+                expect(a2.data).toExist();
+                expect(a2.requestParams).toExist();
+                expect(a2.reqId).toExist();
+                expect(a2.layerMetadata.title).toBe(state.layers.flat[0].title);
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }, state);
+    });
+    it('getFeatureInfoOnFeatureInfoClick with enableInfoForSelectedLayers set to false', (done) => {
+        const NUM_ACTIONS = 5;
+        const state = {
+            map: TEST_MAP_STATE,
+            mapInfo: {
+                clickPoint: { latlng: { lat: 36.95, lng: -79.84 } },
+                highlight: true,
+                enableInfoForSelectedLayers: false
+            },
+            layers: {
+                flat: [{
+                    id: "TEST",
+                    "title": "TITLE",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }, {
+                    id: "TEST2",
+                    name: "TEST2",
+                    "title": "TITLE2",
+                    type: "wms",
+                    visibility: true,
+                    url: 'base/web/client/test-resources/featureInfo-response.json'
+                }],
+                selected: ["TEST"]
+            }
+        };
+        const sentActions = [featureInfoClick({ latlng: { lat: 36.95, lng: -79.84 } })];
+        testEpic(getFeatureInfoOnFeatureInfoClick, NUM_ACTIONS, sentActions, (actions) => {
+            try {
+                expect(actions.length).toBe(NUM_ACTIONS);
+                actions.map((action) => {
+                    switch (action.type) {
+                    case PURGE_MAPINFO_RESULTS:
+                        break;
+                    case NEW_MAPINFO_REQUEST:
+                        expect(action.reqId).toBeTruthy();
+                        expect(action.request).toBeTruthy();
+                        break;
+                    case LOAD_FEATURE_INFO:
+                        expect(action.data).toBeTruthy();
+                        expect(action.requestParams).toBeTruthy();
+                        expect(action.reqId).toBeTruthy();
+                        expect([state.layers.flat[0].title, state.layers.flat[1].title].includes(action.layerMetadata.title)).toBeTruthy();
+                        break;
+                    default:
+                        expect(true).toBe(false);
+
+                    }
+                });
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        }, state);
+    });
     it('handleMapInfoMarker show', done => {
         testEpic(handleMapInfoMarker, 1, featureInfoClick({}), ([ a ]) => {
             expect(a.type).toBe(SHOW_MAPINFO_MARKER);

--- a/web/client/epics/identify.js
+++ b/web/client/epics/identify.js
@@ -33,11 +33,13 @@ import { closeAnnotations } from '../actions/annotations';
 import { MAP_CONFIG_LOADED } from '../actions/config';
 import {addPopup, cleanPopups, removePopup, REMOVE_MAP_POPUP} from '../actions/mapPopups';
 import { cancelSelectedItem } from '../actions/search';
-import { stopGetFeatureInfoSelector, identifyOptionsSelector,
+import {
+    stopGetFeatureInfoSelector, identifyOptionsSelector,
     clickPointSelector, clickLayerSelector,
     isMapPopup, isHighlightEnabledSelector,
     itemIdSelector, overrideParamsSelector, filterNameListSelector,
-    currentEditFeatureQuerySelector, mapTriggerSelector } from '../selectors/mapInfo';
+    currentEditFeatureQuerySelector, mapTriggerSelector, enableInfoForSelectedLayersSelector
+} from '../selectors/mapInfo';
 import { centerToMarkerSelector, queryableLayersSelector, queryableSelectedLayersSelector, selectedNodesSelector } from '../selectors/layers';
 import { modeSelector, getAttributeFilters, isFeatureGridOpen } from '../selectors/featuregrid';
 import { spatialFieldSelector } from '../selectors/queryform';
@@ -126,7 +128,8 @@ export const getFeatureInfoOnFeatureInfoClick = (action$, { getState = () => { }
             // Reverse - To query layer in same order as in TOC
             let queryableLayers = reverse(queryableLayersSelector(getState()));
             const queryableSelectedLayers = queryableSelectedLayersSelector(getState());
-            if (queryableSelectedLayers.length) {
+            const enableInfoForSelectedLayers = enableInfoForSelectedLayersSelector(getState());
+            if (enableInfoForSelectedLayers && queryableSelectedLayers.length) {
                 queryableLayers = queryableSelectedLayers;
             }
 

--- a/web/client/plugins/Identify.jsx
+++ b/web/client/plugins/Identify.jsx
@@ -35,7 +35,8 @@ import {
     toggleShowCoordinateEditor,
     updateCenterToMarker,
     updateFeatureInfoClickPoint,
-    checkIdentifyIsMounted
+    checkIdentifyIsMounted,
+    onInitPlugin
 } from '../actions/mapInfo';
 import DefaultViewerComp from '../components/data/identify/DefaultViewer';
 import { defaultViewerDefaultProps, defaultViewerHandlers } from '../components/data/identify/enhancers/defaultViewer';
@@ -202,6 +203,7 @@ const identifyDefaultProps = defaultProps({
  * @prop cfg.showInMapPopup {boolean} if true show the identify as popup
  * @prop cfg.showMoreInfo {boolean} if true shows the more info icon which allow user to show/hide Geocode viewer as popup (true by default)
  * @prop cfg.showEdit {boolean} if true, and when the FeatureEditor plugin is present, shows and edit button to edit the current feature(s) clicked in the grid.
+ * @prop cfg.enableInfoForSelectedLayers {boolean} if true, if some layer is selected in the TOC, the feature info is performed only on the selected ones. if false, the info is queried for all the layers, independently from selection. (default is true).
  *
  * @example
  * {
@@ -220,6 +222,7 @@ const identifyDefaultProps = defaultProps({
  */
 const IdentifyPlugin = compose(
     connect(selector, {
+        onInitPlugin,
         purgeResults: purgeMapInfoResults,
         closeIdentify,
         onSubmitClickPoint: updateFeatureInfoClickPoint,

--- a/web/client/reducers/__tests__/mapInfo-test.js
+++ b/web/client/reducers/__tests__/mapInfo-test.js
@@ -18,7 +18,8 @@ import {
     changePage,
     toggleHighlightFeature,
     setMapTrigger,
-    setShowInMapPopup
+    setShowInMapPopup,
+    onInitPlugin
 } from '../../actions/mapInfo';
 import {changeMapType} from '../../actions/maptype';
 
@@ -913,5 +914,10 @@ describe('Test the mapInfo reducer', () => {
         const initialState = { configuration: {} };
         const state = mapInfo(initialState, setShowInMapPopup(true));
         expect(state.showInMapPopup).toBeTruthy();
+    });
+    it('onInitPlugin', () => {
+        const initialState = { configuration: {} };
+        const state = mapInfo(initialState, onInitPlugin({cfg1: "test"}));
+        expect(state.cfg1).toBe("test");
     });
 });

--- a/web/client/reducers/mapInfo.js
+++ b/web/client/reducers/mapInfo.js
@@ -31,7 +31,8 @@ import {
     TOGGLE_SHOW_COORD_EDITOR,
     SET_CURRENT_EDIT_FEATURE_QUERY,
     SET_MAP_TRIGGER,
-    SET_SHOW_IN_MAP_POPUP
+    SET_SHOW_IN_MAP_POPUP,
+    INIT_PLUGIN
 } from '../actions/mapInfo';
 
 import { MAP_CONFIG_LOADED } from '../actions/config';
@@ -477,6 +478,9 @@ function mapInfo(state = initState, action) {
             };
         }
         return state;
+    }
+    case INIT_PLUGIN: {
+        return { ...state, ...action.cfg };
     }
     default:
         return state;

--- a/web/client/selectors/__tests__/mapInfo-test.js
+++ b/web/client/selectors/__tests__/mapInfo-test.js
@@ -29,7 +29,8 @@ import {
     hoverEnabledSelector,
     currentFeatureSelector,
     mapInfoEnabledSelector,
-    mapInfoDisabledSelector
+    mapInfoDisabledSelector,
+    enableInfoForSelectedLayersSelector
 } from '../mapInfo';
 
 const QUERY_PARAMS = {
@@ -387,5 +388,10 @@ describe('Test mapinfo selectors', () => {
         const state = { mapInfo: { enabled: true}};
         const mapInfoEnabled = mapInfoDisabledSelector(state);
         expect(mapInfoEnabled).toBeFalsy();
+    });
+    it('test enableInfoForSelectedLayersSelector ', () => {
+        const state = { mapInfo: { enableInfoForSelectedLayers: false}};
+        const enableInfoForSelectedLayers = enableInfoForSelectedLayersSelector(state);
+        expect(enableInfoForSelectedLayers).toBeFalsy();
     });
 });

--- a/web/client/selectors/mapInfo.js
+++ b/web/client/selectors/mapInfo.js
@@ -195,3 +195,4 @@ export const currentEditFeatureQuerySelector = state => state.mapInfo?.currentEd
 
 export const mapTriggerSelector = state => get(state, "mapInfo.configuration.trigger", "click");
 export const hoverEnabledSelector = state => isCesium(state) ? false : true;
+export const enableInfoForSelectedLayersSelector = state => get(state, "mapInfo.enableInfoForSelectedLayers", true);


### PR DESCRIPTION
#7370: enableInfoForSelectedLayers configuration for Identify plugin