### PR TITLE
#7784 #7789 fixes for new charts classifier

### DIFF
--- a/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
+++ b/web/client/components/widgets/builder/wizard/common/WPSWidgetOptions.jsx
@@ -227,6 +227,9 @@ export default ({
                                                     ...(classification ? { classification: formatAutoColorOptions(classification) } : {} ),
                                                     defaultCustomColor: defaultCustomColor ?? '#0888A1'
                                                 });
+                                                if (!v.custom) {
+                                                    onChange("options.classificationAttribute", undefined);
+                                                }
                                             }}/>
                                     </Col>
                                 </FormGroup>

--- a/web/client/observables/autocomplete.js
+++ b/web/client/observables/autocomplete.js
@@ -39,10 +39,10 @@ export const singleAttributeFilter = ({searchText = "", queriableAttributes = []
  * @return {external:Observable} the stream used for fetching data for the autocomplete editor
 */
 export const createPagedUniqueAutompleteStream = (props$) => props$
+    .throttle(props => Rx.Observable.timer(props.delayDebounce || 0))
+    .merge(props$.debounce(props => Rx.Observable.timer(props.delayDebounce || 0)))
     .distinctUntilChanged( ({value, currentPage, attribute}, newProps = {}) =>
         !(newProps.value !== value || newProps.currentPage !== currentPage || newProps.attribute !== attribute))
-    .throttle(props => Rx.Observable.timer(props.delayDebounce || 0))
-    .merge(props$.debounce(props => Rx.Observable.timer(props.delayDebounce || 0))).distinctUntilChanged()
     .switchMap((p) => {
         if (p.performFetch) {
             const data = getWpsPayload({

--- a/web/client/themes/default/less/autocomplete.less
+++ b/web/client/themes/default/less/autocomplete.less
@@ -34,3 +34,7 @@
 .rw-combobox .rw-list {
     width: -webkit-fill-available;
 }
+
+.rw-combobox .rw-btn {
+    overflow: hidden;
+}


### PR DESCRIPTION
## Description
- Debouncing/throttling after "distinctUntilChanged" caused unwanted effect when request was re-executed even if value, currentPage or attribute were not changed.
- Removed classification attribute from store once user switch to color ramp other than custom. This will remove classification attribute from WPS request in such case.
- Corrected CSS for loading spinner.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#7784 

**What is the new behavior?**
1. Corrected behavior of throttling and debouncing for "createPagedUniqueAutompleteStream". Debouncing after "distinctUntilChanged" caused unwanted effect when field fired data re-fetching even when it should be distinct, e.g. dropdown toggle while value is empty or value is set and user toggles dropdown.
2. Removed classification attribute value from the store once user switch from custom color ramp to predefined. It also removes classification attribute from WPS request, though user will have to re-define classification field if color ramp is switched to custom again.
3. Added overflow: hidden to the spinner; in some cases spinner was causing scrollbar to appear in the modal.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information