### PR TITLE
#7671, #6534: Adopt MD5 hash of the style body for a consistent management of visual / code style editor

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -87,6 +87,23 @@ WEB-INF/lib/spring-tx-5.2.15*.jar
 ### Upgrading CesiumJS
 CesiumJS has been upgraded to version 1.42 (from 1.17), with no breaking changes, so you should replace all the instances of  `https://cesium.com/downloads/cesiumjs/releases/1.17` in your projects HTML files with `https://cesium.com/downloads/cesiumjs/releases/1.42`. The new release is needed to implement Bearer based authentication to WMS services.
 
+### Style parsers dynamic import
+
+The style parser libraries introduced a dynamic import to reduce the initial bundle size. This change reflects to the `getStyleParser` function provided by the VectorStyleUtils module. If a downstream project of MapStore is using `getStyleParser` it should update it to this new version:
+
+```diff
+// example
+
+- // old use of parser
+- const parser = getStyleParser('sld');
+
++ // new use of parser
++ getStyleParser('sld')
++     .then((parser) => {
++         // use parser
++     });
+```
+
 ## Migration from 2021.02.00 to 2021.02.01
 
 This update contains a fix for a minor vulnerability found in `log4j` library.

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "leaflet.nontiledlayer": "1.0.7",
     "lodash": "4.17.21",
     "lrucache": "1.0.3",
+    "md5": "2.3.0",
     "moment": "2.21.0",
     "node-geo-distance": "1.2.0",
     "object-assign": "4.1.1",

--- a/web/client/api/geoserver/Styles.js
+++ b/web/client/api/geoserver/Styles.js
@@ -257,7 +257,12 @@ export const getStyleCodeByName = ({baseUrl: geoserverBaseUrl, styleName, option
     return axios.get(url, options)
         .then(response => {
             return response.data && response.data.style && response.data.style.name ?
-                axios.get(getStyleBaseUrl({ workspace, geoserverBaseUrl, name: response.data.style.name, format: getStyleFormatFromFilename(response.data.style.filename) })).then(({data: code}) => ({...response.data.style, code}))
+                axios.get(getStyleBaseUrl({ workspace, geoserverBaseUrl, name: response.data.style.name, format: getStyleFormatFromFilename(response.data.style.filename) }))
+                    .then(({data: code}) => ({
+                        ...response.data.style,
+                        ...(response?.data?.style?.metadata && { metadata: parseStyleMetadata(response.data.style.metadata) }),
+                        code
+                    }))
                 : null;
         });
 };

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -57,7 +57,7 @@ import {
 } from '../selectors/styleeditor';
 
 import { getSelectedLayer, layerSettingSelector } from '../selectors/layers';
-import { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts, compareStyleMetadataAndCode } from '../utils/StyleEditorUtils';
+import { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts, detectStyleCodeChanges } from '../utils/StyleEditorUtils';
 import { initialSettingsSelector, originalSettingsSelector } from '../selectors/controls';
 import { updateStyleService } from '../api/StyleEditor';
 
@@ -72,7 +72,7 @@ const getStyleCodeObservable = ({ status, styleName, baseUrl }) =>
                 styleName
             })
                 .then(style =>
-                    compareStyleMetadataAndCode(style)
+                    detectStyleCodeChanges(style)
                         .then(metadataNeedsReset => [style, metadataNeedsReset])
                         .catch(() => [style, false])
                 )

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -542,19 +542,28 @@ export const updateExternalGraphicNode = (options, parsedSLD) => {
     return { parsedCode, errorObj };
 };
 
-
-export function compareStyleMetadataAndCode({ metadata = {}, format, code } = {}) {
+/**
+ * This function detects if the style code has been changed by external style editor
+ * by comparing the parsed JSON style with the style body code via md5 hash
+ * @param  {object} style a style returned from the style api including the code
+ * @param  {string} style.code the style body
+ * @param  {string} style.format format encoding of the style: css or sld
+ * @param  {object} style.metadata the parsed metadata of the style
+ * @param  {object} style.metadata.msStyleJSON the json representation of the style used by the visual style editor
+ * @return {promise} returns a true if the metadata needs a reset
+ */
+export function detectStyleCodeChanges({ metadata = {}, format, code } = {}) {
 
     const { msStyleJSON } = metadata;
     if (!msStyleJSON) {
-        return new Promise(resolve => resolve(false));
+        return Promise.resolve(false);
     }
 
     let styleJSON;
     try {
         styleJSON = parseJSONStyle(JSON.parse(msStyleJSON));
     } catch (e) {
-        return new Promise(resolve => resolve(true));
+        return Promise.resolve(true);
     }
 
     return import('md5')
@@ -590,5 +599,5 @@ export default {
     formatJSONStyle,
     validateImageSrc,
     updateExternalGraphicNode,
-    compareStyleMetadataAndCode
+    detectStyleCodeChanges
 };

--- a/web/client/utils/StyleEditorUtils.js
+++ b/web/client/utils/StyleEditorUtils.js
@@ -549,26 +549,33 @@ export const updateExternalGraphicNode = (options, parsedSLD) => {
  * @param  {string} style.code the style body
  * @param  {string} style.format format encoding of the style: css or sld
  * @param  {object} style.metadata the parsed metadata of the style
+ * @param  {object} style.metadata.msMD5Hash latest stored hash of the style body code
  * @param  {object} style.metadata.msStyleJSON the json representation of the style used by the visual style editor
  * @return {promise} returns a true if the metadata needs a reset
  */
 export function detectStyleCodeChanges({ metadata = {}, format, code } = {}) {
 
-    const { msStyleJSON } = metadata;
-    if (!msStyleJSON) {
-        return Promise.resolve(false);
-    }
-
-    let styleJSON;
-    try {
-        styleJSON = parseJSONStyle(JSON.parse(msStyleJSON));
-    } catch (e) {
-        return Promise.resolve(true);
-    }
-
     return import('md5')
         .then((mod) => {
             const md5 = mod.default;
+            const { msStyleJSON, msMD5Hash } = metadata;
+
+            if (msMD5Hash && code) {
+                const hash = md5(code);
+                return hash !== msMD5Hash;
+            }
+
+            if (!msStyleJSON) {
+                return Promise.resolve(false);
+            }
+
+            let styleJSON;
+            try {
+                styleJSON = parseJSONStyle(JSON.parse(msStyleJSON));
+            } catch (e) {
+                return Promise.resolve(true);
+            }
+
             return getStyleParser(format)
                 .then(parser =>
                     parser

--- a/web/client/utils/VectorStyleUtils.js
+++ b/web/client/utils/VectorStyleUtils.js
@@ -338,9 +338,14 @@ export const createStylesAsync = (styles = []) => {
     });
 };
 
+/**
+ * Import a style parser based on the format
+ * @param  {string} format format encoding of the style: css, sld or openlayers
+ * @return {promise} returns the parser instance if available
+ */
 export const getStyleParser = (format = 'sld') => {
     if (!StyleParsers[format]) {
-        return new Promise(resolve => resolve(null));
+        return Promise.resolve(null);
     }
     // import parser libraries dynamically
     return StyleParsers[format]();

--- a/web/client/utils/VectorStyleUtils.js
+++ b/web/client/utils/VectorStyleUtils.js
@@ -11,11 +11,16 @@ import { isNil } from 'lodash';
 import { set } from './ImmutableUtils';
 import { colorToRgbaStr } from './ColorUtils';
 import axios from 'axios';
-import SLDParser from '@geosolutions/geostyler-sld-parser';
-import GeoCSSParser from '@geosolutions/geostyler-geocss-parser';
+
+function initParserLib(mod) {
+    const Parser = mod.default;
+    return new Parser();
+}
+
 const StyleParsers = {
-    sld: new SLDParser(),
-    css: new GeoCSSParser()
+    sld: () => import('@geosolutions/geostyler-sld-parser').then(initParserLib),
+    css: () => import('@geosolutions/geostyler-geocss-parser').then(initParserLib),
+    openlayers: () =>  import('geostyler-openlayers-parser').then(initParserLib)
 };
 
 /**
@@ -334,5 +339,9 @@ export const createStylesAsync = (styles = []) => {
 };
 
 export const getStyleParser = (format = 'sld') => {
-    return StyleParsers[format];
+    if (!StyleParsers[format]) {
+        return new Promise(resolve => resolve(null));
+    }
+    // import parser libraries dynamically
+    return StyleParsers[format]();
 };

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -1045,5 +1045,43 @@ describe('StyleEditorUtils test', () => {
                     done();
                 });
         });
+
+        it('should detect changes if the msMD5Hash has different hash of the code', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #ff0000;\n  fill-opacity: 1;\n}\n',
+                format: 'css',
+                metadata: {
+                    msMD5Hash: 'fb84f642f11d431c0bc7801c4fd3b77c'
+                }
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(true);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+
+        it('should not detect changes if the msMD5Hash is equal to the hash of the code', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #0000ff;\n  fill-opacity: 1;\n}\n',
+                format: 'css',
+                metadata: {
+                    msMD5Hash: 'fb84f642f11d431c0bc7801c4fd3b77c'
+                }
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(false);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
     });
 });

--- a/web/client/utils/__tests__/VectorStyleUtils-test.js
+++ b/web/client/utils/__tests__/VectorStyleUtils-test.js
@@ -409,12 +409,31 @@ describe("VectorStyleUtils ", () => {
             expect(results[1].fillColor).toBe("#FF00FF");
         });
     });
-    it('getStyleParser returns parsers for supported style formats', () => {
-        expect(getStyleParser('sld')).toBeTruthy();
-        expect(getStyleParser('sld').readStyle).toBeTruthy();
-        expect(getStyleParser('sld').writeStyle).toBeTruthy();
-        expect(getStyleParser('css')).toBeTruthy();
-        expect(getStyleParser('css').readStyle).toBeTruthy();
-        expect(getStyleParser('css').writeStyle).toBeTruthy();
+    it('getStyleParser returns parsers for sld format', (done) => {
+        getStyleParser('sld')
+            .then((parser) => {
+                expect(parser).toBeTruthy();
+                expect(parser.readStyle).toBeTruthy();
+                expect(parser.writeStyle).toBeTruthy();
+                done();
+            });
+    });
+
+    it('getStyleParser returns parsers for css format', (done) => {
+        getStyleParser('css')
+            .then((parser) => {
+                expect(parser).toBeTruthy();
+                expect(parser.readStyle).toBeTruthy();
+                expect(parser.writeStyle).toBeTruthy();
+                done();
+            });
+    });
+
+    it('should not return a parser with unsupported format', (done) => {
+        getStyleParser('unknown')
+            .then((parser) => {
+                expect(parser).toBeFalsy();
+                done();
+            });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:

- dynamic import of style parser libraries
- md5 hash comparison between the JSON representation and the body of the style

The new workflow of style editor initialization will detect if the code has been changed based on the hash mismatch and switch to the textarea editor dropping the style JSON for the visual style editor

This PR introduces

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#7671
#6534

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
