### PR TITLE
#7653: Share panel advanced settings fix

### DIFF
--- a/web/client/components/share/SharePanel.jsx
+++ b/web/client/components/share/SharePanel.jsx
@@ -25,7 +25,7 @@ import {
     Tooltip
 } from 'react-bootstrap';
 import Message from '../../components/I18N/Message';
-import { join, isNil, isEqual, inRange } from 'lodash';
+import { join, isNil, isEqual, inRange, isEmpty } from 'lodash';
 import { removeQueryFromUrl, getSharedGeostoryUrl, CENTERANDZOOM, BBOX, MARKERANDZOOM, SHARE_TABS } from '../../utils/ShareUtils';
 import { getLonLatFromPoint } from '../../utils/CoordinatesUtils';
 import { getMessageById } from '../../utils/LocaleUtils';
@@ -234,7 +234,7 @@ class SharePanel extends React.Component {
                 onClose={this.props.onClose}>
                 <div role="body" className="share-panels">
                     {tabs}
-                    {this.props.advancedSettings
+                    {!isEmpty(this.props.advancedSettings)
                         && currentTab !== SHARE_TABS[this.props?.advancedSettings?.hideInTab]
                         && this.renderAdvancedSettings()
                     }

--- a/web/client/components/share/__tests__/SharePanel-test.jsx
+++ b/web/client/components/share/__tests__/SharePanel-test.jsx
@@ -81,6 +81,19 @@ describe("The SharePanel component", () => {
         expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.directLinkTitle</span>");
 
     });
+    it('test hide advancedSettings when no settings configured', () => {
+        const advancedSettings = {};
+        let panel = ReactDOM.render(<SharePanel showAPI={false} advancedSettings={advancedSettings} getCount={() => 2} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
+        expect(panel.state.eventKey).toBe(1);
+        expect(document.querySelectorAll('h4')[1].innerHTML).toBe("<span>share.directLinkTitle</span>");
+
+        let advancedSettingsPanel = document.querySelector('.mapstore-switch-panel');
+        expect(advancedSettingsPanel).toBeFalsy();
+
+        ReactDOM.render(<SharePanel showAPI={false} advancedSettings={false} getCount={() => 2} shareUrl="www.geo-solutions.it" isVisible />, document.getElementById("container"));
+        advancedSettingsPanel = document.querySelector('.mapstore-switch-panel');
+        expect(advancedSettingsPanel).toBeFalsy();
+    });
     it('test hide advancedSettings in specific tab', () => {
         const advancedSettings = {
             homeButton: true,


### PR DESCRIPTION
## Description
This PR fixes the advanced settings from shown when no settings configured

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#7653 

**What is the new behavior?**
The advanced settings option in Share panel is shown only when there are settings configured under it based on the component from which it is accessed from

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
