### PR TITLE
[Backport 2021.02.xx] #7719 New link on Measure plugin doc (#7732)

### DIFF
--- a/web/client/plugins/Measure.jsx
+++ b/web/client/plugins/Measure.jsx
@@ -66,7 +66,7 @@ const selector = (state) => {
 const toggleMeasureTool = toggleControl.bind(null, 'measure', null);
 /**
  * Measure plugin. Allows to show the tool to measure dinstances, areas and bearing.<br>
- * See [Application Configuration](local-config) to understand how to configure lengthFormula, showLabel and uom
+ * See [Application Configuration](https://mapstore.readthedocs.io/en/latest/developer-guide/local-config/) to understand how to configure lengthFormula, showLabel and uom
  * @class
  * @name Measure
  * @memberof plugins

--- a/web/client/utils/PrintUtils.js
+++ b/web/client/utils/PrintUtils.js
@@ -38,6 +38,13 @@ export const isAnnotationLayer = (layer) => {
 };
 
 /**
+ * Utility functions for thumbnails
+ * @memberof utils
+ * @static
+ * @name PrintUtils
+ */
+
+/**
  * Extracts the correct opacity from layer. if Undefined, the opacity is `1`.
  * @ignore
  * @param {object} layer the MapStore layer
@@ -45,12 +52,8 @@ export const isAnnotationLayer = (layer) => {
 export const getOpacity = layer => layer.opacity || (layer.opacity === 0 ? 0 : 1.0);
 
 /**
- * Utilities for Print
- * @memberof utils
- */
-/**
  * Preload data (e.g. WFS) before to sent it to the print tool.
- *
+ * @memberof utils.PrintUtils
  */
 export const preloadData = (spec) => {
     // check if remote data
@@ -96,6 +99,7 @@ export const preloadData = (spec) => {
  * URL. Supports file paths with or without origin/protocol.
  * @param {string} uri the uri to transform
  * @param {string} [origin=window.location.origin] the origin to use
+ * @memberof utils.PrintUtils
  */
 export const toAbsoluteURL = (uri, origin) => {
     // Handle absolute URLs (with protocol-relative prefix)
@@ -121,7 +125,8 @@ export const toAbsoluteURL = (uri, origin) => {
  * Tranform the original URL configuration of the layer into a URL
  * usable for the print service.
  * @param  {string|array} input Original URL
- * @return {string}       the URL modified as GeoServer requires
+ * @returns {string}       the URL modified as GeoServer requires
+ * @memberof utils.PrintUtils
  */
 export const normalizeUrl = (input) => {
     let result = isArray(input) ? input[0] : input;
@@ -134,7 +139,7 @@ export const normalizeUrl = (input) => {
  * Find the layout name for the given options.
  * The convention is: `PAGE_FORMAT + ("_2_pages_legend"|"_2_pages_legend"|"") + ("_landscape"|"")``
  * @param  {object} spec the spec with the options
- * @return {string}      the layout name.
+ * @returns {string}      the layout name.
  */
 export const getLayoutName = (spec) => {
     let layoutName = [spec.sheet];
@@ -153,7 +158,8 @@ export const getLayoutName = (spec) => {
 /**
  * Gets the print scales allowed from the capabilities of the print service.
  * @param  {capabilities} capabilities the capabilities of the print service
- * @return {array}              the scales array
+ * @returns {array}              the scales array
+ * @memberof utils.PrintUtils
  */
 export const getPrintScales = (capabilities) => {
     return capabilities.scales.slice(0).reverse().map((scale) => parseFloat(scale.value)) || [];
@@ -163,7 +169,8 @@ export const getPrintScales = (capabilities) => {
  * @param  {number} zoom                      the zoom level
  * @param  {array} scales                    the allowed scales
  * @param  {array} [mapScales=defaultScales] the map scales
- * @return {number}                          the index that best approximates the current map scale
+ * @returns {number}                          the index that best approximates the current map scale
+ * @memberof utils.PrintUtils
  */
 export const getNearestZoom = (zoom, scales, mapScales = defaultScales) => {
     const mapScale = mapScales[Math.round(zoom)];
@@ -172,11 +179,13 @@ export const getNearestZoom = (zoom, scales, mapScales = defaultScales) => {
     }, 0);
 };
 /**
+ * @memberof utils
  * Guess the map zoom level from print scale
  * @param  {number} zoom                      the zoom level
  * @param  {array} scales                    the allowed scales
  * @param  {array} [mapScales=defaultScales] the map scales
- * @return {number}                          the index that best approximates the current map scale
+ * @returns {number}                          the index that best approximates the current map scale
+ * @memberof utils.PrintUtils
  */
 export const getMapZoom = (scaleZoom, scales, mapScales = defaultScales) => {
     const scale = scales[Math.round(scaleZoom)];
@@ -188,7 +197,8 @@ export const getMapZoom = (scaleZoom, scales, mapScales = defaultScales) => {
  * Get the mapSize for print preview, parsing the layout and limiting the width.
  * @param  {object} layout   the layout object
  * @param  {number} maxWidth the max width for the mapSize
- * @return {object}          width and height of a map limited by the maxWidth and with the same ratio of the layout
+ * @returns {object}          width and height of a map limited by the maxWidth and with the same ratio of the layout
+ * @memberof utils.PrintUtils
  */
 export const getMapSize = (layout, maxWidth) => {
     if (layout) {
@@ -207,7 +217,8 @@ export const getMapSize = (layout, maxWidth) => {
 /**
  * Creates the mapfish print specification from the current configuration
  * @param  {object} spec the current configuration
- * @return {object}      the mapfish print configuration to send to the server
+ * @returns {object}      the mapfish print configuration to send to the server
+ * @memberof utils.PrintUtils
  */
 export const getMapfishPrintSpecification = (spec) => {
     const projectedCenter = reproject(spec.center, 'EPSG:4326', spec.projection);
@@ -239,7 +250,8 @@ export const getMapfishPrintSpecification = (spec) => {
  * @param  {array} layers  the layers configurations
  * @param  {spec} spec    the print configurations
  * @param  {string} purpose allowed values: `map|legend`. Tells which spec to generate.
- * @return {array}         the configuration array for layers (or legend) to send to the print service.
+ * @returns {array}         the configuration array for layers (or legend) to send to the print service.
+ * @memberof utils.PrintUtils
  */
 export const getMapfishLayersSpecification = (layers, spec, purpose) => {
     return layers.filter((layer) => PrintUtils.specCreators[layer.type] && PrintUtils.specCreators[layer.type][purpose])
@@ -579,6 +591,7 @@ export const rgbaTorgb = (rgba = "") => {
 /**
  * Useful for print (Or generic Openlayers 2 conversion style)
  * http://dev.openlayers.org/docs/files/OpenLayers/Feature/Vector-js.html#OpenLayers.Feature.Vector.OpenLayers.Feature.Vector.style
+ * @memberof utils.PrintUtils
  */
 export const toOpenLayers2Style = function(layer, style, styleType) {
     if (!style || layer.styleName === "marker") {
@@ -616,6 +629,7 @@ export const toOpenLayers2Style = function(layer, style, styleType) {
 /**
  * Provides the default style for
  * each vector type.
+ * @memberof utils.PrintUtils
  */
 export const getOlDefaultStyle = (layer, styleType) => {
     switch (styleType || getGeomType(layer) || "") {


### PR DESCRIPTION
[Backport 2021.02.xx] #7719 New link on Measure plugin doc (#7732)

It can't be backported completely, part of the changes were applied to the code that is created on master via #7657; these changes were not merged back to the stable branch yet.
Therefore part of the changes of this PR were dropped as of now.