### PR TITLE
#7693 Persist selected media service when switching between media types

### DIFF
--- a/web/client/actions/__tests__/mediaEditor-test.js
+++ b/web/client/actions/__tests__/mediaEditor-test.js
@@ -128,8 +128,10 @@ describe('mediaEditor actions', () => {
     });
     it('setMediaType', () => {
         const mediaType = "image";
-        const action = setMediaType(mediaType);
+        const selectedService = 'geonode';
+        const action = setMediaType(mediaType, selectedService);
         expect(action.mediaType).toEqual(mediaType);
+        expect(action.selectedService).toEqual(selectedService);
         expect(action.type).toEqual(SET_MEDIA_TYPE);
     });
     it('show', () => {

--- a/web/client/actions/mediaEditor.js
+++ b/web/client/actions/mediaEditor.js
@@ -103,7 +103,7 @@ export const setMediaService = (service) => ({ type: SET_MEDIA_SERVICE, id: isOb
  * change the media type in the media editor
  * @param {string} mediaType type of the media, can be one of "image", "video" or "map"
  */
-export const setMediaType = (mediaType) => ({ type: SET_MEDIA_TYPE, mediaType });
+export const setMediaType = (mediaType, selectedService) => ({ type: SET_MEDIA_TYPE, mediaType, selectedService });
 /**
  * editing media
  * @param {boolean} editing

--- a/web/client/components/mediaEditor/MediaEditor.jsx
+++ b/web/client/components/mediaEditor/MediaEditor.jsx
@@ -14,6 +14,7 @@ import localizedProps from '../misc/enhancers/localizedProps';
 import Toolbar from '../misc/toolbar/Toolbar';
 import MediaPreview from './MediaPreview';
 import includes from 'lodash/includes';
+import {selectService} from "../../utils/MediaEditorUtils";
 const Select = localizedProps(["placeholder", "clearValueText", "noResultsText"])(ReactSelect);
 
 /**
@@ -48,19 +49,19 @@ export default ({
                     text: <Message msgId="mediaEditor.images" />,
                     active: mediaType === "image",
                     bsStyle: mediaType === "image" ? "primary" : "default",
-                    onClick: () => { setMediaType("image"); },
+                    onClick: () => { setMediaType("image", selectedService); },
                     disabled: (saveState && saveState.addingMedia) || includes(disabledMediaType, "image")
                 }, {
                     text: <Message msgId="mediaEditor.videos" />,
                     active: mediaType === "video",
                     bsStyle: mediaType === "video" ? "primary" : "default",
-                    onClick: () => { setMediaType("video"); },
+                    onClick: () => { setMediaType("video", selectedService); },
                     disabled: (saveState && saveState.addingMedia) || includes(disabledMediaType, "video")
                 }, {
                     text: <Message msgId="mediaEditor.maps" />,
                     active: mediaType === "map",
                     bsStyle: mediaType === "map" ? "primary" : "default",
-                    onClick: () => { setMediaType("map"); },
+                    onClick: () => { setMediaType("map", selectedService); },
                     disabled: (saveState && saveState.addingMedia) || includes(disabledMediaType, "map")
                 }]} />
             <div className="ms-mediaEditor-services">
@@ -73,7 +74,7 @@ export default ({
                     placeholder="mediaEditor.mediaPicker.selectService"
                     options={services.map(s => ({ label: <Message msgId={s.name} />, value: s.id }))}
                     onChange={setMediaService}
-                    value={selectedService}
+                    value={selectService(services, selectedService)}
                     clearable={false}
                 />
             </div>
@@ -84,7 +85,6 @@ export default ({
             {mediaSelector}
         </div>
     ]}>
-
     <MediaPreview
         selectedItem={selectedItem}
         mediaType={mediaType}

--- a/web/client/reducers/__tests__/mediaEditor-test.js
+++ b/web/client/reducers/__tests__/mediaEditor-test.js
@@ -87,7 +87,7 @@ describe('Test the mediaEditor reducer', () => {
         let state = mediaEditor({}, setMediaService({value}));
         expect(state.settings.sourceId).toEqual(value);
     });
-    it('SET_MEDIA_TYPE', () => {
+    it('SET_MEDIA_TYPE BY DEFAULT', () => {
         const mediaType = "mediaType";
         let state = mediaEditor({}, setMediaType(mediaType));
         expect(state.settings.mediaType).toEqual(mediaType);
@@ -104,6 +104,13 @@ describe('Test the mediaEditor reducer', () => {
         }, setMediaType(mediaType));
         expect(state.settings.mediaType).toEqual(mediaType);
         expect(state.settings.sourceId).toEqual("default");
+    });
+    it('SET_MEDIA_TYPE WITH A SELECTED SERVICE', () => {
+        const mediaType = "mediaType";
+        const selectedService = "geonode";
+        let state = mediaEditor({}, setMediaType(mediaType, selectedService));
+        expect(state.settings.mediaType).toEqual(mediaType);
+        expect(state.settings.sourceId).toEqual(selectedService);
     });
     it('SHOW', () => {
         const owner = "owner";

--- a/web/client/reducers/mediaEditor.js
+++ b/web/client/reducers/mediaEditor.js
@@ -145,7 +145,7 @@ export default (state = DEFAULT_STATE, action) => {
     case SET_MEDIA_TYPE: {
         const defaultSource = get(state, `settings.mediaTypes[${action.mediaType}].defaultSource`, "geostory");
         return compose(
-            set('settings.sourceId', defaultSource), // reset sourceId to default when media type changes
+            set('settings.sourceId', action.selectedService ? action.selectedService : defaultSource), // reset sourceId to default when media type changes and action.selectedService is undefined
             set('settings.mediaType', action.mediaType)
         )(state);
     }

--- a/web/client/utils/MediaEditorUtils.js
+++ b/web/client/utils/MediaEditorUtils.js
@@ -25,3 +25,8 @@ export const defaultLayerMapPreview = {
     loading: false,
     loadingError: false
 };
+export const selectService = (services, selectedItem)=>{
+    return services.find(service => service.id === selectedItem)
+        ? selectedItem : SourceTypes.GEOSTORY;
+};
+


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7693 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The selected media service persists even when switching between media types
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
