### PR TITLE
[Backport 2021.02.xx] #7416: Filter not applied correctly in attribute table (#7529)

### DIFF
--- a/web/client/epics/__tests__/layerdownload-test.js
+++ b/web/client/epics/__tests__/layerdownload-test.js
@@ -71,12 +71,16 @@ describe('layerdownload Epics', () => {
                 queryPanel: { enabled: false },
                 layerdownload: { enabled: true }
             },
-            featuregrid: {}
+            featuregrid: {},
+            layers: {
+                flat: [{ id: 'test layer', layerFilter: { featureTypeName: 'test' } }],
+                selected: ['test layer']
+            }
         };
         testEpic(
             startFeatureExportDownload,
             1,
-            downloadFeatures('/wrong/path?', 'request body', { selectedFormat: "test-format"}),
+            downloadFeatures('/wrong/path?', { featureTypeName: 'test' }, { selectedFormat: "test-format"}),
             epicResult,
             state
         );

--- a/web/client/utils/ogc/WFS/RequestBuilder.js
+++ b/web/client/utils/ogc/WFS/RequestBuilder.js
@@ -98,7 +98,7 @@ module.exports = function({wfsVersion = "1.1.0", gmlVersion, filterNS, wfsNS = "
         sortBy: (property, order = "ASC") =>
             `<${wfsNS}:SortBy><${wfsNS}:SortProperty>${propertyName(property)}<${wfsNS}:SortOrder>${order}</${wfsNS}:SortOrder></${wfsNS}:SortProperty></${wfsNS}:SortBy>`,
         query: (featureName, content, {srsName = "EPSG:4326"} = {}) =>
-            `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" srsName="${srsName}">`
+            `<${wfsNS}:Query ${wfsVersion === "2.0" ? "typeNames" : "typeName"}="${featureName}" ${srsName !== 'native' ? `srsName="${srsName}"` : ''}>`
             + `${Array.isArray(content) ? content.join("") : content}`
             + `</${wfsNS}:Query>`
     };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
Layer filters are now applied in WFS export tool.
Previously `getWFSFeature` did not consider any filters when querying WFS for download. This PR introduces a new functionality to properly query WFS with layer filters.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7416 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
