### PR TITLE
Fix image paths in printing config

### DIFF
--- a/java/printing/resources/geoserver/print/config.yaml
+++ b/java/printing/resources/geoserver/print/config.yaml
@@ -65,7 +65,7 @@ layouts:
           items:
             - !image
               maxWidth: 550
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           height: 600
           width: 400
@@ -170,7 +170,7 @@ layouts:
           items:
             - !image
               maxWidth: 782
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 592
           height: 400
@@ -263,7 +263,7 @@ layouts:
           items:
             - !image
               maxWidth: 550
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           height: 600
           width: 535
@@ -340,7 +340,7 @@ layouts:
           items:
             - !image
               maxWidth: 782
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 780
           height: 400
@@ -405,7 +405,7 @@ layouts:
           items:
             - !image
               maxWidth: 550
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           height: 600
           width: 535
@@ -520,7 +520,7 @@ layouts:
           items:
             - !image
               maxWidth: 782
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 780
           height: 400
@@ -623,7 +623,7 @@ layouts:
           items:
             - !image
               maxWidth: 800
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 550
           height: 850
@@ -728,7 +728,7 @@ layouts:
           items:
             - !image
               maxWidth: 1105
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 837
           height: 594
@@ -821,7 +821,7 @@ layouts:
           items:
             - !image
               maxWidth: 780
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 760
           height: 850
@@ -898,7 +898,7 @@ layouts:
           items:
             - !image
               maxWidth: 1105
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1102
           height: 594
@@ -963,7 +963,7 @@ layouts:
           items:
             - !image
               maxWidth: 780
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 760
           height: 850
@@ -1078,7 +1078,7 @@ layouts:
           items:
             - !image
               maxWidth: 1105
-              url: '/${configDir}/print_header.png'
+              url: 'file://${configDir}/print_header.png'
         - !map
           width: 1102
           height: 594

--- a/java/printing/resources/geoserver/print/config.yaml
+++ b/java/printing/resources/geoserver/print/config.yaml
@@ -107,7 +107,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 30
@@ -212,7 +212,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 30
@@ -277,7 +277,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 30
@@ -354,7 +354,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 30
@@ -419,7 +419,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 30
@@ -534,7 +534,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 30
@@ -665,7 +665,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -770,7 +770,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -835,7 +835,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -912,7 +912,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -977,7 +977,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42
@@ -1092,7 +1092,7 @@ layouts:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
+              url: 'file://${configDir}/Arrow_North_CFCF.svg'
               rotation: '${rotation}'
         - !columns
           absoluteX: 42


### PR DESCRIPTION
## Description
See #7807, embedding north arrow is broken because of a missing / in the `file://` prefix in the svg url.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#7807

**What is the new behavior?**
SVG north arrow is included in the PDF

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
