### PR TITLE
[Backport 2021.02.xx] #7790 Limit home page empty tab icon sizes on large screens (#7791)

### DIFF
--- a/web/client/plugins/Contexts.jsx
+++ b/web/client/plugins/Contexts.jsx
@@ -69,7 +69,8 @@ class Contexts extends React.Component {
         title: PropTypes.string,
         shareOptions: PropTypes.object,
         shareToolEnabled: PropTypes.bool,
-        editDataEnabled: PropTypes.bool
+        editDataEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -104,6 +105,7 @@ class Contexts extends React.Component {
         editDataEnabled: true,
         shareOptions: CONTEXT_DEFAULT_SHARE_OPTIONS,
         shareToolEnabled: true,
+        emptyView: {},
         onEditData: () => {}
     };
 
@@ -169,9 +171,13 @@ const ContextsPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        () => ({
+        (emptyView) => ({
             glyph: "map-context",
-            title: <Message msgId="resources.contexts.noContextAvailable" />
+            title: <Message msgId="resources.contexts.noContextAvailable" />,
+            iconFit: true,
+            imageStyle: {
+                height: emptyView?.iconHeight ?? '200px'
+            }
         })
     )
 )(Contexts);
@@ -184,6 +190,7 @@ const ContextsPlugin = compose(
  * @class
  * @prop {object} cfg.shareOptions configuration applied to share panel
  * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 
 export default createPlugin('Contexts', {

--- a/web/client/plugins/Dashboards.jsx
+++ b/web/client/plugins/Dashboards.jsx
@@ -40,7 +40,9 @@ const dashboardsCountSelector = createSelector(
  * @memberof plugins
  * @class
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
- * @prop {boolean} cfg.shareOptions configuration applied to share panel
+ * @prop {object} cfg.shareOptions configuration applied to share panel
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 class Dashboards extends React.Component {
     static propTypes = {
@@ -53,7 +55,9 @@ class Dashboards extends React.Component {
         mapsOptions: PropTypes.object,
         colProps: PropTypes.object,
         fluid: PropTypes.bool,
-        shareOptions: PropTypes.object
+        shareOptions: PropTypes.object,
+        shareToolEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -75,7 +79,9 @@ class Dashboards extends React.Component {
             className: 'ms-map-card-col'
         },
         maps: [],
-        shareOptions: DASHBOARD_DEFAULT_SHARE_OPTIONS
+        shareOptions: DASHBOARD_DEFAULT_SHARE_OPTIONS,
+        shareToolEnabled: true,
+        emptyView: {}
     };
 
     componentDidMount() {
@@ -91,6 +97,7 @@ class Dashboards extends React.Component {
             viewerUrl={(dashboard) => {this.context.router.history.push(`dashboard/${dashboard.id}`); }}
             getShareUrl={dashboard => `dashboard/${dashboard.id}`}
             shareOptions={this.props.shareOptions}
+            shareToolEnabled={this.props.shareToolEnabled}
             bottom={<PaginationToolbar />}
         />);
     }
@@ -114,10 +121,14 @@ const DashboardsPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        ({showCreateButton = true}) => ({
+        ({showCreateButton = true, emptyView}) => ({
             glyph: "dashboard",
             title: <Message msgId="resources.dashboards.noDashboardAvailable" />,
-            description: <EmptyDashboardsView showCreateButton={showCreateButton}/>
+            description: <EmptyDashboardsView showCreateButton={showCreateButton}/>,
+            iconFit: true,
+            imageStyle: {
+                height: emptyView?.iconHeight ?? '200px'
+            }
         })
 
     )

--- a/web/client/plugins/GeoStories.jsx
+++ b/web/client/plugins/GeoStories.jsx
@@ -39,7 +39,9 @@ const geostoriesCountSelector = createSelector(
  * @class
  * @memberof plugins
  * @prop {boolean} cfg.showCreateButton default true, use to render create a new one button
- * @prop {boolean} cfg.shareOptions configuration applied to share panel
+ * @prop {object} cfg.shareOptions configuration applied to share panel
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 class Geostories extends React.Component {
     static propTypes = {
@@ -52,7 +54,9 @@ class Geostories extends React.Component {
         mapsOptions: PropTypes.object,
         colProps: PropTypes.object,
         fluid: PropTypes.bool,
-        shareOptions: PropTypes.object
+        shareOptions: PropTypes.object,
+        shareToolEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -74,7 +78,9 @@ class Geostories extends React.Component {
             className: 'ms-map-card-col'
         },
         maps: [],
-        shareOptions: GEOSTORY_DEFAULT_SHARE_OPTIONS
+        shareOptions: GEOSTORY_DEFAULT_SHARE_OPTIONS,
+        shareToolEnabled: true,
+        emptyView: {}
     };
 
     componentDidMount() {
@@ -90,6 +96,7 @@ class Geostories extends React.Component {
             viewerUrl={(geostory) => {this.context.router.history.push(`geostory/${geostory.id}`); }}
             getShareUrl={(geostory) => `geostory/${geostory.id}`}
             shareOptions={this.props.shareOptions}
+            shareToolEnabled={this.props.shareToolEnabled}
             bottom={<PaginationToolbar />}
         />);
     }
@@ -113,10 +120,14 @@ const GeoStoriesPlugin = compose(
     }),
     emptyState(
         ({resources = [], loading}) => !loading && resources.length === 0,
-        ({showCreateButton = true}) => ({
+        ({showCreateButton = true, emptyView}) => ({
             glyph: "geostory",
             title: <Message msgId="resources.geostories.noGeostoryAvailable" />,
-            description: <EmptyGeostoriesView showCreateButton={showCreateButton}/>
+            description: <EmptyGeostoriesView showCreateButton={showCreateButton}/>,
+            iconFit: true,
+            imageStyle: {
+                height: emptyView?.iconHeight ?? '200px'
+            }
         })
 
     )

--- a/web/client/plugins/Maps.jsx
+++ b/web/client/plugins/Maps.jsx
@@ -79,7 +79,9 @@ class Maps extends React.Component {
         colProps: PropTypes.object,
         version: PropTypes.string,
         fluid: PropTypes.bool,
-        showAPIShare: PropTypes.bool
+        showAPIShare: PropTypes.bool,
+        shareToolEnabled: PropTypes.bool,
+        emptyView: PropTypes.object
     };
 
     static contextTypes = {
@@ -101,7 +103,9 @@ class Maps extends React.Component {
             className: 'ms-map-card-col'
         },
         maps: [],
-        showAPIShare: true
+        showAPIShare: true,
+        shareToolEnabled: true,
+        emptyView: {}
     };
 
     render() {
@@ -120,6 +124,7 @@ class Maps extends React.Component {
             getShareUrl={(map) => map.contextName ? `context/${map.contextName}/${map.id}` : `viewer/${this.props.mapType}/${map.id}`}
             shareApi={this.props.showAPIShare}
             version={this.props.version}
+            shareToolEnabled={this.props.shareToolEnabled}
             bottom={<PaginationToolbar />}
         />);
     }
@@ -147,10 +152,14 @@ const MapsPlugin = compose(
     }),
     emptyState(
         ({maps = [], loading}) => !loading && maps.length === 0,
-        ({showCreateButton = true}) => ({
+        ({showCreateButton = true, emptyView}) => ({
             glyph: "1-map",
             title: <Message msgId="resources.maps.noMapAvailable" />,
-            content: <EmptyMaps showCreateButton={showCreateButton} />
+            content: <EmptyMaps showCreateButton={showCreateButton} />,
+            iconFit: true,
+            imageStyle: {
+                height: emptyView?.iconHeight ?? '200px'
+            }
         })
     )
 )(Maps);
@@ -163,6 +172,8 @@ const MapsPlugin = compose(
  * @memberof plugins
  * @class
  * @prop {boolean} cfg.showCreateButton default true. Flag to show/hide the button "create a new one" when there is no dashboard yet.
+ * @prop {boolean} cfg.shareToolEnabled default true. Flag to show/hide the "share" button on the item.
+ * @prop {boolean} cfg.emptyView.iconHeight default "200px". Value to override default icon maximum height.
  */
 export default {
     MapsPlugin: assign(MapsPlugin, {


### PR DESCRIPTION
[Backport 2021.02.xx] #7790 Limit home page empty tab icon sizes on large screens (#7791)

It also backports part of the changes from #7126 (For Maps/GeoStories/Dashboards) that were enabled for FeaturedMaps and Contexts tab by #7726 & #7752, but for some reason were not properly taken for original three tabs of the home page.