### PR TITLE
7265 layers order at export

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -18,8 +18,9 @@ import isEmpty from 'lodash/isEmpty';
 import findIndex from 'lodash/findIndex';
 import pick from 'lodash/pick';
 import isNil from 'lodash/isNil';
-let LayersUtils;
 import {addAuthenticationParameter} from './SecurityUtils';
+
+let LayersUtils;
 
 let regGeoServerRule = /\/[\w- ]*geoserver[\w- ]*\//;
 
@@ -381,7 +382,13 @@ export const getLayersByGroup = (configLayers, configGroups) => {
                 group = createGroup(groupId, groupTitle || groupName, groupName, mapLayers, addLayers);
                 subGroups.push(group);
             } else if (addLayers) {
-                group.nodes = group.nodes.concat(getLayersId(groupId, mapLayers));
+                group.nodes = getLayersId(groupId, mapLayers).concat(group.nodes)
+                    .reduce((arr, cur) => {
+                        isObject(cur)
+                            ? arr.push({node: cur, order: mapLayers.find((el) => el.group === cur.id).storeIndex})
+                            : arr.push({node: cur, order: mapLayers.find((el) => el.id === cur).storeIndex});
+                        return arr;
+                    }, []).sort((a, b) => b.order - a.order).map(e => e.node);
             }
             return group.nodes;
         }, groups);

--- a/web/client/utils/ogc/__tests__/WMC-test.js
+++ b/web/client/utils/ogc/__tests__/WMC-test.js
@@ -337,8 +337,8 @@ describe('WMC tests', () => {
             axios.get('base/web/client/test-resources/wmc/config.json'),
             axios.get('base/web/client/test-resources/wmc/exported-context.wmc')
         ]).then(([{data: config}, {data: context}]) => {
-            const exportedLines = toWMC(config, {}).split('\n').map(r => r.trim());
-            const contextLines = context.split('\n').map(r => r.trim());
+            const exportedLines = toWMC(config, {}).split('\n').map(r => r.trim()).filter(e => e);
+            const contextLines = context.split('\n').map(r => r.trim()).filter(e => e);
 
             zip(exportedLines, contextLines).forEach(([exportedLine, contextLine], i) =>
                 expect({text: exportedLine, line: i + 1}).toEqual({text: contextLine, line: i + 1}));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7265  Layers and groups order is not preserved when nested grouping is used.
Layers keep their order naturally by the way they get exported. Groups is no the same case.
This PR propose approach to preserve groups and layers order in both export formats.

**What is the current behavior?**
Groups order is not saved when user exports map and then re-imports it.

**What is the new behavior?**
Proper order is restored during import.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
