### PR TITLE
#7680 Prevent horizontal scrollbar in identify tool + properties template

### DIFF
--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -274,7 +274,7 @@
 
 .ms-properties-viewer {
     width: 100%;
-    min-width: 256px;
+    min-width: 100%;
     padding: 8px;
     + .ms-properties-viewer {
         margin-top: 8px;


### PR DESCRIPTION
## Description
Prevent horizontal scrollbar in identify tool + properties template

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7680
Scrollbar appears when feature info is using properties template and show in a pop-up mode.

**What is the new behavior?**
Content width is capped with the container width correctly.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
