### PR TITLE
backport 2021.02.xx - #7487 - on TOC, change layer name in settings only if supported (#7561)

### DIFF
--- a/web/client/components/TOC/fragments/settings/General.jsx
+++ b/web/client/components/TOC/fragments/settings/General.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { find, isObject, isString, uniqBy } from 'lodash';
+import { find, includes, isObject, isString, uniqBy } from 'lodash';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -108,10 +108,11 @@ class General extends React.Component {
                         }
                         )}
                     </FormGroup>)}
+                    {includes(this.supportedNameEditLayerTypes, this.props.element.type) &&
                     <LayerNameEditField
                         element={this.props.element}
                         enableLayerNameEditFeedback={this.props.enableLayerNameEditFeedback}
-                        onUpdateEntry={this.updateEntry.bind(null)}/>
+                        onUpdateEntry={this.updateEntry.bind(null)}/>}
                     <FormGroup>
                         <ControlLabel><Message msgId="layerProperties.description" /></ControlLabel>
                         {this.props.element.capabilitiesLoading ? <Spinner spinnerName="circle" /> :
@@ -188,6 +189,8 @@ class General extends React.Component {
             </Grid>
         );
     }
+
+    supportedNameEditLayerTypes = ['wms'];
 
     updateEntry = (key, event) => isObject(key) ? this.props.onChange(key) : this.props.onChange(key, event.target.value);
 

--- a/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/General-test.jsx
@@ -25,7 +25,7 @@ describe('test  Layer Properties General module component', () => {
         setTimeout(done);
     });
 
-    it('tests General component', () => {
+    it('tests General component show LayerNameEditField = FALSE', () => {
         const l = {
             name: 'layer00',
             title: 'Layer',
@@ -44,8 +44,29 @@ describe('test  Layer Properties General module component', () => {
         expect(comp).toExist();
         const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
         expect(inputs).toExist();
-        expect(inputs.length).toBe(17);
+        expect(inputs.length).toBe(16);
+    });
 
+    it('tests General component show LayerNameEditField = TRUE', () => {
+        const l = {
+            name: 'layer00',
+            title: 'Layer',
+            visibility: true,
+            storeIndex: 9,
+            type: 'wms',
+            url: 'fakeurl'
+        };
+        const settings = {
+            options: {opacity: 1}
+        };
+
+        // wrap in a stateful component, stateless components render return null
+        // see: https://facebook.github.io/react/docs/top-level-api.html#reactdom.render
+        const comp = ReactDOM.render(<General element={l} settings={settings} />, document.getElementById("container"));
+        expect(comp).toExist();
+        const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag( comp, "input" );
+        expect(inputs).toExist();
+        expect(inputs.length).toBe(17);
     });
     it('tests Layer Properties Display component events', () => {
         const l = {


### PR DESCRIPTION
## Description
backport 2021.02.xx - #7487 - on TOC, change layer name in settings only if supported (#7561)
