### PR TITLE
#7080 Better UI for WMS domain aliases setup

### DIFF
--- a/web/client/api/WMS.js
+++ b/web/client/api/WMS.js
@@ -8,13 +8,14 @@
 
 import urlUtil from 'url';
 
-import {isArray, castArray, get} from 'lodash';
+import {isArray, castArray, get, filter} from 'lodash';
 import assign from 'object-assign';
 import xml2js from 'xml2js';
 
 import axios from '../libs/ajax';
 import { getConfigProp } from '../utils/ConfigUtils';
 import { getWMSBoundingBox } from '../utils/CoordinatesUtils';
+import Rx from "rxjs";
 
 const capabilitiesCache = {};
 
@@ -268,6 +269,12 @@ export const reset = () => {
     });
 };
 
+export const preprocess = (service) => {
+    let { domainAliases } = service;
+    service.domainAliases = filter(domainAliases);
+    return Rx.Observable.of(service);
+};
+
 
 const Api = {
     flatLayers,
@@ -280,7 +287,8 @@ const Api = {
     textSearch,
     parseLayerCapabilities,
     getBBox,
-    reset
+    reset,
+    preprocess
 };
 
 export default Api;

--- a/web/client/api/catalog/common.js
+++ b/web/client/api/catalog/common.js
@@ -20,6 +20,14 @@ export class ServiceValidationError extends Error {
 }
 
 /**
+ * Performs actions on service object prior to its save. This is the default handler that does nothing and returns object as is
+ *  @returns function that takes the service as parameter and return a stream. The stream emit the service again.
+ */
+export const preprocess = (service) => {
+    return Rx.Observable.of(service);
+};
+
+/**
  * Validate the current service setup. This is the default validation that checks url and title to be filled
  *  @returns function that takes the service as parameter and return a stream. The stream emit the service again or throw an exception.
  */

--- a/web/client/api/catalog/index.js
+++ b/web/client/api/catalog/index.js
@@ -13,7 +13,7 @@ import wmts from '../WMTS';
 import * as tms from './TMS';
 import * as wfs from './WFS';
 import backgrounds from '../mapBackground';
-import { validate, testService } from './common';
+import { validate, testService, preprocess } from './common';
 
 
 /**
@@ -41,27 +41,32 @@ export default {
     // TODO: validate could be converted in a simple function
     // TODO: testService could be converted in a simple Promise
     csw: {
+        preprocess,
         validate,
         testService: testService(csw),
         ...csw
     },
     wfs: {
+        preprocess,
         validate,
         testService: testService(wfs),
         ...wfs
     },
     wms: {
+        preprocess,
         validate,
         testService: testService(wms),
         ...wms
     },
     tms, // has it's own validation
     wmts: {
+        preprocess,
         validate,
         testService: testService(wmts),
         ...wmts
     },
     backgrounds: {
+        preprocess,
         validate,
         testService: testService(backgrounds),
         ...backgrounds

--- a/web/client/components/catalog/Catalog.jsx
+++ b/web/client/components/catalog/Catalog.jsx
@@ -30,7 +30,7 @@ import { getMessageById } from '../../utils/LocaleUtils';
 import Message from '../I18N/Message';
 import RecordGrid from './RecordGrid';
 import Loader from '../misc/Loader';
-import { DEFAULT_FORMAT_WMS, getUniqueInfoFormats } from "../../utils/CatalogUtils";
+import { buildServiceUrl, DEFAULT_FORMAT_WMS, getUniqueInfoFormats } from "../../utils/CatalogUtils";
 
 class Catalog extends React.Component {
     static propTypes = {
@@ -361,7 +361,7 @@ class Catalog extends React.Component {
 
     };
     search = ({ services, selectedService, start = 1, searchText = "" } = {}) => {
-        const url = services[selectedService].url;
+        const url = buildServiceUrl(services[selectedService]);
         const type = services[selectedService].type;
         this.props.onSearch({ format: type, url, startPosition: start, maxRecords: this.props.pageSize, text: searchText || "", options: { service: this.props.services[selectedService] } });
     };

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -159,6 +159,6 @@ export default ({
         {!isNil(service.type) && service.type === "csw" &&
         <CSWFilters filter={service?.filter} onChangeServiceProperty={onChangeServiceProperty}/>
         }
-        {(!isNil(service.type) ? service.type === "wms" : false) && (<WMSDomainAliases service={service} onChangeServiceProperty={onChangeServiceProperty} />)}
+        {!isNil(service.type) && service.type === "wms" && (<WMSDomainAliases service={service} onChangeServiceProperty={onChangeServiceProperty} />)}
     </CommonAdvancedSettings>);
 };

--- a/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/RasterAdvancedSettings.js
@@ -19,6 +19,7 @@ import ReactQuill from "react-quill";
 import InfoPopover from '../../../widgets/widget/InfoPopover';
 import CSWFilters from "./CSWFilters";
 import Message from "../../../I18N/Message";
+import WMSDomainAliases from "./WMSDomainAliases";
 
 /**
  * Generates an array of options in the form e.g. [{value: "256", label: "256x256"}]
@@ -158,5 +159,6 @@ export default ({
         {!isNil(service.type) && service.type === "csw" &&
         <CSWFilters filter={service?.filter} onChangeServiceProperty={onChangeServiceProperty}/>
         }
+        {(!isNil(service.type) ? service.type === "wms" : false) && (<WMSDomainAliases service={service} onChangeServiceProperty={onChangeServiceProperty} />)}
     </CommonAdvancedSettings>);
 };

--- a/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 import {FormControl, FormGroup, Col, ControlLabel, Glyphicon, Button} from "react-bootstrap";
 import {debounce, size, map, omit, toInteger} from "lodash";
 import Message from "../../../I18N/Message";
@@ -6,9 +13,9 @@ import React, {useState, useCallback, useEffect} from "react";
 import tooltip from "../../../misc/enhancers/tooltip";
 
 /**
- * @name WMSDomainAliases
- * @param onChangeServiceProperty
- * @param service {Object}
+ * @name WMSDomainAliases - component that renders domain aliases management form
+ * @param {function} onChangeServiceProperty - callback to update service property
+ * @param {object} service - WMS service being edited
  * @returns {JSX.Element}
  */
 export default ({
@@ -28,7 +35,6 @@ export default ({
 
     useEffect(() => {
         onDomainAliasChangeDebounced(aliases);
-        return () => {};
     }, [aliases]);
 
     const onChange = (k) => ({ target }) => setAliases((a) => ({...a, [k]: target.value}));

--- a/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
@@ -3,6 +3,7 @@ import {debounce, size, map, omit, toInteger} from "lodash";
 import Message from "../../../I18N/Message";
 import InfoPopover from "../../../widgets/widget/InfoPopover";
 import React, {useState, useCallback, useEffect} from "react";
+import tooltip from "../../../misc/enhancers/tooltip";
 
 /**
  * @name WMSDomainAliases
@@ -14,6 +15,7 @@ export default ({
     onChangeServiceProperty = () => {},
     service
 }) => {
+    const TooltipButton = tooltip(Button);
     const [aliases, setAliases] = useState(size(service.domainAliases) ? service.domainAliases : { 0: ''});
     const [key, setKey] = useState(1);
 
@@ -40,25 +42,34 @@ export default ({
         <Col xs={12} className="form-group alias-item">
             <FormControl id={`alias-${k}`} key={`alias-${k}`} type="text" value={el} onChange={onChange(k)}/>
             {toInteger(k) !== 0 &&
-            <Button className="remove-alias" onClick={onRemoveAlias(k)}>
+            <TooltipButton
+                tooltip={<Message msgId="catalog.domainAliases.removeAliasTooltip" />}
+                tooltipid="add-alias-button"
+                tooltipPosition="left"
+                className="remove-alias"
+                onClick={onRemoveAlias(k)}>
                 <Glyphicon glyph="minus" />
-            </Button>
+            </TooltipButton>
             }
         </Col>
     ));
-
     return (
         <FormGroup controlId="domain-aliases" key="domain-aliases" className="mapstore-catalog-domain-aliases">
             <Col xs={12}>
-                <ControlLabel>Domain Aliases</ControlLabel>
+                <ControlLabel><Message msgId="catalog.domainAliases.title" /></ControlLabel>
                 &nbsp;
-                <InfoPopover text={<Message msgId="catalog.enableLocalizedLayerStyles.tooltip" />} />
+                <InfoPopover text={<Message msgId="catalog.domainAliases.helpTooltip" />} />
             </Col>
             {elements}
             <Col xs={12}>
-                <Button className="add-alias" tooltip={"Add alias"} onClick={onCreateAlias}>
+                <TooltipButton
+                    className="add-alias"
+                    tooltip={<Message msgId="catalog.domainAliases.addAliasTooltip" />}
+                    tooltipid="add-alias-button"
+                    tooltipPosition="right"
+                    onClick={onCreateAlias}>
                     <Glyphicon glyph={"plus"} />
-                </Button>
+                </TooltipButton>
             </Col>
         </FormGroup>
     );

--- a/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/WMSDomainAliases.js
@@ -1,0 +1,65 @@
+import {FormControl, FormGroup, Col, ControlLabel, Glyphicon, Button} from "react-bootstrap";
+import {debounce, size, map, omit, toInteger} from "lodash";
+import Message from "../../../I18N/Message";
+import InfoPopover from "../../../widgets/widget/InfoPopover";
+import React, {useState, useCallback, useEffect} from "react";
+
+/**
+ * @name WMSDomainAliases
+ * @param onChangeServiceProperty
+ * @param service {Object}
+ * @returns {JSX.Element}
+ */
+export default ({
+    onChangeServiceProperty = () => {},
+    service
+}) => {
+    const [aliases, setAliases] = useState(size(service.domainAliases) ? service.domainAliases : { 0: ''});
+    const [key, setKey] = useState(1);
+
+    const onDomainAliasChangeDebounced = useCallback(
+        debounce((values) => {
+            onChangeServiceProperty('domainAliases', values);
+        }, 300),
+        []
+    );
+
+    useEffect(() => {
+        onDomainAliasChangeDebounced(aliases);
+        return () => {};
+    }, [aliases]);
+
+    const onChange = (k) => ({ target }) => setAliases((a) => ({...a, [k]: target.value}));
+    const onRemoveAlias = (k) => () => setAliases((a) => ({...omit(a, [k])}));
+    const onCreateAlias = () => {
+        setKey((k) => k + 1);
+        setAliases((a) => ({...a, [key]: ''}));
+    };
+
+    const elements = map(aliases, (el, k) => (
+        <Col xs={12} className="form-group alias-item">
+            <FormControl id={`alias-${k}`} key={`alias-${k}`} type="text" value={el} onChange={onChange(k)}/>
+            {toInteger(k) !== 0 &&
+            <Button className="remove-alias" onClick={onRemoveAlias(k)}>
+                <Glyphicon glyph="minus" />
+            </Button>
+            }
+        </Col>
+    ));
+
+    return (
+        <FormGroup controlId="domain-aliases" key="domain-aliases" className="mapstore-catalog-domain-aliases">
+            <Col xs={12}>
+                <ControlLabel>Domain Aliases</ControlLabel>
+                &nbsp;
+                <InfoPopover text={<Message msgId="catalog.enableLocalizedLayerStyles.tooltip" />} />
+            </Col>
+            {elements}
+            <Col xs={12}>
+                <Button className="add-alias" tooltip={"Add alias"} onClick={onCreateAlias}>
+                    <Glyphicon glyph={"plus"} />
+                </Button>
+            </Col>
+        </FormGroup>
+    );
+};

--- a/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
+++ b/web/client/components/catalog/editor/AdvancedSettings/__tests__/RasterAdvancedSettings-test.js
@@ -32,7 +32,7 @@ describe('Test Raster advanced settings', () => {
         const advancedSettingPanel = document.getElementsByClassName("mapstore-switch-panel");
         expect(advancedSettingPanel).toBeTruthy();
         const fields = document.querySelectorAll(".form-group");
-        expect(fields.length).toBe(6);
+        expect(fields.length).toBe(8);
     });
     it('test csw advanced options', () => {
         ReactDOM.render(<RasterAdvancedSettings service={{type: "csw", autoload: false}}/>, document.getElementById("container"));

--- a/web/client/epics/catalog.js
+++ b/web/client/epics/catalog.js
@@ -215,6 +215,7 @@ export default (API) => ({
                 const newService = newServiceSelector(state);
                 return Rx.Observable.of(newService)
                     // validate
+                    .switchMap((service) => API[service.type]?.preprocess?.(service) ?? ( Rx.Observable.of(service)))
                     .switchMap((service) => API[service.type]?.validate?.(service) ?? ( Rx.Observable.of(service)))
                     .switchMap((service) => API[service.type]?.testService?.(service) ?? (Rx.Observable.of(service)))
                     .switchMap(() => {

--- a/web/client/themes/default/less/catalog.less
+++ b/web/client/themes/default/less/catalog.less
@@ -84,4 +84,18 @@
         position: relative;
         display: block !important;
     }
+
+    .mapstore-catalog-domain-aliases {
+        .alias-item {
+            display: flex;
+            justify-content: space-between;
+
+            .remove-alias {
+                margin-left: 1em;
+            }
+        }
+        .add-alias {
+            margin-bottom: 1em;
+        }
+    }
 }

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1477,7 +1477,13 @@
             "autoSetVisibilityLimits": {
                 "label": "Sichtbarkeitslimit festlegen",
                 "tooltip": "Wendet automatisch die vom Server vorgeschlagenen Sichtbarkeitsgrenzen an"
-            }
+            },
+          "domainAliases": {
+            "title": "Domain-Aliasse",
+            "helpTooltip": "Diese Option wird verwendet, um Inhalte auf mehrere Subdomains aufzuteilen",
+            "addAliasTooltip": "Alias hinzufügen",
+            "removeAliasTooltip": "Alias entfernen"
+          }
         },
         "uploader": {
             "filename": "Dateiname",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1439,7 +1439,13 @@
            "autoSetVisibilityLimits": {
                 "label": "Set Visibility Limit",
                 "tooltip": "Automatically applies the visibility limits suggested by the server"
-           }
+           },
+          "domainAliases": {
+            "title": "Domain aliases",
+            "helpTooltip": "This option is used to split content across multiple subdomains",
+            "addAliasTooltip": "Add alias",
+            "removeAliasTooltip": "Remove alias"
+          }
         },
         "uploader": {
             "filename": "File Name",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1439,7 +1439,13 @@
             "autoSetVisibilityLimits": {
                 "label": "Establecer límite de visibilidad",
                 "tooltip": "Aplica automáticamente los límites de visibilidad sugeridos por el servidor"
-            }
+            },
+          "domainAliases": {
+            "title": "Alias de dominio",
+            "helpTooltip": "Esta opción se utiliza para dividir el contenido en varios subdominios",
+            "addAliasTooltip": "Agregar alias",
+            "removeAliasTooltip": "Eliminar alias"
+          }
         },
         "uploader": {
             "filename": "Nombre del fichero",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1440,7 +1440,13 @@
             "autoSetVisibilityLimits": {
                 "label": "Définir la limite de visibilité",
                 "tooltip": "Applique automatiquement les limites de visibilité suggérées par le serveur"
-            }
+            },
+          "domainAliases": {
+            "title": "Alias de domaine",
+            "helpTooltip": "Cette option est utilisée pour diviser le contenu sur plusieurs sous-domaines",
+            "addAliasTooltip": "Ajouter un alias",
+            "removeAliasTooltip": "Supprimer l'alias"
+          }
         },
         "uploader": {
             "filename": "Nom du fichier",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1439,6 +1439,12 @@
             "autoSetVisibilityLimits": {
                 "label": "Imposta limite di visibilità",
                 "tooltip": "Applica automaticamente i limiti di visibilità suggeriti dal server"
+            },
+            "domainAliases": {
+              "title": "Alias di dominio",
+              "helpTooltip": "Questa opzione viene utilizzata per suddividere il contenuto in più sottodomini",
+              "addAliasTooltip": "Aggiungi alias",
+              "removeAliasTooltip": "Rimuovi alias"
             }
         },
         "uploader": {

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -537,6 +537,15 @@ const toURLArray = (url) => {
     return url;
 };
 
+export const buildServiceUrl = (service) => {
+    switch (service.type) {
+    case "wms":
+        return [service.url, ...service.domainAliases].join(',');
+    default:
+        return service.url;
+    }
+};
+
 
 /**
  * Creates a map of SRS based on the record's srs object

--- a/web/client/utils/CatalogUtils.js
+++ b/web/client/utils/CatalogUtils.js
@@ -540,7 +540,7 @@ const toURLArray = (url) => {
 export const buildServiceUrl = (service) => {
     switch (service.type) {
     case "wms":
-        return [service.url, ...service.domainAliases].join(',');
+        return [service.url, ...(service.domainAliases ?? [])].join(',');
     default:
         return service.url;
     }

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -985,6 +985,17 @@ describe('Test the CatalogUtils', () => {
         expect(layer.name).toBe(RECORD.provider);
     });
     it('buildServiceUrl', ( ) => {
+        const legacyWMSServiceWithAlias = {
+            type: "wms",
+            url: "https://a.example.com/wms,https://b.example.com/wms",
+            domainAliases: [
+                "https://c.example.com/wms"
+            ]
+        };
+        const legacyWMSServiceWithoutAlias = {
+            type: "wms",
+            url: "https://a.example.com/wms,https://b.example.com/wms"
+        };
         const WMSService = {
             type: "wms",
             url: "https://a.example.com/wms",
@@ -1003,7 +1014,11 @@ describe('Test the CatalogUtils', () => {
         };
         const mergedURL1 = CatalogUtils.buildServiceUrl(WMSService);
         const mergedURL2 = CatalogUtils.buildServiceUrl(otherService);
+        const mergedURL3 = CatalogUtils.buildServiceUrl(legacyWMSServiceWithAlias);
+        const mergedURL4 = CatalogUtils.buildServiceUrl(legacyWMSServiceWithoutAlias);
         expect(mergedURL1).toBe("https://a.example.com/wms,https://b.example.com/wms,https://c.example.com/wms");
         expect(mergedURL2).toBe("https://a.example.com/wfs");
+        expect(mergedURL3).toBe("https://a.example.com/wms,https://b.example.com/wms,https://c.example.com/wms");
+        expect(mergedURL4).toBe("https://a.example.com/wms,https://b.example.com/wms");
     });
 });

--- a/web/client/utils/__tests__/CatalogUtils-test.js
+++ b/web/client/utils/__tests__/CatalogUtils-test.js
@@ -984,4 +984,26 @@ describe('Test the CatalogUtils', () => {
         expect(layer.provider).toBe(RECORD.provider);
         expect(layer.name).toBe(RECORD.provider);
     });
+    it('buildServiceUrl', ( ) => {
+        const WMSService = {
+            type: "wms",
+            url: "https://a.example.com/wms",
+            domainAliases: [
+                "https://b.example.com/wms",
+                "https://c.example.com/wms"
+            ]
+        };
+        const otherService = {
+            type: "wfs",
+            url: "https://a.example.com/wfs",
+            domainAliases: [
+                "https://b.example.com/wfs",
+                "https://c.example.com/wfs"
+            ]
+        };
+        const mergedURL1 = CatalogUtils.buildServiceUrl(WMSService);
+        const mergedURL2 = CatalogUtils.buildServiceUrl(otherService);
+        expect(mergedURL1).toBe("https://a.example.com/wms,https://b.example.com/wms,https://c.example.com/wms");
+        expect(mergedURL2).toBe("https://a.example.com/wfs");
+    });
 });


### PR DESCRIPTION
## Description
This PR proposes changes to make domain aliases configuration more obvious for end user.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7080

**What is the new behavior?**
There is a separate fields set to define one or multiple aliases for the service.

!NOTE
There is no validation for aliases, and same behavior applied now to the current approach of setting multiple domains for the service (comma-separated list in URL field).
It remains backward compatible with current approach. At the end final URL is composed out of the value set in URL field and aliases defined in newly introduced fields.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
![изображение](https://user-images.githubusercontent.com/4226620/146078269-c099b7b3-54b2-4e26-a269-70bdcb094680.png)
