### PR TITLE
#7246 Do not export styles when map is exported

### DIFF
--- a/web/client/epics/mapexport.js
+++ b/web/client/epics/mapexport.js
@@ -59,7 +59,6 @@ const PersistMap = {
         }
 
         return Rx.Observable.forkJoin(...layers.map(layer => getLayerCapabilities(layer).catch(() => Rx.Observable.of(null))))
-            .switchMap(capArr => capArr.map(({ style, ...cap}) => cap))
             .switchMap(capArr => Rx.Observable.of([
                 toWMC(set('map.layers', zip(layers, capArr).map(([l, capabilities]) => ({...l, capabilities})), config), {}),
                 'context.wmc',

--- a/web/client/epics/mapexport.js
+++ b/web/client/epics/mapexport.js
@@ -59,6 +59,7 @@ const PersistMap = {
         }
 
         return Rx.Observable.forkJoin(...layers.map(layer => getLayerCapabilities(layer).catch(() => Rx.Observable.of(null))))
+            .switchMap(capArr => capArr.map(({ style, ...cap}) => cap))
             .switchMap(capArr => Rx.Observable.of([
                 toWMC(set('map.layers', zip(layers, capArr).map(([l, capabilities]) => ({...l, capabilities})), config), {}),
                 'context.wmc',

--- a/web/client/utils/LayersUtils.js
+++ b/web/client/utils/LayersUtils.js
@@ -540,7 +540,6 @@ export const saveLayer = (layer) => {
         styles: layer.styles,
         style: layer.style,
         styleName: layer.styleName,
-        availableStyles: layer.availableStyles,
         layerFilter: layer.layerFilter,
         title: layer.title,
         transparent: layer.transparent,

--- a/web/client/utils/__tests__/MapUtils-test.js
+++ b/web/client/utils/__tests__/MapUtils-test.js
@@ -305,7 +305,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: "THUMB_URL",
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -357,7 +356,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -409,7 +407,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -461,7 +458,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -686,7 +682,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: "THUMB_URL",
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -738,7 +733,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -790,7 +784,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -842,7 +835,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -894,7 +886,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -946,7 +937,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1138,7 +1128,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: "THUMB_URL",
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1190,7 +1179,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1242,7 +1230,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1449,7 +1436,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1500,7 +1486,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1551,7 +1536,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -1752,7 +1736,6 @@ describe('Test the MapUtils', () => {
                         styles: undefined,
                         style: undefined,
                         styleName: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         title: 'annotations',
                         transparent: undefined,
@@ -1897,7 +1880,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -2058,7 +2040,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -2259,7 +2240,6 @@ describe('Test the MapUtils', () => {
                     layers: [{
                         allowedSRS: {},
                         thumbURL: "THUMB_URL",
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -2311,7 +2291,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -2363,7 +2342,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,
@@ -2415,7 +2393,6 @@ describe('Test the MapUtils', () => {
                     {
                         allowedSRS: {},
                         thumbURL: undefined,
-                        availableStyles: undefined,
                         layerFilter: undefined,
                         bbox: {},
                         requestEncoding: undefined,


### PR DESCRIPTION
## Description
Export to MapStore format will not contain "availableStyles" array regardless if it exists in current map state or not.

Layer's property "availableStyles" is not in the store by default when layer is added to the map. It's getting written into the store with action "UPDATE_NODE" as a result of running "getAvailableStylesFromLayerCapabilities" from "epics/styleeditor.js" when user opens layer settings:
![image](https://user-images.githubusercontent.com/4226620/151012809-c3472431-1f48-4ed1-b09a-a20230395cde.png)

So if user run export when layer settings was never open - there are no availableStyles in exported data when MapStore format is used.

This PR changes such behavior to exclude availableStyles export explicitly, regardless if they were loaded into the store or not.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7246 

**What is the new behavior?**
- MapStore export format - "availableStyles" property won't be exported regardless if it's in store or not.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
