### PR TITLE
#7516: fixed usage of CORS for loading WMS tiled images in Cesium WMS…

### DIFF
--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -1084,7 +1084,7 @@ Openlayers:
 
 Cesium:
 
-- `noCors` forces a tiled layer (singleTile: false) to be loaded as simple images, instead of using ajax (may be useful if the WMS services has issues with CORS)
+- `tileDiscardPolicy` sets a policy for discarding (missing/broken) tiles (https://cesium.com/learn/cesiumjs/ref-doc/TileDiscardPolicy.html). If it is not specified the NeverTileDiscardPolicy will be used. If "none" is specified, no policy at all will be set.
 
 MapStore specific:
 

--- a/docs/developer-guide/maps-configuration.md
+++ b/docs/developer-guide/maps-configuration.md
@@ -1082,6 +1082,10 @@ Openlayers:
 <ol:opacity xmlns:ol="http://openlayers.org/context">1</ol:opacity>
 ```
 
+Cesium:
+
+- `noCors` forces a tiled layer (singleTile: false) to be loaded as simple images, instead of using ajax (may be useful if the WMS services has issues with CORS)
+
 MapStore specific:
 
 - `group` specifies to which group, among listed in "GroupList" element, the layer belongs to

--- a/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
@@ -685,6 +685,7 @@ describe('Cesium layer', () => {
         // expect(map.imageryLayers.length).toBe(1);
         expect(layer.layer._tileProvider._url).toNotExist();
         expect(layer.layer._tileProvider._resource.headers.Authorization).toBe("Bearer ########-####-####-####-###########");
+        expect(layer.layer._tileProvider._tileDiscardPolicy).toExist();
     });
     it('test wms security token', () => {
         const options = {
@@ -742,7 +743,34 @@ describe('Cesium layer', () => {
         expect(layer.layer._tileProvider._resource._queryParameters["ms2-authkey"]).toBe("########-####-$$$$-####-###########");
 
     });
+    it("test wms noCors option", () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            noCors: true,
+            url: "http://sample.server/geoserver/wms"
+        };
+        ConfigUtils.setConfigProp('useAuthenticationRules', true);
+        ConfigUtils.setConfigProp('authenticationRules', [
+            {
+                urlPattern: '.*geostore.*',
+                method: 'bearer'
+            }
+        ]);
 
+        let layer = ReactDOM.render(<CesiumLayer
+            type="wms"
+            options={options}
+            map={map}/>, document.getElementById("container"));
+        expect(layer).toExist();
+        // expect(map.imageryLayers.length).toBe(1);
+        expect(layer.layer._tileProvider._resource._url).toExist();
+        expect(layer.layer._tileProvider._tileDiscardPolicy).toNotExist();
+    });
     it('test wmts security token', () => {
         const options = {
             "type": "wmts",

--- a/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
+++ b/web/client/components/map/cesium/__tests__/Layer-test-chrome.jsx
@@ -743,7 +743,7 @@ describe('Cesium layer', () => {
         expect(layer.layer._tileProvider._resource._queryParameters["ms2-authkey"]).toBe("########-####-$$$$-####-###########");
 
     });
-    it("test wms noCors option", () => {
+    it("test wms tileDiscardPolicy none option", () => {
         const options = {
             type: "wms",
             visibility: true,
@@ -751,7 +751,7 @@ describe('Cesium layer', () => {
             group: "Meteo",
             format: "image/png",
             opacity: 1.0,
-            noCors: true,
+            tileDiscardPolicy: "none",
             url: "http://sample.server/geoserver/wms"
         };
         ConfigUtils.setConfigProp('useAuthenticationRules', true);
@@ -770,6 +770,37 @@ describe('Cesium layer', () => {
         // expect(map.imageryLayers.length).toBe(1);
         expect(layer.layer._tileProvider._resource._url).toExist();
         expect(layer.layer._tileProvider._tileDiscardPolicy).toNotExist();
+    });
+    it("test wms custom tileDiscardPolicy option", () => {
+        const options = {
+            type: "wms",
+            visibility: true,
+            name: "nurc:Arc_Sample",
+            group: "Meteo",
+            format: "image/png",
+            opacity: 1.0,
+            tileDiscardPolicy: {
+                isReady: () => true,
+                shouldDiscardImage: () => false
+            },
+            url: "http://sample.server/geoserver/wms"
+        };
+        ConfigUtils.setConfigProp('useAuthenticationRules', true);
+        ConfigUtils.setConfigProp('authenticationRules', [
+            {
+                urlPattern: '.*geostore.*',
+                method: 'bearer'
+            }
+        ]);
+
+        let layer = ReactDOM.render(<CesiumLayer
+            type="wms"
+            options={options}
+            map={map}/>, document.getElementById("container"));
+        expect(layer).toExist();
+        // expect(map.imageryLayers.length).toBe(1);
+        expect(layer.layer._tileProvider._resource._url).toExist();
+        expect(layer.layer._tileProvider._tileDiscardPolicy).toExist();
     });
     it('test wmts security token', () => {
         const options = {

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -104,7 +104,9 @@ function wmsToCesiumOptions(options) {
         }),
         // #7516 this helps Cesium to use CORS requests in a proper way, even when headers are not
         // present in the Resource
-        tileDiscardPolicy: options.noCors ? undefined : new Cesium.NeverTileDiscardPolicy(),
+        tileDiscardPolicy: options.tileDiscardPolicy === "none" ?
+            undefined :
+            (options.tileDiscardPolicy ?? new Cesium.NeverTileDiscardPolicy()),
         credit,
         subdomains: urls,
         layers: options.name,

--- a/web/client/components/map/cesium/plugins/WMSLayer.js
+++ b/web/client/components/map/cesium/plugins/WMSLayer.js
@@ -102,6 +102,9 @@ function wmsToCesiumOptions(options) {
             headers,
             proxy: proxy && new WMSProxy(proxy) || new NoProxy()
         }),
+        // #7516 this helps Cesium to use CORS requests in a proper way, even when headers are not
+        // present in the Resource
+        tileDiscardPolicy: options.noCors ? undefined : new Cesium.NeverTileDiscardPolicy(),
         credit,
         subdomains: urls,
         layers: options.name,


### PR DESCRIPTION
…Layer implementation

## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Cross origin requests handling has changed in Cesium 1.42 and following, in comparison to 1.17, so some requests to WMS services were failing after the upgrade, because they were not correctly recognized as cross-origin (handled by ajax requests), but as normal images. This was causing a security error when tiles had to drawn on the WebGL context.

To avoid the security error we must ensure those image are requested through ajax. A way to force that when needed is to set a tileDiscardPolicy on the imagery provider. By using the NeverTileDiscardPolicy implementation, we ensure we don't have other side effects (this implementation does nothing). There are other ways to change this behaviour, such as setting headers on the request, but none of them is as safe as using NeverTileDiscardPolicy.

We have also introduced a tileDiscardPolicy option on cesium layers so that if for any reason a project needs to switch back to loading tiles as images for specific services, it can by setting "none" in this option.

Note also that tileDiscardPolicy can also be used to set a real policy, for example to check for missing/broken tiles and load an alternative image, or send events.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7586 
#7516 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Security error on some WMS service layers with tiled configuration.

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
No more security errors on WMS services layers with tiled configuration.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
