### PR TITLE
[Backport 2021.02.xx] #7489: Current group selection in TOC is not "always" the destination of layers when added to the map (#7542) 

### DIFF
--- a/web/client/epics/__tests__/catalog-test.js
+++ b/web/client/epics/__tests__/catalog-test.js
@@ -22,12 +22,13 @@ const {
     autoSearchEpic,
     openCatalogEpic,
     recordSearchEpic,
-    getSupportedFormatsEpic
+    getSupportedFormatsEpic,
+    updateGroupSelectedMetadataExplorerEpic
 } = catalog(API);
 import {SHOW_NOTIFICATION} from '../../actions/notifications';
 import {CLOSE_FEATURE_GRID} from '../../actions/featuregrid';
-import {setControlProperty} from '../../actions/controls';
-import {ADD_LAYER} from '../../actions/layers';
+import {setControlProperty, SET_CONTROL_PROPERTY} from '../../actions/controls';
+import {ADD_LAYER, selectNode} from '../../actions/layers';
 import {PURGE_MAPINFO_RESULTS, HIDE_MAPINFO_MARKER} from '../../actions/mapInfo';
 import {testEpic, addTimeoutEpic, TEST_TIMEOUT} from './epicTestUtils';
 import {
@@ -348,5 +349,44 @@ describe('catalog Epics', () => {
         }, {
             catalog: {}
         });
+    });
+
+    it('updateGroupSelectedMetadataExplorerEpic allows clicking on group to set destination to current group', done => {
+        const state = {
+            layers: {
+                settings: {
+                    expanded: true,
+                    node: 'layerId',
+                    nodeType: 'group'
+                },
+                groups: [{
+                    id: 'layerId',
+                    name: 'layerName'
+                }],
+                selected: ['layerId']
+            },
+            controls: {
+                toolbar: {
+                    active: 'metadataexplorer'
+                },
+                metadataexplorer: {
+                    enabled: true,
+                    group: 'layerId'
+                }
+            }
+        };
+        const id = state.layers.groups[0].id;
+        const nodeType = state.layers.settings.nodeType;
+
+        testEpic(updateGroupSelectedMetadataExplorerEpic, 1, selectNode(id, nodeType), actions => {
+            try {
+                expect(actions.length).toBe(1);
+                expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
+                expect(actions[0].control).toBe('metadataexplorer');
+                expect(actions[0].property).toEqual('group');
+            } catch (error) {
+                done(error);
+            }
+        }, state, done);
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This PR introduces a new `updateGroupSelectedMetadataExplorerEpic` epic to update metadata explorer state when `SELECT_NODE` action is triggered, in order to allow adding layers to new groups on the fly

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7489 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Current group selection in TOC is "always" the destination of layers when added to the map

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
