### PR TITLE
#7506 Proper handling of wildcards in FilterLayer

### DIFF
--- a/web/client/utils/FilterUtils.js
+++ b/web/client/utils/FilterUtils.js
@@ -834,21 +834,57 @@ export const cqlArrayField = function(attribute, operator, value) {
     }
 };
 
+/**
+ * Process CQL filter value, properly converts wildcards at the start and end of the string
+ * so that "like" and "ilike" condition will get "*text" or "text*" conditions as "%text" and "text%".
+ * "like" and "ilike" operators value will be turned into "%value%" if no wildcards were used.
+ * All other operators will receive value as-is, no wildcard processing is applied
+ * @param value
+ * @param operator
+ * @returns {string}
+ */
+export const processCqlWildcards = function(value, operator) {
+    const escapedQuotes = escapeCQLStrings(value);
+    const startCharIsWildcard = value.startsWith('*');
+    const endCharIsWildcard = value.endsWith('*');
+    const startsWithWildcard = startCharIsWildcard && !endCharIsWildcard;
+    const endsWithWildcard = endCharIsWildcard && !startCharIsWildcard;
+    const noWildcardValue = escapedQuotes.replace(/^\*+|\*+$/g, '');
+    switch (operator) {
+    case 'ilike':
+    case 'like':
+        const val = operator === 'ilike' ? noWildcardValue.toLowerCase() : noWildcardValue;
+        if (startsWithWildcard) {
+            return "'%" + val + "'";
+        } else if (endsWithWildcard) {
+            return "'" + val + "%'";
+        }
+        return "'%" + val + "%'";
+    default:
+        return "'" + escapedQuotes + "'";
+    }
+};
+
+/**
+ * Creates SQL condition using provided attribute, operator and value
+ * @param attribute
+ * @param operator
+ * @param value
+ * @returns {string}
+ */
 export const cqlStringField = function(attribute, operator, value) {
     let fieldFilter;
     const wrappedAttr = wrapAttributeWithDoubleQuotes(attribute);
     if (!isNil(value)) {
+        const processedValue = processCqlWildcards(value, operator);
         if (operator === "isNull") {
             fieldFilter = "isNull(" + wrappedAttr + ")=true";
         } else if (["<>", "="].includes(operator)) {
-            let val = "'" + escapeCQLStrings(value) + "'";
-            fieldFilter = wrappedAttr + operator + val;
+            fieldFilter = wrappedAttr + operator + processedValue;
         } else if (operator === "ilike") {
-            let val = "'%" + escapeCQLStrings(value).toLowerCase() + "%'";
-            fieldFilter = "strToLowerCase(" + wrappedAttr + ") LIKE " + val;
+            fieldFilter = "strToLowerCase(" + wrappedAttr + ") LIKE " + processedValue;
         } else {
-            let val = "'%" + escapeCQLStrings(value) + "%'";
-            fieldFilter = wrappedAttr + " LIKE " + val;
+            fieldFilter = wrappedAttr + " LIKE " + processedValue;
         }
     }
     return fieldFilter;

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -1208,7 +1208,7 @@ describe('FilterUtils', () => {
         expect(cqlStringField("attribute_1", "like", "A*")).toBe("\"attribute_1\" LIKE 'A%'");
         // test ilike wrapped with wildcard
         expect(cqlStringField("attribute_1", "ilike", "*A*")).toBe("strToLowerCase(\"attribute_1\") LIKE '%a%'");
-        // test LIKE with wildcard at the end
+        // test LIKE wrapped with wildcard
         expect(cqlStringField("attribute_1", "like", "*A*")).toBe("\"attribute_1\" LIKE '%A%'");
     });
     it('Check if ogcBooleanField(attribute, operator, value, nsplaceholder)', () => {

--- a/web/client/utils/__tests__/FilterUtils-test.js
+++ b/web/client/utils/__tests__/FilterUtils-test.js
@@ -1198,6 +1198,18 @@ describe('FilterUtils', () => {
         expect(cqlStringField("attribute_1", "ilike", "A")).toBe("strToLowerCase(\"attribute_1\") LIKE '%a%'");
         // test LIKE
         expect(cqlStringField("attribute_1", "like", "A")).toBe("\"attribute_1\" LIKE '%A%'");
+        // test ilike with wildcard at the beginning
+        expect(cqlStringField("attribute_1", "ilike", "*A")).toBe("strToLowerCase(\"attribute_1\") LIKE '%a'");
+        // test LIKE with wildcard at the beginning
+        expect(cqlStringField("attribute_1", "like", "*A")).toBe("\"attribute_1\" LIKE '%A'");
+        // test ilike with wildcard at the end
+        expect(cqlStringField("attribute_1", "ilike", "A*")).toBe("strToLowerCase(\"attribute_1\") LIKE 'a%'");
+        // test LIKE with wildcard at the end
+        expect(cqlStringField("attribute_1", "like", "A*")).toBe("\"attribute_1\" LIKE 'A%'");
+        // test ilike wrapped with wildcard
+        expect(cqlStringField("attribute_1", "ilike", "*A*")).toBe("strToLowerCase(\"attribute_1\") LIKE '%a%'");
+        // test LIKE with wildcard at the end
+        expect(cqlStringField("attribute_1", "like", "*A*")).toBe("\"attribute_1\" LIKE '%A%'");
     });
     it('Check if ogcBooleanField(attribute, operator, value, nsplaceholder)', () => {
         // testing operators
@@ -1249,7 +1261,7 @@ describe('FilterUtils', () => {
                     groupId: 1,
                     attribute: "attribute3",
                     exception: null,
-                    operator: "LIKE",
+                    operator: "like",
                     rowId: "3",
                     type: "string",
                     value: "val"
@@ -1412,7 +1424,7 @@ describe('FilterUtils', () => {
                             groupId: 1,
                             attribute: "attribute3",
                             exception: null,
-                            operator: "LIKE",
+                            operator: "like",
                             rowId: "3",
                             type: "string",
                             value: "val"


### PR DESCRIPTION

## Description
Proper handling of wildcards in FilterLayer.
Added utility to process wildcards in the string based on operator used. "like" & "ilike" operators will get wildcards converted to the CQL format where "%" is used for multiple character substitution and "_" is used for a single character.
Following rules are applied:
- WPS requests will not have filter value unconditionally wrapped with ** anymore. There is a check if wildcard is presented in a value. Wrapping will happen only if there are no wildcards in the string.
- CQL: % and _ characters will be escaped with backslash before conversion.
- CQL: * and . will be converted into % and _ only in case if they are not prepended with !
- CQL: !* and !. will be converted into * and .
- CQL: value will be wrapped with %% only if no wildcards are passed into condition. "Te!*s!.t" will be wrapped with %% as there are no wildcards (both cases are escaped with !). "Te*s.t" won't be wrapped.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7506

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
