### PR TITLE
Updated getComponents function to properly work with null geometry.

### DIFF
--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -12,7 +12,7 @@ import {getMessageById} from './LocaleUtils';
 import MarkerUtils from './MarkerUtils';
 import { geometryFunctions, fetchStyle, hashAndStringify } from './VectorStyleUtils';
 import { set } from './ImmutableUtils';
-import { values, isNil, slice, head, castArray, last, isArray, findIndex, isString } from 'lodash';
+import { values, isNil, slice, head, castArray, last, isArray, findIndex, isString, get } from 'lodash';
 import uuid from 'uuid';
 import turfCenter from '@turf/center';
 import assign from 'object-assign';
@@ -529,8 +529,9 @@ export const getBaseCoord = (type) => {
     default: return [[{lat: "", lon: ""}]];
     }
 };
-export const getComponents = ({type, coordinates}) => {
-    switch (type) {
+export const getComponents = (geometry) => {
+    const coordinates = get(geometry, 'coordinates', []);
+    switch (geometry?.type) {
     case "Polygon": {
         return AnnotationsUtils.isCompletePolygon(coordinates) ? AnnotationsUtils.formatCoordinates(slice(coordinates[0], 0, coordinates[0].length - 1)) : AnnotationsUtils.formatCoordinates(coordinates[0]);
     }

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -508,8 +508,8 @@ describe('Test the AnnotationsUtils', () => {
         expect(getComponents(point).length).toBe(1);
         expect(getComponents(point)[0].lon).toBe(1);
         expect(getComponents(point)[0].lat).toBe(1);
-        expect(getComponents(null).lat).toBe(undefined);
-        expect(getComponents(null).lon).toBe(undefined);
+        expect(getComponents(null)[0].lat).toBe(undefined);
+        expect(getComponents(null)[0].lon).toBe(undefined);
     });
     it('test addIds defaults', () => {
         const features = [{properties: {id: "some id"}}, {properties: {}}];

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -508,6 +508,8 @@ describe('Test the AnnotationsUtils', () => {
         expect(getComponents(point).length).toBe(1);
         expect(getComponents(point)[0].lon).toBe(1);
         expect(getComponents(point)[0].lat).toBe(1);
+        expect(getComponents(null).lat).toBe(undefined);
+        expect(getComponents(null).lon).toBe(undefined);
     });
     it('test addIds defaults', () => {
         const features = [{properties: {id: "some id"}}, {properties: {}}];


### PR DESCRIPTION
## Description
Small modification to make getComponents function work properly when passed geometry is null.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Function throws an error when null is being passed as geometry (that's the case when point with invalid coordinates is getting to the list of features to be rendered on the map).

**What is the new behavior?**
No error thrown.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
