### PR TITLE
Issue #7566 - cookies policy modal, close button CSS fix

### DIFF
--- a/web/client/components/cookie/Cookie.jsx
+++ b/web/client/components/cookie/Cookie.jsx
@@ -97,7 +97,7 @@ class Cookie extends React.Component {
         return this.props.show ? (
             <div className={this.props.seeMore ? "mapstore-cookie-panel see-more" : "mapstore-cookie-panel not-see-more"}>
                 <div role="header" className="cookie-header" style={{height: this.props.seeMore ? "44px" : "0px"}}>
-                    {this.props.seeMore ? <Glyphicon className="btn cookie-close-btn" glyph="1-close" onClick={() => this.props.onMoreDetails(false)}/> : null }
+                    {this.props.seeMore ? <Glyphicon className="cookie-close-btn" glyph="1-close" onClick={() => this.props.onMoreDetails(false)}/> : null }
                 </div>
                 <div role="body" className="cookie-body-container">
                     {!this.props.externalCookieUrl && this.props.seeMore ? (

--- a/web/client/components/cookie/Cookie.jsx
+++ b/web/client/components/cookie/Cookie.jsx
@@ -97,7 +97,7 @@ class Cookie extends React.Component {
         return this.props.show ? (
             <div className={this.props.seeMore ? "mapstore-cookie-panel see-more" : "mapstore-cookie-panel not-see-more"}>
                 <div role="header" className="cookie-header" style={{height: this.props.seeMore ? "44px" : "0px"}}>
-                    {this.props.seeMore ? <Glyphicon glyph="1-close" onClick={() => this.props.onMoreDetails(false)}/> : null }
+                    {this.props.seeMore ? <Glyphicon className="btn cookie-close-btn" glyph="1-close" onClick={() => this.props.onMoreDetails(false)}/> : null }
                 </div>
                 <div role="body" className="cookie-body-container">
                     {!this.props.externalCookieUrl && this.props.seeMore ? (

--- a/web/client/themes/default/less/cookie.less
+++ b/web/client/themes/default/less/cookie.less
@@ -13,6 +13,7 @@
 
     .mapstore-cookie-panel,
     .cookie-body-container {
+        .color-var(@theme-vars[main-color]);
         .background-color-var(@theme-vars[main-bg]);
     }
 

--- a/web/client/themes/default/less/cookie.less
+++ b/web/client/themes/default/less/cookie.less
@@ -13,18 +13,17 @@
 
     .mapstore-cookie-panel,
     .cookie-body-container {
-        .color-var(@theme-vars[main-color]);
         .background-color-var(@theme-vars[main-bg]);
     }
 
     .cookie-title,
     .cookie-header {
         .color-var(@theme-vars[primary-contrast]);
+        .cookie-close-btn {
+            .color-var(@theme-vars[main-color]);
+        }
     }
 
-    .cookie-close-btn {
-        .color-var(@theme-vars[main-color]);
-    }
 }
 
 // **************
@@ -149,6 +148,6 @@
 .cookie-header > .cookie-close-btn {
     float: right;
     cursor: pointer;
-    font-size: 30px;
+    font-size: 40px;
     width: 44px;
 }

--- a/web/client/themes/default/less/cookie.less
+++ b/web/client/themes/default/less/cookie.less
@@ -21,6 +21,10 @@
     .cookie-header {
         .color-var(@theme-vars[primary-contrast]);
     }
+
+    .cookie-close-btn {
+        .color-var(@theme-vars[main-color]);
+    }
 }
 
 // **************
@@ -142,9 +146,9 @@
     height: 44px;
 }
 
-.cookie-header > span {
+.cookie-header > .cookie-close-btn {
     float: right;
     cursor: pointer;
-    font-size: 40px;
+    font-size: 30px;
     width: 44px;
 }


### PR DESCRIPTION
## Description
The goal of this PR is to fix some overwritten CSS rules that were preventing the close 'X' button to show in the modal window that shows the cookies policy details to the users when they access the site the first time or the settings has been forgotten in the browsers cookies. 

**Please check if the PR fulfils these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) N/A
- [ ] Docs have been added / updated (for bug fixes / features) N/A


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behaviour?**
In an incognito window, users access Mapstore2 home page. The cookies policy warning will appear on the bottom left corner of the page, users click on the 'More Details' button to open the Cookies modal window. On the modal window the close 'X' button on the top right corner will be there but won't be visible because its colour is the same as the window background.

[#7566](https://github.com/geosolutions-it/MapStore2/issues/7566)

**What is the new behaviour?**
In an incognito window, users access Mapstore2 home page. The cookies policy warning will appear on the bottom left corner of the page, users click on the 'More Details' button to open the Cookies modal window. On the modal window the close 'X' button on the top right corner will be there and will be visible because its colour is opposite than the window background (dark coloured in light default theme, light coloured in dark default theme)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

![cookies_lt](https://user-images.githubusercontent.com/14953970/142646450-ea6ae3df-6580-4c24-ab65-99f975db4623.JPG)


![cookies_dt](https://user-images.githubusercontent.com/14953970/142646474-686240e9-4c5f-4c8c-8352-e567e79b5411.JPG)


