### PR TITLE
 [Backport 2021.02.xx] #7671, #6534: Adopt MD5 hash of the style body for a consistent management of visual / code style editor (#7721)

### DIFF
--- a/docs/developer-guide/mapstore-migration-guide.md
+++ b/docs/developer-guide/mapstore-migration-guide.md
@@ -20,6 +20,23 @@ This is a list of things to check if you want to update from a previous version 
 - Optionally check also accessory files like `.eslinrc`, if you want to keep aligned with lint standards.
 - Follow the instructions below, in order, from your version to the one you want to update to.
 
+## Migration from 2021.02.01 to 2021.02.02
+### Style parsers dynamic import
+
+The style parser libraries introduced a dynamic import to reduce the initial bundle size. This change reflects to the `getStyleParser` function provided by the VectorStyleUtils module. If a downstream project of MapStore is using `getStyleParser` it should update it to this new version:
+
+```diff
+// example
+
+- // old use of parser
+- const parser = getStyleParser('sld');
+
++ // new use of parser
++ getStyleParser('sld')
++     .then((parser) => {
++         // use parser
++     });
+```
 ## Migration from 2021.02.00 to 2021.02.01
 
 This update contains a fix for a minor vulnerability found in `log4j` library.

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "leaflet.nontiledlayer": "1.0.7",
     "lodash": "4.17.21",
     "lrucache": "1.0.3",
+    "md5": "2.3.0",
     "moment": "2.21.0",
     "node-geo-distance": "1.2.0",
     "object-assign": "4.1.1",

--- a/web/client/api/geoserver/Styles.js
+++ b/web/client/api/geoserver/Styles.js
@@ -257,7 +257,12 @@ export const getStyleCodeByName = ({baseUrl: geoserverBaseUrl, styleName, option
     return axios.get(url, options)
         .then(response => {
             return response.data && response.data.style && response.data.style.name ?
-                axios.get(getStyleBaseUrl({ workspace, geoserverBaseUrl, name: response.data.style.name, format: getStyleFormatFromFilename(response.data.style.filename) })).then(({data: code}) => ({...response.data.style, code}))
+                axios.get(getStyleBaseUrl({ workspace, geoserverBaseUrl, name: response.data.style.name, format: getStyleFormatFromFilename(response.data.style.filename) }))
+                    .then(({data: code}) => ({
+                        ...response.data.style,
+                        ...(response?.data?.style?.metadata && { metadata: parseStyleMetadata(response.data.style.metadata) }),
+                        code
+                    }))
                 : null;
         });
 };

--- a/web/client/epics/styleeditor.js
+++ b/web/client/epics/styleeditor.js
@@ -53,34 +53,51 @@ import {
     loadingStyleSelector,
     styleServiceSelector,
     getUpdatedLayer,
-    editorMetadataSelector,
-    selectedStyleMetadataSelector
+    editorMetadataSelector
 } from '../selectors/styleeditor';
 
 import { getSelectedLayer, layerSettingSelector } from '../selectors/layers';
-import { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts } from '../utils/StyleEditorUtils';
+import { generateTemporaryStyleId, generateStyleId, STYLE_OWNER_NAME, getNameParts, detectStyleCodeChanges } from '../utils/StyleEditorUtils';
 import { initialSettingsSelector, originalSettingsSelector } from '../selectors/controls';
 import { updateStyleService } from '../api/StyleEditor';
+
 /*
  * Observable to get code of a style, it works only in edit status
  */
-const getStyleCodeObservable = ({status, styleName, baseUrl}) =>
+const getStyleCodeObservable = ({ status, styleName, baseUrl }) =>
     status === 'edit' ?
         Rx.Observable.defer(() =>
             StylesAPI.getStyleCodeByName({
                 baseUrl,
                 styleName
             })
+                .then(style =>
+                    detectStyleCodeChanges(style)
+                        .then(metadataNeedsReset => [style, metadataNeedsReset])
+                        .catch(() => [style, false])
+                )
         )
-            .switchMap(style => Rx.Observable.of(
-                selectStyleTemplate({
-                    languageVersion: style.languageVersion,
-                    code: style.code,
-                    templateId: '',
-                    format: style.format,
-                    init: true
-                })
-            ))
+            .switchMap(([style, metadataNeedsReset]) => {
+                return Rx.Observable.of(
+                    selectStyleTemplate({
+                        languageVersion: style.languageVersion,
+                        code: style.code,
+                        templateId: '',
+                        format: style.format,
+                        init: true
+                    }),
+                    updateEditorMetadata(metadataNeedsReset
+                        ? {
+                            editorType: 'textarea',
+                            styleJSON: null
+                        }
+                        : {
+                            editorType: style?.metadata?.msEditorType || 'textarea',
+                            styleJSON: style?.metadata?.msStyleJSON
+                        }
+                    )
+                );
+            })
             .catch(err => Rx.Observable.of(errorStyle('edit', err)))
         : Rx.Observable.empty();
 /*
@@ -343,7 +360,6 @@ export const updateLayerOnStatusChangeEpic = (action$, store) =>
             const selectedStyle = selectedStyleSelector(state);
             const styleName = selectedStyle || layer.availableStyles && layer.availableStyles[0] && layer.availableStyles[0].name;
 
-            const selectedStyleMetadata = selectedStyleMetadataSelector(state);
             const { baseUrl = '' } = styleServiceSelector(state);
 
             return describeAction && updateLayerSettingsObservable(action$, store,
@@ -360,26 +376,15 @@ export const updateLayerOnStatusChangeEpic = (action$, store) =>
                             setEditPermissionStyleEditor(!(updatedLayer
                                     && updatedLayer.describeLayer
                                     && updatedLayer.describeLayer.error === 401)),
-                            updateEditorMetadata({
-                                editorType: selectedStyleMetadata.msEditorType || 'textarea',
-                                styleJSON: selectedStyleMetadata.msStyleJSON
-                            }),
                             loadedStyle()
                         )
                     );
                 }
-            ) || Rx.Observable.concat(
-                getStyleCodeObservable({
-                    status: action.status,
-                    styleName,
-                    baseUrl
-                }),
-                Rx.Observable.of(
-                    updateEditorMetadata({
-                        editorType: selectedStyleMetadata.msEditorType || 'textarea',
-                        styleJSON: selectedStyleMetadata.msStyleJSON
-                    })
-                ));
+            ) || getStyleCodeObservable({
+                status: action.status,
+                styleName,
+                baseUrl
+            });
         });
 /**
  * Gets every `SELECT_STYLE_TEMPLATE`, `EDIT_STYLE_CODE` events.
@@ -493,6 +498,16 @@ export const updateTemporaryStyleEpic = (action$, store) =>
             || temporaryId && updateTmpCode(styleName)
             || createTmpCode(styleName);
         });
+
+// import the md5 dynamically
+// we need it only for the style body code
+function getMD5Metadata(code) {
+    return import('md5').then((mod) => {
+        const md5 = mod.default;
+        return md5(code);
+    });
+}
+
 /**
  * Gets every `CREATE_STYLE` event.
  * Create a new style.
@@ -525,15 +540,22 @@ export const createStyleEpic = (action$, store) =>
             };
 
             const status = '';
-
+            const newCode = template(code)({ styleTitle: title, styleAbstract: _abstract });
             return Rx.Observable.defer(() =>
-                StylesAPI.createStyle({
-                    baseUrl,
-                    code: template(code)({ styleTitle: title, styleAbstract: _abstract }),
-                    format,
-                    styleName,
-                    metadata
-                }))
+                getMD5Metadata(newCode)
+                    .then((msMD5Hash) =>
+                        StylesAPI.createStyle({
+                            baseUrl,
+                            code: newCode,
+                            format,
+                            styleName,
+                            metadata: {
+                                ...metadata,
+                                msMD5Hash
+                            }
+                        })
+                    )
+            )
                 .switchMap(() => Rx.Observable.of(
                     updateOptionsByOwner(STYLE_OWNER_NAME, [{}]),
                     updateSettingsParams({style: styleName || ''}, true),
@@ -591,15 +613,21 @@ export const updateStyleCodeEpic = (action$, store) =>
                 });
 
             return Rx.Observable.defer(() =>
-                StylesAPI.updateStyle({
-                    baseUrl,
-                    code,
-                    format,
-                    styleName,
-                    languageVersion,
-                    options: { params: { raw: true } },
-                    metadata
-                })
+                getMD5Metadata(code)
+                    .then((msMD5Hash) =>
+                        StylesAPI.updateStyle({
+                            baseUrl,
+                            code,
+                            format,
+                            styleName,
+                            languageVersion,
+                            options: { params: { raw: true } },
+                            metadata: {
+                                ...metadata,
+                                msMD5Hash
+                            }
+                        })
+                    )
             )
                 .switchMap(() => Rx.Observable.of(
                     loadedStyle(),

--- a/web/client/utils/VectorStyleUtils.js
+++ b/web/client/utils/VectorStyleUtils.js
@@ -11,11 +11,16 @@ import { isNil } from 'lodash';
 import { set } from './ImmutableUtils';
 import { colorToRgbaStr } from './ColorUtils';
 import axios from 'axios';
-import SLDParser from '@geosolutions/geostyler-sld-parser';
-import GeoCSSParser from '@geosolutions/geostyler-geocss-parser';
+
+function initParserLib(mod) {
+    const Parser = mod.default;
+    return new Parser();
+}
+
 const StyleParsers = {
-    sld: new SLDParser(),
-    css: new GeoCSSParser()
+    sld: () => import('@geosolutions/geostyler-sld-parser').then(initParserLib),
+    css: () => import('@geosolutions/geostyler-geocss-parser').then(initParserLib),
+    openlayers: () =>  import('geostyler-openlayers-parser').then(initParserLib)
 };
 
 /**
@@ -333,6 +338,15 @@ export const createStylesAsync = (styles = []) => {
     });
 };
 
+/**
+ * Import a style parser based on the format
+ * @param  {string} format format encoding of the style: css, sld or openlayers
+ * @return {promise} returns the parser instance if available
+ */
 export const getStyleParser = (format = 'sld') => {
-    return StyleParsers[format];
+    if (!StyleParsers[format]) {
+        return Promise.resolve(null);
+    }
+    // import parser libraries dynamically
+    return StyleParsers[format]();
 };

--- a/web/client/utils/__tests__/StyleEditorUtils-test.js
+++ b/web/client/utils/__tests__/StyleEditorUtils-test.js
@@ -28,7 +28,8 @@ import {
     parseJSONStyle,
     formatJSONStyle,
     validateImageSrc,
-    updateExternalGraphicNode
+    updateExternalGraphicNode,
+    detectStyleCodeChanges
 } from '../StyleEditorUtils';
 
 describe('StyleEditorUtils test', () => {
@@ -965,6 +966,122 @@ describe('StyleEditorUtils test', () => {
             expect(errorObj.messageId).toEqual('styleeditor.imageFormatEmpty');
             expect(errorObj.status).toEqual(400);
             expect(parsedCode).toBeFalsy();
+        });
+    });
+
+    describe('test detectStyleCodeChanges', ()=>{
+        it('should not detect changes if msStyleJSON is not defined in metadata', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #ff0000;\n}\n',
+                format: 'css'
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(false);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+        it('should not detect changes if the parsed msStyleJSON has same hash of the code', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #ff0000;\n  fill-opacity: 1;\n}\n',
+                format: 'css',
+                metadata: {
+                    msStyleJSON: JSON.stringify({
+                        name: 'Style',
+                        rules: [ {
+                            name: 'Rule',
+                            symbolizers: [
+                                {
+                                    color: '#ff0000',
+                                    fillOpacity: 1,
+                                    kind: 'Fill'
+                                }
+                            ]
+                        }]
+                    })
+                }
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(false);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+        it('should detect changes if the parsed msStyleJSON has different hash of the code', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #0000ff;\n  fill-opacity: 1;\n}\n',
+                format: 'css',
+                metadata: {
+                    msStyleJSON: JSON.stringify({
+                        name: 'Style',
+                        rules: [ {
+                            name: 'Rule',
+                            symbolizers: [
+                                {
+                                    color: '#ff0000',
+                                    fillOpacity: 1,
+                                    kind: 'Fill'
+                                }
+                            ]
+                        }]
+                    })
+                }
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(true);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+
+        it('should detect changes if the msMD5Hash has different hash of the code', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #ff0000;\n  fill-opacity: 1;\n}\n',
+                format: 'css',
+                metadata: {
+                    msMD5Hash: 'fb84f642f11d431c0bc7801c4fd3b77c'
+                }
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(true);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
+        });
+
+        it('should not detect changes if the msMD5Hash is equal to the hash of the code', (done) => {
+            const style = {
+                code: '@mode \'Flat\';\n@styleTitle \'Style\';\n\n/* @title Rule */\n* {\n  fill: #0000ff;\n  fill-opacity: 1;\n}\n',
+                format: 'css',
+                metadata: {
+                    msMD5Hash: 'fb84f642f11d431c0bc7801c4fd3b77c'
+                }
+            };
+            detectStyleCodeChanges(style)
+                .then((metadataNeedsReset) => {
+                    try {
+                        expect(metadataNeedsReset).toBe(false);
+                    } catch (e) {
+                        done(e);
+                    }
+                    done();
+                });
         });
     });
 });

--- a/web/client/utils/__tests__/VectorStyleUtils-test.js
+++ b/web/client/utils/__tests__/VectorStyleUtils-test.js
@@ -409,12 +409,31 @@ describe("VectorStyleUtils ", () => {
             expect(results[1].fillColor).toBe("#FF00FF");
         });
     });
-    it('getStyleParser returns parsers for supported style formats', () => {
-        expect(getStyleParser('sld')).toBeTruthy();
-        expect(getStyleParser('sld').readStyle).toBeTruthy();
-        expect(getStyleParser('sld').writeStyle).toBeTruthy();
-        expect(getStyleParser('css')).toBeTruthy();
-        expect(getStyleParser('css').readStyle).toBeTruthy();
-        expect(getStyleParser('css').writeStyle).toBeTruthy();
+    it('getStyleParser returns parsers for sld format', (done) => {
+        getStyleParser('sld')
+            .then((parser) => {
+                expect(parser).toBeTruthy();
+                expect(parser.readStyle).toBeTruthy();
+                expect(parser.writeStyle).toBeTruthy();
+                done();
+            });
+    });
+
+    it('getStyleParser returns parsers for css format', (done) => {
+        getStyleParser('css')
+            .then((parser) => {
+                expect(parser).toBeTruthy();
+                expect(parser.readStyle).toBeTruthy();
+                expect(parser.writeStyle).toBeTruthy();
+                done();
+            });
+    });
+
+    it('should not return a parser with unsupported format', (done) => {
+        getStyleParser('unknown')
+            .then((parser) => {
+                expect(parser).toBeFalsy();
+                done();
+            });
     });
 });


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

This PR introduces following changes:

- dynamic import of style parser libraries
- md5 hash comparison between the JSON representation and the body of the style

The new workflow of style editor initialization will detect if the code has been changed based on the hash mismatch and switch to the textarea editor dropping the style JSON for the visual style editor

This PR introduces

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->

#7671
#6534

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
