### PR TITLE
Fix printing WMTS background layers loaded at startup (#7705)

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -561,7 +561,7 @@ export const specCreators = {
                 "matrixSet": tileMatrixSetName,
                 "style": layer.style,
                 "name": layer.name,
-                "requestEncoding": layer.requestEncoding === "RESTful" ? "REST" : layer.requestEncoding,
+                "requestEncoding": layer.requestEncoding === "RESTful" ? "REST" : layer.requestEncoding || "KVP",
                 "opacity": getOpacity(layer),
                 "version": layer.version || "1.0.0"
             };

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -107,7 +107,7 @@ export const getDefaultStyleIdentifier = layer =>{
                 castArray(layer.Style)
                     // the identifier content value is needed
                     .map(l => l["ows:Identifier"]));
-        else {
+        } else {
             return head(
                 castArray(layer.Style)
                     // default is identified by XML attribute isDefault

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -101,12 +101,20 @@ export const getCapabilitiesURL = (record = {}) => {
 
 export const getDefaultStyleIdentifier = layer =>{
     if (layer?.Style) {
-        return head(
-            castArray(layer.Style)
-                // default is identified by XML attribute isDefault
-                .filter(({ $ = {} }) => $.isDefault === "true")
-                // the identifier content value is needed
-                .map(l => l["ows:Identifier"]));
+
+        if (castArray(layer.Style).length === 1) {
+            return head(
+                castArray(layer.Style)
+                    // the identifier content value is needed
+                    .map(l => l["ows:Identifier"]));
+        else {
+            return head(
+                castArray(layer.Style)
+                    // default is identified by XML attribute isDefault
+                    .filter(({ $ = {} }) => $.isDefault === "true")
+                    // the identifier content value is needed
+                    .map(l => l["ows:Identifier"]));
+        }
     }
     return null;
 };

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -102,19 +102,19 @@ export const getCapabilitiesURL = (record = {}) => {
 export const getDefaultStyleIdentifier = layer =>{
     if (layer?.Style) {
 
+        // if there's only one style, assume it's the default
         if (castArray(layer.Style).length === 1) {
             return head(
                 castArray(layer.Style)
                     // the identifier content value is needed
                     .map(l => l["ows:Identifier"]));
-        } else {
-            return head(
-                castArray(layer.Style)
-                    // default is identified by XML attribute isDefault
-                    .filter(({ $ = {} }) => $.isDefault === "true")
-                    // the identifier content value is needed
-                    .map(l => l["ows:Identifier"]));
         }
+        return head(
+            castArray(layer.Style)
+                // default is identified by XML attribute isDefault
+                .filter(({ $ = {} }) => $.isDefault === "true")
+                // the identifier content value is needed
+                .map(l => l["ows:Identifier"]));
     }
     return null;
 };

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -78,6 +78,20 @@ describe('Test the WMTSUtils', () => {
             const style = WMTSUtils.getDefaultStyleIdentifier(layer);
             expect(style).toBe('normal');
         });
+        it('tests fetching the default style when "isDefault" is not present', () => {
+            const layer = {
+                Style: {
+                    "ows:Title": "generic Legend",
+                    "ows:Abstract": "abstract",
+                    "ows:Keywords": {
+                        "ows:Keyword": "default"
+                    },
+                    "ows:Identifier": "default"
+                }
+            };
+            const style = WMTSUtils.getDefaultStyleIdentifier(layer);
+            expect(style).toBe('default');
+        });
 
     });
 });


### PR DESCRIPTION
default requestEncoding to KVP

## Description
try fixing some of the issues printing WMTS layers

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7705 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
printing a WMTS background layer loaded at startup works

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

note that this is only part of the fix, it doesnt fix printing WMTS layers coming from non-geoserver services such as mapproxy, for which `getDefaultStyleIdentifier` returns null.