### PR TITLE
#7598: avoid geostory loading a story configuration twice

### DIFF
--- a/web/client/epics/__tests__/geostory-test.js
+++ b/web/client/epics/__tests__/geostory-test.js
@@ -1778,7 +1778,7 @@ describe('Geostory Epics', () => {
     describe('loadStoryOnHistoryPop', () => {
         it('loadStoryOnHistoryPop without shared', (done) => {
             const NUM_ACTIONS = 1;
-            testEpic(loadStoryOnHistoryPop, NUM_ACTIONS, [{type: "@@router/LOCATION_CHANGE", payload: { action: "POP", location: { pathname: '/geostory/12073/'} }}],
+            testEpic(loadStoryOnHistoryPop, NUM_ACTIONS, [{type: "@@router/LOCATION_CHANGE", payload: { action: "POP", location: { pathname: '/geostory/12073/'}, isFirstRendering: false }}],
                 (actions) => {
                     expect(actions[0].type).toBe(LOAD_GEOSTORY);
                     expect(actions[0].id).toBe('12073');
@@ -1788,10 +1788,18 @@ describe('Geostory Epics', () => {
 
         it('loadStoryOnHistoryPop with shared', (done) => {
             const NUM_ACTIONS = 1;
-            testEpic(loadStoryOnHistoryPop, NUM_ACTIONS, [{type: "@@router/LOCATION_CHANGE", payload: { action: "POP", location: { pathname: '/geostory/shared/344/'} }}],
+            testEpic(loadStoryOnHistoryPop, NUM_ACTIONS, [{type: "@@router/LOCATION_CHANGE", payload: { action: "POP", location: { pathname: '/geostory/shared/344/'}, isFirstRendering: false }}],
                 (actions) => {
                     expect(actions[0].type).toBe(LOAD_GEOSTORY);
                     expect(actions[0].id).toBe('344');
+                    done();
+                });
+        });
+
+        it('loadStoryOnHistoryPop is not triggered on first rendering', (done) => {
+            testEpic(addTimeoutEpic(loadStoryOnHistoryPop, 600), 1, [{type: "@@router/LOCATION_CHANGE", payload: { action: "POP", location: { pathname: '/geostory/shared/344/'}, isFirstRendering: true }}],
+                (actions) => {
+                    expect(actions[0].type).toBe(TEST_TIMEOUT);
                     done();
                 });
         });

--- a/web/client/epics/geostory.js
+++ b/web/client/epics/geostory.js
@@ -619,7 +619,7 @@ export const loadStoryOnHistoryPop = (action$) =>
     action$.ofType(LOCATION_CHANGE)
         .switchMap(({payload}) => {
             const hasGeostory = payload?.location?.pathname.includes('/geostory/');
-            if (hasGeostory && payload.action === 'POP') {
+            if (hasGeostory && payload.action === 'POP' && !payload.isFirstRendering) {
                 const separatedUrl = words(payload?.location?.pathname);
                 return separatedUrl.find(i=> i === 'shared')
                     ? Observable.of(loadGeostory(separatedUrl[2])).delay(500)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Fixes geostory loading a story configuration twice.
For a full explanation look at #7598 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7598 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7598 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Loading the story on LOCATION_CHANGE is skipped at initial page loading.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
