### PR TITLE
[Backport 2021.02.xx] #7649 Set proper trigger for useEffect on plugin initialization (#7650)

### DIFF
--- a/web/client/plugins/FeatureEditor.jsx
+++ b/web/client/plugins/FeatureEditor.jsx
@@ -165,7 +165,11 @@ const FeatureDock = (props = {
 
     useEffect(() => {
         props.initPlugin({virtualScroll, editingAllowedRoles: props.editingAllowedRoles, maxStoredPages: props.maxStoredPages});
-    }, []);
+    }, [
+        virtualScroll,
+        (props.editingAllowedRoles ?? []).join(","), // this avoids multiple calls when the array remains the equal
+        props.maxStoredPages
+    ]);
 
     return (
         <Dock {...dockProps} onSizeChange={size => { props.onSizeChange(size, dockProps); }}>

--- a/web/client/plugins/__tests__/FeatureEditor-test.jsx
+++ b/web/client/plugins/__tests__/FeatureEditor-test.jsx
@@ -45,4 +45,33 @@ describe('FeatureEditor Plugin', () => {
         expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
         expect(state.maxStoredPages).toBe(props.maxStoredPages);
     });
+    it('onInit FeatureEditor plugin be-recalled when props change', () => {
+        const props = {
+            virtualScroll: false,
+            editingAllowedRoles: ['ADMIN'],
+            maxStoredPages: 5
+        };
+        const props2 = {
+            editingAllowedRoles: ['USER', 'ADMIN'],
+            maxStoredPages: 5
+        };
+        const props3 = {
+            editingAllowedRoles: ['USER', 'ADMIN'],
+            maxStoredPages: 5
+        };
+        const {Plugin, store} = getPluginForTest(FeatureEditor, {featuregrid});
+        ReactDOM.render(<Plugin {...props}/>, document.getElementById("container"));
+        const state = store.getState().featuregrid;
+        expect(state.virtualScroll).toBeFalsy();
+        expect(state.editingAllowedRoles).toEqual(props.editingAllowedRoles);
+        expect(state.maxStoredPages).toBe(props.maxStoredPages);
+        ReactDOM.render(<Plugin {...props2}/>, document.getElementById("container"));
+        const state2 = store.getState().featuregrid;
+        expect(state2.virtualScroll).toBeTruthy(); // the default
+        expect(state2.editingAllowedRoles).toEqual(props2.editingAllowedRoles); // changed
+        expect(state2.maxStoredPages).toBe(props2.maxStoredPages);
+        ReactDOM.render(<Plugin {...props3}/>, document.getElementById("container"));
+        const state3 = store.getState().featuregrid;
+        expect(state2.editingAllowedRoles === state3.editingAllowedRoles).toBeTruthy(); // no double call
+    });
 });


### PR DESCRIPTION
[Backport 2021.02.xx] #7649 Set proper trigger for useEffect on plugin initialization (#7650) 

- in draft awaiting for test on dev #7649