### PR TITLE
Revert "#7708 Allow latin chars in username and password"

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "ag-grid-community": "20.2.0",
     "ag-grid-react": "20.2.0",
     "assert": "2.0.0",
-    "axios": "0.24.0",
+    "axios": "0.18.1",
     "b64-to-blob": "1.2.19",
     "babel-polyfill": "6.8.0",
     "babel-standalone": "6.7.7",

--- a/web/client/actions/__tests__/maps-test.js
+++ b/web/client/actions/__tests__/maps-test.js
@@ -75,9 +75,8 @@ describe('Test correctness of the maps actions', () => {
         const resourceId = 1;
         const type = "STRING";
 
-        mockAxios.onPut().reply(({url, baseURL, data }) => {
-            expect(url).toBe(`resources/resource/${resourceId}/attributes/`);
-            expect(baseURL).toEqual(BASE_URL);
+        mockAxios.onPut().reply(({url, data }) => {
+            expect(url).toBe(`${BASE_URL}resources/resource/${resourceId}/attributes/`);
             expect(JSON.parse(data)).toEqual({
                 "restAttribute": {
                     name,

--- a/web/client/api/GeoStoreDAO.js
+++ b/web/client/api/GeoStoreDAO.js
@@ -154,7 +154,7 @@ const Api = {
         let authData;
         return axios.post(url, null, this.addBaseUrl(merge((username && password) ? {
             auth: {
-                username: unescape(encodeURIComponent(username)),
+                username: username,
                 password: password
             }
         } : {}, options))).then((response) => {

--- a/web/client/api/geofence/__tests__/RuleService-test.js
+++ b/web/client/api/geofence/__tests__/RuleService-test.js
@@ -40,7 +40,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     it('getRulesCount', (done) => {
         const PARAMS = { roleName: "ADMIN" };
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rules/count`);
+            expect(config.url).toBe(`${BASE_URL}/rules/count`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.params).toEqual(PARAMS);
             return [200, '2'];
@@ -55,7 +55,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     it('loadRules', (done) => {
         const PARAMS = { roleName: "ADMIN" };
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rules`);
+            expect(config.url).toBe(`${BASE_URL}/rules`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.params).toEqual({...PARAMS, page: 1, entries: 10});
             return [200, RULES];
@@ -71,7 +71,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     });
     it('moveRules', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rules/move`);
+            expect(config.url).toBe(`${BASE_URL}/rules/move`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.params).toEqual({ targetPriority: 1, rulesIds: '1,2' });
             return [200, RULES];
@@ -82,7 +82,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     });
     it('addRule', (done) => {
         mockAxios.onPost().reply(config => {
-            expect(config.url).toBe(`/rules`);
+            expect(config.url).toBe(`${BASE_URL}/rules`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.method).toBe('post');
             const rule = JSON.parse(config.data);
@@ -97,7 +97,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     });
     it('deleteRule', (done) => {
         mockAxios.onDelete().reply(config => {
-            expect(config.url).toBe(`/rules/id/1`);
+            expect(config.url).toBe(`${BASE_URL}/rules/id/1`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.method).toBe('delete');
             return [200];

--- a/web/client/api/geoserver/geofence/__tests__/RuleService-test.js
+++ b/web/client/api/geoserver/geofence/__tests__/RuleService-test.js
@@ -38,7 +38,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     it('getRulesCount', (done) => {
         const PARAMS = { roleName: "ADMIN" };
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rules/count`);
+            expect(config.url).toBe(`${BASE_URL}/rules/count`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.params).toEqual(PARAMS);
             return [200, RULES];
@@ -53,7 +53,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     it('loadRules', (done) => {
         const PARAMS = { roleName: "ADMIN" };
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rules`);
+            expect(config.url).toBe(`${BASE_URL}/rules`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.params).toEqual({...PARAMS, page: 1, entries: 10});
             return [200, RULES];
@@ -69,7 +69,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     });
     it('moveRules', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rules/move`);
+            expect(config.url).toBe(`${BASE_URL}/rules/move`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.params).toEqual({ targetPriority: 1, rulesIds: '1,2' });
             return [200, RULES];
@@ -82,7 +82,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     });
     it('addRule', (done) => {
         mockAxios.onPost().reply(config => {
-            expect(config.url).toBe(`/rules`);
+            expect(config.url).toBe(`${BASE_URL}/rules`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.method).toBe('post');
             const rule = JSON.parse(config.data).Rule;
@@ -98,7 +98,7 @@ describe('RuleService API for GeoFence StandAlone', () => {
     });
     it('deleteRule', (done) => {
         mockAxios.onDelete().reply(config => {
-            expect(config.url).toBe(`/rules/id/1`);
+            expect(config.url).toBe(`${BASE_URL}/rules/id/1`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             expect(config.method).toBe('delete');
             return [200];

--- a/web/client/api/geoserver/geofence/__tests__/UserService-test.js
+++ b/web/client/api/geoserver/geofence/__tests__/UserService-test.js
@@ -45,7 +45,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getUsersCount', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/users.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -58,7 +58,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getUsers', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/users.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -71,7 +71,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getUsers pagination', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/users.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -85,7 +85,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getUsers from service', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/service/geostore/users.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/service/geostore/users.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -100,7 +100,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getUsersCount from service', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/service/geostore/users.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/service/geostore/users.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -114,7 +114,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
 
     it('getUsersCount with filter', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/users.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -127,7 +127,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getUsers with filter, case insensitive', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/usergroup/users.json`); // test_user1, test_user10, test_user11
+            expect(config.url).toBe(`${BASE_URL}/rest/security/usergroup/users.json`); // test_user1, test_user10, test_user11
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, USERS];
         });
@@ -140,7 +140,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getRolesCount, case insensitive', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/roles.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, ROLES];
         });
@@ -153,7 +153,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getRoles', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/roles.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, ROLES];
         });
@@ -166,7 +166,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getRoles pagination', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/roles.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, ROLES];
         });
@@ -179,7 +179,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getRolesCount with filter, case insensitive', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/roles.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, ROLES];
         });
@@ -192,7 +192,7 @@ describe('UserService API for GeoFence StandAlone (GeoServer API)', () => {
     });
     it('getRoles with filter, case insensitive', (done) => {
         mockAxios.onGet().reply(config => {
-            expect(config.url).toBe(`/rest/security/roles.json`);
+            expect(config.url).toBe(`${BASE_URL}/rest/security/roles.json`);
             expect(config.baseURL).toBe(`${BASE_URL}`);
             return [200, ROLES];
         });

--- a/web/client/components/manager/users/UserDialog.jsx
+++ b/web/client/components/manager/users/UserDialog.jsx
@@ -304,6 +304,14 @@ class UserDialog extends React.Component {
             };
         }
 
+        if (/[^a-zA-Z0-9\!\@\#\$\%\&\*\_]/.test(p)) {
+            return {
+                valid: false,
+                message: "user.passwordInvalidChar",
+                args: p.match(/[^a-zA-Z0-9\!\@\#\$\%\&\*\_]/).toString()
+            };
+        }
+
         return validation;
     };
 

--- a/web/client/components/manager/users/__tests__/UserDialog-test.jsx
+++ b/web/client/components/manager/users/__tests__/UserDialog-test.jsx
@@ -106,7 +106,7 @@ describe("Test UserDialog Component", () => {
         comp = ReactDOM.render(
             <UserDialog user={{...enabledUser, newPassword: "aaabbbà", confirmPassword: "aaabbbà"}}/>, document.getElementById("container"));
         expect(comp).toExist();
-        expect(comp.isValidPassword()).toBe(true);
+        expect(comp.isValidPassword()).toBe(false);
         // New user, empty password
         comp = ReactDOM.render(
             <UserDialog user={{...newUser, newPassword: "", confirmPassword: ""}}/>, document.getElementById("container"));

--- a/web/client/components/security/forms/PasswordReset.jsx
+++ b/web/client/components/security/forms/PasswordReset.jsx
@@ -67,7 +67,7 @@ class PasswordReset extends React.Component {
         }
         let pw = this.state.password;
         if (pw !== null && pw.length < this.props.minPasswordSize && pw.length > 0) {
-            return <Alert bsStyle="danger"><Message msgId="user.passwordMinlenght" msgParams={{data: this.props.minPasswordSize}}/></Alert>;
+            return <Alert bsStyle="danger"><Message msgId="user.passwordMinlenght" msgParams={{minSize: this.props.minPasswordSize}}/></Alert>;
         } else if (!this.isMainPasswordValid()) {
             return <Alert bsStyle="danger"><Message msgId="user.passwordInvalid" /></Alert>;
         } else if (pw !== null && pw !== this.state.passwordcheck ) {
@@ -114,7 +114,7 @@ class PasswordReset extends React.Component {
 
     isMainPasswordValid = (password) => {
         let p = password || this.state.password;
-        return (p.length >= this.props.minPasswordSize);
+        return (p.length >= this.props.minPasswordSize) && !(/[^a-zA-Z0-9\!\@\#\$\%\&\*]/.test(p));
     };
 
     isValid = (password, passwordcheck) => {

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1217,7 +1217,7 @@
             "passwordInvalid": "Ungültiges Passwort",
             "username": "Benutzername",
             "password": "Passwort",
-            "passwordMessage": "Das Passwort muss aus mindestens 6 Zeichen bestehen.",
+            "passwordMessage": "Das Passwort muss aus mindestens 6 Zeichen bestehen. Gültige Werte für Kennwörter sind Ziffern, Klein- oder Großbuchstaben und die folgenden Sonderzeichen: !,@,#,$,%,&,*,_",
             "passwordInvalidChar": "Das Passwort darf diese Zeichen nicht enthalten: {data}",
             "passwordChanged": "Passwort geändert",
             "passwordError": "Fehler beim Ändern des Passworts",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1178,7 +1178,7 @@
             "passwordInvalid": "Invalid password",
             "username": "Username",
             "password": "Password",
-            "passwordMessage": "Password must contain at least 6 characters",
+            "passwordMessage": "Password must contain at least 6 characters. Valid values for passwords include numerals, lower or upper-case letters and the following special characters: ! @ # $ % & * _.",
             "passwordInvalidChar": "The password must not contain these characters: {data}",
             "passwordChanged": "Password changed",
             "passwordError": "Error changing password",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1178,7 +1178,7 @@
             "passwordInvalid": "Clave incorrecta",
             "username": "Nombre de usuario",
             "password": "Clave",
-            "passwordMessage": "La contraseña debe contener al menos 6 caracteres.",
+            "passwordMessage": "La contraseña debe contener al menos 6 caracteres. Los valores válidos para las contraseñas incluyen números, letras mayúsculas o minúsculas y los siguientes caracteres especiales: !,@,#,$,%,&,*,_",
             "passwordInvalidChar": "La contraseña no debe contener estos caracteres: {data}",
             "passwordChanged": "Clave actualizada",
             "passwordError": "Error en el cambio de clave",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1178,7 +1178,7 @@
             "passwordInvalid": "Mot de passe erroné",
             "username": "Nom d'utilisateur",
             "password": "Mot de passe",
-            "passwordMessage": "Le mot de passe doit contenir au moins 6 caractères.",
+            "passwordMessage": "Le mot de passe doit contenir au moins 6 caractères. Les valeurs valides pour les mots de passe incluent des chiffres, des lettres minuscules ou majuscules et les caractères spéciaux suivants: !,@,#,$,%,&,*,_",
             "passwordInvalidChar": "Le mot de passe ne doit pas contenir ces caractères: {data}",
             "passwordChanged": "Mot de passe changé",
             "passwordError": "Erreur lors du changement de mot de passe",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1178,7 +1178,7 @@
             "passwordInvalid": "Password non valida",
             "username": "Username",
             "password": "Password",
-            "passwordMessage": "La password deve contenere almeno 6 caratteri.",
+            "passwordMessage": "La password deve contenere almeno 6 caratteri. I valori validi per le password includono numeri, lettere minuscole o maiuscole e i seguenti caratteri speciali: !,@,#,$,%,&,*,_",
             "passwordInvalidChar": "La password non deve contenere questi caratteri: {data}",
             "passwordChanged": "La password è stata cambiata",
             "passwordError": "Errore nel cambio della password",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1188,7 +1188,7 @@
             "passwordInvalid": "Ongeldig wachtwoord",
             "username": "Gebruikersnaam",
             "password": "Wachtwoord",
-            "passwordMessage": "Wachtwoord moet minstens 6 karakters bevatten.",
+            "passwordMessage": "Wachtwoord moet minstens 6 karakters bevatten. Geldige waarden voor wachtwoorden zijn cijfers, kleine letters of hoofdletters en de volgende speciale tekens:! @ # $% & * _.",
             "passwordInvalidChar": "Het wachtwoord mag deze tekens niet bevatten: {data}",
             "passwordChanged": "Wachtwoord gewijzigd",
             "passwordError": "Fout bij wijzigen van wachtwoord",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1169,7 +1169,7 @@
             "passwordInvalid": "Ogiltigt lösenord",
             "username": "Användarnamn",
             "password": "Lösenord",
-            "passwordMessage": "Lösenordet måste innehålla minst 6 tecken.",
+            "passwordMessage": "Lösenordet måste innehålla minst 6 tecken. Giltiga värden för lösenord är siffror, små eller stora bokstäver och följande specialtecken:! @ # $ % & * _.",
             "passwordInvalidChar": "Lösenordet får inte innehålla dessa tecken: {data}",
             "passwordChanged": "Lösenord ändrat",
             "passwordError": "Fel vid ändring av lösenord",


### PR DESCRIPTION
Reverts geosolutions-it/MapStore2#7723

It causes https://github.com/geosolutions-it/MapStore2/issues/7736 

I tried to solve it by changing `"Content-Type": "application/json"` to ` 'Content-Type': 'application/xml'`  [here](https://github.com/geosolutions-it/MapStore2/blob/master/web/client/observables/wfs.js#L198) that was anyway not correct, but probably new axios version do not ignore this error.

It worked but I also noticed that the interceptor for proxy doesn't work if I do no specify content-type. So we should do a double check before to merge it again.


We can solve #7708 issue with latin chars manually, instead of updating axios, by workarounding as described in the original axios issue, or finalize the axios update.