### PR TITLE
#7146 - Properly handle visibility limits in Cesium

### DIFF
--- a/web/client/components/map/cesium/Layer.jsx
+++ b/web/client/components/map/cesium/Layer.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import Layers from '../../../utils/cesium/Layers';
 import assign from 'object-assign';
 import PropTypes from 'prop-types';
-import isNil from 'lodash/isNil';
+import { round, isNil } from 'lodash';
 import { getResolutions } from '../../../utils/MapUtils';
 
 class CesiumLayer extends React.Component {
@@ -136,14 +136,15 @@ class CesiumLayer extends React.Component {
         // use the global resolutions as fallback
         // cesium does not provide resolutions
         const { options = {}, zoom, resolutions = getResolutions() } = props;
+        const intZoom = round(zoom);
         const {
             visibility,
             minResolution = -Infinity,
             maxResolution = Infinity,
             disableResolutionLimits
         } = options || {};
-        if (!disableResolutionLimits && !isNil(resolutions[zoom])) {
-            const resolution = resolutions[zoom];
+        if (!disableResolutionLimits && !isNil(resolutions[intZoom])) {
+            const resolution = resolutions[intZoom];
             // use similar approach of ol
             // maxResolution is exclusive
             // minResolution is inclusive

--- a/web/client/plugins/TOC.jsx
+++ b/web/client/plugins/TOC.jsx
@@ -60,7 +60,7 @@ import { getMessageById } from '../utils/LocaleUtils';
 import Message from '../components/I18N/Message';
 import assign from 'object-assign';
 import layersIcon from './toolbar/assets/img/layers.png';
-import { isObject, head, find } from 'lodash';
+import { isObject, head, find, round } from 'lodash';
 import { setControlProperties, setControlProperty } from '../actions/controls';
 import { createWidget } from '../actions/widgets';
 import { getMetadataRecordById } from '../actions/catalog';
@@ -368,7 +368,7 @@ class LayerTree extends React.Component {
     getDefaultLayer = () => {
         const LayerNode = this.props.layerNodeComponent || DefaultLayer;
         const resolutions = this.props.resolutions || getResolutions();
-        const resolution = resolutions[this.props.currentZoomLvl];
+        const resolution = resolutions[round(this.props.currentZoomLvl)];
         return (
             <LayerNode
                 {...this.props.layerOptions}


### PR DESCRIPTION


## Description
Cesium doesn't use integer zoom levels, therefore few places in code needs to be updated to properly calculate current resolution. With that being fixed all works fine.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7146 
Layer with visibility limits stays visible in Cesium no matter of what.

**What is the new behavior?**
Active resolution is calculated properly and layer getting hidden/visible once it hits defined limits.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
