### PR TITLE
#7565: Set layer visibility limits from Catalog

### DIFF
--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -176,7 +176,7 @@ Set `selectedService` value to one of the ID of the services object ("Demo CSW S
   "readOnly": "if true, makes the service not editable from catalog plugin"
   "titleMsgId": "optional, string used to localize the title of the service, the string must be present in translations",
   "format": "image/png8" // the image format to use by default for layers coming from this catalog (or tiles).
-  "autoSetVisibilityLimits": "if true, allows to fetch and set visibility limits of the layer from capabilities"
+  "autoSetVisibilityLimits": "if true, allows to fetch and set visibility limits of the layer from capabilities on layer add"
   "layerOptions": { // optional
       "format": "image/png8", // image format needs to be configured also inside layerOptions
       "tileSize": 512 // determine the default tile size for the catalog, valid for WMS and CSW catalogs

--- a/docs/developer-guide/local-config.md
+++ b/docs/developer-guide/local-config.md
@@ -176,6 +176,7 @@ Set `selectedService` value to one of the ID of the services object ("Demo CSW S
   "readOnly": "if true, makes the service not editable from catalog plugin"
   "titleMsgId": "optional, string used to localize the title of the service, the string must be present in translations",
   "format": "image/png8" // the image format to use by default for layers coming from this catalog (or tiles).
+  "autoSetVisibilityLimits": "if true, allows to fetch and set visibility limits of the layer from capabilities"
   "layerOptions": { // optional
       "format": "image/png8", // image format needs to be configured also inside layerOptions
       "tileSize": 512 // determine the default tile size for the catalog, valid for WMS and CSW catalogs

--- a/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
+++ b/web/client/components/TOC/fragments/settings/__tests__/VisibilityLimitsForm-test.jsx
@@ -47,6 +47,8 @@ describe('VisibilityLimitsForm', () => {
             '1 : 37795',
             'layerProperties.visibilityLimits.scale'
         ]);
+        const message = document.querySelector('.alert-success');
+        expect(message.textContent).toBe('layerProperties.visibilityLimits.serverValuesUpdate');
     });
     it('should render maxResolution and minResolution labels as resolution', () => {
         const layer = {

--- a/web/client/components/catalog/RecordItem.jsx
+++ b/web/client/components/catalog/RecordItem.jsx
@@ -36,6 +36,7 @@ import AddTileProvider from './buttons/AddTileProvider';
 import defaultThumb from './img/default.jpg';
 import defaultBackgroundThumbs from '../../plugins/background/DefaultThumbs';
 import unknown from "../../plugins/background/assets/img/dafault.jpg";
+import { getResolutions } from "../../utils/MapUtils";
 
 class RecordItem extends React.Component {
     static propTypes = {
@@ -356,6 +357,7 @@ class RecordItem extends React.Component {
         }
 
         const localizedLayerStyles = this.props.service && this.props.service.localizedLayerStyles;
+        const autoSetVisibilityLimits = this.props?.service?.autoSetVisibilityLimits;
 
         return recordToLayer(
             this.props.record,
@@ -377,7 +379,13 @@ class RecordItem extends React.Component {
                         formats: {
                             imageFormats: this.props.formatOptions,
                             infoFormats: this.props.infoFormatOptions
-                        }
+                        },
+                        ...(autoSetVisibilityLimits && {
+                            map: {
+                                projection: this.props.crs,
+                                resolutions: getResolutions()
+                            }
+                        })
                     }
                     : {
                         format: this.getLayerFormat(

--- a/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/CommonAdvancedSettings.jsx
@@ -7,23 +7,21 @@
  */
 import React from 'react';
 import { isNil } from 'lodash';
-import ReactQuill from "react-quill";
 import { FormGroup, Checkbox, Col } from "react-bootstrap";
 
 import Message from "../../../I18N/Message";
-import InfoPopover from '../../../widgets/widget/InfoPopover';
-import CSWFilters from "./CSWFilters";
 
 /**
- * Common Advanced settings form, used by WMS/CSW/WMTS
+ * Common Advanced settings form WMS/CSW/WMTS/WFS
+ *
+ * - autoload: Option allows the automatic fetching of the results upon selecting the service from Service dropdown
+ * - hideThumbnail: Options allows to hide the thumbnail on the result
+ *
  */
 export default ({
     children,
     service,
-    isLocalizedLayerStylesEnabled,
-    onChangeMetadataTemplate = () => { },
     onChangeServiceProperty = () => { },
-    onToggleTemplate = () => { },
     onToggleThumbnail = () => { }
 }) => (
     <div>
@@ -44,61 +42,6 @@ export default ({
                 </Checkbox>
             </Col>
         </FormGroup>
-        {(isLocalizedLayerStylesEnabled && !isNil(service.type) ? service.type === "wms" : false) && (<FormGroup controlId="localized-styles" key="localized-styles">
-            <Col xs={12}>
-                <Checkbox data-qa="service-lacalized-layer-styles-option"
-                    onChange={(e) => onChangeServiceProperty("localizedLayerStyles", e.target.checked)}
-                    checked={!isNil(service.localizedLayerStyles) ? service.localizedLayerStyles : false}>
-                    <Message msgId="catalog.enableLocalizedLayerStyles.label" />&nbsp;<InfoPopover text={<Message msgId="catalog.enableLocalizedLayerStyles.tooltip" />} />
-                </Checkbox>
-            </Col>
-        </FormGroup>)}
-        {(!isNil(service.type) ? (service.type === "csw" && !service.excludeShowTemplate) : false) && (<FormGroup controlId="metadata-template" key="metadata-template" className="metadata-template-editor">
-            <Col xs={12}>
-                <Checkbox
-                    onChange={() => onToggleTemplate()}
-                    checked={service && service.showTemplate}>
-                    <Message msgId="catalog.showTemplate" />
-                </Checkbox>
-                <br />
-            </Col>
-            {service && service.showTemplate &&
-                (<Col xs={12}>
-                    <span>
-                        <p>
-                            <Message msgId="layerProperties.templateFormatInfoAlert2" msgParams={{ attribute: "{ }" }} />
-                            &nbsp;&nbsp;
-
-                        </p>
-                        <pre>
-                            <Message msgId="catalog.templateFormatDescriptionExample" />{" ${ description }"}
-                        </pre>
-                    </span>
-                </Col>)}
-            <Col xs={12}>
-                {service && service.showTemplate && <ReactQuill
-                    modules={{
-                        toolbar: [
-                            [{ "size": ["small", false, "large", "huge"] }, "bold", "italic", "underline", "blockquote"],
-                            [{ "list": "bullet" }, { "align": [] }],
-                            [{ "color": [] }, { "background": [] }, "clean"], ["link"]
-                        ]
-                    }}
-                    value={service.metadataTemplate || ""}
-                    onChange={(metadataTemplate) => {
-                        if (metadataTemplate && metadataTemplate !== "<p><br></p>") {
-                            onChangeMetadataTemplate(metadataTemplate);
-                        } else {
-                            // TODO think about this
-                            onChangeMetadataTemplate("");
-                        }
-                    }} />
-                }
-            </Col>
-        </FormGroup>)}
         {children}
-        {!isNil(service.type) && service.type === "csw" &&
-            <CSWFilters filter={service?.filter} onChangeServiceProperty={onChangeServiceProperty}/>
-        }
     </div>
 );

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -6,13 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-import { FormGroup, Col, ControlLabel } from "react-bootstrap";
+import {FormGroup, Col, ControlLabel, Checkbox} from "react-bootstrap";
 import RS from 'react-select';
 import { DEFAULT_FORMAT_WMS } from '../../../../utils/CatalogUtils';
 import localizedProps from '../../../misc/enhancers/localizedProps';
 const Select = localizedProps('noResultsText')(RS);
 
 import CommonAdvancedSettings from './CommonAdvancedSettings';
+import {isNil} from "lodash";
+import ReactQuill from "react-quill";
+
+import InfoPopover from '../../../widgets/widget/InfoPopover';
+import CSWFilters from "./CSWFilters";
+import Message from "../../../I18N/Message";
+
 /**
  * Generates an array of options in the form e.g. [{value: "256", label: "256x256"}]
  * @param {number[]} opts an array of tile sizes
@@ -21,6 +28,28 @@ const getTileSizeSelectOptions = (opts) => {
     return opts.map(opt => ({label: `${opt}x${opt}`, value: opt}));
 };
 
+/**
+ * Raster advanced settings form, used by WMS/CSW
+ *
+ * **WMS**
+ * - localizedLayerStyles: Option if `enabled` allows to include the MapStore's locale in each `GetMap`, `GetLegendGraphic` and `GetFeatureInfo` requests to the server so that the WMS server,
+ *  if properly configured, can use that locale. For more info [Localized Style](https://mapstore.readthedocs.io/en/latest/user-guide/catalog/#wmswmts-catalog)
+ * - autoSetVisibilityLimits: Option allows to fetch and set visibility limits of the layer from GetCapabilities
+ *
+ * **CSW**
+ * - excludeShowTemplate: Configuration if set to false, displays `metadata template` configurable option
+ *  * showTemplate: Options allows the user to insert layer description text with metadata information. For more info [Show metadata template](https://mapstore.readthedocs.io/en/latest/user-guide/catalog/#metadata-templates)
+ * - Filters (Option allows user to configure the ogcFilter with custom filtering conditions
+ *   *staticFilter: filter to fetch all record applied always i.e even when no search text is present
+ *   *dynamicFilter: filter when search text is present and is applied in conjunction with static filter
+ *
+ * **WMS|CSW**
+ * - tileSize: Option allows to select and configure the default tile size of the layer to be requested with
+ * - format: Option allows to select and configure the default format of the layer to be requested with
+ * - autoload: Option allows automatic fetching of the results upon selecting the service from Service dropdown
+ * - hideThumbnail: Options allows to hide the thumbnail on the result
+ *
+ */
 export default ({
     service,
     formatOptions =  DEFAULT_FORMAT_WMS,
@@ -30,11 +59,75 @@ export default ({
     selectedService,
     onFormatOptionsFetch = () => {},
     advancedRasterSettingsStyles = {},
-    tileSizeOptions,
+    tileSizeOptions = [256, 512],
+    isLocalizedLayerStylesEnabled,
+    onChangeMetadataTemplate = () => { },
+    onToggleTemplate = () => { },
     ...props
 }) => {
     const tileSelectOptions = getTileSizeSelectOptions(tileSizeOptions);
     return (<CommonAdvancedSettings {...props} onChangeServiceProperty={onChangeServiceProperty} service={service} >
+        {(isLocalizedLayerStylesEnabled && !isNil(service.type) ? service.type === "wms" : false) && (<FormGroup controlId="localized-styles" key="localized-styles">
+            <Col xs={12}>
+                <Checkbox data-qa="service-lacalized-layer-styles-option"
+                    onChange={(e) => onChangeServiceProperty("localizedLayerStyles", e.target.checked)}
+                    checked={!isNil(service.localizedLayerStyles) ? service.localizedLayerStyles : false}>
+                    <Message msgId="catalog.enableLocalizedLayerStyles.label" />&nbsp;<InfoPopover text={<Message msgId="catalog.enableLocalizedLayerStyles.tooltip" />} />
+                </Checkbox>
+            </Col>
+        </FormGroup>)}
+        {(!isNil(service.type) ? service.type === "wms" : false) && (<FormGroup controlId="autoSetVisibilityLimits" key="autoSetVisibilityLimits">
+            <Col xs={12}>
+                <Checkbox
+                    onChange={(e) => onChangeServiceProperty("autoSetVisibilityLimits", e.target.checked)}
+                    checked={!isNil(service.autoSetVisibilityLimits) ? service.autoSetVisibilityLimits : false}>
+                    <Message msgId="catalog.autoSetVisibilityLimits.label" />&nbsp;<InfoPopover text={<Message msgId="catalog.autoSetVisibilityLimits.tooltip" />} />
+                </Checkbox>
+            </Col>
+        </FormGroup>)}
+        {(!isNil(service.type) ? (service.type === "csw" && !service.excludeShowTemplate) : false) && (<FormGroup controlId="metadata-template" key="metadata-template" className="metadata-template-editor">
+            <Col xs={12}>
+                <Checkbox
+                    onChange={() => onToggleTemplate()}
+                    checked={service && service.showTemplate}>
+                    <Message msgId="catalog.showTemplate" />
+                </Checkbox>
+                <br />
+            </Col>
+            {service && service.showTemplate &&
+            (<Col xs={12}>
+                <span>
+                    <p>
+                        <Message msgId="layerProperties.templateFormatInfoAlert2" msgParams={{ attribute: "{ }" }} />
+                            &nbsp;&nbsp;
+
+                    </p>
+                    <pre>
+                        <Message msgId="catalog.templateFormatDescriptionExample" />{" ${ description }"}
+                    </pre>
+                </span>
+            </Col>)}
+            <Col xs={12}>
+                {service && service.showTemplate && <ReactQuill
+                    modules={{
+                        toolbar: [
+                            [{ "size": ["small", false, "large", "huge"] }, "bold", "italic", "underline", "blockquote"],
+                            [{ "list": "bullet" }, { "align": [] }],
+                            [{ "color": [] }, { "background": [] }, "clean"], ["link"]
+                        ]
+                    }}
+                    value={service.metadataTemplate || ""}
+                    onChange={(metadataTemplate) => {
+                        if (metadataTemplate && metadataTemplate !== "<p><br></p>") {
+                            onChangeMetadataTemplate(metadataTemplate);
+                        } else {
+                            // TODO think about this
+                            onChangeMetadataTemplate("");
+                        }
+                    }} />
+                }
+            </Col>
+        </FormGroup>)}
         <FormGroup style={advancedRasterSettingsStyles}>
             <Col xs={6}>
                 <ControlLabel>Format</ControlLabel>
@@ -62,5 +155,8 @@ export default ({
                     onChange={event => onChangeServiceProperty("layerOptions", { tileSize: event && event.value })} />
             </Col >
         </FormGroup>
+        {!isNil(service.type) && service.type === "csw" &&
+        <CSWFilters filter={service?.filter} onChangeServiceProperty={onChangeServiceProperty}/>
+        }
     </CommonAdvancedSettings>);
 };

--- a/web/client/components/catalog/editor/AdvancedSettings/TMSAdvancedEditor.jsx
+++ b/web/client/components/catalog/editor/AdvancedSettings/TMSAdvancedEditor.jsx
@@ -23,6 +23,13 @@ const INITIAL_CODE_VALUE = {
 };
 /**
  * Advanced settings form, used by TMS
+ *
+ * - autoload: Option allows the automatic fetching of the results upon selecting the service from Service dropdown
+ * - hideThumbnail: Options allows to hide the thumbnail on the result
+ * - *forceDefaultTileGrid*: When `provider` is `tms`, the option allows to force the usage of global projection's tile grid rather than one provided by server.
+ *  Useful for TMS services that advertise wrong origin or resolutions
+ * - *customTMSConfiguration*: Allows user to configure the tile URL template manually. For more info [Custom TMS](https://mapstore.readthedocs.io/en/latest/user-guide/catalog/#custom-tms)
+ *
  * @prop {object} service the service to edit
  * @prop {function} onChangeServiceProperty handler (key, value) to change a property of service.
  */

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+import expect from 'expect';
+import RasterAdvancedSettings from "../RasterAdvancedSettings";
+import TestUtils from "react-dom/test-utils";
+
+describe('Test Raster advanced settings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+    it('creates the component with defaults', () => {
+        ReactDOM.render(<RasterAdvancedSettings service={{type: "wms"}}/>, document.getElementById("container"));
+        const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingPanel).toBeTruthy();
+    });
+    it('test wms advanced options', () => {
+        ReactDOM.render(<RasterAdvancedSettings service={{type: "wms", autoload: false}} isLocalizedLayerStylesEnabled/>, document.getElementById("container"));
+        const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingPanel).toBeTruthy();
+        const fields = document.querySelectorAll(".form-group");
+        expect(fields.length).toBe(6);
+    });
+    it('test csw advanced options', () => {
+        ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));
+        const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingPanel).toBeTruthy();
+        const fields = document.querySelectorAll(".form-group");
+        const cswFilters = document.getElementsByClassName("catalog-csw-filters");
+        expect(fields.length).toBe(7);
+        expect(cswFilters).toBeTruthy();
+    });
+    it('test component onChangeServiceProperty autoload', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings onChangeServiceProperty={action.onChangeServiceProperty}
+            service={{type: "wms", autoload: false}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const autload = document.querySelectorAll('input[type="checkbox"]')[0];
+        expect(autload).toExist();
+        TestUtils.Simulate.change(autload, { "target": { "checked": true }});
+        expect(spyOn).toHaveBeenCalled();
+    });
+    it('test component onToggleThumbnail hideThumbnail', () => {
+        const action = {
+            onToggleThumbnail: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onToggleThumbnail');
+        ReactDOM.render(<RasterAdvancedSettings onToggleThumbnail={action.onToggleThumbnail}
+            service={{type: "wms", hideThumbnail: false}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const hideThumbnail = document.querySelectorAll('input[type="checkbox"]')[0];
+        expect(hideThumbnail).toExist();
+        TestUtils.Simulate.change(hideThumbnail, { "target": { "checked": true }});
+        expect(spyOn).toHaveBeenCalled();
+    });
+    it('test component onChangeServiceProperty localizedLayerStyles', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings onChangeServiceProperty={action.onChangeServiceProperty}
+            isLocalizedLayerStylesEnabled  service={{type: "wms", localizedLayerStyles: false}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const localizedLayerStyles = document.querySelectorAll('input[type="checkbox"]')[1];
+        expect(localizedLayerStyles).toExist();
+        TestUtils.Simulate.change(localizedLayerStyles, { "target": { "checked": true }});
+        expect(spyOn).toHaveBeenCalled();
+    });
+    it('test component onChangeServiceProperty autoSetVisibilityLimits', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings
+            onChangeServiceProperty={action.onChangeServiceProperty}
+            service={{type: "wms", autoSetVisibilityLimits: false}}
+        />, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const autoSetVisibilityLimits = document.querySelectorAll('input[type="checkbox"]')[1];
+        const formGroup = document.querySelectorAll('.form-group')[2];
+        expect(formGroup.textContent.trim()).toBe('catalog.autoSetVisibilityLimits.label');
+        expect(autoSetVisibilityLimits).toExist();
+        TestUtils.Simulate.change(autoSetVisibilityLimits, { "target": { "checked": true }});
+        expect(spyOn).toHaveBeenCalled();
+        expect(spyOn.calls[0].arguments).toEqual([ 'autoSetVisibilityLimits', true ]);
+    });
+    it('test component when showTemplate true', () => {
+        ReactDOM.render(<RasterAdvancedSettings
+            service={{type: "csw", showTemplate: true}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const metadataTemplate = document.querySelector('.ql-editor');
+        expect(metadataTemplate).toExist();
+    });
+    it('test component onToggleTemplate showTemplate', () => {
+        const action = {
+            onToggleTemplate: () => {}
+        };
+        const spyOnToggleTemplate = expect.spyOn(action, 'onToggleTemplate');
+        ReactDOM.render(<RasterAdvancedSettings
+            onToggleTemplate={action.onToggleTemplate}
+            service={{type: "csw", showTemplate: false}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const showTemplate = document.querySelectorAll('input[type="checkbox"]')[1];
+        expect(showTemplate).toExist();
+        TestUtils.Simulate.change(showTemplate, { "target": { "checked": true }});
+        expect(spyOnToggleTemplate).toHaveBeenCalled();
+    });
+    it('test component onChangeServiceFormat formats', () => {
+        const action = {
+            onChangeServiceFormat: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceFormat');
+        ReactDOM.render(<RasterAdvancedSettings
+            onChangeServiceFormat={action.onChangeServiceFormat}
+            service={{type: "wms"}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const format = document.querySelectorAll('input')[2];
+        expect(format).toExist();
+        TestUtils.Simulate.change(format, { target: { value: 'image/png' } });
+        TestUtils.Simulate.keyDown(format, { keyCode: 9, key: 'Tab' });
+        expect(spyOn).toHaveBeenCalled();
+        expect(spyOn.calls[0].arguments[0]).toBe('image/png');
+    });
+    it('test component onChangeServiceProperty layerOption', () => {
+        const action = {
+            onChangeServiceProperty: () => {}
+        };
+        const spyOn = expect.spyOn(action, 'onChangeServiceProperty');
+        ReactDOM.render(<RasterAdvancedSettings
+            onChangeServiceProperty={action.onChangeServiceProperty}
+            service={{type: "wms", layerOptions: {tileSize: 256}}}/>, document.getElementById("container"));
+        const advancedSettingsPanel = document.getElementsByClassName("mapstore-switch-panel");
+        expect(advancedSettingsPanel).toBeTruthy();
+        const layerOption = document.querySelectorAll('input')[3];
+        expect(layerOption).toExist();
+        TestUtils.Simulate.change(layerOption, { target: { value: "512" }});
+        TestUtils.Simulate.keyDown(layerOption, { keyCode: 9, key: 'Tab' });
+        expect(spyOn).toHaveBeenCalled();
+    });
+});

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1477,7 +1477,7 @@
             },
             "autoSetVisibilityLimits": {
                 "label": "Sichtbarkeitslimit festlegen",
-                "tooltip": "Legen Sie automatisch Sichtbarkeitsgrenzen des Layers aus den Funktionen fest"
+                "tooltip": "Wendet automatisch die vom Server vorgeschlagenen Sichtbarkeitsgrenzen an"
             }
         },
         "uploader": {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1474,6 +1474,10 @@
                     "helpText": "Verwenden Sie eine Vorlage mit dem Platzhalter ${searchText}, um die Suchzeichenfolge zu erfassen"
                 },
               "error": "Ungültige XML-Syntax"
+            },
+            "autoSetVisibilityLimits": {
+                "label": "Sichtbarkeitslimit festlegen",
+                "tooltip": "Legen Sie automatisch Sichtbarkeitsgrenzen des Layers aus den Funktionen fest"
             }
         },
         "uploader": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1439,7 +1439,7 @@
             },
            "autoSetVisibilityLimits": {
                 "label": "Set Visibility Limit",
-                "tooltip": "Automatically set visibility limits of the layer from capabilities"
+                "tooltip": "Automatically applies the visibility limits suggested by the server"
            }
         },
         "uploader": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1436,7 +1436,11 @@
                     "helpText": "Use template with ${searchText} placeholder to capture search string"
                 },
                 "error": "Invalid xml syntax"
-            }
+            },
+           "autoSetVisibilityLimits": {
+                "label": "Set Visibility Limit",
+                "tooltip": "Automatically set visibility limits of the layer from capabilities"
+           }
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1439,7 +1439,7 @@
             },
             "autoSetVisibilityLimits": {
                 "label": "Establecer límite de visibilidad",
-                "tooltip": "Establezca automáticamente los límites de visibilidad de la capa a partir de las capacidades."
+                "tooltip": "Aplica automáticamente los límites de visibilidad sugeridos por el servidor"
             }
         },
         "uploader": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1436,6 +1436,10 @@
                     "helpText": "Utilice la plantilla con el marcador de posición $ {searchText} para capturar la cadena de búsqueda"
                 },
                 "error": "Sintaxis XML no válida"
+            },
+            "autoSetVisibilityLimits": {
+                "label": "Establecer límite de visibilidad",
+                "tooltip": "Establezca automáticamente los límites de visibilidad de la capa a partir de las capacidades."
             }
         },
         "uploader": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1440,7 +1440,7 @@
             },
             "autoSetVisibilityLimits": {
                 "label": "Définir la limite de visibilité",
-                "tooltip": "Définir automatiquement les limites de visibilité de la couche à partir des capacités"
+                "tooltip": "Applique automatiquement les limites de visibilité suggérées par le serveur"
             }
         },
         "uploader": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1437,6 +1437,10 @@
                     "helpText": "Utilisez un modèle avec un espace réservé ${searchText} pour capturer la chaîne de recherche"
                 },
                 "error": "Syntaxe xml non valide"
+            },
+            "autoSetVisibilityLimits": {
+                "label": "Définir la limite de visibilité",
+                "tooltip": "Définir automatiquement les limites de visibilité de la couche à partir des capacités"
             }
         },
         "uploader": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1440,7 +1440,7 @@
             },
             "autoSetVisibilityLimits": {
                 "label": "Imposta limite di visibilità",
-                "tooltip": "Imposta automaticamente i limiti di visibilità del livello dalle capacità"
+                "tooltip": "Applica automaticamente i limiti di visibilità suggeriti dal server"
             }
         },
         "uploader": {

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1437,6 +1437,10 @@
                     "helpText": "Usa il segnaposto ${searchText} nel modello per inserire la stringa di ricerca"
                 },
                 "error": "Sintassi xml non valida"
+            },
+            "autoSetVisibilityLimits": {
+                "label": "Imposta limite di visibilità",
+                "tooltip": "Imposta automaticamente i limiti di visibilità del livello dalle capacità"
             }
         },
         "uploader": {

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -31,6 +31,7 @@ import * as WMTSUtils from './WMTSUtils';
 import { cleanAuthParamsFromURL } from './SecurityUtils';
 import WMS from '../api/WMS';
 import { getAvailableInfoFormat } from "./MapInfoUtils";
+import { getResolutionObject } from "./MapUtils";
 
 const getBaseCatalogUrl = (url) => {
     return url && url.replace(/\/csw$/, "/");
@@ -493,7 +494,7 @@ const toURLArray = (url) => {
  *  - `removeParameters` if you didn't provided an `url` option and you want to use record's one, you can remove some params (typically authkey params) using this.
  *  - `url`, if you already have the correct service URL (typically when you want to use you URL already stripped from some parameters, e.g. authkey params)
  */
-export const recordToLayer = (record, type = "wms", {removeParams = [], format, catalogURL, url, formats = {}} = {}, baseConfig = {}, localizedLayerStyles) => {
+export const recordToLayer = (record, type = "wms", {removeParams = [], format, catalogURL, url, formats = {}, map = {}} = {}, baseConfig = {}, localizedLayerStyles) => {
     if (!record || !record.references) {
         // we don't have a valid record so no buttons to add
         return null;
@@ -524,7 +525,9 @@ export const recordToLayer = (record, type = "wms", {removeParams = [], format, 
     const layerURL = toLayerURL(url || originalUrl);
 
     const allowedSRS = buildSRSMap(ogcServiceReference.SRS);
-    return {
+    const { MaxScaleDenominator: maxScaleDenominator, MinScaleDenominator: minScaleDenominator }
+        = record?.capabilities ?? {};
+    let layer = {
         type: type,
         requestEncoding: record.requestEncoding, // WMTS KVP vs REST, KVP by default
         style: record.style,
@@ -555,9 +558,21 @@ export const recordToLayer = (record, type = "wms", {removeParams = [], format, 
         catalogURL,
         ...baseConfig,
         ...record.layerOptions,
-        localizedLayerStyles: !isNil(localizedLayerStyles) ? localizedLayerStyles : undefined,
-        ...(type === 'wms' && !isEmpty(formats) && {imageFormats: formats.imageFormats, infoFormats: formats.infoFormats})
+        localizedLayerStyles: !isNil(localizedLayerStyles) ? localizedLayerStyles : undefined
     };
+    if (type === "wms") {
+        if (!isEmpty(formats)) {
+            layer = {...layer, imageFormats: formats.imageFormats, infoFormats: formats.infoFormats};
+        }
+        if (!isEmpty(map) && (maxScaleDenominator || minScaleDenominator)) {
+            const {resolution: minResolution} = !isNil(minScaleDenominator)
+            && getResolutionObject(minScaleDenominator, 'scale', map) || {};
+            const {resolution: maxResolution} = !isNil(maxScaleDenominator)
+            && getResolutionObject(maxScaleDenominator, 'scale', map) || {};
+            layer = {...layer, minResolution, maxResolution};
+        }
+    }
+    return layer;
 };
 export const getCatalogRecords = (format, records, options, locales) => {
     return converters[format] && converters[format](records, options, locales) || null;

--- a/web/client/utils/MapUtils.js
+++ b/web/client/utils/MapUtils.js
@@ -719,6 +719,32 @@ export const detectIdentifyInMapPopUp = (state)=>{
     return false;
 };
 
+/**
+ * Derive resolution object with scale and zoom info
+ * based on visibility limit's type
+ * @param value {number} computed with dots per map unit to get resolution
+ * @param type {string} of visibility limit ex. scale
+ * @param projection {string} map projection
+ * @param resolutions {array} map resolutions
+ * @return {object} resolution object
+ */
+export const getResolutionObject = (value, type, {projection, resolutions} = {}) => {
+    const dpu = dpi2dpu(DEFAULT_SCREEN_DPI, projection);
+    if (type === 'scale') {
+        const resolution = value / dpu;
+        return {
+            resolution: resolution,
+            scale: value,
+            zoom: getZoomFromResolution(resolution, resolutions)
+        };
+    }
+    return {
+        resolution: value,
+        scale: value * dpu,
+        zoom: getZoomFromResolution(value, resolutions)
+    };
+};
+
 export default {
     createRegisterHooks,
     EXTENT_TO_ZOOM_HOOK,
@@ -758,5 +784,6 @@ export default {
     prepareMapObjectToCompare,
     updateObjectFieldKey,
     compareMapChanges,
-    clearHooks
+    clearHooks,
+    getResolutionObject
 };

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -128,6 +128,22 @@ describe('Test the CatalogUtils', () => {
         expect(layer.tileSize).toBe(512);
     });
 
+    it('wms layer with visibility limits', () => {
+        const records = CatalogUtils.getCatalogRecords('wms', {
+            records: [{
+                MaxScaleDenominator: "78271",
+                MinScaleDenominator: "1222"
+            }]
+        }, {
+            url: 'http://sample'
+        });
+        const resolutions =  [156543, 78271, 39135, 19567, 9783, 4891, 2445, 1222];
+        expect(records.length).toBe(1);
+        const layer = CatalogUtils.recordToLayer(records[0], "wms", {map: {projection: "EPSG:900913", resolutions}});
+        expect(Math.ceil(layer.minResolution)).toBe(1);
+        expect(Math.ceil(layer.maxResolution)).toBe(21);
+    });
+
     it('wms with no ogcServiceReference.url', () => {
         const records = CatalogUtils.getCatalogRecords(
             'wms',

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -38,7 +38,8 @@ import {
     mergeMapConfigs,
     addRootParentGroup,
     mapUpdated,
-    getZoomFromResolution
+    getZoomFromResolution,
+    getResolutionObject
 } from '../MapUtils';
 
 const POINT = "Point";
@@ -3115,5 +3116,16 @@ describe('Test the MapUtils', () => {
     it('addRootParentGroup', () => {
         const resolution = 1000; // ~zoom 7 in Web Mercator
         expect(getZoomFromResolution(resolution)).toBe(7);
+    });
+    describe("getResolutionObject tests", () => {
+        const resolutions =  [156543, 78271, 39135, 19567, 9783, 4891, 2445, 1222];
+        it('getResolutionObject for visibility limit type scale', ()=> {
+            expect(getResolutionObject(9028, 'scale', {projection: "EPSG:900913", resolutions}))
+                .toEqual({ resolution: 2.3886583333333333, scale: 9028, zoom: 7 });
+        });
+        it('getResolutionObject for visibility limit type other than scale', ()=> {
+            expect(getResolutionObject(9028, 'scale1', {projection: "EPSG:900913", resolutions}))
+                .toEqual({ resolution: 9028, scale: 34121574.80314961, zoom: 4 });
+        });
     });
 });


### PR DESCRIPTION
## Description
This PR adds a new advanced settings option to WMS service of Catalog to be configured. With this option, user can now configure to services to automatically include visibility limits info to the layer which can later be viewed and modified from layer settings in TOC
Option: **Auto-set Visibility Limits**

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Feature
 - [x] Refactoring

## Issue

**What is the current behavior?**
#7565 

**What is the new behavior?**
- Configure WMS service to automatically include visibility limits info on adding layer from catalog
- Configuration can be done directly from advanced settings of WMS service in Catalog or from localConfig

**Example WMS service cfg from localConfig**
```
catalog: {
  services: {
    "service_wms": {
      "url": "https://gs-stable.geo-solutions.it/geoserver/wms",
      "type": "wms",
      "title": "GeoSolutions GeoServer WMS",
      "autoSetVisibilityLimits": true
    }
  }
}
```

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
Ref: https://github.com/georchestra/mapstore2-georchestra/issues/424