### PR TITLE
#7790 Limit home page empty tab icon sizes on large screens

### DIFF
--- a/web/client/plugins/Contexts.jsx
+++ b/web/client/plugins/Contexts.jsx
@@ -171,7 +171,11 @@ const ContextsPlugin = compose(
         ({resources = [], loading}) => !loading && resources.length === 0,
         () => ({
             glyph: "map-context",
-            title: <Message msgId="resources.contexts.noContextAvailable" />
+            title: <Message msgId="resources.contexts.noContextAvailable" />,
+            iconFit: true,
+            imageStyle: {
+                height: '200px'
+            }
         })
     )
 )(Contexts);

--- a/web/client/plugins/Contexts.jsx
+++ b/web/client/plugins/Contexts.jsx
@@ -69,7 +69,8 @@ class Contexts extends React.Component {
         title: PropTypes.string,
         shareOptions: PropTypes.object,
         shareToolEnabled: PropTypes.bool,
-        editDataEnabled: PropTypes.bool
+        editDataEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -104,6 +105,7 @@ class Contexts extends React.Component {
         editDataEnabled: true,
         shareOptions: CONTEXT_DEFAULT_SHARE_OPTIONS,
         shareToolEnabled: true,
+        emptyView: {},
         onEditData: () => {}
     };
 
@@ -169,12 +171,12 @@ const ContextsPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        () => ({
+        (emptyView) => ({
             glyph: "map-context",
             title: <Message msgId="resources.contexts.noContextAvailable" />,
             iconFit: true,
             imageStyle: {
-                height: '200px'
+                height: emptyView?.iconHeight ?? '200px'
             }
         })
     )
@@ -188,6 +190,7 @@ const ContextsPlugin = compose(
  * @class
  * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 
 export default createPlugin('Contexts', {

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -42,6 +42,7 @@ const dashboardsCountSelector = createSelector(
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
  * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 class Dashboards extends React.Component {
     static propTypes = {
@@ -55,7 +56,8 @@ class Dashboards extends React.Component {
         colProps: PropTypes.object,
         fluid: PropTypes.bool,
         shareOptions: PropTypes.object,
-        shareToolEnabled: PropTypes.bool
+        shareToolEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -78,7 +80,8 @@ class Dashboards extends React.Component {
         },
         maps: [],
         shareOptions: DASHBOARD_DEFAULT_SHARE_OPTIONS,
-        shareToolEnabled: true
+        shareToolEnabled: true,
+        emptyView: {}
     };
 
     componentDidMount() {
@@ -118,13 +121,13 @@ const DashboardsPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        ({showCreateButton = true}) => ({
+        ({showCreateButton = true, emptyView}) => ({
             glyph: "dashboard",
             title: <Message msgId="resources.dashboards.noDashboardAvailable" />,
             description: <EmptyDashboardsView showCreateButton={showCreateButton}/>,
             iconFit: true,
             imageStyle: {
-                height: '200px'
+                height: emptyView?.iconHeight ?? '200px'
             }
         })
 

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -121,7 +121,11 @@ const DashboardsPlugin = compose(
         ({showCreateButton = true}) => ({
             glyph: "dashboard",
             title: <Message msgId="resources.dashboards.noDashboardAvailable" />,
-            description: <EmptyDashboardsView showCreateButton={showCreateButton}/>
+            description: <EmptyDashboardsView showCreateButton={showCreateButton}/>,
+            iconFit: true,
+            imageStyle: {
+                height: '200px'
+            }
         })
 
     )

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -41,6 +41,7 @@ const geostoriesCountSelector = createSelector(
  * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
  * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 class Geostories extends React.Component {
     static propTypes = {
@@ -54,7 +55,8 @@ class Geostories extends React.Component {
         colProps: PropTypes.object,
         fluid: PropTypes.bool,
         shareOptions: PropTypes.object,
-        shareToolEnabled: PropTypes.bool
+        shareToolEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -77,7 +79,8 @@ class Geostories extends React.Component {
         },
         maps: [],
         shareOptions: GEOSTORY_DEFAULT_SHARE_OPTIONS,
-        shareToolEnabled: true
+        shareToolEnabled: true,
+        emptyView: {}
     };
 
     componentDidMount() {
@@ -117,13 +120,13 @@ const GeoStoriesPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        ({showCreateButton = true}) => ({
+        ({showCreateButton = true, emptyView}) => ({
             glyph: "geostory",
             title: <Message msgId="resources.geostories.noGeostoryAvailable" />,
             description: <EmptyGeostoriesView showCreateButton={showCreateButton}/>,
             iconFit: true,
             imageStyle: {
-                height: '200px'
+                height: emptyView?.iconHeight ?? '200px'
             }
         })
 

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -120,7 +120,11 @@ const GeoStoriesPlugin = compose(
         ({showCreateButton = true}) => ({
             glyph: "geostory",
             title: <Message msgId="resources.geostories.noGeostoryAvailable" />,
-            description: <EmptyGeostoriesView showCreateButton={showCreateButton}/>
+            description: <EmptyGeostoriesView showCreateButton={showCreateButton}/>,
+            iconFit: true,
+            imageStyle: {
+                height: '200px'
+            }
         })
 
     )

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -153,7 +153,11 @@ const MapsPlugin = compose(
         ({showCreateButton = true}) => ({
             glyph: "1-map",
             title: <Message msgId="resources.maps.noMapAvailable" />,
-            content: <EmptyMaps showCreateButton={showCreateButton} />
+            content: <EmptyMaps showCreateButton={showCreateButton} />,
+            iconFit: true,
+            imageStyle: {
+                height: '200px'
+            }
         })
     )
 )(Maps);

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -80,7 +80,8 @@ class Maps extends React.Component {
         version: PropTypes.string,
         fluid: PropTypes.bool,
         showAPIShare: PropTypes.bool,
-        shareToolEnabled: PropTypes.bool
+        shareToolEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -103,7 +104,8 @@ class Maps extends React.Component {
         },
         maps: [],
         showAPIShare: true,
-        shareToolEnabled: true
+        shareToolEnabled: true,
+        emptyView: {}
     };
 
     render() {
@@ -150,13 +152,13 @@ const MapsPlugin = compose(
     }),
     emptyState(
         ({maps = [], loading}) => !loading && maps.length === 0,
-        ({showCreateButton = true}) => ({
+        ({showCreateButton = true, emptyView}) => ({
             glyph: "1-map",
             title: <Message msgId="resources.maps.noMapAvailable" />,
             content: <EmptyMaps showCreateButton={showCreateButton} />,
             iconFit: true,
             imageStyle: {
-                height: '200px'
+                height: emptyView?.iconHeight ?? '200px'
             }
         })
     )
@@ -171,6 +173,7 @@ const MapsPlugin = compose(
  * @class
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 export default {
     MapsPlugin: assign(MapsPlugin, {


### PR DESCRIPTION
## Description
Icons sizes is capped with 200px height which should be ok for any desktop device.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [x] Other... Please describe: Change into empty view component configuration

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7790 

**What is the new behavior?**
Icon height is capped with 200px. For very small screens it's getting smaller as it was before this change.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
![image](https://user-images.githubusercontent.com/4226620/151393498-9f2570cf-5bb9-412b-ad21-45554fe7fa7b.png)
