### PR TITLE
Log4j dependency replaced with custom one

### DIFF
--- a/java/services/pom.xml
+++ b/java/services/pom.xml
@@ -27,7 +27,19 @@
         <groupId>eu.medsea.mimeutil</groupId>
         <artifactId>mime-util</artifactId>
         <version>2.1.3</version>
+        <exclusions>
+            <exclusion>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
+    <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17.norce</version>
+    </dependency>
+    <!-- Replace log4j coming from mimeutil with the secure one-->
 
     <!-- Spring -->
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->


### PR DESCRIPTION
## Description
This PR removes transitive dependency for mapstore-services and replace it with the `norce` one. 
This change united to the PRs indicated in #7651 should solve jar duplication and avoid minor vulnerability for log4j.

