### PR TITLE
#7649 Set proper trigger for useEffect on plugin initialization

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -166,7 +166,11 @@ const FeatureDock = (props = {
 
     useEffect(() => {
         props.initPlugin({virtualScroll, editingAllowedRoles: props.editingAllowedRoles, maxStoredPages: props.maxStoredPages});
-    }, []);
+    }, [
+        virtualScroll,
+        (props.editingAllowedRoles ?? []).join(","), // this avoids multiple calls when the array remains the equal
+        props.maxStoredPages
+    ]);
 
     return (
         <Dock {...dockProps} onSizeChange={size => { props.onSizeChange(size, dockProps); }}>

--- a/web/client/plugins/__tests__/FeatureEditor-test.jsx
+++ b/web/client/plugins/__tests__/FeatureEditor-test.jsx
@@ -45,4 +45,33 @@ describe('FeatureEditor Plugin', () => {
         expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
         expect(state.maxStoredPages).toBe(props.maxStoredPages);
     });
+    it('onInit FeatureEditor plugin be-recalled when props change', () => {
+        const props = {
+            virtualScroll: false,
+            editingAllowedRoles: ['ADMIN'],
+            maxStoredPages: 5
+        };
+        const props2 = {
+            editingAllowedRoles: ['USER', 'ADMIN'],
+            maxStoredPages: 5
+        };
+        const props3 = {
+            editingAllowedRoles: ['USER', 'ADMIN'],
+            maxStoredPages: 5
+        };
+        const {Plugin, store} = getPluginForTest(FeatureEditor, {featuregrid});
+        ReactDOM.render(<Plugin {...props}/>, document.getElementById("container"));
+        const state = store.getState().featuregrid;
+        expect(state.virtualScroll).toBeFalsy();
+        expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
+        expect(state.maxStoredPages).toBe(props.maxStoredPages);
+        ReactDOM.render(<Plugin {...props2}/>, document.getElementById("container"));
+        const state2 = store.getState().featuregrid;
+        expect(state2.virtualScroll).toBeTruthy(); // the default
+        expect(state2.editingAllowedRoles).toEqual(props2.editingAllowedRoles); // changed
+        expect(state2.maxStoredPages).toBe(props2.maxStoredPages);
+        ReactDOM.render(<Plugin {...props3}/>, document.getElementById("container"));
+        const state3 = store.getState().featuregrid;
+        expect(state2.editingAllowedRoles === state3.editingAllowedRoles).toBeTruthy(); // no double call
+    });
 });


### PR DESCRIPTION
## Description
In plugin rendering inside the contexts there are 2 renders, one with defaults, one with cfg applied. The initPlugin is only triggered on mount, so it doesn't consider any change of these properties. 
I fixed it by setting up the proper arguments to the `useEffect` to re-lunch.

Probably caused by this. https://github.com/geosolutions-it/MapStore2/pull/7222/files#diff-aeac8e5aa0da539c9d9d6beeae11a52cf425d6a6cea20ece50a34769b074886fR171

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7649
**What is the new behavior?**
Now the feature editor correctly configures. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
