### PR TITLE
[Backport 2021.02.xx] #7474: The GeoCasousel section and the Paragraph section are not highlighted in the navigation toolbar

### DIFF
--- a/web/client/components/geostory/navigation/ScrollMenu.jsx
+++ b/web/client/components/geostory/navigation/ScrollMenu.jsx
@@ -11,6 +11,7 @@ import { Glyphicon } from 'react-bootstrap';
 import debounce from 'lodash/debounce';
 import useSwipeControls from '../common/hooks/useSwipeControls';
 import { withResizeDetector } from 'react-resize-detector';
+import { SectionTypes } from '../../../utils/GeoStoryUtils';
 
 import Button from '../../misc/Button';
 
@@ -51,7 +52,23 @@ const ScrollMenu = ({
     });
 
     const currentColumn = currentPage && currentPage.columns && currentPage.sectionId && currentPage.columns[currentPage.sectionId];
+
     const selected = currentColumn || currentPage && currentPage.sectionId;
+
+    /**
+     * Indicates which MenuItem is currently active.
+     * In case of GeoCarousel, it checks with sectionId since selectedId would be an inner column
+     * @param {String} itemId column Id or section Id of current page
+     * @param {String} selectedId Id of navigation item for current page
+     * @param {String} type type of geostory section (Paragraph, Carousel, etc)
+     * @returns a Boolean telilng if MenuItem id corresponds to the id of current page
+     */
+    const selectedItem = (itemId, selectedId, type) => {
+        if (type === SectionTypes.CAROUSEL) {
+            return currentPage && currentPage.sectionId === itemId;
+        }
+        return selectedId === itemId;
+    };
 
     const updateItemInView = useRef(null);
     useEffect(() => {
@@ -79,7 +96,7 @@ const ScrollMenu = ({
             { ...containerPropsHandlers() }
             className="ms-horizontal-menu">
             <div { ...contentPropsHandlers() }>
-                {items.map(({ title, id }) => {
+                {items.map(({ title, id, type }) => {
                     const itemProps = itemPropsHandlers({
                         id,
                         onClick: () => {
@@ -96,8 +113,8 @@ const ScrollMenu = ({
                                 tabindex="-1"
                                 id={id}
                                 text={title || "title"}
-                                selected={id === selected}
-                                style={getItemStyle(id === selected)}
+                                selected={selectedItem(id, selected, type)}
+                                style={getItemStyle(selectedItem(id, selected, type))}
                             />
                         </div>
                     );

--- a/web/client/selectors/__tests__/geostory-test.js
+++ b/web/client/selectors/__tests__/geostory-test.js
@@ -38,7 +38,8 @@ import {
     isGeoCarouselSection,
     getAllCarouselContentsOfSection,
     isDrawControlEnabled,
-    geoCarouselSettings
+    geoCarouselSettings,
+    getPageIndex
 } from "../geostory";
 import TEST_STORY from "../../test-resources/geostory/sampleStory_1.json";
 
@@ -115,6 +116,28 @@ describe('geostory selectors', () => { // TODO: check default
     it('currentPositionSelector ', () => expect(currentPositionSelector({ geostory: { currentStory: TEST_STORY, currentPage: {
         sectionId: "SomeID"
     } } })).toBe(0));
+    it('currentPositionSelector works correctly for geocarousel ', () => {
+        const state = {
+            geostory: {
+                currentStory: TEST_STORY,
+                currentPage: {
+                    sectionId: "SomeID_carousel",
+                    SomeID_carousel: {columnId: "carouselID"}
+                }
+            }
+        };
+        expect(currentPositionSelector(state)).toBe(5);
+    });
+    it('getPageIndex ', () => {
+        const state = {
+            geostory: {
+                currentStory: TEST_STORY, currentPage: {
+                    sectionId: "SomeID"
+                }
+            }
+        };
+        expect(getPageIndex(state)).toBe(0);
+    });
     it('totalItemsSelector ', () => expect(totalItemsSelector({ geostory: { currentStory: TEST_STORY } })).toBe(6));
     it('settingsSelector ', () => expect(settingsSelector({ geostory: { currentStory: {...TEST_STORY, settings: {
         checked: ["col2"]

--- a/web/client/selectors/geostory.js
+++ b/web/client/selectors/geostory.js
@@ -207,16 +207,31 @@ export const navigableItemsSelectorCreator = ({withImmersiveSection = false, inc
 };
 
 /**
+ * Finds index of currentPage position or returns -1 if id does not match page
+ * In special cases like GeoCarousel, id would be an inner column and would return a -1
+ * We can quickly make a check with id set to currentPageSelector(state).sectionId in that case
+ * @param {Object} state
+ * @returns {number} index of currentPage position or -1
+ */
+export const getPageIndex = (state) => {
+    const currentPage = currentPageSelector(state);
+    return findIndex(navigableItemsSelectorCreator({ includeAlways: true })(state), {
+        id: currentPage.columns &&
+            currentPage.columns[currentPage.sectionId]
+            ? currentPage.columns[currentPage.sectionId]
+            : currentPage.sectionId || ""
+    });
+};
+/**
  * gets the current position of currentPage
  * @returns {function} function that returns a selector
  */
 export const totalItemsSelector = state => navigableItemsSelectorCreator({includeAlways: true})(state).length;
-export const currentPositionSelector = state => findIndex(navigableItemsSelectorCreator({includeAlways: true})(state), {
-    id: currentPageSelector(state).columns &&
-        currentPageSelector(state).columns[currentPageSelector(state).sectionId]
-        ? currentPageSelector(state).columns[currentPageSelector(state).sectionId]
-        : currentPageSelector(state).sectionId || ""
-});
+export const currentPositionSelector = state => {
+    const pageIndex = getPageIndex(state);
+    return pageIndex !== -1 ? pageIndex : findIndex(navigableItemsSelectorCreator({ includeAlways: true })(state), { id: currentPageSelector(state).sectionId });
+};
+
 
 /**
  * return if at least one content has its exclusive focus active


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR handles the geocarousel section of the issue and does not include a fix for the Paragraph section. The problem with the Paragraph section may require a separate issue to be opened as explained in [this comment](https://github.com/geosolutions-it/MapStore2/issues/7474#issuecomment-962968653).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7474 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The Geocarousel section is highlighted in the Navigation bar as expected when set as current page

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
