### PR TITLE
Mapstore log4j fixes update on stable branch

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -20,6 +20,74 @@ This is a list of things to check if you want to update from a previous version 
 - Optionally check also accessory files like `.eslinrc`, if you want to keep aligned with lint standards.
 - Follow the instructions below, in order, from your version to the one you want to update to.
 
+## Migration from 2021.02.00 to 2021.02.01
+
+This update contains a fix for a minor vulnerability found in `log4j` library.
+For this reason you may need to update the dependencies of your project
+
+!!! note
+    This vulnerability **is not** [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228)
+    but only a couple of smaller ones, that involve `Log4J` ( [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) is for `Log4J2` ).
+    Anyway MapStore is not prone to these vulnerabilities with the default configuration.
+    For more information, see the dedicated [blog post](https://www.geosolutionsgroup.com/blog/geosolutions-lo4shell/)
+
+here the instructions:
+
+### Align `pom.xml` files
+
+Here the changes in `pom.xml` and `web/pom.xml` to update:
+
+- Change `mapstore-backend` into `mapstore-services` and set the version to `1.2.2`
+
+```diff
+<!-- MapStore backend -->
+    <dependency>
+    <groupId>it.geosolutions.mapstore</groupId>
+-      <artifactId>mapstore-backend</artifactId>
+-      <version>1.2.1</version>
++      <artifactId>mapstore-services</artifactId>
++      <version>1.2.2</version>
+    </dependency>
+```
+
+- Set `geostore-webapp` version to `1.7.1`
+
+```diff
+    <dependency>
+    <groupId>it.geosolutions.geostore</groupId>
+    <artifactId>geostore-webapp</artifactId>
+-      <version>1.7.0</version>
++      <version>1.7.1</version>
+    <type>war</type>
+    <scope>runtime</scope>
+    </dependency>
+```
+
+- Set `http_proxy` version to `1.1.1` (should already be there)
+
+```diff
+    <dependency>
+    <!-- ... -->
+    <groupId>proxy</groupId>
+    <artifactId>http_proxy</artifactId>
+-      <version>1.1.0</version>
++      <version>1.1.1</version>
+    <type>war</type>
+    <scope>runtime</scope>
+    </dependency>
+```
+
+- Set `print-lib` version `geosolutions-2.0` to version `geosolutions-2.0.1`
+
+```diff
+    <dependency>
+        <groupId>org.mapfish.print</groupId>
+        <artifactId>print-lib</artifactId>
+-        <version>geosolutions-2.0</version>
++        <version>geosolutions-2.0.1</version>
+    </dependency>
+```
+
 ## Migration from 2021.01.04 to 2021.02.00
 
 ### Theme updates and CSS variables

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-java</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.2</version>
+  <version>1.2-SNAPSHOT</version>
   <name>MapStore 2</name>
   <url>http://www.geo-solutions.it</url>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-java</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>MapStore 2</name>
   <url>http://www.geo-solutions.it</url>
 

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>geosolutions-2.0</version>
+        <version>geosolutions-2.0.1</version>
     </dependency>
   </dependencies>
 

--- a/java/printing/pom.xml
+++ b/java/printing/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-print</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.1</version>
+  <version>1.2-SNAPSHOT</version>
   <name>MapStore 2 - Printing extension bundle</name>
   <url>http://www.geo-solutions.it</url>
 

--- a/java/services/pom.xml
+++ b/java/services/pom.xml
@@ -26,7 +26,19 @@
         <groupId>eu.medsea.mimeutil</groupId>
         <artifactId>mime-util</artifactId>
         <version>2.1.3</version>
+        <exclusions>
+            <exclusion>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
+    <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17.norce</version>
+    </dependency>
+    <!-- Replace log4j coming from mimeutil with the secure one-->
 
     <!-- Spring -->
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->

--- a/java/services/pom.xml
+++ b/java/services/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-services</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>MapStore 2 - Backend Services</name>
   <url>http://www.geo-solutions.it</url>
 

--- a/java/services/pom.xml
+++ b/java/services/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-services</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.2</version>
+  <version>1.2-SNAPSHOT</version>
   <name>MapStore 2 - Backend Services</name>
   <url>http://www.geo-solutions.it</url>
 

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.7.0</version>
+      <version>1.7.1</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-webapp</artifactId>
   <packaging>war</packaging>
-  <version>1.2.1</version>
+  <version>1.2-SNAPSHOT</version>
   <name>MapStore 2 - WAR</name>
   <url>http://www.geo-solutions.it</url>
 
@@ -19,7 +19,7 @@
     <dependency>
         <groupId>it.geosolutions.mapstore</groupId>
         <artifactId>mapstore-services</artifactId>
-        <version>1.2.1</version>
+        <version>1.2-SNAPSHOT</version>
     </dependency>
 
     <!-- ================================================================ -->
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-root</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.1</version>
+  <version>1.2-SNAPSHOT</version>
   <name>MapStore Root</name>
 
   <properties>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -4,7 +4,7 @@
   <groupId>it.geosolutions.mapstore</groupId>
   <artifactId>mapstore-product</artifactId>
   <packaging>war</packaging>
-  <version>1.2.1</version>
+  <version>1.2-SNAPSHOT</version>
   <name>MapStore Product Web Application</name>
 
   <properties>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>it.geosolutions.mapstore</groupId>
       <artifactId>mapstore-webapp</artifactId>
-      <version>1.2.1</version>
+      <version>1.2-SNAPSHOT</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
@@ -409,7 +409,7 @@
         <dependency>
             <groupId>org.mapfish.print</groupId>
             <artifactId>print-lib</artifactId>
-            <version>geosolutions-2.0</version>
+            <version>geosolutions-2.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>

--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.7.0</version>
+      <version>1.7.1</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/custom/templates/web/pom.xml
+++ b/project/custom/templates/web/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>it.geosolutions.mapstore</groupId>
       <artifactId>mapstore-services</artifactId>
-      <version>1.2.1</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <!-- ================================================================ -->
     <!-- GeoStore modules -->
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>it.geosolutions.geostore</groupId>
       <artifactId>geostore-webapp</artifactId>
-      <version>1.7.0</version>
+      <version>1.7.1</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
@@ -536,7 +536,7 @@
                 <dependency>
                     <groupId>org.mapfish.print</groupId>
                     <artifactId>print-lib</artifactId>
-                    <version>geosolutions-2.0</version>
+                    <version>geosolutions-2.0.1</version>
                 </dependency>
             </dependencies>
             </profile>

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>it.geosolutions.mapstore</groupId>
       <artifactId>mapstore-services</artifactId>
-      <version>1.2.1</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <!-- ================================================================ -->
     <!-- GeoStore modules -->
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>proxy</groupId>
       <artifactId>http_proxy</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>

--- a/release/bin-war/pom.xml
+++ b/release/bin-war/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>it.geosolutions.mapstore</groupId>
             <artifactId>mapstore-product</artifactId>
-            <version>1.2.1</version>
+            <version>1.2-SNAPSHOT</version>
             <type>war</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
This PR contains the updates necessary to use `log4j.norce` on stable branch.
Includes: 
- backport of https://github.com/geosolutions-it/MapStore2/pull/7663 
- Update of dependencies to avoid log4j issues and duplications
- Update of migration guidelines
- Set packages to -SNAPSHOT (this was missing)