### PR TITLE
7508 - Crash on geometry removal while selected geometry is in invalid state

### DIFF
--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -7,7 +7,7 @@
  */
 
 import Rx from 'rxjs';
-import { head, findIndex, castArray, isArray, find, values, isEmpty, isUndefined, get, includes } from 'lodash';
+import { head, findIndex, castArray, isArray, find, values, isEmpty, isUndefined, get } from 'lodash';
 import assign from 'object-assign';
 import axios from 'axios';
 import uuidv1 from 'uuid/v1';
@@ -73,7 +73,8 @@ import {
     STYLE_POINT_MARKER,
     STYLE_POINT_SYMBOL,
     DEFAULT_SHAPE,
-    DEFAULT_PATH, ANNOTATIONS } from '../utils/AnnotationsUtils';
+    DEFAULT_PATH, ANNOTATIONS, modifySelectedInEdited
+} from '../utils/AnnotationsUtils';
 import { MEASURE_TYPE } from '../utils/MeasurementUtils';
 import { createSvgUrl } from '../utils/VectorStyleUtils';
 
@@ -311,7 +312,7 @@ export default {
         .switchMap((action) => {
             if (action.attribute === 'geometry') {
                 let state = store.getState();
-                const feature = state.annotations.editing;
+                let { feature } = modifySelectedInEdited(state.annotations.selected, state.annotations.editing);
                 const type = state.annotations.featureType;
                 const multiGeom = multiGeometrySelector(state);
                 const drawOptions = {
@@ -593,49 +594,13 @@ export default {
         }),
     onChangedSelectedFeatureEpic: (action$, {getState}) => action$.ofType(CHANGED_SELECTED )
         .switchMap(({}) => {
-            const featureTypes = ["LineString", "MultiPoint", "Polygon", "Point"];
             const state = getState();
-            let feature = state.annotations.editing;
-            let selected = state.annotations.selected;
-            let nullGeometryModifier = false;
-            switch (selected.geometry.type) {
-            case "Polygon": {
-                selected = set("geometry.coordinates", [selected.geometry.coordinates[0].filter(validateCoordsArray)], selected);
-                break;
-            }
-            case "LineString": case "MultiPoint": {
-                selected = set("geometry.coordinates", selected.geometry.coordinates.filter(validateCoordsArray), selected);
-                break;
-            }
-            // point
-            default: {
-                selected = set("geometry.coordinates", [selected.geometry.coordinates].filter(validateCoordsArray)[0] || [], selected);
-                if (!selected.geometry.coordinates.length) nullGeometryModifier = true;
-            }
-            }
+            let { selected, feature } = modifySelectedInEdited(state.annotations.selected, state.annotations.editing);
 
             let method = selected.geometry.type;
             if (selected.properties?.isCircle) method = "Circle";
             if (selected.properties?.isText) method = "Text";
 
-            if (selected.properties && selected.properties.isCircle) {
-                selected = set("geometry", selected.properties.polygonGeom, selected);
-            }
-
-            // TODO update selected feature in editing features
-
-            let selectedIndex = findIndex(feature.features, (f) => f.properties.id === selected.properties.id);
-            if (selected.properties.isValidFeature || includes(featureTypes, selected.geometry.type)) {
-                const tempSelected = nullGeometryModifier ? set('geometry', null, selected) : selected;
-                if (selectedIndex === -1) {
-                    feature = set(`features`, feature.features.concat([tempSelected]), feature);
-                } else {
-                    feature = set(`features[${selectedIndex}]`, tempSelected, feature);
-                }
-            }
-            if (selectedIndex !== -1 && !selected.properties.isValidFeature && !includes(featureTypes, selected.geometry.type)) {
-                feature = set(`features`, feature.features.filter((f, i) => i !== selectedIndex ), feature);
-            }
             const multiGeometry = multiGeometrySelector(state);
             const style = feature.style;
             const action = changeDrawingStatus("drawOrEdit", method, ANNOTATIONS, [feature], {

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -69,11 +69,12 @@ import {
     removeDuplicate,
     validateCoordsArray,
     getStartEndPointsForLinestring,
+    modifySelectedInEdited,
     DEFAULT_ANNOTATIONS_STYLES,
     STYLE_POINT_MARKER,
     STYLE_POINT_SYMBOL,
     DEFAULT_SHAPE,
-    DEFAULT_PATH, ANNOTATIONS, modifySelectedInEdited
+    DEFAULT_PATH, ANNOTATIONS
 } from '../utils/AnnotationsUtils';
 import { MEASURE_TYPE } from '../utils/MeasurementUtils';
 import { createSvgUrl } from '../utils/VectorStyleUtils';

--- a/web/client/epics/annotations.js
+++ b/web/client/epics/annotations.js
@@ -313,7 +313,7 @@ export default {
         .switchMap((action) => {
             if (action.attribute === 'geometry') {
                 let state = store.getState();
-                let { feature } = modifySelectedInEdited(state.annotations.selected, state.annotations.editing);
+                let { editing: feature } = modifySelectedInEdited(state.annotations.selected, state.annotations.editing);
                 const type = state.annotations.featureType;
                 const multiGeom = multiGeometrySelector(state);
                 const drawOptions = {
@@ -596,7 +596,7 @@ export default {
     onChangedSelectedFeatureEpic: (action$, {getState}) => action$.ofType(CHANGED_SELECTED )
         .switchMap(({}) => {
             const state = getState();
-            let { selected, feature } = modifySelectedInEdited(state.annotations.selected, state.annotations.editing);
+            let { selected, editing: feature } = modifySelectedInEdited(state.annotations.selected, state.annotations.editing);
 
             let method = selected.geometry.type;
             if (selected.properties?.isCircle) method = "Circle";

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -643,7 +643,7 @@ export const isAnnotation = (json) => json?.type === ANNOTATION_TYPE || json?.na
  * @returns {{feature, selected: null}|{feature, selected: ({properties}|*)}}
  */
 export const modifySelectedInEdited = (selectedFeature, editingFeatures) => {
-    if (selectedFeature === null) return { selected: null, feature: editingFeatures};
+    if (isNil(selectedFeature)) return { selected: selectedFeature, feature: editingFeatures };
 
     const featureTypes = ["LineString", "MultiPoint", "Polygon", "Point"];
     let selected = selectedFeature;

--- a/web/client/utils/AnnotationsUtils.js
+++ b/web/client/utils/AnnotationsUtils.js
@@ -637,17 +637,17 @@ export const isCompletePolygon = (coords = [[[]]]) => {
 export const isAnnotation = (json) => json?.type === ANNOTATION_TYPE || json?.name === "Annotations";
 
 /**
- * utility to validate and fix coordinates for selected feature and update corresponding entry in editingFeatures array
+ * utility to validate and fix coordinates for selected feature and update corresponding entry in editingFeatures object
  * @param selectedFeature
  * @param editingFeatures
  * @returns {{feature, selected: null}|{feature, selected: ({properties}|*)}}
  */
 export const modifySelectedInEdited = (selectedFeature, editingFeatures) => {
-    if (isNil(selectedFeature)) return { selected: selectedFeature, feature: editingFeatures };
+    if (isNil(selectedFeature)) return { selected: selectedFeature, editing: editingFeatures };
 
     const featureTypes = ["LineString", "MultiPoint", "Polygon", "Point"];
     let selected = selectedFeature;
-    let feature = editingFeatures;
+    let editing = editingFeatures;
     let nullGeometryModifier = false;
     switch (selected.geometry.type) {
     case "Polygon": {
@@ -669,20 +669,20 @@ export const modifySelectedInEdited = (selectedFeature, editingFeatures) => {
         selected = set("geometry", selected.properties.polygonGeom, selected);
     }
 
-    let selectedIndex = findIndex(feature.features, (f) => f.properties.id === selected.properties.id);
+    let selectedIndex = findIndex(editing.features, (f) => f.properties.id === selected.properties.id);
     if (selected.properties.isValidFeature || includes(featureTypes, selected.geometry.type)) {
         const tempSelected = nullGeometryModifier ? set('geometry', null, selected) : selected;
         if (selectedIndex === -1) {
-            feature = set(`features`, feature.features.concat([tempSelected]), feature);
+            editing = set(`features`, editing.features.concat([tempSelected]), editing);
         } else {
-            feature = set(`features[${selectedIndex}]`, tempSelected, feature);
+            editing = set(`features[${selectedIndex}]`, tempSelected, editing);
         }
     }
     if (selectedIndex !== -1 && !selected.properties.isValidFeature && !includes(featureTypes, selected.geometry.type)) {
-        feature = set(`features`, feature.features.filter((f, i) => i !== selectedIndex ), feature);
+        editing = set(`features`, editing.features.filter((f, i) => i !== selectedIndex ), editing);
     }
 
-    return { selected, feature };
+    return { selected, editing };
 };
 
 AnnotationsUtils = {

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -45,7 +45,8 @@ import {
     isCompletePolygon,
     getDashArrayFromStyle,
     getGeometryType,
-    getGeometryGlyphInfo
+    getGeometryGlyphInfo,
+    modifySelectedInEdited
 } from '../AnnotationsUtils';
 
 const featureCollection = {
@@ -54,15 +55,40 @@ const featureCollection = {
         geometry: {
             type: "Point",
             coordinates: [1, 1]
+        },
+        properties: {
+            id: 1
         }
     },
     {
         type: "Feature",
         geometry: {
             type: "LineString",
-            coordinates: [1, 1]
+            coordinates: [[1, 1], [2, 2]]
+        },
+        properties: {
+            id: 2
         }
-    }],
+    },
+    {
+        type: "Feature",
+        geometry: {
+            type: "Polygon",
+            coordinates: [
+                [
+                    [1, 45],
+                    [2, 45],
+                    [2, 44],
+                    [1, 44],
+                    [1, 45]
+                ]
+            ]
+        },
+        properties: {
+            id: 3
+        }
+    }
+    ],
     type: "FeatureCollection"
 };
 const circle1 = {
@@ -926,5 +952,58 @@ describe('Test the AnnotationsUtils', () => {
         expect(fts.length).toBe(1);
         expect(fts[0].properties.ms_style).toExist();
         expect(fts[0].properties.ms_style.labelOutlineColor).toExist();
+    });
+
+    it('test modifySelectedInEdited', () => {
+        const selectedPoint = {
+            type: "Feature",
+            geometry: {
+                type: "Point",
+                coordinates: ['', 1]
+            },
+            properties: {
+                id: 1
+            }
+        };
+        const selectedPolygon = {
+            type: "Feature",
+            geometry: {
+                type: "Polygon",
+                coordinates: [
+                    [
+                        [1, 45],
+                        ['', 45],
+                        [2, 44],
+                        [1, 44],
+                        [1, 45]
+                    ]
+                ]
+            },
+            properties: {
+                id: 3
+            }
+        };
+
+        const { selected: pointSelected, editing: editingWithPoint } = modifySelectedInEdited(selectedPoint, featureCollection);
+        const { selected: nullSelected, editing: editingWithNull } = modifySelectedInEdited(null, featureCollection);
+        const { selected: polygonSelected, editing: editingWithPolygon } = modifySelectedInEdited(selectedPolygon, featureCollection);
+
+        expect(Array.isArray(pointSelected.geometry.coordinates)).toBe(true);
+        expect(pointSelected.geometry.coordinates.length).toBe(0);
+        expect(editingWithPoint.features[0].geometry).toBe(null);
+        expect(editingWithPoint.features[0].properties.id).toBe(1);
+        expect(editingWithPoint.features[1].geometry.coordinates.length).toBe(2);
+        expect(editingWithPoint.features[2].geometry.coordinates[0].length).toBe(5);
+
+        expect(nullSelected).toBe(null);
+        expect(editingWithNull.features[0].geometry.coordinates.length).toBe(2);
+        expect(editingWithNull.features[1].geometry.coordinates.length).toBe(2);
+        expect(editingWithNull.features[2].geometry.coordinates[0].length).toBe(5);
+
+        expect(polygonSelected.geometry.coordinates[0].length).toBe(4);
+        expect(editingWithPolygon.features[2].geometry.coordinates[0].length).toBe(4);
+        expect(editingWithPolygon.features[0].geometry.coordinates.length).toBe(2);
+        expect(editingWithPolygon.features[1].geometry.coordinates.length).toBe(2);
+
     });
 });

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -663,9 +663,10 @@ describe('Test the AnnotationsUtils', () => {
     it('test annotationsToPrint from featureCollection', () => {
         let fts = annotationsToPrint([featureCollection]);
         expect(fts).toExist();
-        expect(fts.length).toBe(2);
+        expect(fts.length).toBe(3);
         expect(fts[0].geometry.type).toBe("Point");
         expect(fts[1].geometry.type).toBe("LineString");
+        expect(fts[2].geometry.type).toBe("Polygon");
     });
     it('test annotationsToPrint from array of geometryCollection', () => {
         let fts = annotationsToPrint([feature]);


### PR DESCRIPTION
## Description
App crash when user tries to remove one geometry while editing another geometry that is invalid at the moment.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7531 
Check last comment

**What is the new behavior?**
Validation is running for selected geometry after another geometry is being removed. This way incorrect coordinates doesn't go to the render level and app won't crash.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
