### PR TITLE
[Backport 2021.02.xx] Geometries become invisible when Marker or Text element is being added #7511

### DIFF
--- a/web/client/reducers/__tests__/annotations-test.js
+++ b/web/client/reducers/__tests__/annotations-test.js
@@ -830,6 +830,64 @@ describe('Test the annotations reducer', () => {
         expect(state.featureType).toBe("Text");
         expect(state.drawing).toBe(true);
     });
+    it('toggle add point, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Point"
+        });
+        expect(state.editing.features[0].geometry).toBe(null);
+    });
+    it('toggle add text, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Text"
+        });
+        expect(state.editing.features[0].geometry).toBe(null);
+        expect(state.editing.features[0].properties.isText).toBe(true);
+    });
+    it('toggle add line, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "LineString"
+        });
+        testAllProperty(state.editing.features[0].geometry, {
+            type: "LineString",
+            coordinates: []
+        });
+    });
+    it('toggle add polygon, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Polygon"
+        });
+        testAllProperty(state.editing.features[0].geometry, {
+            type: "Polygon",
+            coordinates: []
+        });
+    });
+    it('toggle add circle, check geometry', ()=>{
+        let state = annotations({
+            editing: {
+                features: []
+            }}, {
+            type: TOGGLE_ADD,
+            featureType: "Circle"
+        });
+        expect(state.editing.features[0].geometry.type).toBe("Polygon");
+        expect(state.editing.features[0].geometry.coordinates).toEqual([[]]);
+    });
     it('validate error', () => {
         const state = annotations({validationErrors: {}}, {
             type: VALIDATION_ERROR,

--- a/web/client/utils/__tests__/AnnotationsUtils-test.js
+++ b/web/client/utils/__tests__/AnnotationsUtils-test.js
@@ -534,6 +534,8 @@ describe('Test the AnnotationsUtils', () => {
         expect(getComponents(point).length).toBe(1);
         expect(getComponents(point)[0].lon).toBe(1);
         expect(getComponents(point)[0].lat).toBe(1);
+        expect(getComponents(null)[0].lat).toBe(undefined);
+        expect(getComponents(null)[0].lon).toBe(undefined);
     });
     it('test addIds defaults', () => {
         const features = [{properties: {id: "some id"}}, {properties: {}}];


### PR DESCRIPTION
Geometries become invisible when Marker or Text element is being added #7511
All logic is already backported via #7570
PR:
#7541 
#7557 