### PR TITLE
improvements and fixes for the PrintProjection Plugin

### DIFF
--- a/web/client/components/background/PreviewIcon.jsx
+++ b/web/client/components/background/PreviewIcon.jsx
@@ -47,7 +47,7 @@ class PreviewIcon extends React.Component {
         const compatibleWmts = this.props.layer.type === "wmts" && has(this.props.layer.allowedSRS, this.props.projection);
         const containerClass = this.props.vertical ? 'background-preview-icon-container-vertical' : 'background-preview-icon-container-horizontal';
         const type = this.props.layer.visibility ? ' bg-primary' : ' bg-body';
-        const valid = ((validCrs || compatibleWmts || includes(["wms", "empty", "osm"], this.props.layer.type)) && !this.props.layer.invalid );
+        const valid = ((validCrs || compatibleWmts || includes(["wms", "empty", "osm", "tileprovider"], this.props.layer.type)) && !this.props.layer.invalid );
 
         const click = !valid ? () => {} : () => {
             this.props.onToggle();

--- a/web/client/components/background/__tests__/PreviewIcon-test.jsx
+++ b/web/client/components/background/__tests__/PreviewIcon-test.jsx
@@ -49,6 +49,10 @@ describe("test the PreviewIcon", () => {
             type: "osm",
             visibility: true,
             id: 'layer'
+        }, {
+            type: "tileprovider",
+            visibility: true,
+            id: 'layer'
         }];
 
         const spyPropertiesChange = expect.spyOn(actions, 'onPropertiesChange');
@@ -71,8 +75,55 @@ describe("test the PreviewIcon", () => {
             expect(spyPropertiesChange).toHaveBeenCalledWith("layer", {visibility: true});
             expect(spySetCurrentBackgroundLayer).toHaveBeenCalledWith("layer");
         });
+    });
 
+    it('test PreviewIcon actions in custom crs', () => {
+        const actions = {
+            onPropertiesChange: () => {},
+            onToggle: () => {},
+            onLayerChange: () => {},
+            setCurrentBackgroundLayer: () => {}
+        };
 
+        const layers = [{
+            type: "empty",
+            visibility: true,
+            id: 'layerempty'
+        },
+        {
+            type: "wms",
+            visibility: true,
+            id: 'layerwms'
+        },
+        {
+            type: "osm",
+            visibility: true,
+            id: 'layerosm'
+        }, {
+            type: "tileprovider",
+            visibility: true,
+            id: 'layertileprovider'
+        }];
+
+        layers.forEach((layer, i)=>{
+            const spyPropertiesChange = expect.spyOn(actions, 'onPropertiesChange');
+            const spyToggle = expect.spyOn(actions, 'onToggle');
+            const spyLayerChange = expect.spyOn(actions, 'onLayerChange');
+            const spySetCurrentBackgroundLayer = expect.spyOn(actions, 'setCurrentBackgroundLayer');
+            const previewIcon = ReactDOM.render(<PreviewIcon projection="EPSG:3003" onPropertiesChange={actions.onPropertiesChange} onToggle={actions.onToggle} onLayerChange={actions.onLayerChange} setCurrentBackgroundLayer={actions.setCurrentBackgroundLayer} vertical layer={layer}/>, document.getElementById("container"));
+            expect(previewIcon).toExist();
+            const node = ReactDOM.findDOMNode(previewIcon);
+            expect(node).toExist();
+            const image = node.querySelector('.background-preview-icon-frame').children[0];
+            ReactTestUtils.Simulate.mouseOver(image);
+            expect(spyLayerChange).toHaveBeenCalled();
+            expect(spyLayerChange.calls[i].arguments[1].type).toBe(layer.type);
+            ReactTestUtils.Simulate.click(image);
+            expect(spyPropertiesChange).toHaveBeenCalled();
+            expect(spyToggle).toHaveBeenCalled();
+            expect(spyPropertiesChange).toHaveBeenCalledWith("layer" + layer.type, {visibility: true});
+            expect(spySetCurrentBackgroundLayer).toHaveBeenCalledWith("layer" + layer.type);
+        });
     });
 
     it('test PreviewIcon is invalid', () => {
@@ -92,6 +143,34 @@ describe("test the PreviewIcon", () => {
         const spyLayerChange = expect.spyOn(actions, 'onLayerChange');
 
         const previewIcon = ReactDOM.render(<PreviewIcon onPropertiesChange={actions.onPropertiesChange} onToggle={actions.onToggle} onLayerChange={actions.onLayerChange} layer={layer}/>, document.getElementById("container"));
+        expect(previewIcon).toExist();
+        const node = ReactDOM.findDOMNode(previewIcon);
+        expect(node).toExist();
+        const image = node.querySelector('.background-preview-icon-frame').children[0];
+        ReactTestUtils.Simulate.mouseOver(image);
+        expect(spyLayerChange).toHaveBeenCalled();
+        ReactTestUtils.Simulate.click(image);
+        expect(spyPropertiesChange).toNotHaveBeenCalled();
+        expect(spyToggle).toNotHaveBeenCalled();
+    });
+
+    it('test PreviewIcon in custom crs and invalid background', () => {
+        const actions = {
+            onPropertiesChange: () => {},
+            onToggle: () => {},
+            onLayerChange: () => {}
+        };
+
+        const layer = {
+            id: 'layer',
+            type: "unknown"
+        };
+
+        const spyPropertiesChange = expect.spyOn(actions, 'onPropertiesChange');
+        const spyToggle = expect.spyOn(actions, 'onToggle');
+        const spyLayerChange = expect.spyOn(actions, 'onLayerChange');
+
+        const previewIcon = ReactDOM.render(<PreviewIcon projection="EPSG:3003" onPropertiesChange={actions.onPropertiesChange} onToggle={actions.onToggle} onLayerChange={actions.onLayerChange} layer={layer}/>, document.getElementById("container"));
         expect(previewIcon).toExist();
         const node = ReactDOM.findDOMNode(previewIcon);
         expect(node).toExist();

--- a/web/client/plugins/CRSSelector.jsx
+++ b/web/client/plugins/CRSSelector.jsx
@@ -11,7 +11,7 @@ import assign from 'object-assign';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Dropdown, Glyphicon, ListGroupItem } from 'react-bootstrap';
-import { connect } from 'react-redux';
+import { connect } from '../utils/PluginsUtils';
 import { createSelector } from 'reselect';
 
 import { setInputValue } from '../actions/crsselector';
@@ -78,8 +78,9 @@ class Selector extends React.Component {
         }
         const currentCRS = normalizeSRS(this.props.selected, this.props.filterAllowedCRS);
         const compatibleCrs = ['EPSG:4326', 'EPSG:3857', 'EPSG:900913'];
+        const allowedLayerTypes = ["wms", "osm", "tileprovider", "empty"];
         const changeCrs = (crs) => {
-            if ( indexOf(compatibleCrs, crs) > -1 || this.props.currentBackground.type === "wms" || this.props.currentBackground.type === "empty" ||
+            if ( indexOf(compatibleCrs, crs) > -1 || indexOf(allowedLayerTypes, this.props.currentBackground.type) > -1 ||
             (this.props.currentBackground.allowedSRS && has(this.props.currentBackground.allowedSRS, crs))) {
                 this.props.setCrs(crs);
             } else {

--- a/web/client/plugins/__tests__/CRSSelector-test.jsx
+++ b/web/client/plugins/__tests__/CRSSelector-test.jsx
@@ -3,8 +3,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import CRSSelectorPlugin from '../CRSSelector';
-import { getPluginForTest } from './pluginsTestUtils';
+import { getPluginForTest, getByXPath } from './pluginsTestUtils';
 import security from '../../reducers/security';
+import ReactTestUtils from 'react-dom/test-utils';
 
 describe('CRSSelector Plugin', () => {
     beforeEach((done) => {
@@ -206,5 +207,103 @@ describe('CRSSelector Plugin', () => {
 
         ReactDOM.render(<Plugin filterAllowedCRS={["EPSG:4326", "EPSG:3857"]} additionalCRS={{}}/>, document.getElementById("container"));
         expect(document.getElementsByClassName('ms-prj-selector').length).toBe(0);
+    });
+
+    it('error on switch with custom CRS and invalid background', () => {
+        const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
+            map: {
+                projection: "EPSG:3003"
+            },
+            layers: [{
+                group: "background",
+                visible: true,
+                type: "unknown"
+            }],
+            localConfig: {
+                projectionDefs: [{
+                    "code": "EPSG:3003",
+                    "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+                    "extent": [1241482.0019, 973563.1609, 1830078.9331, 5215189.0853],
+                    "worldExtent": [6.6500, 8.8000, 12.0000, 47.0500]
+                }]
+            },
+            security: {
+                user: {
+                    role: "USER"
+                }
+            }
+        });
+
+        const actions = {
+            onError: () => {}
+        };
+        const spyError = expect.spyOn(actions, 'onError');
+
+        ReactDOM.render(<Plugin
+            pluginCfg={{
+                onError: actions.onError
+            }}
+            filterAllowedCRS={["EPSG:4326", "EPSG:3857"]}
+            additionalCRS={{
+                "EPSG:3003": { "label": "EPSG:3003" }
+            }}
+            allowedRoles={["ALL"]}
+        />, document.getElementById("container"));
+        const switchButton = getByXPath("//button[text()='EPSG:3003']");
+        expect(switchButton).toExist();
+        ReactTestUtils.Simulate.click(switchButton);
+        expect(spyError).toHaveBeenCalled();
+    });
+
+    it('switches to custom CRS with OSM background', () => {
+        const { Plugin } = getPluginForTest(CRSSelectorPlugin, {
+            map: {
+                projection: "EPSG:3003"
+            },
+            layers: {
+                flat: [{
+                    group: "background",
+                    visibility: true,
+                    type: "osm"
+                }]
+            },
+            localConfig: {
+                projectionDefs: [{
+                    "code": "EPSG:3003",
+                    "def": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl+towgs84=-104.1,-49.1,-9.9,0.971,-2.917,0.714,-11.68 +units=m +no_defs",
+                    "extent": [1241482.0019, 973563.1609, 1830078.9331, 5215189.0853],
+                    "worldExtent": [6.6500, 8.8000, 12.0000, 47.0500]
+                }]
+            },
+            security: {
+                user: {
+                    role: "USER"
+                }
+            }
+        });
+
+        const actions = {
+            onError: () => {},
+            setCrs: () => {}
+        };
+        const spyError = expect.spyOn(actions, 'onError');
+        const spySet = expect.spyOn(actions, 'setCrs');
+
+        ReactDOM.render(<Plugin
+            pluginCfg={{
+                onError: actions.onError,
+                setCrs: actions.setCrs
+            }}
+            filterAllowedCRS={["EPSG:4326", "EPSG:3857"]}
+            additionalCRS={{
+                "EPSG:3003": { "label": "EPSG:3003" }
+            }}
+            allowedRoles={["ALL"]}
+        />, document.getElementById("container"));
+        const switchButton = getByXPath("//button[text()='EPSG:3003']");
+        expect(switchButton).toExist();
+        ReactTestUtils.Simulate.click(switchButton);
+        expect(spyError).toNotHaveBeenCalled();
+        expect(spySet).toHaveBeenCalledWith("EPSG:3003");
     });
 });

--- a/web/client/plugins/__tests__/Print-test.jsx
+++ b/web/client/plugins/__tests__/Print-test.jsx
@@ -10,12 +10,36 @@ import {setStore} from "../../utils/StateUtils";
 import axios from '../../libs/ajax';
 import MockAdapter from 'axios-mock-adapter';
 import {addTransformer, resetDefaultPrintingService} from "../../utils/PrintUtils";
+import ReactTestUtils from 'react-dom/test-utils';
 
 const initialState = {
     controls: {
         print: {
             enabled: true
         }
+    },
+    maptype: {
+        mapType: "openlayers"
+    },
+    map: {
+        center: {
+            x: 0,
+            y: 0,
+            crs: "EPSG:4326"
+
+        },
+        zoom: 5,
+        bbox: {
+            bounds: {
+                minx: 0,
+                miny: 0,
+                maxx: 100,
+                maxy: 100
+            },
+            crs: "EPSG:3857"
+        },
+        projection: "EPSG:3857",
+        resolutions: [0.5, 1, 2, 4, 8, 16, 32]
     },
     print: {
         spec: {
@@ -62,18 +86,22 @@ function expectDefaultItems() {
     expect(document.getElementById("mapstore-print-preview-panel")).toNotExist();
 }
 
-function getPrintPlugin({items = [], layers = [], preview = false} = {}) {
+function getPrintPlugin({items = [], layers = [], preview = false, projection = "EPSG:3857"} = {}) {
     return getLazyPluginForTest({
         plugin: Print,
         storeState: {
             ...initialState,
             browser: "good",
             layers,
+            map: {
+                ...initialState.map,
+                projection
+            },
             print: {
                 pdfUrl: preview ? "http://fakepreview" : undefined,
                 ...initialState.print,
                 map: {
-                    projection: "EPSG:3857",
+                    projection,
                     center: {x: 0, y: 0},
                     layers
                 }
@@ -260,7 +288,11 @@ describe('Print Plugin', () => {
     it("print using custom printing service", (done) => {
         const printingService = {
             print() {},
-            getMapConfiguration(map) {return map;},
+            getMapConfiguration() {
+                return {
+                    layers: []
+                };
+            },
             validate() { return {};}
         };
         let spy = expect.spyOn(printingService, "print");
@@ -272,6 +304,44 @@ describe('Print Plugin', () => {
                 submit.click();
                 setTimeout(() => {
                     expect(spy.calls.length).toBe(1);
+                    done();
+                }, 0);
+            } catch (ex) {
+                done(ex);
+            }
+        });
+    });
+
+    it("print using alternative background", (done) => {
+        const actions = {
+            onPrint: () => {}
+        };
+        let spy = expect.spyOn(actions, "onPrint");
+        getPrintPlugin({
+            layers: [{visibility: true, type: "osm"}],
+            projection: "EPSG:4326"
+        }).then(({ Plugin }) => {
+            try {
+                ReactDOM.render(<Plugin
+                    pluginCfg={{
+                        onPrint: actions.onPrint
+                    }}
+                    defaultBackground={["osm", "empty"]}
+                />, document.getElementById("container"));
+                const input = getByXPath("//*[text()='print.defaultBackground']");
+                expect(input).toExist();
+                ReactTestUtils.Simulate.change(input, {
+                    target: {
+                        checked: true
+                    }
+                });
+                input.click();
+                const submit = document.getElementsByClassName("print-submit").item(0);
+                expect(submit).toExist();
+                ReactTestUtils.Simulate.click(submit);
+                setTimeout(() => {
+                    expect(spy.calls.length).toBe(1);
+                    expect(spy.calls[0].arguments[1].layers.length).toBe(0);
                     done();
                 }, 0);
             } catch (ex) {

--- a/web/client/plugins/__tests__/pluginsTestUtils.js
+++ b/web/client/plugins/__tests__/pluginsTestUtils.js
@@ -23,6 +23,7 @@ import controls from '../../reducers/controls';
 import annotations from '../../reducers/annotations';
 import context from '../../reducers/context';
 import security from '../../reducers/security';
+import localConfig from "../../reducers/localConfig";
 
 import { getPlugins } from "../../utils/PluginsUtils";
 
@@ -34,7 +35,8 @@ const rootReducers = {
     maptype,
     annotations,
     context,
-    security
+    security,
+    localConfig
 };
 
 const createRegisterActionsMiddleware = (actions) => {

--- a/web/client/plugins/__tests__/print/Projection-test.jsx
+++ b/web/client/plugins/__tests__/print/Projection-test.jsx
@@ -42,11 +42,24 @@ const initialState = {
 };
 
 const baseSpec = {
-    layers: [],
-    center: {x: 0, y: 0, projection: "EPSG:4326"},
+    layers: [{
+        type: "Vector",
+        geoJson: {
+            type: "FeatureCollection",
+            features: [{
+                type: "Point",
+                coordinates: [100000, 200000]
+            }]
+        }
+    }, {
+        type: "unknown"
+    }],
     projection: "EPSG:3857",
     srs: "EPSG:3857",
-    pages: []
+    pages: [{
+        center: [100000, 200000],
+        scale: 10000
+    }]
 };
 
 function getPrintProjectionPlugin() {
@@ -123,6 +136,9 @@ describe('PrintProjection Plugin', () => {
             try {
                 ReactDOM.render(<Plugin projections={[{"name": "Mercator", "value": "EPSG:3857"}, {"name": "WGS84", "value": "EPSG:4326"}]}/>, document.getElementById("container"));
                 callTransformer(store.getState(), (spec) => {
+                    expect(spec.pages[0].center[0].toFixed(2)).toEqual(100000);
+                    expect(spec.pages[0].center[1].toFixed(2)).toEqual(200000);
+                    expect(spec.pages[0].scale.toFixed(0)).toEqual(10000);
                     expect(spec.srs).toBe('EPSG:3857');
                     done();
                 });
@@ -143,7 +159,15 @@ describe('PrintProjection Plugin', () => {
                     }
                 });
                 callTransformer(store.getState(), (spec) => {
+                    expect(spec.pages[0].center[0].toFixed(2)).toEqual(0.9);
+                    expect(spec.pages[0].center[1].toFixed(2)).toEqual(1.80);
+                    expect(spec.pages[0].scale.toFixed(0)).toEqual(125483353);
                     expect(spec.srs).toBe('EPSG:4326');
+                    expect(spec.layers.length).toBe(2);
+                    expect(spec.layers[0].type).toBe("Vector");
+                    expect(spec.layers[0].geoJson.features.length).toBe(1);
+                    expect(spec.layers[0].geoJson.features[0].coordinates[0].toFixed(2)).toEqual(0.90);
+                    expect(spec.layers[0].geoJson.features[0].coordinates[1].toFixed(2)).toEqual(1.80);
                     done();
                 });
             } catch (ex) {

--- a/web/client/plugins/print/MapPreview.jsx
+++ b/web/client/plugins/print/MapPreview.jsx
@@ -10,6 +10,7 @@ export const MapPreview = ({mapSize, layout, layoutName, resolutions, useFixedSc
     const scales = capabilities.scales.slice(0).reverse().map((scale) => parseFloat(scale.value)) || [];
     return validation.valid ? (
         <MapPreviewComp
+            {...rest}
             map={map}
             layers={map?.layers ?? []}
             scales={scales}
@@ -20,7 +21,6 @@ export const MapPreview = ({mapSize, layout, layoutName, resolutions, useFixedSc
             resolutions={resolutions}
             useFixedScales={useFixedScales}
             env={localizedLayerStylesEnv}
-            {...rest}
             {...mapPreviewOptions}
         />
     ) : <div id="map-preview-disabled-message"><Message msgId="print.disabledpreview"/></div>;

--- a/web/client/plugins/print/Projection.jsx
+++ b/web/client/plugins/print/Projection.jsx
@@ -106,7 +106,8 @@ export const Projection = ({
     items,
     onChangeParameter,
     allowPreview = false,
-    projections
+    projections,
+    onRefresh = () => {}
 }, context) => {
     useEffect(() => {
         addTransformer("projection", transformer, 3);
@@ -119,6 +120,7 @@ export const Projection = ({
     }, []);
     function changeProjection(crs) {
         onChangeParameter("params.projection", crs);
+        onRefresh();
     }
     return (
         <>

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -672,7 +672,7 @@
             "description": "Beschreibung",
             "descriptionplaceholder": "Gib eine Beschreibung ein...",
             "resolution": "Auflösung:",
-            "defaultBackground": "Nutze OSM als Hintergrund",
+            "defaultBackground": "Verwenden Sie den Standardhintergrund",
             "printtooltip": "Drucken",
             "alternatives": {
                 "legend": "Legende einschließen",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -633,7 +633,7 @@
             "description": "Description",
             "descriptionplaceholder": "Enter a description...",
             "resolution": "Resolution:",
-            "defaultBackground": "Use OSM as background",
+            "defaultBackground": "Use the default background",
             "printtooltip": "Print",
             "alternatives": {
                 "legend": "Include legend",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -633,7 +633,7 @@
             "description": "Descripción",
             "descriptionplaceholder": "Introduzca una descripción...",
             "resolution": "Resolución:",
-            "defaultBackground": "Utilizar OSM como fondo",
+            "defaultBackground": "Usar el fondo predeterminado",
             "printtooltip": "Impresión",
             "alternatives": {
                 "legend": "Incluir la leyenda",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -633,7 +633,7 @@
             "description": "Description",
             "descriptionplaceholder": "Entrer une description...",
             "resolution": "Résolution :",
-            "defaultBackground": "Utiliser OSM comme fond de plan",
+            "defaultBackground": "Utiliser l'arrière-plan par défaut",
             "printtooltip": "Impression",
             "alternatives": {
                 "legend": "Inclure la légende",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -633,7 +633,7 @@
             "description": "Descrizione",
             "descriptionplaceholder": "Inserisci una descrizione...",
             "resolution": "Risoluzione:",
-            "defaultBackground": "Usa OSM come background",
+            "defaultBackground": "Usa il background di default",
             "printtooltip": "Stampa",
             "alternatives": {
                 "legend": "Includere la legenda",

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -425,9 +425,13 @@ export function addValidator(id, name, validator) {
  */
 export const getDefaultPrintingService = () => {
     return {
-        print: () => {
+        print: (layers) => {
             const state = getStore().getState();
-            const intialSpec = printSpecificationSelector(state);
+            const printSpec = printSpecificationSelector(state);
+            const intialSpec = layers ? {
+                ...printSpec,
+                layers
+            } : printSpec;
             return getSpecTransformerChain().map(t => t.transformer).reduce((previous, f) => {
                 return previous.then(spec=> f(state, spec));
             }, Promise.resolve(intialSpec));


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->
 - Fixes a bug of the PrintProjection plugin, not reprojecting vector layers.
 - enables osm and tileprovider layers usage with custom projections (in CRSSelector and BackgroundSelector plugins)
 - allow multiple default backgrounds, to be chosen when the current one is incompatible with the current projection

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7747 
#7748 
#7759 

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7747
#7748
#7759

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
 - Vector layers are properly reprojected when sent to the mapfish engine, if projection has been changed through the PrintProjection plugin. Tested with annotations and imported shapefiles.
 - osm and tileprovider layers are correctly handled by the CRSSelector and BackgroundSelector plugins when using/switching to a custom projection
 - a list of layers can be configured in the defaultBackground property of the Print plugin, so that the first one "compatible" is chosen, based on the current projection

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
