### PR TITLE
#7595: PrintScale plugin for the printing dialog

### DIFF
--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -3,17 +3,13 @@ import ReactDOM from "react-dom";
 import expect from "expect";
 
 import Print from "../Print";
-import { getLazyPluginForTest } from './pluginsTestUtils';
+import { getLazyPluginForTest, getByXPath } from './pluginsTestUtils';
 
 import {setStore} from "../../utils/StateUtils";
 
 import axios from '../../libs/ajax';
 import MockAdapter from 'axios-mock-adapter';
 import {addTransformer, resetTransformers} from "../../utils/PrintUtils";
-
-function getByXPath(xpath) {
-    return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-}
 
 const initialState = {
     controls: {

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -171,3 +171,7 @@ export const getLazyPluginForTest = ({
     }
     return Promise.resolve(getPluginForTest(plugin, storeState, plugins, testEpics, containersReducers, actions, additionalPlugins, items));
 };
+
+export function getByXPath(xpath) {
+    return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+}

--- a/web/client/plugins/__tests__/print/Scale-test.jsx
+++ b/web/client/plugins/__tests__/print/Scale-test.jsx
@@ -1,0 +1,163 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import expect from "expect";
+import { getPluginForTest, getByXPath } from '../pluginsTestUtils';
+import { getTransformerChain, resetTransformers } from "../../../utils/PrintUtils";
+import ReactTestUtils from "react-dom/test-utils";
+
+import PrintScale from "../../print/Scale";
+import last from "lodash/last";
+
+const initialState = {
+    controls: {
+        print: {
+            enabled: true
+        }
+    },
+    locale: {
+        current: "en-US"
+    },
+    print: {
+        spec: {
+            sheet: "A4"
+        },
+        map: {
+            scale: 1784
+        },
+        capabilities: {
+            createURL: "http://fakeservice",
+            layouts: [{
+                name: "A4_no_legend",
+                map: {
+                    width: 100,
+                    height: 100
+                }
+            }],
+            dpis: [],
+            scales: []
+        }
+    }
+};
+
+const baseSpec = {
+    layers: [],
+    center: {x: 0, y: 0, projection: "EPSG:4326"},
+    projection: "EPSG:4326"
+};
+
+function getPrintScalePlugin() {
+    return Promise.resolve(getPluginForTest(PrintScale, {
+        ...initialState
+    }));
+}
+
+function callTransformer(state, callback) {
+    setTimeout(() => {
+        last(getTransformerChain()).transformer(state, {
+            ...baseSpec,
+            includeScale: state.print.spec?.params?.includeScale ?? false
+        }).then(callback);
+    }, 0);
+}
+
+describe('PrintScale Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        resetTransformers();
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('default configuration', (done) => {
+        getPrintScalePlugin().then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin />, document.getElementById("container"));
+                expect(getByXPath("//*[text()='print.scale']")).toExist();
+                expect(getByXPath("//*[text()='print.includeScale']")).toExist();
+                expect(getByXPath("//*[text()='1:1,784']")).toExist();
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('transformer with checked flag', (done) => {
+        getPrintScalePlugin().then(({ Plugin, store }) => {
+            try {
+                ReactDOM.render(<Plugin />, document.getElementById("container"));
+                ReactTestUtils.Simulate.change(getByXPath("//input[@type='checkbox']"), {
+                    target: {
+                        checked: true
+                    }
+                });
+                callTransformer(store.getState(), (spec) => {
+                    expect(spec.mapScale).toBe('1:1,784');
+                    done();
+                });
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('transformer with unchecked flag', (done) => {
+        getPrintScalePlugin().then(({ Plugin, store}) => {
+            try {
+                ReactDOM.render(<Plugin />, document.getElementById("container"));
+                callTransformer(store.getState(), (spec) => {
+                    expect(spec.mapScale).toNotExist();
+                    done();
+                });
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('custom formatting', (done) => {
+        const customFormat = (scale) => (`MyScale ${scale}`);
+
+        getPrintScalePlugin().then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin format={customFormat}/>, document.getElementById("container"));
+                expect(getByXPath("//*[text()='MyScale 1784']")).toExist();
+                done();
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it('custom formatting for printing', (done) => {
+        const customFormat = (scale, locale, forPrint) => {
+            if (forPrint) {
+                return `MyPrintedScale ${scale}`;
+            }
+            return `MyScale ${scale}`;
+        };
+
+        getPrintScalePlugin().then(({ Plugin, store }) => {
+            try {
+                ReactDOM.render(<Plugin format={customFormat}/>, document.getElementById("container"));
+                ReactTestUtils.Simulate.change(getByXPath("//input[@type='checkbox']"), {
+                    target: {
+                        checked: true
+                    }
+                });
+                expect(getByXPath("//*[text()='MyScale 1784']")).toExist();
+                callTransformer(store.getState(), (spec) => {
+                    expect(spec.mapScale).toBe('MyPrintedScale 1784');
+                    done();
+                });
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+});

--- a/web/client/plugins/print/Option.jsx
+++ b/web/client/plugins/print/Option.jsx
@@ -11,7 +11,7 @@ export const Option = (props, context) => {
     const {spec, property, label, onChangeParameter, enabled = true, actions, path = "params.", additionalProperty = true} = props;
     const fullProperty = path + property;
     useEffect(() => {
-        if (additionalProperty) actions.addParameter(property, get(spec, fullProperty) ?? false);
+        if (additionalProperty) actions?.addParameter(property, get(spec, fullProperty) ?? false);
     }, []);
     return handleExpression({}, {...props}, "{" + enabled + "}") ? (<PrintOptionComp checked={!!get(spec, fullProperty)}
         label={getMessageById(context.messages, label)}

--- a/web/client/plugins/print/Scale.jsx
+++ b/web/client/plugins/print/Scale.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect } from "react";
+import {Option} from "./Option";
+import {createPlugin} from "../../utils/PluginsUtils";
+import {connect} from "react-redux";
+import {setPrintParameter, addPrintParameter} from "../../actions/print";
+import Message from "../../components/I18N/Message";
+import {addTransformer} from "../../utils/PrintUtils";
+
+import localeReducer from "../../reducers/locale";
+import printReducer from "../../reducers/print";
+
+/**
+ * Default formatter function for scale.
+ *
+ * @param {*} scale current map/printed scale
+ * @param {*} locale current application locale
+ * @returns 1:<scale>, using the current locale for formatting the denominator.
+ */
+export function defaultFormat(scale, locale = "en-US") {
+    const val = new Intl.NumberFormat(locale, {maximumFractionDigits: 0}).format(scale);
+    return `1:${val}`;
+}
+
+const printScaleSelector = (state) => ({
+    spec: state?.print?.spec ?? {},
+    scale: state?.print?.map?.scale,
+    locale: state?.locale?.current ?? "en-US"
+});
+
+const scaleTransformer = (format) => (state, spec) => {
+    const {scale, locale} = printScaleSelector(state);
+    return Promise.resolve({
+        ...spec,
+        mapScale: spec?.includeScale ? `${format(scale, locale, true)}` : ""
+    });
+};
+
+export const Scale = (props) => {
+    const {scale, locale, label = "print.scale", optionLabel = "print.includeScale", actions, onAddParameter, ...rest} = props;
+    const formatScale = props.format || defaultFormat;
+    useEffect(() => {
+        addTransformer("scale", scaleTransformer(formatScale));
+    }, []);
+    return (<div id="print-scale">
+        <div style={{"float": "left", "marginRight": 5}}><Message msgId={label}/> {formatScale(scale, locale)}</div>
+        <Option {...rest} actions={{addParameter: onAddParameter}} property="includeScale" label={optionLabel}/>
+    </div>);
+};
+
+/**
+ * Scale plugin for Print. This plugin adds an option to include the scale in the printed pages.
+ * It requires a config.yaml with the mapScale variable in it, or you will get an error when printing.
+ *
+ * You can customize the scale formatting, by specifying a format property, with a custom formatter
+ * function. The formatter function is used both to show the scale on the dialog, and on the
+ * printed page. It receives as parameters :
+ *  - the actual scale denominator
+ *  - the current application locale
+ *  - a boolean flag, true for printing, false for the UI dialog, so that formatting can be
+ *    different in the two cases, if desired.
+ *
+ * @class PrintScale
+ * @memberof plugins.print
+ * @static
+ *
+ * @prop {boolean} cfg.format function to customize the actual printed scale (default format produces something like 1:10,000)
+ * @prop {string} cfg.label label localized text
+ * @prop {string} cfg.optionLabel label for the checkbox localized text
+ *
+ * @example
+ * // include the widget in the Print plugin left-panel container, after title and description
+ * // and a custom formatting function
+ * {
+ *   "name": "PrintScale",
+ *   "override": {
+ *      "Print": {
+ *           "target": "left-panel",
+ *           "position": 3
+ *      }
+ *   },
+ *   "cfg": {
+ *       "format": "{(function(scale, locale, forPrint) {return (forPrint ? 'MyScale ' : '' ) + scale;})}"
+ *   }
+ * }
+ */
+export default createPlugin("PrintScale", {
+    component: connect(
+        printScaleSelector, {
+            onChangeParameter: setPrintParameter,
+            onAddParameter: addPrintParameter
+        }
+    )(Scale),
+    reducers: {locale: localeReducer, print: printReducer},
+    containers: {
+        Print: {
+            priority: 1,
+            target: "left-panel",
+            position: 3
+        }
+    }
+});

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -681,7 +681,9 @@
                 "iconsSize": "Symbolgröße:",
                 "dpi": "dpi:"
             },
-            "layoutWarning": "Layout nicht erlaubt"
+            "layoutWarning": "Layout nicht erlaubt",
+            "scale": "Maßstab",
+            "includeScale": "in Druck einschließen"
         },
         "backgroundSwither":{
             "tooltip": "Wähle Hintergrund"

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -642,7 +642,9 @@
                 "iconsSize": "Icons size:",
                 "dpi": "Dpi:"
             },
-            "layoutWarning": "Not allowed layout"
+            "layoutWarning": "Not allowed layout",
+            "scale": "Scale",
+            "includeScale": "Include in print"
         },
         "backgroundSwither":{
             "tooltip": "Select Background"

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -642,7 +642,9 @@
                 "iconsSize": "Tamaño de los iconos:",
                 "dpi": "ppp:"
             },
-            "layoutWarning": "Lienzo no permitido"
+            "layoutWarning": "Lienzo no permitido",
+            "scale": "escala",
+            "includeScale": "incluir en la impresión"
         },
         "backgroundSwither":{
             "tooltip": "Selección del fondo"

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -642,7 +642,9 @@
                 "iconsSize": "Taille d'icône :",
                 "dpi": "Ppp :"
             },
-            "layoutWarning": "Mise en page non permise"
+            "layoutWarning": "Mise en page non permise",
+            "scale": "échelle",
+            "includeScale": "inclure dans l'impression"
         },
         "backgroundSwither": {
             "tooltip": "Sélection du fond de plan"

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -642,7 +642,9 @@
                 "iconsSize": "Dimensione icone:",
                 "dpi": "Dpi:"
             },
-            "layoutWarning": "Layout non consentito"
+            "layoutWarning": "Layout non consentito",
+            "scale": "Scala",
+            "includeScale": "Includi nella stampa"
         },
         "backgroundSwither":{
             "tooltip": "Scegli lo sfondo"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
This is a plugin that adds an option to the Print printing dialog, to include the current map scale in the printed page, by defining a mapScale variable, that can be used in the config.yaml template.
The plugin is not included by default in the product build.

![image](https://user-images.githubusercontent.com/2770528/146742004-10fdbdb7-aae6-488c-ba04-79ab88bb7637.png)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7595 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
