### PR TITLE
#7177 - Avoid horizontal scroll in text widgets

### DIFF
--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -188,6 +188,10 @@
                 padding: 0;
             }
             margin: 10px 5%;
+            // avoid images to be wider than their container
+            img {
+                max-width: 100%;
+            }
         }
         .mapstore-widget-description {
             text-align: center;


### PR DESCRIPTION
## Description
Images width is capped by editor width when widget content is being edited. User may expect same behavior when content is rendered, therefore image width should be always capped to the container width by using max-width: 100%;

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7177 

**What is the new behavior?**
Image will have max-width: 100%, inheriting behavior of wysiwyg editor.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
### Updated behavior:
![image](https://user-images.githubusercontent.com/4226620/143784061-46700485-c5b2-486f-aa3f-271b79b20211.png)
