### PR TITLE
backport 2021.02.xx  - #7712 - Redux devtools chrome extension upgrade to v3.0.0 won't work in MS2 (#7713)

### DIFF
--- a/web/client/components/development/Debug.jsx
+++ b/web/client/components/development/Debug.jsx
@@ -17,7 +17,7 @@ const urlQuery = url.parse(window.location.href, true).query;
 
 class Debug extends React.Component {
     render() {
-        if (urlQuery && urlQuery.debug && __DEVTOOLS__ && !window.devToolsExtension) {
+        if (urlQuery && urlQuery.debug && __DEVTOOLS__ && !window.__REDUX_DEVTOOLS_EXTENSION__) {
             const DevTools = require('./DevTools').default;
             return (
                 <DevTools/>

--- a/web/client/utils/StateUtils.js
+++ b/web/client/utils/StateUtils.js
@@ -164,9 +164,9 @@ export const createStore = ({
     const epic = rootEpic || combineEpics(...wrapEpics(epics));
     const allMiddlewares = epic ? [persistMiddleware(createEpicMiddleware(epic)), ...middlewares] : middlewares;
     const middleware = applyMiddleware.apply(null, getMiddlewares(allMiddlewares, debug));
-    const finalCreateStore = (window.devToolsExtension && debug ? compose(
+    const finalCreateStore = (window.__REDUX_DEVTOOLS_EXTENSION__ && debug ? compose(
         middleware,
-        window.devToolsExtension()
+        window.__REDUX_DEVTOOLS_EXTENSION__()
     ) : middleware)(createReduxStore);
     return setStore(finalCreateStore(reducer, state, enhancer));
 };


### PR DESCRIPTION
backport 2021.02.xx  - #7712 - Redux devtools chrome extension upgrade to v3.0.0 won't work in MS2 (#7713)