### PR TITLE
backport 2021.02.xx - #7486 Missing translation string in background selector (#7538)

### DIFF
--- a/web/client/components/background/BackgroundDialog.jsx
+++ b/web/client/components/background/BackgroundDialog.jsx
@@ -140,7 +140,7 @@ export default class BackgroundDialog extends React.Component {
         if (this.props.layer.type === "wms") {
             return (<React.Fragment>
                 <FormGroup controlId="formControlsSelect">
-                    <ControlLabel><Message msgId="layerProperties.format" /></ControlLabel>
+                    <ControlLabel><Message msgId="layerProperties.format.title" /></ControlLabel>
                     <Select
                         onChange={event => this.setState({ format: event && event.value })}
                         value={this.state.format || this.props.defaultFormat}


### PR DESCRIPTION
backport 2021.02.xx - [#7486](https://github.com/geosolutions-it/mapstore2/issues/7486) Missing translation string in background selector ([#7538](https://github.com/geosolutions-it/MapStore2/pull/7538))