### PR TITLE
Issue #7487 - Wrong string for group settings tooltip

### DIFF
--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -72,9 +72,7 @@ class General extends React.Component {
         ];
         const groups = this.props.groups && flattenGroups(this.props.groups);
         const eleGroupLabel = this.findGroupLabel(this.props.element && this.props.element.group || "Default");
-
         const SelectCreatable = this.props.allowNew ? Select.Creatable : Select;
-
         return (
             <Grid fluid style={{ paddingTop: 15, paddingBottom: 15 }}>
                 <form ref="settings">
@@ -109,6 +107,7 @@ class General extends React.Component {
                         )}
                     </FormGroup>)}
                     <LayerNameEditField
+                        groups={groups}
                         element={this.props.element}
                         enableLayerNameEditFeedback={this.props.enableLayerNameEditFeedback}
                         onUpdateEntry={this.updateEntry.bind(null)}/>

--- a/web/client/components/TOC/fragments/settings/LayerNameEditField.jsx
+++ b/web/client/components/TOC/fragments/settings/LayerNameEditField.jsx
@@ -13,7 +13,6 @@ import Spinner from 'react-spinkit';
 
 import Message from '../../../I18N/Message';
 import OverlayTrigger from '../../../misc/OverlayTrigger';
-import { debug } from 'util';
 
 const LayerNameEditField = ({
     enableOverlayTrigger,
@@ -54,11 +53,11 @@ const LayerNameEditField = ({
         </InputGroup.Addon>
     );
 
-    const overlayTriggerNameEdit = (button, isGroup) => (
+    const overlayTriggerNameEdit = button => (
         <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip-layer-name-edit">
-            { isGroup ? 
-            (<Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}GroupName`}/>) : 
-            (<Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}LayerName`}/>) } 
+            { isGroup ?
+                (<Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}GroupName`}/>) :
+                (<Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}LayerName`}/>) }
         </Tooltip>}>
             {button}
         </OverlayTrigger>
@@ -74,7 +73,7 @@ const LayerNameEditField = ({
                     type="text"
                     disabled={!editingLayerName}
                     onChange={evt => setLayerName(evt.target.value)} />
-                {enableOverlayTrigger ? overlayTriggerNameEdit(editButton, isGroup) : editButton}
+                {enableOverlayTrigger ? overlayTriggerNameEdit(editButton) : editButton}
             </InputGroup>
         </FormGroup>
     );
@@ -106,7 +105,7 @@ export default compose(
     lifecycle({
         componentDidMount() {
             this.props.setLayerName(this.props.element?.name);
-            this.props.setIsGroup(this.props.groups.some(group => group.value === this.props.element.id))
+            this.props.setIsGroup(this.props.groups.some(group => group.value === this.props.element.id));
         },
         componentDidUpdate() {
             const {

--- a/web/client/components/TOC/fragments/settings/LayerNameEditField.jsx
+++ b/web/client/components/TOC/fragments/settings/LayerNameEditField.jsx
@@ -13,6 +13,7 @@ import Spinner from 'react-spinkit';
 
 import Message from '../../../I18N/Message';
 import OverlayTrigger from '../../../misc/OverlayTrigger';
+import { debug } from 'util';
 
 const LayerNameEditField = ({
     enableOverlayTrigger,
@@ -23,6 +24,7 @@ const LayerNameEditField = ({
     layerError,
     waitingForLayerLoading = false,
     waitingForLayerLoad = false,
+    isGroup = false,
     setLayerName = () => {},
     setWaitingForLayerLoading = () => {},
     setEditingLayerName = () => {},
@@ -52,9 +54,11 @@ const LayerNameEditField = ({
         </InputGroup.Addon>
     );
 
-    const overlayTriggerNameEdit = button => (
+    const overlayTriggerNameEdit = (button, isGroup) => (
         <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip-layer-name-edit">
-            <Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}LayerName`}/>
+            { isGroup ? 
+            (<Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}GroupName`}/>) : 
+            (<Message msgId={`layerProperties.tooltip.${editingLayerName ? 'confirm' : 'edit'}LayerName`}/>) } 
         </Tooltip>}>
             {button}
         </OverlayTrigger>
@@ -70,7 +74,7 @@ const LayerNameEditField = ({
                     type="text"
                     disabled={!editingLayerName}
                     onChange={evt => setLayerName(evt.target.value)} />
-                {enableOverlayTrigger ? overlayTriggerNameEdit(editButton) : editButton}
+                {enableOverlayTrigger ? overlayTriggerNameEdit(editButton, isGroup) : editButton}
             </InputGroup>
         </FormGroup>
     );
@@ -84,6 +88,7 @@ export default compose(
     withState('waitingForLayerLoading', 'setWaitingForLayerLoading', false),
     withState('waitingForLayerLoad', 'setWaitingForLayerLoad', false),
     withState('layerError', 'setLayerError'),
+    withState('isGroup', 'setIsGroup', false),
     withHandlers({
         setEditingLayerName: ({ editingLayerName = false, overlayTriggerDelayID, setEditingLayerName = () => {}, setOverlayTriggerDelayID = () => {}, setEnableOverlayTrigger = () => {} }) => editing => {
             if (editingLayerName !== editing) {
@@ -101,6 +106,7 @@ export default compose(
     lifecycle({
         componentDidMount() {
             this.props.setLayerName(this.props.element?.name);
+            this.props.setIsGroup(this.props.groups.some(group => group.value === this.props.element.id))
         },
         componentDidUpdate() {
             const {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -138,7 +138,9 @@
                 "bottom": "Bottom",
                 "top": "Top",
                 "editLayerName": "Edit layer name",
-                "confirmLayerName": "Confirm layer name change"
+                "confirmLayerName": "Confirm layer name change",
+                "editGroupName": "Edit group name",
+                "confirmGroupName": "Confirm group name change"
             },
             "legendOptions": {
               "title": "Legend",


### PR DESCRIPTION
## Description
The goal of this PR is to fix some wrong tooltip strings appearing when the user hovered on the button to edit/confirm name changes for the group in the TOC component.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Provided that a user already created and added a group to the TOC.
Whenever they access the group settings (clicking on the TOC item and on the 'spanner' icon button) and hover over the edit/confirm name button the pencil button the appearing tooltip says `Edit layer name` / `Confirm layer name change`, despite the object being edited is a group and not a layer.

#<issue>

**What is the new behavior?**
Provided that a user already created and added a group to the TOC.
Whenever they access the group settings (clicking on the TOC item and on the 'spanner' icon button) and hover over the edit/confirm name button the pencil button the appearing tooltip says `Edit group name` / `Confirm group name change`.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
![recording_1](https://user-images.githubusercontent.com/14953970/141824016-d4c7644d-576c-4acc-9601-0c07d8d73368.gif)

