### PR TITLE
#7777; fixed shared GeoStory home icon styling

### DIFF
--- a/web/client/components/home/Home.jsx
+++ b/web/client/components/home/Home.jsx
@@ -54,7 +54,7 @@ class Home extends React.Component {
                         bsStyle="primary"
                         onClick={this.checkUnsavedChanges}
                         tooltip={tooltip}
-                        {...pick(restProps, ['disabled', 'active', 'block', 'componentClass', 'href', 'children'])}
+                        {...pick(restProps, ['disabled', 'active', 'block', 'componentClass', 'href', 'children', 'icon', 'bsStyle', 'className'])}
                     >{this.props.icon}</Button>
                 </OverlayTrigger>
                 <ConfirmModal


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7777 

**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
The shared GeoStory's home button is now having the correct styling
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
