### PR TITLE
[Backport 2021.02.xx] #7536: WPS export payload requests must include mimeType inside wps:Output (#7648)

### DIFF
--- a/web/client/components/data/download/ExportDataResults.jsx
+++ b/web/client/components/data/download/ExportDataResults.jsx
@@ -54,7 +54,7 @@ const ExportDataResults = ({
                             </OverlayTrigger> : null}
                         {status === 'failed' && (!result || !result.msgId) ? failButton : null}
                         {status === 'completed' &&
-                            <a href={result}>
+                            <a href={result} target="_blank" rel="noopener noreferrer">
                                 <Button bsStyle="primary" bsSize="small">
                                     <Glyphicon glyph="floppy-disk"/>
                                 </Button>

--- a/web/client/observables/wps/__tests__/download-test.js
+++ b/web/client/observables/wps/__tests__/download-test.js
@@ -381,4 +381,144 @@ describe('WPS download tests', () => {
             }
         );
     });
+    it('should use the resultOutput property', (done) => {
+
+        const options = {
+            layerName: 'layer',
+            resultOutput: 'application/zip',
+            outputFormat: 'application/json',
+            asynchronous: true,
+            outputAsReference: true,
+            notifyDownloadEstimatorSuccess: true
+        };
+
+        const expectedDataPayload = `<?xml version="1.0" encoding="UTF-8"?>` +
+            `<wps:Execute version="1.0.0" service="WPS" ` +
+            `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ` +
+            `xmlns="http://www.opengis.net/wps/1.0.0" ` +
+            `xmlns:wfs="http://www.opengis.net/wfs" ` +
+            `xmlns:wps="http://www.opengis.net/wps/1.0.0" ` +
+            `xmlns:ows="http://www.opengis.net/ows/1.1" ` +
+            `xmlns:gml="http://www.opengis.net/gml" ` +
+            `xmlns:ogc="http://www.opengis.net/ogc" ` +
+            `xmlns:wcs="http://www.opengis.net/wcs/1.1.1" ` +
+            `xmlns:dwn="http://geoserver.org/wps/download" ` +
+            `xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+            `xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">` +
+            `<ows:Identifier>gs:Download</ows:Identifier>` +
+            `<wps:DataInputs>` +
+                `<wps:Input>` +
+                    `<ows:Identifier>layerName</ows:Identifier>` +
+                    `<wps:Data>` +
+                        `<wps:LiteralData>layer</wps:LiteralData>` +
+                    `</wps:Data>` +
+                `</wps:Input>` +
+                `<wps:Input>` +
+                    `<ows:Identifier>outputFormat</ows:Identifier>` +
+                    `<wps:Data>` +
+                        `<wps:LiteralData>application/json</wps:LiteralData>` +
+                    `</wps:Data>` +
+                `</wps:Input>` +
+                `<wps:Input>` +
+                    `<ows:Identifier>cropToROI</ows:Identifier>` +
+                    `<wps:Data>` +
+                        `<wps:LiteralData>false</wps:LiteralData>` +
+                    `</wps:Data>` +
+                `</wps:Input>` +
+            `</wps:DataInputs>` +
+            `<wps:ResponseForm>` +
+                `<wps:ResponseDocument storeExecuteResponse="true" status="true">` +
+                    `<wps:Output mimeType="application/zip" asReference="true">` +
+                        `<ows:Identifier>result</ows:Identifier>` +
+                    `</wps:Output>` +
+                `</wps:ResponseDocument>` +
+            `</wps:ResponseForm>` +
+            `</wps:Execute>`;
+
+        mockAxios
+            .onPost()
+            .replyOnce(200, downloadEstimatorSucceededResponse, {'content-type': 'application/xml'})
+            .onPost()
+            .replyOnce((config) => {
+                try {
+                    expect(config.data).toBe(expectedDataPayload);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+                return [200, responseWithComplexDataOutput, {'content-type': 'application/xml'}];
+            });
+
+        download('http://testserver', options, {executeStatusUpdateInterval: 0}).subscribe();
+    });
+
+    it('should use the outputFormat if resultOutput is undefined as output format', (done) => {
+
+        const options = {
+            layerName: 'layer',
+            outputFormat: 'application/json',
+            asynchronous: true,
+            outputAsReference: true,
+            notifyDownloadEstimatorSuccess: true
+        };
+
+        const expectedDataPayload = `<?xml version="1.0" encoding="UTF-8"?>` +
+            `<wps:Execute version="1.0.0" service="WPS" ` +
+            `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ` +
+            `xmlns="http://www.opengis.net/wps/1.0.0" ` +
+            `xmlns:wfs="http://www.opengis.net/wfs" ` +
+            `xmlns:wps="http://www.opengis.net/wps/1.0.0" ` +
+            `xmlns:ows="http://www.opengis.net/ows/1.1" ` +
+            `xmlns:gml="http://www.opengis.net/gml" ` +
+            `xmlns:ogc="http://www.opengis.net/ogc" ` +
+            `xmlns:wcs="http://www.opengis.net/wcs/1.1.1" ` +
+            `xmlns:dwn="http://geoserver.org/wps/download" ` +
+            `xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+            `xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">` +
+            `<ows:Identifier>gs:Download</ows:Identifier>` +
+            `<wps:DataInputs>` +
+                `<wps:Input>` +
+                    `<ows:Identifier>layerName</ows:Identifier>` +
+                    `<wps:Data>` +
+                        `<wps:LiteralData>layer</wps:LiteralData>` +
+                    `</wps:Data>` +
+                `</wps:Input>` +
+                `<wps:Input>` +
+                    `<ows:Identifier>outputFormat</ows:Identifier>` +
+                    `<wps:Data>` +
+                        `<wps:LiteralData>application/json</wps:LiteralData>` +
+                    `</wps:Data>` +
+                `</wps:Input>` +
+                `<wps:Input>` +
+                    `<ows:Identifier>cropToROI</ows:Identifier>` +
+                    `<wps:Data>` +
+                        `<wps:LiteralData>false</wps:LiteralData>` +
+                    `</wps:Data>` +
+                `</wps:Input>` +
+            `</wps:DataInputs>` +
+            `<wps:ResponseForm>` +
+                `<wps:ResponseDocument storeExecuteResponse="true" status="true">` +
+                    `<wps:Output mimeType="application/json" asReference="true">` +
+                        `<ows:Identifier>result</ows:Identifier>` +
+                    `</wps:Output>` +
+                `</wps:ResponseDocument>` +
+            `</wps:ResponseForm>` +
+            `</wps:Execute>`;
+
+        mockAxios
+            .onPost()
+            .replyOnce(200, downloadEstimatorSucceededResponse, {'content-type': 'application/xml'})
+            .onPost()
+            .replyOnce((config) => {
+                try {
+                    expect(config.data).toBe(expectedDataPayload);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+                return [200, responseWithComplexDataOutput, {'content-type': 'application/xml'}];
+            });
+
+        download('http://testserver', options, {executeStatusUpdateInterval: 0}).subscribe();
+    });
 });

--- a/web/client/observables/wps/download.js
+++ b/web/client/observables/wps/download.js
@@ -116,10 +116,16 @@ export const download = (url, downloadOptions, executeOptions) => {
             dataFilter: downloadOptions.dataFilter,
             targetCRS: downloadOptions.targetCRS
         }), {outputsExtractor: makeOutputsExtractor(literalDataOutputExtractor)});
+
+        // use the same format of outputFormat for result
+        // if resultOutput param is undefined
+        const resultOutput = downloadOptions.resultOutput || downloadOptions.outputFormat || 'application/zip';
+
         const executeProcess$ = executeProcess(url, downloadXML({
             ...omit(downloadOptions, 'notifyDownloadEstimatorSuccess'),
-            outputAsReference: downloadOptions.asynchronous ? downloadOptions.outputAsReference : false
-        }), executeOptions, {headers: {'Content-Type': 'application/xml', 'Accept': `application/xml, ${downloadOptions.resultOutput || 'application/zip'}`}});
+            outputAsReference: downloadOptions.asynchronous ? downloadOptions.outputAsReference : false,
+            resultOutput
+        }), executeOptions, {headers: {'Content-Type': 'application/xml', 'Accept': `application/xml, ${resultOutput}`}});
 
         return downloadEstimator$
             .catch(() => {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR fixes the download output mime type for layer download. Currently the download link was using always mimetype=image/tiff:

![image](https://user-images.githubusercontent.com/19175505/145800131-3cf3c261-8e3d-48fb-8347-762679af0ccc.png)

and with the fix the mime type of the link will match the file type.
This PR introduces also a redirect to a new page for the download link in case of Content-Disposition header equal to inline (this means the content of the download is displayed in the web page).

Note: Now GeoJSON will open a new tab instead of direct download because the server is adding a Content-Disposition header inline for json format.

You can test all WPS download with this map `#/viewer/openlayers/37141`

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7536

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
