### PR TITLE
#7764 Fix street view api load

### DIFF
--- a/web/client/plugins/StreetView/StreetView.jsx
+++ b/web/client/plugins/StreetView/StreetView.jsx
@@ -20,13 +20,13 @@ import streetView from './reducers/streetview';
 import * as epics from './epics/streetView';
 import './css/style.css';
 
-const StreetViewPluginComponent = ({onMount, onUnmount, ...props}) => {
+const StreetViewPluginComponent = ({onMount, onUnmount, apiKey, useDataLayer, dataLayerConfig}) => {
     useEffect(() => {
-        onMount(props);
+        onMount({apiKey, useDataLayer, dataLayerConfig});
         return () => {
             onUnmount();
         };
-    }, []);
+    }, [apiKey, useDataLayer, dataLayerConfig]);
     return <StreetViewContainer />;
 };
 
@@ -45,6 +45,7 @@ const StreetViewPluginContainer = connect(() => ({}), {
  * - `googleAPIKey` (for retro-compatibility only)
  *
  * Generally speaking, you should prefer general settings in `localConfig.json` over the plugin configuration, in order to reuse the same configuration for default viewer and all the contexts, automatically. This way you will not need to configure the `apiKey` in every context.
+ * <br>**Important**: You can use only **one** API-key for a MapStore instance. The api-key can be configured replicated in every plugin configuration or using one of the unique global settings (suggested) in `localConfig.json`). @see {@link https://github.com/googlemaps/js-api-loader/issues/5|here} and @see {@link https://github.com/googlemaps/js-api-loader/issues/100|here}
  * @property {boolean} [cfg.useDataLayer=true] If true, adds to the map a layer for street view data availability when the plugin is turned on.
  * @property {object} [cfg.dataLayerConfig] configuration for the data layer. By default `{provider: 'custom', type: "tileprovider", url: "https://mts1.googleapis.com/vt?hl=en-US&lyrs=svv|cb_client:apiv3&style=40,18&x={x}&y={y}&z={z}"}`
  * @class

--- a/web/client/plugins/StreetView/__tests__/streetview-epic-test.js
+++ b/web/client/plugins/StreetView/__tests__/streetview-epic-test.js
@@ -1,0 +1,45 @@
+import expect from 'expect';
+import { testEpic, addTimeoutEpic, TEST_TIMEOUT } from '../../../epics/__tests__/epicTestUtils';
+
+import { UPDATE_ADDITIONAL_LAYER } from '../../../actions/additionallayers';
+
+import { streetViewSyncLayer } from '../epics/streetView';
+import { setPov, setLocation } from '../actions/streetView';
+
+describe('StreetView epics', () => {
+    it('update layer on setLocation', (done) => {
+        let action = setLocation({});
+        const NUM_ACTIONS = 1;
+        const LAT = 1;
+        const LNG = 2;
+        testEpic(streetViewSyncLayer, NUM_ACTIONS, action, ([update]) => {
+            expect(update).toExist();
+            expect(update.type).toBe(UPDATE_ADDITIONAL_LAYER);
+            expect(update.options.features[0].geometry.coordinates).toEqual([LNG, LAT]);
+            done();
+        }, {streetView: {location: {latLng: {lat: LAT, lng: LNG}}}});
+    });
+    it('update layer on setPov', (done) => {
+        let action = setPov({});
+        const NUM_ACTIONS = 1;
+        const LAT = 1;
+        const LNG = 2;
+        const rotation = 42;
+        testEpic(streetViewSyncLayer, NUM_ACTIONS, action, ([update]) => {
+            expect(update).toExist();
+            expect(update.type).toBe(UPDATE_ADDITIONAL_LAYER);
+            expect(update.options.features[0].geometry.coordinates).toEqual([LNG, LAT]);
+            expect(decodeURIComponent(update.options.features[0].style[0].symbolUrl).includes(`rotate(${rotation})`)).toBeTruthy();
+            done();
+        }, {streetView: {pov: {heading: rotation}, location: {latLng: {lat: LAT, lng: LNG}}}});
+    });
+    it('prevent layer to be updated if location is not set', (done) => {
+        let action = setPov({});
+        const NUM_ACTIONS = 1;
+        testEpic(addTimeoutEpic(streetViewSyncLayer, 50), NUM_ACTIONS, action, ([timeout]) => {
+            expect(timeout).toExist();
+            expect(timeout.type).toBe(TEST_TIMEOUT);
+            done();
+        }, {layers: {flat: [{name: "layerName", url: "clearlyNotAUrl", visibility: true, queryable: false, type: "wms"}]}});
+    });
+});

--- a/web/client/plugins/StreetView/epics/streetView.js
+++ b/web/client/plugins/StreetView/epics/streetView.js
@@ -180,13 +180,14 @@ export const streetViewSyncLayer = (action$, {getState = () => {}}) => {
             }]
         };
     };
-    return action$.ofType(SET_LOCATION, SET_POV).map(() => {
+    return action$.ofType(SET_LOCATION, SET_POV).switchMap(() => {
         const state = getState();
         const location = locationSelector(state);
         const pov = povSelector(state);
-        return locationToFeature(location, pov);
-    })
-        .map((feature) => {
+        if (!location) {
+            return Rx.Observable.empty();
+        }
+        return Rx.Observable.of(locationToFeature(location, pov)).map((feature) => {
             const options = getStreetViewMarkerLayer(getState());
             return updateAdditionalLayer(
                 MARKER_LAYER_ID,
@@ -194,4 +195,5 @@ export const streetViewSyncLayer = (action$, {getState = () => {}}) => {
                 "overlay", {...options, features: [feature]}
             );
         });
+    });
 };


### PR DESCRIPTION
## Description
This fixes the problem notified in #7764.

Anyway using different configuration (no-API and/or multiple api key) in the same application is not allowed because of a limitation of the dynamic api loader provided by google.

- see https://github.com/googlemaps/js-api-loader/issues/5
- and see https://github.com/googlemaps/js-api-loader/issues/100

For now, when trying to use mapstore will ignore different configurations, and uses the first api-key loaded (When the tool is effectively opened).

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue
#7764

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
