### PR TITLE
Issue #7712 - Redux devtools chrome extension upgrade to v3.0.0 won't work in MS2

### DIFF
--- a/web/client/components/development/Debug.jsx
+++ b/web/client/components/development/Debug.jsx
@@ -17,7 +17,7 @@ const urlQuery = url.parse(window.location.href, true).query;
 
 class Debug extends React.Component {
     render() {
-        if (urlQuery && urlQuery.debug && __DEVTOOLS__ && !window.devToolsExtension) {
+        if (urlQuery && urlQuery.debug && __DEVTOOLS__ && !window.__REDUX_DEVTOOLS_EXTENSION__) {
             const DevTools = require('./DevTools').default;
             return (
                 <DevTools/>

--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -164,9 +164,9 @@ export const createStore = ({
     const epic = rootEpic || combineEpics(...wrapEpics(epics));
     const allMiddlewares = epic ? [persistMiddleware(createEpicMiddleware(epic)), ...middlewares] : middlewares;
     const middleware = applyMiddleware.apply(null, getMiddlewares(allMiddlewares, debug));
-    const finalCreateStore = (window.devToolsExtension && debug ? compose(
+    const finalCreateStore = (window.__REDUX_DEVTOOLS_EXTENSION__ && debug ? compose(
         middleware,
-        window.devToolsExtension()
+        window.__REDUX_DEVTOOLS_EXTENSION__()
     ) : middleware)(createReduxStore);
     return setStore(finalCreateStore(reducer, state, enhancer));
 };


### PR DESCRIPTION
Applies changes to Debug.jsx and StateUtils.js replacing `window.devToolsExtension` (deprecated)
with `window.__REDUX_DEVTOOLS_EXTENSION__`

## Description
This PR solves a bug for a breaking change in the Redux Devtools upgrade to v3.0.0
deprecating the `window.devToolsExtension` variable in the store creation 


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Run MS2 in a local dev server with npm start.
On Chrome Go to http://localhost:8081/?debug=true.
Observe the redux Devtools icon is disabled and an error message will appear in the console.
#7712 

**What is the new behavior?**
Run MS2 in a local dev server with npm start.
On Chrome Go to http://localhost:8081/?debug=true.
Observe the redux Devtools icon is now enabled and it is possible to debug the Redux store/workflow.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
