### PR TITLE
#5560 Properly check if "navigator.geolocation" is available in browser.

### DIFF
--- a/web/client/components/mapcontrols/locate/LocateBtn.jsx
+++ b/web/client/components/mapcontrols/locate/LocateBtn.jsx
@@ -110,15 +110,22 @@ class LocateBtn extends React.Component {
         if (this.props.locate !== 'PERMISSION_DENIED' && !checkingGeoLocation && !geoLocationAllowed) {
             // check if we are allowed to use geolocation feature
             checkingGeoLocation = true;
-            navigator.geolocation.getCurrentPosition(() => {
+            if (typeof navigator.geolocation !== 'undefined') {
+                navigator.geolocation.getCurrentPosition(() => {
+                    checkingGeoLocation = false;
+                    geoLocationAllowed = true;
+                }, (error) => {
+                    checkingGeoLocation = false;
+                    if (error.code === 1) {
+                        this.props.onClick("PERMISSION_DENIED");
+                    }
+                });
+            } else {
+                // geolocation is deactivated in browser settings
                 checkingGeoLocation = false;
-                geoLocationAllowed = true;
-            }, (error) => {
-                checkingGeoLocation = false;
-                if (error.code === 1) {
-                    this.props.onClick("PERMISSION_DENIED");
-                }
-            });
+                this.props.onClick("PERMISSION_DENIED");
+            }
+
         }
     }
 

--- a/web/client/components/mapcontrols/locate/LocateBtn.jsx
+++ b/web/client/components/mapcontrols/locate/LocateBtn.jsx
@@ -110,7 +110,7 @@ class LocateBtn extends React.Component {
         if (this.props.locate !== 'PERMISSION_DENIED' && !checkingGeoLocation && !geoLocationAllowed) {
             // check if we are allowed to use geolocation feature
             checkingGeoLocation = true;
-            if (typeof navigator.geolocation !== 'undefined') {
+            if (navigator?.geolocation?.getCurrentPosition) {
                 navigator.geolocation.getCurrentPosition(() => {
                     checkingGeoLocation = false;
                     geoLocationAllowed = true;


### PR DESCRIPTION
## Description
Properly check if "navigator.geolocation" is available in browser.
It will be undefined if geolocation is disabled in browser configuration flags.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#5560

**What is the new behavior?**
No error is thrown to the console log. Geolocation button behaves like if user denied the request to get geolocation.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
