### PR TITLE
[Backport 2021.02.xx] #7607: The size of the background does not change (#7664)

### DIFF
--- a/web/client/components/geostory/contents/ToolbarButtons.jsx
+++ b/web/client/components/geostory/contents/ToolbarButtons.jsx
@@ -55,7 +55,7 @@ const getToolbarSizeProps = (size, sizeType) => {
  * @prop {function} filterOptions filter dropdown options by value (eg `({ value }) => value !== 'full'` to exclude `full` option)
  * @prop {function} pullRight pull dropdown right
  */
-export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {}, filterOptions, pullRight, id = 'size', sizeType}) => {
+export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType, size, update = () => {}, filterOptions, pullRight, sizeType}) => {
     const {pre, _size, glyph, sizeProp} = getToolbarSizeProps(size, sizeType);
     return (<ToolbarDropdownButton
         value={_size}
@@ -81,7 +81,7 @@ export const SizeButtonToolbar = ({editMap: disabled = false, align, sectionType
             glyph: 'size-extra-large',
             label: <Message msgId="geostory.contentToolbar.fullSizeLabel"/>
         }].filter((option) => !filterOptions || filterOptions(option))}
-        onSelect={(selected) => update(id, sizeProp(selected))}
+        onSelect={(selected) => update('size', sizeProp(selected))}
         {...sizeType && {showSelectionInTitle: false}}
     />);
 };


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

The toolbar was using the id of the section instead of `size` key. This PR restores the correct property key for `size`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7607

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
Restored the resize behaviour in backgrounds keeping the new resizing for web page

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
