### PR TITLE
#7126 - share tool visibility is configurable at Home page elements grid

### DIFF
--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -40,7 +40,7 @@ const dashboardsCountSelector = createSelector(
  * @memberof plugins
  * @class
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
- * @prop {boolean} cfg.shareOptions configuration applied to share panel
+ * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  */
 class Dashboards extends React.Component {

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -41,6 +41,7 @@ const dashboardsCountSelector = createSelector(
  * @class
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
  * @prop {boolean} cfg.shareOptions configuration applied to share panel
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  */
 class Dashboards extends React.Component {
     static propTypes = {
@@ -53,7 +54,8 @@ class Dashboards extends React.Component {
         mapsOptions: PropTypes.object,
         colProps: PropTypes.object,
         fluid: PropTypes.bool,
-        shareOptions: PropTypes.object
+        shareOptions: PropTypes.object,
+        shareToolEnabled: PropTypes.bool
     };
 
     static contextTypes = {
@@ -75,7 +77,8 @@ class Dashboards extends React.Component {
             className: 'ms-map-card-col'
         },
         maps: [],
-        shareOptions: DASHBOARD_DEFAULT_SHARE_OPTIONS
+        shareOptions: DASHBOARD_DEFAULT_SHARE_OPTIONS,
+        shareToolEnabled: true
     };
 
     componentDidMount() {
@@ -91,6 +94,7 @@ class Dashboards extends React.Component {
             viewerUrl={(dashboard) => {this.context.router.history.push(`dashboard/${dashboard.id}`); }}
             getShareUrl={dashboard => `dashboard/${dashboard.id}`}
             shareOptions={this.props.shareOptions}
+            shareToolEnabled={this.props.shareToolEnabled}
             bottom={<PaginationToolbar />}
         />);
     }

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -172,7 +172,7 @@ const updateFeaturedMapsStream = mapPropsStream(props$ =>
  * Typically used in the {@link #pages.Maps|home page}.
  * @name FeaturedMaps
  * @prop {string} cfg.pageSize change the page size (only desktop)
- * @prop {boolean} cfg.shareOptions configuration applied to share panel grouped by category name
+ * @prop {object} cfg.shareOptions configuration applied to share panel grouped by category name
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  * @memberof plugins
  * @class

--- a/web/client/plugins/FeaturedMaps.jsx
+++ b/web/client/plugins/FeaturedMaps.jsx
@@ -49,12 +49,17 @@ class FeaturedMaps extends React.Component {
         enableFeaturedMaps: PropTypes.func,
         version: PropTypes.string,
         showAPIShare: PropTypes.bool,
-        shareOptions: PropTypes.object
+        shareOptions: PropTypes.object,
+        shareToolEnabled: PropTypes.bool
     };
 
     static contextTypes = {
         router: PropTypes.object
     };
+
+    static defaultProps = {
+        shareToolEnabled: true
+    }
 
     UNSAFE_componentWillMount() {
         this.props.enableFeaturedMaps(true);
@@ -98,6 +103,7 @@ class FeaturedMaps extends React.Component {
                 viewerUrl={(res) => this.context.router.history.push('/' + this.makeShareUrl(res).url)}
                 getShareUrl={this.makeShareUrl}
                 shareOptions={this.getShareOptions} // TODO: share options depending on the content type
+                shareToolEnabled={this.props.shareToolEnabled}
                 bottom={this.props.bottom}
                 style={items.length === 0 ? {display: 'none'} : {}}/>
         );
@@ -167,6 +173,7 @@ const updateFeaturedMapsStream = mapPropsStream(props$ =>
  * @name FeaturedMaps
  * @prop {string} cfg.pageSize change the page size (only desktop)
  * @prop {boolean} cfg.shareOptions configuration applied to share panel grouped by category name
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  * @memberof plugins
  * @class
  * @example
@@ -174,6 +181,7 @@ const updateFeaturedMapsStream = mapPropsStream(props$ =>
  *   "name": "FeaturedMaps",
  *   "cfg": {
  *     "shareOptions": {
+ *       "pageSize": 6,
  *       "dashboard": {
  *         "embedPanel": false
  *       }

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -40,6 +40,7 @@ const geostoriesCountSelector = createSelector(
  * @memberof plugins
  * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
  * @prop {boolean} cfg.shareOptions configuration applied to share panel
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  */
 class Geostories extends React.Component {
     static propTypes = {
@@ -52,7 +53,8 @@ class Geostories extends React.Component {
         mapsOptions: PropTypes.object,
         colProps: PropTypes.object,
         fluid: PropTypes.bool,
-        shareOptions: PropTypes.object
+        shareOptions: PropTypes.object,
+        shareToolEnabled: PropTypes.bool
     };
 
     static contextTypes = {
@@ -74,7 +76,8 @@ class Geostories extends React.Component {
             className: 'ms-map-card-col'
         },
         maps: [],
-        shareOptions: GEOSTORY_DEFAULT_SHARE_OPTIONS
+        shareOptions: GEOSTORY_DEFAULT_SHARE_OPTIONS,
+        shareToolEnabled: true
     };
 
     componentDidMount() {
@@ -90,6 +93,7 @@ class Geostories extends React.Component {
             viewerUrl={(geostory) => {this.context.router.history.push(`geostory/${geostory.id}`); }}
             getShareUrl={(geostory) => `geostory/${geostory.id}`}
             shareOptions={this.props.shareOptions}
+            shareToolEnabled={this.props.shareToolEnabled}
             bottom={<PaginationToolbar />}
         />);
     }

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -39,7 +39,7 @@ const geostoriesCountSelector = createSelector(
  * @class
  * @memberof plugins
  * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
- * @prop {boolean} cfg.shareOptions configuration applied to share panel
+ * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  */
 class Geostories extends React.Component {

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -79,7 +79,8 @@ class Maps extends React.Component {
         colProps: PropTypes.object,
         version: PropTypes.string,
         fluid: PropTypes.bool,
-        showAPIShare: PropTypes.bool
+        showAPIShare: PropTypes.bool,
+        shareToolEnabled: PropTypes.bool
     };
 
     static contextTypes = {
@@ -101,7 +102,8 @@ class Maps extends React.Component {
             className: 'ms-map-card-col'
         },
         maps: [],
-        showAPIShare: true
+        showAPIShare: true,
+        shareToolEnabled: true
     };
 
     render() {
@@ -120,6 +122,7 @@ class Maps extends React.Component {
             getShareUrl={(map) => map.contextName ? `context/${map.contextName}/${map.id}` : `viewer/${this.props.mapType}/${map.id}`}
             shareApi={this.props.showAPIShare}
             version={this.props.version}
+            shareToolEnabled={this.props.shareToolEnabled}
             bottom={<PaginationToolbar />}
         />);
     }
@@ -163,6 +166,7 @@ const MapsPlugin = compose(
  * @memberof plugins
  * @class
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
  */
 export default {
     MapsPlugin: assign(MapsPlugin, {


### PR DESCRIPTION
Updated localConfig to store defaults for new configuration options;
Passed new property to the grid components: featured, maps, dashboards, geostories.

## Description
Share tool visibility is configurable at Home page elements grid.
Updated localConfig to store defaults for new configuration options;
Passed new property to the grid components: featured, maps, dashboards, geostories.
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
It's not possible to configure share tool visibility via localConfig.json
#7126

**What is the new behavior?**
Configuration value is properly passed to the grid components on the home page.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
