### PR TITLE
[Backport 2021.02.xx] #7177 - Avoid horizontal scroll in text widgets. (#7604)

### DIFF
--- a/web/client/themes/default/less/widget.less
+++ b/web/client/themes/default/less/widget.less
@@ -188,6 +188,10 @@
                 padding: 0;
             }
             margin: 10px 5%;
+            // avoid images to be wider than their container
+            img {
+                max-width: 100%;
+            }
         }
         .mapstore-widget-description {
             text-align: center;


### PR DESCRIPTION
Avoid horizontal scroll in text widgets. (#7604)