### PR TITLE
#7513 Removed JAVA_HOME variable usage for mapstore binary

### DIFF
--- a/release/bin/mapstore2-startup.bat
+++ b/release/bin/mapstore2-startup.bat
@@ -15,17 +15,10 @@ set "EXECUTABLE=%CATALINA_HOME%\bin\catalina.bat"
 set CMD_LINE_ARGS=
 set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
 
-rem JAVA_HOME not defined
-if "%JAVA_HOME%" == "" goto nativeJava
-
-echo JAVA_HOME: %JAVA_HOME%
-echo.
-
-rem No errors
-goto run
-
 :nativeJava
   set "JAVA_HOME=%CURRENT_DIR%\jre\win"
+
+rem if you want to customize java version used, override JAVA_HOME variable here
 
 rem JAVA_HOME defined incorrectly
 :checkJava
@@ -37,7 +30,7 @@ goto run
 goto JavaFail
 
 :JavaFail
-  echo Java 7 is needed to run MapStore2.
+  echo Java is needed to run MapStore2.
   echo.
   echo Install it from:
   echo    http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html


### PR DESCRIPTION
## Description
This PR removes the usage of JAVA_HOME env variable. This because this variable may be configured on the machine for other purposes, so it should not be used for this switch. In this way this lunch script is aligned with linux one. 
If a user wants to customize the java version to use, he have to customize the script (and this is fine, because any change to the binary for this purposes is not suggested for non-developers). 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7513

**What is the new behavior?**
Even if JAVA_HOME is defined as environment variable, the binary starts by default with the embedded VM. 

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
