### PR TITLE
[Backport 2021.02.xx] #7680 Prevent horizontal scrollbar in identify tool + properties template (#7700)

### DIFF
--- a/web/client/themes/default/less/get-feature.less
+++ b/web/client/themes/default/less/get-feature.less
@@ -274,7 +274,7 @@
 
 .ms-properties-viewer {
     width: 100%;
-    min-width: 256px;
+    min-width: 100%;
     padding: 8px;
     + .ms-properties-viewer {
         margin-top: 8px;


### PR DESCRIPTION
[Backport 2021.02.xx] #7680 Prevent horizontal scrollbar in identify tool + properties template (#7700)