### PR TITLE
#7717 Contexts tab on home page

### DIFF
--- a/web/client/actions/contexts.js
+++ b/web/client/actions/contexts.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const SET_CONTEXTS_AVAILABLE = "CONTEXTS:SET_CONTEXTS_AVAILABLE";
+export const SEARCH_CONTEXTS = "CONTEXTS:SEARCH_CONTEXTS";
+export const CONTEXTS_LIST_LOADED = "CONTEXTS:CONTEXTS_LIST_LOADED";
+export const DELETE_CONTEXT = "CONTEXTS:DELETE_CONTEXT";
+export const CONTEXT_DELETED = "CONTEXTS:CONTEXT_DELETED";
+export const RELOAD_CONTEXTS = "CONTEXTS:RELOAD_CONTEXTS";
+export const LOADING = "CONTEXTS:LOADING";
+
+
+export const setContextsAvailable = (available = true) => ({ type: SET_CONTEXTS_AVAILABLE, available });
+export const searchContexts = (searchText, params) => ({ type: SEARCH_CONTEXTS, searchText, params });
+/**
+ * @param {boolean} value the value of the flag
+ * @param {string} [name] the name of the flag to set. loading is anyway always triggered
+ */
+export const contextsLoading = (value, name = "loading") => ({
+    type: LOADING,
+    name,
+    value
+});
+export const contextsListLoaded = ({results, success, totalCount}, searchText, options) => ({ type: CONTEXTS_LIST_LOADED, results, success, totalCount, searchText, options });
+export const deleteContext = id => ({type: DELETE_CONTEXT, id});
+export const reloadContexts = () => ({ type: RELOAD_CONTEXTS});
+export const contextDeleted = id => ({type: CONTEXT_DELETED, id});

--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -15,7 +15,10 @@ import Message from '../../components/I18N/Message';
 import ConfirmModal from '../../components/misc/ResizableModal';
 import { get, pick } from "lodash";
 import ConfigUtils from "../../utils/ConfigUtils";
-
+export const getPath = () => {
+    const miscSettings = ConfigUtils.getConfigProp('miscSettings');
+    return get(miscSettings, ['homePath'], '/');
+};
 class Home extends React.Component {
     static propTypes = {
         icon: PropTypes.node,
@@ -87,9 +90,7 @@ class Home extends React.Component {
     }
 
     goHome = () => {
-        const miscSettings = ConfigUtils.getConfigProp('miscSettings');
-        const path = get(miscSettings, ['home', 'path'], '/');
-        this.context.router.history.push(path);
+        this.context.router.history.push(getPath());
     };
 }
 

--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -13,7 +13,8 @@ import { Glyphicon, Tooltip } from 'react-bootstrap';
 import OverlayTrigger from '../misc/OverlayTrigger';
 import Message from '../../components/I18N/Message';
 import ConfirmModal from '../../components/misc/ResizableModal';
-import {pick} from "lodash/object";
+import { get, pick } from "lodash";
+import ConfigUtils from "../../utils/ConfigUtils";
 
 class Home extends React.Component {
     static propTypes = {
@@ -86,7 +87,9 @@ class Home extends React.Component {
     }
 
     goHome = () => {
-        this.context.router.history.push("/");
+        const miscSettings = ConfigUtils.getConfigProp('miscSettings');
+        const path = get(miscSettings, ['home', 'path'], '/');
+        this.context.router.history.push(path);
     };
 }
 

--- a/web/client/components/resources/ResourceCard.jsx
+++ b/web/client/components/resources/ResourceCard.jsx
@@ -14,6 +14,7 @@ import FitIcon from '../misc/FitIcon';
 import thumbUrl from '../maps/style/default.jpg';
 import assign from 'object-assign';
 import ConfirmModal from '../misc/ResizableModal';
+import { isFunction } from "lodash";
 
 class ResourceCard extends React.Component {
     static propTypes = {
@@ -22,7 +23,7 @@ class ResourceCard extends React.Component {
         backgroundOpacityStart: PropTypes.number,
         backgroundOpacityEnd: PropTypes.number,
         resource: PropTypes.object,
-        editDataEnabled: PropTypes.bool,
+        editDataEnabled: PropTypes.oneOfType(PropTypes.bool, PropTypes.func),
         shareToolEnabled: PropTypes.bool,
         // CALLBACKS
         viewerUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -104,6 +105,7 @@ class ResourceCard extends React.Component {
 
     render() {
         const isFeatured = this.props.resource && (this.props.resource.featured === 'true' || this.props.resource.featured === 'added');
+        const editDataEnabled = isFunction(this.props.editDataEnabled) ? this.props.editDataEnabled(this.props.resource) : this.props.editDataEnabled;
         const availableAction = [
             {
                 visible: this.props.resource.canEdit === true,
@@ -117,7 +119,7 @@ class ResourceCard extends React.Component {
                 }
             },
             {
-                visible: this.props.resource.canEdit === true && this.props.editDataEnabled === true,
+                visible: this.props.resource.canEdit === true && editDataEnabled === true,
                 glyph: 'pencil',
                 disabled: this.props.resource.updating,
                 loading: this.props.resource.updating,

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -59,11 +59,6 @@
       "enabled": true
     },
     "projectionDefs": [],
-    "miscSettings": {
-      "home": {
-        "path": "/"
-      }
-    },
     "initialState": {
       "defaultState": {
         "annotations": {
@@ -635,16 +630,6 @@
           },
           {
             "name": "GeoStories",
-            "cfg": {
-              "mapsOptions": {
-                "start": 0,
-                "limit": 12
-              },
-              "fluid": true
-            }
-          },
-          {
-            "name": "Contexts",
             "cfg": {
               "mapsOptions": {
                 "start": 0,

--- a/web/client/configs/localConfig.json
+++ b/web/client/configs/localConfig.json
@@ -59,6 +59,11 @@
       "enabled": true
     },
     "projectionDefs": [],
+    "miscSettings": {
+      "home": {
+        "path": "/"
+      }
+    },
     "initialState": {
       "defaultState": {
         "annotations": {

--- a/web/client/epics/__tests__/contenttabs-test.js
+++ b/web/client/epics/__tests__/contenttabs-test.js
@@ -13,6 +13,7 @@ import { MAPS_LOAD_MAP, MAPS_LIST_LOADED } from '../../actions/maps';
 import { DASHBOARDS_LIST_LOADED } from '../../actions/dashboards';
 import { GEOSTORIES_LIST_LOADED } from '../../actions/geostories';
 import { updateMapsDashboardTabs } from '../contenttabs';
+import {CONTEXTS_LIST_LOADED} from "../../actions/contextmanager";
 
 describe('Test Maps Dashboard Content Tabs', () => {
     it('test updateMapsDashboardTabs flow ', done => {
@@ -20,7 +21,8 @@ describe('Test Maps Dashboard Content Tabs', () => {
             {type: MAPS_LOAD_MAP},
             {type: MAPS_LIST_LOADED, maps: {totalCount: 0}},
             {type: DASHBOARDS_LIST_LOADED, totalCount: 1},
-            {type: GEOSTORIES_LIST_LOADED, totalCount: 2}
+            {type: GEOSTORIES_LIST_LOADED, totalCount: 2},
+            {type: CONTEXTS_LIST_LOADED, totalCount: 1}
         ];
         testEpic(updateMapsDashboardTabs, 1, act, (res) => {
             const action = res[0];

--- a/web/client/epics/__tests__/contextmanager-test.js
+++ b/web/client/epics/__tests__/contextmanager-test.js
@@ -12,8 +12,8 @@ import { testEpic } from './epicTestUtils';
 import ConfigUtils from '../../utils/ConfigUtils';
 
 import {
-    searchContextsEpic,
-    reloadOnContexts,
+    contextManagerSearchContextsEpic,
+    contextManagerReloadOnContexts,
     editContext as editContextEpic
 } from '../contextmanager';
 
@@ -50,7 +50,7 @@ describe('contextmanager epics', () => {
         });
 
         const startActions = [searchContexts("Search Text")];
-        testEpic(searchContextsEpic, 3, startActions, actions => {
+        testEpic(contextManagerSearchContextsEpic, 3, startActions, actions => {
             expect(actions.length).toBe(3);
             expect(actions[0].type).toBe(LOADING);
             expect(actions[0].name).toBe("loading");
@@ -65,7 +65,7 @@ describe('contextmanager epics', () => {
     });
     it('reload on contextSaved', (done) => {
         const startActions = [contextSaved("Search Text")];
-        testEpic(reloadOnContexts, 1, startActions, ([a]) => {
+        testEpic(contextManagerReloadOnContexts, 1, startActions, ([a]) => {
             expect(a.type).toBe(SEARCH_CONTEXTS);
             expect(a.options).toExist();
             expect(a.options.params).toExist();
@@ -92,7 +92,7 @@ describe('contextmanager epics', () => {
         });
 
         const startActions = [searchContexts("Search Text")];
-        testEpic(searchContextsEpic, 3, startActions, actions => {
+        testEpic(contextManagerSearchContextsEpic, 3, startActions, actions => {
             expect(actions.length).toBe(3);
             expect(actions[0].type).toBe(LOADING);
             expect(actions[0].name).toBe("loading");

--- a/web/client/epics/contenttabs.js
+++ b/web/client/epics/contenttabs.js
@@ -12,15 +12,20 @@ import { keys, findIndex, difference } from 'lodash';
 import { MAPS_LOAD_MAP, MAPS_LIST_LOADED } from '../actions/maps';
 import { DASHBOARDS_LIST_LOADED } from '../actions/dashboards';
 import { GEOSTORIES_LIST_LOADED } from '../actions/geostories';
+import { CONTEXTS_LIST_LOADED } from "../actions/contextmanager";
 import { onTabSelected, SET_TABS_HIDDEN } from '../actions/contenttabs';
 /**
-* Update Maps, Dashboards and Geostories counts to select contenttabs each tab has to have a key in its ContentTab configuration
-* @param {object} action
-*/
+ * Update Maps, Dashboards and Geostories counts to select contenttabs each tab has to have a key in its ContentTab configuration
+ * @param {object} action
+ */
 export const updateMapsDashboardTabs = (action$, {getState = () => {}}) =>
     action$.ofType(MAPS_LOAD_MAP)
         .switchMap(() => {
-            return Rx.Observable.forkJoin(action$.ofType(MAPS_LIST_LOADED).take(1), action$.ofType(DASHBOARDS_LIST_LOADED).take(1), action$.ofType(GEOSTORIES_LIST_LOADED).take(1))
+            return Rx.Observable.forkJoin(
+                action$.ofType(MAPS_LIST_LOADED).take(1),
+                action$.ofType(DASHBOARDS_LIST_LOADED).take(1),
+                action$.ofType(GEOSTORIES_LIST_LOADED).take(1),
+                action$.ofType(CONTEXTS_LIST_LOADED).take(1))
                 .switchMap((r) => {
                     const results = {maps: r[0].maps, dashboards: r[1], geostories: r[2]};
                     const {contenttabs = {}} = getState() || {};
@@ -44,7 +49,7 @@ export const updateSelectedOnHiddenTabs = (action$, store) =>
             const hiddenKeys = keys(hiddenTabs).filter(key => !!hiddenTabs[key]);
 
             return findIndex(hiddenKeys, key => key === selected) > -1 ?
-                Rx.Observable.of(onTabSelected(difference(['dashboards', 'geostories', 'maps'], hiddenKeys)[0])) :
+                Rx.Observable.of(onTabSelected(difference(['dashboards', 'geostories', 'maps', 'contexts'], hiddenKeys)[0])) :
                 Rx.Observable.empty();
         });
 

--- a/web/client/epics/contextmanager.js
+++ b/web/client/epics/contextmanager.js
@@ -38,7 +38,7 @@ const calculateNewParams = state => {
     };
 };
 
-export const searchContextsEpic = action$ => action$
+export const contextManagerSearchContextsEpic = action$ => action$
     .ofType(SEARCH_CONTEXTS)
     .map(({text, options}) => ({
         text,
@@ -69,7 +69,7 @@ export const editContext = action$ => action$
         Rx.Observable.empty()
     );
 
-export const deleteContextEpic = action$ => action$
+export const contextManagerDeleteContextEpic = action$ => action$
     .ofType(DELETE_CONTEXT)
     .switchMap(id => deleteResource(id).map(() => contextDeleted(id)))
     .let(wrapStartStop(
@@ -87,7 +87,7 @@ export const resetContextSearch = action$ => action$
     .ofType(SEARCH_RESET)
     .switchMap(() => Rx.Observable.of(searchContexts('', {params: {start: 0, limit: 12}})));
 
-export const reloadOnContexts = (action$, store) => action$
+export const contextManagerReloadOnContexts = (action$, store) => action$
     .ofType(CONTEXT_DELETED, RELOAD_CONTEXTS, ATTRIBUTE_UPDATED, CONTEXT_SAVED)
     .delay(1000)
     .switchMap(() => Rx.Observable.of(searchContexts(

--- a/web/client/epics/contexts.js
+++ b/web/client/epics/contexts.js
@@ -5,11 +5,88 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import Rx from 'rxjs';
+import GeoStoreApi from '../api/GeoStoreDAO';
+import {wrapStartStop} from '../observables/epics';
+import {error} from '../actions/notifications';
 
-import Rx from "rxjs";
-import {MAPS_LIST_LOADING} from "../actions/maps";
-import {searchContexts} from "../actions/contextmanager";
+import {ATTRIBUTE_UPDATED, MAPS_LIST_LOADING} from '../actions/maps';
 
-export const searchContextsOnMapSearch = action$ =>
-    action$.ofType(MAPS_LIST_LOADING)
-        .switchMap(({ searchText }) => Rx.Observable.of(searchContexts(searchText)));
+import {
+    SEARCH_CONTEXTS,
+    CONTEXT_DELETED,
+    RELOAD_CONTEXTS,
+    SET_CONTEXTS_AVAILABLE,
+    searchContexts, contextsListLoaded, contextsLoading } from "../actions/contexts";
+import {searchParamsSelector, searchOptionsSelector, searchTextSelector, totalCountSelector} from "../selectors/contexts";
+
+import {CONTEXT_SAVED} from "../actions/contextcreator";
+
+const calculateNewParams = state => {
+    const totalCount = totalCountSelector(state);
+    const searchOptions = searchOptionsSelector(state) || {};
+    const {start, limit, ...otherParams} = searchOptions.params;
+    if (start === totalCount - 1) {
+        return {
+            start: Math.max(0, start - limit),
+            limit
+        };
+    }
+    return {
+        ...searchOptions,
+        params: {
+            ...otherParams,
+            start,
+            limit
+        }
+    };
+};
+
+export const searchContextsOnMapSearch = (action$, store) =>
+    action$.ofType(MAPS_LIST_LOADING, SET_CONTEXTS_AVAILABLE)
+        .switchMap(({ searchText }) => {
+            const state = store.getState();
+            if (state.contexts.available) {
+                return Rx.Observable.of(searchContexts(searchText));
+            }
+            return Rx.Observable.empty();
+        });
+
+export const searchContextsEpic = (action$, { getState = () => { } }) => action$
+    .ofType(SEARCH_CONTEXTS)
+    .map( ({params, searchText, geoStoreUrl}) => ({
+        searchText,
+        options: {
+            params: params || searchParamsSelector(getState()) || {start: 0, limit: 12},
+            ...(geoStoreUrl ? { baseURL: geoStoreUrl } : {})
+        }
+    }))
+    .switchMap(
+        ({ searchText, options }) =>
+            Rx.Observable.defer(() => GeoStoreApi.getResourcesByCategory("CONTEXT", searchText, options))
+                .map(results => contextsListLoaded(results, searchText, options))
+                .let(wrapStartStop(
+                    contextsLoading(true, "loading"),
+                    contextsLoading(false, "loading"),
+                    () => Rx.Observable.of(error({
+                        title: "notification.error",
+                        message: "resources.contexts.errorLoadingContexts",
+                        autoDismiss: 6,
+                        position: "tc"
+                    }))
+                ))
+    );
+
+export const reloadOnContexts = (action$, store) => action$
+    .ofType(CONTEXT_DELETED, RELOAD_CONTEXTS, ATTRIBUTE_UPDATED, CONTEXT_SAVED)
+    .delay(1000)
+    .switchMap(() => {
+        const state = store.getState();
+        if (state.contexts.available) {
+            return Rx.Observable.of(searchContexts(
+                searchTextSelector(store.getState()),
+                calculateNewParams(store.getState())
+            ));
+        }
+        return Rx.Observable.empty();
+    });

--- a/web/client/epics/contexts.js
+++ b/web/client/epics/contexts.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Rx from "rxjs";
+import {MAPS_LIST_LOADING} from "../actions/maps";
+import {searchContexts} from "../actions/contextmanager";
+
+export const searchContextsOnMapSearch = action$ =>
+    action$.ofType(MAPS_LIST_LOADING)
+        .switchMap(({ searchText }) => Rx.Observable.of(searchContexts(searchText)));

--- a/web/client/epics/maps.js
+++ b/web/client/epics/maps.js
@@ -200,10 +200,12 @@ export const hideTabsOnSearchFilterChange = (action$) =>
             setTabsHidden(
                 (filterData || []).length === 0 ? {
                     geostories: false,
-                    dashboards: false
+                    dashboards: false,
+                    contexts: false
                 } : {
                     geostories: true,
-                    dashboards: true
+                    dashboards: true,
+                    contexts: true
                 }
             )
         ));

--- a/web/client/plugins/Contexts.jsx
+++ b/web/client/plugins/Contexts.jsx
@@ -1,0 +1,190 @@
+/*
+* Copyright 2022, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import { compose } from 'recompose';
+import {createSelector} from 'reselect';
+
+import Message from "../components/I18N/Message";
+
+import {createPlugin} from '../utils/PluginsUtils';
+import { userRoleSelector } from '../selectors/security';
+import { versionSelector } from '../selectors/version';
+import { totalCountSelector, searchTextSelector, searchOptionsSelector, resultsSelector, isLoadingSelector } from '../selectors/contextmanager';
+import { searchContexts, searchTextChanged, editContext, searchReset } from '../actions/contextmanager';
+import PaginationToolbar from '../plugins/contextmanager/PaginationToolbar';
+import ContextGrid from './contexts/ContextsGrid';
+
+import { mapTypeSelector } from '../selectors/maptype';
+import { isFeaturedMapsEnabled } from '../selectors/featuredmaps';
+import emptyState from '../components/misc/enhancers/emptyState';
+
+import EmptyMaps from '../plugins/maps/EmptyMaps';
+
+import { loadMaps } from '../actions/maps';
+
+import * as contextManagerEpics from '../epics/contextmanager';
+import * as contextsEpics from '../epics/contexts';
+import contextmanager from '../reducers/contextmanager';
+
+
+const contextsCountSelector = createSelector(
+    totalCountSelector,
+    count => ({ count })
+);
+
+class Contexts extends React.Component {
+    static propTypes = {
+        className: PropTypes.string,
+        splitTools: PropTypes.bool,
+        showOptions: PropTypes.bool,
+        searchOptions: PropTypes.object,
+        isSearchClickable: PropTypes.bool,
+        hideOnBlur: PropTypes.bool,
+        placeholderMsgId: PropTypes.string,
+        typeAhead: PropTypes.bool,
+        searchText: PropTypes.string,
+        onSearch: PropTypes.func,
+        onSearchReset: PropTypes.func,
+        onSearchTextChange: PropTypes.func,
+        onEditData: PropTypes.func,
+        resources: PropTypes.array,
+        colProps: PropTypes.object,
+        fluid: PropTypes.bool,
+        title: PropTypes.string,
+        editDataEnabled: PropTypes.bool
+    };
+
+    static contextTypes = {
+        router: PropTypes.object
+    };
+
+    static defaultProps = {
+        className: "user-search",
+        hideOnBlur: false,
+        isSearchClickable: true,
+        showOptions: false,
+        splitTools: false,
+        placeholderMsgId: "contextManager.searchPlaceholder",
+        typeAhead: false,
+        searchText: "",
+        searchOptions: {
+            params: {
+                start: 0,
+                limit: 12
+            }
+        },
+        resources: [],
+        colProps: {
+            xs: 12,
+            sm: 6,
+            lg: 3,
+            md: 4,
+            className: 'ms-map-card-col'
+        },
+        fluid: true,
+        editDataEnabled: true,
+        onSearch: () => {},
+        onSearchReset: () => {},
+        onSearchTextChange: () => {},
+        onEditData: () => {}
+    };
+
+    render() {
+        return (<ContextGrid
+            resources={this.props.resources}
+            fluid={this.props.fluid}
+            title={this.props.title}
+            colProps={this.props.colProps}
+            viewerUrl={(context) => this.context.router.history.push(`/context/${context.name}`)}
+            getShareUrl={(context) => `context/${context.name}`}
+            editDataEnabled={this.props.editDataEnabled}
+            onEditData={this.props.onEditData}
+            nameFieldFilter={name => name.replace(/[^a-zA-Z0-9\-_]/, '')}
+            cardTooltips={{
+                deleteResource: "resources.resource.deleteResource",
+                editResource: "resources.resource.editResource",
+                editResourceData: "contextManager.editContextTooltip",
+                shareResource: "share.title",
+                addToFeatured: "resources.resource.addToFeatured",
+                showDetails: "resources.resource.showDetails",
+                removeFromFeatured: "resources.resource.removeFromFeatured"
+            }}
+            bottom={<PaginationToolbar/>} />
+        );
+    }
+}
+
+const contextsPluginSelector = createSelector([
+    mapTypeSelector,
+    searchTextSelector,
+    searchOptionsSelector,
+    resultsSelector,
+    isLoadingSelector,
+    isFeaturedMapsEnabled,
+    userRoleSelector,
+    versionSelector
+], (mapType, searchText, searchOptions, resources = [], loading, featuredEnabled, role, version) => ({
+    mapType,
+    searchText,
+    version,
+    resources: resources.map(resource => ({...resource, featuredEnabled: featuredEnabled && role === 'ADMIN'})),
+    loading
+}));
+
+const ContextsPlugin = compose(
+    connect(contextsPluginSelector, {
+        loadMaps
+    }),
+    emptyState(
+        ({resources = [], loading}) => !loading && resources.length === 0,
+        ({showCreateButton = false}) => ({
+            glyph: "wrench",
+            title: <Message msgId="resources.contexts.noContextAvailable" />,
+            content: <EmptyMaps showCreateButton={showCreateButton} />
+        })
+    )
+)(Contexts);
+
+/**
+ * Plugin for context resources browsing.
+ * Can be rendered inside {@link #plugins.ContentTabs|ContentTabs} plugin
+ * @name Maps
+ * @memberof plugins
+ * @class
+ * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
+ */
+
+export default createPlugin('Contexts', {
+    component: connect(contextsPluginSelector, {
+        onSearch: searchContexts,
+        onSearchReset: searchReset,
+        onSearchTextChange: searchTextChanged,
+        onEditData: editContext
+    })(ContextsPlugin),
+    containers: {
+        ContentTabs: {
+            name: 'contexts',
+            key: 'contexts',
+            TitleComponent:
+                connect(contextsCountSelector)(({ count = "" }) => <Message msgId="resources.contexts.title" msgParams={{ count: count + "" }} />),
+            position: 4,
+            tool: true,
+            priority: 1
+        }
+    },
+    reducers: {
+        contextmanager
+    },
+    epics: {
+        ...contextManagerEpics,
+        ...contextsEpics
+    }
+});

--- a/web/client/plugins/Contexts.jsx
+++ b/web/client/plugins/Contexts.jsx
@@ -83,6 +83,7 @@ class Contexts extends React.Component {
         showOptions: false,
         splitTools: false,
         placeholderMsgId: "contextManager.searchPlaceholder",
+        title: <h3><Message msgId="resources.contexts.titleNoCount" /></h3>,
         typeAhead: false,
         searchText: "",
         searchOptions: {

--- a/web/client/plugins/Home.jsx
+++ b/web/client/plugins/Home.jsx
@@ -13,7 +13,7 @@ import { goToPage } from '../actions/router';
 import { comparePendingChanges } from '../epics/pendingChanges';
 import Message from './locale/Message';
 import { Glyphicon } from 'react-bootstrap';
-import Home from '../components/home/Home';
+import Home, {getPath} from '../components/home/Home';
 import { connect } from 'react-redux';
 import { checkPendingChanges } from '../actions/pendingChanges';
 import { setControlProperty } from '../actions/controls';
@@ -42,8 +42,8 @@ const HomeConnected = connect((state) => ({
 /**
  * Renders a button that redirects to the home page.
  * It can be rendered in {@link #plugins.OmniBar|OmniBar}.
- * Supports as containers, lower priority, also {@link #plugins.BurgerMenu|BurgerMenu}
- * or {@link #plugins.Toolbar|Toolbar}.
+ * Supports as containers at lower priority {@link #plugins.Toolbar|Toolbar}.
+ * You can configure the home target path globally by setting `miscSettings.homePath` in `localConfig.json`. By default it redirects to `"#/"`;
  * @name Home
  * @class
  * @memberof plugins
@@ -56,7 +56,7 @@ export default {
             tooltip: "gohome",
             icon: <Glyphicon glyph="home"/>,
             help: <Message msgId="helptexts.gohome"/>,
-            action: (context) => goToPage('/', context.router),
+            action: (context) => goToPage(getPath(), context.router),
             priority: 1
         },
         BurgerMenu: {
@@ -64,14 +64,13 @@ export default {
             position: 1,
             text: <Message msgId="gohome"/>,
             icon: <Glyphicon glyph="home"/>,
-            action: (context) => goToPage('/', context.router),
+            action: (context) => goToPage(getPath(), context.router),
             priority: 2
         },
         OmniBar: {
             name: 'home',
             position: 4,
             tool: true,
-            action: (context) => goToPage('/', context.router),
             priority: 3
         }
     }),

--- a/web/client/plugins/contextmanager/ContextGrid.jsx
+++ b/web/client/plugins/contextmanager/ContextGrid.jsx
@@ -21,6 +21,9 @@ const Grid = compose(
             if (props.invalidateFeaturedMaps) {
                 props.invalidateFeaturedMaps();
             }
+            if (props.onShowSuccessNotification) {
+                props.onShowSuccessNotification();
+            }
         }
     }),
     defaultProps({

--- a/web/client/plugins/contexts/ContextsGrid.jsx
+++ b/web/client/plugins/contexts/ContextsGrid.jsx
@@ -13,17 +13,21 @@ import { compose } from 'recompose';
 import ContextGridComponent from '../contextmanager/ContextGrid';
 
 import { userSelector } from '../../selectors/security';
-import { deleteContext, reloadContexts} from '../../actions/contextmanager';
-import { updateAttribute } from '../../actions/maps';
+import {deleteContext, editContext, reloadContexts} from '../../actions/contextmanager';
+import {invalidateFeaturedMaps, updateAttribute} from '../../actions/maps';
+import {success} from "../../actions/notifications";
 
 
 const Grid = compose(
     connect(createStructuredSelector({
         user: userSelector
     }), {
+        onEditData: editContext,
         onDelete: deleteContext,
+        onUpdateAttribute: updateAttribute,
         reloadContexts,
-        onUpdateAttribute: updateAttribute
+        invalidateFeaturedMaps,
+        onShowSuccessNotification: () => success({ title: "success", message: "resources.successSaved" })
     })
 )(ContextGridComponent);
 

--- a/web/client/plugins/contexts/ContextsGrid.jsx
+++ b/web/client/plugins/contexts/ContextsGrid.jsx
@@ -1,0 +1,30 @@
+/*
+* Copyright 2022, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
+import { compose } from 'recompose';
+
+import ContextGridComponent from '../contextmanager/ContextGrid';
+
+import { userSelector } from '../../selectors/security';
+import { deleteContext, reloadContexts} from '../../actions/contextmanager';
+import { updateAttribute } from '../../actions/maps';
+
+
+const Grid = compose(
+    connect(createStructuredSelector({
+        user: userSelector
+    }), {
+        onDelete: deleteContext,
+        reloadContexts,
+        onUpdateAttribute: updateAttribute
+    })
+)(ContextGridComponent);
+
+export default Grid;

--- a/web/client/plugins/contexts/PaginationToolbar.jsx
+++ b/web/client/plugins/contexts/PaginationToolbar.jsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { connect } from 'react-redux';
+import { compose, renameProp, withHandlers } from 'recompose';
+import { createSelector } from 'reselect';
+
+import { searchContexts } from '../../actions/contexts';
+import PaginationToolbarComp from '../../components/misc/PaginationToolbar';
+import {
+    isLoadingSelector,
+    resultsSelector,
+    searchParamsSelector,
+    searchTextSelector,
+    totalCountSelector
+} from '../../selectors/contexts';
+
+const PaginationToolbar = compose(
+    connect(
+        createSelector(
+            searchTextSelector,
+            searchParamsSelector,
+            resultsSelector,
+            totalCountSelector,
+            isLoadingSelector,
+            () => false, // TODO: loading
+            (searchText, { start = 0, limit = 12 } = {}, results, totalCount, loading) => {
+                const total = Math.min(totalCount || 0, limit || 0);
+                const page = results && total && Math.ceil(start / total) || 0;
+                return {
+                    page: page,
+                    pageSize: limit,
+                    items: results,
+                    total: totalCount,
+                    searchText,
+                    loading
+                };
+            }
+        ),
+        {
+            searchContexts
+        }
+    ),
+    renameProp('searchContexts', 'loadPage'),
+    withHandlers({
+        onSelect: ({ loadPage = () => { }, searchText, pageSize }) => (pageNumber) => {
+            let start = pageSize * pageNumber;
+            let limit = pageSize;
+            loadPage(searchText, { start, limit });
+        }
+    })
+)(PaginationToolbarComp);
+export default PaginationToolbar;

--- a/web/client/product/assets/css/viewer.css
+++ b/web/client/product/assets/css/viewer.css
@@ -29,6 +29,9 @@ html, body, #container, .fill {
 #home-button {
     float: left;
 }
+#navigationBar #home-button {
+    float: none;
+}
 
 .leaflet-control-attribution > a:first-child{
     display: none;

--- a/web/client/product/plugins.js
+++ b/web/client/product/plugins.js
@@ -33,6 +33,7 @@ export default {
         ContextPlugin: require('../plugins/Context').default,
         ContextCreatorPlugin: require('../plugins/ContextCreator').default,
         ContextManagerPlugin: require('../plugins/contextmanager/ContextManager').default,
+        ContextsPlugin: require('../plugins/Contexts').default,
         CookiePlugin: require('../plugins/Cookie').default,
         CreateNewMapPlugin: require('../plugins/CreateNewMap').default,
         Dashboard: require('../plugins/Dashboard').default,

--- a/web/client/reducers/contexts.js
+++ b/web/client/reducers/contexts.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { MAPS_LIST_LOADING } from '../actions/maps';
+
+import { LOCATION_CHANGE } from 'connected-react-router';
+import { CONTEXTS_LIST_LOADED, SET_CONTEXTS_AVAILABLE, LOADING } from '../actions/contexts';
+import { set } from '../utils/ImmutableUtils';
+import { castArray } from 'lodash';
+
+function contexts(state = {
+    enabled: false,
+    start: 0,
+    limit: 12,
+    errors: [],
+    searchText: "",
+    available: false
+}, action) {
+    switch (action.type) {
+    case SET_CONTEXTS_AVAILABLE: {
+        return set("available", action.available, state);
+    }
+    case LOCATION_CHANGE: {
+        return set('showModal', {}, state);
+    }
+    case CONTEXTS_LIST_LOADED:
+        return {
+            ...state,
+            results: action.results !== "" ? castArray(action.results) : [],
+            success: action.success,
+            totalCount: action.totalCount,
+            start: action.params && action.params.start,
+            limit: action.params && action.params.limit,
+            searchText: action.searchText,
+            options: action.options
+        };
+    case MAPS_LIST_LOADING:
+        return {
+            ...state,
+            start: action.params && action.params.start,
+            limit: action.params && action.params.limit,
+            searchText: action.searchText
+        };
+    case LOADING:
+        // anyway sets loading to true
+        return set(action.name === "loading" ? "loading" : `loadFlags.${action.name}`, action.value, set(
+            "loading", action.value, state
+        ));
+    default:
+        return state;
+    }
+}
+
+export default contexts;

--- a/web/client/selectors/contexts.js
+++ b/web/client/selectors/contexts.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { createSelector } from 'reselect';
+
+export const searchTextSelector = state => state && state.contexts && state.contexts.searchText;
+export const searchOptionsSelector = state => state && state.contexts && state.contexts.options;
+export const searchParamsSelector = createSelector(searchOptionsSelector, options => options && options.params);
+export const resultsSelector = state => state && state.contexts && state.contexts.results;
+export const totalCountSelector = state => state && state.contexts && state.contexts.totalCount;
+export const isLoadingSelector = state => state && state.contexts && state.contexts.loading;
+export const isAvailableSelector = state => state && state.contexts && state.contexts.available;

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -437,6 +437,7 @@
             },
             "contexts": {
               "title": "Kontexte ({count})",
+              "titleNoCount": "Kontexte",
               "noContextAvailable": "Kein Kontext verfügbar"
             }
         },

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -434,6 +434,10 @@
                 "createANewOne": "Erstelle eine neue",
                 "deleteError": "Beim Löschen der GeoStory ist ein Fehler aufgetreten",
                 "errorLoadingGeostories": "Beim Laden von GeoStories ist ein Fehler aufgetreten"
+            },
+            "contexts": {
+              "title": "Kontexte ({count})",
+              "noContextAvailable": "Kein Kontext verfügbar"
             }
         },
         "map": {

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -396,6 +396,10 @@
                 "createANewOne": "Create a new one",
                 "deleteError": "There was an error deleting the GeoStory",
                 "errorLoadingGeostories": "There was an error loading GeoStories"
+            },
+            "contexts": {
+              "title": "Contexts ({count})",
+              "noContextAvailable": "No context available"
             }
         },
         "map": {
@@ -1784,7 +1788,7 @@
                         "classValue": "Class Value",
                         "color": "Color",
                         "classificationAttribute": "Classification Attribute",
-                        "customLabels": "Custom Labels",                        
+                        "customLabels": "Custom Labels",
                         "customLabelsExample": "<div><p><code>${legendValue}</code> can be used as placeholder to replace the legend original value.</p><p>legend items with the same text content will be grouped in the chart.</p><h5>Example</h5><dl><dt><b>Attribute:</b></dt><dd>POPULATION</dd><dt><b>Class Label:</b></dt><dd><code>${legendValue}</code> California</dd><dt><b>Result:</b></dt><dd>POPULATION California</dd></dl></div>",
                         "defaultClassLabel": "Default Class Label",
                         "defaultColorRamp": "Default Color Ramp",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -399,6 +399,7 @@
             },
             "contexts": {
               "title": "Contexts ({count})",
+              "titleNoCount": "Contexts",
               "noContextAvailable": "No context available"
             }
         },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -396,6 +396,10 @@
                 "createANewOne": "Crea una nueva GeoStory",
                 "deleteError": "Hubo un error al eliminar GeoStory",
                 "errorLoadingGeostories": "Hubo un error al cargar GeoStories"
+            },
+            "contexts": {
+              "title": "Contextos ({count})",
+              "noContextAvailable": "Sin contexto disponible"
             }
         },
         "map": {

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -399,6 +399,7 @@
             },
             "contexts": {
               "title": "Contextos ({count})",
+              "titleNoCount": "Contextos",
               "noContextAvailable": "Sin contexto disponible"
             }
         },

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -396,6 +396,10 @@
                 "createANewOne": "Créer une nouvelle GeoStory",
                 "deleteError": "Une erreur s'est produite lors de la suppression du GeoStory",
                 "errorLoadingGeostories": "Une erreur s'est produite lors du chargement de GeoStories"
+            },
+            "contexts": {
+              "title": "Contextes ({count})",
+              "noContextAvailable": "Aucun contexte disponible"
             }
         },
         "map": {

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -399,6 +399,7 @@
             },
             "contexts": {
               "title": "Contextes ({count})",
+              "titleNoCount": "Contextes",
               "noContextAvailable": "Aucun contexte disponible"
             }
         },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -399,6 +399,7 @@
             },
             "contexts": {
               "title": "Contesti ({count})",
+              "titleNoCount": "Contesti",
               "noContextAvailable": "Nessun contesto disponibile"
             }
         },

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -396,6 +396,10 @@
                 "createANewOne": "Crea una nuova GeoStory",
                 "deleteError": "Si è verificato un errore durante l'eliminazione della GeoStory",
                 "errorLoadingGeostories": "Si è verificato un errore durante il caricamento di GeoStories"
+            },
+            "contexts": {
+              "title": "Contesti ({count})",
+              "noContextAvailable": "Nessun contesto disponibile"
             }
         },
         "map": {


### PR DESCRIPTION
## Description
Ported geOrchestra changes that allows user to add contexts tab to the home page, customize Home path, patch ResourcesCard component on home page to support conditional display of available tools (used to display custom tools for contexts if it's in featured list)

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7717 

**What is the new behavior?**
Users have opportunity to activate "Contexts" plugin on home page in order to list contexts in addition to Maps, Geostories and Dashboards.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
![image](https://user-images.githubusercontent.com/4226620/148937657-09793126-86f4-46e4-8c00-db2d470abc55.png)
