### PR TITLE
C027 Issue 72 - layer name parsing

### DIFF
--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -128,17 +128,16 @@ const converters = {
                     const URI = isArray(dc.URI) ? dc.URI : (dc.URI && [dc.URI] || []);
                     let thumb = head([].filter.call(URI, (uri) => {return uri.name === "thumbnail"; }) ) || head([].filter.call(URI, (uri) => !uri.name && uri.protocol?.indexOf('image/') > -1));
                     thumbURL = thumb ? thumb.value : null;
-                    wms = head([].filter.call(URI, (uri) => {
+                    wms = head(URI.map( uri => {
                         return uri.protocol && (
                             /** wms protocol params are explicitly defined as attributes (INSPIRE)*/
                             uri.protocol.match(/^OGC:WMS-(.*)-http-get-map/g) ||
                             uri.protocol.match(/^OGC:WMS/g) ||
                             /** wms protocol params must be extracted from the element text (RNDT / INSPIRE) */
-                            uri.protocol.match(/serviceType\/ogc\/wms/g));
-                    }));
+                            uri.protocol.match(/serviceType\/ogc\/wms/g) && extractWMSParamsFromURL(uri)
+                        );
+                    }).filter(item => item));
                 }
-                /** wms protocol params must be extracted from the element text (RNDT / INSPIRE) */
-                wms = (wms && wms.protocol.match(/serviceType\/ogc\/wms/g) && extractWMSParamsFromURL(wms));
                 // look in references objects
                 if (!wms && dc && dc.references && dc.references.length) {
                     let refs = Array.isArray(dc.references) ? dc.references : [dc.references];

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -72,12 +72,13 @@ const extractWMSParamsFromURL = wms => {
         lowerCaseParams.append(name.toLocaleLowerCase(), value);
     }
     const layerName = lowerCaseParams.get('layers');
+    const wmsVersion = lowerCaseParams.get('version');
     if (layerName) {
         return {
             ...wms,
             protocol: 'OGC:WMS',
             name: layerName,
-            value: wms.value.split('?')[0]
+            value: `${wms.value.match( /[^\?]+[\?]+/g)}SERIVCE=WMS${wmsVersion && `&VERSION=${wmsVersion}`}`
         };
     }
     return false;
@@ -107,7 +108,7 @@ const converters = {
                             uri.protocol.match(/serviceType\/ogc\/wms/g));
                     }));
                 }
-                if (wms && wms.protocol.match(/serviceType\/ogc\/wms/g).length && wms.description === "access point") {
+                if (wms && wms.protocol.match(/serviceType\/ogc\/wms/g) && wms.description === "access point") {
                     wms = extractWMSParamsFromURL(wms);
                 }
                 // look in references objects

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -97,7 +97,7 @@ const getMetaDataDownloadFormat = (protocol) => {
         {
             protocol: 'http://www.opengis.net/def/serviceType/ogc/wfs',
             displayValue: 'WFS'
-        },
+        }
     ];
     const format = formatsMap.filter(formatItem => (formatItem.protocol === protocol))[0]?.displayValue;
     return format ?? 'Link';

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -84,7 +84,7 @@ const extractWMSParamsFromURL = wms => {
     return false;
 };
 
-const getMetaDataDownloadFormat = (protocol, value) => {
+const getMetaDataDownloadFormat = (protocol = '', value = '') => {
     let format = '';
     const formatsMap = [
         {

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -542,6 +542,14 @@ describe('Test the CatalogUtils', () => {
     });
 
     it('csw with DC references with implicit name in wms URI (RNDT / INSPIRE)', () => {
+        const wmsReferences = [{
+            type: "OGC:WMS",
+            url: "http://geoserver/wms?SERIVCE=WMS&VERSION=1.3.0",
+            SRS: [],
+            params: {
+                name: "workspace:layer"
+            }
+        }];
         const records = CatalogUtils.getCatalogRecords('csw', {
             records: [{
                 dc: {
@@ -557,6 +565,7 @@ describe('Test the CatalogUtils', () => {
             }]
         }, {});
         expect(records.length).toBe(1);
+        expect(records[0].references).toEqual(wmsReferences);
     });
 
     it('csw with DC references with implicit name in wms URI (RNDT / INSPIRE) - download link - no title', () => {
@@ -578,7 +587,7 @@ describe('Test the CatalogUtils', () => {
                 }
             }]
         }, {}, locales);
-        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/shp/test_layer.zip">Not Available - shapefile</a></li></ul>';
+        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/shp/test_layer.zip">Not Available - Download</a></li></ul>';
         expect(records.length).toBe(1);
         expect(records[0].metadata.uri.length).toBe(1);
         expect(records[0].metadata.uri[0]).toBe(resourceLink);
@@ -597,7 +606,7 @@ describe('Test the CatalogUtils', () => {
                 }
             }]
         }, {});
-        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1">Test Layer - WMS</a></li></ul>';
+        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1">Test Layer - Link</a></li></ul>';
         expect(records.length).toBe(1);
         expect(records[0].metadata.uri.length).toBe(1);
         expect(records[0].metadata.uri[0]).toBe(resourceLink);

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -541,6 +541,24 @@ describe('Test the CatalogUtils', () => {
         expect(records.length).toBe(1);
     });
 
+    it('csw with DC references with implicit name in wms URI (RNDT / INSPIRE)', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    URI: [
+                        {
+                            TYPE_NAME: 'DC_1_1.URI',
+                            protocol: 'http://www.opengis.net/def/serviceType/ogc/wms',
+                            description: 'access point',
+                            value: 'http://geoserver/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=workspace:layer'
+                        }
+                    ]
+                }
+            }]
+        }, {});
+        expect(records.length).toBe(1);
+    });
+
     it('wms check for reference url', () => {
         const records = CatalogUtils.getCatalogRecords('wms', {
             records: [{

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -600,13 +600,14 @@ describe('Test the CatalogUtils', () => {
                     title: 'Test Layer',
                     URI: [
                         {
+                            protocol: 'http://www.opengis.net/def/serviceType/ogc/wms',
                             value: 'http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1'
                         }
                     ]
                 }
             }]
         }, {});
-        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1">Test Layer - Link</a></li></ul>';
+        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1">Test Layer - WMS</a></li></ul>';
         expect(records.length).toBe(1);
         expect(records[0].metadata.uri.length).toBe(1);
         expect(records[0].metadata.uri[0]).toBe(resourceLink);

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -584,6 +584,25 @@ describe('Test the CatalogUtils', () => {
         expect(records[0].metadata.uri[0]).toBe(resourceLink);
     });
 
+    it('csw with DC references with implicit name in wms URI (RNDT / INSPIRE) - download link - value only', () => {
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    title: 'Test Layer',
+                    URI: [
+                        {
+                            value: 'http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1'
+                        }
+                    ]
+                }
+            }]
+        }, {});
+        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/geoserver/wms?tiled=true&version=1.1.1">Test Layer - WMS</a></li></ul>';
+        expect(records.length).toBe(1);
+        expect(records[0].metadata.uri.length).toBe(1);
+        expect(records[0].metadata.uri[0]).toBe(resourceLink);
+    });
+
     it('wms check for reference url', () => {
         const records = CatalogUtils.getCatalogRecords('wms', {
             records: [{

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -559,6 +559,31 @@ describe('Test the CatalogUtils', () => {
         expect(records.length).toBe(1);
     });
 
+    it('csw with DC references with implicit name in wms URI (RNDT / INSPIRE) - download link - no title', () => {
+        const locales = {
+            catalog: {
+                notAvailable: "Not Available"
+            }
+        };
+        const records = CatalogUtils.getCatalogRecords('csw', {
+            records: [{
+                dc: {
+                    URI: [
+                        {
+                            protocol: 'https://registry.geodati.gov.it/metadata-codelist/ProtocolValue/www-download',
+                            description: 'access point',
+                            value: 'http://gisdata.provider.host/shp/test_layer.zip'
+                        }
+                    ]
+                }
+            }]
+        }, {}, locales);
+        const resourceLink = '<ul><li><a target="_blank" href="http://gisdata.provider.host/shp/test_layer.zip">Not Available - shapefile</a></li></ul>';
+        expect(records.length).toBe(1);
+        expect(records[0].metadata.uri.length).toBe(1);
+        expect(records[0].metadata.uri[0]).toBe(resourceLink);
+    });
+
     it('wms check for reference url', () => {
         const records = CatalogUtils.getCatalogRecords('wms', {
             records: [{


### PR DESCRIPTION
## Description
This PR fixes an issue raised that has got to be fixed in 2021.01.xx  - 2021.02.xx and MapStore2 downstream project C027 (where it was originally raised from).

Implements an additional method to parse `csw` XML responses to grab the relevant information to display on the `Catalog` component in MapStore. Changes to the structure and specification of the returned XML document (introduced with  (RNDT / INSPIRE)) caused misfunctioning in the component.

1. It was not possible to add the WMS service from the CSW respective service on the base map.
2. In the metadata template of the item, the links titles to download the source data were showing as `undefined` rather than showing the name of the resource.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) N/A


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Handles an additional CSW data response specification

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
User adds a CSW service endpoint returning XML based responses with the RNDT / INSPIRE specification, an example of such URL is the following:
`http://sr-vm107-sitgs1.comune.intranet:8080/geonetwork/srv/ita/csw` (can be accessed only if connected the customer VPN).

User saves the service settings with `Show Preview` and `Show Metadata Template` in `Advanced Settings`, the user provides the customer defined metadata template for the metadata. 

User clicks on the search button, returned records won't show the add '+' button on the top right corner of the record card. User expands the card component to show the extended information for the dataset on the metadata template. Links texts to download the source data (shp, kmz, etc.) are showing with the text `undefined`.

#[C027-#72](https://github.com/geosolutions-it/MapStore2-C027/issues/72)

**What is the new behavior?**
User adds a CSW service endpoint returning XML based responses with the RNDT / INSPIRE specification, an example of such URL is the following:
`http://sr-vm107-sitgs1.comune.intranet:8080/geonetwork/srv/ita/csw` (can be accessed only if connected the customer VPN).

User saves the service settings with `Show Preview` and `Show Metadata Template` in `Advanced Settings`, the user provides the customer defined metadata template for the metadata. 

User clicks on the search button, returned records will show the add '+' button on the top right corner of the record card where WMS getMap request template is correctly returned from the CSW service. User expands the card component to show the extended information for the dataset on the metadata template. Links texts to download the source data (shp, kmz, etc.) are showing with the text `Title of the resource - download format`.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

![recording_1](https://user-images.githubusercontent.com/14953970/142438877-2f732bd6-22ef-48aa-9c82-20e379017664.gif)

