### PR TITLE
#7241 - Removed duplicated keys from translation files

### DIFF
--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -499,7 +499,6 @@
             },
             "errors": {
                 "loading": {
-                    "title": "Fehler beim Laden der Karte",
                     "notFound": "Karte nicht gefunden",
                     "notAccessible": "Karte nicht zugänglich",
                     "unknownError": "<p> <small> Einer der folgenden Gründe könnte die Ursache sein: </small> <ul><li> Sie haben keine Zugriffsberechtigung </li> <li> Sie versuchen, auf eine nicht vorhandene Map zuzugreifen </li> <li> Die Karte wurde entfernt </li> <li>Die Projektion der Karte ist nicht konfiguriert</li></ul> <p>",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -461,7 +461,6 @@
             },
             "errors": {
                 "loading": {
-                    "title": "Error loading map",
                     "notFound": "Map not found",
                     "notAccessible": "Map not accessible",
                     "unknownError": "<p><small>One of the following reason could be the cause:</small> <ul><li>you don't have permission to access the map</li> <li>you are trying to access a map that doesn't exist</li> <li>the map has been removed</li> <li>the projection of the map is not configured</li></ul> <p>",
@@ -1977,18 +1976,16 @@
             "errors":{
                 "loading": {
                     "title": "Error loading context",
-                    "notAccessible": "You don't have permission to access some resource. Please contact the resource owner",
                     "pleaseLogin": "Some resource may not be public. Please try to login",
                     "unknownError": "There was an error loading the map or the context. Please contact the administrator",
                     "notFound": "Resource not found",
-	                "notAccessible": "Resource not accessible"
+	                  "notAccessible": "Resource not accessible"
                 },
                 "context": {
-                    "notAccessible": "You don't have permission to access this context. Please contact the resource owner",
                     "pleaseLogin": "This context is not public. Please try to login",
                     "unknownError": "There was an error loading the context. Please contact the administrator",
                     "notFound": "The context you are trying to access doesn't exist",
-	                "notAccessible": "You don't have the right permission to access to this context. Please contact the administrator to get access"
+	                  "notAccessible": "You don't have the right permission to access to this context. Please contact the administrator to get access"
                 },
                 "template": {
                     "title": "Error loading template",
@@ -1998,11 +1995,10 @@
                     "notFound": "The template you are trying to access doesn't exist"
                 },
                 "map": {
-                    "notAccessible": "You don't have permission to access this map. Please contact the resource owner",
                     "pleaseLogin": "This map or the map is not public. Please try to login",
                     "unknownError": "There was an error loading the map. Please contact the administrator",
                     "notFound": "The map you are trying to access doesn't exist",
-	                "notAccessible": "You don't have the right permission to access to this map. Please contact the administrator to get access"
+	                  "notAccessible": "You don't have the right permission to access to this map. Please contact the administrator to get access"
                 },
                 "plugins": {
                   "upload": "Error during plugin upload",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -461,7 +461,6 @@
             },
             "errors": {
                 "loading": {
-                    "title": "Error al cargar el mapa",
                     "notFound": "Mapa no encontrado",
                     "notAccessible": "Mapa no accesible",
                     "unknownError": "<p> <small> Uno de los siguientes motivos podría ser la causa: </small> <ul><li> no tiene permiso para acceder </li> <li> está intentando acceder a un mapa que no existe </li> <li> el mapa se ha eliminado </li> <li>La proyección del mapa no está configurada </li></ul> <p>",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -461,7 +461,6 @@
             },
             "errors": {
                 "loading": {
-                    "title": "Erreur pendant le chargement de la carte",
                     "notFound": "Carte introuvable",
                     "notAccessible": "Carte inaccessible",
                     "unknownError": "<p><small> L'une des raisons suivantes pourrait être la cause :</small> <ul><li>vous n'avez pas la permission d'accéder à la carte</li> <li>vous essayez d'accéder à une carte qui n'existe pas</li> <li>la carte a été supprimée</li> <li>la projection de la carte n'a pas été définie</li></ul> <p>",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -461,7 +461,6 @@
             },
             "errors": {
                 "loading": {
-                    "title": "Errore di caricamento della mappa",
                     "notFound": "Mappa non trovata",
                     "notAccessible": "Mappa non accessibile",
                     "unknownError": "<p> <small> Uno dei seguenti motivi potrebbe essere la causa: </small> <ul><li> non hai il permesso di accedere </li> <li> stai cercando di accedere a una mappa che non esiste </li> <li> la mappa è stata rimossa </li> <li>la proiezione della mappa non è configurata</li></ul> <p>",
@@ -1356,7 +1355,6 @@
             "end": "Data di fine ",
             "notAvailable": "Non disponibile",
             "title": "Catalogo",
-            "tooltip": "Aggiungi livelli alla mappa",
             "autoload": "Ricerca alla selezione del servizio",
             "clearValueText": "Cancella selezione",
             "noResultsText": "Nessun risultato trovato",


### PR DESCRIPTION
## Description
Removed duplicated keys from translation files.
Last occurrence of key is always in use. Therefore, last key is kept, while others are removed.
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7241 

**What is the new behavior?**
No duplicates

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
