### PR TITLE
7444 Layer styles - Update "like" filter tooltip message if CSS style format is used

### DIFF
--- a/web/client/components/data/query/GroupField.jsx
+++ b/web/client/components/data/query/GroupField.jsx
@@ -46,7 +46,8 @@ class GroupField extends React.Component {
         stringOperators: PropTypes.array,
         booleanOperators: PropTypes.array,
         defaultOperators: PropTypes.array,
-        comboOptions: PropTypes.object
+        comboOptions: PropTypes.object,
+        format: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
     };
 
     static contextTypes = {
@@ -86,7 +87,8 @@ class GroupField extends React.Component {
         stringOperators: ["=", "<>", "like", "ilike", "isNull"],
         arrayOperators: ["contains"],
         booleanOperators: ["="],
-        defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "><"]
+        defaultOperators: ["=", ">", "<", ">=", "<=", "<>", "><"],
+        format: false
     };
 
     getComboValues = (selected, attributes) => {
@@ -196,6 +198,7 @@ class GroupField extends React.Component {
                             filterField={filterField}
                             attType="string"/>) :
                         (<TextField
+                            tooltipMessage={this.props.format === 'css' ? "queryform.attributefilter.tooltipTextFieldCSS" : "queryform.attributefilter.tooltipTextField"}
                             operator={filterField.operator}
                             attType="string"/>)
                 }

--- a/web/client/components/data/query/TextField.jsx
+++ b/web/client/components/data/query/TextField.jsx
@@ -23,6 +23,7 @@ class TextField extends React.Component {
         attType: PropTypes.string,
         fieldValue: PropTypes.string,
         label: PropTypes.string,
+        tooltipMessage: PropTypes.string,
         fieldException: PropTypes.oneOfType([
             PropTypes.object,
             PropTypes.string
@@ -60,7 +61,7 @@ class TextField extends React.Component {
     }
     renderField = () => {
         let placeholder = getMessageById(this.context.messages, "queryform.attributefilter.text_placeholder");
-        let tooltip = <Tooltip id={"textField-tooltip" + this.props.fieldRowId}><HTML msgId="queryform.attributefilter.tooltipTextField"/></Tooltip>;
+        let tooltip = <Tooltip id={"textField-tooltip" + this.props.fieldRowId}><HTML msgId={this.props.tooltipMessage ?? "queryform.attributefilter.tooltipTextField"}/></Tooltip>;
         let field = (<FormControl
             disabled={this.props.operator === "isNull"}
             placeholder={placeholder}

--- a/web/client/components/resources/ResourceCard.jsx
+++ b/web/client/components/resources/ResourceCard.jsx
@@ -23,7 +23,7 @@ class ResourceCard extends React.Component {
         backgroundOpacityStart: PropTypes.number,
         backgroundOpacityEnd: PropTypes.number,
         resource: PropTypes.object,
-        editDataEnabled: PropTypes.oneOfType(PropTypes.bool, PropTypes.func),
+        editDataEnabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
         shareToolEnabled: PropTypes.bool,
         // CALLBACKS
         viewerUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/web/client/components/styleeditor/FilterBuilder.jsx
+++ b/web/client/components/styleeditor/FilterBuilder.jsx
@@ -46,6 +46,7 @@ const FilterBuilder = ({
         groupFields: [{ id: 1, logic: 'OR', index: 0 }]
     },
     attributes = [],
+    format,
     groupLevels = 0,
     onChange = () => {}
 }) => {
@@ -53,6 +54,7 @@ const FilterBuilder = ({
     return (
         <div className="ms-style-rule-filter">
             <GroupField
+                format={format}
                 attributes={attributes}
                 filterFields={filterFields}
                 groupFields={groupFields}
@@ -158,6 +160,7 @@ export function FilterBuilderPopover({
     value,
     hide,
     attributes,
+    format,
     onChange,
     placement = 'right'
 }) {
@@ -171,6 +174,7 @@ export function FilterBuilderPopover({
                 <FilterBuilder
                     filterObj={value}
                     attributes={attributes}
+                    format={format}
                     onChange={(filter) => onChange({ filter })}
                 />
             }>

--- a/web/client/components/styleeditor/RulesEditor.jsx
+++ b/web/client/components/styleeditor/RulesEditor.jsx
@@ -300,6 +300,7 @@ const RulesEditor = forwardRef(({
                                         hide={hideFilter}
                                         value={filter}
                                         attributes={attributes}
+                                        format={format}
                                         onChange={(values) => handleChanges({ values, ruleId }, true)}
                                     />
                                     <ScaleDenominatorPopover

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1043,7 +1043,8 @@
                 "combo_placeholder": "Attribut",
                 "text_placeholder": "Gib den zu filternden Text ein",
                 "attribute_filter_header": "Attributfilter",
-                "tooltipTextField": "Verwenden <b>*</b> für ein beliebiges Zeichen</br>Verwenden <b>.</b> für ein einzelnes Zeichen</br>Verwenden <b>!</b> für Sonderzeichen (* und .)</br>",
+                "tooltipTextField": "Verwenden <b>*</b> für ein beliebiges Zeichen</br>Verwenden . für ein einzelnes Zeichen</br>Verwenden <b>!</b> für Sonderzeichen (* und .)</br>",
+                "tooltipTextFieldCSS": "Verwenden <b>%</b> für ein beliebiges Zeichen</br>Verwenden <b>_</b> für ein einzelnes Zeichen</br>Verwenden <b>\\</b> für Sonderzeichen (% und _)</br>",
                 "groupField": {
                     "any": "einer",
                     "all": "aller",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1004,7 +1004,8 @@
                 "combo_placeholder": "Attribute",
                 "text_placeholder": "Type text to search",
                 "attribute_filter_header": "Attribute filter",
-                "tooltipTextField": "use <b>*</b> for any number of any char</br>use <b>.</b> for a single char</br>use <b>!</b> to escape the above two (* and .)</br>",
+                "tooltipTextField": "use <b>*</b> for any number of any char</br>use . for a single char</br>use <b>!</b> to escape the above two (* and .)</br>",
+                "tooltipTextFieldCSS": "use <b>%</b> for any number of any char</br>use <b>_</b> for a single char</br>use <b>\\</b> to escape the above two (% and _)</br>",
                 "groupField": {
                     "any": "any",
                     "all": "all",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1004,7 +1004,8 @@
                 "combo_placeholder": "Atributo",
                 "text_placeholder": "Introduzca el texto para buscar",
                 "attribute_filter_header": "Filtro por atributo",
-                "tooltipTextField": "utiliza <b>*</b> para cualquier carácter</br>utiliza <b>.</b> para un solo carácter</br>utiliza <b>!</b> para caracteres especiales (* y .)</br>",
+                "tooltipTextField": "utiliza <b>*</b> para cualquier carácter</br>utiliza . para un solo carácter</br>utiliza <b>!</b> para caracteres especiales (* y .)</br>",
+                "tooltipTextFieldCSS": "utiliza <b>%</b> para cualquier carácter</br>utiliza <b>_</b> para un solo carácter</br>utiliza <b>\\</b> para caracteres especiales (% y _)</br>",
                 "groupField": {
                     "any": "alguna",
                     "all": "todas",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1004,7 +1004,8 @@
                 "combo_placeholder": "Attribut",
                 "text_placeholder": "Entrer le texte à rechercher",
                 "attribute_filter_header": "Attribut filtre",
-                "tooltipTextField": "utilise <b>*</b> pour tout caractère</br>utilise <b>.</b> pour un seul caractère</br>utilise <b>!</b> pour les caractères spéciaux (* et .)</br>",
+                "tooltipTextField": "utilise <b>*</b> pour tout caractère</br>utilise . pour un seul caractère</br>utilise <b>!</b> pour les caractères spéciaux (* et .)</br>",
+                "tooltipTextFieldCSS": "utilise <b>%</b> pour tout caractère</br>utilise <b>_</b> pour un seul caractère</br>utilise <b>\\</b> pour les caractères spéciaux (% et _)</br>",
                 "groupField": {
                     "any": "certain",
                     "all": "tous",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1004,7 +1004,8 @@
                 "combo_placeholder": "Attributo",
                 "text_placeholder": "Digita il testo da cercare",
                 "attribute_filter_header": "Filtro Attributi",
-                "tooltipTextField": "usa <b>*</b> per qualsiasi carattere</br>usa <b>.</b> un solo carattere</br>usa <b>!</b> per i caratteri speciali (* e .)</br>",
+                "tooltipTextField": "usa <b>*</b> per qualsiasi carattere</br>usa . un solo carattere</br>usa <b>!</b> per i caratteri speciali (* e .)</br>",
+                "tooltipTextFieldCSS": "usa <b>%</b> per qualsiasi carattere</br>usa <b>_</b> un solo carattere</br>usa <b>\\</b> per i caratteri speciali (% e _)</br>",
                 "groupField": {
                     "any": "almeno una delle",
                     "all": "tutte le",


### PR DESCRIPTION
## Description
This PR introduces changes required to have custom tooltip text for style filter when "like" operator is used. For "CSS" format message will be altered to use proper wildcards (% and \ instead of * and .)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7444 

**What is the new behavior?**
Tooltip message is different for "like" operator & "css" format.
Also tooltip message for "SLD" format is slightly updated: bold style removed from dot because it was looking confusing, user might think it was underscore.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information

https://user-images.githubusercontent.com/4226620/150815452-6eefdb6f-abf0-4693-adcd-70025e64b39b.mp4


