### PR TITLE
Fixes geosolutions-it/MapStore2#6368

### DIFF
--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -59,7 +59,7 @@ class DataGrid extends Grid {
             // force scroll top
             if (scrollToTopCounter !== oldProps.scrollToTopCounter && this.canvas) {
                 this.canvas.scrollTop = 0;
-            } else if (this.canvas) {
+            } else if (this.canvas && this.header) {
                 this.canvas.scrollLeft = this.header.scrollLeft; // makes sure header x-scroll matches canvas x-scroll
             }
         }

--- a/web/client/components/data/grid/DataGrid.jsx
+++ b/web/client/components/data/grid/DataGrid.jsx
@@ -59,6 +59,8 @@ class DataGrid extends Grid {
             // force scroll top
             if (scrollToTopCounter !== oldProps.scrollToTopCounter && this.canvas) {
                 this.canvas.scrollTop = 0;
+            } else if (this.canvas) {
+                this.canvas.scrollLeft = this.header.scrollLeft; // makes sure header x-scroll matches canvas x-scroll
             }
         }
     }
@@ -75,6 +77,7 @@ class DataGrid extends Grid {
     }
     setCanvasListener = () => {
         this.canvas = ReactDOM.findDOMNode(this).querySelector('.react-grid-Canvas');
+        this.header = ReactDOM.findDOMNode(this).querySelector('.react-grid-HeaderRow');
         if (this.canvas) {
             this.canvas.addEventListener('scroll', this.scrollListener);
         }


### PR DESCRIPTION
## Description
This pull-request aims to solve the issue described at  #6368 by basically making sure that the horizontal scroll of the grid's header always matches the horizontal scroll of the grid's canvas.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue

**What is the current behavior?**
#6368

**What is the new behavior?**
Now the horizontal attribute-table's header always matches the horizontal attribute-table's canvas.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

