### PR TITLE
Added tooltip to zoom icon in gridTools

### DIFF
--- a/web/client/plugins/featuregrid/gridTools.jsx
+++ b/web/client/plugins/featuregrid/gridTools.jsx
@@ -15,7 +15,10 @@ export default [{
             return p.geometry ? zoomToExtent(bbox(p), crs || "EPSG:4326", maxZoom) : {type: "NONE"};
         }
     },
-    formatter: ({value} = {}) => value ? <Glyphicon glyph="zoom-to" /> :
+    formatter: ({value} = {}) => value ?
+        <OverlayTrigger placement="top" overlay={<Tooltip id="fe-zoom-object"><Message msgId="featuregrid.zoomObject"/></Tooltip>}>
+            <Glyphicon glyph="zoom-to" />
+        </OverlayTrigger> :
         <OverlayTrigger placement="top" overlay={<Tooltip id="fe-save-features"><Message msgId="featuregrid.missingGeometry"/></Tooltip>}>
             <Glyphicon glyph="exclamation-mark" />
         </OverlayTrigger>

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1641,7 +1641,7 @@
             "featureClose": "Wollen Sie das Raster wirklich schließen?",
             "delete": "Wollen Sie die {count} Elemente entfernen?",
             "missingGeometry": "Fehlende Geometrie",
-            "zoomObject": "Auf Objekt zoomen",
+            "zoomObject": "Zum Objekt zoomen",
             "filter": {
                 "placeholders": {
                     "default": "Beispiele...",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1641,6 +1641,7 @@
             "featureClose": "Wollen Sie das Raster wirklich schließen?",
             "delete": "Wollen Sie die {count} Elemente entfernen?",
             "missingGeometry": "Fehlende Geometrie",
+            "zoomObject": "Auf Objekt zoomen",
             "filter": {
                 "placeholders": {
                     "default": "Beispiele...",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1603,7 +1603,7 @@
             "featureClose": "Are you sure to close the feature grid?",
             "delete": "Do you confirm to delete {count} features?",
             "missingGeometry": "Missing geometry",
-            "zoomObject": "Zoom on object",
+            "zoomObject": "Zoom to feature",
             "filter": {
                 "placeholders": {
                     "default": "Search...",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1603,6 +1603,7 @@
             "featureClose": "Are you sure to close the feature grid?",
             "delete": "Do you confirm to delete {count} features?",
             "missingGeometry": "Missing geometry",
+            "zoomObject": "Zoom on object",
             "filter": {
                 "placeholders": {
                     "default": "Search...",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1603,7 +1603,7 @@
             "featureClose": "¿Realmente desea cerrar la tabla?",
             "delete": "¿Confirma la eliminación de {count} características?",
             "missingGeometry": "Geometría no encontrada",
-            "zoomObject": "Zoom sobre el objeto",
+            "zoomObject": "Acercamiento a objeto espacial",
             "filter": {
                 "placeholders": {
                     "default": "Buscar...",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1603,6 +1603,7 @@
             "featureClose": "¿Realmente desea cerrar la tabla?",
             "delete": "¿Confirma la eliminación de {count} características?",
             "missingGeometry": "Geometría no encontrada",
+            "zoomObject": "Zoom sobre el objeto",
             "filter": {
                 "placeholders": {
                     "default": "Buscar...",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -1367,6 +1367,7 @@
       "featureClose": "Oletko varma, että suljet ominaisuusruudun?",
       "delete": "Vahvistatko kohteiden poistamisen ({count} kpl)?",
       "missingGeometry": "Geometria puuttuu",
+      "zoomObject": "Zoomaa kohteeseen",
       "filter": {
         "placeholders": {
           "default": "Haku...",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1604,6 +1604,7 @@
             "featureClose": "Voulez vous vraiment fermer la grille ?",
             "delete": "Valider pour supprimer les éléments ?",
             "missingGeometry": "Géométrie manquante",
+            "zoomObject": "Zoom sur l'objet",
             "filter": {
                 "placeholders": {
                     "default": "Recherche...",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1604,7 +1604,7 @@
             "featureClose": "Voulez vous vraiment fermer la grille ?",
             "delete": "Valider pour supprimer les éléments ?",
             "missingGeometry": "Géométrie manquante",
-            "zoomObject": "Zoom sur l'objet",
+            "zoomObject": "Zoom sur l'entité",
             "filter": {
                 "placeholders": {
                     "default": "Recherche...",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -1324,6 +1324,7 @@
             "featureClose": "Želite li zaista zatvoriti tablicu objekata?",
             "delete": "Želite li potvrditi brisanje {count} objekata?",
             "missingGeometry": "Nedostaje geometrija",
+            "zoomObject": "Zumirajte predmet",
             "filter": {
                 "placeholders": {
                     "default": "Traži...",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1604,7 +1604,7 @@
             "featureClose": "Sicuro di voler chiudere la griglia?",
             "delete": "Confermi di cancellare {count} feature?",
             "missingGeometry": "Geometria mancante",
-            "zoomObject": "Zoom sull'oggetto",
+            "zoomObject": "Zoom alla feature",
             "filter": {
                 "placeholders": {
                     "default": "Cerca...",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1604,6 +1604,7 @@
             "featureClose": "Sicuro di voler chiudere la griglia?",
             "delete": "Confermi di cancellare {count} feature?",
             "missingGeometry": "Geometria mancante",
+            "zoomObject": "Zoom sull'oggetto",
             "filter": {
                 "placeholders": {
                     "default": "Cerca...",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1589,6 +1589,7 @@
             "featureClose": "Weet u zeker dat u het objectengrid wilt sluiten?",
             "delete": "Bevestigt u dat u {count} objecten wilt verwijderen?",
             "missingGeometry": "Ontbrekende geometrie",
+            "zoomObject": "Zoom naar object",
             "filter": {
                 "placeholders": {
                     "default": "Zoeken...",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -1301,6 +1301,7 @@
             "featureClose": "Are you sure to close the feature grid?",
             "delete": "Do you confirm to delete {count} features?",
             "missingGeometry": "Missing geometry",
+            "zoomObject": "Zoom a objecto",
             "filter": {
                 "placeholders": {
                     "default": "Search...",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1584,6 +1584,7 @@
             "featureClose": "Är du säker på att stänga objektnätet?",
             "delete": "Bekräftar du att radera {count} objekt?",
             "missingGeometry": "Saknad geometri",
+            "zoomObject": "Zooma till objektet",
             "filter": {
                 "placeholders": {
                     "default": "Sök ...",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -411,6 +411,7 @@
             },
             "header": "Danh sách kết quả tìm kiếm",
             "missingGeometry": "Thiếu hình",
+            "zoomObject": "Phóng to đối tượng",
             "noButton": "Không",
             "noFeaturesAvailable": "Không có tính năng có sẵn",
             "notSupportedGeometry": "Kiểu hình lớp này không được hỗ trợ bằng chỉnh sửa nhưng bạn vẫn có thể chỉnh sửa các thuộc tính",

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -1278,6 +1278,7 @@
             "featureClose": "Are you sure to close the feature grid?",
             "delete": "Do you confirm to delete {count} features?",
             "missingGeometry": "Missing geometry",
+            "zoomObject": "Zoom to object",
             "filter": {
                 "placeholders": {
                     "default": "Search...",


### PR DESCRIPTION
## Description
Just for consistency, it adds a tooltip to the zoom button in the grid tools.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [X] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

## Issue
#7711 
**What is the current behavior?**
There's no tooltip displayed for the zoom button in the grid tools from the attribute table

**What is the new behavior?**
On mouse over, a tooltip is shown with a suitable descriptive text

![grafik](https://user-images.githubusercontent.com/1714616/148215790-804745dd-7531-4903-89f5-3ce439939b71.png)

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No