### PR TITLE
[Backport 2021.02.xx] #7705: Fix printing WMTS background layers loaded at startup (#7706)

### DIFF
--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -462,7 +462,7 @@ export const specCreators = {
                 "matrixSet": tileMatrixSetName,
                 "style": layer.style,
                 "name": layer.name,
-                "requestEncoding": layer.requestEncoding === "RESTful" ? "REST" : layer.requestEncoding,
+                "requestEncoding": layer.requestEncoding === "RESTful" ? "REST" : layer.requestEncoding || "KVP",
                 "opacity": getOpacity(layer),
                 "version": layer.version || "1.0.0"
             };

--- a/web/client/utils/WMTSUtils.js
+++ b/web/client/utils/WMTSUtils.js
@@ -101,6 +101,14 @@ export const getCapabilitiesURL = (record = {}) => {
 
 export const getDefaultStyleIdentifier = layer =>{
     if (layer?.Style) {
+
+        // if there's only one style, assume it's the default
+        if (castArray(layer.Style).length === 1) {
+            return head(
+                castArray(layer.Style)
+                    // the identifier content value is needed
+                    .map(l => l["ows:Identifier"]));
+        }
         return head(
             castArray(layer.Style)
                 // default is identified by XML attribute isDefault

--- a/web/client/utils/__tests__/WMTSUtils-test.js
+++ b/web/client/utils/__tests__/WMTSUtils-test.js
@@ -78,6 +78,20 @@ describe('Test the WMTSUtils', () => {
             const style = WMTSUtils.getDefaultStyleIdentifier(layer);
             expect(style).toBe('normal');
         });
+        it('tests fetching the default style when "isDefault" is not present', () => {
+            const layer = {
+                Style: {
+                    "ows:Title": "generic Legend",
+                    "ows:Abstract": "abstract",
+                    "ows:Keywords": {
+                        "ows:Keyword": "default"
+                    },
+                    "ows:Identifier": "default"
+                }
+            };
+            const style = WMTSUtils.getDefaultStyleIdentifier(layer);
+            expect(style).toBe('default');
+        });
 
     });
 });


### PR DESCRIPTION
[Backport 2021.02.xx] #7705: Fix printing WMTS background layers loaded at startup (#7706)