### PR TITLE
#7720 Map import fix

### DIFF
--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -386,7 +386,7 @@ export const getLayersByGroup = (configLayers, configGroups) => {
                     .reduce((arr, cur) => {
                         isObject(cur)
                             ? arr.push({node: cur, order: mapLayers.find((el) => el.group === cur.id)?.storeIndex})
-                            : arr.push({node: cur, order: mapLayers.find((el) => el.id === cur).storeIndex});
+                            : arr.push({node: cur, order: mapLayers.find((el) => el.id === cur)?.storeIndex});
                         return arr;
                     }, []).sort((a, b) => b.order - a.order).map(e => e.node);
             }

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -385,7 +385,7 @@ export const getLayersByGroup = (configLayers, configGroups) => {
                 group.nodes = getLayersId(groupId, mapLayers).concat(group.nodes)
                     .reduce((arr, cur) => {
                         isObject(cur)
-                            ? arr.push({node: cur, order: mapLayers.find((el) => el.group === cur.id).storeIndex})
+                            ? arr.push({node: cur, order: mapLayers.find((el) => el.group === cur.id)?.storeIndex})
                             : arr.push({node: cur, order: mapLayers.find((el) => el.id === cur).storeIndex});
                         return arr;
                     }, []).sort((a, b) => b.order - a.order).map(e => e.node);


### PR DESCRIPTION
## Description
Added optional chaining operator to avoid error when sub-group has no layers (empty or with another groups inside).

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7720

**What is the new behavior?**
Error won't appear when imported map has layer sub-groups that are empty or sub-groups that have only another groups inside.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
