### PR TITLE
#6313 - Avoid icon to become opaque when opacity is set to 0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "fs-extra": "3.0.1",
     "geostyler-geocss-parser": "https://github.com/allyoucanmap/geostyler-geocss-parser/tarball/build",
     "geostyler-openlayers-parser": "1.1.4",
-    "geostyler-sld-parser": "2.0.1",
+    "geostyler-sld-parser": "https://github.com/geosolutions-it/geostyler-sld-parser/tarball/release_v2.0.1_opacity_fix",
     "history": "4.6.1",
     "html-to-draftjs": "npm:@geosolutions/html-to-draftjs@1.5.1",
     "html2canvas": "0.5.0-beta4",


### PR DESCRIPTION
## Description
Avoid icon to become opaque when opacity is set to 0.0.
Use fork of geostyler-sld-parser library instead of NPM version. Fork has minor changes to prevent 0 opacity to be skipped in SLD creation.


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#6313 

**What is the new behavior?**
Icons stays transparent when opacity is set to 0.0


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
